### PR TITLE
Allow long paths in CoreCLR managed code

### DIFF
--- a/clr.coreclr.props
+++ b/clr.coreclr.props
@@ -101,4 +101,8 @@
 
     <FeatureCoreFxGlobalization>true</FeatureCoreFxGlobalization>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetsUnix)' != 'true'">
+    <FeatureImplicitLongPath>true</FeatureImplicitLongPath>
+  </PropertyGroup>
 </Project>

--- a/clr.defines.targets
+++ b/clr.defines.targets
@@ -8,7 +8,7 @@
         <CDefines Condition="'$(FeatureAppdomainmanagerInitoptions)' == 'true'">$(CDefines);FEATURE_APPDOMAINMANAGER_INITOPTIONS</CDefines>
         <CDefines Condition="'$(FeatureAppX)' == 'true'">$(CDefines);FEATURE_APPX</CDefines>
         <CDefines Condition="'$(FeatureAppXBinder)' == 'true'">$(CDefines);FEATURE_APPX_BINDER</CDefines>
-        <CDefines Condition="'$(FeatureAptca)' == 'true'">$(CDefines);FEATURE_APTCA</CDefines>        
+        <CDefines Condition="'$(FeatureAptca)' == 'true'">$(CDefines);FEATURE_APTCA</CDefines>
         <CDefines Condition="'$(FeatureArrayStubAsIL)' == 'true'">$(CDefines);FEATURE_ARRAYSTUB_AS_IL</CDefines>
         <CDefines Condition="'$(FeatureStubsAsIL)' == 'true'">$(CDefines);FEATURE_STUBS_AS_IL</CDefines>
         <CDefines Condition="'$(FeatureBclFormatting)' == 'true'">$(CDefines);FEATURE_BCL_FORMATTING</CDefines>
@@ -162,6 +162,7 @@
         <DefineConstants Condition="'$(FeatureIdentityReference)' == 'true'">$(DefineConstants);FEATURE_IDENTITY_REFERENCE</DefineConstants>
         <DefineConstants Condition="'$(FeatureImpersonation)' == 'true'">$(DefineConstants);FEATURE_IMPERSONATION</DefineConstants>
         <DefineConstants Condition="'$(FeatureIncludeAllInterfaces)' == 'true'">$(DefineConstants);FEATURE_INCLUDE_ALL_INTERFACES</DefineConstants>
+        <DefineConstants Condition="'$(FeatureImplicitLongPath)' == 'true'">$(DefineConstants);FEATURE_IMPLICIT_LONGPATH</DefineConstants>
         <DefineConstants Condition="'$(FeatureIsolatedStorageQuotaEnforcement)' == 'true'">$(DefineConstants);FEATURE_ISOLATED_STORAGE_QUOTA_ENFORCEMENT</DefineConstants>
         <DefineConstants Condition="'$(FeatureIsostore)' == 'true'">$(DefineConstants);FEATURE_ISOSTORE</DefineConstants>
         <DefineConstants Condition="'$(FeatureIsostoreLight)' == 'true'">$(DefineConstants);FEATURE_ISOSTORE_LIGHT</DefineConstants>
@@ -178,6 +179,7 @@
         <DefineConstants Condition="'$(FeatureNongenericCollections)' == 'true'">$(DefineConstants);FEATURE_NONGENERIC_COLLECTIONS</DefineConstants>
         <DefineConstants Condition="'$(FeatureNormIdnaOnly)' == 'true'">$(DefineConstants);FEATURE_NORM_IDNA_ONLY</DefineConstants>
         <DefineConstants Condition="'$(FeaturePal)' == 'true'">$(DefineConstants);FEATURE_PAL</DefineConstants>
