### PR TITLE
Mark two tests as always optimized and exclude two others from x86/JI…

### DIFF
--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b103058/b103058.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b103058/b103058.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <NoStandardLib>True</NoStandardLib>
     <Noconfig>True</Noconfig>
+    <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>

--- a/tests/src/JIT/opt/perf/doublealign/Locals.csproj
+++ b/tests/src/JIT/opt/perf/doublealign/Locals.csproj
@@ -32,6 +32,7 @@
     <NoLogo>True</NoLogo>
     <NoStandardLib>True</NoStandardLib>
     <Noconfig>True</Noconfig>
+    <Optimize>True</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>

--- a/tests/x86_jit32_issues.targets
+++ b/tests/x86_jit32_issues.targets
@@ -449,5 +449,11 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd">
              <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_468598\Test_HndIndex_10_Plain\Test_HndIndex_10_Plain.cmd">
+            <Issue>5286</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_468598\Test_HndIndex_10_Reordered\Test_HndIndex_10_Reordered.cmd">
+            <Issue>5286</Issue>
+        </ExcludeList>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
…T32.

The former tests require optimization in order to pass and the latter require further
deliberation re: the appropriate fix (see #5286 for more info).

Fixes #5292.