### PR TITLE
Fixed a build error on ARM

### DIFF
--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1825,7 +1825,6 @@ public:
     static emitJumpKind     emitReverseJumpKind(emitJumpKind jumpKind);
 
 #ifdef _TARGET_ARM_
-    static emitJumpKind     emitInsToJumpKind(instruction ins);
     static unsigned         emitJumpKindCondCode(emitJumpKind jumpKind);
 #endif
 


### PR DESCRIPTION
The recent commit (61fe464) breaks ARM build.
It defines emitInsToJumpKind twice in src/jit/emit.h on ARM.

Fix #4925 

Signed-off-by: Dongyun Jin <dongyun.jin@samsung.com>
Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>