### PR TITLE
WinMD Adapter should only lookup mscorlib in WinMD references

### DIFF
--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -62,6 +62,7 @@ const WCHAR kWatsonName2[] = W("drwtsn32");
 #define CoreLibNameLen 22
 #define CoreLibSatelliteName_A "System.Private.CoreLib.resources"
 #define CoreLibSatelliteNameLen 32
+#define LegacyCoreLibName_A "mscorlib"
 #else // !defined(FEATURE_CORECLR)
 #define CoreLibName_W W("mscorlib")
 #define CoreLibName_IL_W W("mscorlib.dll")
@@ -74,6 +75,7 @@ const WCHAR kWatsonName2[] = W("drwtsn32");
 #define CoreLibNameLen 8
 #define CoreLibSatelliteName_A "mscorlib.resources"
 #define CoreLibSatelliteNameLen 18
+#define LegacyCoreLibName_A "mscorlib"
 #endif // defined(FEATURE_CORECLR)
 
 class StringArrayList;

--- a/src/md/winmd/adapter.cpp
+++ b/src/md/winmd/adapter.cpp
@@ -157,7 +157,9 @@ HRESULT CheckIfWinMDAdapterNeeded(IMDCommon *pRawMDCommon)
         LPCSTR arefName;
         USHORT usMajorVersion;
         IfFailGo(pNewAdapter->m_pRawMetaModelCommonRO->CommonGetAssemblyRefProps(mdar, &usMajorVersion, NULL, NULL, NULL, NULL, NULL, NULL, &arefName, NULL, NULL, NULL));
-        if (0 == strcmp(arefName, CoreLibName_A))
+        
+        // We check for legacy Core library name since Windows.winmd references mscorlib and not System.Private.CoreLib
+        if (0 == strcmp(arefName, LegacyCoreLibName_A))
         {
             pNewAdapter->m_assemblyRefMscorlib = mdar;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/5229

@RyanByi @jkotas PTAL