### PR TITLE
In coreclr, expose GetUninitializedObject on RuntimeHelpers

### DIFF
--- a/src/mscorlib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -17,6 +17,7 @@ namespace System.Runtime.CompilerServices {
     using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
     using System.Runtime.ConstrainedExecution;
+    using System.Runtime.Serialization;
     using System.Security.Permissions;
     using System.Threading;
     using System.Runtime.Versioning;
@@ -24,6 +25,15 @@ namespace System.Runtime.CompilerServices {
 
     public static class RuntimeHelpers
     {
+#if FEATURE_CORECLR
+        // Exposed here as a more appropriate place than on FormatterServices itself,
+        // which is a high level reflection heavy type.
+        public static Object GetUninitializedObject(Type type)
+        {
+            return FormatterServices.GetUninitializedObject(type);
+        }
+#endif // FEATURE_CORECLR
+
         [System.Security.SecuritySafeCritical]  // auto-generated
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern void InitializeArray(Array array,RuntimeFieldHandle fldHandle);

--- a/src/mscorlib/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/mscorlib/src/System/Runtime/Serialization/FormatterServices.cs
@@ -255,7 +255,11 @@ namespace System.Runtime.Serialization {
         // instance of an immutable type.
         //
         [System.Security.SecurityCritical]  // auto-generated_required
+#if FEATURE_CORECLR // In CoreCLR, we expose on RuntimeHelpers instead
+        internal static Object GetUninitializedObject(Type type) {
+#else
         public static Object GetUninitializedObject(Type type) {
+#endif // FEATURE_CORECLR
             if ((object)type == null) {
                 throw new ArgumentNullException("type");
             }


### PR DESCRIPTION
@jkotas @weshaggard As suggested by Jan, move this API from FormatterServices, which is a relatively high level type dependent on Reflection, to a lower level location on S.R.CompilerServices.RuntimeHelpers.

I'll make a follow up change to corefx to expose it in S.R.Serialization.Primitives.dll.
https://github.com/dotnet/corefx/pull/8691