### PR TITLE
Remove unnecessary use of volatile from Encoding

### DIFF
--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -86,16 +86,16 @@ namespace System.Text
     [Serializable]
     public abstract class Encoding : ICloneable
     {
-        private static volatile Encoding defaultEncoding;
-        private static volatile Encoding unicodeEncoding;
-        private static volatile Encoding bigEndianUnicode;
-        private static volatile Encoding utf7Encoding;
-        private static volatile Encoding utf8Encoding;
-        private static volatile Encoding utf32Encoding;
-        private static volatile Encoding asciiEncoding;
-        private static volatile Encoding latin1Encoding;
+        private static Encoding defaultEncoding;
+        private static UnicodeEncoding unicodeEncoding;
+        private static UnicodeEncoding bigEndianUnicode;
+        private static UTF7Encoding utf7Encoding;
+        private static UTF8Encoding utf8Encoding;
+        private static UTF32Encoding utf32Encoding;
+        private static ASCIIEncoding asciiEncoding;
+        private static Latin1Encoding latin1Encoding;
         
-        static volatile Hashtable encodings;
+        private static Hashtable encodings;
 
         //
         // The following values are from mlang.idl.  These values


### PR DESCRIPTION
Looking through the `Encoding` code, I noticed `volatile` was being used when it wasn't necessary. For example, the code for `Encoding.UTF8` looks like this:

```cs
public static Encoding UTF8 {
    get {
        if (utf8Encoding == null) utf8Encoding = new UTF8Encoding(true);
        return utf8Encoding;
    }
}
```

Using `volatile` here isn't actually protecting against race conditions, since thread 1 and thread 2 can both enter the `if` block before `utf8Encoding` is actually initialized. Besides, since AFAIK `UTF8Encoding` is immutable, it won't actually matter if two different instances are returned. An exception to this is if someone does an `object.ReferenceEquals` on them, but 1) these classes overload the `Equals` method and 2) this will only happen in the event of a race condition.

This PR removes the `volatile` specifier from each of the fields, and also types them more strongly.

Extra notes:

- Removed `volatile` from the Hashtable field as well, since the only time it's initialized is in a lock.
- Not sure if the initializer for `Encoding.Default` can return a different encoding each time/can return a mutable encoding. `CreateDefaultEncoding` calls a native function/does some other stuff if `FEATURE_CODEPAGES_FILE` is enabled.

cc @tarekgh @jkotas @mikedn 