### PR TITLE
Fix breakpoints on jitted code for Linux/ARM

### DIFF
--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -6105,8 +6105,11 @@ void IssueDebuggerBPCommand ( CLRDATA_ADDRESS addr )
 
     // on ARM the debugger requires breakpoint addresses to be sanitized
     if (IsDbgTargetArm())
-        addr &= ~THUMB_CODE;
-    
+#ifndef FEATURE_PAL
+      addr &= ~THUMB_CODE;
+#else
+      addr |= THUMB_CODE; // lldb expects thumb code bit set
+#endif      
 
     // if we overflowed our cache consider all new BPs unique...
     BOOL bUnique = curLimit >= MaxBPsCached;


### PR DESCRIPTION
This fixes issue #4671. On Linux/ARM LLDB places breakpoint opcode (ARM or Thumb) based on info from binary image. For jitted code however it places ARM opcode breakpoint. We need to set thumb code bit for addresses in jitted code to make it works correctly.