+        <DefineConstants Condition="'$(FeaturePathCompat)' == 'true'">$(DefineConstants);FEATURE_PATHCOMPAT</DefineConstants>
         <DefineConstants Condition="'$(FeatureXplatEventSource)' == 'true'">$(DefineConstants);FEATURE_EVENTSOURCE_XPLAT</DefineConstants>
         <DefineConstants Condition="'$(FeaturePerfmon)' == 'true'">$(DefineConstants);FEATURE_PERFMON</DefineConstants>
         <DefineConstants Condition="'$(FeaturePls)' == 'true'">$(DefineConstants);FEATURE_PLS</DefineConstants>

--- a/clr.desktop.props
+++ b/clr.desktop.props
@@ -67,6 +67,7 @@
     <FeatureMultiModuleAssemblies>true</FeatureMultiModuleAssemblies>
     <FeatureNativeImageGeneration>true</FeatureNativeImageGeneration>
     <FeatureNongenericCollections>true</FeatureNongenericCollections>
+    <FeaturePathCompat>true</FeaturePathCompat>
     <FeaturePerfmon>true</FeaturePerfmon>
     <FeaturePls>true</FeaturePls>
     <FeaturePrejit>true</FeaturePrejit>

--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -784,7 +784,7 @@
     <IoSources Include="$(BclSourcesRoot)\System\IO\MemoryStream.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\Path.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\PathHelper.cs" />
-    <IoSources Include="$(BclSourcesRoot)\System\IO\LongPathHelper.cs" />
+    <IoSources Condition="'$(TargetsUnix)' != 'true'" Include="$(BclSourcesRoot)\System\IO\LongPathHelper.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\PathInternal.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\PathTooLongException.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\PinnedBufferMemoryStream.cs" />

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -1301,6 +1301,9 @@ namespace Microsoft.Win32 {
                   int nBufferLength,
                   [Out]StringBuilder lpBuffer);
 
+        [DllImport(KERNEL32, SetLastError = true, ExactSpelling = true)]
+        internal static extern uint GetCurrentDirectoryW(uint nBufferLength, SafeHandle lpBuffer);
+
         [DllImport(KERNEL32, SetLastError=true, CharSet=CharSet.Auto, BestFitMapping=false)]
         internal static extern bool GetFileAttributesEx(String name, int fileInfoLevel, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
 

--- a/src/mscorlib/src/System/AppContext/AppContextSwitches.cs
+++ b/src/mscorlib/src/System/AppContext/AppContextSwitches.cs
@@ -39,6 +39,36 @@ namespace System
             }
         }
 
+#if FEATURE_PATHCOMPAT
+        private static int _useLegacyPathHandling;
+
+        /// <summary>
+        /// Use legacy path normalization logic and blocking of extended syntax.
+        /// </summary>
+        public static bool UseLegacyPathHandling
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return GetCachedSwitchValue(AppContextDefaultValues.SwitchUseLegacyPathHandling, ref _useLegacyPathHandling);
+            }
+        }
+
+        private static int _blockLongPaths;
+
+        /// <summary>
+        /// Throw PathTooLongException for paths greater than MAX_PATH or directories greater than 248 (as per CreateDirectory Win32 limitations)
+        /// </summary>
+        public static bool BlockLongPaths
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return GetCachedSwitchValue(AppContextDefaultValues.SwitchBlockLongPaths, ref _blockLongPaths);
+            }
+        }
+#endif // FEATURE_PATHCOMPAT
+
         //
         // Implementation details
         //

