### PR TITLE
ARM64: Fix LR update in a few stubs

### DIFF
--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -288,6 +288,7 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
     context.X27 = unwoundstate->captureX19_X29[8] = baseState->captureX19_X29[8];
     context.X28 = unwoundstate->captureX19_X29[9] = baseState->captureX19_X29[9];
     context.Fp  = unwoundstate->captureX19_X29[10] = baseState->captureX19_X29[10];	
+    context.Lr = unwoundstate->captureX19_X29[11] = baseState->captureX19_X29[11];
 
     context.Sp = baseState->captureSp;
     context.Pc = baseState->captureIp;
@@ -308,6 +309,8 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
     nonVolContextPtrs.X27 = &unwoundstate->captureX19_X29[8];
     nonVolContextPtrs.X28 = &unwoundstate->captureX19_X29[9];
     nonVolContextPtrs.Fp  = &unwoundstate->captureX19_X29[10];	
+    nonVolContextPtrs.Lr = &unwoundstate->captureX19_X29[11];
+
 #endif // DACCESS_COMPILE
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    LazyMachState::unwindLazyState(ip:%p,sp:%p)\n", baseState->captureIp, baseState->captureSp));
@@ -366,7 +369,8 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
     unwoundstate->captureX19_X29[7] = context.X26;
     unwoundstate->captureX19_X29[8] = context.X27;
     unwoundstate->captureX19_X29[9] = context.X28;
-    unwoundstate->captureX19_X29[10] = context.Fp;	
+    unwoundstate->captureX19_X29[10] = context.Fp;
+    unwoundstate->captureX19_X29[11] = context.Lr;
 #else // !DACCESS_COMPILE
     // For non-DAC builds, update the register state from context pointers
     unwoundstate->ptrX19_X29[0] = nonVolContextPtrs.X19;
@@ -380,6 +384,7 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
     unwoundstate->ptrX19_X29[8] = nonVolContextPtrs.X27;
     unwoundstate->ptrX19_X29[9] = nonVolContextPtrs.X28;
     unwoundstate->ptrX19_X29[10] = nonVolContextPtrs.Fp;	
+    unwoundstate->ptrX19_X29[11] = nonVolContextPtrs.Lr;
 #endif // DACCESS_COMPILE
 
     unwoundstate->_pc = context.Pc;
@@ -432,7 +437,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
         pRD->pCurrentContext->X27 = (DWORD64)(pUnwoundState->captureX19_X29[8]);
         pRD->pCurrentContext->X28 = (DWORD64)(pUnwoundState->captureX19_X29[9]);
         pRD->pCurrentContext->Fp = (DWORD64)(pUnwoundState->captureX19_X29[10]);
-
+        pRD->pCurrentContext->Lr = (DWORD64)(pUnwoundState->captureX19_X29[11]);
         return;
     }
 #endif // DACCESS_COMPILE
@@ -456,6 +461,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->pCurrentContext->X27 = *m_MachState.ptrX19_X29[8];
     pRD->pCurrentContext->X28 = *m_MachState.ptrX19_X29[9];
     pRD->pCurrentContext->Fp  = *m_MachState.ptrX19_X29[10];
+    pRD->pCurrentContext->Lr = *m_MachState.ptrX19_X29[11];
 
 #if !defined(DACCESS_COMPILE)    
     pRD->pCurrentContextPointers->X19 = m_MachState.ptrX19_X29[0];
@@ -469,7 +475,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->pCurrentContextPointers->X27 = m_MachState.ptrX19_X29[8];
     pRD->pCurrentContextPointers->X28 = m_MachState.ptrX19_X29[9];
     pRD->pCurrentContextPointers->Fp = m_MachState.ptrX19_X29[10];
-    pRD->pCurrentContextPointers->Lr = NULL;
+    pRD->pCurrentContextPointers->Lr = m_MachState.ptrX19_X29[11];
 #endif
 }
 #endif // CROSSGEN_COMPILE


### PR DESCRIPTION
Fix LR capture/restore in a few stubs helpers.
This change fixed failures in 6 GC tests under GCStress.