### PR TITLE
Use different value for win32resource for System.Private.CoreLib.

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -192,6 +192,12 @@
   <Import Project="$(MSBuildThisFileDirectory)Tools\Versioning\GenerateVersionInfo.targets"/>
   <!-- Override versioning targets -->
   <Import Condition="Exists('$(ToolsDir)versioning.targets')" Project="$(ToolsDir)versioning.targets" />
+
+  <PropertyGroup>
+    <!-- Use a different nativeresource file to avoid conflicts with mscorlib-->
+    <Win32Resource Condition="'$(GenerateNativeVersionInfo)'=='true'">$(IntermediateOutputPath)\System.Private.CoreLib.res</Win32Resource>
+  </PropertyGroup>
+
   <Import Project="GenerateSplitStringResources.targets"/>
   <Import Project="GenerateCompilerResponseFile.targets"/>
   <Import Project="$(PostProcessingToolsPath)" />


### PR DESCRIPTION
When building both mscorlib and System.Private.CoreLib we should use a different name to avoid conflicting on this file.

Fixes #4960