### PR TITLE
[ARM/Linux] Fix incorrect return marshaling in PInvoke stub

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7901,6 +7901,9 @@ public :
         // Methods returning a struct in two registers is considered having a return value of TYP_STRUCT.
         // Such method's compRetNativeType is TYP_STRUCT without a hidden RetBufArg
         return varTypeIsStruct(info.compRetNativeType) && (info.compRetBuffArg == BAD_VAR_NUM);
+#elif defined(_TARGET_ARM_)
+        // TODO-ARM IsHfa check
+        return varTypeIsStruct(info.compRetType) && (info.compRetBuffArg == BAD_VAR_NUM);
 #endif 
 #endif
         return false;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7897,12 +7897,9 @@ public :
     bool                compMethodReturnsMultiRegRetType() 
     {       
 #if FEATURE_MULTIREG_RET
-#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+#if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING) || defined(_TARGET_ARM_)
         // Methods returning a struct in two registers is considered having a return value of TYP_STRUCT.
         // Such method's compRetNativeType is TYP_STRUCT without a hidden RetBufArg
-        return varTypeIsStruct(info.compRetNativeType) && (info.compRetBuffArg == BAD_VAR_NUM);
-#elif defined(_TARGET_ARM_)
-        // TODO-ARM HFA Support
         return varTypeIsStruct(info.compRetNativeType) && (info.compRetBuffArg == BAD_VAR_NUM);
 #endif 
 #endif

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7902,8 +7902,8 @@ public :
         // Such method's compRetNativeType is TYP_STRUCT without a hidden RetBufArg
         return varTypeIsStruct(info.compRetNativeType) && (info.compRetBuffArg == BAD_VAR_NUM);
 #elif defined(_TARGET_ARM_)
-        // TODO-ARM IsHfa check
-        return varTypeIsStruct(info.compRetType) && (info.compRetBuffArg == BAD_VAR_NUM);
+        // TODO-ARM HFA Support
+        return varTypeIsStruct(info.compRetNativeType) && (info.compRetBuffArg == BAD_VAR_NUM);
 #endif 
 #endif
         return false;

--- a/src/vm/ilmarshalers.h
+++ b/src/vm/ilmarshalers.h
@@ -600,7 +600,7 @@ public:
                 nativeSize = wNativeSize;
             }
 
-#if !defined(_TARGET_ARM) && !(defined(UNIX_AMD64_ABI) && defined(FEATURE_UNIX_AMD64_STRUCT_PASSING))
+#if !defined(_TARGET_ARM_) && !(defined(UNIX_AMD64_ABI) && defined(FEATURE_UNIX_AMD64_STRUCT_PASSING))
             switch (nativeSize)
             {
                 case 1: typ = ELEMENT_TYPE_U1; break;


### PR DESCRIPTION
For ARM, the current implementation of 'compMethodReturnsMultiRegRetType'
always returns false.

Unfortunately, this behavior is inconsistent with JIT importer. JIT impoter
attempts to merge various return statements as one statement via inserting
an assignment statement just before each return statement if there are more
than 4 returns.

If the method of interest has a return value, then JIT importer
introduces a local temporary variable, and use it to return value.

Due to the above implementation, JIT importer never generates a return
variable, which results in assertion violation inside JIT morph, which
is discussed in #5009.

This commit attempts to fix #5009 via implementing 'compMethodReturnsMultiRegRetType'
for ARM.