### PR TITLE
Move nuget packages to RC4

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -138,7 +138,7 @@
 
   <!-- Packaging properties -->
   <PropertyGroup>
-    <PreReleaseLabel>rc3</PreReleaseLabel>
+    <PreReleaseLabel>rc4</PreReleaseLabel>
     <PackageDescriptionFile>$(SourceDir).nuget/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(SourceDir).nuget/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(SourceDir).nuget/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>

--- a/src/.nuget/Microsoft.NETCore.Jit/dir.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/dir.props
@@ -4,7 +4,7 @@
 
   <!-- Packaging properties -->
   <PropertyGroup>
-    <PreReleaseLabel>rc3</PreReleaseLabel>
+    <PreReleaseLabel>rc4</PreReleaseLabel>
     <PackageDescriptionFile>$(MSBuildThisFileDirectory)descriptions.json</PackageDescriptionFile>
 
     <!-- NOTE: for various required properties, we use the values from the imported dir.props. -->


### PR DESCRIPTION
@ellismg PTAL. This is to correspond with your closed build change for both CoreCLR and JIT packages.

@pgavlin @russellhadley FYI