### PR TITLE
Implement integer to long/ulong casts for x86

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2430,6 +2430,11 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
                 }
                 else
                 {
+                    if ((treeNode->gtNext != nullptr) && (treeNode->gtNext->OperGet() != GT_JTRUE))
+                    {
+                        NYI("Long compare/reload/jtrue sequence");
+                    }
+
                     // We generate the compare when we generate the GT_JTRUE, but we need to consume
                     // the operands now.
                     genConsumeOperands(treeNode->AsOp());


### PR DESCRIPTION
Implement various integer to long/ulong casts for x86. Sign extension is performed using an arithmetic shift to avoid the need for the x86 specific `cdq`. Overflow checks are implemented by using int->uint casts for which codegen provides the necessary overflow support.

Fixes #4664, #4174, #4175