### PR TITLE
Add missing quote in new runtest.cmd arg

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -40,30 +40,30 @@ if /i "%1" == "-h"    goto Usage
 if /i "%1" == "/help" goto Usage
 if /i "%1" == "-help" goto Usage
 
-if /i "%1" == "x64"                 (set __BuildArch=x64&set __MSBuildBuildArch=x64&shift&goto Arg_Loop)
-if /i "%1" == "x86"                 (set __BuildArch=x86&set __MSBuildBuildArch=x86&shift&goto Arg_Loop)
+if /i "%1" == "x64"                   (set __BuildArch=x64&set __MSBuildBuildArch=x64&shift&goto Arg_Loop)
+if /i "%1" == "x86"                   (set __BuildArch=x86&set __MSBuildBuildArch=x86&shift&goto Arg_Loop)
 
-if /i "%1" == "debug"               (set __BuildType=Debug&shift&goto Arg_Loop)
-if /i "%1" == "release"             (set __BuildType=Release&shift&goto Arg_Loop)
-if /i "%1" == "checked"             (set __BuildType=Checked&shift&goto Arg_Loop)
+if /i "%1" == "debug"                 (set __BuildType=Debug&shift&goto Arg_Loop)
+if /i "%1" == "release"               (set __BuildType=Release&shift&goto Arg_Loop)
+if /i "%1" == "checked"               (set __BuildType=Checked&shift&goto Arg_Loop)
 
-if /i "%1" == "vs2013"              (set __VSVersion=%1&shift&goto Arg_Loop)
-if /i "%1" == "vs2015"              (set __VSVersion=%1&shift&goto Arg_Loop)
+if /i "%1" == "vs2013"                (set __VSVersion=%1&shift&goto Arg_Loop)
+if /i "%1" == "vs2015"                (set __VSVersion=%1&shift&goto Arg_Loop)
 
 if /i "%1" == "SkipWrapperGeneration" (set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
-if /i "%1" == "Exclude"             (set __Exclude=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "Exclude0"            (set __Exclude0=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "TestEnv"             (set __TestEnv=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "sequential"          (set __Sequential=1&shift&goto Arg_Loop)
-if /i "%1" == "crossgen"            (set __DoCrossgen=1&shift&goto Arg_Loop)
-if /i "%1" == "longgctests"         (set __LongGCTests=1&shift&goto Arg_Loop)
-if /i "%1" == "jitstress"            (set COMPlus_JitStress=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "jitstressregs"        (set COMPlus_JitStressRegs=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "jitminopts           (set COMPlus_JITMinOpts=1&shift&shift&goto Arg_Loop)
-if /i "%1" == "jitforcerelocs"      (set COMPlus_ForceRelocs=1&shift&shift&goto Arg_Loop)
-if /i "%1" == "GenerateLayoutOnly"  (set __GenerateLayoutOnly=1&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
-if /i "%1" == "PerfTests"           (set __PerfTests=true&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
-if /i "%1" == "runcrossgentests"    (set __RunCrossgenTests=1&shift&goto Arg_Loop)
+if /i "%1" == "Exclude"               (set __Exclude=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "Exclude0"              (set __Exclude0=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "TestEnv"               (set __TestEnv=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "sequential"            (set __Sequential=1&shift&goto Arg_Loop)
+if /i "%1" == "crossgen"              (set __DoCrossgen=1&shift&goto Arg_Loop)
+if /i "%1" == "longgctests"           (set __LongGCTests=1&shift&goto Arg_Loop)
+if /i "%1" == "jitstress"             (set COMPlus_JitStress=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "jitstressregs"         (set COMPlus_JitStressRegs=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "jitminopts"            (set COMPlus_JITMinOpts=1&shift&shift&goto Arg_Loop)
+if /i "%1" == "jitforcerelocs"        (set COMPlus_ForceRelocs=1&shift&shift&goto Arg_Loop)
+if /i "%1" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
+if /i "%1" == "PerfTests"             (set __PerfTests=true&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
+if /i "%1" == "runcrossgentests"      (set __RunCrossgenTests=1&shift&goto Arg_Loop)
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.


### PR DESCRIPTION
https://github.com/dotnet/coreclr/pull/5153 introduced a bug when passing args to runtest.cmd (just a missing closing quote). This should fix that.