### PR TITLE
Fix Guid's GetHashCode to work better (not ignore parts of it)

### DIFF
--- a/src/mscorlib/src/System/Guid.cs
+++ b/src/mscorlib/src/System/Guid.cs
@@ -921,9 +921,12 @@ namespace System {
             return ToString("D",null);
         }
 
-        public override int GetHashCode()
+        [System.Security.SecuritySafeCritical]
+        public unsafe override int GetHashCode()
         {
-            return _a ^ (((int)_b << 16) | (int)(ushort)_c) ^ (((int)_f << 24) | _k);
+            // Simply XOR all the bits of the GUID 32 bits at a time.
+            fixed (int* ptr = &this._a)
+                 return ptr[0] ^ ptr[1] ^ ptr[2] ^ ptr[3];
         }
 
         // Returns true if and only if the guid represented


### PR DESCRIPTION
A common pattern is that the last bits of the GUID are the most unique, however our current hash code ignores most of them (only 6 of the last 8 bytes are ignored).  Fix this by simply XOR all bits in the GUID 32 bits at a time.   This is more efficient and a better hash than what we have currently.

This is not a theoretical problem.   Users in OSG had a large dictionary indexed by GUID and had a scenario that took 60 seconds and using a good hash code reduced it to 200msec.  

This does use unsafe code but we already have unsafe code elsewhere in guid.cs.   We could decide to have union fields to avoid the unsafe code but this is a smaller delta.  