### PR TITLE
Fix a build break due to PR #5101

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3926,7 +3926,7 @@ void                 Compiler::compCompile(void * * methodCodePtr,
         assert(!compIsForInlining());
 #ifdef DEBUG // We only have access to info.compFullName in DEBUG builds.
         fprintf(compJitFuncInfoFile, "%s\n", info.compFullName);
-#else
+#elif FEATURE_SIMD
         fprintf(compJitFuncInfoFile, " %s\n", eeGetMethodFullName(info.compMethodHnd));
 #endif
         fprintf(compJitFuncInfoFile, "");         // in our logic this causes a flush

--- a/src/jit/eeinterface.cpp
+++ b/src/jit/eeinterface.cpp
@@ -20,6 +20,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #pragma hdrstop
 #endif
 
+#if defined(DEBUG) || defined(FEATURE_JIT_METHOD_PERF) || defined(FEATURE_SIMD)
+
 #pragma warning(push)
 #pragma warning(disable:4701) // difficult to get rid of C4701 with 'sig' below
 
@@ -196,5 +198,7 @@ const char* Compiler::eeGetMethodFullName (CORINFO_METHOD_HANDLE  hnd)
 }
 
 #pragma warning(pop)
+
+#endif // defined(DEBUG) || defined(FEATURE_JIT_METHOD_PERF) || defined(FEATURE_SIMD)
 
 /*****************************************************************************/


### PR DESCRIPTION
The declaration, definition and uses of eeGetMethodFullName
didn't match.