### PR TITLE
Prevent seg faults at shutdown when emitting LTTng events

### DIFF
--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -4188,7 +4188,6 @@ static void TerminateDebugger(void)
 
         // This will kill the helper thread, delete the Debugger object, and free all resources.
         g_pDebugInterface->StopDebugger();
-        g_pDebugInterface = NULL;
     }
 
     // Delete this after Debugger, since Debugger may use this.

--- a/src/vm/eedbginterfaceimpl.cpp
+++ b/src/vm/eedbginterfaceimpl.cpp
@@ -1657,8 +1657,6 @@ BOOL EEDbgInterfaceImpl::ObjIsInstanceOf(Object *pElement, TypeHandle toTypeHnd)
 void EEDbgInterfaceImpl::ClearAllDebugInterfaceReferences()
 {
     LIMITED_METHOD_CONTRACT;
-
-    g_pDebugInterface = NULL;
 }
 
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
This change fixes issue https://github.com/dotnet/coreclr/issues/3101.

When we are emitting LTTng events (via the ETW system in CLR) we end up setting g_pDebugInterface to null on one thread while attempting to use that value on another.  This change leaves the shutdown codepath for the debugger interface in place, but allows etw to still call into it even during shutdown.