### PR TITLE
Encapsulate or replace references to CORINFO_PAGE_SIZE.

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3523,7 +3523,7 @@ CodeGen::genLclHeap(GenTreePtr tree)
             
             goto ALLOC_DONE;
         }
-        else if (!compiler->info.compInitMem && (amount < CORINFO_PAGE_SIZE))  // must be < not <=
+        else if (!compiler->info.compInitMem && (amount < compiler->eeGetPageSize()))  // must be < not <=
         {               
             // Since the size is a page or less, simply adjust the SP value              
             // The SP might already be in the guard page, must touch it BEFORE
@@ -3636,7 +3636,7 @@ CodeGen::genLclHeap(GenTreePtr tree)
         getEmitter()->emitIns_R_R_I(INS_ldr, EA_4BYTE, REG_ZR, REG_SPBASE, 0);
 
         // decrement SP by PAGE_SIZE
-        getEmitter()->emitIns_R_R_I(INS_sub, EA_PTRSIZE, regTmp, REG_SPBASE, CORINFO_PAGE_SIZE);
+        getEmitter()->emitIns_R_R_I(INS_sub, EA_PTRSIZE, regTmp, REG_SPBASE, compiler->eeGetPageSize());
 
         getEmitter()->emitIns_R_R(INS_cmp, EA_PTRSIZE, regTmp, regCnt);
         emitJumpKind jmpLTU = genJumpKindForOper(GT_LT, CK_UNSIGNED);

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -21064,7 +21064,7 @@ regNumber           CodeGen::genLclHeap(GenTreePtr size)
                 // Re-bias amount to be number of bytes to adjust the SP 
                 amount <<= STACK_ALIGN_SHIFT;
                 size->gtIntCon.gtIconVal = amount;  // update the GT_CNS value in the node
-                if (amount < CORINFO_PAGE_SIZE)   // must be < not <=
+                if (amount < compiler->eeGetPageSize())   // must be < not <=
                 {
                     // Since the size is a page or less, simply adjust ESP 
                     
@@ -21249,7 +21249,7 @@ regNumber           CodeGen::genLclHeap(GenTreePtr size)
         inst_RV_RV(INS_mov, regTemp, REG_SPBASE, TYP_I_IMPL);
         regTracker.rsTrackRegTrash(regTemp);
 
-        inst_RV_IV(INS_sub, regTemp, CORINFO_PAGE_SIZE, EA_PTRSIZE);
+        inst_RV_IV(INS_sub, regTemp, compiler->eeGetPageSize(), EA_PTRSIZE);
         inst_RV_RV(INS_mov, REG_SPBASE, regTemp, TYP_I_IMPL);
 
         genRecoverReg(size, RBM_ALLINT, RegSet::KEEP_REG); // not purely the 'size' tree anymore; though it is derived from 'size'

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -3008,7 +3008,7 @@ CodeGen::genLclHeap(GenTreePtr tree)
             
             goto ALLOC_DONE;
         }
-        else if (!compiler->info.compInitMem && (amount < CORINFO_PAGE_SIZE))  // must be < not <=
+        else if (!compiler->info.compInitMem && (amount < compiler->eeGetPageSize()))  // must be < not <=
         {               
             // Since the size is less than a page, simply adjust ESP.
             // ESP might already be in the guard page, so we must touch it BEFORE
@@ -3118,7 +3118,7 @@ CodeGen::genLclHeap(GenTreePtr tree)
         regNumber regTmp = genRegNumFromMask(tmpRegsMask);
 
         inst_RV_RV(INS_mov, regTmp, REG_SPBASE, TYP_I_IMPL);
-        inst_RV_IV(INS_sub, regTmp, CORINFO_PAGE_SIZE, EA_PTRSIZE);
+        inst_RV_IV(INS_sub, regTmp, compiler->eeGetPageSize(), EA_PTRSIZE);
         inst_RV_RV(INS_mov, REG_SPBASE, regTmp, TYP_I_IMPL);
 
         inst_RV_RV(INS_cmp, REG_SPBASE, regCnt, TYP_I_IMPL);

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -815,7 +815,7 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
                         else if (!compiler->info.compInitMem)
                         {
                             // No need to initialize allocated stack space.
-                            if (sizeVal < CORINFO_PAGE_SIZE)
+                            if (sizeVal < compiler->eeGetPageSize())
                             {
                                 info->internalIntCount = 0;
                             }

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1399,7 +1399,7 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
                     else if (!compiler->info.compInitMem)
                     {
                         // No need to initialize allocated stack space.
-                        if (sizeVal < CORINFO_PAGE_SIZE)
+                        if (sizeVal < compiler->eeGetPageSize())
                         {
                             info->internalIntCount = 0;
                         }

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3002,12 +3002,12 @@ unsigned SKIP_ALLOC_FRAME(int size, PTR_CBYTE base, unsigned offset)
         return (SKIP_PUSH_REG(base, offset));
     }
 
-    if (size >= CORINFO_PAGE_SIZE)
+    if (size >= OS_PAGE_SIZE)
     {
-        if (size < (3 * CORINFO_PAGE_SIZE))
+        if (size < (3 * OS_PAGE_SIZE))
         {
-            // add 7 bytes for one or two TEST EAX, [ESP+CORINFO_PAGE_SIZE]
-            offset += (size / CORINFO_PAGE_SIZE) * 7;
+            // add 7 bytes for one or two TEST EAX, [ESP+OS_PAGE_SIZE]
+            offset += (size / OS_PAGE_SIZE) * 7;
         }
         else
         {


### PR DESCRIPTION
This symbol will be replaced with a new field in CORINFO_EE_INFO as part of #4912.
These changes prepare the JIT and EE for that change by (respectively) encapsulating
references to CORINFO_PAGE_SIZE in Compiler::eeGetPageSize and replacing
CORINFO_PAGE_SIZE with OS_PAGE_SIZE.