### PR TITLE
Don't use GCC libstdc++ wrappers for stdlib.h

### DIFF
--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -567,6 +567,10 @@ function_name() to call the system's implementation
 #endif
 #include <ctype.h>
 
+// Don't use C++ wrappers for stdlib.h
+// https://gcc.gnu.org/ml/libstdc++/2016-01/msg00025.html 
+#define _GLIBCXX_INCLUDE_NEXT_C_HEADERS 1
+
 #define _WITH_GETLINE
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Recent GCC-Versions (>= 6) added  [C++-conforming wrappers for stdlib.h and math.h](https://github.com/gcc-mirror/gcc/commit/6c8ced3f4f867b72a623fe2f23efa204c5786a28),  which [broke](https://github.com/dotnet/coreclr/issues/5006) the build of _pal_:

`mbstring.cpp:182:20: error: use of undeclared identifier 'min'
`
[Detailed description of root cause](https://github.com/dotnet/coreclr/issues/5006#issuecomment-
222191925)

The definition of `_GLIBCXX_INCLUDE_NEXT_C_HEADERS` prevents the use of the new wrappers.
