### PR TITLE
Add Fedora, OpenSuse and Ubuntu 16.04 packages

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -103,18 +103,13 @@ case $OSName in
 esac
 
 if [ "$__BuildOS" == "Linux" ]; then
-        # Detect Distro
-        if [ "$(cat /etc/*-release | grep -cim1 ubuntu)" -eq 1 ]; then
-            export __DistroName=ubuntu
-        elif [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
-            export __DistroName=rhel
-        elif [ "$(cat /etc/*-release | grep -cim1 rhel)" -eq 1 ]; then
-            export __DistroName=rhel
-        elif [ "$(cat /etc/*-release | grep -cim1 debian)" -eq 1 ]; then
-            export __DistroName=debian
-        else
-            export __DistroName=""
-        fi
+    if [ ! -e /etc/os-release ]; then
+        echo "WARNING: Can not determine runtime id for current distro."
+        export __DistroRid=""
+    else
+        source /etc/os-release
+        export __DistroRid="$ID.$VERSION_ID-$__BuildArch"
+    fi
 fi
 
 __IntermediatesDir="$__ProjectRoot/bin/obj/$__BuildOS.$__BuildArch.$__BuildType"

--- a/dir.props
+++ b/dir.props
@@ -132,7 +132,7 @@
     <TargetsUnix Condition="'$(TargetsFreeBSD)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsNetBSD)' == 'true' or '$(TargetsOSX)' == 'true'">true</TargetsUnix>
 
     <!-- We are only tracking Linux Distributions for Nuget RID mapping -->
-    <DistroName Condition="'$(TargetsLinux)' == 'true'">$(__DistroName)</DistroName>
+    <DistroRid Condition="'$(TargetsLinux)' == 'true'">$(__DistroRid)</DistroRid>
 
   </PropertyGroup>
 

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -3,17 +3,12 @@
 initDistroName()
 {
     if [ "$1" == "Linux" ]; then
-        # Detect Distro
-        if [ "$(cat /etc/*-release | grep -cim1 ubuntu)" -eq 1 ]; then
-            export __DistroName=ubuntu
-        elif [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
-            export __DistroName=centos
-        elif [ "$(cat /etc/*-release | grep -cim1 rhel)" -eq 1 ]; then
-            export __DistroName=rhel
-        elif [ "$(cat /etc/*-release | grep -cim1 debian)" -eq 1 ]; then
-            export __DistroName=debian
+        if [ ! -e /etc/os-release ]; then
+            echo "WARNING: Can not determine runtime id for current distro."
+            export __DistroRid=""
         else
-            export __DistroName=""
+            source /etc/os-release
+            export __DistroRid="$ID.$VERSION_ID-$__BuildArch"
         fi
     fi
 }
@@ -41,7 +36,7 @@ __BUILD_TOOLS_PATH=$__PACKAGES_DIR/Microsoft.DotNet.BuildTools/$__BUILD_TOOLS_PA
 __PROJECT_JSON_PATH=$__TOOLRUNTIME_DIR/$__BUILD_TOOLS_PACKAGE_VERSION
 __PROJECT_JSON_FILE=$__PROJECT_JSON_PATH/project.json
 __PROJECT_JSON_CONTENTS="{ \"dependencies\": { \"Microsoft.DotNet.BuildTools\": \"$__BUILD_TOOLS_PACKAGE_VERSION\" }, \"frameworks\": { \"dnxcore50\": { } } }"
-__DistroName=""
+__DistroRid=""
 
 OSName=$(uname -s)
 case $OSName in
@@ -65,12 +60,12 @@ esac
 # Initialize Linux Distribution name and .NET CLI package name.
 
 initDistroName $OS
-if [ "$__DistroName" == "centos" ]; then
+if [ "$__DistroRid" == "centos.7-x64" ]; then
     __DOTNET_PKG=dotnet-dev-centos-x64
 fi
 
-if [ "$__DistroName" == "rhel" ]; then
-    __DOTNET_PKG=dotnet-dev-centos-x64
+if [ "$__DistroRid" == "rhel.7.2-x64" ]; then
+    __DOTNET_PKG=dotnet-dev-rhel-x64
 fi
 
 # Work around mac build issue 

--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
@@ -19,15 +19,27 @@
       <OSGroup>Windows_NT</OSGroup>
       <Platform>x86</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'rhel'" Include="rhel/Microsoft.NETCore.ILAsm.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.ILAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'debian'" Include="debian/Microsoft.NETCore.ILAsm.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.23-x64'" Include="fedora/23/Microsoft.NETCore.ILAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'ubuntu'" Include="ubuntu/Microsoft.NETCore.ILAsm.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.ILAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.ILAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-x64'" Include="ubuntu/14.04/Microsoft.NETCore.ILAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-x64'" Include="ubuntu/16.04/Microsoft.NETCore.ILAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
@@ -24,16 +24,25 @@
     <ProjectReference Include="win\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>arm</Platform>
     </ProjectReference>
-    <ProjectReference Include="rhel\Microsoft.NETCore.ILAsm.pkgproj">
-      <Platform>amd64</Platform>
-    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="osx\Microsoft.NETCore.ILAsm.pkgproj">
+    <ProjectReference Include="fedora\23\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="ubuntu\Microsoft.NETCore.ILAsm.pkgproj">
+    <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.ILAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="rhel\Microsoft.NETCore.ILAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\Microsoft.NETCore.ILAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.ILAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="osx\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/fedora/23/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/fedora/23/Microsoft.NETCore.ILAsm.pkgproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ilasm"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/opensuse/13.2/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/opensuse/13.2/Microsoft.NETCore.ILAsm.pkgproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ilasm"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/14.04/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/14.04/Microsoft.NETCore.ILAsm.pkgproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ilasm"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/16.04/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/16.04/Microsoft.NETCore.ILAsm.pkgproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ilasm"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
@@ -19,15 +19,27 @@
       <OSGroup>Windows_NT</OSGroup>
       <Platform>x86</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'rhel'" Include="rhel/Microsoft.NETCore.ILDAsm.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.ILDAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'debian'" Include="debian/Microsoft.NETCore.ILDAsm.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.23-x64'" Include="fedora/23/Microsoft.NETCore.ILDAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'ubuntu'" Include="ubuntu/Microsoft.NETCore.ILDAsm.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.ILDAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.ILDAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-x64'" Include="ubuntu/14.04/Microsoft.NETCore.ILDAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-x64'" Include="ubuntu/16.04/Microsoft.NETCore.ILDAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
@@ -24,16 +24,25 @@
     <ProjectReference Include="win\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>arm</Platform>
     </ProjectReference>
-    <ProjectReference Include="rhel\Microsoft.NETCore.ILDAsm.pkgproj">
-      <Platform>amd64</Platform>
-    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="osx\Microsoft.NETCore.ILDAsm.pkgproj">
+    <ProjectReference Include="fedora\23\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="ubuntu\Microsoft.NETCore.ILDAsm.pkgproj">
+    <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.ILDAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="rhel\Microsoft.NETCore.ILDAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\Microsoft.NETCore.ILDAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.ILDAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="osx\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/fedora/23/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/fedora/23/Microsoft.NETCore.ILDAsm.pkgproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ildasm"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/opensuse/13.2/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/opensuse/13.2/Microsoft.NETCore.ILDAsm.pkgproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ildasm"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/14.04/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/14.04/Microsoft.NETCore.ILDAsm.pkgproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ildasm"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/16.04/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/16.04/Microsoft.NETCore.ILDAsm.pkgproj
@@ -5,13 +5,13 @@
   <PropertyGroup>
     <Version>1.0.2</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
   
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)ilasm"/>
+    <NativeSplittableBinary Include="$(BinDir)ildasm"/>
 
     <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
 
@@ -26,7 +26,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
 
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
@@ -19,15 +19,27 @@
       <OSGroup>Windows_NT</OSGroup>
       <Platform>x86</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'rhel'" Include="rhel/Microsoft.NETCore.Jit.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.Jit.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'debian'" Include="debian/Microsoft.NETCore.Jit.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.23-x64'" Include="fedora/23/Microsoft.NETCore.Jit.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'ubuntu'" Include="ubuntu/Microsoft.NETCore.Jit.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.Jit.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.Jit.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-x64'" Include="ubuntu/14.04/Microsoft.NETCore.Jit.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-x64'" Include="ubuntu/16.04/Microsoft.NETCore.Jit.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
@@ -21,16 +21,25 @@
     <ProjectReference Include="win\Microsoft.NETCore.Jit.pkgproj">
       <Platform>arm</Platform>
     </ProjectReference>
-    <ProjectReference Include="rhel\Microsoft.NETCore.Jit.pkgproj">
-      <Platform>amd64</Platform>
-    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.Jit.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="osx\Microsoft.NETCore.Jit.pkgproj">
+    <ProjectReference Include="fedora\23\Microsoft.NETCore.Jit.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="ubuntu\Microsoft.NETCore.Jit.pkgproj">
+    <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.Jit.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="rhel\Microsoft.NETCore.Jit.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\Microsoft.NETCore.Jit.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.Jit.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="osx\Microsoft.NETCore.Jit.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/.nuget/Microsoft.NETCore.Jit/fedora/23/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/fedora/23/Microsoft.NETCore.Jit.pkgproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Version>1.0.2</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
-    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
     <!-- only build for x64 -->
     <PackagePlatforms>x64;</PackagePlatforms>
   </PropertyGroup>
@@ -26,7 +26,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
 
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>

--- a/src/.nuget/Microsoft.NETCore.Jit/opensuse/13.2/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/opensuse/13.2/Microsoft.NETCore.Jit.pkgproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.so"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/ubuntu/14.04/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/ubuntu/14.04/Microsoft.NETCore.Jit.pkgproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)ildasm"/>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.so"/>
 
     <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
 
@@ -26,7 +26,7 @@
     <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
 
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>

--- a/src/.nuget/Microsoft.NETCore.Jit/ubuntu/16.04/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/ubuntu/16.04/Microsoft.NETCore.Jit.pkgproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.so"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
@@ -19,15 +19,27 @@
       <OSGroup>Windows_NT</OSGroup>
       <Platform>x86</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'rhel'" Include="rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'debian'" Include="debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.23-x64'" Include="fedora/23/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
-    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'ubuntu'" Include="ubuntu/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-x64'" Include="ubuntu/14.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-x64'" Include="ubuntu/16.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -29,16 +29,25 @@
     <ProjectReference Include="win\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>arm</Platform>
     </ProjectReference>
-    <ProjectReference Include="rhel\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
-      <Platform>amd64</Platform>
-    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="osx\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+    <ProjectReference Include="fedora\23\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
-    <ProjectReference Include="ubuntu\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+    <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="rhel\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="osx\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
   </ItemGroup>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/fedora/23/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/fedora/23/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libcoreclr.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libdbgshim.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libmscordbi.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libsos.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libsosplugin.so"/>
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll"/>
+    <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll"/>
+    <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll"/>
+    <ArchitectureSpecificToolFile Include="$(BinDir)crossgen"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+
+    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
+    <File Include="@(ArchitectureSpecificLibFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
+    </File>
+
+    <!-- No reference: don't permit reference to the implementation from lib -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/netstandard1.0</TargetPath>
+    </File>
+
+    <File Include="@(ArchitectureSpecificToolFile)">
+      <TargetPath>tools</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/13.2/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/13.2/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libcoreclr.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libdbgshim.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libmscordbi.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libsos.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libsosplugin.so"/>
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll"/>
+    <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll"/>
+    <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll"/>
+    <ArchitectureSpecificToolFile Include="$(BinDir)crossgen"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+
+    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
+    <File Include="@(ArchitectureSpecificLibFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
+    </File>
+
+    <!-- No reference: don't permit reference to the implementation from lib -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/netstandard1.0</TargetPath>
+    </File>
+
+    <File Include="@(ArchitectureSpecificToolFile)">
+      <TargetPath>tools</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/14.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/14.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -55,7 +55,7 @@
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt"/>
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen"/>
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
 
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/16.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/16.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.2</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libcoreclr.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libdbgshim.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libmscordbi.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libsos.so"/>
+    <NativeSplittableBinary Include="$(BinDir)libsosplugin.so"/>
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll"/>
+    <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll"/>
+    <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll"/>
+    <ArchitectureSpecificToolFile Include="$(BinDir)crossgen"/>
+
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
+
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+
+    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
+    <File Include="@(ArchitectureSpecificLibFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
+    </File>
+
+    <!-- No reference: don't permit reference to the implementation from lib -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/netstandard1.0</TargetPath>
+    </File>
+
+    <File Include="@(ArchitectureSpecificToolFile)">
+      <TargetPath>tools</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')"/>
+
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen"/>
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb"/>
+
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
 - Add packages for Fedora 23 and OpenSuse 13.2
 - Move the package authoring for Ubuntu into versioned folders
 - Update our selection logic for what to produce to be based on an
   actual RID instead of just a distro name, since that's now not enough
   with us building for two Ubuntu versions