### PR TITLE
Generate perfmap symbol file for System.Private.CoreLib

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -258,6 +258,15 @@ build_CoreLib_ni()
             echo "Failed to generate native image for mscorlib facade."
             exit 1
         fi
+
+        if [ "$__BuildOS" == "Linux" ]; then
+            echo "Generating symbol file for System.Private.CoreLib."
+            $__BinDir/crossgen /CreatePerfMap $__BinDir $__BinDir/System.Private.CoreLib.ni.dll
+            if [ $? -ne 0 ]; then
+                echo "Failed to generate symbol file for System.Private.CoreLib."
+                exit 1
+            fi
+        fi
     fi
 }
 


### PR DESCRIPTION
Generate the perfmap file for System.Private.CoreLib as part of the build.  Initially, this is beneficial to help catch regressions in crossgen that affect perfmap generation.

Going forward, we'd like to ship perfmap files so that they don't need to be re-generated every time profiling needs them.