### PR TITLE
Enable overriding assemblies from TPA

### DIFF
--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -50,7 +50,9 @@ BOOL IsCompilationProcess();
 #include "clrprivbindercoreclr.h"
 #include "clrprivbinderassemblyloadcontext.h"
 // Helper function in the VM, invoked by the Binder, to invoke the host assembly resolver
-extern HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToBindWithin, IAssemblyName *pIAssemblyName, ICLRPrivAssembly **ppLoadedAssembly);
+extern HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToBindWithin, 
+                                                IAssemblyName *pIAssemblyName, CLRPrivBinderCoreCLR *pTPABinder,
+                                                BINDER_SPACE::AssemblyName *pAssemblyName, ICLRPrivAssembly **ppLoadedAssembly);
 
 // Helper to check if we have a host assembly resolver set
 extern BOOL RuntimeCanUseAppPathAssemblyResolver(DWORD adid);
@@ -1814,6 +1816,7 @@ namespace BINDER_SPACE
 HRESULT AssemblyBinder::BindUsingHostAssemblyResolver (/* in */ INT_PTR pManagedAssemblyLoadContextToBindWithin,
                                                        /* in */ AssemblyName       *pAssemblyName,
                                                       /* in */ IAssemblyName      *pIAssemblyName,
+                                                      /* in */ CLRPrivBinderCoreCLR *pTPABinder,
                                                       /* out */ Assembly           **ppAssembly)
 {
     HRESULT hr = E_FAIL;
@@ -1821,9 +1824,10 @@ HRESULT AssemblyBinder::BindUsingHostAssemblyResolver (/* in */ INT_PTR pManaged
     
     _ASSERTE(pManagedAssemblyLoadContextToBindWithin != NULL);
     
-    // Call into the VM to use the HostAssemblyResolver and load the assembly
+    // RuntimeInvokeHostAssemblyResolver will perform steps 2-4 of CLRPrivBinderAssemblyLoadContext::BindAssemblyByName.
     ICLRPrivAssembly *pLoadedAssembly = NULL;
-    hr = RuntimeInvokeHostAssemblyResolver(pManagedAssemblyLoadContextToBindWithin, pIAssemblyName, &pLoadedAssembly);
+    hr = RuntimeInvokeHostAssemblyResolver(pManagedAssemblyLoadContextToBindWithin, pIAssemblyName, 
+                                           pTPABinder, pAssemblyName, &pLoadedAssembly);
     if (SUCCEEDED(hr))
     {
         _ASSERTE(pLoadedAssembly != NULL);

--- a/src/binder/clrprivbindercoreclr.cpp
+++ b/src/binder/clrprivbindercoreclr.cpp
@@ -80,7 +80,8 @@ HRESULT CLRPrivBinderCoreCLR::BindAssemblyByName(IAssemblyName     *pIAssemblyNa
             INT_PTR pManagedAssemblyLoadContext = GetManagedAssemblyLoadContext();
             if (pManagedAssemblyLoadContext != NULL)
             {
-              hr = AssemblyBinder::BindUsingHostAssemblyResolver(pManagedAssemblyLoadContext, pAssemblyName, pIAssemblyName, &pCoreCLRFoundAssembly);
+              hr = AssemblyBinder::BindUsingHostAssemblyResolver(pManagedAssemblyLoadContext, pAssemblyName, pIAssemblyName, 
+              NULL, &pCoreCLRFoundAssembly);
               if (SUCCEEDED(hr))
               {
                   // We maybe returned an assembly that was bound to a different AssemblyLoadContext instance.

--- a/src/binder/inc/assemblybinder.hpp
+++ b/src/binder/inc/assemblybinder.hpp
@@ -78,6 +78,7 @@ namespace BINDER_SPACE
         static HRESULT BindUsingHostAssemblyResolver (/* in */ INT_PTR pManagedAssemblyLoadContextToBindWithin,
                                                       /* in */ AssemblyName       *pAssemblyName,
                                                       /* in */ IAssemblyName      *pIAssemblyName,
+                                                      /* in */ CLRPrivBinderCoreCLR *pTPABinder,
                                                       /* out */ Assembly           **ppAssembly);
                                                       
         static HRESULT BindUsingPEImage(/* in */  ApplicationContext *pApplicationContext,

--- a/src/mscorlib/model.CoreLib.xml
+++ b/src/mscorlib/model.CoreLib.xml
@@ -951,6 +951,7 @@
       <Member Name="LoadFromStream(System.IO.Stream)" />
       <Member Name="LoadFromStream(System.IO.Stream,System.IO.Stream)" />
       <Member Name="Resolve(System.IntPtr,System.Reflection.AssemblyName)" />
+      <Member Name="ResolveUsingResolvingEvent(System.IntPtr,System.Reflection.AssemblyName)" />
       <Member Name="ResolveUnmanagedDll(System.String,System.IntPtr)" />
       <Member Name="LoadUnmanagedDll(System.String)" />
       <Member Name="LoadUnmanagedDllFromPath(System.String)" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -951,6 +951,7 @@
       <Member Name="LoadFromStream(System.IO.Stream)" />
       <Member Name="LoadFromStream(System.IO.Stream,System.IO.Stream)" />
       <Member Name="Resolve(System.IntPtr,System.Reflection.AssemblyName)" />
+      <Member Name="ResolveUsingResolvingEvent(System.IntPtr,System.Reflection.AssemblyName)" />
       <Member Name="ResolveUnmanagedDll(System.String,System.IntPtr)" />
       <Member Name="LoadUnmanagedDll(System.String)" />
       <Member Name="LoadUnmanagedDllFromPath(System.String)" />

--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -111,13 +111,6 @@ namespace System.Runtime.Loader
                 throw new ArgumentException( Environment.GetResourceString("Argument_AbsolutePathRequired"), "nativeImagePath");
             }
 
-            // Check if the nativeImagePath has ".ni.dll" or ".ni.exe" extension
-            if (!(nativeImagePath.EndsWith(".ni.dll", StringComparison.InvariantCultureIgnoreCase) || 
-                  nativeImagePath.EndsWith(".ni.exe", StringComparison.InvariantCultureIgnoreCase)))
-            {
-                throw new ArgumentException("nativeImagePath");
-            }
-
             if (assemblyPath != null && Path.IsRelative(assemblyPath))
             {
                 throw new ArgumentException(Environment.GetResourceString("Argument_AbsolutePathRequired"), "assemblyPath");
@@ -184,7 +177,17 @@ namespace System.Runtime.Loader
         {
             AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchManagedAssemblyLoadContext).Target);
             
-            return context.LoadFromAssemblyName(assemblyName);
+            return context.ResolveUsingLoad(assemblyName);
+        }
+        
+        // This method is invoked by the VM to resolve an assembly reference using the Resolving event
+        // after trying assembly resolution via Load override and TPA load context without success.
+        private static Assembly ResolveUsingResolvingEvent(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
+        {
+            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchManagedAssemblyLoadContext).Target);
+            
+            // Invoke the AssemblyResolve event callbacks if wired up
+            return context.ResolveUsingEvent(assemblyName);
         }
         
         private Assembly GetFirstResolvedAssembly(AssemblyName assemblyName)
@@ -210,23 +213,8 @@ namespace System.Runtime.Loader
             return resolvedAssembly;
         }
 
-        public Assembly LoadFromAssemblyName(AssemblyName assemblyName)
+        private Assembly ValidateAssemblyNameWithSimpleName(Assembly assembly, string requestedSimpleName)
         {
-            // AssemblyName is mutable. Cache the expected name before anybody gets a chance to modify it.
-            string requestedSimpleName = assemblyName.Name;
- 
-            Assembly assembly = Load(assemblyName);
-            if (assembly == null)
-            {
-                // Invoke the AssemblyResolve event callbacks if wired up
-                assembly = GetFirstResolvedAssembly(assemblyName);
-            }
-
-            if (assembly == null)
-            {
-                throw new FileNotFoundException(Environment.GetResourceString("IO.FileLoad"), requestedSimpleName);
-            }
-            
             // Get the name of the loaded assembly
             string loadedSimpleName = null;
             
@@ -244,7 +232,56 @@ namespace System.Runtime.Loader
                 throw new InvalidOperationException(Environment.GetResourceString("Argument_CustomAssemblyLoadContextRequestedNameMismatch"));
  
             return assembly;
+            
+        }
+        
+        private Assembly ResolveUsingLoad(AssemblyName assemblyName)
+        {
+            string simpleName = assemblyName.Name;
+            Assembly assembly = Load(assemblyName);
+            
+            if (assembly != null)
+            {
+                assembly = ValidateAssemblyNameWithSimpleName(assembly, simpleName);
+            }
+            
+            return assembly;
+        }
+        
+        private Assembly ResolveUsingEvent(AssemblyName assemblyName)
+        {
+            string simpleName = assemblyName.Name;
+            
+            // Invoke the AssemblyResolve event callbacks if wired up
+            Assembly assembly = GetFirstResolvedAssembly(assemblyName);
+            if (assembly != null)
+            {
+                assembly = ValidateAssemblyNameWithSimpleName(assembly, simpleName);
+            }
+            
+            // Since attempt to resolve the assembly via Resolving event is the last option,
+            // throw an exception if we do not find any assembly.
+            if (assembly == null)
+            {
+                throw new FileNotFoundException(Environment.GetResourceString("IO.FileLoad"), simpleName);
+            }
+            
+            return assembly;
+        }
+        
+        public Assembly LoadFromAssemblyName(AssemblyName assemblyName)
+        {
+            // AssemblyName is mutable. Cache the expected name before anybody gets a chance to modify it.
+            string requestedSimpleName = assemblyName.Name;
+            
+            Assembly assembly = ResolveUsingLoad(assemblyName);
+            if (assembly == null)
+            {
+                // Invoke the AssemblyResolve event callbacks if wired up
+                assembly = ResolveUsingEvent(assemblyName);
+            }
 
+            return assembly;
         }
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -1674,6 +1674,7 @@ DEFINE_METHOD(FIRSTCHANCE_EVENTARGS,  CTOR,                   .ctor,            
 DEFINE_CLASS(ASSEMBLYLOADCONTEXT,  Loader,                AssemblyLoadContext)    
 DEFINE_METHOD(ASSEMBLYLOADCONTEXT,  RESOLVE,          Resolve,                      SM_IntPtr_AssemblyName_RetAssemblyBase)
 DEFINE_METHOD(ASSEMBLYLOADCONTEXT,  RESOLVEUNMANAGEDDLL,          ResolveUnmanagedDll,                      SM_Str_IntPtr_RetIntPtr)
+DEFINE_METHOD(ASSEMBLYLOADCONTEXT,  RESOLVEUSINGEVENT,          ResolveUsingResolvingEvent,                      SM_IntPtr_AssemblyName_RetAssemblyBase)
 
 #endif // defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
 


### PR DESCRIPTION
Enable custom load context to override the assemblies specified in TPA (excluding the core library). Also, removed the ".ni" checks in LoadFromNIImage paths since R2R images are not having that extension.

Refactored ALC.cs to support the resolution order.

@jkotas PTAL