### PR TITLE
Fix ucol_setMaxVariable detection for Gentoo Linux

### DIFF
--- a/src/corefx/System.Globalization.Native/configure.cmake
+++ b/src/corefx/System.Globalization.Native/configure.cmake
@@ -8,11 +8,18 @@ CHECK_CXX_SOURCE_COMPILES("
     int main() { UDateFormatSymbolType e = UDAT_STANDALONE_SHORTER_WEEKDAYS; }
 " HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS)
 
+if(NOT CLR_CMAKE_PLATFORM_DARWIN)
+    set(CMAKE_REQUIRED_LIBRARIES ${ICUUC} ${ICUI18N})
+else()
+    set(CMAKE_REQUIRED_LIBRARIES ${ICUCORE})
+endif()
+
 check_symbol_exists(
     ucol_setMaxVariable
     "unicode/ucol.h"
     HAVE_SET_MAX_VARIABLE)
 
+unset(CMAKE_REQUIRED_LIBRARIES)
 unset(CMAKE_REQUIRED_INCLUDES)
 
 configure_file(


### PR DESCRIPTION
The issue was the symbol is exported by the ICU lib. Including headers
was not enough. The linker requires the libraries to succeed.

With this fix, CoreCLR successfully builds on Gentoo Linux 100%.
Tested with LXC gentoo container on Ubuntu machine.

Steps to configure and build:
https://gist.github.com/jasonwilliams200OK/1a2e2c0e904ffa95faf6333fcd88d9b8
*(updated this guide with additional steps to build CoreFX native)*

Fix #5160