### PR TITLE
ARM-CI: Mount Linux ARM emulator rootfs during each build

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1710,6 +1710,8 @@ combinedScenarios.each { scenario ->
                                         break
                                     }
                                     else {
+                                        // Unmount previously mounted rootfs and mount the Linux ARM emulator rootfs at /opt/linux-arm-emulator-root/
+                                        buildCommands += "sudo umount /opt/linux-arm-emulator-root/; sudo mount /opt/linux-arm-emulator/platform/rootfs-t30.ext4 /opt/linux-arm-emulator-root/"
                                         // Remove old copy of coreclr and copy the latest version of coreclr
                                         // This need to be done as it is not possible to clone the repository inside the chroot jail
                                         buildCommands += "sudo rm -rf /opt/linux-arm-emulator-root/home/coreclr; sudo mkdir /opt/linux-arm-emulator-root/home/coreclr; sudo cp -R ./ /opt/linux-arm-emulator-root/home/coreclr"


### PR DESCRIPTION
* Previous PR #4141 assumed that the rootfs is mounted
  throughout the lifespan of the CI machine
* Changing this to mount and unmount everytime a build is triggered

Signed-off-by: Prajwal A N <an.prajwal@samsung.com>