### PR TITLE
Linux/ARM: display default clang version info at build-time

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,7 @@ check_prereqs()
     hash cmake 2>/dev/null || { echo >&2 "Please install cmake before running this script"; exit 1; }
 
     # Check for clang
-    hash clang-$__ClangMajorVersion.$__ClangMinorVersion 2>/dev/null ||  hash clang$__ClangMajorVersion$__ClangMinorVersion 2>/dev/null ||  hash clang 2>/dev/null || { echo >&2 "Please install clang before running this script"; exit 1; }
+    hash clang-$__ClangMajorVersion.$__ClangMinorVersion 2>/dev/null ||  hash clang$__ClangMajorVersion$__ClangMinorVersion 2>/dev/null ||  hash clang 2>/dev/null || { echo >&2 "Please install clang-$__ClangMajorVersion.$__ClangMinorVersion before running this script"; exit 1; }
 
 }
 


### PR DESCRIPTION
This is trivial patch. However, it helps that developers can know a default clang version that is used at build-time.

Before PR: Please install clang before running this script
After  PR: Please install clang-3.5 before running this script

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>