### PR TITLE
Move NATIVE_DLL_SEARCH_DIRECTORIES probing earlier right before we pr…

### DIFF
--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -7041,6 +7041,14 @@ HINSTANCE NDirect::LoadLibraryModule(NDirectMethodDesc * pMD, LoadLibErrorTracke
     }
 #endif // FEATURE_CORESYSTEM && !FEATURE_PAL
 
+#ifdef FEATURE_CORECLR
+    if (hmod == NULL)
+    {
+        // NATIVE_DLL_SEARCH_DIRECTORIES set by host is considered well known path 
+        hmod = LoadFromNativeDllSearchDirectories(pDomain, wszLibName, loadWithAlteredPathFlags, pErrorTracker);
+    }
+#endif // FEATURE_CORECLR   
+
     DWORD dllImportSearchPathFlag = 0;
     BOOL searchAssemblyDirectory = TRUE;
     bool libNameIsRelativePath = Path::IsRelative(wszLibName);
@@ -7158,14 +7166,6 @@ HINSTANCE NDirect::LoadLibraryModule(NDirectMethodDesc * pMD, LoadLibErrorTracke
 #endif // !FEATURE_CORECLR
         }
     }
-
-#ifdef FEATURE_CORECLR
-    if (hmod == NULL)
-    {
-        LoadFromNativeDllSearchDirectories(pDomain, wszLibName, loadWithAlteredPathFlags, pErrorTracker);
-    }
-
-#endif // FEATURE_CORECLR
 
     // This call searches the application directory instead of the location for the library.
     if (hmod == NULL)


### PR DESCRIPTION
…obe for absolute path and assembly path. This is needed to make sure servicing directories (set in NATIVE_DLL_SEARCH_DIRECTORIES by host) are honored correctly before everything else, along with rest of the NATIVE_DLL_SEARCH_DIRECTORIES probing path. In order to preserve compat with UWP host, I kept the rest of the interop probing logic even when NATIVE_DLL_SEARCH_DIRECTORIES probing path is specified.

To my horror I discovered the fact that we actually never set hmod when loading DLL from NATIVE_DLL_SEARCH_DIRECTORIES probing, and the probably the only saving grace is that our ultimate fallback LoadLibrary call after that would "just work" and return the HMODULE we just loaded... This is now fixed.