### PR TITLE
Add JitOptimizationSensitive property to GC/API/WeakReference/IsAlive…

### DIFF
--- a/tests/src/GC/API/GCHandle/Weak.csproj
+++ b/tests/src/GC/API/GCHandle/Weak.csproj
@@ -32,6 +32,9 @@
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Weak.cs" />
   </ItemGroup>

--- a/tests/src/GC/API/WeakReference/IsAlive.csproj
+++ b/tests/src/GC/API/WeakReference/IsAlive.csproj
@@ -33,6 +33,9 @@
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="IsAlive.cs" />
   </ItemGroup>


### PR DESCRIPTION
….csproj and GC/API/GCHandle/Weak.csproj

The testcases could fail if a reference is assigned to a stack temp.