### PR TITLE
Fix sos ClrStack print of GC frames for ARM/Linux

### DIFF
--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -13408,7 +13408,7 @@ Exit:
             {
                 DWORD_PTR vtAddr;
                 MOVE(vtAddr, TO_TADDR(FrameData.frameAddr));
-                if (g_sos->GetFrameName(vtAddr, 1024, wszNameBuffer, NULL) == S_OK)
+                if (g_sos->GetFrameName(TO_CDADDR(vtAddr), 1024, wszNameBuffer, NULL) == S_OK)
                     ExtDbgOut("[%ls: %08x] ", wszNameBuffer, FrameData.frameAddr);  
                 else
                     ExtDbgOut("[Frame: %08x] ", FrameData.frameAddr);

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -6467,7 +6467,7 @@ WString GetFrameFromAddress(TADDR frameAddr, IXCLRDataStackWalk *pStackWalk, BOO
     WString frameOutput;
     frameOutput += W("[");
 
-    if (SUCCEEDED(g_sos->GetFrameName(vtAddr, mdNameLen, g_mdName, NULL)))
+    if (SUCCEEDED(g_sos->GetFrameName(TO_CDADDR(vtAddr), mdNameLen, g_mdName, NULL)))
         frameOutput += g_mdName;
     else
         frameOutput += W("Frame");


### PR DESCRIPTION
This PR fixes output from ClrStack for GC frames on Linux/ARM. Corresponding issue #5037. 
\cc @chunseoklee @seanshpark @mikem8361 @janvorli 