### PR TITLE
Speed up CreateComparer in Comparer/EqualityComparer

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Comparer.cs
@@ -41,23 +41,30 @@ namespace System.Collections.Generic
         // saves the right instantiations
         //
         [System.Security.SecuritySafeCritical]  // auto-generated
-        private static Comparer<T> CreateComparer() {
+        private static Comparer<T> CreateComparer()
+        {
+            object result = null;
             RuntimeType t = (RuntimeType)typeof(T);
 
             // If T implements IComparable<T> return a GenericComparer<T>
-            if (typeof(IComparable<T>).IsAssignableFrom(t)) {
-                return (Comparer<T>)RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericComparer<int>), t);
+            if (typeof(IComparable<T>).IsAssignableFrom(t))
+            {
+                result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericComparer<int>), t);
             }
-
-            // If T is a Nullable<U> where U implements IComparable<U> return a NullableComparer<U>
-            if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>)) {
-                RuntimeType u = (RuntimeType)t.GetGenericArguments()[0];
-                if (typeof(IComparable<>).MakeGenericType(u).IsAssignableFrom(u)) {
-                    return (Comparer<T>)RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(NullableComparer<int>), u);
+            else if (default(T) == null)
+            {
+                // If T is a Nullable<U> where U implements IComparable<U> return a NullableComparer<U>
+                if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>)) {
+                    RuntimeType u = (RuntimeType)t.GetGenericArguments()[0];
+                    if (typeof(IComparable<>).MakeGenericType(u).IsAssignableFrom(u)) {
+                        result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(NullableComparer<int>), u);
+                    }
                 }
             }
-            // Otherwise return an ObjectComparer<T>
-          return new ObjectComparer<T>();
+            
+            return result != null ?
+                (Comparer<T>)result :
+                new ObjectComparer<T>(); // Fallback to ObjectComparer, which uses boxing
         }
 
         public abstract int Compare(T x, T y);


### PR DESCRIPTION
Changes:

- Check if the value of `default(T) == null` before checking if the type is an enum/is nullable. These checks will be optimized away by the jit once it specializes the type parameters, and saves us the trouble of calling `IsGenericType` (and possibly `GetGenericTypeDefinition`) for non-Nullable structs.
- Replaced some ordinary casts with `JitHelpers.UnsafeCast`, since the jit was generating calls to `CORINFO_HELP_CHKCASTCLASS_SPECIAL` even though when it knew the type of T.

Note: I didn't replace the casts to `RuntimeType` as it seems to be generating a call to a different method, `CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE` instead of the `CHKCASTCLASS` one. Would it help to replace those sites with `JitHelpers.UnsafeCast<RuntimeType>` as well?

cc: @jkotas @omariom