### PR TITLE
Use a JIT-specific stdout `FILE*`.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -3094,7 +3094,7 @@ void                CodeGen::genGenerateCode(void * * codePtr,
         genCreateAndStoreGCInfo(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
 
 #ifdef  DEBUG
-    FILE* dmpf = stdout;
+    FILE* dmpf = jitstdout;
 
     compiler->opts.dmpHex = false;
     if  (!strcmp(compiler->info.compMethodName, "<name of method you want the hex dump for"))
@@ -3133,7 +3133,7 @@ void                CodeGen::genGenerateCode(void * * codePtr,
         fflush(dmpf);
     }
 
-    if (dmpf != stdout)
+    if (dmpf != jitstdout)
     {
         fclose(dmpf);
     }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -73,14 +73,12 @@ void Compiler::JitLogEE(unsigned level, const char* fmt, ...)
 {
     va_list args;
 
-#ifndef CROSSGEN_COMPILE
     if (verbose)
     {
         va_start(args, fmt);
-        logf_stdout(fmt, args);
+        vflogf(jitstdout, fmt, args);
         va_end(args);
     }
-#endif
 
     va_start(args, fmt);
     vlogf(level, fmt, args);
@@ -657,7 +655,7 @@ void                Compiler::compStartup()
     // Static vars of ValueNumStore
     ValueNumStore::InitValueNumStoreStatics();
 
-    compDisplayStaticSizes(stdout);
+    compDisplayStaticSizes(jitstdout);
 }
 
 /*****************************************************************************
@@ -695,7 +693,7 @@ void                Compiler::compShutdown()
 #endif
 
     // Where should we write our statistics output?
-    FILE* fout = stdout;
+    FILE* fout = jitstdout;
 
 #ifdef FEATURE_JIT_METHOD_PERF
     if (compJitTimeLogFilename != NULL)
@@ -926,10 +924,10 @@ void                Compiler::compShutdown()
 #endif
     {
         fprintf(fout, "\nAll allocations:\n");
-        s_aggMemStats.Print(stdout);
+        s_aggMemStats.Print(jitstdout);
 
         fprintf(fout, "\nLargest method:\n");
-        s_maxCompMemStats.Print(stdout);
+        s_maxCompMemStats.Print(jitstdout);
     }
 
 #endif // MEASURE_MEM_ALLOC
@@ -939,7 +937,7 @@ void                Compiler::compShutdown()
     if (JitConfig.DisplayLoopHoistStats() != 0)
 #endif // DEBUG
     {
-        PrintAggregateLoopHoistStats(stdout);
+        PrintAggregateLoopHoistStats(jitstdout);
     }
 #endif // LOOP_HOIST_STATS
 
@@ -2826,7 +2824,7 @@ void JitDump(const char* pcFormat, ...)
 {
     va_list lst;    
     va_start(lst, pcFormat);
-    logf_stdout(pcFormat, lst);
+    vflogf(jitstdout, pcFormat, lst);
     va_end(lst);
 }
 
@@ -4135,7 +4133,7 @@ int           Compiler::compCompile(CORINFO_METHOD_HANDLE methodHnd,
     }
 #endif // FUNC_INFO_LOGGING
 
-//  if (s_compMethodsCount==0) setvbuf(stdout, NULL, _IONBF, 0);
+//  if (s_compMethodsCount==0) setvbuf(jitstdout, NULL, _IONBF, 0);
 
     info.compCompHnd     = compHnd;
     info.compMethodHnd   = methodHnd;
@@ -4363,7 +4361,7 @@ void Compiler::compCompileFinish()
     {
         printf("\nAllocations for %s (MethodHash=%08x)\n",
                info.compFullName, info.compMethodHash());
-        genMemStats.Print(stdout);
+        genMemStats.Print(jitstdout);
     }
 #endif // DEBUG
 #endif // MEASURE_MEM_ALLOC

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8087,7 +8087,7 @@ public :
             nraTotalSizeUsed  += ms.nraTotalSizeUsed;
         }
 
-        void Print(FILE* f); // Print these stats to stdout.
+        void Print(FILE* f); // Print these stats to jitstdout.
     };
 
     static CritSecObject s_memStatsLock;    // This lock protects the data structures below.

--- a/src/jit/disasm.cpp
+++ b/src/jit/disasm.cpp
@@ -1543,13 +1543,13 @@ void    DisAssembler::disAsmCode(BYTE* hotCodePtr, size_t hotCodeSize, BYTE* col
         }
     }
 #else // !DEBUG
-    // NOTE: non-DEBUG builds always use stdout currently!
-    disAsmFile = stdout;
+    // NOTE: non-DEBUG builds always use jitstdout currently!
+    disAsmFile = jitstdout;
 #endif // !DEBUG
 
     if (disAsmFile == nullptr)
     {
-        disAsmFile = stdout;
+        disAsmFile = jitstdout;
     }
 
     // As this writes to a common file, this is not reentrant.
@@ -1591,7 +1591,7 @@ void    DisAssembler::disAsmCode(BYTE* hotCodePtr, size_t hotCodeSize, BYTE* col
     DisasmBuffer(disAsmFile, /* printIt */ true);
     fprintf(disAsmFile, "\n");
 
-    if (disAsmFile != stdout)
+    if (disAsmFile != jitstdout)
     {
         fclose(disAsmFile);
     }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -19188,7 +19188,7 @@ ONE_FILE_PER_METHOD:;
     }
     else if (wcscmp(filename, W("stdout")) == 0)
     {
-        fgxFile = stdout;
+        fgxFile = jitstdout;
         *wbDontClose = true;
     }
     else if (wcscmp(filename, W("stderr")) == 0)
