### PR TITLE
Comment typo fix: removed double word

### DIFF
--- a/src/vm/amd64/JitHelpers_InlineGetThread.asm
+++ b/src/vm/amd64/JitHelpers_InlineGetThread.asm
@@ -164,7 +164,7 @@ LEAF_ENTRY AllocateStringFastMP_InlineGetThread, _TEXT
 
         ; Instead of doing elaborate overflow checks, we just limit the number of elements
         ; to (LARGE_OBJECT_SIZE - 256)/sizeof(WCHAR) or less.
-        ; This will avoid avoid all overflow problems, as well as making sure
+        ; This will avoid all overflow problems, as well as making sure
         ; big string objects are correctly allocated in the big object heap.
 
         cmp     ecx, (ASM_LARGE_OBJECT_SIZE - 256)/2


### PR DESCRIPTION
The overflow check comment for AllocateStringFastMP_InlineGetThread contained an extra "avoid".