### PR TITLE
Fix environment settings for Unix JIT stress scenarios

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -181,15 +181,15 @@ def static genStressModeScriptStep(def os, def stressModeName, def stressModeVar
         }
     }
     else {
-        // For these we don't use a script, we use directly
         stepScript += "echo Setting variables for ${stressModeName}\n"
-        stepScript += "rm -f ${stepScriptLocation}\n"
+        stepScript += "echo \\#\\!/usr/bin/env bash > ${stepScriptLocation}\n"
         stressModeVars.each{ k, v -> 
             // Write out what we are writing to the script file
             stepScript += "echo Setting ${k}=${v}\n"
             // Write out the set itself to the script file`
             stepScript += "echo export ${k}=${v} >> ${stepScriptLocation}\n"
         }
+        stepScript += "chmod +x ${stepScriptLocation}\n"
     }
     return stepScript
 }

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -918,6 +918,8 @@ fi
 scriptPath=$(dirname $0)
 ${scriptPath}/setup-runtime-dependencies.sh --outputDir=$coreOverlayDir
 
+export __TestEnv=$testEnv
+
 cd "$testRootDir"
 if [ -z "$testDirectories" ]
 then

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -301,8 +301,10 @@ cd "$%28dirname "$0")"
 LockFile="lock"
 
 
-# The __TestEnv variable may be used to specify something to run before the test.
-$__TestEnv
+# The __TestEnv variable may be used to specify a script to source before the test.
+if [ -n "$__TestEnv" ]%3B then
+    source $__TestEnv
+fi
 
 $(BashEnvironmentVariables)
 $(BashCLRTestEnvironmentCompatibilityCheck)


### PR DESCRIPTION
The environment settings necessary to run tests in these modes were being
dropped.  They need to be tunneled through properly in a couple of places.

Fixes #5278