### PR TITLE
Add gchist SOS commands for Unix

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -114,6 +114,7 @@ else(WIN32)
     datatarget.cpp
     eeheap.cpp
     exts.cpp
+    gchist.cpp
     gcroot.cpp
     metadata.cpp
     sildasm.cpp

--- a/src/ToolBox/SOS/Strike/gchist.cpp
+++ b/src/ToolBox/SOS/Strike/gchist.cpp
@@ -33,13 +33,13 @@
 #include <string.h>
 #include <stddef.h>
 
+#include "strike.h"
 // We need to define the target address type.  This will be used in the 
 // functions that read directly from the debuggee address space, vs. using 
 // the DAC tgo read the DAC-ized data structures.
 #include "daccess.h"
 //#include "dbgeng.h"
 
-#include "strike.h"
 
 #ifndef STRESS_LOG
 #define STRESS_LOG

--- a/src/ToolBox/SOS/Strike/stressLogDump.cpp
+++ b/src/ToolBox/SOS/Strike/stressLogDump.cpp
@@ -20,10 +20,8 @@
 #include "stresslog.h"
 
 
-#ifndef FEATURE_PAL
 void GcHistClear();
 void GcHistAddLog(LPCSTR msg, StressMsg* stressMsg);
-#endif
 
 
 /*********************************************************************************/
@@ -334,12 +332,7 @@ HRESULT StressLog::Dump(ULONG64 outProcLog, const char* fileName, struct IDebugD
 
     if (bDoGcHist)
     {
-#ifdef FEATURE_PAL
-        ExtOut ("GC history not supported\n");
-        return S_FALSE;
-#else
         GcHistClear();
-#endif
     }
     else
     {
@@ -496,13 +489,11 @@ HRESULT StressLog::Dump(ULONG64 outProcLog, const char* fileName, struct IDebugD
             double deltaTime = ((double) (latestMsg->timeStamp - inProcLog.startTimeStamp)) / inProcLog.tickFrequency;
             if (bDoGcHist)
             {
-#ifndef FEATURE_PAL
                 if (strcmp(format, ThreadStressLog::TaskSwitchMsg()) == 0)
                 {
                     latestLog->threadId = (unsigned)(size_t)latestMsg->args[0];
                 }
                 GcHistAddLog(format, latestMsg);                                
-#endif // FEATURE_PAL
             }
             else
             {

--- a/src/ToolBox/SOS/lldbplugin/soscommand.cpp
+++ b/src/ToolBox/SOS/lldbplugin/soscommand.cpp
@@ -142,6 +142,11 @@ sosCommandInitialize(lldb::SBDebugger debugger)
     interpreter.AddCommand("ip2md", new sosCommand("IP2MD"), "Displays the MethodDesc structure at the specified address in code that has been JIT-compiled.");
     interpreter.AddCommand("name2ee", new sosCommand("Name2EE"), "Displays the MethodTable structure and EEClass structure for the specified type or method in the specified module.");
     interpreter.AddCommand("pe", new sosCommand("PrintException"), "Displays and formats fields of any object derived from the Exception class at the specified address.");
+    interpreter.AddCommand("histclear", new sosCommand("HistClear"), "Releases any resources used by the family of Hist commands.");
+    interpreter.AddCommand("histinit", new sosCommand("HistInit"), "Initializes the SOS structures from the stress log saved in the debuggee.");
+    interpreter.AddCommand("histobj", new sosCommand("HistObj"), "Examines all stress log relocation records and displays the chain of garbage collection relocations that may have led to the address passed in as an argument.");
+    interpreter.AddCommand("histobjfind", new sosCommand("HistObjFind"), "Displays all the log entries that reference an object at the specified address.");
+    interpreter.AddCommand("histroot", new sosCommand("HistRoot"), "Displays information related to both promotions and relocations of the specified root.");
     interpreter.AddCommand("soshelp", new sosCommand("Help"), "Displays all available commands when no parameter is specified, or displays detailed help information about the specified command. soshelp <command>");
     return true;
 }


### PR DESCRIPTION
This change adds HistClear, HistInit, HistObj, HistObjFind and HistRoot
commands to SOS on Unix.