### PR TITLE
Improve performance of Array.GetLowerBound(0)

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -214,10 +214,14 @@ namespace System {
             for (int i=0;i<lengths.Length;i++)
                 if (lengths[i] < 0)
                     throw new ArgumentOutOfRangeException("lengths["+i+']', Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-                            
+            
             fixed(int* pLengths = lengths)
-                fixed(int* pLowerBounds = lowerBounds)
-                    return InternalCreate((void*)t.TypeHandle.Value,lengths.Length,pLengths,pLowerBounds);
+            fixed(int* pLowerBounds = lowerBounds)
+            {
+                Array array = InternalCreate((void*)t.TypeHandle.Value, lengths.Length, pLengths, pLowerBounds);
+                array._lowerBound0 = pLowerBounds[0];
+                return array;
+            }
         }
         [System.Security.SecurityCritical]  // auto-generated
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -651,11 +655,22 @@ namespace System {
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         public extern int GetUpperBound(int dimension);
 
+        private int _lowerBound0 = 0;
+
+        public int GetLowerBound(int dimension)
+        {
+            if (dimension == 0)
+            {
+                return _lowerBound0;
+            }
+            return GetLowerBoundInternal(dimension);
+        }
+
         [System.Security.SecuritySafeCritical]  // auto-generated
         [Pure]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        public extern int GetLowerBound(int dimension);
+        private extern int GetLowerBoundInternal(int dimension);
 
         [System.Security.SecurityCritical]  // auto-generated
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]


### PR DESCRIPTION
Array.GetLowerBounds(0) is an **extremely** common operation on an Array: it is called pretty much everytime you call an Array method (Copy, Contains, IndexOf, BinarySearch, GetEnumerator, LastIndexOf, Reverse, Sort)

Currently, the implentation of GetLowerBound calls native code and validates parameters etc.
It can be found [here](https://github.com/dotnet/coreclr/blob/775003a4c72f0acc37eab84628fcef541533ba4e/src/classlibnative/bcltype/arraynative.cpp#L34-51)

Instead, we can check immediately for the LowerBound of an array for dimension 0.

Currently, this PR is a slight WIP, as I don't know how to conduct perf tests for a locally built mscorlib. If someone could help me with this I'd really appreciate that. I expect perf to improve for `GetLowerBound(0)` but to worsen very slightly for `GetLowerBound(dimension)` where `dimension > 0` as we have one additional branch and method invoke.

I think arrays are only created with custom lower bounds via `CreateInstance(Type, int[], int[])` but let me know if I'm wrong here, and I will update the code to set `_lowerBound0` where necessary.

/cc @jkotas @jamesqo