### PR TITLE
Improve vtbl matching loop in DacGetVtNameW.

### DIFF
--- a/src/debug/daccess/dacfn.cpp
+++ b/src/debug/daccess/dacfn.cpp
@@ -1104,6 +1104,7 @@ PWSTR    DacGetVtNameW(TADDR targetVtable)
         if (targetVtable == (*targ + DacGlobalBase()))
         {
             pszRet = (PWSTR) *(g_dacVtStrings + (targ - targStart));
+            break;
         }
 
         targ++;


### PR DESCRIPTION
The loop in `DacGetVtNameW` continues even after match is found. This PR improves the loop by breaking it out in such situation.
\cc @janvorli @mikem8361 @seanshpark @chunseoklee @lucenticus @kvochko .