### PR TITLE
Run fgMorphCopyBlock for newly inserted assignment

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -14856,7 +14856,9 @@ void                Compiler::fgMorphBlocks()
                     noway_assert(ret->gtGetOp1() != nullptr);
                     noway_assert(ret->gtGetOp2() == nullptr);
 
-                    last->gtStmt.gtStmtExpr = gtNewTempAssign(genReturnLocal, ret->gtGetOp1());
+                    GenTreePtr tree = gtNewTempAssign(genReturnLocal, ret->gtGetOp1());
+
+                    last->gtStmt.gtStmtExpr = (tree->OperIsCopyBlkOp()) ? fgMorphCopyBlock(tree) : tree;
 
                     //make sure that copy-prop ignores this assignment.
                     last->gtStmt.gtStmtExpr->gtFlags |= GTF_DONT_CSE;


### PR DESCRIPTION
When one return modification is turned on, the current implementation of
fgMorphBlocks converts the return statement as an assigment at the end of
block aftter fgMorphStmts is performed.

As a result, unfortunately, the newly inserted assignment statement is
never morphed, which results in some strange behavior inside codegen
(which is discussed in #5357).

This commit tries to run fgMorphCopyBlock on newly inserted assignment in
order to fix #5357.