### PR TITLE
Enable managed heap dumps on Linux

### DIFF
--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -298,12 +298,6 @@ extern "C" {
 
 #include "clretwallmain.h"
 
-// The bulk type event is too complex for MC.exe to auto-generate proper code.
-// Use code:BulkTypeEventLogger instead.
-#ifdef FireEtwBulkType
-#undef FireEtwBulkType
-#endif // FireEtwBulkType
-
 #endif // FEATURE_EVENT_TRACE 
 
 /**************************/

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -1205,10 +1205,11 @@ void BulkComLogger::FlushRcw()
     EventDataDescCreate(&eventData[2], m_etwRcwData, sizeof(EventRCWEntry) * m_currRcw);
 
     ULONG result = EventWrite(Microsoft_Windows_DotNETRuntimeHandle, &GCBulkRCW, _countof(eventData), eventData);
-    _ASSERTE(result == ERROR_SUCCESS);
 #else
-// UNIXTODO: "Eventing Not Implemented"
+    ULONG result = FireEtXplatGCBulkRCW(m_currRcw, instance, sizeof(EventRCWEntry) * m_currRcw, m_etwRcwData);
 #endif // !defined(FEATURE_PAL)
+
+    _ASSERTE(result == ERROR_SUCCESS);
 
     m_currRcw = 0;
 }
@@ -1293,11 +1294,11 @@ void BulkComLogger::FlushCcw()
     EventDataDescCreate(&eventData[2], m_etwCcwData, sizeof(EventCCWEntry) * m_currCcw);
 
     ULONG result = EventWrite(Microsoft_Windows_DotNETRuntimeHandle, &GCBulkRootCCW, _countof(eventData), eventData);
-    _ASSERTE(result == ERROR_SUCCESS);
 #else
-// UNIXTODO: "Eventing Not Implemented"
+    ULONG result = FireEtXplatGCBulkRootCCW(m_currCcw, instance, sizeof(EventCCWEntry) * m_currCcw, m_etwCcwData);
 #endif //!defined(FEATURE_PAL)
 
+    _ASSERTE(result == ERROR_SUCCESS);
 
     m_currCcw = 0;
 }
@@ -1497,10 +1498,11 @@ void BulkStaticsLogger::FireBulkStaticsEvent()
     EventDataDescCreate(&eventData[3], m_buffer, m_used);
 
     ULONG result = EventWrite(Microsoft_Windows_DotNETRuntimeHandle, &GCBulkRootStaticVar, _countof(eventData), eventData);
-    _ASSERTE(result == ERROR_SUCCESS);
 #else
-// UNIXTODO: "Eventing Not Implemented"
+    ULONG result = FireEtXplatGCBulkRootStaticVar(m_count, appDomain, instance, m_used, m_buffer);
 #endif //!defined(FEATURE_PAL)
+
+    _ASSERTE(result == ERROR_SUCCESS);
 
     m_used = 0;
     m_count = 0;
@@ -1700,7 +1702,6 @@ void BulkTypeValue::Clear()
 //
 //
 
-#if !defined(FEATURE_PAL)
 void BulkTypeEventLogger::FireBulkTypeEvent()
 {
     LIMITED_METHOD_CONTRACT;
@@ -1710,7 +1711,10 @@ void BulkTypeEventLogger::FireBulkTypeEvent()
         // No types were batched up, so nothing to send
         return;
     }
+    
+    UINT16 nClrInstanceID = GetClrInstanceId();
 
+#if !defined(FEATURE_PAL)
     // Normally, we'd use the MC-generated FireEtwBulkType for all this gunk, but
     // it's insufficient as the bulk type event is too complex (arrays of structs of
     // varying size). So we directly log the event via EventDataDescCreate and
@@ -1722,7 +1726,6 @@ void BulkTypeEventLogger::FireBulkTypeEvent()
     // before the 64K event size limit, and we already limit our batch size
     // (m_nBulkTypeValueCount) to stay within the 128 descriptor limit.
     EVENT_DATA_DESCRIPTOR EventData[128];
-    UINT16 nClrInstanceID = GetClrInstanceId();
 
     UINT iDesc = 0;
 
