### PR TITLE
Removing ' from bash command line

### DIFF
--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString.csproj
@@ -16,7 +16,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestExecutionArguments>empty "This is a long string that I am trying to test to be sure that the Exchange can handle this long of a string.  If it can't then that's bad and we will have to fix it."</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_1.csproj
@@ -16,6 +16,7 @@
     <CLRTestKind>RunOnly</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ExchangeTString.csproj</CLRTestProjectToRun>
+    <CLRTestExecutionArguments>empty "This is a long string that I am trying to test to be sure that the Exchange can handle this long of a string.  If it can not then that is bad and we will have to fix it."</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
@sergiy-k PTAL
http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/x64_release_ubuntu_pri1_tst/238/consoleFull

apparently linux hates " ' " when used in the following command 

 export CLRTestExecutionArguments='empty "This is a long string that I am trying to test to be sure that the Exchange can handle this long of a string.  If it can't"';
