### PR TITLE
Mark b103058 as stress sensitive

### DIFF
--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b103058/b103058.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b103058/b103058.csproj
@@ -32,6 +32,7 @@
     <NoStandardLib>True</NoStandardLib>
     <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This test will not work under min opts, disable it under stress scenarios to address this.

@RussKeldorph @dotnet/jit-contrib ptal