### PR TITLE
Validate new object construction in Ready to Run

### DIFF
--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3434,6 +3434,9 @@ bool ZapInfo::getReadyToRunHelper(CORINFO_RESOLVED_TOKEN * pResolvedToken,
 	switch (id)
 	{
 	case CORINFO_HELP_READYTORUN_NEW:
+        // Call CEEInfo::getNewHelper to validate the request (e.g., check for abstract class).
+        m_pEEJitInfo->getNewHelper(pResolvedToken, m_currentMethodHandle);
+
 		if ((getClassAttribs(pResolvedToken->hClass) & CORINFO_FLG_SHAREDINST) != 0)
 			return false;   // Requires runtime lookup.
 		pImport = m_pImage->GetImportTable()->GetDynamicHelperCell(


### PR DESCRIPTION
Existing Ready to Run implementation doesn't fully validate requests
to create object instances, and allows some invalidate requests (e.g.,
to create an instance of an abstract class). This causes failure of
test case Loader.classloader_generics_Instantiation_Negative_abstract01
in issue #5366.