### PR TITLE
Reenable NativeCallable test on x86 legacy backend

### DIFF
--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -229,9 +229,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\fault_il_r\fault_il_r.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\Interop\NativeCallable\NativeCallableTest\NativeCallableTest.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\forceinlining\PositiveCases\PositiveCases.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>


### PR DESCRIPTION
Checking whether this is working now that #4740 is in.

It's also disabled in [ryujit_x86_no_fallback_issues.targets](https://github.com/dotnet/coreclr/blob/master/tests/ryujit_x86_no_fallback_issues.targets#L14610), but apparently that's due to issue #4179 which is still open.