### PR TITLE
Task & Thread Pool scheduled item optimizations

### DIFF
--- a/src/mscorlib/model.CoreLib.xml
+++ b/src/mscorlib/model.CoreLib.xml
@@ -6898,7 +6898,7 @@
       <Member Name="Write(System.Double@,System.Double)"/>
       <Member Name="Write&lt;T&gt;(T@,T)"/>
     </Type>
-    <Type Status="ImplRoot" Name="System.Threading.IThreadPoolWorkItem">
+    <Type Status="ImplRoot" Name="System.Threading.DeferrableWorkItem">
       <Member Status="ImplRoot" Name="ExecuteWorkItem"/>
     </Type>
     <Type Name="System.Threading.Monitor">
@@ -6921,10 +6921,10 @@
     <Type Name="System.Threading.ManualResetEvent">
       <Member Name="#ctor(System.Boolean)" />
     </Type>
-    <Type Status="ImplRoot" Name="System.Threading.QueueUserWorkItemCallback">
+    <Type Status="ImplRoot" Name="System.Threading.QueueUserWorkItemCallbackWithContext">
       <Member Status="ImplRoot" Name="#ctor(System.Threading.WaitCallback,System.Object,System.Threading.ExecutionContext)"/>
     </Type>
-    <Type Status="ImplRoot" Name="System.Threading.QueueUserWorkItemCallbackDefaultContext">
+    <Type Status="ImplRoot" Name="System.Threading.QueueUserWorkItemCallback">
       <Member Status="ImplRoot" Name="#ctor(System.Threading.WaitCallback,System.Object)"/>
     </Type>
     <Type Name="System.Threading.SynchronizationContext">
@@ -6995,8 +6995,8 @@
       <Member Name="GetMinThreads(System.Int32@,System.Int32@)" />
       <Member Status="ImplRoot" Name="RegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,System.UInt32,System.Boolean,System.Threading.StackCrawlMark@,System.Boolean)" />
       <Member Status="ImplRoot" Name="RegisterWaitForSingleObjectNative(System.Threading.WaitHandle,System.Object,System.UInt32,System.Boolean,System.Threading.RegisteredWaitHandle,System.Threading.StackCrawlMark@,System.Boolean)" />
-      <Member Status="ImplRoot" Name="UnsafeQueueCustomWorkItem(System.Threading.IThreadPoolWorkItem,System.Boolean)"/>
-      <Member Status="ImplRoot" Name="TryPopCustomWorkItem(System.Threading.IThreadPoolWorkItem)"/>
+      <Member Status="ImplRoot" Name="UnsafeQueueCustomWorkItem(System.Threading.DeferrableWorkItem,System.Boolean)"/>
+      <Member Status="ImplRoot" Name="TryPopCustomWorkItem(System.Threading.DeferrableWorkItem)"/>
       <Member Status="ImplRoot" Name="GetQueuedWorkItemsForDebugger"/>
       <Member Status="ImplRoot" Name="GetGloballyQueuedWorkItemsForDebugger"/>
       <Member Status="ImplRoot" Name="GetLocallyQueuedWorkItemsForDebugger"/>

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6898,7 +6898,7 @@
       <Member Name="Write(System.Double@,System.Double)"/>
       <Member Name="Write&lt;T&gt;(T@,T)"/>
     </Type>
-    <Type Status="ImplRoot" Name="System.Threading.IThreadPoolWorkItem">
+    <Type Status="ImplRoot" Name="System.Threading.DeferrableWorkItem">
       <Member Status="ImplRoot" Name="ExecuteWorkItem"/>
     </Type>
     <Type Name="System.Threading.Monitor">
@@ -6921,10 +6921,10 @@
     <Type Name="System.Threading.ManualResetEvent">
       <Member Name="#ctor(System.Boolean)" />
     </Type>
-    <Type Status="ImplRoot" Name="System.Threading.QueueUserWorkItemCallback">
+    <Type Status="ImplRoot" Name="System.Threading.QueueUserWorkItemCallbackWithContext">
       <Member Status="ImplRoot" Name="#ctor(System.Threading.WaitCallback,System.Object,System.Threading.ExecutionContext)"/>
     </Type>
-    <Type Status="ImplRoot" Name="System.Threading.QueueUserWorkItemCallbackDefaultContext">
+    <Type Status="ImplRoot" Name="System.Threading.QueueUserWorkItemCallback">
       <Member Status="ImplRoot" Name="#ctor(System.Threading.WaitCallback,System.Object)"/>
     </Type>
     <Type Name="System.Threading.SynchronizationContext">
