### PR TITLE
Add limit to number of generics methods to compile by CrossGen

### DIFF
--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -4939,6 +4939,8 @@ CEEPreloader::CEEPreloader(Module *pModule,
 
     GetAppDomain()->ToCompilationDomain()->SetTargetImage(m_image, this);
 
+    m_methodCompileLimit = pModule->GetMDImport()->GetCountWithTokenKind(mdtMethodDef) * 10;
+
 #ifdef FEATURE_FULL_NGEN
     m_fSpeculativeTriage = FALSE;
     m_fDictionariesPopulated = FALSE;
@@ -5148,7 +5150,7 @@ void CEEPreloader::MethodReferencedByCompiledCode(CORINFO_METHOD_HANDLE handle)
 
         if (pEntry->fScheduled)
             return;        
-        m_uncompiledMethods.Append(pMD);
+        AppendUncompiledMethod(pMD);
     }
     else
     {
@@ -5358,7 +5360,7 @@ void CEEPreloader::AddToUncompiledMethods(MethodDesc *pMD, BOOL fForStubs)
     }
 
     // Add it to the set of uncompiled methods
-    m_uncompiledMethods.Append(pMD);
+    AppendUncompiledMethod(pMD);
 }
 
 //

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -527,6 +527,17 @@ class CEEPreloader : public ICorCompilePreloader
     // Array of methods that we need to compile.
     SArray<MethodDesc*> m_uncompiledMethods;
 
+    int m_methodCompileLimit;
+
+    void AppendUncompiledMethod(MethodDesc *pMD)
+    {
+        if (m_methodCompileLimit > 0)
+        {
+            m_uncompiledMethods.Append(pMD);
+            m_methodCompileLimit--;
+        }
+    }
+
     struct DuplicateMethodEntry
     {
         MethodDesc * pMD;


### PR DESCRIPTION
Fixes the following test failure in issue #5366: JIT.Regression_clr_x64_JIT_v4_0_devdiv374539_DevDiv_374539_DevDiv_374539._Regression_clr_x64_JIT_v4_0_devdiv374539_DevDiv_374539_DevDiv_374539_cmd

Recursive generic definitions can easily make CrossGen take very
long time to complete. This is the cause of a failure in issue #5366.
This is fixed by limiting the number of methods to compile by CrossGen.