### PR TITLE
Fix Interop TCs to use long long instead of long

### DIFF
--- a/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.h
+++ b/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.h
@@ -395,8 +395,8 @@ void PrintNumberSequential(NumberSequential* str, char const * name)
 	printf("\t%s.sb = %d\n", name, str->sb);
 	printf("\t%s.i16 = %d\n", name, str->i16);
 	printf("\t%s.ui16 = %u\n", name, str->ui16);
-	printf("\t%s.i64 = %ld\n", name, str->i64);
-	printf("\t%s.ui64 = %lu\n", name, str->ui64);
+	printf("\t%s.i64 = %lld\n", name, str->i64);
+	printf("\t%s.ui64 = %llu\n", name, str->ui64);
 	printf("\t%s.sgl = %f\n", name, str->sgl);
 	printf("\t%s.d = %f\n",name, str->d);
 }
@@ -773,8 +773,8 @@ void PrintU(U* str, char const * name)
 	printf("\t%s.us = %u\n", name, str->us);
 	printf("\t%s.b = %u\n", name, str->b);
 	printf("\t%s.sb = %d\n", name, str->sb);
-	printf("\t%s.l = %ld\n", name, str->l);
-	printf("\t%s.ul = %lu\n", name, str->ul);
+	printf("\t%s.l = %lld\n", name, str->l);
+	printf("\t%s.ul = %llu\n", name, str->ul);
 	printf("\t%s.f = %f\n", name, str->f);
 	printf("\t%s.d = %f\n", name, str->d);
 }
@@ -884,8 +884,8 @@ struct LongStructPack16Explicit // size = 16 bytes
 
 void PrintLongStructPack16Explicit(LongStructPack16Explicit* str, char const * name)
 {
-	printf("\t%s.l1 = %ld", name, str->l1);
-	printf("\t%s.l2 = %ld", name, str->l2);
+	printf("\t%s.l1 = %lld", name, str->l1);
+	printf("\t%s.l2 = %lld", name, str->l2);
 }
 void ChangeLongStructPack16Explicit(LongStructPack16Explicit* p)
 {

--- a/tests/src/Interop/common/types.h
+++ b/tests/src/Interop/common/types.h
@@ -33,10 +33,10 @@ typedef WCHAR OLECHAR;
 
 typedef unsigned int UINT_PTR;
 
-typedef unsigned long ULONG64;
+typedef unsigned long long ULONG64;
 typedef double DOUBLE;
 typedef float FLOAT;
-typedef signed long LONG64, *PLONG64;
+typedef signed long long LONG64, *PLONG64;
 typedef int INT, *LPINT;
 typedef unsigned int UINT;
 typedef char CHAR, *PCHAR;


### PR DESCRIPTION
Some TCs were using long for 64bit variable.
While it is correct on x86, long is 32bit on ARM.
Fix TCs to use long long instead so that they can pass on ARM as well.

Fix #5053

Signed-off-by: Dongyun Jin <dongyun.jin@samsung.com>