### PR TITLE
Change Unix HW exception unwinding to start at the exception location

### DIFF
--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -211,6 +211,8 @@ Return value:
 VOID
 SEHProcessException(PEXCEPTION_POINTERS pointers)
 {
+    pointers->ContextRecord->ContextFlags |= CONTEXT_EXCEPTION_ACTIVE;
+
     if (!IsInDebugBreak(pointers->ExceptionRecord->ExceptionAddress))
     {
         PAL_SEHException exception(pointers->ExceptionRecord, pointers->ContextRecord);


### PR DESCRIPTION
This change modifies the HW exception handling on Unix so that it doesn't unwind
from the context of the DispatchManagedException through the signal trampoline
to the actual location of the exception and uses the exception's context instead.
This fixes problem that some target systems like ARM Linux have with unwinding
through that trampoline.