### PR TITLE
Track call offsets

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2637,7 +2637,7 @@ protected :
                                              GenTreePtr     newobjThis,
                                              int            prefixFlags,
                                              CORINFO_CALL_INFO* callInfo,
-                                             IL_OFFSETX     ilOffset = BAD_IL_OFFSET);
+                                             IL_OFFSET      rawILOffset);
 
     bool                impMethodInfo_hasRetBuffArg(CORINFO_METHOD_INFO * methInfo);
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21481,7 +21481,7 @@ void                Compiler::fgInline()
             if ((expr->gtOper == GT_CALL) && ((expr->gtFlags & GTF_CALL_INLINE_CANDIDATE) != 0))
             {
                 GenTreeCall* call = expr->AsCall();
-                InlineResult inlineResult(this, call, stmt->gtInlineContext, "fgInline");
+                InlineResult inlineResult(this, call, stmt, "fgInline");
 
                 fgMorphStmt = stmt;
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5356,8 +5356,10 @@ GenTreeCall*          Compiler::gtNewCallNode(gtCallTypes     callType,
     node->gtCall.gtEntryPoint.addr = nullptr;
 #endif
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(INLINE_DATA)
+    // These get updated after call node is built.
     node->gtCall.gtInlineObservation = InlineObservation::CALLEE_UNUSED_INITIAL;
+    node->gtCall.gtRawILOffset = BAD_IL_OFFSET;
 #endif
 
 #ifdef DEBUGGING_SUPPORT

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2914,11 +2914,14 @@ struct GenTreeCall final : public GenTree
     CORINFO_CONST_LOOKUP gtEntryPoint;
 #endif
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(INLINE_DATA)
     // For non-inline candidates, track the first observation
     // that blocks candidacy.
     InlineObservation gtInlineObservation;
-#endif
+
+    // IL offset of the call wrt its parent method.
+    IL_OFFSET gtRawILOffset;
+#endif // defined(DEBUG) || defined(INLINE_DATA)
 
     GenTreeCall(var_types type) : 
         GenTree(GT_CALL, type) 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -5570,46 +5570,58 @@ bool                Compiler::impIsImplicitTailCallCandidate(OPCODE opcode,
 #endif  //FEATURE_TAILCALL_OPT    
 }
 
-/*****************************************************************************
- *
- *  Import the call instructions.
- *  For CEE_NEWOBJ, newobjThis should be the temp grabbed for the allocated
- *     uninitalized object.
- */
+//------------------------------------------------------------------------
+// impImportCall: import a call-inspiring opcode
+//
+// Arguments:
+//    opcode                    - opcode that inspires the call
+//    pResolvedToken            - resolved token for the call target
+//    pConstrainedResolvedToken - resolved constraint token (or nullptr)
+//    newObjThis                - tree for this pointer or uninitalized newobj temp (or nullptr)
+//    prefixFlags               - IL prefix flags for the call
+//    callInfo                  - EE supplied info for the call
+//    rawILOffset               - IL offset of the opcode
+//
+// Returns:
+//    Type of the call's return value.
+//
+// Notes:
+//    opcode can be CEE_CALL, CEE_CALLI, CEE_CALLVIRT, or CEE_NEWOBJ.
+//
+//    For CEE_NEWOBJ, newobjThis should be the temp grabbed for the allocated
+//    uninitalized object.
 
 #ifdef _PREFAST_
 #pragma warning(push)
 #pragma warning(disable:21000) // Suppress PREFast warning about overly large function
 #endif
 
-var_types           Compiler::impImportCall (OPCODE         opcode,
-                                             CORINFO_RESOLVED_TOKEN * pResolvedToken,
-                                             CORINFO_RESOLVED_TOKEN * pConstrainedResolvedToken, // Is this a "constrained." call on a type parameter?
-                                             GenTreePtr     newobjThis,
-                                             int            prefixFlags,
-                                             CORINFO_CALL_INFO * callInfo,
-                                             IL_OFFSETX     ilOffset)
+var_types  Compiler::impImportCall(OPCODE                  opcode,
+                                   CORINFO_RESOLVED_TOKEN* pResolvedToken,
+                                   CORINFO_RESOLVED_TOKEN* pConstrainedResolvedToken,
+                                   GenTreePtr              newobjThis,
+                                   int                     prefixFlags,
+                                   CORINFO_CALL_INFO*      callInfo,
+                                   IL_OFFSET               rawILOffset)
 {
     assert(opcode == CEE_CALL   || opcode == CEE_CALLVIRT ||
            opcode == CEE_NEWOBJ || opcode == CEE_CALLI);
 
+    IL_OFFSETX              ilOffset    = impCurILOffset(rawILOffset, true);
     var_types               callRetTyp  = TYP_COUNT;
     CORINFO_SIG_INFO*       sig         = nullptr;
     CORINFO_METHOD_HANDLE   methHnd     = nullptr;
     CORINFO_CLASS_HANDLE    clsHnd      = nullptr;
-
     unsigned                clsFlags    = 0;
     unsigned                mflags      = 0;
     unsigned                argFlags    = 0;
     GenTreePtr              call        = nullptr;
     GenTreeArgList*         args        = nullptr;
     CORINFO_THIS_TRANSFORM  constraintCallThisTransform = CORINFO_NO_THIS_TRANSFORM;
-
     CORINFO_CONTEXT_HANDLE  exactContextHnd = 0;
     BOOL                    exactContextNeedsRuntimeLookup = FALSE;
     bool                    canTailCall = true;
     const char*             szCanTailCallFailReason = nullptr;
-
     int                     tailCall     = prefixFlags & PREFIX_TAILCALL;
     bool                    readonlyCall = (prefixFlags & PREFIX_READONLY) != 0;
 
@@ -5693,7 +5705,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
         // supply the instantiation parameters necessary to make direct calls to underlying
         // shared generic code, rather than calling through instantiating stubs.  If the 
         // returned signature has CORINFO_CALLCONV_PARAMTYPE then this indicates that the JIT
-        // must indeed pass an instantaition parameter.
+        // must indeed pass an instantiation parameter.
 
         methHnd = callInfo->hMethod;
 
@@ -6554,6 +6566,14 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
                 
             if (!bIntrinsicImported)
             {
+
+#if defined(DEBUG) || defined(INLINE_DATA)
+
+                // Keep track of the raw IL offset of the call
+                call->gtCall.gtRawILOffset = rawILOffset;
+
+#endif // defined(DEBUG) || defined(INLINE_DATA)
+
                 // Is it an inline candidate?
                 impMarkInlineCandidate(call, exactContextHnd, callInfo);
             }
@@ -6769,6 +6789,14 @@ DONE_CALL:
                 impInlineInfo->thisDereferencedFirst = true;
             }
         }
+
+
+#if defined(DEBUG) || defined(INLINE_DATA)
+
+        // Keep track of the raw IL offset of the call
+        call->gtCall.gtRawILOffset = rawILOffset;
+
+#endif // defined(DEBUG) || defined(INLINE_DATA)
 
         // Is it an inline candidate?        
         impMarkInlineCandidate(call, exactContextHnd, callInfo);
@@ -9509,7 +9537,7 @@ RET:
             //All calls and delegates need a security callout.
             impHandleAccessAllowed(callInfo.accessAllowed, &callInfo.callsiteCalloutHelper);
 
-            callTyp = impImportCall(CEE_CALL, &resolvedToken, NULL, NULL, PREFIX_TAILCALL_EXPLICIT, &callInfo, impCurILOffset(opcodeOffs, true));
+            callTyp = impImportCall(CEE_CALL, &resolvedToken, NULL, NULL, PREFIX_TAILCALL_EXPLICIT, &callInfo, opcodeOffs);
 
             // And finish with the ret
             goto RET;
@@ -11681,7 +11709,7 @@ DO_LDFTN:
 #endif // FEATURE_CORECLR
             }
 
