### PR TITLE
Remove duplicate avoid in comments from a few files

### DIFF
--- a/src/vm/amd64/JitHelpers_Slow.asm
+++ b/src/vm/amd64/JitHelpers_Slow.asm
@@ -277,7 +277,7 @@ NESTED_ENTRY AllocateStringFastMP, _TEXT
 
         ; Instead of doing elaborate overflow checks, we just limit the number of elements
         ; to (LARGE_OBJECT_SIZE - 256)/sizeof(WCHAR) or less.
-        ; This will avoid avoid all overflow problems, as well as making sure
+        ; This will avoid all overflow problems, as well as making sure
         ; big string objects are correctly allocated in the big object heap.
 
         cmp     ecx, (ASM_LARGE_OBJECT_SIZE - 256)/2
@@ -588,7 +588,7 @@ LEAF_ENTRY AllocateStringFastUP, _TEXT
 
         ; Instead of doing elaborate overflow checks, we just limit the number of elements
         ; to (LARGE_OBJECT_SIZE - 256)/sizeof(WCHAR) or less.
-        ; This will avoid avoid all overflow problems, as well as making sure
+        ; This will avoid all overflow problems, as well as making sure
         ; big string objects are correctly allocated in the big object heap.
 
         cmp     ecx, (ASM_LARGE_OBJECT_SIZE - 256)/2

--- a/src/vm/array.cpp
+++ b/src/vm/array.cpp
@@ -527,7 +527,7 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
     }
 
     // The type is sufficiently initialized for most general purpose accessor methods to work.
-    // Mark the type as restored to avoid avoid asserts. Note that this also enables IBC logging.
+    // Mark the type as restored to avoid asserts. Note that this also enables IBC logging.
     pMTWriteableData->SetIsFullyLoadedForBuildMethodTable();
 
     {

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -1227,7 +1227,7 @@ void *JIT_TrialAlloc::GenAllocString(Flags flags)
 
     // Instead of doing elaborate overflow checks, we just limit the number of elements
     // to (LARGE_OBJECT_SIZE - 256)/sizeof(WCHAR) or less.
-    // This will avoid avoid all overflow problems, as well as making sure
+    // This will avoid all overflow problems, as well as making sure
     // big string objects are correctly allocated in the big object heap.
 
     _ASSERTE(sizeof(WCHAR) == 2);


### PR DESCRIPTION
Just fixing some duplicate words (`avoid avoid`) in a handful of comments from a few native code files.