### PR TITLE
Linux/ARM: Display execution time of ./tests/runtest.sh

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -899,6 +899,7 @@ scriptPath=$(dirname $0)
 ${scriptPath}/setup-runtime-dependencies.sh --outputDir=$coreOverlayDir
 
 cd "$testRootDir"
+time_start=$(date +"%s")
 if [ -z "$testDirectories" ]
 then
     # No test directories were specified, so run everything in the current 
@@ -918,6 +919,11 @@ fi
 finish_remaining_tests
 
 print_results
+
+time_end=$(date +"%s")
+time_diff=$(($time_end-$time_start))
+echo "$(($time_diff / 60)) minutes and $(($time_diff % 60)) seconds taken to run CoreCLR tests."
+
 xunit_output_end
 
 if [ "$CoreClrCoverage" == "ON" ]


### PR DESCRIPTION
We have to wait for a long time to complete all unit tests on the ARM-based
embedded boards (e.g, Raspberry Pi, Odroid, Chromebook) compared to the
X86-based server environment. So, let's display execution time after finishing
the unit test.

* After PR:

`128 minutes and 36 seconds elapsed for unit test.`



Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>