@@ -19527,7 +19527,7 @@ bool               Compiler::fgDumpFlowGraph(Phases phase)
 
     if (dontClose)
     {
-        // fgxFile is stdout or stderr
+        // fgxFile is jitstdout or stderr
         fprintf(fgxFile, "\n");
     }
     else

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7512,7 +7512,7 @@ void                Compiler::gtDispVN(GenTree* tree)
 }
 
 //------------------------------------------------------------------------
-// gtDispNode: Print a tree to stdout.
+// gtDispNode: Print a tree to jitstdout.
 //
 // Arguments:
 //    tree - the tree to be printed
@@ -8257,7 +8257,7 @@ void Compiler::gtDispFieldSeq(FieldSeqNode* pfsn)
 }
 
 //------------------------------------------------------------------------
-// gtDispLeaf: Print a single leaf node to stdout.
+// gtDispLeaf: Print a single leaf node to jitstdout.
 //
 // Arguments:
 //    tree - the tree to be printed
@@ -8496,7 +8496,7 @@ Compiler::gtDispLeaf(GenTree *tree, IndentStack* indentStack)
 }
 
 //------------------------------------------------------------------------
-// gtDispLeaf: Print a child node to stdout.
+// gtDispLeaf: Print a child node to jitstdout.
 //
 // Arguments:
 //    tree - the tree to be printed

--- a/src/jit/host.h
+++ b/src/jit/host.h
@@ -9,6 +9,10 @@
 #define printf logf
 #endif
 
+#ifndef fprintf
+#define fprintf flogf
+#endif
+
 class Compiler;
 class LogEnv
 {
@@ -21,26 +25,13 @@ public:
 };
 
 BOOL vlogf(unsigned level, const char* fmt, va_list args);
+int vflogf(FILE* file, const char* fmt, va_list args);
 
-int logf_stdout(const char* fmt, va_list args);
-int logf(const char*, ...);
+int logf(const char* fmt, ...);
+int flogf(FILE* file, const char* fmt, ...);
 void gcDump_logf(const char* fmt, ...);
 
 void logf(unsigned level, const char* fmt, ...);
-
-#if defined(CROSSGEN_COMPILE) && !defined(PLATFORM_UNIX) && !defined(fprintf)
-// On Windows, CrossGen configures its stdout to allow Unicode output only.
-// The following wrapper allows fprintf to work with stdout.
-inline int fprintfCrossgen(FILE *stream, const char *fmt, ...)
-{
-    va_list args;
-    va_start(args, fmt);
-    int ret = stream == stdout ? logf_stdout(fmt, args) : vfprintf(stream, fmt, args);
-    va_end(args);
-    return ret;
-}
-#define fprintf fprintfCrossgen
-#endif
 
 extern  "C" 
 void    __cdecl     assertAbort(const char *why, const char *file, unsigned line);
@@ -60,6 +51,13 @@ void    __cdecl     assertAbort(const char *why, const char *file, unsigned line
 /*****************************************************************************/
 
 const   size_t      OS_page_size = (4*1024);
+
+extern FILE* jitstdout;
+
+#if !defined(ALLOW_STDOUT)
+#undef stdout
+#define stdout use_jitstdout
+#endif
 
 /*****************************************************************************/
 #endif

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -345,7 +345,7 @@ InlineContext::InlineContext(InlineStrategy* strategy)
 #if defined(DEBUG) || defined(INLINE_DATA)
 
 //------------------------------------------------------------------------
-// Dump: Dump an InlineContext entry and all descendants to stdout
+// Dump: Dump an InlineContext entry and all descendants to jitstdout
 //
 // Arguments:
 //    indent   - indentation level for this node
@@ -451,7 +451,7 @@ void InlineContext::DumpData(unsigned indent)
     {
         const char* inlineReason = InlGetObservationString(m_Observation);
         printf("%*s%u,\"%s\",\"%s\"", indent, "", m_Ordinal, inlineReason, calleeName);
-        m_Policy->DumpData(stdout);
+        m_Policy->DumpData(jitstdout);
         printf("\n");
     }
 


### PR DESCRIPTION
Historically, the JIT has had issues with logging inside of processes
that change the output mode of stdout (e.g. crossgen). This change
replaces the previous solution (which relied on #ifdefs) by dup'ing
the stdout file and wrapping it in a new `FILE*` set to a known
output mode.