### PR TITLE
Linux/ARM: Regression fix in release build after applying "UNW_ARM_UNWIND_METHOD=6"

### DIFF
--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -264,20 +264,6 @@ int ExecuteManagedAssembly(
     // Indicates failure
     int exitCode = -1;
 
-#ifdef _ARM_
-    // LIBUNWIND-ARM has a bug of side effect with DWARF mode
-    // Ref: https://github.com/dotnet/coreclr/issues/3462
-    // This is why Fedora is disabling it by default as well.
-    // Assuming that we cannot enforce the user to set
-    // environmental variables for third party packages,
-    // we set the environmental variable of libunwind locally here.
-
-    // Without this, any exception handling will fail, so let's do this
-    // as early as possible.
-    // 0x1: DWARF / 0x2: FRAME / 0x4: EXIDX
-    putenv(const_cast<char *>("UNW_ARM_UNWIND_METHOD=6"));
-#endif // _ARM_
-
     std::string coreClrDllPath(clrFilesAbsolutePath);
     coreClrDllPath.append("/");
     coreClrDllPath.append(coreClrDll);


### PR DESCRIPTION
> https://github.com/dotnet/coreclr/pull/3502/
>   Fix Stack Unwind Behavior of Libunwind-ARM

We have been getting the 300+ failures(in ./JIT/ directory) in release-build
mode whenever we have always run CoreCLR unit-test since
https://github.com/myungjoo/coreclr/commit/35b5df6888f1574e6ef9313c6bc8522d1817573d.

Let's keep continually the existing unwind environment variable if build
environment is not ARM32 and debug build mode(that tested with the patch  #3502).

(ref - https://wiki.linaro.org/KenWerner/Sandbox/libunwind#overhead_of_the_ARM_specific_unwind-tables)

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>