### PR TITLE
Shrink Task size by 10%

### DIFF
--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -350,7 +350,13 @@ namespace System.Threading.Tasks
 
             // Only set a parent if AttachedToParent is specified.
             if ((creationOptions & TaskCreationOptions.AttachedToParent) != 0)
-                EnsureContingentPropertiesInitializedUnsafe().m_parent = Task.InternalCurrent;
+            {
+                Task parent = Task.InternalCurrent;
+                if (parent != null)
+                {
+                    EnsureContingentPropertiesInitializedUnsafe().m_parent = parent;
+                }
+            }
 
             TaskConstructorCore(null, state, default(CancellationToken), creationOptions, InternalTaskOptions.PromiseTask, null);
         }
@@ -552,11 +558,10 @@ namespace System.Threading.Tasks
             }
             Contract.EndContractBlock();
 
-            // This is readonly, and so must be set in the constructor
             // Keep a link to your parent if: (A) You are attached, or (B) you are self-replicating.
-            if (((creationOptions & TaskCreationOptions.AttachedToParent) != 0) ||
-                ((internalOptions & InternalTaskOptions.SelfReplicating) != 0)
-                )
+            if (parent != null &&
+                ((creationOptions & TaskCreationOptions.AttachedToParent) != 0 ||
+                 (internalOptions & InternalTaskOptions.SelfReplicating) != 0))
             {
                 EnsureContingentPropertiesInitializedUnsafe().m_parent = parent;
             }

--- a/src/mscorlib/src/System/Threading/Tasks/future.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/future.cs
@@ -500,7 +500,7 @@ namespace System.Threading.Tasks
             Contract.Assert(!IsCompleted, "The promise must not yet be completed.");
 
             // If we have a parent, we need to notify it of the completion.  Take the slow path to handle that.
-            if (m_parent != null)
+            if (m_contingentProperties?.m_parent != null)
             {
                 bool success = TrySetResult(result);
 
@@ -593,7 +593,7 @@ namespace System.Threading.Tasks
             //
             // The lazy initialization may not be strictly necessary, but I'd like to keep it here
             // anyway.  Some downstream logic may depend upon an inflated m_contingentProperties.
-            EnsureContingentPropertiesInitialized(needsProtection: true);
+            EnsureContingentPropertiesInitialized();
             if (AtomicStateUpdate(TASK_STATE_COMPLETION_RESERVED,
                 TASK_STATE_COMPLETION_RESERVED | TASK_STATE_RAN_TO_COMPLETION | TASK_STATE_FAULTED | TASK_STATE_CANCELED))
             {


### PR DESCRIPTION
Task is currently 8 fields (6 reference fields and 2 Int32 fields), which with its object header on 32-bit makes it 40 bytes and on 64-bit 80 bytes.  One of those reference fields points to a lazily-instantiated "contingent properties" object of lesser used state, e.g. the ExceptionDispatchInfo for when the task faults.  Another one of those reference fields points to the Task's "parent".  This is the Task that was currently running when this task was created and if this task was created with TaskCreationOptions.AttachedToParent.  The vast majority of tasks created (e.g. those created by async methods, by Task.Run, and by every other task creation method unless AttachedToParent is explicitly specified) have this field as null.

This PR moves that m_parent field to contingent properties, shrinking the memory required for the vast majority of tasks by 10%.  Since many apps create lots and lots of tasks, this is a nice benefit.

However, there are two downsides...

One is that Tasks that do use AttachedToParent get bigger, as they need to instantiate the contingent properties.  I'm not particularly concerned about this, since as mentioned they're much more rare.  Further, parent tasks already need to store state about their children, and that state is all held in contingent properties already.  Note that corefx itself only uses AttachedToParent in one place, in PLINQ, and so while those tasks will get bigger, it's only creating N such tasks per query, where N is the degree of parallelism used by the query (this doesn't appear to be at all measurable, but if it did become an issue, we could restructure PLINQ slightly to not need them).

The bigger potential downside is that the Visual Studio debugger unfortunately has a direct dependency on this m_parent field.  It uses it to display a parent/child view in the Tasks window in VS.  If you're not using parent/child tasks, the view is irrelevant.  If you are, this view will no longer work after this change and until VS (eventually?) gets updated to know where to look for the state.  In my mind, this is the primary reason this change isn't a sure thing, and I'd like the opinions of others (to be clear, I still think we should go ahead with it).  Note that when I previously experimented with this, VS would simply grey out the parent/child menu option… today when I tried, even without my change I couldn’t get VS to display any tasks for coreclr, but I’m probably just doing something wrong.

Opinions?

cc: @jkotas, @vancem, @ericeil, @AlfredoMS, @gregg-miskelly 