### PR TITLE
Remove Encoding FEATURE_* defines from mscorlib

### DIFF
--- a/clr.coreclr.props
+++ b/clr.coreclr.props
@@ -60,11 +60,6 @@
     <FeatureCominteropWinRTManagedActivation>true</FeatureCominteropWinRTManagedActivation>
     <FeatureHostAssemblyResolver>true</FeatureHostAssemblyResolver>
     <FeatureLazyCOWPages Condition="('$(TargetArch)' == 'i386') or ('$(TargetArch)' == 'arm')">true</FeatureLazyCOWPages>
-    <FeatureLatin1>true</FeatureLatin1>
-    <FeatureEncodingNls>true</FeatureEncodingNls>
-    <FeatureAscii>true</FeatureAscii>
-    <FeatureUtf7>true</FeatureUtf7>
-    <FeatureUtf32>true</FeatureUtf32>
     <FeatureRandomizedStringHashing>true</FeatureRandomizedStringHashing>
     <!-- The rejit feature is available only on supported architectures (x86 & x64) -->
     <FeatureReJIT Condition="('$(TargetArch)' == 'i386') or ('$(TargetArch)' == 'amd64')">true</FeatureReJIT>

--- a/clr.defines.targets
+++ b/clr.defines.targets
@@ -133,7 +133,6 @@
         <DefineConstants Condition="'$(FeatureAptca)' == 'true'">$(DefineConstants);FEATURE_APTCA</DefineConstants>
         <DefineConstants Condition="'$(FeatureArrayStubAsIL)' == 'true'">$(DefineConstants);FEATURE_ARRAYSTUB_AS_IL</DefineConstants>
         <DefineConstants Condition="'$(FeatureStubsAsIL)' == 'true'">$(DefineConstants);FEATURE_STUBS_AS_IL</DefineConstants>
-        <DefineConstants Condition="'$(FeatureAscii)' == 'true'">$(DefineConstants);FEATURE_ASCII</DefineConstants>
         <DefineConstants Condition="'$(FeatureBclFormatting)' == 'true'">$(DefineConstants);FEATURE_BCL_FORMATTING</DefineConstants>
         <DefineConstants Condition="'$(FeatureCasPolicy)' == 'true'">$(DefineConstants);FEATURE_CAS_POLICY</DefineConstants>
         <DefineConstants Condition="'$(FeatureClassicCominterop)' == 'true'">$(DefineConstants);FEATURE_CLASSIC_COMINTEROP</DefineConstants>
@@ -154,7 +153,6 @@
         <DefineConstants Condition="'$(FeatureCrypto)' == 'true'">$(DefineConstants);FEATURE_CRYPTO</DefineConstants>
         <DefineConstants Condition="'$(FeatureDisplayCultureInfo)' == 'true'">$(DefineConstants);FEATURE_DISPLAY_CULTURE_INFO</DefineConstants>
         <DefineConstants Condition="'$(FeatureDisplayRegionInfo)' == 'true'">$(DefineConstants);FEATURE_DISPLAY_REGION_INFO</DefineConstants>
-        <DefineConstants Condition="'$(FeatureEncodingNls)' == 'true'">$(DefineConstants);FEATURE_ENCODINGNLS</DefineConstants>
         <DefineConstants Condition="'$(FeatureExceptionDispatchInfo)' == 'true'">$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
         <DefineConstants Condition="'$(FeatureExceptionNotifications)' == 'true'">$(DefineConstants);FEATURE_EXCEPTION_NOTIFICATIONS</DefineConstants>
         <DefineConstants Condition="'$(FeatureFusion)' == 'true'">$(DefineConstants);FEATURE_FUSION</DefineConstants>
@@ -167,7 +165,6 @@
         <DefineConstants Condition="'$(FeatureIsolatedStorageQuotaEnforcement)' == 'true'">$(DefineConstants);FEATURE_ISOLATED_STORAGE_QUOTA_ENFORCEMENT</DefineConstants>
         <DefineConstants Condition="'$(FeatureIsostore)' == 'true'">$(DefineConstants);FEATURE_ISOSTORE</DefineConstants>
         <DefineConstants Condition="'$(FeatureIsostoreLight)' == 'true'">$(DefineConstants);FEATURE_ISOSTORE_LIGHT</DefineConstants>
