### PR TITLE
Enable FEATURE_MULTIREG_RET for x86 RyuJIT

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1330,7 +1330,7 @@ public:
 #endif
 
 #if FEATURE_MULTIREG_RET
-    GenTreePtr               impAssignStructClassToVar(GenTreePtr op, CORINFO_CLASS_HANDLE hClass);
+    GenTreePtr               impAssignMultiRegTypeToVar(GenTreePtr op, CORINFO_CLASS_HANDLE hClass);
 #endif // FEATURE_MULTIREG_RET
 
 #ifdef _TARGET_ARM_
@@ -2643,6 +2643,9 @@ protected :
 
     GenTreePtr          impFixupCallStructReturn(GenTreePtr           call,
                                                  CORINFO_CLASS_HANDLE retClsHnd);
+
+    GenTreePtr          impFixupCallLongReturn(GenTreePtr           call,
+                                               CORINFO_CLASS_HANDLE retClsHnd);
 
     GenTreePtr          impFixupStructReturnType(GenTreePtr       op,
                                                  CORINFO_CLASS_HANDLE retClsHnd);

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -385,9 +385,17 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define FEATURE_FASTTAILCALL     0       // Tail calls made as epilog+jmp
   #define FEATURE_TAILCALL_OPT     0       // opportunistic Tail calls (without ".tail" prefix) made as fast tail calls.
   #define FEATURE_SET_FLAGS        0       // Set to true to force the JIT to mark the trees with GTF_SET_FLAGS when the flags need to be set
+#ifdef LEGACY_BACKEND
   #define FEATURE_MULTIREG_ARGS_OR_RET  0  // Support for passing and/or returning single values in more than one register
   #define FEATURE_MULTIREG_ARGS         0  // Support for passing a single argument in more than one register  
   #define FEATURE_MULTIREG_RET          0  // Support for returning a single value in more than one register  
+#else
+  #define FEATURE_MULTIREG_ARGS_OR_RET  1  // Support for passing and/or returning single values in more than one register
+  #define FEATURE_MULTIREG_ARGS         0  // Support for passing a single argument in more than one register  
+  #define FEATURE_MULTIREG_RET          1  // Support for returning a single value in more than one register  
+  #define MAX_RET_MULTIREG_BYTES        8  // Maximum size of a struct that could be returned in more than one register
+#endif
+
   #define MAX_ARG_REG_COUNT             2  // Maximum registers used to pass an argument.
   #define MAX_RET_REG_COUNT             2  // Maximum registers used to return a value.
 


### PR DESCRIPTION
This change enables the following:

1) Enable FEATURE_MULTIREG_RET for x86 RyuJIT, which is used for calls
with long return types.

2) Enable ReturnTypeDesc for x86 RyuJIT to describe the return types for
longs. Included in this is setting up the correct number of return
registers for longs on x86, and setting up the correct registers for long
returns. This is required for enabling impFixupCallLongReturn.

3) Enabling HasMultiRegRetVal for longs on x86.

4) Enabling impFixupCallLongReturn and impAssignStructClassToVar for x86
longs. Sets up the call's ReturnTypeDesc and sets lvIsMultiRegArgOrRet for
long's tmp.