### PR TITLE
Documentation: Add CoreCLR binary folder to test results

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -61,6 +61,7 @@ function print_results {
     echo "======================="
     echo "     Test Results"
     echo "======================="
+    echo "# CoreCLR Bin Dir  : $coreClrBinDir"
     echo "# Tests Discovered : $countTotalTests"
     echo "# Passed           : $countPassedTests"
     echo "# Failed           : $countFailedTests"


### PR DESCRIPTION
When we get the test result with ./coreclr/tests/runtest.sh,
it is difficult to classify the build mode that we used after some days.

Let's add information of the CoreCLR binary folder in order to
know easily the build mode  that we used between debug-build and release-build mode.

* Before PR:

```
=======================
     Test Results
=======================
# Tests Discovered : 9870
# Passed           : 9094
# Failed           : 432
# Skipped          : 344
=======================
```

* After PR:
```
=======================
     Test Results
=======================
# CoreCLR Bin Dir : coreclr/bin/Product/Linux.arm.Release
# Tests Discovered : 9870
# Passed           : 9094
# Failed           : 432
# Skipped          : 344
=======================
```


Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>