### PR TITLE
Revise variable offset on double in ARM HFA

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -4358,8 +4358,14 @@ void            CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg,
 #endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING
             if (varDsc->lvIsHfaRegArg())
             {
+#ifdef _TARGET_ARM_
+                // On ARM32 the storeType for HFA args is always TYP_FLOAT
+                storeType = TYP_FLOAT;
+                slotSize  = (unsigned) emitActualTypeSize(storeType);
+#else // TARGET_ARM64
                 storeType = genActualType(varDsc->GetHfaType());
                 slotSize  = (unsigned) emitActualTypeSize(storeType);
+#endif // TARGET_ARM64
             }
         }
         else  // Not a struct type
@@ -4382,14 +4388,7 @@ void            CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg,
         else
         {
             // Since slot is typically 1, baseOffset is typically 0
-            int slot = regArgTab[argNum].slot;
-            
-#ifdef _TARGET_ARM_
-            if (storeType == TYP_DOUBLE)
-                slot = (slot + 1) / 2;
-#endif // _TARGET_ARM_
-            
-            int baseOffset = (slot - 1) * slotSize;
+            int baseOffset = (regArgTab[argNum].slot - 1) * slotSize;
 
             getEmitter()->emitIns_S_R(ins_Store(storeType),
                                         size,

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -393,6 +393,9 @@ public:
     {
         assert(lvIsHfa());
         assert(lvType==TYP_STRUCT);
+#ifdef _TARGET_ARM_
+        return lvExactSize / sizeof(float);
+#else
         if (lvHfaTypeIsFloat())
         {
             return lvExactSize / sizeof(float);
@@ -401,6 +404,7 @@ public:
         {
             return lvExactSize / sizeof(double);
         }
+#endif // _TARGET_ARM_
     }
 
 private:


### PR DESCRIPTION
ARM codegen currently uses the incorrect offset when it saves the
arguments onto the stack if the argument is HFA of double type.

This commit tries to make it correct in order to fix #5326.