### PR TITLE
Fix crossgen /createpdb when input filename is given without path

### DIFF
--- a/src/binder/applicationcontext.cpp
+++ b/src/binder/applicationcontext.cpp
@@ -265,8 +265,17 @@ namespace BINDER_SPACE
             
             if (!fileName.FindBack(iSimpleNameStart, DIRECTORY_SEPARATOR_CHAR_W))
             {
+#ifdef CROSSGEN_COMPILE
+                iSimpleNameStart = fileName.Begin();
+#else
                 // Couldn't find a directory separator.  File must have been specified as a relative path.  Not allowed.
                 GO_WITH_HRESULT(E_INVALIDARG);
+#endif
+            }
+            else
+            {
+                // Advance past the directory separator to the first character of the file name
+                iSimpleNameStart++;
             }
 
             if (iSimpleNameStart == fileName.End())
@@ -274,9 +283,6 @@ namespace BINDER_SPACE
                 GO_WITH_HRESULT(E_INVALIDARG);
             }
 
-            // Advance past the directory separator to the first character of the file name
-            iSimpleNameStart++;
-            
             SString simpleName;
             bool isNativeImage = false;
 


### PR DESCRIPTION
Fix a bug in "crossgen /createpdb" command that can cause it to fail
if the input filename is given without a path.