### PR TITLE
Cache GetLowerBound in Array.Reverse and Array.Sort

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -1708,11 +1708,11 @@ namespace System {
             if (keys.Rank != 1 || (items != null && items.Rank != 1))
                 throw new RankException(Environment.GetResourceString("Rank_MultiDimNotSupported"));
             int keysLowerBound = keys.GetLowerBound(0);
-            if (items != null && keysLowerBound != items.GetLowerBound(0)))
+            if (items != null && keysLowerBound != items.GetLowerBound(0))
                 throw new ArgumentException(Environment.GetResourceString("Arg_LowerBoundsMustMatch"));
             if (index < keysLowerBound || length < 0)
                 throw new ArgumentOutOfRangeException((length<0 ? "length" : "index"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            if (keys.Length - (index - keysLowerBound) < length || (items != null && (index - items.GetLowerBound(0)) > items.Length - length))
+            if (keys.Length - (index - keysLowerBound) < length || (items != null && (index - keysLowerBound) > items.Length - length))
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
 
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -1564,9 +1564,10 @@ namespace System {
         public static void Reverse(Array array, int index, int length) {
             if (array==null) 
                 throw new ArgumentNullException("array");
-            if (index < array.GetLowerBound(0) || length < 0)
+            int lowerBound = array.GetLowerBound(0);
+            if (index < lowerBound || length < 0)
                 throw new ArgumentOutOfRangeException((index<0 ? "index" : "length"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            if (array.Length - (index - array.GetLowerBound(0)) < length)
+            if (array.Length - (index - lowerBound) < length)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             if (array.Rank != 1)
                 throw new RankException(Environment.GetResourceString("Rank_MultiDimNotSupported"));
@@ -1706,11 +1707,12 @@ namespace System {
                 throw new ArgumentNullException("keys");
             if (keys.Rank != 1 || (items != null && items.Rank != 1))
                 throw new RankException(Environment.GetResourceString("Rank_MultiDimNotSupported"));
-            if (items != null && keys.GetLowerBound(0) != items.GetLowerBound(0))
+            int keysLowerBound = keys.GetLowerBound(0);
+            if (items != null && keysLowerBound != items.GetLowerBound(0)))
                 throw new ArgumentException(Environment.GetResourceString("Arg_LowerBoundsMustMatch"));
-            if (index < keys.GetLowerBound(0) || length < 0)
+            if (index < keysLowerBound || length < 0)
                 throw new ArgumentOutOfRangeException((length<0 ? "length" : "index"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            if (keys.Length - (index - keys.GetLowerBound(0)) < length || (items != null && (index - items.GetLowerBound(0)) > items.Length - length))
+            if (keys.Length - (index - keysLowerBound) < length || (items != null && (index - items.GetLowerBound(0)) > items.Length - length))
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
 
             Contract.EndContractBlock();


### PR DESCRIPTION
- Avoids calling internal native method 4 times per sort: 2 times is
enough
- Avoids calling internal native method 2 times per reverse: 1 time is
enough

Thanks to @jamesqo's great `GetLowerBound(0)` improvement, the method is superfast.

However, each time we call it we still need to call a native method.

This means that across methods in Array, we cache the result of `GetLowerBound(0)`. However, Sort and Reverse don't do this, so we can boost their perf slightly and be consistent.

/cc @jkotas @mikedn @jamesqo 