### PR TITLE
Enable the GCSimulator CI run to run on a regular basis

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -136,6 +136,9 @@ def static setTestJobTimeOut(newJob, scenario) {
     else if (isCoverage(scenario)) {
         Utilities.setJobTimeout(newJob, 1440)  
     }
+    else if (isLongGc(scenario)) {
+        Utilities.setJobTimeout(newJob, 1440)
+    }
     // Non-test jobs use the default timeout value.
 }
 
@@ -372,7 +375,11 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                 addEmailPublisher(job, 'dotnetgctests@microsoft.com')
                 break
             case 'gcsimulator':
-                // GCSimulator is currently only triggered by PR
+                assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX')
+                assert configuration == 'Release'
+                assert architecture == 'x64'
+                Utilities.addPeriodicTrigger(job, 'H H * * 3,6') // some time every Wednesday and Saturday
+                addEmailPublisher(job, 'dotnetgctests@microsoft.com')
                 break
             case 'ilrt':
                 assert !(os in bidailyCrossList)

--- a/tests/gcSimulatorTests.txt
+++ b/tests/gcSimulatorTests.txt
@@ -172,7 +172,6 @@ GC/Scenarios/GCSimulator/GCSimulator_254/GCSimulator_254.sh
 GC/Scenarios/GCSimulator/GCSimulator_255/GCSimulator_255.sh
 GC/Scenarios/GCSimulator/GCSimulator_256/GCSimulator_256.sh
 GC/Scenarios/GCSimulator/GCSimulator_257/GCSimulator_257.sh
