### PR TITLE
ARM/Linux: Fix Exception Handler PAL Test Fail

### DIFF
--- a/src/pal/src/arch/arm/exceptionhelper.S
+++ b/src/pal/src/arch/arm/exceptionhelper.S
@@ -22,12 +22,12 @@ LEAF_ENTRY ThrowExceptionFromContextInternal, _TEXT
     ldr	r10,	[r0, #(CONTEXT_R10)]
     ldr	r11,	[r0, #(CONTEXT_R11)]
     ldr	sp,	[r0, #(CONTEXT_Sp)]
-    ldr	lr,	[r0, #(CONTEXT_Lr)]
 
     ldr	r2,	[r0, #(CONTEXT_Pc)]
 
     // Store return address to the stack
-    push    {r2}
+    // Added r7 as a dummy to keep the stack aligned by 8 bytes.
+    push    {r2, r7}
 
     // The PAL_SEHException pointer
     mov	r0,	r1


### PR DESCRIPTION
The return address should be kept intact, not recovered
just yet. It is going to be recovered by libgcc's
rescore_core_regs much later, few instructions before
heading back to "catch".

Fixes #5358 

This fixes stack misalignment during exception handling as well.
With this, we see ALL the ARM/Linux PAL tests pass.
