### PR TITLE
Make Microsoft.NetCore.JIT package dependency of CoreCLR package

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
     <PackagePlatforms>x64;x86;arm</PackagePlatforms>
@@ -16,6 +16,9 @@
          Despite the unconditioned package dependency it is constrained by runtime IDs within it's own package -->
     <Dependency Include="Microsoft.NETCore.Windows.ApiSets">
       <Version>1.0.1-rc3-23915</Version>
+    </Dependency>
+    <Dependency Include="Microsoft.NETCore.Jit">
+      <Version>1.0.2$(VersionSuffix)</Version>
     </Dependency>
     <ProjectReference Include="win\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)libclrjit.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so"/>
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.so"/>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/osx/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/osx/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)libclrjit.dylib"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.dylib"/>
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.dylib"/>
     <NativeSplittableBinary Include="$(BinDir)libmscordaccore.dylib"/>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)libclrjit.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so"/>
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.so"/>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)libclrjit.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so"/>
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.so"/>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -12,7 +12,6 @@
   
   <ItemGroup>
     <ArchitectureSpecificNativeFile Include="$(BinDir)clretwrc.dll"/>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)clrjit.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)coreclr.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)dbgshim.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscordaccore.dll"/>


### PR DESCRIPTION
This change make Microsoft.NetCore.Jit package a dependency of CoreCLR nuget package and remove JIT binary from the CoreCLR nuget package.

Also fixed a version issue.

Fixes https://github.com/dotnet/coreclr/issues/4531

@ericstj @pgavlin PTAL.

CC @jkotas 