### PR TITLE
Support to build tests in Unix

### DIFF
--- a/tests/override.targets
+++ b/tests/override.targets
@@ -3,8 +3,6 @@
     Overrides for all other targets (including build tools) can go in this file.
   -->
 
-  <Import Project="mono.targets" Condition="'$(OsEnvironment)'=='Unix'" />
-  <Import Project="roslyn.xplat.targets" Condition="'$(OsEnvironment)'=='Unix'" />
   <!-- Contains overrides for the nuget reference resolution.  The regular nuget reference resolution will not 
        copy references local, which we need in order to correctly execute the xunit project -->
   <Import Project="xunitwrapper.targets" Condition="'$(IsXunitWrapperProject)'=='true'" />

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -163,7 +163,7 @@ fi
         <Command><![CDATA[        export _DebuggerFullPath="${i#*=}"
         if [ ! -f "$_DebuggerFullPath" ]
         then
-            echo The Debugger FullPath \"$_DebuggerFullPath\" doesn\'t exist
+            echo "The Debugger FullPath "$_DebuggerFullPath" doesn't exist"
             usage
         fi]]></Command>
         <Description>Run testcases under debugger.</Description>
@@ -228,10 +228,7 @@ CLRTestExpectedExitCode=0
     <!-- Raise an error if any value in _RequiredProperties is missing  -->
     <Error Condition=" '%(_RequiredProperties.Value)'=='' "
       Text="Missing required test property [%(_RequiredProperties.Identity)]. Something isn't plumbed through correctly.  Contact $(_CLRTestBuildSystemOwner)." />
-      <!-- TODO: this is weird.  Consider eliminating it. -->
-    <GenerateParamList ArgumentItems="@(BashCLRTestExecutionScriptArgument)">
-      <Output TaskParameter="ParamList" PropertyName="_CLRTestParamList"/>
-    </GenerateParamList>
+
     <PropertyGroup>
       <!--
       This generates the script portion to parse all of the command line arguments.
@@ -241,7 +238,6 @@ CLRTestExpectedExitCode=0
       <BashCLRTestArgPrep><![CDATA[
 usage()
 {
-    echo "Usage: $0  $(_CLRTestParamList)"
     echo 
     echo "Arguments:"
 @(BashCLRTestExecutionScriptArgument -> '    echo "-%(Identity)=%(ParamName)"

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -265,10 +265,6 @@ set CLRTestExitCode=!ERRORLEVEL!
     <!-- Raise an error if any value in _RequiredProperties is missing  -->
     <Error Condition=" '%(_RequiredProperties.Value)'=='' "
       Text="Missing required test property [%(_RequiredProperties.Identity)]. Something isn't plumbed through correctly.  Contact $(_CLRTestBuildSystemOwner)." />
-      <!-- TODO: this is weird.  Consider eliminating it. -->
-    <GenerateParamList ArgumentItems="@(BatchCLRTestExecutionScriptArgument)">
-      <Output TaskParameter="ParamList" PropertyName="_CLRTestParamList"/>
-    </GenerateParamList>
     
     <PropertyGroup>
       <!--
@@ -305,7 +301,6 @@ goto ArgsDone
 
 :USAGE
 ECHO.Usage
-ECHO %0 $(_CLRTestParamList)
 ECHO.
 ECHO                         - OPTIONS -
 @(BatchCLRTestExecutionScriptArgument -> 'ECHO -%(Identity) %(ParamName)

--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -17,6 +17,7 @@
       <DisabledProjects Include="TestWrappers*\*\*.csproj" />
       <DisabledProjects Include="*\**\cs_template.csproj" />
       <DisabledProjects Include="Common\Coreclr.TestWrapper\Coreclr.TestWrapper.csproj" />
+      <DisabledProjects Condition="'$(OsEnvironment)' != 'Windows_NT'" Include="Common\Desktop.Coreclr.TestWrapper\Desktop.Coreclr.TestWrapper.csproj" />
       <DisabledProjects Include="Common\test_runtime\test_runtime.csproj" />
       <DisabledProjects Include="GC\Performance\Framework\GCPerfTestFramework.csproj" />
       <DisabledProjects Include="Loader\classloader\generics\regressions\DD117522\Test.csproj" />


### PR DESCRIPTION
Support to build tests in Unix

Fix #4437

Support to build tests in Unix.
But this option still turns off because of some build failure issues.
The build failure issues will be fixed on next step.

Added tests options.
It also provides to pass some tests option like priority,
gcstresslevel, sequential and ilasmroundtrip.

Do not import mono.targets and roslyn.xplat.targets.
Unix can not find these targets in this project. It seems not to be used anymore.

DebugType and DebugSymbols are disabled.
Roslyn does not support writing PDBs on Unix. To disable these properties in
whole projects, buildtest.sh script will pass below options directly.
/p:DebugSymbols=false /p:DebugType=none

By not supporting CodeTaskFactory in Linux .NET Core, do not use it.
It does not affect the real operation of tests running.

Signed-off-by: Jiyoung Yun jy910.yun@samsung.com
