### PR TITLE
Prevent core dumps at shutdown due to ETW subsystem

### DIFF
--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -4190,10 +4190,6 @@ static void TerminateDebugger(void)
         g_pDebugInterface->StopDebugger();
     }
 
-    // Delete this after Debugger, since Debugger may use this.
-    EEDbgInterfaceImpl::Terminate();
-    _ASSERTE(g_pEEDbgInterfaceImpl == NULL); // Terminate nulls this out for us.
-
     g_CORDebuggerControlFlags = DBCF_NORMAL_OPERATION;
 
 #if !defined(FEATURE_CORECLR) // simple hosting

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -4188,7 +4188,6 @@ static void TerminateDebugger(void)
 
         // This will kill the helper thread, delete the Debugger object, and free all resources.
         g_pDebugInterface->StopDebugger();
-        g_pDebugInterface = NULL;
     }
 
     // Delete this after Debugger, since Debugger may use this.

--- a/src/vm/eedbginterfaceimpl.cpp
+++ b/src/vm/eedbginterfaceimpl.cpp
@@ -1657,8 +1657,6 @@ BOOL EEDbgInterfaceImpl::ObjIsInstanceOf(Object *pElement, TypeHandle toTypeHnd)
 void EEDbgInterfaceImpl::ClearAllDebugInterfaceReferences()
 {
     LIMITED_METHOD_CONTRACT;
-
-    g_pDebugInterface = NULL;
 }
 
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
Fix an instance where debugger shutdown races with ETW subsystem, causing segfaults.