--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -3816,11 +3816,19 @@ namespace System {
         [SecuritySafeCritical]
         internal static string NormalizePath(string path, bool fullCheck)
         {
-            return Path.NormalizePath(
+#if FEATURE_PATHCOMPAT
+            // Appcontext switches can't currently be safely hit during AppDomain bringup
+            return Path.LegacyNormalizePath(
                 path: path,
                 fullCheck: fullCheck,
                 maxPathLength: PathInternal.MaxShortPath,
                 expandShortPaths: true);
+#else
+            return Path.NormalizePath(
+                path: path,
+                fullCheck: fullCheck,
+                expandShortPaths: true);
+#endif
         }
 
 #if FEATURE_APTCA
@@ -3933,9 +3941,9 @@ namespace System {
 
 #endif
 
-    // This routine is called from unmanaged code to
-    // set the default fusion context.
-    [System.Security.SecurityCritical]  // auto-generated
+        // This routine is called from unmanaged code to
+        // set the default fusion context.
+        [System.Security.SecurityCritical]  // auto-generated
         private void SetupDomain(bool allowRedirects, String path, String configFile, String[] propertyNames, String[] propertyValues)
         {
             // It is possible that we could have multiple threads initializing

--- a/src/mscorlib/src/System/AppDomainSetup.cs
+++ b/src/mscorlib/src/System/AppDomainSetup.cs
@@ -340,8 +340,16 @@ namespace System {
 
             // If we add very long file name support ("\\?\") to the Path class then this is unnecesary,
             // but we do not plan on doing this for now.
+
+            // Long path checks can be quirked, and as loading default quirks too early in the setup of an AppDomain is risky
+            // we'll avoid checking path lengths- we'll still fail at MAX_PATH later if we're !useAppBase when we call Path's
+            // NormalizePath.
             if (!useAppBase)
-                path = System.Security.Util.URLString.PreProcessForExtendedPathRemoval(path, false);
+                path = Security.Util.URLString.PreProcessForExtendedPathRemoval(
+                    checkPathLength: false,
+                    url: path,
+                    isFileUrl: false);
+
 
             int len = path.Length;
             if (len == 0)

--- a/src/mscorlib/src/System/IO/FileSecurityState.cs
+++ b/src/mscorlib/src/System/IO/FileSecurityState.cs
@@ -122,16 +122,11 @@ namespace System.IO
                 path = path.Trim();
 
 #if !PLATFORM_UNIX
-                if (path.Length > 2 && path.IndexOf( ':', 2 ) != -1)
-                    throw new NotSupportedException( Environment.GetResourceString( "Argument_PathFormatNotSupported" ) );
-#endif // !PLATFORM_UNIX
+                if (!PathInternal.IsDevice(path) && PathInternal.HasInvalidVolumeSeparator(path))
+                    throw new ArgumentException(Environment.GetResourceString("Argument_PathFormatNotSupported"));
+#endif
 
-                System.IO.Path.CheckInvalidPathChars(path);
-
-#if !PLATFORM_UNIX
-                if (path.IndexOfAny( m_illegalCharacters ) != -1)
-                    throw new ArgumentException( Environment.GetResourceString( "Argument_InvalidPathChars" ) );
-#endif // !PLATFORM_UNIX
+                System.IO.Path.CheckInvalidPathChars(path, checkAdditional: true);
             }
         }
     }

--- a/src/mscorlib/src/System/Security/Util/StringExpressionSet.cs
+++ b/src/mscorlib/src/System/Security/Util/StringExpressionSet.cs
@@ -219,10 +219,12 @@ namespace System.Security.Util {
                 if (str[index] == null)
                     throw new ArgumentNullException( "str" );
 
+                // Replace alternate directory separators
                 String oneString = StaticProcessWholeString( str[index] );
 
                 if (oneString != null && oneString.Length != 0)
                 {
+                    // Trim leading and trailing spaces
                     String temp = StaticProcessSingleString( oneString);
 
                     int indexOfNull = temp.IndexOf( '\0' );
@@ -232,13 +234,12 @@ namespace System.Security.Util {
 
                     if (temp != null && temp.Length != 0)
                     {
-                        if (Path.IsRelative(temp))
+                        if (PathInternal.IsPartiallyQualified(temp))
                         {
-                            throw new ArgumentException( Environment.GetResourceString( "Argument_AbsolutePathRequired" ) );
+                            throw new ArgumentException(Environment.GetResourceString( "Argument_AbsolutePathRequired" ) );
                         }
 
                         temp = CanonicalizePath( temp, needFullPath );
-
 
                         retArrayList.Add( temp );
                     }
@@ -737,27 +738,14 @@ namespace System.Security.Util {
         }
 
         [System.Security.SecurityCritical]  // auto-generated
-        internal static String CanonicalizePath( String path, bool needFullPath )
+        internal static string CanonicalizePath(string path, bool needFullPath)
         {
-
-#if !PLATFORM_UNIX
-            if (path.IndexOf( '~' ) != -1)
-            {
-                string longPath = null;
-                GetLongPathName(path, JitHelpers.GetStringHandleOnStack(ref longPath));
-                path = (longPath != null) ? longPath : path;
-            }
-
-            if (path.IndexOf( ':', 2 ) != -1)
-                throw new NotSupportedException( Environment.GetResourceString( "Argument_PathFormatNotSupported" ) );
-#endif // !PLATFORM_UNIX               
-
             if (needFullPath)
             {
-                String newPath = System.IO.Path.GetFullPathInternal( path );
-                if (path.EndsWith( m_directorySeparator + ".", StringComparison.Ordinal ))
+                string newPath = Path.GetFullPathInternal(path);
+                if (path.EndsWith(m_directorySeparator + ".", StringComparison.Ordinal))
                 {
-                    if (newPath.EndsWith( m_directorySeparator ))
+                    if (newPath.EndsWith(m_directorySeparator))
                     {
                         newPath += ".";
                     }
@@ -765,11 +753,25 @@ namespace System.Security.Util {
                     {
                         newPath += m_directorySeparator + ".";
                     }
-                }                
-                return newPath;
+                }
+                path = newPath;
             }
-            else
-                return path;
+#if !PLATFORM_UNIX
+            else if (path.IndexOf('~') != -1)
+            {
+                // GetFullPathInternal() will expand 8.3 file names
+                string longPath = null;
+                GetLongPathName(path, JitHelpers.GetStringHandleOnStack(ref longPath));
+                path = (longPath != null) ? longPath : path;
+            }
+
+            // This blocks usage of alternate data streams and some extended syntax paths (\\?\C:\). Checking after
+            // normalization allows valid paths such as " C:\" to be considered ok (as it will become "C:\").
+            if (path.IndexOf(':', 2) != -1)
+                throw new NotSupportedException(Environment.GetResourceString("Argument_PathFormatNotSupported"));
+#endif // !PLATFORM_UNIX
+
+            return path;
         }
     }
 }


### PR DESCRIPTION
Allows long paths in mscorlib.

- Fixes wraps for FEATURE_PATHCOMPAT and enables for desktop builds.
- Add feature FEATURE_IMPLICIT_LONGPATH for implicit long path support (adding \\?\).
- Implicit support added to Path.GetFullPath, which allows execution over MAX_PATH.

Without this change corerun would fail here:
```
 HOSTLOG: AppDomainCompatSwitch=UseLatestBehaviorWhenTFMNotSpecified
 HOSTLOG: APP_LOCAL_WINMETADATA=
 HOSTLOG: Failed call to CreateAppDomainWithManager. ERRORCODE: 0x800700ce
 HOSTLOG: Execution failed
```
when run from this path (248 characters long):

```
D:\Test\coreclr\runtime\HowLongDoYouLikeYourPathsToBe\PersonallyILikeMyPathsToBeReallyReallyReallyLong\ButYouLikeYoursToBeEvenLongerISeeIHopeThatYouAre\AmusedByMyInabilityToComeUpWithCoolDirectoryNames\AtLeastITriedToComeUpWithSomethingInteresting\
```

It's awkward to test launching from within the CMD shell as there is very limited support currently. I had to write custom support code to set up the scenario. My followup is to validate/fix scenarios around Process.Start() and implicit/explicit loading of referenced assemblies.

Some additional notes about this change:

- It is primarily a port of the CoreFx work through the desktop (NetFx) code
- Unix tweaks are ports directly from relevant CoreFx code
- Implicit support is ported directly from CoreFx

@weshaggard, @ramarag, @terrajobst, @ianhays

#731, #1776, #3384