@@ -1783,18 +1786,62 @@ void BulkTypeEventLogger::FireBulkTypeEvent()
     }
 
     Win32EventWrite(Microsoft_Windows_DotNETRuntimeHandle, &BulkType, iDesc, EventData);
+    
+#else // FEATURE_PAL
 
+    UINT iSize = 0;
+    
+    for (int iTypeData = 0; iTypeData < m_nBulkTypeValueCount; iTypeData++)
+    {
+        BulkTypeValue& target = m_rgBulkTypeValues[iTypeData];
+        
+        // Do fixed-size data as one bulk copy
+        memcpy(
+                m_BulkTypeEventBuffer + iSize,
+                &(target.fixedSizedData),
+                sizeof(target.fixedSizedData));
+        iSize += sizeof(target.fixedSizedData);
+
+        // Do var-sized data individually per field
+
+        LPCWSTR wszName = target.sName.GetUnicode();
+        if (wszName == NULL)
+        {
+            m_BulkTypeEventBuffer[iSize++] = 0;
+            m_BulkTypeEventBuffer[iSize++] = 0;
+        }
+        else
+        {
+            UINT nameSize = (target.sName.GetCount() + 1) * sizeof(WCHAR);
+            memcpy(m_BulkTypeEventBuffer + iSize, wszName, nameSize);
+            iSize += nameSize;
+        }
+
+        // Type parameter count
+        ULONG params = target.rgTypeParameters.GetCount();
+        
+        ULONG *ptrInt = (ULONG*)(m_BulkTypeEventBuffer + iSize);
+        *ptrInt = params;
+        iSize += 4;
+        
+        target.cTypeParameters = params;
+
+        // Type parameter array
+        if (target.cTypeParameters > 0)
+        {
+            memcpy(m_BulkTypeEventBuffer + iSize, target.rgTypeParameters.GetElements(), sizeof(ULONGLONG) * target.cTypeParameters);
+            iSize += sizeof(ULONGLONG) * target.cTypeParameters;
+        }
+    }
+
+    FireEtwBulkType(m_nBulkTypeValueCount, GetClrInstanceId(), iSize, m_BulkTypeEventBuffer);
+
+#endif // FEATURE_PAL
     // Reset state
     m_nBulkTypeValueCount = 0;
     m_nBulkTypeValueByteCount = 0;
 }
 
-#else
-void BulkTypeEventLogger::FireBulkTypeEvent()
-{
-// UNIXTODO: "Eventing Not Implemented"
-}
-#endif //!defined(FEATURE_PAL)
 #ifndef FEATURE_REDHAWK
 
 //---------------------------------------------------------------------------------------
@@ -4225,7 +4272,6 @@ Return Value:
 
 --*/
 
-#if !defined(FEATURE_PAL)
 void InitializeEventTracing()
 {
     CONTRACTL
@@ -4242,6 +4288,7 @@ void InitializeEventTracing()
     if (FAILED(hr))
         return;
 
+#if !defined(FEATURE_PAL)
     // Register CLR providers with the OS
     if (g_pEtwTracer == NULL)
     {
@@ -4249,6 +4296,7 @@ void InitializeEventTracing()
         if (tempEtwTracer != NULL && tempEtwTracer->Register () == ERROR_SUCCESS)
             g_pEtwTracer = tempEtwTracer.Extract ();
     }
+#endif
 
     g_nClrInstanceId = GetRuntimeId() & 0x0000FFFF; // This will give us duplicate ClrInstanceId after UINT16_MAX
 
@@ -4256,6 +4304,8 @@ void InitializeEventTracing()
     // providers can do so now
     ETW::TypeSystemLog::PostRegistrationInit();
 }
+
+#if !defined(FEATURE_PAL)
 HRESULT ETW::CEtwTracer::Register()
 {
     WRAPPER_NO_CONTRACT;
@@ -4413,9 +4463,9 @@ extern "C"
         PMCGEN_TRACE_CONTEXT context = (PMCGEN_TRACE_CONTEXT)CallbackContext;
 
         BOOLEAN bIsPublicTraceHandle = (context->RegistrationHandle==Microsoft_Windows_DotNETRuntimeHandle);
-        
+
         BOOLEAN bIsPrivateTraceHandle = (context->RegistrationHandle==Microsoft_Windows_DotNETRuntimePrivateHandle);
-        
+
         BOOLEAN bIsRundownTraceHandle = (context->RegistrationHandle==Microsoft_Windows_DotNETRuntimeRundownHandle);
 
 
@@ -4502,13 +4552,9 @@ extern "C"
 
     }
 }
