### PR TITLE
Refactoring the way GC Stress logic is used while running tests

### DIFF
--- a/Documentation/building/windows-test-instructions.md
+++ b/Documentation/building/windows-test-instructions.md
@@ -25,12 +25,6 @@ This will use crossgen.exe to precompile the test executables before they are ex
 
 The number '2' is just an example. The default value (if no priority is specified) is 0. To clarify, if '2' is specified, all tests with CLRTestPriorty 0, 1 AND 2 will be built and consequently run.
 
-*Specify GCStress Level*
-
-    C:\git\coreclr>tests\buildtest.cmd gcstresslevel 2
-
-GCStress is used to help with identifying GC holes in the implementation of the managed runtime or GC life-time reporting done by the JIT. Valid values are the values supported by GCStressFlags enum in src/vm/eeconfig.h.
-
 **Example**
 
 To run a clean, priority 1, crossgen test pass:

--- a/build.cmd
+++ b/build.cmd
@@ -69,7 +69,6 @@ set __BuildArchArm64=0
 set __BuildTypeDebug=0
 set __BuildTypeChecked=0
 set __BuildTypeRelease=0
-set __GCStressLevel=0
 set __BuildJit32="-DBUILD_JIT32=0"
 
 REM __PassThroughArgs is a set of things that will be passed through to nested calls to build.cmd
