### PR TITLE
Fix missing assignment in dllimport code

### DIFF
--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -7162,7 +7162,7 @@ HINSTANCE NDirect::LoadLibraryModule(NDirectMethodDesc * pMD, LoadLibErrorTracke
 #ifdef FEATURE_CORECLR
     if (hmod == NULL)
     {
-        LoadFromNativeDllSearchDirectories(pDomain, wszLibName, loadWithAlteredPathFlags, pErrorTracker);
+        hmod = LoadFromNativeDllSearchDirectories(pDomain, wszLibName, loadWithAlteredPathFlags, pErrorTracker);
     }
 
 #endif // FEATURE_CORECLR


### PR DESCRIPTION
This fixes an issue in `LoadLibraryModule` where the result of `LoadFromNativeDllSearchDirectories` wasn't being stored.

Fixes #5038 

Thanks @manu-silicon for finding this bug!