### PR TITLE
ARM64: Fix Liveness update for Division By Zero

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1328,6 +1328,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* treeNode)
 
 //------------------------------------------------------------------------
 // genCodeForBinary: Generate code for many binary arithmetic operators
+// This method is expected to have called genConsumeOperands() before calling it.
 //
 // Arguments:
 //    treeNode - The binary operation for which we are generating code.
@@ -1388,8 +1389,6 @@ void CodeGen::genCodeForBinary(GenTree* treeNode)
 
     GenTreePtr dst;
     GenTreePtr src;
-
-    genConsumeOperands(treeNode->AsOp());
 
     // This is the case of reg1 = reg1 op reg2
     // We're ready to emit the instruction without any moves
@@ -1958,6 +1957,7 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 #endif // !defined(_TARGET_64BIT_)
     case GT_ADD:
     case GT_SUB:
+        genConsumeOperands(treeNode->AsOp());
         genCodeForBinary(treeNode);
         break;
 

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -9503,7 +9503,7 @@ RelativePath=CoreMangLib\cti\system\dividebyzeroexception\DivideByZeroExceptionC
 WorkingDir=CoreMangLib\cti\system\dividebyzeroexception\DivideByZeroExceptionCtor
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL;REGRESS
+Categories=Pri1;RT;EXPECTED_PASS
 HostStyle=0
 [DivideByZeroExceptionCtor2.cmd_1358]
 RelativePath=CoreMangLib\cti\system\dividebyzeroexception\DivideByZeroExceptionCtor2\DivideByZeroExceptionCtor2.cmd
@@ -18890,7 +18890,7 @@ RelativePath=CoreMangLib\cti\system\type\TypeGetType1\TypeGetType1.cmd
 WorkingDir=CoreMangLib\cti\system\type\TypeGetType1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL;REGRESS
+Categories=Pri1;RT;EXPECTED_PASS
 HostStyle=0
 [TypeGetType2.cmd_2699]
 RelativePath=CoreMangLib\cti\system\type\TypeGetType2\TypeGetType2.cmd


### PR DESCRIPTION
We've missed updating liveness when converting division by zero to a
throw. This fixes an assertion failure in `assert(!varDsc->lvIsRegCandidate());` in
codegenarm64.cpp/L1903.