### PR TITLE
EventSource Events that use complex types do not get logged

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -1974,7 +1974,7 @@ namespace System.Diagnostics.Tracing
                                         m_eventData[eventId].Descriptor.Level,
                                         m_eventData[eventId].Descriptor.Opcode,
                                         m_eventData[eventId].Descriptor.Task,
-                                        unchecked((long)(ulong)etwSessions | origKwd));
+                                        unchecked((long)etwSessions.ToEventKeywords() | origKwd));
 
                                     if (!m_provider.WriteEvent(ref desc, pActivityId, childActivityID, args))
                                         ThrowEventSourceException(m_eventData[eventId].Name);
@@ -1995,7 +1995,7 @@ namespace System.Diagnostics.Tracing
                                 // TODO: activity ID support
                                 EventSourceOptions opt = new EventSourceOptions
                                 {
-                                    Keywords = (EventKeywords)unchecked((long)(ulong)etwSessions | origKwd),
+                                    Keywords = (EventKeywords)unchecked((long)etwSessions.ToEventKeywords() | origKwd),
                                     Level = (EventLevel)m_eventData[eventId].Descriptor.Level,
                                     Opcode = (EventOpcode)m_eventData[eventId].Descriptor.Opcode
                                 };


### PR DESCRIPTION
The Azure Tools team has a tool called Service Profiler that can be used to diagnose performance problems in web services.   It works by collecting detailed ETW events from the .NET Runtime.   it works well on desktop scenarios and they very much want it to work for .NET Core scenarios as well.  As key aspect of this is to get events when an incoming request starts and ends.   There is instrumentation for this in .NET Core in the form of DiagnosticSource logging.   There is also a bridge that forwards these events on to EventLIsteners / ETW.   Unfortunately, there was a latent bug that is triggered by a certain combination of EventSource feature that this bridge happens to use.   As a result we can't get the events we need.  As a result the Service Profiler tool can not be used 'out of the box'.    This means that users of .NET Core will have a significantly harder time diagnosing their performance problems (in just the past week we have instances of people wishing to do just this, and had to turn them away).  

The bug simply cause events that should have been logged to be dropped.   It does not change behavior otherwise.    It is also a very safe change as it only affects logging, and only the particular combination of logging features that were failing (it does not affect other scenarios).    This fix has already been checked in to the master branch but we would like to have the Service Profiler scenario working on the first RTM bits.  