### PR TITLE
Fix kill set of rep stos to include ECX

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2527,14 +2527,10 @@ LinearScan::getKillSetForNode(GenTree* tree)
             case GenTreeBlkOp::BlkOpKindHelper:
                 killMask = compiler->compHelperCallKillSet(CORINFO_HELP_MEMSET);
                 break;
-#ifdef _TARGET_AMD64_
+#ifdef _TARGET_XARCH_
             case GenTreeBlkOp::BlkOpKindRepInstr:
                 // rep stos kills RCX and RDI
-                killMask = RBM_RDI;
-                if (!initBlkNode->InitVal()->IsCnsIntOrI())
-                {
-                    killMask |= RBM_RCX;
-                }
+                killMask = RBM_RCX | RBM_RDI;
                 break;
 #else
             case GenTreeBlkOp::BlkOpKindRepInstr:

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -353,18 +353,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Serialization\Serialize\Serialize.cmd">
              <Issue>3597</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd0E_d\hfa_nd0E_d.cmd">
-             <Issue>4817</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd0E_r\hfa_nd0E_r.cmd">
-             <Issue>4817</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd1E_d\hfa_nd1E_d.cmd">
-             <Issue>4817</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd1E_r\hfa_nd1E_r.cmd">
-             <Issue>4817</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\V8\DeltaBlue\DeltaBlue\DeltaBlue.cmd">
              <Issue>4817</Issue>
         </ExcludeList>


### PR DESCRIPTION
There was a very strange condition in the existing code to only
conditionally include ECX in the kill set. I convinced myself that
for AMD64, this condition always holds in this code path (which
makes a lot more sense anyway), so I removed the condition, and
also made all this code execute for x86 as well.

Fixes #4817

@CarolEidt @adiaaida PTAL
/cc @dotnet/jit-contrib 