### PR TITLE
Exclude smallFrame for JIT32

### DIFF
--- a/tests/x86_jit32_issues.targets
+++ b/tests/x86_jit32_issues.targets
@@ -277,5 +277,8 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_relsin_il_il\_relsin_il_il.cmd" >
              <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\smallFrame\smallFrame.cmd" >
+             <Issue>4548</Issue>
+        </ExcludeList>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This test was flagged as incompatible with COMPlus_JITMinOpts in the
previous test harness.  It doesn't fail for RyuJIT, though, even under
MinOpts, so, rather than disabling it everywhere under MinOpts, I'm only
disabling it for JIT32.

Related to #4548