### PR TITLE
Fix issue with Arm64 AsmDiffs

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -1871,7 +1871,6 @@ unsigned ReinterpretHexAsDecimal(unsigned in)
     return result;
 }
 
-inline
 void                Compiler::compInitOptions(CORJIT_FLAGS* jitFlags)
 {
 #ifdef UNIX_AMD64_ABI

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -10328,10 +10328,6 @@ void                emitter::emitDispIns(instrDesc *  id,
             printf("(LARGELDC)");
         }
 
-        if (fmt == IF_LARGELDC)
-        {
-            printf("(LARGELDC)");
-        }
         printf("[");
         if (id->idAddr()->iiaIsJitDataOffset())
         {
@@ -10349,7 +10345,12 @@ void                emitter::emitDispIns(instrDesc *  id,
         else
         {
             assert(imm == 0);
-            if (id->idIsBound())
+            if (id->idIsReloc())
+            {
+                printf("RELOC ");
+                emitDispImm((ssize_t)id->idAddr()->iiaAddr, false);
+            }
+            else if (id->idIsBound())
             {
                 printf("G_M%03u_IG%02u", Compiler::s_compMethodsCount, id->idAddr()->iiaIGlabel->igNum);
             }


### PR DESCRIPTION
The Arm64 assembly display for the adrp instruction was incorrect resulting in many unnecessary asm diffs