-        <DefineConstants Condition="'$(FeatureLatin1)' == 'true'">$(DefineConstants);FEATURE_LATIN1</DefineConstants>
         <DefineConstants Condition="'$(FeatureLeakCultureInfo)' == 'true'">$(DefineConstants);FEATURE_LEAK_CULTURE_INFO</DefineConstants>
         <DefineConstants Condition="'$(FeatureLegacySurface)' == 'true'">$(DefineConstants);FEATURE_LEGACYSURFACE</DefineConstants>
         <DefineConstants Condition="'$(FeatureLoaderOptimization)' == 'true'">$(DefineConstants);FEATURE_LOADER_OPTIMIZATION</DefineConstants>
@@ -194,8 +191,6 @@
         <DefineConstants Condition="'$(FeatureSyntheticCultures)' == 'true'">$(DefineConstants);FEATURE_SYNTHETIC_CULTURES</DefineConstants>
         <DefineConstants Condition="'$(FeatureTypeEquivalence)' == 'true'">$(DefineConstants);FEATURE_TYPEEQUIVALENCE</DefineConstants>
         <DefineConstants Condition="'$(FeatureUseLcid)' == 'true'">$(DefineConstants);FEATURE_USE_LCID</DefineConstants>
-        <DefineConstants Condition="'$(FeatureUtf32)' == 'true'">$(DefineConstants);FEATURE_UTF32</DefineConstants>
-        <DefineConstants Condition="'$(FeatureUtf7)' == 'true'">$(DefineConstants);FEATURE_UTF7</DefineConstants>
         <DefineConstants Condition="'$(FeatureValidator)' == 'true'">$(DefineConstants);FEATURE_VALIDATOR</DefineConstants>
         <DefineConstants Condition="'$(FeatureVersioning)' == 'true'">$(DefineConstants);FEATURE_VERSIONING</DefineConstants>
         <DefineConstants Condition="'$(FeatureWin32Registry)' == 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>

--- a/clr.desktop.props
+++ b/clr.desktop.props
@@ -10,7 +10,6 @@
     <FeatureAppXBinder>true</FeatureAppXBinder>
     <FeatureAptca>true</FeatureAptca>
     <FeatureArrayStubAsIL Condition="('$(TargetArch)' == 'arm')">true</FeatureArrayStubAsIL>
-    <FeatureAscii>true</FeatureAscii>
     <FeatureBclFormatting>true</FeatureBclFormatting>
     <FeatureCasPolicy>true</FeatureCasPolicy>
     <FeatureTraceLogging>true</FeatureTraceLogging>
@@ -36,7 +35,6 @@
     <FeatureDbiOopDebugging_HostWindowsx86>false</FeatureDbiOopDebugging_HostWindowsx86>
     <FeatureDisplayCultureInfo>true</FeatureDisplayCultureInfo>
     <FeatureDisplayRegionInfo>true</FeatureDisplayRegionInfo>
-    <FeatureEncodingNls>true</FeatureEncodingNls>
     <FeatureEventTrace>true</FeatureEventTrace>
     <FeatureExceptionDispatchInfo>true</FeatureExceptionDispatchInfo>
     <FeatureExceptionNotifications>true</FeatureExceptionNotifications>
@@ -55,7 +53,6 @@
     <FeatureIsymReader>true</FeatureIsymReader>
     <!-- This is here for testing purposes only, and only on checked builds for x86/ARM -->
     <FeatureLazyCOWPages Condition="'$(_BuildType)'!='ret' and (('$(TargetArch)' == 'i386') or ('$(TargetArch)' == 'arm'))">true</FeatureLazyCOWPages>
-    <FeatureLatin1>true</FeatureLatin1>
     <FeatureLeakCultureInfo>true</FeatureLeakCultureInfo>
     <FeatureLoaderOptimization>true</FeatureLoaderOptimization>
     <FeatureMacl>true</FeatureMacl>
@@ -88,8 +85,6 @@
     <FeatureTypeEquivalence>true</FeatureTypeEquivalence>
     <FeatureUefChainmanager>true</FeatureUefChainmanager>
     <FeatureUseLcid>true</FeatureUseLcid>
-    <FeatureUtf32>true</FeatureUtf32>
-    <FeatureUtf7>true</FeatureUtf7>
     <FeatureValidator>true</FeatureValidator>
     <FeatureWatson>true</FeatureWatson>
     <FeatureWin32Registry>true</FeatureWin32Registry>

