### PR TITLE
Mark doublealign test as incompatible with GCStress

### DIFF
--- a/tests/src/JIT/opt/perf/doublealign/objects.csproj
+++ b/tests/src/JIT/opt/perf/doublealign/objects.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="objects.cs" />


### PR DESCRIPTION
The test makes assumptions about allocation alignment that cannot be
expected to hold under GCStress, particularly on 32-bit platforms.