-            callTyp = impImportCall(opcode, &resolvedToken, constraintCall ? &constrainedResolvedToken : nullptr, newObjThisPtr, prefixFlags, &callInfo, impCurILOffset(opcodeOffs, true));
+            callTyp = impImportCall(opcode, &resolvedToken, constraintCall ? &constrainedResolvedToken : nullptr, newObjThisPtr, prefixFlags, &callInfo, opcodeOffs);
             if (compDonotInline())
             {
                 return;

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -1416,6 +1416,14 @@ void InlineStrategy::DumpXml(FILE* file, unsigned indent)
         s_HasDumpedXmlHeader = true;
     }
 
+    // If we're dumping "minimal" Xml, and we didn't do
+    // any inlines into this method, then there's nothing
+    // to emit here.
+    if ((m_InlineCount == 0) && (JitConfig.JitInlineDumpXml() == 2))
+    {
+        return;
+    }
+
     // Cache references to compiler substructures.
     const Compiler::Info& info = m_Compiler->info;
     const Compiler::Options& opts = m_Compiler->opts;

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -218,7 +218,7 @@ class InlinePolicy
 public:
 
     // Factory method for getting policies
-    static InlinePolicy* GetPolicy(Compiler* compiler, InlineContext* context, bool isPrejitRoot);
+    static InlinePolicy* GetPolicy(Compiler* compiler, bool isPrejitRoot);
 
     // Obligatory virtual dtor
     virtual ~InlinePolicy() {}
