### PR TITLE
[WIP] according to arm64 calling convention valuetypes can be returned in

### DIFF
--- a/src/vm/arm64/CallDescrWorkerARM64.asm
+++ b/src/vm/arm64/CallDescrWorkerARM64.asm
@@ -119,7 +119,7 @@ LNoDoubleHFAReturn
 
 LIntReturn
         ;; Save return value into retbuf for int
-        str     x0, [x19, #(CallDescrData__returnValue + 0)]
+        stp     x0, x1, [x19, #(CallDescrData__returnValue + 0)]
 
 LReturnDone
 

--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -780,7 +780,7 @@ UMThunkStub_WrongAppDomain
     bl                  UM2MDoADCallBack
 
     ; restore integral return value
-    ldr                 x0, [fp, #16]
+    ldp                 x0, x1, [fp, #16]
 
     ; restore FP or HFA return value
     RESTORE_FLOAT_ARGUMENT_REGISTERS sp, 0
@@ -858,7 +858,7 @@ UM2MThunk_WrapperHelper_RegArgumentsSetup
     blr                 x16
 
     ; save integral return value
-    str                 x0, [x19]
+    stp                 x0, x1, [x19]
     ; save FP/HFA return values
     SAVE_FLOAT_ARGUMENT_REGISTERS x19, -1 * (SIZEOF__FloatArgumentRegisters + 16)
 
@@ -931,13 +931,13 @@ UM2MThunk_WrapperHelper_RegArgumentsSetup
     PROLOG_SAVE_REG_PAIR   x25, x26, #64
     PROLOG_SAVE_REG_PAIR   x27, x28, #80
 
-    str x0, [sp, #96]
+    stp x0, x1, [sp, #96]
     ; HFA return value can be in d0-d3
     stp d0, d1, [sp, #112]
     stp d2, d3, [sp, #128]
     mov x0, sp
     bl OnHijackScalarWorker
-    ldr x0, [sp, #96]
+    ldp x0, x1, [sp, #96]
     ldp d0, d1, [sp, #112]
     ldp d2, d3, [sp, #128]
 

--- a/src/vm/arm64/cgencpu.h
+++ b/src/vm/arm64/cgencpu.h
@@ -54,8 +54,8 @@ class ComCallMethodDesc;
 #define CACHE_LINE_SIZE                         32  // As per Intel Optimization Manual the cache line size is 32 bytes
 #define LOG2SLOT                                LOG2_PTRSIZE
 
-#define ENREGISTERED_RETURNTYPE_MAXSIZE         64  // bytes (maximum HFA size is 8 doubles)
-#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE 8   // bytes
+#define ENREGISTERED_RETURNTYPE_MAXSIZE         32  // bytes (maximum HFA size is 4 doubles)
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE 16   // bytes
 #define ENREGISTERED_PARAMTYPE_MAXSIZE          16  // bytes (max value type size that can be passed by value)
 
 #define CALLDESCR_ARGREGS                       1   // CallDescrWorker has ArgumentRegister parameter
@@ -456,8 +456,11 @@ struct HijackArgs
     DWORD64 X19, X20, X21, X22, X23, X24, X25, X26, X27, X28;
     union
     {
-        DWORD64 X0;
-        size_t ReturnValue;
+        struct {
+            DWORD64 X0;
+            DWORD64 X1;
+        };
+        size_t ReturnValue[2];
     };
 };
 


### PR DESCRIPTION
registers x0 & x1. Earlier it was assumed that return value can only be
present in x0. This fixes that. Return for float & HFA were correctly implemented.