### PR TITLE
ARM64: Fix R2R EntryPoint for Intrinsic

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -7036,19 +7036,19 @@ GenTreePtr    Compiler::fgOptimizeDelegateConstructor(GenTreePtr call, CORINFO_C
             {
                 // The first argument of the helper is delegate this pointer
                 GenTreeArgList* helperArgs = gtNewArgList(call->gtCall.gtCallObjp);
+                CORINFO_CONST_LOOKUP entryPoint;
 
                 // The second argument of the helper is the target object pointers
                 helperArgs->gtOp.gtOp2 = gtNewArgList(call->gtCall.gtCallArgs->gtOp.gtOp1);
 
                 call = gtNewHelperCallNode(CORINFO_HELP_READYTORUN_DELEGATE_CTOR, TYP_VOID, GTF_EXCEPT, helperArgs);
 #if COR_JIT_EE_VERSION > 460
-                info.compCompHnd->getReadyToRunDelegateCtorHelper(targetMethod->gtFptrVal.gtLdftnResolvedToken, clsHnd, &call->gtCall.gtEntryPoint);
+                info.compCompHnd->getReadyToRunDelegateCtorHelper(targetMethod->gtFptrVal.gtLdftnResolvedToken, clsHnd, &entryPoint);
 #else
                 info.compCompHnd->getReadyToRunHelper(targetMethod->gtFptrVal.gtLdftnResolvedToken,
-                    CORINFO_HELP_READYTORUN_DELEGATE_CTOR, &call->gtCall.gtEntryPoint);
+                    CORINFO_HELP_READYTORUN_DELEGATE_CTOR, &entryPoint);
 #endif
-                // This is the case from GetDynamicHelperCell.
-                call->gtCall.setR2RRelativeIndir();
+                call->gtCall.setEntryPoint(entryPoint);
             }
         }
         else

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6537,7 +6537,7 @@ GenTreePtr          Compiler::gtCloneExpr(GenTree * tree,
 #endif
 
 #ifdef FEATURE_READYTORUN_COMPILER
-        copy->gtCall.gtEntryPoint = tree->gtCall.gtEntryPoint;
+        copy->gtCall.setEntryPoint(tree->gtCall.gtEntryPoint);
 #endif
 
 #ifdef DEBUG

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2874,7 +2874,8 @@ struct GenTreeCall final : public GenTree
     bool IsVirtualStubRelativeIndir() { return (gtCallMoreFlags & GTF_CALL_M_VIRTSTUB_REL_INDIRECT) != 0; } 
 #ifdef FEATURE_READYTORUN_COMPILER
     bool IsR2RRelativeIndir() { return (gtCallMoreFlags & GTF_CALL_M_R2R_REL_INDIRECT) != 0; }
-    void setR2RRelativeIndir() {
+    void setEntryPoint(CORINFO_CONST_LOOKUP entryPoint) {
+        gtEntryPoint = entryPoint;
         if (gtEntryPoint.accessType == IAT_PVALUE)
         {
             gtCallMoreFlags |= GTF_CALL_M_R2R_REL_INDIRECT;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1645,10 +1645,7 @@ GenTreePtr          Compiler::impReadyToRunHelperToTree(
 
     GenTreePtr op1 = gtNewHelperCallNode(helper, type, GTF_EXCEPT, args);
 
-    op1->gtCall.gtEntryPoint = lookup;
-
-    // This is the case from GetDynamicHelperCell.
-    op1->gtCall.setR2RRelativeIndir();
+    op1->gtCall.setEntryPoint(lookup);
 
     return op1;
 }
@@ -4520,10 +4517,8 @@ GenTreePtr Compiler::impImportLdvirtftn (GenTreePtr thisPtr,
         GenTreeCall* call = gtNewHelperCallNode(CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR,
             TYP_I_IMPL, GTF_EXCEPT, gtNewArgList(thisPtr));
 
-        call->gtEntryPoint = pCallInfo->codePointerLookup.constLookup;
+        call->setEntryPoint(pCallInfo->codePointerLookup.constLookup);
 
-        // This is the case from GetDynamicHelperCell.
-        call->setR2RRelativeIndir();
         return call;
     }
 #endif
@@ -5196,10 +5191,7 @@ GenTreePtr Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN * pResolv
 
             op1 = gtNewHelperCallNode(CORINFO_HELP_READYTORUN_STATIC_BASE, TYP_BYREF, callFlags);
 
-            op1->gtCall.gtEntryPoint = pFieldInfo->fieldLookup;
-
-            // This is the case from GetDynamicHelperCell.
-            op1->gtCall.setR2RRelativeIndir();
+            op1->gtCall.setEntryPoint(pFieldInfo->fieldLookup);
         }
         else
 #endif
@@ -6035,10 +6027,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
 #ifdef FEATURE_READYTORUN_COMPILER
                 if (opts.IsReadyToRun())
                 {
-                    call->gtCall.gtEntryPoint = callInfo->codePointerLookup.constLookup;
-
-                    // This is the case from GetExternalMethodCell.
-                    call->gtCall.setR2RRelativeIndir();
+                    call->gtCall.setEntryPoint(callInfo->codePointerLookup.constLookup);
                 }
 #endif
                 break;

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -1643,7 +1643,7 @@ void Rationalizer::RewriteNodeAsCall(GenTreePtr* ppTree, Compiler::fgWalkData* d
     call = comp->fgMorphArgs(call);
     call->CopyCosts(tree);
 #ifdef FEATURE_READYTORUN_COMPILER
-    call->gtCall.gtEntryPoint = entryPoint;
+    call->gtCall.setEntryPoint(entryPoint);
 #endif
 
     // Replace "tree" with "call"

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -68156,14 +68156,14 @@ RelativePath=readytorun\mainv1\mainv1.cmd
 WorkingDir=readytorun\mainv1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=NEW;EXPECTED_FAIL
+Categories=NEW;EXPECTED_PASS
 HostStyle=0
 [mainv2.cmd_9807]
 RelativePath=readytorun\mainv2\mainv2.cmd
 WorkingDir=readytorun\mainv2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=NEW;EXPECTED_FAIL
+Categories=NEW;EXPECTED_PASS
 HostStyle=0
 [Dev10_629953.cmd_9808]
 RelativePath=reflection\regression\dev10bugs\Dev10_629953\Dev10_629953.cmd


### PR DESCRIPTION
This is fix for missing case that we should handle call that needs to pass
indirect cell address. The call appears in rationalizer, which is
originally an intrinsic when we import it.
I also refactor the code so that when we set entryPoint we ensure
tagging such information on the tree.