-#else
-
-void InitializeEventTracing(){}
-
-#endif // !defined(FEATURE_PAL)
 #endif // FEATURE_REDHAWK
 
+#endif // FEATURE_PAL
 #ifndef FEATURE_REDHAWK
 
 /****************************************************************************/
@@ -5013,6 +5059,7 @@ VOID ETW::InfoLog::RuntimeInformation(INT32 type)
 
 VOID ETW::CodeSymbolLog::EmitCodeSymbols(Module* pModule)
 {
+#if  !defined(FEATURE_PAL) //UNIXTODO: Enable EmitCodeSymbols
     CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
@@ -5042,15 +5089,14 @@ VOID ETW::CodeSymbolLog::EmitCodeSymbols(Module* pModule)
                     // estmate. 
                     static const DWORD maxDataSize = 63000;
 
-                    DWORD quot = length / maxDataSize;
-                    
+                    ldiv_t qr = ldiv(length, maxDataSize);
+
                     // We do not allow pdbs of size greater than 2GB for now, 
                     // so totalChunks should fit in 16 bits.
-                    if (quot < UINT16_MAX)
+                    if (qr.quot < UINT16_MAX)
                     {
                         // If there are trailing bits in the last chunk, then increment totalChunks by 1
-                        DWORD rem = length % maxDataSize;
-                        UINT16 totalChunks = (UINT16)(quot + ((rem != 0) ? 1 : 0));
+                        UINT16 totalChunks = (UINT16)(qr.quot + ((qr.rem != 0) ? 1 : 0));
                         NewArrayHolder<BYTE> chunk(new BYTE[maxDataSize]);
                         DWORD offset = 0;
                         for (UINT16 chunkNum = 0; offset < length; chunkNum++)
@@ -5071,6 +5117,7 @@ VOID ETW::CodeSymbolLog::EmitCodeSymbols(Module* pModule)
             }
         }
     } EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);
+#endif//  !defined(FEATURE_PAL)
 }
 
 /* Returns the length of an in-memory symbol stream

--- a/src/vm/eventtracepriv.h
+++ b/src/vm/eventtracepriv.h
@@ -291,6 +291,10 @@ private:
     // List of types we've batched.
     BulkTypeValue m_rgBulkTypeValues[kMaxCountTypeValues];
 
+#ifdef FEATURE_PAL
+    BYTE m_BulkTypeEventBuffer[65536];
+#endif
+
 #ifdef FEATURE_REDHAWK
     int LogSingleType(EEType * pEEType);
 #else

--- a/src/vm/finalizerthread.h
+++ b/src/vm/finalizerthread.h
@@ -11,6 +11,10 @@ class FinalizerThread
     static BOOL fRunFinalizersOnUnload;
     static BOOL fQuitFinalizer;
     static AppDomain *UnloadingAppDomain;
+    
+#if defined(__linux__)
+    static ULONGLONG LastHeapDumpTime;
+#endif
 
     static CLREvent *hEventFinalizer;
     static CLREvent *hEventFinalizerDone;

--- a/src/vm/vars.hpp
+++ b/src/vm/vars.hpp
@@ -605,6 +605,10 @@ extern ULONGLONG g_ObjFinalizeStartTime;
 extern Volatile<BOOL> g_FinalizerIsRunning;
 extern Volatile<ULONG> g_FinalizerLoopCount;
 
+#ifdef FEATURE_PAL
+extern Volatile<BOOL> g_TriggerHeapDump;
+#endif // FEATURE_PAL
+
 extern LONG GetProcessedExitProcessEventCount();
 
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
This change enables the existing heap dump infrastructure from Windows to work on Linux. It allows us to do managed memory investigations on Linux.

Fixes #5242 

@leculver @Maoni0 @lt72 