### PR TITLE
[ARM/Linux] Fix for #5275 Delegate Invocation Fix For arm-softfp

### DIFF
--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -12,6 +12,10 @@ add_definitions(-DFEATURE_LEAVE_RUNTIME_HOLDER=1)
 add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)
 
+if (ARM_SOFTFP)
+  add_definitions(-DARM_SOFTFP)
+endif (ARM_SOFTFP)
+
 if(CMAKE_CONFIGURATION_TYPES) # multi-configuration generator?
   foreach (Config DEBUG CHECKED)  
      set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:${Config}>:WRITE_BARRIER_CHECK=1>)

--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -1119,6 +1119,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
 
     // Ignore floating point argument placement in registers if we're dealing with a vararg function (the ABI
     // specifies this so that vararg processing on the callee side is simplified).
+#ifndef ARM_SOFTFP
     if (fFloatingPoint && !this->IsVarArg())
     {
         // Handle floating point (primitive) arguments.
@@ -1171,6 +1172,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
 
         return argOfs;
     }
+#endif // ARM_SOFTFP
 
     //
     // Handle the non-floating point case.


### PR DESCRIPTION
@janvorli could you please suggest a better place to store isARMSoftFP variable. Especially in case it needs to be applied anywhere else in vm. E.g. in jit it's stored as an option.