### PR TITLE
Fix shm directory creation for named mutexes

### DIFF
--- a/src/pal/src/include/pal/sharedmemory.h
+++ b/src/pal/src/include/pal/sharedmemory.h
@@ -38,6 +38,8 @@ static_assert_no_msg(_countof(SHARED_MEMORY_LOCK_FILES_DIRECTORY_PATH) >= _count
 #define SHARED_MEMORY_SESSION_DIRECTORY_NAME_PREFIX "session"
 static_assert_no_msg(_countof(SHARED_MEMORY_SESSION_DIRECTORY_NAME_PREFIX) >= _countof(SHARED_MEMORY_GLOBAL_DIRECTORY_NAME));
 
+#define SHARED_MEMORY_UNIQUE_TEMP_NAME_TEMPLATE "/tmp/.coreclr.XXXXXX"
+
 #define SHARED_MEMORY_MAX_SESSION_ID_CHAR_COUNT (10)
 
 #define SHARED_MEMORY_MAX_FILE_PATH_CHAR_COUNT \
@@ -103,8 +105,9 @@ public:
 
     template<SIZE_T DestinationByteCount, SIZE_T SourceByteCount> static SIZE_T CopyString(char (&destination)[DestinationByteCount], SIZE_T destinationStartOffset, const char (&source)[SourceByteCount]);
     template<SIZE_T DestinationByteCount> static SIZE_T CopyString(char (&destination)[DestinationByteCount], SIZE_T destinationStartOffset, LPCSTR source, SIZE_T sourceCharCount);
+    template<SIZE_T DestinationByteCount> static SIZE_T AppendUInt32String(char (&destination)[DestinationByteCount], SIZE_T destinationStartOffset, UINT32 value);
 
-    static bool EnsureDirectoryExists(const char *path, bool createIfNotExist = true);
+    static bool EnsureDirectoryExists(const char *path, bool isGlobalLockAcquired, bool createIfNotExist = true);
 private:
     static int Open(LPCSTR path, int flags, mode_t mode = static_cast<mode_t>(0));
 public:

--- a/src/pal/src/include/pal/sharedmemory.inl
+++ b/src/pal/src/include/pal/sharedmemory.inl
@@ -9,9 +9,11 @@
 
 #include "dbgmsg.h"
 
+#include <string.h>
+
 template<SIZE_T DestinationByteCount, SIZE_T SourceByteCount>
 SIZE_T SharedMemoryHelpers::CopyString(
-    char(&destination)[DestinationByteCount],
+    char (&destination)[DestinationByteCount],
     SIZE_T destinationStartOffset,
     const char(&source)[SourceByteCount])
 {
@@ -20,16 +22,32 @@ SIZE_T SharedMemoryHelpers::CopyString(
 
 template<SIZE_T DestinationByteCount>
 SIZE_T SharedMemoryHelpers::CopyString(
-    char(&destination)[DestinationByteCount],
+    char (&destination)[DestinationByteCount],
     SIZE_T destinationStartOffset,
     LPCSTR source,
     SIZE_T sourceCharCount)
 {
-    _ASSERTE(destinationStartOffset <= DestinationByteCount);
+    _ASSERTE(destinationStartOffset < DestinationByteCount);
     _ASSERTE(sourceCharCount < DestinationByteCount - destinationStartOffset);
+    _ASSERTE(strlen(source) == sourceCharCount);
 
     memcpy_s(&destination[destinationStartOffset], DestinationByteCount - destinationStartOffset, source, sourceCharCount + 1);
     return destinationStartOffset + sourceCharCount;
+}
+
+template<SIZE_T DestinationByteCount>
+SIZE_T SharedMemoryHelpers::AppendUInt32String(
+    char (&destination)[DestinationByteCount],
+    SIZE_T destinationStartOffset,
+    UINT32 value)
+{
+    _ASSERTE(destination != nullptr);
+    _ASSERTE(destinationStartOffset < DestinationByteCount);
+
+    int valueCharCount =
+        sprintf_s(&destination[destinationStartOffset], DestinationByteCount - destinationStartOffset, "%u", value);
+    _ASSERTE(valueCharCount > 0);
+    return destinationStartOffset + valueCharCount;
 }
 
 #endif // !_PAL_SHARED_MEMORY_INL_

--- a/src/pal/src/synchobj/mutex.cpp
+++ b/src/pal/src/synchobj/mutex.cpp
@@ -1146,7 +1146,7 @@ SharedMemoryProcessDataHeader *NamedMutexProcessData::CreateOrOpen(
             SharedMemoryHelpers::CopyString(lockFilePath, 0, SHARED_MEMORY_LOCK_FILES_DIRECTORY_PATH);
         if (created)
         {
-            SharedMemoryHelpers::EnsureDirectoryExists(lockFilePath);
+            SharedMemoryHelpers::EnsureDirectoryExists(lockFilePath, true /* isGlobalLockAcquired */);
         }
 
         // Create the session directory
@@ -1155,7 +1155,7 @@ SharedMemoryProcessDataHeader *NamedMutexProcessData::CreateOrOpen(
         lockFilePathCharCount = id->AppendSessionDirectoryName(lockFilePath, lockFilePathCharCount);
         if (created)
         {
-            SharedMemoryHelpers::EnsureDirectoryExists(lockFilePath);
+            SharedMemoryHelpers::EnsureDirectoryExists(lockFilePath, true /* isGlobalLockAcquired */);
             autoCleanup.m_lockFilePath = lockFilePath;
             autoCleanup.m_sessionDirectoryPathCharCount = lockFilePathCharCount;
         }


### PR DESCRIPTION
Port f668a73f4e8dbd819e1d59fe27f23aa6ce229232 to release/1.0.0

- Creating a directory involves mkdir and chmod. Due to this, there could be a race where one process running as one user creates the directory but does not update permissions for all uses to have access, and at that point another process tries to use the directory.
- Fixed by creating a temp directory using mkdtemp(), chmod to set appropriate permissions for all users, and rename the directory. This is only done when a global lock is not held during the directory creation operation (applies only to /tmp/.dotnet and /tmp/.dotnet/shm).
- Tested manually by adding sleeps at the race points with a second process running as a different user, to make sure it works in any order.