### PR TITLE
Add noexcept specifier to some non-throwing new operators

### DIFF
--- a/src/inc/new.hpp
+++ b/src/inc/new.hpp
@@ -8,11 +8,17 @@
 #ifndef __new__hpp
 #define __new__hpp
 
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define NOEXCEPT
+#else
+#define NOEXCEPT noexcept
+#endif
+
 struct NoThrow { int x; };
 extern const NoThrow nothrow;
 
-void * __cdecl operator new(size_t n, const NoThrow&);
-void * __cdecl operator new[](size_t n, const NoThrow&);
+void * __cdecl operator new(size_t n, const NoThrow&) NOEXCEPT;
+void * __cdecl operator new[](size_t n, const NoThrow&) NOEXCEPT;
 
 #ifdef _DEBUG
 void DisableThrowCheck();

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -29,6 +29,7 @@
 #include "winnls.h"
 #include "check.h"
 #include "safemath.h"
+#include "new.hpp"
 
 #ifdef PAL_STDCPP_COMPAT
 #include <type_traits>
@@ -210,12 +211,6 @@ typedef LPSTR   LPUTF8;
 #ifndef sizeofmember
 // Returns the size of a class or struct member.
 #define sizeofmember(c,m) (sizeof(((c*)0)->m))
-#endif
-
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define NOEXCEPT
-#else
-#define NOEXCEPT noexcept
 #endif
 
 //=--------------------------------------------------------------------------=

--- a/src/utilcode/clrhost_nodependencies.cpp
+++ b/src/utilcode/clrhost_nodependencies.cpp
@@ -441,7 +441,7 @@ operator new[](size_t n)
 
 #endif // HAS_ADDRESS_SANITIZER
 
-void * __cdecl operator new(size_t n, const NoThrow&)
+void * __cdecl operator new(size_t n, const NoThrow&) NOEXCEPT
 {
 #ifdef HAS_ADDRESS_SANITIZER
     // use standard heap functions for address santizier (which doesn't provide for NoThrow)
@@ -461,7 +461,7 @@ void * __cdecl operator new(size_t n, const NoThrow&)
     return result;
 }
 
-void * __cdecl operator new[](size_t n, const NoThrow&)
+void * __cdecl operator new[](size_t n, const NoThrow&) NOEXCEPT
 {
 #ifdef HAS_ADDRESS_SANITIZER
     // use standard heap functions for address santizier (which doesn't provide for NoThrow)


### PR DESCRIPTION
This change fixes a couple of non-throwing new operators to specify they they are `noexcept`. 

MSVC generates code that checks the pointer to the memory allocated by `operator new` before trying to use it, but by the C++ standard, it's okay to skip that check since any `operator new` that doesn't have an empty exception specification will throw if the allocation failed.

Clang doesn’t add the extra check, so even if allocation fails, the constructor for the object will be called and it’ll try to dereference null. GCC has a flag (`-fcheck-new`) to force checking the pointer, but it appears that Clang doesn’t have an equivalent. As a fix, we'll add the `noexcept` specifier to tell the compiler that these `new` operators won’t throw if they fail to allocate.

Example of behavior before:
```
   0x00007ffff68fee02 <+50>:    callq  0x7ffff65a4550 <operator new(unsigned long, NoThrow const&)>
   0x00007ffff68fee07 <+55>:    mov    %rax,%rbx
   0x00007ffff68fee0a <+58>:    mov    %rbx,%rdi
   0x00007ffff68fee0d <+61>:    callq  0x7ffff6929350 <CMiniMdRW::CMiniMdRW()>
```

Same example after adding `noexcept`:
```
   0x00007ffff68ff192 <+50>:    callq  0x7ffff65a4560 <operator new(unsigned long, NoThrow const&)>
   0x00007ffff68ff197 <+55>:    mov    %rax,%rbx
   0x00007ffff68ff19a <+58>:    test   %rbx,%rbx
   0x00007ffff68ff19d <+61>:    je     0x7ffff68ff322 <RegMeta::CreateNewMD()+450>
   0x00007ffff68ff1a3 <+67>:    mov    %rbx,%rdi
   0x00007ffff68ff1a6 <+70>:    callq  0x7ffff6929800 <CMiniMdRW::CMiniMdRW()>
```

Fixes #5193 