### PR TITLE
ARM, SOS: correct IP and SP value in ClrStack command

### DIFF
--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -745,7 +745,7 @@ namespace Output
                     if (precision > width)
                         precision = width;
 
-                    ExtOut(leftAlign ? "%-*.*p" : "%*.*p", width, precision, (__int64)mValue);
+                    ExtOut(leftAlign ? "%-*.*p" : "%*.*p", width, precision, SOS_PTR(mValue));
                 }
                 else
                 {


### PR DESCRIPTION
This fixes casting 64bit pointer value in 32bit machines
that show wrong IP and SP values in ClrStack command.

Related Issue: #5037