### PR TITLE
ARM-CI: Make the Linux ARM emulator check automatic

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1044,7 +1044,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                         Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} Cross ${configuration} Build")
                     }
                     else {
-                        Utilities.addGithubPRTriggerForBranch(job, branch, "Linux ARM Emulator Cross ${configuration} Build", "(?i).*test\\W+Linux\\W+arm\\W+emulator\\W+${configuration}.*")
+                        Utilities.addGithubPRTriggerForBranch(job, branch, "Linux ARM Emulator Cross ${configuration} Build")
                     }
                     break
                 default:


### PR DESCRIPTION
* Previously the Linux ARM emulator build had to be triggered manually
* Making this check automatic based on the stability of emulator build

Signed-off-by: Prajwal A N <an.prajwal@samsung.com>