### PR TITLE
Use LatchedExitCode as ExitCode for void Main(...)

### DIFF
--- a/src/vm/assembly.cpp
+++ b/src/vm/assembly.cpp
@@ -2588,6 +2588,7 @@ HRESULT RunMain(MethodDesc *pFD ,
             // Set the return value to 0 instead of returning random junk
             *pParam->piRetVal = 0;
             threadStart.Call(&stackVar);
+            *pParam->piRetVal = GetLatchedExitCode();
         }
         else 
         {


### PR DESCRIPTION
Main should return System.Environment.ExitCode if its return type is
'void' (according to https://msdn.microsoft.com/en-us/library/system.environment.exitcode(v=vs.100).aspx)

However, it seems that CoreCLR currently does not support this.

This commit tries to implement such functionality into CoreCLR in order
to fix #4906.