### PR TITLE
Linux/ARM: Change default clang version from 3.5 to 3.6

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -440,8 +440,8 @@ __CleanBuild=0
 __VerboseBuild=0
 __SignTypeReal=""
 __CrossBuild=0
-__ClangMajorVersion=3
-__ClangMinorVersion=5
+__ClangMajorVersion=0
+__ClangMinorVersion=0
 __MSBuildPath=$__ProjectRoot/Tools/MSBuild.exe
 __NuGetPath="$__PackagesDir/NuGet.exe"
 __DistroName=""
@@ -610,6 +610,17 @@ while :; do
 
     shift
 done
+
+# Set default clang version
+if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
+    if [ $__CrossBuild == 1 ]; then
+        __ClangMajorVersion=3
+        __ClangMinorVersion=6
+    else
+        __ClangMajorVersion=3
+        __ClangMinorVersion=5
+    fi
+fi
 
 # Set dependent variables
 __LogsDir="$__RootBinDir/Logs"


### PR DESCRIPTION
In case of the cross compilation on the ubuntu 14.04 x64 for Linux/ARM, the default version of clang/llvm that is generated by "#> sudo ./cross/build-rootfs.sh arm" command is 3.6 without 3.5 as following:

u14.04@x64> ls ./coreclr/cross/rootfs/arm/usr/lib/clang/3.6
include  lib
u14.04@x64> ls ./coreclr/cross/rootfs/arm/usr/lib/llvm-3.6/
bin  build  include  lib  share

Let's keep the clang/llvm version consistently by moving the default version from 'clang3.5' to 'clang3.6' at build-time for Linux/ARM.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
