### PR TITLE
Fix CircleInConvex to check result within 1 ULP

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -306,12 +306,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_239804\ShowLocallocAlignment\ShowLocallocAlignment.cmd">
              <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_r\CircleInConvex_r.cmd">
-             <Issue>3964</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.cmd">
-             <Issue>3964</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\managed\Compilation\Compilation\Compilation.cmd">
              <Issue>needs triage</Issue>
         </ExcludeList>
@@ -341,5 +335,11 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\stringarr_cs_do\stringarr_cs_do.cmd">
              <Issue>4844</Issue>
         </ExcludeList>
+      <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_r\CircleInConvex_r.cmd">
+        <Issue>4992</Issue>
+      </ExcludeList>
+      <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.cmd">
+        <Issue>4992</Issue>
+      </ExcludeList>
     </ItemGroup>
 </Project>

--- a/tests/src/JIT/SIMD/CircleInConvex.cs
+++ b/tests/src/JIT/SIMD/CircleInConvex.cs
@@ -17,7 +17,7 @@ namespace ClassLibrary
 
     public class test
     {
-        const float EPS = 1E-9F;
+        const float EPS = Single.Epsilon;
         const int steps = 100;
         const float INF = Single.PositiveInfinity;
 
@@ -259,8 +259,9 @@ namespace ClassLibrary
             float r;
             FindCircle(points, out O, out r);
 
-            float expRes = 7.565624E7F;
-            if (Math.Abs(r - expRes) > EPS)
+            float expRes = 75656240.0F;
+            float ulp    =        8.0F;
+            if (Math.Abs(r - expRes) <= ulp)
                 return 100;
             return 0;
         }

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -175,9 +175,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\regression\mismatch32\mismatch32\mismatch32.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\verify\verify01_small\verify01_small.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -269,9 +266,6 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic3\rva_rvastatic3.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_r\CircleInConvex_r.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b410474\b410474\b410474.cmd Timed Out">


### PR DESCRIPTION
This test was checking for the result to be within epsilon of the
expected result, but this is not correct unless the algorithm is
evaluating all interim results to a larger precision.
It would also be more reasonable for the test to compute the expected
result (e.g. using an alternate algorithm), and it would also be nice
to have a method to compute ULP for a given value, but those are beyond
the scope of this fix.

Fix #3964