--- a/src/mscorlib/src/System/IO/StreamReader.cs
+++ b/src/mscorlib/src/System/IO/StreamReader.cs
@@ -460,13 +460,11 @@ namespace System.IO
                     CompressBuffer(2);
                     changedEncoding = true;
                 }
-#if FEATURE_UTF32   
                 else {
                     encoding = Encoding.UTF32;
                     CompressBuffer(4);
                 changedEncoding = true;
-            }
-#endif            
+                }
             }
          
             else if (byteLen >= 3 && byteBuffer[0]==0xEF && byteBuffer[1]==0xBB && byteBuffer[2]==0xBF) {
@@ -475,7 +473,6 @@ namespace System.IO
                 CompressBuffer(3);
                 changedEncoding = true;
             }
-#if FEATURE_UTF32            
             else if (byteLen >= 4 && byteBuffer[0] == 0 && byteBuffer[1] == 0 &&
                      byteBuffer[2] == 0xFE && byteBuffer[3] == 0xFF) {
                 // Big Endian UTF32
@@ -483,7 +480,6 @@ namespace System.IO
                 CompressBuffer(4);
                 changedEncoding = true;
             }
-#endif            
             else if (byteLen == 2)
                 _detectEncoding = true;
             // Note: in the future, if we change this algorithm significantly,
@@ -1117,7 +1113,7 @@ namespace System.IO
 
         #region Private properties for async method performance
         // Access to instance fields of MarshalByRefObject-derived types requires special JIT helpers that check
-        // if the instance operated on is remote. This is optimised for fields on “this” but if a method is Async
+        // if the instance operated on is remote. This is optimised for fields on this but if a method is Async
         // and is thus lifted to a state machine type, access will be slow.
         // As a workaround, we either cache instance fields in locals or use properties to access such fields.
         

--- a/src/mscorlib/src/System/Security/Permissions/PermissionAttributes.cs
+++ b/src/mscorlib/src/System/Security/Permissions/PermissionAttributes.cs
@@ -1113,9 +1113,7 @@ namespace System.Security.Permissions
         private PermissionSet BruteForceParseStream(Stream stream)
         {
             Encoding[] encodings = new Encoding[] { Encoding.UTF8, 
-#if FEATURE_ASCII
                                                     Encoding.ASCII, 
-#endif                                              
                                                     Encoding.Unicode };
 
             StreamReader reader = null;

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -210,7 +210,7 @@ namespace System.Text
         }
 
         // This constructor is needed to allow any sub-classing implementation to provide encoder/decoder fallback objects 
-        // because the encoding object is always created as read-only object and don�t allow setting encoder/decoder fallback 
+        // because the encoding object is always created as read-only object and don't allow setting encoder/decoder fallback 
         // after the creation is done. 
         protected Encoding(int codePage, EncoderFallback encoderFallback, DecoderFallback decoderFallback)
         {

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -89,19 +89,12 @@ namespace System.Text
         private static volatile Encoding defaultEncoding;
         private static volatile Encoding unicodeEncoding;
         private static volatile Encoding bigEndianUnicode;
-#if FEATURE_UTF7        
         private static volatile Encoding utf7Encoding;
-#endif
         private static volatile Encoding utf8Encoding;
-#if FEATURE_UTF32        
         private static volatile Encoding utf32Encoding;
-#endif
-#if FEATURE_ASCII
         private static volatile Encoding asciiEncoding;
-#endif
-#if FEATURE_LATIN1
         private static volatile Encoding latin1Encoding;
-#endif
+        
         static volatile Hashtable encodings;
 
         //
@@ -217,7 +210,7 @@ namespace System.Text
         }
 
         // This constructor is needed to allow any sub-classing implementation to provide encoder/decoder fallback objects 
