### PR TITLE
Fix the optimization check to call ordinal

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -165,7 +165,7 @@ namespace System.Globalization
                 return IndexOfOrdinal(source, target, startIndex, count, ignoreCase: false);
             }
 
-            if (m_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsAscii() && target.IsAscii())
+            if (m_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsFastSort() && target.IsFastSort())
             {
                 return IndexOf(source, target, startIndex, count, GetOrdinalCompareOptions(options));
             }
@@ -195,7 +195,7 @@ namespace System.Globalization
                 return LastIndexOfOrdinal(source, target, startIndex, count, ignoreCase: false);
             }
 
-            if (m_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsAscii() && target.IsAscii())
+            if (m_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsFastSort() && target.IsFastSort())
             {
                 return LastIndexOf(source, target, startIndex, count, GetOrdinalCompareOptions(options));
             }
@@ -219,7 +219,7 @@ namespace System.Globalization
             Contract.Assert(!string.IsNullOrEmpty(prefix));
             Contract.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
-            if (m_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsAscii() && prefix.IsAscii())
+            if (m_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsFastSort() && prefix.IsFastSort())
             {
                 return IsPrefix(source, prefix, GetOrdinalCompareOptions(options));
             }
@@ -234,7 +234,7 @@ namespace System.Globalization
             Contract.Assert(!string.IsNullOrEmpty(suffix));
             Contract.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
-            if (m_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsAscii() && suffix.IsAscii())
+            if (m_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsFastSort() && suffix.IsFastSort())
             {
                 return IsSuffix(source, suffix, GetOrdinalCompareOptions(options));
             }

--- a/src/utilcode/util_nodependencies.cpp
+++ b/src/utilcode/util_nodependencies.cpp
@@ -978,10 +978,18 @@ HighCharHelper::HighCharTable[]= {
     TRUE, /* 0x7, .*/
     TRUE, /* 0x8, .*/
     FALSE, /* 0x9,   */
+#ifdef PLATFORM_UNIX
+    TRUE, /* 0xA,  */
+#else    
     FALSE, /* 0xA,  */
+#endif // PLATFORM_UNIX
     FALSE, /* 0xB, .*/
     FALSE, /* 0xC, .*/
+#ifdef PLATFORM_UNIX
+    TRUE, /* 0xD,  */
+#else    
     FALSE, /* 0xD,  */
+#endif // PLATFORM_UNIX
     TRUE, /* 0xE, .*/
     TRUE, /* 0xF, .*/
     TRUE, /* 0x10, .*/

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -220,8 +220,8 @@ FCFuncStart(gStringFuncs)
     FCFuncElementSig(COR_CTOR_METHOD_NAME, &gsig_IM_PtrSByt_Int_Int_RetVoid, COMString::StringInitCharPtrPartial)
 #ifndef FEATURE_CORECLR
     FCFuncElementSig(COR_CTOR_METHOD_NAME, &gsig_IM_PtrSByt_Int_Int_Encoding_RetVoid, COMString::StringInitSBytPtrPartialEx)
-    FCFuncElement("IsFastSort", COMString::IsFastSort)
 #endif // FEATURE_CORECLR
+    FCFuncElement("IsFastSort", COMString::IsFastSort)
     FCFuncElement("nativeCompareOrdinalIgnoreCaseWC", COMString::FCCompareOrdinalIgnoreCaseWC)
     FCIntrinsic("get_Length", COMString::Length, CORINFO_INTRINSIC_StringLength)
     FCIntrinsic("get_Chars", COMString::GetCharAt, CORINFO_INTRINSIC_StringGetChar)


### PR DESCRIPTION
we have some optimization to check if we can perform the string search as ordinal operation instead of lingustic operation. we used to check if the string is Ascii which check if all chars in the string are in range 0~7F.
This check was not enough because in Linux, ICU do some special handling for some characters in the Ascii range. so we need to avoid calling the ordinal operation when encountering such chracters.
The fix is to take the advantage of String.IsFastSort which do exactly what we need