### PR TITLE
Start using CODE_OWNERS.TXT

### DIFF
--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -1,0 +1,23 @@
+The following is a list of owners for different areas of the coreclr code. 
+Each of the owners is responsible for ensuring that changes in their areas 
+are reviewed, either by themselves or by someone they designate, in 
+addition to being the final word for the architecture and content of an area.
+
+List sorted by last name and the fields are Name (N), GitHub user account (G), 
+Description (D).
+
+Note: If you don't find the area in the below list, or you have a general 
+question, send a message to Jan Kotas (@jkotas) and Richard Lander
+(@richlander). They can ensure that the question gets forwarded to the
+right person or answer it themselves.  
+
+N: Mike McLaughlin
+G: mikem8361
+D: Debugging APIs and implementation (anything under the debug directory), sos
+
+N: Kshama Pawar
+G: kspawa
+D: Profiling APIs and implementation
+
+This list is incomplete, if you need to find other owners work with Jan Kotas
+to get them filled in.

--- a/Documentation/project-docs/contributing-workflow.md
+++ b/Documentation/project-docs/contributing-workflow.md
@@ -8,7 +8,7 @@ Getting Started
 
 If you are looking at getting your feet wet with some simple (but still beneficial) changes, check out _up for grabs_ issues on the [CoreCLR](https://github.com/dotnet/coreclr/labels/up for grabs) and [CoreFX](https://github.com/dotnet/corefx/labels/up for grabs) repos. 
 
-For new ideas, please always start with an issue before starting development of an implementation. See [project priorities](project-priorities.md) to understand the Microsoft team's approach to engagement on general improvements to the product.
+For new ideas, please always start with an issue before starting development of an implementation. See [project priorities](project-priorities.md) to understand the Microsoft team's approach to engagement on general improvements to the product. Use [CODE_OWNERS.TXT](https://github.com/dotnet/coreclr/blob/CODE_OWNERS.TXT) to find relevant maintainers and @ mention them to ask for feedback on your issue.
 
 You do not need to file an issue for trivial changes (e.g. typo fixes). Just create a PR for those changes.
 
@@ -85,6 +85,7 @@ We use and recommend the following workflow:
 1. Create an issue for your work. 
   - You can skip this step for trivial changes.
   - Reuse an existing issue on the topic, if there is one.
+  - Use [CODE_OWNERS.TXT](https://github.com/dotnet/coreclr/blob/CODE_OWNERS.TXT) to find relevant maintainers and @ mention them to ask for feedback on your issue.
   - Get agreement from the team and the community that your proposed change is a good one.
   - If your change adds a new API, follow the [API Review Process](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md). 
   - Clearly state that you are going to take on implementing it, if that's the case. You can request that the issue be assigned to you. Note: The issue filer and the implementer don't have to be the same person.


### PR DESCRIPTION
Our current approach to get eyeballs on issues relies on generous developers frequently triaging all issues. While convenient sometimes issues fall through the cracks. Providing a directory of maintainers allows contributors to take control and more quickly seek out the right maintainers to collaborate with.