### PR TITLE
Mark opt/perf/doublealign/Locals stress sensitive

### DIFF
--- a/tests/src/JIT/opt/perf/doublealign/Locals.csproj
+++ b/tests/src/JIT/opt/perf/doublealign/Locals.csproj
@@ -32,6 +32,7 @@
     <NoLogo>True</NoLogo>
     <NoStandardLib>True</NoStandardLib>
     <Noconfig>True</Noconfig>
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
The test is known to not work correctly under JitMinOpts. Disable it from running in that configuration.

@RussKeldorph @dotnet/jit-contrib ptal