### PR TITLE
Add more help options to corerun

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -657,7 +657,7 @@ int __cdecl wmain(const int argc, const wchar_t* argv[])
         } else if ( stringsEqual(arg, W("/d")) || stringsEqual(arg, W("-d")) ) {
                 waitForDebugger = true;
                 return true;
-        } else if ( stringsEqual(arg, W("/?")) || stringsEqual(arg, W("-?")) ) {
+        } else if ( stringsEqual(arg, W("/?")) || stringsEqual(arg, W("-?")) || stringsEqual(arg, W("-h")) || stringsEqual(arg, W("--help")) ) {
             helpRequested = true;
             return true;
         } else {

--- a/src/coreclr/hosts/unixcorerun/corerun.cpp
+++ b/src/coreclr/hosts/unixcorerun/corerun.cpp
@@ -56,7 +56,7 @@ bool ParseArguments(
                         break;
                     }
                 }
-                else if (strcmp(argv[i], "--help") == 0)
+                else if (strcmp(argv[i], "-?") == 0 || strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0)
                 {
                     DisplayUsage();
                     break;


### PR DESCRIPTION
Was trying to use corerun the other day and ran `corerun --help` on Windows, to which it replied with a `FileNotFoundException` for the assembly `--help`. It didn't cross my mind to try `/?` or `-?`, so I ended up having to look into the source code to get help.

This PR adds `-h` and `--help` switches to corerun so it's easier to show help for people who aren't familiar with the tooling; it also adds some switches to the Unix corerun to match with the Windows version (except `/?`).