@@ -120,7 +119,6 @@ if /i "%1" == "skipbuildpackages"   (set __SkipBuildPackages=1&shift&goto Arg_Lo
 if /i "%1" == "sequential"          (set __BuildSequential=1&shift&goto Arg_Loop)
 if /i "%1" == "disableoss"          (set __SignTypeReal="/p:SignType=real"&shift&goto Arg_Loop)
 if /i "%1" == "priority"            (set __TestPriority=%2&set __PassThroughArgs=%__PassThroughArgs% %2&shift&shift&goto Arg_Loop)
-if /i "%1" == "gcstresslevel"       (set __GCStressLevel=%2&set __PassThroughArgs=%__PassThroughArgs% %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "buildjit32"          (set __BuildJit32="-DBUILD_JIT32=1"&shift&goto Arg_Loop)
 
 @REM For backwards compatibility, continue accepting "skiptestbuild", which was the original name of the option.
@@ -571,10 +569,6 @@ if defined __TestPriority (
     set "__BuildtestArgs=%__BuildtestArgs% Priority %__TestPriority%"
 )
 
-if %__GCStressLevel% GTR 0 (
-    set "__BuildtestArgs=%__BuildtestArgs% gcstresslevel %__GCStressLevel%"   
-)
-
 rem arm64 builds currently use private toolset which has not been released yet
 REM TODO, remove once the toolset is open.
 if /i "%__BuildArch%" == "arm64" call :PrivateToolSet 
@@ -702,7 +696,6 @@ echo     or windowsmscorlib. If one of these is passed, only System.Private.Core
 echo     for the specified platform ^(FreeBSD, Linux, NetBSD, OS X or Windows,
 echo     respectively^).
 echo priority ^<N^> : specify a set of test that will be built and run, with priority N.
-echo gcstresslevel ^<N^> : specify the GCStress level the tests should run under.
 echo sequential: force a non-parallel build ^(default is to build in parallel
 echo     using all processors^).
 echo configureonly: skip all builds; only run CMake ^(default: CMake and builds are run^)

--- a/netci.groovy
+++ b/netci.groovy
@@ -1411,18 +1411,13 @@ combinedScenarios.each { scenario ->
                                     // binaries are sent to a default directory whose name is about
                                     // 35 characters long.
 
-                                    else if (scenario == 'pri1' || scenario == 'pri1r2r' || scenario == 'coverage') {
+                                    else if (scenario == 'pri1' || scenario == 'pri1r2r' || scenario == 'gcstress15_pri1r2r'|| scenario == 'coverage') {
                                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} Priority 1"
                                     }
                                     else if (scenario == 'ilrt') {
                                         // First do the build with skiptests and then build the tests with ilasm roundtrip
                                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} skiptests"
                                         buildCommands += "set __TestIntermediateDir=int&&tests\\buildtest.cmd ${lowerConfiguration} ${arch} ilasmroundtrip"
-                                    }
-                                    else if (scenario == 'gcstress15_pri1r2r') {
-                                        //Build pri1 R2R tests with GC stress level 15
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} skiptests"
-                                        buildCommands += "set __TestIntermediateDir=int&&tests\\buildtest.cmd ${lowerConfiguration} ${arch}  Priority 1 gcstresslevel 0xf"
                                     }
                                     else if (scenario == 'longgc') {
                                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} skiptests"
@@ -1448,6 +1443,7 @@ combinedScenarios.each { scenario ->
                                         def runjitstressregsStr = ''
                                         def runjitmioptsStr = ''
                                         def runjitforcerelocsStr = ''
+                                        def gcstressStr = ''
 
                                         if (scenario == 'r2r' ||
                                             scenario == 'pri1r2r' ||
@@ -1490,6 +1486,10 @@ combinedScenarios.each { scenario ->
                                                     runjitforcerelocsStr = 'jitforcerelocs'
                                                 }
                                         }
+                                        if (scenario == 'gcstress15_pri1r2r')
+                                        {
+                                           gcstressStr = 'gcstresslevel 0xF'
+                                        }
                                         if (Constants.jitStressModeScenarios.containsKey(scenario)) {
                                             if (enableCorefxTesting) {
                                                 // Sync to corefx repo
@@ -1510,7 +1510,7 @@ combinedScenarios.each { scenario ->
                                                 
                                                 // Run tests with the 
                                                 
-                                                buildCommands += "tests\\runtest.cmd ${lowerConfiguration} ${arch} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} TestEnv ${stepScriptLocation}"
+                                                buildCommands += "tests\\runtest.cmd ${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} TestEnv ${stepScriptLocation}"
                                             }                                            
                                         }
                                         else if (architecture == 'x64') {
@@ -1890,7 +1890,7 @@ combinedScenarios.each { scenario ->
                     // so we didn't create a build only job for windows_nt specific to that stress mode.  Just copy
                     // from the default scenario
                     def testBuildScenario = scenario
-                    if (testBuildScenario == 'coverage' || testBuildScenario == 'pri1r2r') {
+                    if (testBuildScenario == 'coverage' || testBuildScenario == 'pri1r2r'|| testBuildScenario == 'gcstress15_pri1r2r') {
                         testBuildScenario = 'pri1'
                     }
                     else if ( testBuildScenario == 'r2r'){
@@ -1927,6 +1927,7 @@ combinedScenarios.each { scenario ->
                     def runjitstressregsStr = ''
                     def runjitmioptsStr = ''
                     def runjitforcerelocsStr = ''
+                    def gcstressStr = ''
 
                     if (scenario == 'r2r' ||
                         scenario == 'pri1r2r' ||
@@ -1968,6 +1969,10 @@ combinedScenarios.each { scenario ->
                             else if (scenario == 'r2r_jitforcerelocs') {
                                 runjitforcerelocsStr = '--jitforcerelocs'
                             }
+                    }
+                    if  (scenario == 'gcstress15_pri1r2r')
+                    {
+                        gcstressStr = '--gcstresslevel=0xF'
                     }
 
                     if (isLongGc(scenario)) {
@@ -2127,7 +2132,7 @@ combinedScenarios.each { scenario ->
                 --mscorlibDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --coreFxBinDir=\"\${WORKSPACE}/bin/${osGroup}.AnyCPU.Release;\${WORKSPACE}/bin/Unix.AnyCPU.Release;\${WORKSPACE}/bin/AnyOS.AnyCPU.Release\" \\
                 --coreFxNativeBinDir=\"\${WORKSPACE}/bin/${osGroup}.${architecture}.Release\" \\
-                ${testEnvOpt} ${serverGCString} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${sequentialString} ${playlistString}""")
+                ${testEnvOpt} ${serverGCString} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${sequentialString} ${playlistString}""")
                             }
                         }
                     }

--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -36,7 +36,6 @@ set __GCSimulatorTests=
 set __msbuildCleanBuildArgs=
 set __msbuildExtraArgs=
 set __verbosity=normal
-set __GCStressLevel=0
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -66,7 +65,6 @@ if /i "%1" == "crossgen"            (set __crossgen=true&shift&goto Arg_Loop)
 if /i "%1" == "ilasmroundtrip"      (set __ILAsmRoundtrip=true&shift&goto Arg_Loop)
 if /i "%1" == "sequential"          (set __BuildSequential=1&shift&goto Arg_Loop)
 if /i "%1" == "priority"            (set __TestPriority=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "gcstresslevel"       (set __GCStressLevel=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "longgctests"         (set __LongGCTests=1&shift&goto Arg_Loop)
 if /i "%1" == "gcsimulator"         (set __GCSimulatorTests=1&shift&goto Arg_Loop)
 
@@ -265,11 +263,6 @@ if not defined VSINSTALLDIR (
 
 set __msbuildManagedBuildArgs=%__msbuildCleanBuildArgs%
 
-if defined __crossgen (
-    echo Building tests with CrossGen enabled.
-    set __msbuildManagedBuildArgs=%__msbuildManagedBuildArgs% /p:CrossGen=true
-)
-
 if defined __ILAsmRoundtrip (
     echo Building tests with IlasmRoundTrip enabled.
     set __msbuildManagedBuildArgs=%__msbuildManagedBuildArgs% /p:IlasmRoundTrip=true
@@ -278,11 +271,6 @@ if defined __ILAsmRoundtrip (
 if defined __TestPriority (
     echo Building Test Priority %__TestPriority%
     set __msbuildManagedBuildArgs=%__msbuildManagedBuildArgs% /p:CLRTestPriorityToBuild=%__TestPriority%
-)
-
-if %__GCStressLevel% GTR 0 (
-    echo Tests will run under GCStressLevel = %__GCStressLevel%
-    set __msbuildManagedBuildArgs=%__msbuildManagedBuildArgs% /p:GCStressLevel=%__GCStressLevel%   
 )
 
 if defined __LongGCTests (
@@ -377,7 +365,6 @@ echo clean: force a clean build ^(default is to perform an incremental build^).
 echo CrossGen: enables the tests to run crossgen on the test executables before executing them. 
 echo msbuildargs ... : all arguments following this tag will be passed directly to msbuild.
 echo priority ^<N^> : specify a set of test that will be built and run, with priority N.
-echo gcstresslevel ^<N^> : specify the GCStress level the tests should run under.
 echo sequential: force a non-parallel build ^(default is to build in parallel
 echo     using all processors^).
 echo longgctests: Build tests so that runtests.cmd will do a long-running GC test.

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -63,7 +63,9 @@ if /i "%1" == "jitminopts"            (set COMPlus_JITMinOpts=1&shift&shift&goto
 if /i "%1" == "jitforcerelocs"        (set COMPlus_ForceRelocs=1&shift&shift&goto Arg_Loop)
 if /i "%1" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
 if /i "%1" == "PerfTests"             (set __PerfTests=true&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
-if /i "%1" == "runcrossgentests"      (set __RunCrossgenTests=1&shift&goto Arg_Loop)
+if /i "%1" == "runcrossgentests"      (set RunCrossGen=true&shift&goto Arg_Loop)
+REM change it to COMPlus_GCStress when we stop using xunit harness
+if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&shift&shift&goto Arg_Loop) 
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.
@@ -163,8 +165,7 @@ REM These log files are created automatically by the test run process. Q: what d
 set __TestRunHtmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%__%__BuildType%.html
 set __TestRunXmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%__%__BuildType%.xml
 
-REM set ENV variables here:
-if defined __RunCrossgenTests ( set RunCrossGen=true)
+
 if "%__PerfTests%"=="true" goto RunPerfTests
 if "%__SkipWrapperGeneration%"=="true" goto SkipWrapperGeneration
 
@@ -350,10 +351,11 @@ echo TestEnv- Optional parameter - this will run a custom script to set custom t
 echo VSVersion- Optional parameter - VS2013 or VS2015 ^(default: VS2015^)
 echo GenerateLayoutOnly - If specified will not run the tests and will only create the Runtime Dependency Layout
 echo RunCrossgenTests   - Runs ReadytoRun tests
-echo jitstress <n>      - Runs the tests with COMPlus_JitStress=n
-echo jitstressregs <n>  - Runs the tests with COMPlus_JitStressRegs=n
+echo jitstress n        - Runs the tests with COMPlus_JitStress=n
+echo jitstressregs n    - Runs the tests with COMPlus_JitStressRegs=n
 echo jitminopts         - Runs the tests with COMPlus_JITMinOpts=1
 echo jitforcerelocs     - Runs the tests with COMPlus_ForceRelocs=1
+echo gcstresslevel n    - Runs the tests with COMPlus_GCStress=n
 echo CORE_ROOT The path to the runtime  
 exit /b 1
 

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -805,7 +805,7 @@ do
             ((disableEventLogging = 1))
             ;;
         --runcrossgentests)
-            ((RunCrossGenTests = 1))
+            export RunCrossGen=1
             ;;
         --sequential)
             ((maxProcesses = 1))
@@ -831,6 +831,9 @@ do
         --test-env=*)
             testEnv=${i#*=}
             ;;            
+        --gcstresslevel=*)
+            export COMPlus_GCStress=${i#*=}
+            ;;            
         *)
             echo "Unknown switch: $i"
             print_usage
@@ -843,9 +846,6 @@ if ((disableEventLogging == 0)); then
     export COMPlus_EnableEventLog=1
 fi
 
-if ((RunCrossGenTests == 1)); then
-    export RunCrossGen=1
-fi
 export CORECLR_SERVER_GC="$serverGC"
 
 if [ -z "$testRootDir" ]; then

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -18,10 +18,6 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <ItemGroup>
-    <CLRTestBashEnvironmentVariable Condition="'$(GCStressLevel)' != '' and '$(GCStressLevel)' != '0'" Include="export complus_gcstress=$(GCStressLevel)" />
-  </ItemGroup>
-
   <Target
     Name="GetIlasmRoundTripBashScript"
     Returns="$(IlasmRoundTripBashScript)">

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -18,10 +18,6 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <ItemGroup>
-    <CLRTestBatchEnvironmentVariable Condition="'$(GCStressLevel)' != '' and '$(GCStressLevel)' != '0'" Include="set complus_gcstress=$(GCStressLevel)" />
-  </ItemGroup>
-
   <Target
     Name="GetIlasmRoundTripBatchScript"
     Returns="$(IlasmRoundTripBatchScript)">

--- a/tests/src/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/tests/src/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -18,6 +18,7 @@ namespace CoreclrTestLib
         public const int EXIT_SUCCESS_CODE = 0;
         public const string TIMEOUT_ENVIRONMENT_VAR = "__TestTimeout";
         public const int DEFAULT_TIMEOUT = 1000 * 60*10;
+        public const string GC_STRESS_LEVEL = "__GCSTRESSLEVEL";
 
         public int RunTest(string executable, string outputFile, string errorFile)
         {
@@ -30,6 +31,8 @@ namespace CoreclrTestLib
             string environmentVar = Environment.GetEnvironmentVariable(TIMEOUT_ENVIRONMENT_VAR);
             int timeout = environmentVar != null ? int.Parse(environmentVar) : DEFAULT_TIMEOUT;
 
+            string gcstressVar = Environment.GetEnvironmentVariable(GC_STRESS_LEVEL);
+
             var outputStream = new FileStream(outputFile, FileMode.Create);
             var errorStream = new FileStream(errorFile, FileMode.Create);
 
@@ -37,6 +40,13 @@ namespace CoreclrTestLib
             using (var errorWriter = new StreamWriter(errorStream))
             using (Process process = new Process())
             {
+                if (gcstressVar!=null)
+                {
+                    //Note: this is not the best way to set the Env, but since we are using 
+                    //Desktop to start the tests, this Env will affect the test harness behavior
+                    process.StartInfo.EnvironmentVariables["COMPlus_GCStress"] = gcstressVar;
+                }
+
                 process.StartInfo.FileName = executable;
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.RedirectStandardOutput = true;


### PR DESCRIPTION
A separate test build is no longer needed for GC stress test Runs

Fixes #5245

@gkhanna79 @RussKeldorph  @swgillespie @wtgodbe PTAL