### PR TITLE
Update StringObject comment in object.h

### DIFF
--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -1060,8 +1060,7 @@ typedef PTR_StringObject STRINGREF;
  *
  * Special String implementation for performance.   
  *
- *   m_StringLength - Length of string in number of WCHARs. The high two bits of this field
- *                    are used to indicate if the String has characters higher than 0x7F
+ *   m_StringLength - Length of string in number of WCHARs
  *   m_Characters   - The string buffer
  *
  */

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -1060,11 +1060,8 @@ typedef PTR_StringObject STRINGREF;
  *
  * Special String implementation for performance.   
  *
- *   m_ArrayLength  - Length of buffer (m_Characters) in number of WCHARs
- *   m_StringLength - Length of string in number of WCHARs, may be smaller
- *                    than the m_ArrayLength implying that there is extra
- *                    space at the end. The high two bits of this field are used
- *                    to indicate if the String has characters higher than 0x7F
+ *   m_StringLength - Length of string in number of WCHARs. The high two bits of this field
+ *                    are used to indicate if the String has characters higher than 0x7F
  *   m_Characters   - The string buffer
  *
  */


### PR DESCRIPTION
I think that `m_ArrayLength` is no longer present (I did a search of the source and couldn't find it), so this comment is misleading. I believe that it existed in older versions of .NET, but was removed in .NET 4.0 (I just can't find a link to where I read this)

It certainly doesn't exist in the [private variables](https://github.com/dotnet/coreclr/blob/master/src/vm/object.h#L1099-L1105) for the `StringObject` class.