### PR TITLE
Fix generic non-virtual method call in Ready-to-Run images

### DIFF
--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -880,6 +880,14 @@ Dictionary::PopulateEntry(
                 result = (CORINFO_GENERIC_HANDLE)pMethod->GetMultiCallableAddrOfCode();
             }
             else
+            if (kind == DispatchStubAddrSlot)
+            {
+                _ASSERTE((methodFlags & ENCODE_METHOD_SIG_SlotInsteadOfToken) == 0);
+                PCODE *ppCode = (PCODE*)(void*)pMethod->GetLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(PCODE)));
+                *ppCode = pMethod->GetMultiCallableAddrOfCode();
+                result = (CORINFO_GENERIC_HANDLE)ppCode;
+            }
+            else
             {
                 _ASSERTE(kind == MethodDescSlot);
                 result = (CORINFO_GENERIC_HANDLE)pMethod;

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -3468,7 +3468,7 @@ NoSpecialCase:
                 methodFlags |= ENCODE_METHOD_SIG_SlotInsteadOfToken;
             }
             else
-            if (entryKind == DispatchStubAddrSlot)
+            if (entryKind == DispatchStubAddrSlot && pTemplateMD->IsVtableMethod())
             {
                 // Encode the method for dispatch stub using slot to avoid touching the interface method MethodDesc at runtime
 

--- a/tests/src/readytorun/main.cs
+++ b/tests/src/readytorun/main.cs
@@ -203,6 +203,19 @@ class Program
         }
     }
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    static void TestGenericNonVirtualMethod()
+    {
+        var c = new MyChildGeneric<string>();
+        Assert.AreEqual(CallGeneric(c), "MyGeneric.NonVirtualMethod");
+    }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    static string CallGeneric<T>(MyGeneric<T, T> g)
+    {
+        return g.NonVirtualMethod();
+    }
+
     static void TestInstanceFields()
     {
         var t = new InstanceFieldTest2();
@@ -375,6 +388,7 @@ class Program
 
         TestGenericVirtualMethod();
         TestMovedGenericVirtualMethod();
+        TestGenericNonVirtualMethod();
 
         TestInstanceFields();
 

--- a/tests/src/readytorun/test.cs
+++ b/tests/src/readytorun/test.cs
@@ -255,6 +255,11 @@ public class MyGeneric<T,U>
         return typeof(List<W>).ToString();
     }
 #endif
+
+    public string NonVirtualMethod()
+    {
+        return "MyGeneric.NonVirtualMethod";
+    }
 }
 
 public class MyChildGeneric<T> : MyGeneric<T,T>


### PR DESCRIPTION
Issue #5201 revealed a bug in the Ready-to-Run implementation. This bug can cause the runtime to dispatch a method call to the wrong target when all the following conditions are met:
* A shared generic method in a Ready-to-Run module calls a method in a shared generic class.
* The target is a non-virtual instance method, but is called through callvirt instruction (as C# compiler normally does).
* The target is in a different module.
* The target method is defined in a base class, while the actual object instance is of a derived class.

This commit fixes this bug by changing a virtual call to a regular call when the target is non-virtual.