### PR TITLE
Tail call test failure fixes.

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -1,9 +1,6 @@
 <Project DefaultTargets = "GetListOfTestCmds"
     xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
-             <Issue>2329</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\delegate\_simpleoddpower_il_d\_simpleoddpower_il_d.cmd" >
              <Issue>2407</Issue>
         </ExcludeList>
@@ -289,6 +286,9 @@
       </ExcludeList>
       <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.cmd">
         <Issue>4992</Issue>
+      </ExcludeList>
+      <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
+         <Issue>x86 JIT doesn't support tail call opt</Issue>
       </ExcludeList>
     </ItemGroup>
 </Project>

--- a/tests/src/JIT/opt/Tailcall/TailcallVerifyWithPrefix.il
+++ b/tests/src/JIT/opt/Tailcall/TailcallVerifyWithPrefix.il
@@ -96,7 +96,7 @@
       IL_0031:  ldstr      "Caller"
       IL_0036:  callvirt   instance int32 [mscorlib]System.String::IndexOf(string)
       IL_003b:  ldc.i4.m1
-      IL_003c:  bne.un.s   IL_006e
+      IL_003c:  beq.s   IL_006e
 
       IL_003e:  ldstr      "FAILED: Found the word 'Caller' in the stacktrace."
       IL_0043:  call       void [System.Console]System.Console::WriteLine(string)
@@ -173,7 +173,7 @@
   {
     // Code size       154 (0x9a)
     .maxstack  3
-    .locals init ([0] class [mscorlib]System.Exception e)
+    .locals init ([0] class [System.Console]System.Exception e)
     IL_0000:  ldstr      "Executing Condition18.Test2 - Caller(imperative se"
     + "curity): Arguments: None - ReturnType: 3 byte struct; Callee: Arguments"
     + ": None - ReturnType: 3 byte struct"
@@ -6686,8 +6686,10 @@
     IL_011d:  box        [mscorlib]System.Int16
     IL_0122:  stelem.ref
     IL_0123:  ldloc.0
-    IL_0124:  call       void [System.Console]System.Console::WriteLine(string,
-                                                                  object[])
+    IL_0124:  call       void [System.Console]System.Console::Write(string)
+              callvirt   instance string [mscorlib]System.Object::ToString()
+              call       void [System.Console]System.Console::WriteLine(string)
+
     IL_0129:  ldc.i4.1
     IL_012a:  volatile.
     IL_012c:  ldsfld     int32 modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) TailcallVerify.Condition7::zero
@@ -8793,17 +8795,19 @@
       IL_0035:  ldstr      "FAILED: The fields in the return type struct have "
       + "the wrong values."
       IL_003a:  call       void [System.Console]System.Console::WriteLine(string)
-      IL_003f:  ldstr      "v.i1: {0} != byte.MinValue || v.i2: {1} != short.M"
+      IL_003f:  ldstr      "v.i1: != byte.MinValue || v.i2: != short.M"
       + "axValue"
+                call       void [System.Console]System.Console::WriteLine(string)
       IL_0044:  ldloca.s   v
       IL_0046:  ldfld      uint8 TailcallVerify.ValueType3Bytes::i1
       IL_004b:  box        [mscorlib]System.Byte
+                callvirt   instance string [mscorlib]System.Object::ToString()
+                call       void [System.Console]System.Console::WriteLine(string)
       IL_0050:  ldloca.s   v
       IL_0052:  ldfld      int16 TailcallVerify.ValueType3Bytes::i2
       IL_0057:  box        [mscorlib]System.Int16
-      IL_005c:  call       void [System.Console]System.Console::WriteLine(string,
-                                                                    object,
-                                                                    object)
+                callvirt   instance string [mscorlib]System.Object::ToString()
+      IL_005c:  call       void [System.Console]System.Console::WriteLine(string)
       IL_0061:  leave.s    IL_0082
 
     }  // end .try

--- a/tests/src/JIT/opt/Tailcall/TailcallVerifyWithPrefix.ilproj
+++ b/tests/src/JIT/opt/Tailcall/TailcallVerifyWithPrefix.ilproj
@@ -28,8 +28,9 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
-    
+     <DebugType>None</DebugType>
+     <Optimize>True</Optimize>
+     <JitOptimizationSensitive>true</JitOptimizationSensitive>    
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TailcallVerifyWithPrefix.il TailcallVerifyTransparentLibraryWithPrefix.il TailcallVerifyVerifiableLibraryWithPrefix.il" />

--- a/tests/x86_jit32_issues.targets
+++ b/tests/x86_jit32_issues.targets
@@ -149,7 +149,7 @@
              <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
-             <Issue>needs triage</Issue>
+             <Issue>x86 JIT doesn't support tail call opt</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\global_il_d\global_il_d.cmd" >
              <Issue>needs triage</Issue>

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -242,7 +242,7 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd">
-      <Issue>needs triage</Issue>
+      <Issue>x86 JIT doesn't support tail call opt</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\Threading\ThreadStatics\ThreadStatic06\ThreadStatic06.cmd Timed Out">
       <Issue>needs triage</Issue>


### PR DESCRIPTION
This is the fix to issue #2329 .

The repro is a case of following tail call IL pattern:

```
// Caller method is TYP_VOID and hence to make tail call
// possible return value of callee method is discarded using pop
tail.call
pop
ret
```

Say the above repro case is Ilasm'ed in debug mode, then JIT will generate debuggable code.  Tail prefix is honored even while generating debuggable code.  While generating debuggable code JIT spills type stack contents and the IR generated for the above IL is as follows

var = tail.call
GT_COMM(var, GT_NOP)
GT_RETURN

This IR form is not handled by tail call morphing logic. In fact morph logic is expecting pop in the following IR form alone:

```
tail.call
pop generated side-effect free tree
GT_RETURN
```

Hence the assert failure in morph.

On close examination I found multiple issues
1) impIsTailCallILPattern() allows the following tail call IL patterns on Amd64
```
tail.call, nop*, ret
tail.call, nop*, pop, nop*, ret

```
This would mean the resulting IR forms could be
```
a) tail.call, GT_NOP*, GT_RETURN
b) var=tail.call, GT_NOP*, GT_RETURN(var)
c) tail.call, GT_NOP*, pop generated IR tree, GT_NOP*, GT_RETURN
d) var=tail.call, GT_NOP*, pop generated IR tree, GT_NOP*, GT_RETURN

```
But tail call morph logic is not handling the above IR forms.

This didn't surface surface so far on desktop because tail prefixed tests seem to be always getting ilasm'ed in release mode.

2) TailCallVerifyWithPrefix.exe test itself has a bug (wrong if condition) due to which a test method is failing.  Plus it is using Console.WriteLine() method from mscorlib instead of System.Console.dll on coreclr, plus it is using some WriteLine() methods that are available only on desktop.

3) TailCallVerifyWithPrefix.exe has some sub-tests that depend on tail call optimization (i.e. implicit tail call optimization).  Hence for this test to pass in its entirety, it needs to be always ilasm'ed in release mode.
4) We have test hole that we need tail prefixed tests that always get ilasm'ed in debug mode so that some of the IR forms mentioned above get exercised.

This change fixes issues 1, 2 and 3.
For issue 4 above, I am going to open a git issue for extracting tail prefixed tests cases from tailCallVerifywithPrefix.exe into a separate test case that is always ilasm'ed in debug mode.

I ran SuperPMI asmdiffs by sync'ing back to the changeset at which SuperPMI is functional and re-applying my fix.  There were no asm diffs.


Fixes #2329 