### PR TITLE
Add typeInfo::GetMehtod2 to avoid checking GetType == TI_METHOD. 

### DIFF
--- a/src/jit/_typeinfo.h
+++ b/src/jit/_typeinfo.h
@@ -555,6 +555,13 @@ public:
         return m_method;
     }
 
+    // If FEATURE_CORECLR is enabled, GetMethod can be called
+    // before the pointer type is known to be a method pointer type.
+    CORINFO_METHOD_HANDLE GetMethod2()  const
+    {
+        return m_method;
+    }    
+    
     // Get this item's type
     // If primitive, returns the primitive type (TI_*)
     // If not primitive, returns:

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -11610,7 +11610,7 @@ DO_LDFTN:
 #ifdef FEATURE_CORECLR
                 // In coreclr the delegate transparency rule needs to be enforced even if verification is disabled
                 typeInfo tiActualFtn = impStackTop(0).seTypeInfo;
-                CORINFO_METHOD_HANDLE delegateMethodHandle = tiActualFtn.GetMethod();
+                CORINFO_METHOD_HANDLE delegateMethodHandle = tiActualFtn.GetMethod2();
                             
                 impInsertCalloutForDelegate(info.compMethodHnd,
                                             delegateMethodHandle,

--- a/tests/testsUnsupportedOutsideWindows.txt
+++ b/tests/testsUnsupportedOutsideWindows.txt
@@ -219,8 +219,6 @@ JIT/Methodical/cctor/xassem/xprecise3_cs_do/xprecise3_cs_do.sh
 JIT/Methodical/cctor/xassem/xprecise3_cs_r/xprecise3_cs_r.sh
 JIT/Methodical/cctor/xassem/xprecise3_cs_ro/xprecise3_cs_ro.sh
 JIT/Methodical/Coverage/arglist_pos/arglist_pos.sh
-JIT/Methodical/delegate/_simpleoddpower_il_d/_simpleoddpower_il_d.sh
-JIT/Methodical/delegate/_simpleoddpower_il_r/_simpleoddpower_il_r.sh
 JIT/Methodical/delegate/_XModuledeleg1_d/_XModuledeleg1_d.sh
 JIT/Methodical/delegate/_XModuledeleg1_do/_XModuledeleg1_do.sh
 JIT/Methodical/delegate/_XModuledeleg1_r/_XModuledeleg1_r.sh


### PR DESCRIPTION

Add typeInfo::GetMehtod2 to avoid checking GetType == TI_METHOD. If FEATURE_CORECLR is enabled, the pointer type is not known to be a method pointer type when GetMethod is called in the importer.