### PR TITLE
Fix runtest.sh issues

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -350,16 +350,19 @@ function create_core_overlay {
             if [ ! -d "$currDir" ]; then
                 exit_with_error "$errorSource" "Directory specified in --coreFxBinDir does not exist: $currDir"
             fi
-
-            (cd $currDir && find . -iname '*.dll' \! -iwholename '*test*' \! -iwholename '*/ToolRuntime/*' \! -iwholename '*/RemoteExecutorConsoleApp/*' \! -iwholename '*/net*' \! -iwholename '*aot*' -exec cp -n '{}' "$coreOverlayDir/" \;)
+            pushd $currDir > /dev/null
+            for dirName in $(find . -iname '*.dll' \! -iwholename '*test*' \! -iwholename '*/ToolRuntime/*' \! -iwholename '*/RemoteExecutorConsoleApp/*' \! -iwholename '*/net*' \! -iwholename '*aot*' -exec dirname {} \; | uniq | sed 's/\.\/\(.*\)/\1/g'); do
+                cp -n -v "$currDir/$dirName/$dirName.dll" "$coreOverlayDir/"
+            done
+            popd > /dev/null
         done
     done <<< $coreFxBinDir
 
-    cp -f "$coreFxNativeBinDir/Native/"*."$libExtension" "$coreOverlayDir/" 2>/dev/null
+    cp -f -v "$coreFxNativeBinDir/Native/"*."$libExtension" "$coreOverlayDir/" 2>/dev/null
 
-    cp -f "$coreClrBinDir/"* "$coreOverlayDir/" 2>/dev/null
-    cp -f "$mscorlibDir/mscorlib.dll" "$coreOverlayDir/"
-    cp -n "$testDependenciesDir"/* "$coreOverlayDir/" 2>/dev/null
+    cp -f -v "$coreClrBinDir/"* "$coreOverlayDir/" 2>/dev/null
+    cp -f -v "$mscorlibDir/mscorlib.dll" "$coreOverlayDir/"
+    cp -n -v "$testDependenciesDir"/* "$coreOverlayDir/" 2>/dev/null
     if [ -f "$coreOverlayDir/mscorlib.ni.dll" ]; then
         # Test dependencies come from a Windows build, and mscorlib.ni.dll would be the one from Windows
         rm -f "$coreOverlayDir/mscorlib.ni.dll"


### PR DESCRIPTION
 - Prevent exceptions from leaking out of StackTrace (presently we are hitting ref/def mismatches because of dotnet/corefx#8836)
 - Expand the copy logic to try to be better around how we select what version of a library we pick up from CoreFX.