### PR TITLE
ARM64: Switch Expansion Using Jump Table

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -3804,10 +3804,9 @@ AGAIN:
 #if defined(_TARGET_ARM64_)
         // JIT code and data will be allocated together for arm64 so the relative offset to JIT data is known.
         // In case such offset can be encodeable for `ldr` (+-1MB), shorten it.
-        if (emitIsLoadConstant(jmp))
+        if (jmp->idAddr()->iiaIsJitDataOffset())
         {
             // Reference to JIT data
-            assert(jmp->idAddr()->iiaIsJitDataOffset());
             assert(jmp->idIsBound());
             UNATIVE_OFFSET srcOffs = jmpIG->igOffs + jmp->idjOffs;
 
@@ -4288,6 +4287,14 @@ void                emitter::emitCheckFuncletBranch(instrDesc * jmp, insGroup * 
         return;
     }
 #endif // _TARGET_ARMARCH_
+
+#ifdef _TARGET_ARM64_
+    // No interest if it's not jmp.
+    if (emitIsLoadLabel(jmp) || emitIsLoadConstant(jmp))
+    {
+        return;
+    }
+#endif // _TARGET_ARM64_
 
     insGroup * tgtIG = jmp->idAddr()->iiaIGlabel;
     assert(tgtIG);

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -900,6 +900,7 @@ public:
 
     BYTE*           emitOutputLJ  (insGroup  *ig, BYTE *dst, instrDesc *i);
     unsigned        emitOutputCall(insGroup  *ig, BYTE *dst, instrDesc *i, code_t code);
+    BYTE*           emitOutputLoadLabel(BYTE* dst, BYTE* srcAddr, BYTE* dstAddr, instrDescJmp* id);
     BYTE*           emitOutputShortBranch(BYTE *dst, instruction ins, insFormat fmt, ssize_t distVal, instrDescJmp* id);
     BYTE*           emitOutputShortAddress(BYTE *dst, instruction ins, insFormat fmt, ssize_t distVal, regNumber reg);
     BYTE*           emitOutputShortConstant(BYTE *dst, instruction ins, insFormat fmt, ssize_t distVal, regNumber reg, emitAttr opSize);

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -771,6 +771,7 @@ void Lowering::LowerNode(GenTreePtr* ppTree, Compiler::fgWalkData* data)
  *     internal temporaries to maintain the index we're evaluating plus we're using existing code from LinearCodeGen
  *     to implement this instead of implement all the control flow constructs using InstrDscs and InstrGroups downstream.
  */
+
 void Lowering::LowerSwitch(GenTreePtr* pTree)
 {
     unsigned     jumpCnt;
@@ -876,14 +877,7 @@ void Lowering::LowerSwitch(GenTreePtr* pTree)
     // because the code to load the base of the switch
     // table is huge and hideous due to the relocation... :(
     minSwitchTabJumpCnt += 2;
-#elif defined(_TARGET_ARM64_) // _TARGET_ARM_
-    // In the case of ARM64 we'll stick to generate a sequence of
-    // compare and branch for now to get switch working and revisit
-    // to implement jump tables in the future.
-    //
-    // TODO-AMD64-NYI: Implement Jump Tables.
-    minSwitchTabJumpCnt = -1; 
-#endif // _TARGET_ARM64_
+#endif // _TARGET_ARM_
     // Once we have the temporary variable, we construct the conditional branch for
     // the default case.  As stated above, this conditional is being shared between
     // both GT_SWITCH lowering code paths.


### PR DESCRIPTION
Fixes #3332
To validate various addressing in #4896, I just enable this.
Previously, we only allow a load operation to JIT data (`ldr` or
`IF_LARGELDC`).
For switch expansion, jump table is also recorded into JIT data.
In this case, we only get the address of jump table head, and
load the right entry after computing offset. So, basically `adr` or
`IF_LARGEADR` is used to not only load label within code but also refer to
the location of JIT data.
The typical code sequence for switch expansion is like this:
```
  adr     x8, [@RWD00]          // load address of jump table head
  ldr     w8, [x8, x0, LSL #2]  // load jump entry from table addr + x0 * 4
  adr     x9, [G_M56320_IG02]   // load address of current baisc block
  add     x8, x8, x9            // Add them to compute the final target
  br      x8                    // Indirectly jump to the target
```