### PR TITLE
Add budget check to RandomPolicy

### DIFF
--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -999,6 +999,18 @@ void RandomPolicy::DetermineProfitability(CORINFO_METHOD_INFO* methodInfo)
     assert(InlDecisionIsCandidate(m_Decision));
     assert(m_Observation == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
 
+    // Budget check.
+    if (!m_IsPrejitRoot)
+    {
+        InlineStrategy* strategy = m_RootCompiler->m_inlineStrategy;
+        bool overBudget = strategy->BudgetCheck(m_CodeSize);
+        if (overBudget)
+        {
+            SetFailure(InlineObservation::CALLSITE_OVER_BUDGET);
+            return;
+        }
+    }
+
     // Use a probability curve that roughly matches the observed
     // behavior of the LegacyPolicy. That way we're inlining
     // differently but not creating enormous methods.

--- a/tests/src/JIT/opt/Inline/tests/LotsOfInlines.csproj
+++ b/tests/src/JIT/opt/Inline/tests/LotsOfInlines.csproj
@@ -32,7 +32,6 @@
     <NoStandardLib>True</NoStandardLib>
     <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="LotsOfInlines.cs" />


### PR DESCRIPTION
Prevents RandomPolicy from being overly aggressive with small methods
that can lead to excessive inlining.

Closes #4711. Undoes #4704.