### PR TITLE
Fix PreRelease label

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -138,7 +138,6 @@
 
   <!-- Packaging properties -->
   <PropertyGroup>
-    <PreReleaseLabel>rc3</PreReleaseLabel>
     <PackageDescriptionFile>$(SourceDir).nuget/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(SourceDir).nuget/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(SourceDir).nuget/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>

--- a/src/.nuget/Microsoft.NETCore.Jit/dir.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/dir.props
@@ -4,9 +4,7 @@
 
   <!-- Packaging properties -->
   <PropertyGroup>
-    <PreReleaseLabel>rc3</PreReleaseLabel>
     <PackageDescriptionFile>$(MSBuildThisFileDirectory)descriptions.json</PackageDescriptionFile>
-
     <!-- NOTE: for various required properties, we use the values from the imported dir.props. -->
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Currently, the props file forces a specific preRelease label used in versioning. Instead of doing so, rely on the build infrastructure to generate the same.

Post this change, both CoreCLR and JIT packages have "rc2" prerelease label, which comes from the infra, instead of "rc3".

@ericstj PTAL.

CC @pgavlin @russellhadley 