### PR TITLE
Remove jitOnDllProcess{Attach,Detach}.

### DIFF
--- a/src/dlls/mscoree/mscoree.cpp
+++ b/src/dlls/mscoree/mscoree.cpp
@@ -69,12 +69,6 @@ HINSTANCE g_hThisInst;  // This library.
 // Handle lifetime of loaded library.
 //*****************************************************************************
 
-#ifdef FEATURE_MERGE_JIT_AND_ENGINE
-void            jitOnDllProcessAttach();
-void            jitOnDllProcessDetach();
-#endif // FEATURE_MERGE_JIT_AND_ENGINE
-
-
 #ifdef FEATURE_CORECLR
 
 #include <shlwapi.h>
@@ -181,21 +175,12 @@ BOOL WINAPI DllMain(HANDLE hInstance, DWORD dwReason, LPVOID lpReserved)
             {
                 return FALSE;
             }
-
-#ifdef FEATURE_MERGE_JIT_AND_ENGINE
-            jitOnDllProcessAttach();
-#endif // FEATURE_MERGE_JIT_AND_ENGINE
         }
         break;
 
     case DLL_PROCESS_DETACH:
         {
             EEDllMain((HINSTANCE)hInstance, dwReason, lpReserved);
-
-#ifdef FEATURE_MERGE_JIT_AND_ENGINE
-            jitOnDllProcessDetach();
-#endif // FEATURE_MERGE_JIT_AND_ENGINE
-
         }
         break;
 

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -803,10 +803,6 @@ do { \
 #define IfFailGoLog(EXPR) IfFailGotoLog(EXPR, ErrExit)
 #endif
 
-#if defined(FEATURE_MERGE_JIT_AND_ENGINE)
-void            jitOnDllProcessAttach();
-#endif // defined(FEATURE_MERGE_JIT_AND_ENGINE)
-
 void EEStartupHelper(COINITIEE fFlags)
 {
     CONTRACTL
@@ -854,10 +850,6 @@ void EEStartupHelper(COINITIEE fFlags)
             IfFailGo(g_pConfig->SetupConfiguration());
 #endif // !FEATURE_CORECLR && !CROSSGEN_COMPILE
         }
-
-#if defined(CROSSGEN_COMPILE) && defined(FEATURE_MERGE_JIT_AND_ENGINE)
-        jitOnDllProcessAttach();
-#endif // defined(CROSSGEN_COMPILE) && defined(FEATURE_MERGE_JIT_AND_ENGINE)
 
 #ifndef CROSSGEN_COMPILE
         // Initialize Numa and CPU group information


### PR DESCRIPTION
These functions have been obviated by a more clearly-defined JIT
startup and shutdown interface.

This fixes a crash in coreclr.dll on ARM64 during DLL unload: the runtime was
calling jitOnDllProcessDetach (which calls jitShutdown) without having
called jitStartup to initialized the JIT.