### PR TITLE
Fix GCStress=0xC when build(tests).cmd called from outside root

### DIFF
--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -187,7 +187,7 @@ REM ===
 REM === Resolve runtime dependences
 REM ===
 REM =========================================================================================
-call tests\setup-runtime-dependencies.cmd /arch %__BuildArch% /outputdir %__BinDir%
+call %__TestDir%\setup-runtime-dependencies.cmd /arch %__BuildArch% /outputdir %__BinDir%
 
 REM =========================================================================================
 REM ===


### PR DESCRIPTION
Use absolute path intead of relative path when invoking
setup-runtime-dependencies.cmd, which is required for GCStress=0xC to
work.