### PR TITLE
Increase the timeout of long GC tests

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -316,10 +316,10 @@ if "%CORE_ROOT%" == "" (
 
 :: Long GC tests take about 10 minutes per test on average, so
 :: they often bump up against the default 10 minute timeout.
-:: 20 minutes is more than enough time for a test to complete successfully.
+:: 30 minutes is more than enough time for a test to complete successfully.
 if defined __LongGCTests (
-    echo Running Long GC tests, extending timeout to 20 minutes
-    set __TestTimeout=1200000
+    echo Running Long GC tests, extending timeout to 30 minutes
+    set __TestTimeout=1800000
 )
 
 set __BuildLogRootName=Tests_GenerateRuntimeLayout


### PR DESCRIPTION
Some of the GCSimulator tests are timing out on Windows, so this raises the timeout a little bit to ease that a little. Any tests that still timeout will be removed from the GCSimulator playlist.