### PR TITLE
Introduce a way to override AppContext switches from the project.json

### DIFF
--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -261,6 +261,7 @@
     <SystemSources Include="$(BclSourcesRoot)\System\AppContext\AppContext.cs" />
     <SystemSources Include="$(BclSourcesRoot)\System\AppContext\AppContextSwitches.cs" />
     <SystemSources Include="$(BclSourcesRoot)\System\AppContext\AppContextDefaultValues.cs" />
+    <SystemSources Condition="'$(FeatureCoreClr)'=='true'" Include="$(BclSourcesRoot)\System\AppContext\AppContextDefaultValues.CoreClrOverrides.cs" />
     <SystemSources Include="$(BclSourcesRoot)\System\AppContext\AppContextDefaultValues.Defaults.cs" />
     <SystemSources Include="$(BclSourcesRoot)\System\AppContext\AppContextDefaultValues.Defaults.Central.cs" />
     <SystemSources Include="$(BclSourcesRoot)\System\Object.cs" />

--- a/src/mscorlib/src/System/AppContext/AppContextDefaultValues.CoreClrOverrides.cs
+++ b/src/mscorlib/src/System/AppContext/AppContextDefaultValues.CoreClrOverrides.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    internal static partial class AppContextDefaultValues
+    {
+        static partial void TryGetSwitchOverridePartial(string switchName, ref bool overrideFound, ref bool overrideValue)
+        {
+            overrideFound = false;
+            overrideValue = false;
+
+            string value = AppContext.GetData(switchName) as string;
+            if (value != null)
+            {
+                overrideFound = bool.TryParse(value, out overrideValue);
+            }
+        }
+    }
+}


### PR DESCRIPTION
When switch value is requested, we are going to check and see if we have an
override that we read from the project.json file. If we do, we are going to try
and parse that as a boolean and use as the value for that switch.