### PR TITLE
Remove some lexical-CSE-related code.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5401,7 +5401,7 @@ protected :
                         }
 
 #ifdef DEBUG
-    bool                optConfigDisableCSE(bool lexicalCSE);
+    bool                optConfigDisableCSE();
     bool                optConfigDisableCSE2();
 #endif
     void                optOptimizeCSEs();

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2074,7 +2074,7 @@ void                Compiler::optOptimizeValnumCSEs()
     if  (verbose) 
         printf("\n*************** In optOptimizeValnumCSEs()\n");
 
-    if (optConfigDisableCSE(false))
+    if (optConfigDisableCSE())
         return;   // Disabled by JitNoCSE 
 #endif
 
@@ -2271,18 +2271,8 @@ bool                Compiler::optIsCSEcandidate(GenTreePtr tree)
 // If this method returns false then the CSE phase should be performed.
 // If the method returns true then the CSE phase should be skipped.
 //
-bool                Compiler::optConfigDisableCSE(bool lexicalCSE)
+bool                Compiler::optConfigDisableCSE()
 {
-    bool enabled = true;
-
-#if VALNUM_CSE_ENABLED
-    if (lexicalCSE)
-        return true;        // lexical CSE phase is disabled
-#else
-    if (!lexicalCSE)
-        return true;        // valnum CSE phase is disabled
-#endif
-
     // Next check if COMPlus_JitNoCSE is set and applies to this method
     //
     unsigned jitNoCSE = JitConfig.JitNoCSE();
@@ -2297,20 +2287,27 @@ bool                Compiler::optConfigDisableCSE(bool lexicalCSE)
             unsigned bitsOne         = (jitNoCSE >>  0) & 0xFFF;
              
             if ((( methodCountMask & bitsOne)  == bitsOne) &&
-                ((~methodCountMask & bitsZero) == bitsZero)   )
+                ((~methodCountMask & bitsZero) == bitsZero))
             {
-                if  (verbose) 
+                if (verbose)
+                {
                     printf(" Disabled by JitNoCSE methodCountMask\n");
+                }
+
                 return true;  // The CSE phase for this method is disabled
             }
         }
         else if (jitNoCSE <= (methodCount+1))
         {
-            if  (verbose) 
+            if (verbose)
+            {
                 printf(" Disabled by JitNoCSE > methodCount\n");
+            }
+
             return true;  // The CSE phase for this method is disabled
         }
     }
+
     return false;
 }
 

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -330,10 +330,6 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
 
 /*****************************************************************************/
 
-#define VALNUM_CSE_ENABLED      1
-
-/*****************************************************************************/
-
 #if defined(_TARGET_X86_)
 
   #define CPU_LOAD_STORE_ARCH      0
@@ -415,7 +411,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
 #else // LEGACY_BACKEND
   #define FEATURE_STACK_FP_X87     1       // Use flat register file model    
 #endif // LEGACY_BACKEND
-  #define FEATURE_X87_DOUBLES      (1-VALNUM_CSE_ENABLED)       // FP tree temps always use x87 doubles (when 1) or can be double or float (when 0)
+  #define FEATURE_X87_DOUBLES      0       // FP tree temps always use x87 doubles (when 1) or can be double or float (when 0).
   #define ETW_EBP_FRAMED           1       // if 1 we cannot use EBP as a scratch register and must create EBP based frames for most methods
   #define CSE_CONSTS               1       // Enable if we want to CSE constants
 


### PR DESCRIPTION
Lexical CSE is no more; remove some related code:
- Remove the `lexicalCSE` parameter and related checks from `optConfigDisableCSE`.
- Remove the `VALNUM_CSE_ENABLED` symbol: this symbol is unconditionally
  set to 1 and doesn't control much other than the behavior of
  `optConfigDisableCSE`