### PR TITLE
Excluding Weak-GCReferences tests from GC stress runs

### DIFF
--- a/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceCtor1_PSC.csproj
+++ b/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceCtor1_PSC.csproj
@@ -17,6 +17,7 @@
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceCtor2_PSC.csproj
+++ b/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceCtor2_PSC.csproj
@@ -17,6 +17,7 @@
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceCtor2b_PSC.csproj
+++ b/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceCtor2b_PSC.csproj
@@ -17,6 +17,7 @@
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceIsAlive_PSC.csproj
+++ b/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceIsAlive_PSC.csproj
@@ -17,6 +17,7 @@
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceIsAliveb_PSC.csproj
+++ b/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceIsAliveb_PSC.csproj
@@ -17,6 +17,7 @@
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceTargetb_PSC.csproj
+++ b/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceTargetb_PSC.csproj
@@ -17,6 +17,7 @@
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceTrackResurrection_cti_PSC.csproj
+++ b/tests/src/CoreMangLib/cti/system/weakreference/WeakReferenceTrackResurrection_cti_PSC.csproj
@@ -17,6 +17,7 @@
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
@ramarag PTAL.

Fix for issue #3792. Tested that this fix does exclude the tests from running when complus_gcstress is set.