### PR TITLE
Import `new` multi-dimmensional array using the non-vararg helper

### DIFF
--- a/src/inc/readytorun.h
+++ b/src/inc/readytorun.h
@@ -229,6 +229,7 @@ enum ReadyToRunHelper
     READYTORUN_HELPER_Unbox                     = 0x5A,
     READYTORUN_HELPER_Unbox_Nullable            = 0x5B,
     READYTORUN_HELPER_NewMultiDimArr            = 0x5C,
+    READYTORUN_HELPER_NewMultiDimArr_NonVarArg  = 0x5D,
 
     // Helpers used with generic handle lookup cases
     READYTORUN_HELPER_NewObject                 = 0x60,

--- a/src/inc/readytorunhelpers.h
+++ b/src/inc/readytorunhelpers.h
@@ -41,6 +41,7 @@ HELPER(READYTORUN_HELPER_Box_Nullable,              CORINFO_HELP_BOX_NULLABLE,  
 HELPER(READYTORUN_HELPER_Unbox,                     CORINFO_HELP_UNBOX,                             )
 HELPER(READYTORUN_HELPER_Unbox_Nullable,            CORINFO_HELP_UNBOX_NULLABLE,                    )
 HELPER(READYTORUN_HELPER_NewMultiDimArr,            CORINFO_HELP_NEW_MDARR,                         )
+HELPER(READYTORUN_HELPER_NewMultiDimArr_NonVarArg,  CORINFO_HELP_NEW_MDARR_NONVARARG,               )
 
 HELPER(READYTORUN_HELPER_NewObject,                 CORINFO_HELP_NEWFAST,                           )
 HELPER(READYTORUN_HELPER_NewArray,                  CORINFO_HELP_NEWARR_1_DIRECT,                   )

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2303,6 +2303,8 @@ public :
     
     unsigned            lvaLocAllocSPvar;               // variable which has the result of the last alloca/localloc
 
+    unsigned            lvaNewObjArrayArgs;             // variable with arguments for new MD array helper
+
     // TODO-Review: Prior to reg predict we reserve 24 bytes for Spill temps.
     //              after the reg predict we will use a computed maxTmpSize 
     //              which is based upon the number of spill temps predicted by reg predict
@@ -2678,6 +2680,8 @@ protected :
 
     void                impImportAndPushBox (CORINFO_RESOLVED_TOKEN * pResolvedToken);
 
+    void                impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken,
+                                             CORINFO_CALL_INFO* pCallInfo);
 
     bool                impCanPInvokeInline(var_types callRetTyp);
     bool                impCanPInvokeInlineCallSite(var_types callRetTyp);

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -56,7 +56,6 @@ INLINE_OBSERVATION(NEEDS_SECURITY_CHECK,      bool,   "needs security check",   
 INLINE_OBSERVATION(NO_METHOD_INFO,            bool,   "cannot get method info",        FATAL,       CALLEE)
 INLINE_OBSERVATION(NOT_PROFITABLE_INLINE,     bool,   "unprofitable inline",           FATAL,       CALLEE)
 INLINE_OBSERVATION(RANDOM_REJECT,             bool,   "random reject",                 FATAL,       CALLEE)
-INLINE_OBSERVATION(RETURN_TYPE_IS_COMPOSITE,  bool,   "has composite return type",     FATAL,       CALLEE)
 INLINE_OBSERVATION(STACK_CRAWL_MARK,          bool,   "uses stack crawl mark",         FATAL,       CALLEE)
 INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",            FATAL,       CALLEE)
 INLINE_OBSERVATION(THROW_WITH_INVALID_STACK,  bool,   "throw with invalid stack",      FATAL,       CALLEE)

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -55,6 +55,7 @@ void                Compiler::lvaInit()
     lvaPromotedStructAssemblyScratchVar = BAD_VAR_NUM;
 #endif // _TARGET_ARM_
     lvaLocAllocSPvar = BAD_VAR_NUM;
+    lvaNewObjArrayArgs = BAD_VAR_NUM;
     lvaGSSecurityCookie  = BAD_VAR_NUM;
 #ifdef _TARGET_X86_
     lvaVarargsBaseOfStkArgs = BAD_VAR_NUM;


### PR DESCRIPTION
Enabled for CoreRT ABI only for now. Enabling this for all targets would require ReadyToRun version bump that I am not sure we are ready for with 1.0 RTM still in flight.