### PR TITLE
Update runtest.sh to accommodate a change in CoreFX

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -356,7 +356,7 @@ function create_core_overlay {
                 exit_with_error "$errorSource" "Directory specified in --coreFxBinDir does not exist: $currDir"
             fi
 
-            (cd $currDir && find . -iname '*.dll' \! -iwholename '*test*' \! -iwholename '*/ToolRuntime/*' \! -iwholename '*/RemoteExecutorConsoleApp/*' \! -iwholename '*/net*' \! -iwholename '*aot*' -exec cp -n '{}' "$coreOverlayDir/" \;)
+            (cd $currDir && find . -iwholename '*/netstandard/*.dll' \! -iwholename '*test*' \! -iwholename '*/ToolRuntime/*' \! -iwholename '*/RemoteExecutorConsoleApp/*' \! -iwholename '*aot*' -exec cp -n '{}' "$coreOverlayDir/" \;)
         done
     done <<< $coreFxBinDir
 


### PR DESCRIPTION
There was a change in CoreFX that broke creation of CoreOverlay on Unix platforms and caused all CoreCLR tests to fail with the 'System.DllNotFoundException: Unable to load DLL 'api-ms-win-*.dll' error.
This change updates runtest.sh to take into account the new layout of the CoreFX build.