### PR TITLE
Fix and reenable lifetime2

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -1,9 +1,6 @@
 <Project DefaultTargets = "GetListOfTestCmds"
     xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\lifetime\lifetime2\lifetime2.cmd" >
-             <Issue>1037</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
              <Issue>2329</Issue>
         </ExcludeList>

--- a/tests/src/JIT/Directed/lifetime/lifetime2.csproj
+++ b/tests/src/JIT/Directed/lifetime/lifetime2.csproj
@@ -28,7 +28,8 @@
   </ItemGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>
-    
+    <Optimize>True</Optimize> 
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lifetime2.cs" />

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -6,7 +6,6 @@ JIT/Directed/UnrollLoop/loop6_cs_d/loop6_cs_d.sh
 JIT/Directed/UnrollLoop/loop6_cs_do/loop6_cs_do.sh
 JIT/Directed/UnrollLoop/loop6_cs_r/loop6_cs_r.sh
 JIT/Directed/UnrollLoop/loop6_cs_ro/loop6_cs_ro.sh
-JIT/Directed/lifetime/lifetime2/lifetime2.sh
 JIT/Methodical/refany/_dbgstress1/_dbgstress1.sh
 JIT/Methodical/refany/_dbgstress3/_dbgstress3.sh
 JIT/Methodical/refany/_il_dbgseq/_il_dbgseq.sh

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -292,9 +292,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Roslyn\CscBench\CscBench.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\lifetime\lifetime2\lifetime2.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\delegate\_simpleoddpower_il_r\_simpleoddpower_il_r.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>


### PR DESCRIPTION
lifetime2 is another questionable test case that relies on lifetime
guarantees that don't exist.  Per our convention, force optimization on
and mark it as "optimization sensitive" to make a best effort to get it to
pass.

Fixes #1037