### PR TITLE
EventSource Events that use complex types do not get logged (silently…

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -1974,7 +1974,7 @@ namespace System.Diagnostics.Tracing
                                         m_eventData[eventId].Descriptor.Level,
                                         m_eventData[eventId].Descriptor.Opcode,
                                         m_eventData[eventId].Descriptor.Task,
-                                        unchecked((long)(ulong)etwSessions | origKwd));
+                                        unchecked((long)etwSessions.ToEventKeywords() | origKwd));
 
                                     if (!m_provider.WriteEvent(ref desc, pActivityId, childActivityID, args))
                                         ThrowEventSourceException(m_eventData[eventId].Name);
@@ -1995,7 +1995,7 @@ namespace System.Diagnostics.Tracing
                                 // TODO: activity ID support
                                 EventSourceOptions opt = new EventSourceOptions
                                 {
-                                    Keywords = (EventKeywords)unchecked((long)(ulong)etwSessions | origKwd),
+                                    Keywords = (EventKeywords)unchecked((long)etwSessions.ToEventKeywords() | origKwd),
                                     Level = (EventLevel)m_eventData[eventId].Descriptor.Level,
                                     Opcode = (EventOpcode)m_eventData[eventId].Descriptor.Opcode
                                 };


### PR DESCRIPTION
When complex types were added to EventSource (in V4.6) there was a latent bug where if the event had specified keywords the event would not be emitted to TraceEvent-style ETW controlers (e.g. PerfVIew).    Basically there was confusion between a session bitmask (where the bits were 0, 1, 2,  and 3), and the ETW keywords bitmask which uses different bits and the 'ToEventKeywords() morphs from one to the other.  

This bug has existed for a while, but we are now using both of those features (keywords and complex types), in the DiagnosticEventSource and when we started to really use it we found the problem.

You will see in lines 1221 and 1242 is another code path that was already fixed, but we missed the code path at 1977 and 1998.

This needs to be back-ported to the Desktop framework as well.

@davmason 