### PR TITLE
Disable RegPair for x86 Longs

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1837,8 +1837,6 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
     {
         // All long enregistered nodes will have been decomposed into their
         // constituent lo and hi nodes.
-        regPairNo targetPair = treeNode->gtRegPair;
-        noway_assert(targetPair == REG_PAIR_NONE);
         targetReg = REG_NA;
     }
     else

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1103,7 +1103,7 @@ Compiler::fgWalkResult  Compiler::fgWalkTree(GenTreePtr  * pTree,
 void
 GenTree::gtClearReg(Compiler* compiler)
 {
-#if !defined(LEGACY_BACKEND) && !defined(_TARGET_64BIT_)
+#if CPU_LONG_USES_REGPAIR
     if (isRegPairType(TypeGet()) ||
         // (IsLocal() && isRegPairType(compiler->lvaTable[gtLclVarCommon.gtLclNum].TypeGet())) ||
         (OperGet() == GT_MUL && (gtFlags & GTF_MUL_64RSLT)))
@@ -1111,7 +1111,7 @@ GenTree::gtClearReg(Compiler* compiler)
         gtRegPair = REG_PAIR_NONE;
     }
     else
-#endif // !defined(LEGACY_BACKEND) && !defined(_TARGET_64BIT_)
+#endif // CPU_LONG_USES_REGPAIR
     {
         gtRegNum = REG_NA;
     }

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -1483,7 +1483,7 @@ AGAIN:
 
         assert(!instIsFP(ins));
 
-#ifndef _TARGET_64BIT_
+#if CPU_LONG_USES_REGPAIR
         if  (tree->gtType == TYP_LONG)
         {
             if  (offs)
@@ -1497,7 +1497,7 @@ AGAIN:
             }
         }
         else
-#endif // !_TARGET_64BIT_
+#endif // CPU_LONG_USES_REGPAIR
         {
             reg = tree->gtRegNum;
         }
@@ -1663,6 +1663,8 @@ AGAIN:
 #ifdef _TARGET_XARCH_
         assert(!instIsFP(ins));
 #endif
+
+#if CPU_LONG_USES_REGPAIR
         if  (tree->gtType == TYP_LONG)
         {
             if  (offs)
@@ -1676,6 +1678,7 @@ AGAIN:
             }
         }
         else
+#endif // CPU_LONG_USES_REGPAIR
         {
             rg2 = tree->gtRegNum;
         }
@@ -1899,7 +1902,7 @@ LONGREG_TT_IV:
 
         assert(instIsFP(ins) == 0);
 
-#ifndef _TARGET_64BIT_
+#if CPU_LONG_USES_REGPAIR
         if  (tree->gtType == TYP_LONG)
         {
             if  (offs == 0)
@@ -1921,7 +1924,7 @@ LONGREG_TT_IV:
 #endif
         }
         else
-#endif // !_TARGET_64BIT_
+#endif // CPU_LONG_USES_REGPAIR
         {
             reg = tree->gtRegNum;
         }
@@ -2347,6 +2350,7 @@ LONGREG_RVTT:
 
         regNumber rg2;
 
+#if CPU_LONG_USES_REGPAIR
         if  (tree->gtType == TYP_LONG)
         {
             if  (offs)
@@ -2361,6 +2365,7 @@ LONGREG_RVTT:
             }
         }
         else
+#endif // LEGACY_BACKEND
         {
             rg2 = tree->gtRegNum;
         }

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -337,7 +337,16 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
 #if defined(_TARGET_X86_)
 
   #define CPU_LOAD_STORE_ARCH      0
+
+#ifdef LEGACY_BACKEND
   #define CPU_LONG_USES_REGPAIR    1
+#else
+  #define CPU_LONG_USES_REGPAIR    0       // RyuJIT x86 doesn't use the regPairNo field to record register pairs for long
+                                           // type tree nodes, and instead either decomposes them (for non-atomic operations)
+                                           // or stores multiple regNumber values for operations such as calls where the
+                                           // register definitions are effectively "atomic".
+#endif // LEGACY_BACKEND
+
   #define CPU_HAS_FP_SUPPORT       1
   #define ROUND_FLOAT              1       // round intermed float expression results
   #define CPU_HAS_BYTE_REGS        1


### PR DESCRIPTION
We are not using regpairs for longs on x86 ryujit, so we need to turn off
CPU_LONG_USES_REGPAIR. This is the first step to getting var = call for
GT_CALLs with long return types on x86.