### PR TITLE
Add private properties for debugger access to Task fields

### DIFF
--- a/src/mscorlib/model.CoreLib.xml
+++ b/src/mscorlib/model.CoreLib.xml
@@ -10376,6 +10376,8 @@
       <Member Status="ImplRoot" Name="GetDelegateContinuationsForDebugger" />
       <Member Status="ImplRoot" Name="GetActiveTaskFromId(System.Int32)" />
       <Member Status="ImplRoot" Name="GetActiveTasks" />
+      <Member Status="ImplRoot" Name="get_ParentForDebugger" />
+      <Member Status="ImplRoot" Name="get_StateFlagsForDebugger" />
     </Type>
     <Type Status="ImplRoot" Name="System.Threading.Tasks.SystemThreadingTasks_TaskDebugView">
       <Member Status="ImplRoot" Name="#ctor(System.Threading.Tasks.Task)" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -10390,6 +10390,8 @@
       <Member Status="ImplRoot" Name="GetDelegateContinuationsForDebugger" />
       <Member Status="ImplRoot" Name="GetActiveTaskFromId(System.Int32)" />
       <Member Status="ImplRoot" Name="GetActiveTasks" />
+      <Member Status="ImplRoot" Name="get_ParentForDebugger" />
+      <Member Status="ImplRoot" Name="get_StateFlagsForDebugger" />
     </Type>
     <Type Status="ImplRoot" Name="System.Threading.Tasks.SystemThreadingTasks_TaskDebugView">
       <Member Status="ImplRoot" Name="#ctor(System.Threading.Tasks.Task)" />

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -166,8 +166,10 @@ namespace System.Threading.Tasks
 
         internal readonly Task m_parent; // A task's parent, or null if parent-less.
 
-
         internal volatile int m_stateFlags;
+
+        private Task ParentForDebugger => m_parent; // Private property used by a debugger to access this Task's parent
+        private int StateFlagsForDebugger => m_stateFlags; // Private property used by a debugger to access this Task's state flags
 
         // State constants for m_stateFlags;
         // The bits of m_stateFlags are allocated as follows:


### PR DESCRIPTION
Per discussion at https://github.com/dotnet/coreclr/pull/4918#issuecomment-219783375.

I added properties for Task.m_parent and Task.m_stateFlags.

I did not add a property for Task.m_taskId, as Task.Id already exists and represents what we'd want such a property to do.

Similarly, I did not add one for Thread.m_ManagedThreadId, as there's already the ManagedThreadId property, and at the moment I don't believe there's a good alternative to the internal call.

cc: @gregg-miskelly, @jkotas 