### PR TITLE
Guard Crossgen Test Runtime logic with RunCrossGen Env

### DIFF
--- a/tests/src/CLRTest.CrossGen.targets
+++ b/tests/src/CLRTest.CrossGen.targets
@@ -1,0 +1,101 @@
+<!--
+***********************************************************************************************
+CLRTest.Execute.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+This file contains the logic for providing Execution Script generation.
+
+WARNING:   When setting properties based on their current state (for example:
+           <Foo Condition="'$(Foo)'==''>Bar</Foo>).  Be very careful.  Another script generation
+           target might be trying to do the same thing.  It's better to avoid this by instead setting a new property.
+           
+           Additionally, be careful with itemgroups.  Include will propagate outside of the target too!
+
+***********************************************************************************************
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <BashScriptSnippetGen>$(BashScriptSnippetGen);GetCrossgenBashScript</BashScriptSnippetGen>
+    <BatchScriptSnippetGen>$(BatchScriptSnippetGen);GetCrossgenBatchScript</BatchScriptSnippetGen>
+  </PropertyGroup>
+  <ItemGroup>
+    <CLRTestBashEnvironmentVariable  Condition="'$(CrossGenTest)' == 'true'" Include = "export RunCrossGen=1"/>
+    <CLRTestBatchEnvironmentVariable Condition="'$(CrossGenTest)' == 'true'" Include = "set RunCrossGen=1"/>
+  </ItemGroup>
+
+  <!--
+    Target: GetCrossgenBatctchcript
+    This returns the portion of the execution script that generates the required lines to crossgen the test executable.
+  -->
+  <Target Name="GetCrossgenBashScript">
+    
+    <PropertyGroup>
+      <CrossgenBashScript Condition="'$(CLRTestKind)' == 'BuildAndRun'">
+        <![CDATA[
+# CrossGen Script
+if [ ! -z ${RunCrossGen+x} ]%3B then
+    export complus_zaprequire=2
+    export complus_zaprequireexcludelist=corerun
+    export complus_zaprequirelist=$(MSBuildProjectName)
+    if [ ! -f $(MSBuildProjectName).ni.exe ]%3B then
+        TakeLock
+        if [ ! -f $(MSBuildProjectName).ni.exe ]%3B then
+          echo $_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD $(MSBuildProjectName).exe
+          $_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD $(MSBuildProjectName).exe
+          __cgExitCode=$?
+          if [ $__cgExitCode -ne 0 ]
+          then
+            echo Crossgen failed with exitcode: $__cgExitCode
+            ReleaseLock
+            exit 1
+          fi
+        fi 
+        ReleaseLock       
+    fi        
+fi        
+        ]]>        
+      </CrossgenBashScript>
+
+      <BashCLRTestPreCommands>$(BashCLRTestPreCommands);$(CrossgenBashScript)</BashCLRTestPreCommands>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="GetCrossgenBatchScript">
+    
+    <PropertyGroup>
+      <CrossgenBatchScript Condition="'$(CLRTestKind)' == 'BuildAndRun'">
+        <![CDATA[
+
+REM CrossGen Script
+if defined RunCrossGen ( 
+    set complus_zaprequire=2
+    set complus_zaprequireexcludelist=corerun
+    set complus_zaprequirelist=$(MSBuildProjectName)
+    if not exist "$(MSBuildProjectName).ni.exe" (
+        call :TakeLock
+        if not exist "$(MSBuildProjectName).ni.exe" (
+            echo "%_DebuggerFullPath% %CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%~dp0 $(MSBuildProjectName).exe
+            %_DebuggerFullPath% "%CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%~dp0 $(MSBuildProjectName).exe
+            IF NOT !ERRORLEVEL!==0 (
+            ECHO Crossgen failed with exitcode - !ERRORLEVEL!
+            call :ReleaseLock
+            Exit /b 1
+            )
+          )
+          call :ReleaseLock
+    )
+) 
+        ]]>
+      </CrossgenBatchScript>
+
+      <CLRTestBatchPreCommands>$(CLRTestBatchPreCommands);$(CrossgenBatchScript)</CLRTestBatchPreCommands>
+    </PropertyGroup>
+  </Target>
+
+
+  
+</Project>

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -19,38 +19,8 @@ WARNING:   When setting properties based on their current state (for example:
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <CLRTestBashEnvironmentVariable Condition="'$(CrossGen)' == 'true'" Include="export complus_zaprequire=2" />
-    <CLRTestBashEnvironmentVariable Condition="'$(CrossGen)' == 'true'" Include="export complus_zaprequireexcludelist=corerun" />
     <CLRTestBashEnvironmentVariable Condition="'$(GCStressLevel)' != '' and '$(GCStressLevel)' != '0'" Include="export complus_gcstress=$(GCStressLevel)" />
   </ItemGroup>
-
-    <!--
-    Target: GetBatchCrossgenScript
-    This returns the portion of the execution script that generates the required lines to crossgen the test executable.
-  -->
-  <Target
-    Condition="'$(CrossGen)'=='true'"
-    Name="GetCrossgenBashScript"
-    Returns="$(CrossgenBashScript)">  
-    
-    <PropertyGroup>
-      <!-- CrossGen will create output if it needs to crossgen. Otherwise there will be silence. -->
-      <CrossgenBashScript Condition="'$(CLRTestKind)' == 'BuildAndRun'">
-        <![CDATA[
-if [ ! -f $(MSBuildProjectName).ni.exe ]; then
-  echo "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD $(MSBuildProjectName).exe
-  "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD $(MSBuildProjectName).exe
-  __cgExitCode=$?
-  if [ $__cgExitCode -ne 0 ]
-  then
-    echo Crossgen failed with exitcode: $__cgExitCode
-    exit 1
-  fi
-fi        
-        ]]>        
-      </CrossgenBashScript>
-    </PropertyGroup>
-  </Target>
 
   <Target
     Name="GetIlasmRoundTripBashScript"
@@ -133,7 +103,7 @@ fi
   <Target Name="GenerateBashExecutionScript"
     Inputs="$(MSBuildProjectFullPath)"
     Outputs="$(OutputPath)\$(MSBuildProjectName).sh"
-    DependsOnTargets="FetchExternalPropertiesForXpalt;GetCrossgenBashScript;GetIlasmRoundTripBashScript">
+    DependsOnTargets="FetchExternalPropertiesForXpalt;$(BashScriptSnippetGen);GetIlasmRoundTripBashScript">
 
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
@@ -212,11 +182,6 @@ fi
       </BashCLRTestExecutionScriptArgument>
     </ItemGroup>
 
-
-    <ItemGroup>
-      <CLRTestBashEnvironmentVariable Condition="'$(CrossGen)' == 'true' AND '$(_CLRTestNeedsProjectToRun)' == 'true'" Include="complus_zaprequirelist=$(_CLRTestToRunFileFullPath)" />
-      <CLRTestBashEnvironmentVariable Condition="'$(CrossGen)' == 'true' AND '$(_CLRTestNeedsProjectToRun)' == 'false'" Include="complus_zaprequirelist=$(MSBuildProjectName)" />
-    </ItemGroup>
     
     <PropertyGroup>
       <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun"</_CLRTestRunFile>
@@ -312,7 +277,29 @@ $(BashCLRTestArgPrep)
       <!-- NOTE! semicolons must be escaped with %3B boooo -->
       <_CLRTestExecutionScriptText>
         <![CDATA[
+TakeLock()
+{
+    echo "in takeLock"
+    if mkdir $LockFile%3B then
+        return 2
+    else
+        sleep 10
+        TakeLock
+    fi
+    echo "exiting takelock"
+}
+
+ReleaseLock()
+{
+    echo "in ReleaseLock"
+    if [ -d "$LockFile" ]%3B then
+        rm -rf "$LockFile"
+        return 3
+    fi
+}
 cd "$%28dirname "$0")"
+LockFile="lock"
+
 
 # The __TestEnv variable may be used to specify something to run before the test.
 $__TestEnv
@@ -324,8 +311,6 @@ $(BashCLRTestExitCodePrep)
 # Long-running GC test checks
 $(BashCLRTestGCSimulatorSkipCondition)
 $(BashCLRTestGCLongTestSkipCondition)
-# CrossGen Script (when /p:CrossGen=true)
-$(CrossgenBashScript)
 # IlasmRoundTrip Script
 $(IlasmRoundTripBashScript)
 # PreCommands

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -19,35 +19,8 @@ WARNING:   When setting properties based on their current state (for example:
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <CLRTestBatchEnvironmentVariable Condition="'$(CrossGen)' == 'true'" Include="set complus_zaprequire=2" />
-    <CLRTestBatchEnvironmentVariable Condition="'$(CrossGen)' == 'true'" Include="set complus_zaprequireexcludelist=corerun" />
     <CLRTestBatchEnvironmentVariable Condition="'$(GCStressLevel)' != '' and '$(GCStressLevel)' != '0'" Include="set complus_gcstress=$(GCStressLevel)" />
   </ItemGroup>
-  <!--
-    Target: GetBatchCrossgenScript
-    This returns the portion of the execution script that generates the required lines to crossgen the test executable.
-  -->
-  <Target
-    Condition="'$(CrossGen)'=='true'"
-    Name="GetCrossgenBatchScript"
-    Returns="$(CrossgenBatchScript)">
-    
-    <PropertyGroup>
-<!-- CrossGen will create output if it needs to crossgen. Otherwise there will be silence. -->
-      <CrossgenBatchScript Condition="'$(CLRTestKind)' == 'BuildAndRun'">
-        <![CDATA[
-if not exist "$(MSBuildProjectName).ni.exe" (
-    echo "%CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%~dp0 $(MSBuildProjectName).exe
-    "%CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%~dp0 $(MSBuildProjectName).exe
-    IF NOT "!ERRORLEVEL!"=="0" (
-    ECHO Crossgen failed with exitcode - !ERRORLEVEL!
-    Exit /b 1
-    )
-  )      
-        ]]>
-      </CrossgenBatchScript>
-    </PropertyGroup>
-  </Target>
 
   <Target
     Name="GetIlasmRoundTripBatchScript"
@@ -126,7 +99,7 @@ IF NOT "!ERRORLEVEL!"=="0" (
   <Target Name="GenerateBatchExecutionScript"
     Inputs="$(MSBuildProjectFullPath)"
     Outputs="$(OutputPath)\$(MSBuildProjectName).cmd"
-    DependsOnTargets="FetchExternalProperties;GetCrossgenBatchScript;GetIlasmRoundTripBatchScript">
+    DependsOnTargets="FetchExternalProperties;$(BatchScriptSnippetGen);GetIlasmRoundTripBatchScript">
 
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
@@ -185,6 +158,19 @@ IF NOT "%CLRTestExitCode%"=="%CLRTestExpectedExitCode%" (
   ECHO PASSED
   Exit /b 0
 )
+
+:TakeLock
+md %lockFolder%
+IF NOT "!ERRORLEVEL!"=="0" (
+timeout /t 10 /nobreak
+goto :TakeLock
+)
+Exit /b 2
+
+
+:ReleaseLock
+if exist %lockFolder% rd /s /q %lockFolder%
+Exit /b 0
       ]]></BatchCLRTestExitCodeCheck>
     </PropertyGroup>
   
@@ -227,11 +213,6 @@ IF NOT "%CLRTestExitCode%"=="%CLRTestExpectedExitCode%" (
         ]]></Command>
         <Description>Set CORE_ROOT to the specified value before running the test.</Description>
       </BatchCLRTestExecutionScriptArgument>
-    </ItemGroup>
-      
-    <ItemGroup>
-      <CLRTestBatchEnvironmentVariable Condition="'$(CrossGen)' == 'true' AND '$(_CLRTestNeedsProjectToRun)' == 'true'" Include="set complus_zaprequirelist=$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))" />
-      <CLRTestBatchEnvironmentVariable Condition="'$(CrossGen)' == 'true' AND '$(_CLRTestNeedsProjectToRun)' == 'false'" Include="set complus_zaprequirelist=$(MSBuildProjectName)" />
     </ItemGroup>
 
     <PropertyGroup> 
@@ -344,7 +325,9 @@ $(BatchCLRTestArgPrep)
   <![CDATA[
 @ECHO OFF
 setlocal ENABLEDELAYEDEXPANSION
+set "lockFolder=%~dp0\lock"
 pushd %~dp0
+
 $(BatchCLRTestArgPrep)
 $(BatchCLRTestExitCodePrep)
 
@@ -355,9 +338,6 @@ REM Environment Variables
 $(BatchEnvironmentVariables)
 
 $(BatchCLRTestEnvironmentCompatibilityCheck)
-
-REM CrossGen Script (when /p:CrossGen=true)
-$(CrossgenBatchScript)
 
 REM IlasmRoundTrip Script
 $(IlasmRoundTripBatchScript)

--- a/tests/src/CLRTest.Execute.targets
+++ b/tests/src/CLRTest.Execute.targets
@@ -99,7 +99,13 @@ This file contains the logic for providing Execution Script generation.
     <ExecutionScriptKind Include="Batch" />
     <ExecutionScriptKind Include="Bash" />
   </ItemGroup>
-  
+
+  <PropertyGroup>
+    <BashScriptSnippetGen></BashScriptSnippetGen>
+    <BatchScriptSnippetGen></BatchScriptSnippetGen>
+  </PropertyGroup>
+ 
+  <Import Project="CLRTest.CrossGen.targets" />
   <Import Project="CLRTest.Execute.*.targets" />
   
   <Target Name="GenerateExecutionScriptsInternal"


### PR DESCRIPTION
Adds Semaphores to prevent race conditions
Basic Cleanup for how test Run logic should be generated 


@wtgodbe @rahku @gkhanna79 @russellhadley  PTAL