### PR TITLE
Fix Assert Error "Unexpected size when returning struct by value" on …

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -134,7 +134,7 @@ void                Compiler::lvaInitTypeRef()
     if (!hasRetBuffArg && varTypeIsStruct(info.compRetNativeType))
     {
 #if FEATURE_MULTIREG_RET && defined(FEATURE_HFA)
-        if (!info.compIsVarArgs && !opts.compUseSoftFP && IsHfa(info.compMethodInfo->args.retTypeClass))
+        if (!info.compIsVarArgs && IsHfa(info.compMethodInfo->args.retTypeClass))
         {
             info.compRetNativeType = TYP_STRUCT;
         }


### PR DESCRIPTION
…arm-softfp

For only arm-softfp there is an assert error when returning struct as value.

Fixes #4924

Signed-off-by: Hanjoung Lee hanjoung.lee@samsung.com