### PR TITLE
Fix JIT PInvoke Check Failure on Linux/ARM

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -20522,15 +20522,15 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
             BasicBlock  *   esp_check;
 
             CORINFO_EE_INFO * pInfo = compiler->eeGetEEInfo();
-
+#ifdef _TARGET_X86_
             /* mov   ecx, dword ptr [frame.callSiteTracker] */
 
-            getEmitter()->emitIns_R_S (ins_Load(TYP_I_IMPL),
-                                      EA_PTRSIZE,
-                                      REG_OPT_RSVD,
+            getEmitter()->emitIns_R_S (INS_mov,
+                                      EA_4BYTE,
+                                      REG_ARG_0,
                                       compiler->lvaInlinedPInvokeFrameVar,
                                       pInfo->inlinedCallFrameInfo.offsetOfCallSiteSP);
-            regTracker.rsTrackRegTrash(REG_OPT_RSVD);
+            regTracker.rsTrackRegTrash(REG_ARG_0);
 
             /* Generate the conditional jump */
 
@@ -20540,11 +20540,11 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
                 {
                     getEmitter()->emitIns_R_I  (INS_add,
                                               EA_PTRSIZE,
-                                              REG_OPT_RSVD,
+                                              REG_ARG_0,
                                               argSize);
                 }
             }
-
+#endif
             /* cmp   ecx, esp */
 
             getEmitter()->emitIns_R_R(INS_cmp, EA_PTRSIZE, REG_OPT_RSVD, REG_SPBASE);
@@ -22319,7 +22319,7 @@ regNumber          CodeGen::genPInvokeCallProlog(LclVarDsc*            frameList
         regTracker.rsTrackRegTrash(tcbReg);
     }
 
-#if defined(_TARGET_X86_) || defined(_TARGET_ARM_)
+#if defined(_TARGET_X86_)
     /* mov   dword ptr [frame.callSiteTracker], esp */
 
     getEmitter()->emitIns_S_R  (ins_Store(TYP_I_IMPL),

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -20516,13 +20516,13 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
     {
         genDefineTempLabel(returnLabel);
 
+#ifdef _TARGET_X86_
         if (getInlinePInvokeCheckEnabled())
         {
             noway_assert(compiler->lvaInlinedPInvokeFrameVar != BAD_VAR_NUM);
             BasicBlock  *   esp_check;
 
             CORINFO_EE_INFO * pInfo = compiler->eeGetEEInfo();
-#ifdef _TARGET_X86_
             /* mov   ecx, dword ptr [frame.callSiteTracker] */
 
             getEmitter()->emitIns_R_S (INS_mov,
@@ -20544,10 +20544,9 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
                                               argSize);
                 }
             }
-#endif
             /* cmp   ecx, esp */
 
-            getEmitter()->emitIns_R_R(INS_cmp, EA_PTRSIZE, REG_OPT_RSVD, REG_SPBASE);
+            getEmitter()->emitIns_R_R(INS_cmp, EA_PTRSIZE, REG_ARG_0, REG_SPBASE);
 
             esp_check = genCreateTempLabel();
 
@@ -20560,6 +20559,7 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
 
             genDefineTempLabel(esp_check);
         }
+#endif
     }
 
     /* Are we supposed to pop the arguments? */

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -20525,12 +20525,12 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
 
             /* mov   ecx, dword ptr [frame.callSiteTracker] */
 
-            getEmitter()->emitIns_R_S (INS_mov,
-                                      EA_4BYTE,
-                                      REG_ARG_0,
+            getEmitter()->emitIns_R_S (ins_Load(TYP_I_IMPL),
+                                      EA_PTRSIZE,
+                                      REG_OPT_RSVD,
                                       compiler->lvaInlinedPInvokeFrameVar,
                                       pInfo->inlinedCallFrameInfo.offsetOfCallSiteSP);
-            regTracker.rsTrackRegTrash(REG_ARG_0);
+            regTracker.rsTrackRegTrash(REG_OPT_RSVD);
 
             /* Generate the conditional jump */
 
@@ -20539,15 +20539,15 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
                 if (argSize)
                 {
                     getEmitter()->emitIns_R_I  (INS_add,
-                                              EA_4BYTE,
-                                              REG_ARG_0,
+                                              EA_PTRSIZE,
+                                              REG_OPT_RSVD,
                                               argSize);
                 }
             }
 
             /* cmp   ecx, esp */
 
-            getEmitter()->emitIns_R_R(INS_cmp, EA_4BYTE, REG_ARG_0, REG_SPBASE);
+            getEmitter()->emitIns_R_R(INS_cmp, EA_PTRSIZE, REG_OPT_RSVD, REG_SPBASE);
 
             esp_check = genCreateTempLabel();
 
@@ -22319,7 +22319,7 @@ regNumber          CodeGen::genPInvokeCallProlog(LclVarDsc*            frameList
         regTracker.rsTrackRegTrash(tcbReg);
     }
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) || defined(_TARGET_ARM_)
     /* mov   dword ptr [frame.callSiteTracker], esp */
 
     getEmitter()->emitIns_S_R  (ins_Store(TYP_I_IMPL),

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -22319,7 +22319,7 @@ regNumber          CodeGen::genPInvokeCallProlog(LclVarDsc*            frameList
         regTracker.rsTrackRegTrash(tcbReg);
     }
 
-#if defined(_TARGET_X86_)
+#ifdef _TARGET_X86_
     /* mov   dword ptr [frame.callSiteTracker], esp */
 
     getEmitter()->emitIns_S_R  (ins_Store(TYP_I_IMPL),


### PR DESCRIPTION
This commit revieses some x86-specific codes for JIT PInvoke Check to
allow JIT PInvoke Check for ARM.

This PR tries to fix #5163.