@@ -234,6 +234,10 @@ public:
     virtual void NoteBool(InlineObservation obs, bool value) = 0;
     virtual void NoteFatal(InlineObservation obs) = 0;
     virtual void NoteInt(InlineObservation obs, int value) = 0;
+
+    // Optional observations. Most policies ignore these.
+    virtual void NoteContext(InlineContext* context) { (void) context; }
+    virtual void NoteOffset(IL_OFFSETX offset) { (void) offset; }
 
     // Policy determinations
     virtual void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) = 0;
@@ -289,7 +293,7 @@ public:
     // particular call for inlining.
     InlineResult(Compiler*              compiler,
                  GenTreeCall*           call,
-                 InlineContext*         inlineContext,
+                 GenTreeStmt*           stmt,
                  const char*            description);
 
     // Construct a new InlineResult to evaluate a particular
@@ -620,6 +624,12 @@ public:
     unsigned GetCodeSizeEstimate() const
     {
         return m_CodeSizeEstimate;
+    }
+
+    // Get the offset of the call site
+    IL_OFFSETX GetOffset() const
+    {
+        return m_Offset;
     }
 
     // True if this is the root context

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -346,7 +346,18 @@ class ReplayPolicy : public DiscretionaryPolicy
 public:
 
     // Construct a ReplayPolicy
-    ReplayPolicy(Compiler* compiler, InlineContext* inlineContext, bool isPrejitRoot);
+    ReplayPolicy(Compiler* compiler, bool isPrejitRoot);
+
+    // Optional observations
+    void NoteContext(InlineContext* context) override
+    {
+        m_InlineContext = context;
+    }
+
+    void NoteOffset(IL_OFFSETX offset) override
+    {
+        m_Offset = offset;
+    }
 
     // Policy determinations
     void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) override;
@@ -361,12 +372,13 @@ private:
     bool FindMethod();
     bool FindContext(InlineContext* context);
     bool FindInline(CORINFO_METHOD_HANDLE callee);
-    bool FindInline(unsigned token, unsigned hash);
+    bool FindInline(unsigned token, unsigned hash, unsigned offset);
 
     static bool          s_WroteReplayBanner;
     static FILE*         s_ReplayFile;
     static CritSecObject s_XmlReaderLock;
     InlineContext*       m_InlineContext;
+    IL_OFFSETX           m_Offset;
 };
 
 #endif // defined(DEBUG) || defined(INLINE_DATA)

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -192,7 +192,7 @@ CONFIG_STRING(TailCallOpt, W("TailCallOpt"))
 
 #if defined(DEBUG) || defined(INLINE_DATA)
 CONFIG_INTEGER(JitInlineDumpData, W("JitInlineDumpData"), 0)
-CONFIG_INTEGER(JitInlineDumpXml, W("JitInlineDumpXml"), 0)
+CONFIG_INTEGER(JitInlineDumpXml, W("JitInlineDumpXml"), 0)   // 1 = full xml (all methods), 2 = minimal xml (only method with inlines)
 CONFIG_INTEGER(JitInlineLimit, W("JitInlineLimit"), -1)
 CONFIG_INTEGER(JitInlinePolicyDiscretionary, W("JitInlinePolicyDiscretionary"), 0)
 CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)


### PR DESCRIPTION
Note this is intentionally set up as a sequence of 3 commits. See commit messages for more details.

Overview:

The first sets up accurate tracking of IL offsets for calls.
The second uses this in inline Xml to validate call site identities.
The third enables a minimal Inline Xml where only method with inlines are described.