@@ -6995,8 +6995,8 @@
       <Member Name="GetMinThreads(System.Int32@,System.Int32@)" />
       <Member Status="ImplRoot" Name="RegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,System.UInt32,System.Boolean,System.Threading.StackCrawlMark@,System.Boolean)" />
       <Member Status="ImplRoot" Name="RegisterWaitForSingleObjectNative(System.Threading.WaitHandle,System.Object,System.UInt32,System.Boolean,System.Threading.RegisteredWaitHandle,System.Threading.StackCrawlMark@,System.Boolean)" />
-      <Member Status="ImplRoot" Name="UnsafeQueueCustomWorkItem(System.Threading.IThreadPoolWorkItem,System.Boolean)"/>
-      <Member Status="ImplRoot" Name="TryPopCustomWorkItem(System.Threading.IThreadPoolWorkItem)"/>
+      <Member Status="ImplRoot" Name="UnsafeQueueCustomWorkItem(System.Threading.DeferrableWorkItem,System.Boolean)"/>
+      <Member Status="ImplRoot" Name="TryPopCustomWorkItem(System.Threading.DeferrableWorkItem)"/>
       <Member Status="ImplRoot" Name="GetQueuedWorkItemsForDebugger"/>
       <Member Status="ImplRoot" Name="GetGloballyQueuedWorkItemsForDebugger"/>
       <Member Status="ImplRoot" Name="GetLocallyQueuedWorkItemsForDebugger"/>

--- a/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
@@ -81,20 +81,17 @@ namespace System.Threading
         private const int NO_MAXIMUM = Int32.MaxValue;
 
         // Task in a linked list of asynchronous waiters
-        private sealed class TaskNode : Task<bool>, IThreadPoolWorkItem
+        private sealed class TaskNode : Task<bool>
         {
             internal TaskNode Prev, Next;
             internal TaskNode() : base() {}
 
             [SecurityCritical]
-            void IThreadPoolWorkItem.ExecuteWorkItem()
+            internal override void ExecuteWorkItem()
             {
                 bool setSuccessfully = TrySetResult(true);
                 Contract.Assert(setSuccessfully, "Should have been able to complete task");
             }
-
-            [SecurityCritical]
-            void IThreadPoolWorkItem.MarkAborted(ThreadAbortException tae) { /* nop */ }
         }
         #endregion
 

--- a/src/mscorlib/src/System/Threading/Tasks/TaskToApm.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskToApm.cs
@@ -139,7 +139,7 @@ namespace System.Threading.Tasks
             // to capture both the Action delegate and the ExecutionContext in a single object).  
             // In the future, if performance requirements drove a need, those four 
             // allocations could be reduced to one.  This would be achieved by having TaskWrapperAsyncResult
-            // also implement ITaskCompletionAction (and optionally IThreadPoolWorkItem).  It would need
+            // also implement ITaskCompletionAction (and optionally DeferrableWorkItem).  It would need
             // additional fields to store the AsyncCallback and an ExecutionContext.  Once configured, 
             // it would be set into the Task as a continuation.  Its Invoke method would then be run when 
             // the antecedent completed, and, doing all of the necessary work to flow ExecutionContext, 

--- a/src/mscorlib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -108,9 +108,9 @@ namespace System.Threading.Tasks
             return FilterTasksFromWorkItems(ThreadPool.GetQueuedWorkItems());
         }
 
-        private IEnumerable<Task> FilterTasksFromWorkItems(IEnumerable<IThreadPoolWorkItem> tpwItems)
+        private IEnumerable<Task> FilterTasksFromWorkItems(IEnumerable<DeferrableWorkItem> tpwItems)
         {
-            foreach (IThreadPoolWorkItem tpwi in tpwItems)
+            foreach (DeferrableWorkItem tpwi in tpwItems)
             {
                 if (tpwi is Task)
                 {


### PR DESCRIPTION
Interface `IThreadPoolWorkItem` => abstract class `DeferrableWorkItem` to reduce interface implementations, as larger number of implementers.

Smaller `QueueUserWorkItemCallback`, `AwaitTaskContinuation`, `SynchronizationContextAwaitTaskContinuation`, `TaskSchedulerAwaitTaskContinuation` depending on what execution context needs to be stored.

3 variants of each for DefaultContext, FlowSuppressed, CustomContext

Might be too far? 

Testing now