### PR TITLE
Linux/ARM: Adding rpath for shared library of exception_handling.pal_sxs.test1

### DIFF
--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
@@ -7,6 +7,15 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
+# Set the RPATH of paltest_pal_sxs_test1 so that it can find dependencies without needing to set LD_LIBRARY
+# For more information: http://www.cmake.org/Wiki/CMake_RPATH_handling.
+if(CORECLR_SET_RPATH)
+  if(CLR_CMAKE_PLATFORM_LINUX)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+  endif(CLR_CMAKE_PLATFORM_LINUX)
+endif(CORECLR_SET_RPATH)
+
 # Test DLL1
 
 set(DEF_SOURCES1 dlltest1.src)


### PR DESCRIPTION
Let's add the 'rpath' in order to fix error happened while 'paltest_pal_sxs_test1' (ELF) of PAL test is loading a shared library. This 'rpath' statement is derived from the existing files such as ./ToolBox/SOS/Strike/CMakeLists.txt and dlls/mscordbi/CMakeLists.txt.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>