### PR TITLE
Add sign.builds projects to facilitate real signing in official builds.

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -181,6 +181,10 @@
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.Targets" />
 
+  <PropertyGroup>
+    <StrongNameSig>Silverlight</StrongNameSig>
+  </PropertyGroup>
+
   <!-- Import signing tools -->
   <Import Condition="Exists('$(ToolsDir)\sign.targets')" Project="$(ToolsDir)\sign.targets" />
 

--- a/src/mscorlib/facade/mscorlib.csproj
+++ b/src/mscorlib/facade/mscorlib.csproj
@@ -61,10 +61,21 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <StrongNameSig>Silverlight</StrongNameSig>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
- <PropertyGroup>
+  <PropertyGroup>
     <!-- Overwrite the key that we are going to use for signing -->
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Tools\Signing\mscorlib.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
+  <!-- the signing marker file is incorrectly named mscorlib.dll.requires_signing -->
+  <Target Name="RenameSigningMarker" AfterTargets="WriteSigningRequired" Condition="Exists('$(TargetPath).requires_signing')">
+    <Move SourceFiles="$(TargetPath).requires_signing" DestinationFiles="$(OutputPath)\System.Private.CoreLib.dll.requires_signing" />
+  </Target>
+
 </Project>

--- a/src/mscorlib/mscorlib.csproj
+++ b/src/mscorlib/mscorlib.csproj
@@ -179,6 +179,10 @@
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.Targets" />
 
+  <PropertyGroup>
+    <StrongNameSig>Silverlight</StrongNameSig>
+  </PropertyGroup>
+
   <!-- Import signing tools -->
   <Import Condition="Exists('$(ToolsDir)\sign.targets')" Project="$(ToolsDir)\sign.targets" />
 

--- a/src/mscorlib/ref/mscorlib.csproj
+++ b/src/mscorlib/ref/mscorlib.csproj
@@ -68,6 +68,10 @@
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.Targets" />
 
+  <PropertyGroup>
+    <StrongNameSig>Silverlight</StrongNameSig>
+  </PropertyGroup>
+
   <!-- Import signing tools -->
   <Import Condition="Exists('$(ToolsDir)\sign.targets')" Project="$(ToolsDir)\sign.targets" />
 

--- a/src/sign.builds
+++ b/src/sign.builds
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="SignFiles" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- must set the default before importing targets -->
+  <PropertyGroup>
+    <SignType Condition="'$(SignType)' == ''">test</SignType>
+    <StrongNameSig>Silverlight</StrongNameSig>
+  </PropertyGroup>
+
+  <Import Project="..\dir.props"/>
+  <Import Project="..\dir.targets" />
+
+  <!-- OutDir is used by the MicroBuild signing target -->
+  <PropertyGroup>
+    <OutDir>$(BinDir)</OutDir>
+  </PropertyGroup>
+
+  <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="ReadSigningRequired" />
+
+  <!-- apply the default signing certificates (defined in sign.targets) -->
+  <ItemDefinitionGroup>
+    <FilesToSign>
+      <Authenticode>$(AuthenticodeSig)</Authenticode>
+      <StrongName>$(StrongNameSig)</StrongName>
+    </FilesToSign>
+  </ItemDefinitionGroup>
+
+  <!-- gather the list of binaries to sign with the default certificates -->
+  <ItemGroup>
+    <FilesToSign Include="$(BinDir)*.dll" Exclude="$(BinDir)*.ni.dll" />
+    <FilesToSign Include="$(BinDir)*.exe" />
+  </ItemGroup>
+
+  <!--
+    for some reason the signing task incorrectly attemps to strong-name sign
+    native images which causes the signing step to fail for obvious reasons.
+  -->
+  <ItemGroup>
+    <FilesToSign Include="$(BinDir)*.ni.dll">
+      <StrongName>None</StrongName>
+    </FilesToSign>
+  </ItemGroup>
+
+  <!-- populates item group FilesToSign with the list of files to sign -->
+  <Target Name="GetFilesToSignItems" BeforeTargets="SignFiles">
+    <!-- read all of the marker files and populate the FilesToSign item group -->
+    <ItemGroup>
+      <SignMarkerFile Include="$(OutDir)**\*.requires_signing" />
+    </ItemGroup>
+    <ReadSigningRequired MarkerFiles="@(SignMarkerFile)">
+      <Output TaskParameter="SigningMetadata" ItemName="FilesToSign" />
+    </ReadSigningRequired>
+  </Target>
+
+  <!-- now that signing is done clean up any marker files -->
+  <Target Name="CleanUpMarkerFiles" AfterTargets="SignFiles">
+    <!-- now that the files have been signed delete the marker files -->
+    <Delete Files="@(SignMarkerFile)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
New build project, sign.builds, is to be built post building of binaries
so that they can be real-signed in the official build.