### PR TITLE
Fix a few bugs in named mutexes

### DIFF
--- a/src/pal/src/include/pal/mutex.hpp
+++ b/src/pal/src/include/pal/mutex.hpp
@@ -146,6 +146,7 @@ private:
     HANDLE m_processLockHandle;
     int m_sharedLockFileDescriptor;
 #endif // !HAVE_FULLY_FEATURED_PTHREAD_MUTEXES
+    CorUnix::CPalThread *m_lockOwnerThread;
     NamedMutexProcessData *m_nextInThreadOwnedNamedMutexList;
 
 public:
@@ -166,6 +167,7 @@ public:
 
 private:
     NamedMutexSharedData *GetSharedData() const;
+    void SetLockOwnerThread(CorUnix::CPalThread *lockOwnerThread);
 public:
     NamedMutexProcessData *GetNextInThreadOwnedNamedMutexList() const;
     void SetNextInThreadOwnedNamedMutexList(NamedMutexProcessData *next);

--- a/src/pal/src/include/pal/synchobjects.hpp
+++ b/src/pal/src/include/pal/synchobjects.hpp
@@ -114,6 +114,8 @@ namespace CorUnix
         Volatile<LONG>         m_lLocalSynchLockCount;
         Volatile<LONG>         m_lSharedSynchLockCount;
         LIST_ENTRY             m_leOwnedObjsList;
+
+        CRITICAL_SECTION       m_ownedNamedMutexListLock;
         NamedMutexProcessData *m_ownedNamedMutexListHead;
 
         ThreadNativeWaitData   m_tnwdNativeData;
@@ -172,7 +174,7 @@ namespace CorUnix
         void AddOwnedNamedMutex(NamedMutexProcessData *processData);
         void RemoveOwnedNamedMutex(NamedMutexProcessData *processData);
         NamedMutexProcessData *RemoveFirstOwnedNamedMutex();
-        bool OwnsNamedMutex(NamedMutexProcessData *processData) const;
+        bool OwnsNamedMutex(NamedMutexProcessData *processData);
 
         // The following methods provide access to the native wait lock for 
         // those implementations that need a lock to protect the support for 


### PR DESCRIPTION
- When using pthread mutexes, if the mutex tells us that it was abandoned (due to owning process abruptly shutting down), it was calling ReleaseMutex (which takes a handle) on the pthread mutex object. It shouldn't be releasing the lock anyway.
- When a locked mutex is closed, it wasn't being removed from the owner thread's list of owned named mutexes. This case should be treated as abandoned.
  - Since this could potentially happen from a different thread too, added the lock owner thread to the process data, added a critical section around list operations, and I now remove the process data from the owner thread's list on Close.
- Parent/child named mutex pal tests:
  - Cleaned up tests by refactoring the setup/cleanup code
  - Fixed a race where the parent may start a new child test before the previous child test closes its events
  - Added new tests for verifying that a mutex is locked after it reports that it was abandoned, and abandoning by closing a locked mutex