-        // because the encoding object is always created as read-only object and don’t allow setting encoder/decoder fallback 
+        // because the encoding object is always created as read-only object and donï¿½t allow setting encoder/decoder fallback 
         // after the creation is done. 
         protected Encoding(int codePage, EncoderFallback encoderFallback, DecoderFallback decoderFallback)
         {
@@ -473,24 +466,17 @@ namespace System.Text
                             result = new SBCSCodePageEncoding(codepage);
                             break;
 #else
-
-#if FEATURE_UTF7
                             // on desktop, UTF7 is handled by GetEncodingRare.
                             // On Coreclr, we handle this directly without bringing GetEncodingRare, so that we get real UTF-7 encoding.
                         case CodePageUTF7:                      // 65000, UTF7
                             result = UTF7;
                             break;
-#endif 
-
-#if FEATURE_UTF32        
                         case CodePageUTF32:             // 12000
                             result = UTF32;
                             break;
                         case CodePageUTF32BE:           // 12001
                             result = new UTF32Encoding(true, true);
                             break;
-#endif
-
 #endif
                         case CodePageUTF8:                      // 65001, UTF8
                             result = UTF8;
@@ -511,17 +497,13 @@ namespace System.Text
                             // #define CP_SYMBOL                 42          // SYMBOL translations
                             throw new ArgumentException(Environment.GetResourceString(
                                 "Argument_CodepageNotSupported", codepage), "codepage");
-#if FEATURE_ASCII
                         // Have to do ASCII and Latin 1 first so they don't get loaded as code pages
                         case CodePageASCII:             // 20127
                             result = ASCII;
                             break;
-#endif
-#if FEATURE_LATIN1
                         case ISO_8859_1:                // 28591
                             result = Latin1;
                             break;
-#endif                      
                         default:
                         {
 #if FEATURE_CODEPAGES_FILE
@@ -908,7 +890,6 @@ namespace System.Text
             }
         }
 
-#if FEATURE_ASCII
 
         // Returns an encoding for the ASCII character set. The returned encoding
         // will be an instance of the ASCIIEncoding class.
@@ -922,9 +903,7 @@ namespace System.Text
                 return asciiEncoding;
             }
         }
-#endif 
 
-#if FEATURE_LATIN1
         // Returns an encoding for the Latin1 character set. The returned encoding
         // will be an instance of the Latin1Encoding class.
         //
@@ -937,7 +916,6 @@ namespace System.Text
                 return latin1Encoding;
             }
         }
-#endif  
 
         // Returns the number of bytes required to encode the given character
         // array.
@@ -1524,7 +1502,6 @@ namespace System.Text
             }
         }
 
-#if FEATURE_UTF7
         // Returns an encoding for the UTF-7 format. The returned encoding will be
         // an instance of the UTF7Encoding class.
         //
@@ -1534,7 +1511,7 @@ namespace System.Text
                 return utf7Encoding;
             }
         }
-#endif 
+        
         // Returns an encoding for the UTF-8 format. The returned encoding will be
         // an instance of the UTF8Encoding class.
         //
@@ -1549,15 +1526,12 @@ namespace System.Text
         // Returns an encoding for the UTF-32 format. The returned encoding will be
         // an instance of the UTF32Encoding class.
         //
-#if FEATURE_UTF32
         public static Encoding UTF32 {
             get {
                 if (utf32Encoding == null) utf32Encoding = new UTF32Encoding(false, true);
                 return utf32Encoding;
             }
         }
-#endif
-
 
         public override bool Equals(Object value) {
             Encoding that = value as Encoding;

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_ENCODINGNLS
 namespace System.Text
 {
     
@@ -371,4 +370,3 @@ namespace System.Text
         }
     }
 }
-#endif // FEATURE_ENCODINGNLS

--- a/src/mscorlib/src/System/Text/ISCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ISCIIEncoding.cs
@@ -6,7 +6,6 @@
 //
 //  Ported from windows c_iscii.  If you find bugs here, there're likely similar
 //  bugs in the windows version
-#if FEATURE_ENCODINGNLS
 namespace System.Text
 {
     using System;
@@ -2626,4 +2625,3 @@ namespace System.Text
     }
 
 }
-#endif // FEATURE_ENCODINGNLS

--- a/src/mscorlib/src/System/Text/Latin1Encoding.cs
+++ b/src/mscorlib/src/System/Text/Latin1Encoding.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if FEATURE_ENCODINGNLS
 namespace System.Text
 {
     using System;
@@ -914,4 +913,3 @@ namespace System.Text
         };
     }
 }
-#endif // FEATURE_ENCODINGNLS

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -6,8 +6,6 @@
 // Don't override IsAlwaysNormalized because it is just a Unicode Transformation and could be confused.
 //
 
-#if FEATURE_UTF32
-
 namespace System.Text
 {
 
@@ -1258,5 +1256,3 @@ namespace System.Text
         }
     }
 }
-
-#endif // FEATURE_UTF32


### PR DESCRIPTION
Removes a bunch of `FEATURE_` defines related to Encodings; I'm assuming since these APIs are stable that the #ifdefs can be removed.

cc @jkotas 