-GC/Scenarios/GCSimulator/GCSimulator_258/GCSimulator_258.sh
 GC/Scenarios/GCSimulator/GCSimulator_259/GCSimulator_259.sh
 GC/Scenarios/GCSimulator/GCSimulator_25/GCSimulator_25.sh
 GC/Scenarios/GCSimulator/GCSimulator_260/GCSimulator_260.sh

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator.csproj
@@ -15,10 +15,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
-    <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
-    <IsGCSimulatorTest>true</IsGCSimulatorTest>
-    <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_1.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_1.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 8000 -lt 2 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_10.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_10.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_100.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_100.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_101.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_101.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_102.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_102.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_103.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_103.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_104.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_104.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_105.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_105.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_106.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_106.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_107.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_107.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_108.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_108.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_109.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_109.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_11.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_11.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_110.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_110.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_111.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_111.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_112.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_112.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 8000 -lt 4 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_113.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_113.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_114.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_114.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_115.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_115.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_116.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_116.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_117.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_117.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_118.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_118.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_119.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_119.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_12.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_12.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_120.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_120.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_121.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_121.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_122.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_122.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_123.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_123.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_124.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_124.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_125.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_125.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_126.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_126.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_127.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_127.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_128.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_128.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_129.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_129.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_13.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_13.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_130.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_130.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_131.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_131.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_132.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_132.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_133.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_133.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_134.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_134.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_135.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_135.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_136.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_136.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_137.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_137.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_138.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_138.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_139.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_139.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_14.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_14.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_140.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_140.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_141.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_141.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_142.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_142.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_143.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_143.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_144.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_144.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_145.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_145.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_146.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_146.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_147.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_147.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_148.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_148.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_149.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_149.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_15.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_15.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_150.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_150.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_151.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_151.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_152.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_152.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_153.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_153.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_154.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_154.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_155.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_155.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_156.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_156.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_157.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_157.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_158.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_158.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_159.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_159.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_16.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_16.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_160.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_160.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_161.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_161.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_162.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_162.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_163.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_163.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_164.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_164.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_165.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_165.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_166.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_166.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_167.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_167.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_168.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_168.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_169.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_169.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_17.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_17.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_170.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_170.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_171.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_171.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_172.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_172.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_173.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_173.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_174.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_174.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_175.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_175.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_176.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_176.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_177.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_177.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_178.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_178.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_179.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_179.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 8517 -sdz 17 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_18.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_18.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_180.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_180.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_181.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_181.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_182.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_182.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_183.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_183.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_184.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_184.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_185.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_185.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_186.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_186.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_187.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_187.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_188.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_188.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_189.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_189.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_19.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_19.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_191.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_191.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_192.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_192.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 5 -tp 0 -dz 17 -sdz 17 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_193.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_193.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 5 -tp 0 -dz 17 -sdz 17 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_194.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_194.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 5 -tp 0 -dz 17 -sdz 17 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_195.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_195.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 7 -tp 0 -dz 17 -sdz 17 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_196.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_196.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_197.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_197.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_198.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_198.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_199.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_199.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_2.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_2.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_20.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_20.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_200.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_200.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_201.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_201.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_202.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_202.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_203.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_203.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_204.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_204.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_205.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_205.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 30000 -sdc 6000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_206.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_206.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 6000 -lt 2 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_207.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_207.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 8000 -lt 2 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_208.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_208.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 8000 -lt 4 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_209.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_209.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_21.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_21.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_210.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_210.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_211.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_211.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_212.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_212.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_213.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_213.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 8000 -lt 2 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_214.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_214.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_215.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_215.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_216.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_216.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_217.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_217.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_218.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_218.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_219.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_219.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_22.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_22.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_220.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_220.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_221.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_221.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_222.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_222.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_223.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_223.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_224.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_224.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_225.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_225.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_226.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_226.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_227.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_227.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_228.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_228.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_229.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_229.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_23.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_23.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_230.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_230.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_231.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_231.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_232.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_232.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_233.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_233.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_234.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_234.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_235.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_235.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_236.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_236.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_237.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_237.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_238.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_238.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_239.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_239.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_24.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_24.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_240.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_240.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_241.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_241.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_242.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_242.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_243.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_243.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_244.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_244.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_245.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_245.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_246.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_246.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_247.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_247.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_248.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_248.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_249.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_249.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_25.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_25.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_250.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_250.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_251.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_251.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_252.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_252.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_253.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_253.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_254.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_254.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_255.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_255.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_256.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_256.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_257.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_257.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_258.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_258.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_259.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_259.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_26.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_26.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_260.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_260.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_261.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_261.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_262.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_262.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_263.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_263.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_264.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_264.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_265.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_265.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_266.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_266.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_267.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_267.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_268.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_268.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_269.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_269.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_27.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_27.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_270.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_270.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_271.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_271.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_272.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_272.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_273.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_273.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_274.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_274.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_275.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_275.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_276.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_276.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_277.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_277.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_278.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_278.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_279.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_279.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_28.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_28.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_280.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_280.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_281.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_281.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_282.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_282.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_283.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_283.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_284.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_284.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_285.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_285.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_286.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_286.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_287.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_287.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_288.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_288.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_289.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_289.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_29.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_29.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_290.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_290.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_291.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_291.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_292.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_292.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_293.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_293.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_294.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_294.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_295.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_295.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_296.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_296.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_297.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_297.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_298.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_298.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_299.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_299.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_3.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_3.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_30.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_30.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_300.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_300.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_301.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_301.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_302.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_302.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_303.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_303.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_304.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_304.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_305.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_305.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_306.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_306.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_307.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_307.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_308.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_308.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_309.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_309.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_31.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_31.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_310.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_310.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_311.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_311.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_312.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_312.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_313.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_313.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_314.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_314.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_315.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_315.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_316.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_316.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_317.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_317.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_318.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_318.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_319.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_319.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_32.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_32.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_320.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_320.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_321.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_321.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_322.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_322.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_323.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_323.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_324.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_324.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 8000 -lt 4 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_325.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_325.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_326.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_326.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_327.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_327.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_328.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_328.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_329.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_329.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_33.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_33.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_330.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_330.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_331.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_331.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_332.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_332.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_333.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_333.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_334.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_334.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_335.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_335.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_336.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_336.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_337.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_337.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_338.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_338.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_339.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_339.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_34.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_34.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_340.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_340.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_341.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_341.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_342.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_342.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_343.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_343.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_344.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_344.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_345.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_345.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_346.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_346.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_347.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_347.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_348.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_348.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_349.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_349.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_35.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_35.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_350.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_350.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_351.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_351.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_352.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_352.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_353.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_353.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_354.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_354.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_355.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_355.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_356.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_356.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_357.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_357.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_358.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_358.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_359.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_359.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_36.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_36.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_360.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_360.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_361.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_361.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_362.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_362.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_363.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_363.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_364.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_364.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_365.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_365.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_366.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_366.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_367.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_367.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_368.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_368.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_369.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_369.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_37.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_37.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_370.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_370.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_371.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_371.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_372.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_372.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_373.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_373.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_374.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_374.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_375.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_375.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_376.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_376.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_377.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_377.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_378.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_378.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_379.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_379.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_38.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_38.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_380.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_380.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_381.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_381.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_382.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_382.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_383.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_383.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_384.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_384.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_385.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_385.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_386.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_386.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_387.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_387.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_388.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_388.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_389.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_389.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_39.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_39.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_390.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_390.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_391.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_391.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 8517 -sdz 17 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_392.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_392.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_393.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_393.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_394.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_394.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_395.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_395.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_396.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_396.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_397.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_397.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 2 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_398.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_398.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_399.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_399.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_4.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_4.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_40.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_40.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_400.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_400.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_401.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_401.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_402.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_402.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 4 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_403.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_403.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_404.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_404.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 5 -tp 0 -dz 17 -sdz 17 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_405.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_405.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 5 -tp 0 -dz 17 -sdz 17 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_406.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_406.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 5 -tp 0 -dz 17 -sdz 17 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_407.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_407.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 7 -tp 0 -dz 17 -sdz 17 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_408.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_408.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_409.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_409.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_41.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_41.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_410.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_410.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_411.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_411.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_412.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_412.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_413.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_413.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_414.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_414.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_415.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_415.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_416.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_416.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_417.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_417.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 30000 -sdc 6000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_418.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_418.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 6000 -lt 2 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_419.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_419.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 8000 -lt 2 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_42.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_42.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_420.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_420.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 17 -dc 20000 -sdc 8000 -lt 4 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_421.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_421.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_422.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_422.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_423.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_423.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_424.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_424.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_425.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_425.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 7 -tp 0 -dz 17 -sdc 1024 -dc 10000 -sdz 17 -lt 2 -dp 0.1 -dw 0.0 -f</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_426.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_426.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 8 -tp 0 -dz 17 -sdc 1024 -dc 10000 -sdz 17 -lt 2 -dp 0.2 -dw 0.0 -f</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_427.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_427.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 10 -tp 0 -dz 17 -sdc 1024 -dc 10000 -sdz 17 -lt 2 -dp 0.2 -dw 0.0 -f</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_428.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_428.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 10 -tp 0 -dz 17 -sdc 1024 -dc 10000 -sdz 17 -lt 2 -dp 0.3 -dw 0.0 -f</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_429.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_429.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 8 -tp 0 -dz 17 -sdc 1024 -dc 10000 -sdz 17 -lt 2 -dp 0.3 -dw 0.1 -f</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_43.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_43.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_430.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_430.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_431.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_431.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_432.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_432.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_44.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_44.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_45.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_45.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_46.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_46.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_47.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_47.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_48.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_48.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_49.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_49.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_5.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_5.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_50.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_50.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_51.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_51.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_52.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_52.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_53.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_53.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_54.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_54.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_55.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_55.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_56.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_56.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_57.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_57.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_58.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_58.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_59.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_59.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_6.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_6.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_60.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_60.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_61.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_61.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_62.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_62.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_63.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_63.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_64.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_64.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_65.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_65.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_66.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_66.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_67.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_67.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_68.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_68.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_69.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_69.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_7.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_7.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_70.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_70.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_71.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_71.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_72.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_72.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_73.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_73.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_74.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_74.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_75.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_75.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.0 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_76.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_76.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_77.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_77.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_78.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_78.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_79.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_79.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.8</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_8.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_8.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_80.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_80.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_81.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_81.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_82.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_82.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_83.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_83.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_84.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_84.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.4 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_85.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_85.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_86.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_86.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_87.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_87.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_88.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_88.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_89.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_89.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_9.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_9.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_90.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_90.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8517 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.8 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_91.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_91.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_92.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_92.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_93.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_93.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 3 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -f -dp 0.8 -dw 0.4</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_94.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_94.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_95.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_95.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_96.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_96.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 4 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_97.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_97.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 5 -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_98.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_98.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 2 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/GCSimulator/GCSimulator_99.csproj
+++ b/tests/src/GC/Scenarios/GCSimulator/GCSimulator_99.csproj
@@ -17,6 +17,8 @@
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
     <CLRTestExecutionArguments>-t 1 -tp 0 -dz 17 -sdz 8500 -dc 10000 -sdc 5000 -lt 3 -f -dp 0.0 -dw 0.0</CLRTestExecutionArguments>
     <IsGCSimulatorTest>true</IsGCSimulatorTest>
+    <CLRTestKind>RunOnly</CLRTestKind>
+    <CLRTestProjectToRun>GCSimulator.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This PR does several things:

  1. Enables the GCSimulator CI job to run every Wednesday and Saturday,
  2. Extends the timeout for both longgc and gcsimulator to 24 hours (it'll never get anywhere near that)
  3. Remove one of the GCSimulator tests (GCSimulator_258) that runs for well over two hours,
  4. Convert the many GCSimulator tests to "RunOnly" so that we only build GCSimulator.exe itself one time.