### PR TITLE
Enable other distros for building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -211,13 +211,30 @@ isMSBuildOnNETCoreSupported()
 
     if [ "$__HostArch" == "x64" ]; then
         if [ "$__HostOS" == "Linux" ]; then
-            if [ "$__DistroRid" == "ubuntu.14.04-x64" ]; then
-                __isMSBuildOnNETCoreSupported=1
-            elif [ "$__DistroRid" == "rhel.7.2-x64" ]; then
-                __isMSBuildOnNETCoreSupported=1
-            elif [ "$__DistroRid" == "debian.8-x64" ]; then
-                __isMSBuildOnNETCoreSupported=1
-            fi
+            case "$__DistroRid" in
+                "centos.7-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
+                "debian.8-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
+                "fedora.23-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
+                "opensuse.13.2-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
+                "rhel.7.2-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
+                "ubuntu.14.04-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
+                "ubuntu.16.04-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
+                *)
+            esac
         elif [ "$__HostOS" == "OSX" ]; then
             __isMSBuildOnNETCoreSupported=1
         fi

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -47,26 +47,26 @@ case $OSName in
 
     Linux)
         OS=Linux
-        __DOTNET_PKG=dotnet-dev-ubuntu-x64
+
+        if [ ! -e /etc/os-release ]; then
+            echo "Cannot determine Linux distribution, asuming Ubuntu 14.04."
+            __DOTNET_PKG=dotnet-dev-ubuntu.14.04-x64
+        else
+            source /etc/os-release
+            __DOTNET_PKG="dotnet-dev-$ID.$VERSION_ID-x64"
+        fi
         ;;
 
     *)
         echo "Unsupported OS $OSName detected. Downloading ubuntu-x64 tools"
         OS=Linux
-        __DOTNET_PKG=dotnet-dev-ubuntu-x64
+        __DOTNET_PKG=dotnet-dev-ubuntu.14.04-x64
         ;;
 esac
 
 # Initialize Linux Distribution name and .NET CLI package name.
 
 initDistroName $OS
-if [ "$__DistroRid" == "centos.7-x64" ]; then
-    __DOTNET_PKG=dotnet-dev-centos-x64
-fi
-
-if [ "$__DistroRid" == "rhel.7.2-x64" ]; then
-    __DOTNET_PKG=dotnet-dev-rhel-x64
-fi
 
 # Work around mac build issue 
 if [ "$OS"=="OSX" ]; then


### PR DESCRIPTION
This builds on top of @joperezr recent pull requests, because he went through the trouble of updating buildtools and the CLI for me.  Once his is merged, this could go it.

I am still doing validation on the new platforms in docker, but Ubuntu 16.04 worked as expected.  Opening now to get a CI run.

/cc @gkhanna79 @weshaggard 