### PR TITLE
Inliner: enable inlining of methods with cpblk

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4604,7 +4604,6 @@ DECODE_OPCODE:
         case CEE_CALLI:
             //Needs weight value in SMWeights.cpp
         case CEE_LOCALLOC:
-        case CEE_CPBLK:
         case CEE_MKREFANY:
         case CEE_RETHROW:
             //Consider making this only for not force inline.

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -13241,8 +13241,6 @@ INITBLK_OR_INITOBJ:
 
         case CEE_CPBLK:
 
-            assert(!compIsForInlining());
-                        
             if (tiVerificationNeeded)
                 Verify(false, "bad opcode");
             op3 = impPopStack().val;        // Size

--- a/tests/src/JIT/config/extra/project.json
+++ b/tests/src/JIT/config/extra/project.json
@@ -14,6 +14,7 @@
     "System.Reflection.TypeExtensions": "4.1.0-rc3-24117-00",
     "System.Runtime": "4.1.0-rc3-24117-00",
     "System.Runtime.Extensions": "4.0.10",
+    "System.Runtime.CompilerServices.Unsafe": "4.0.0-rc3-24117-00",
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {

--- a/tests/src/JIT/opt/Inline/tests/UnsafeBlockCopy.cs
+++ b/tests/src/JIT/opt/Inline/tests/UnsafeBlockCopy.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Test 
+{
+    static int SIZE = 100;
+
+    public static unsafe int Main()
+    {
+        byte* source = stackalloc byte[SIZE];
+        byte* dest   = stackalloc byte[SIZE];
+
+        for (int i = 0; i < SIZE; i++)
+        {
+            source[i] = (byte)(i % 255);
+            dest[i] = 0;
+        }
+
+        Unsafe.CopyBlock(dest, source, (uint) SIZE);
+
+        bool result = true;
+
+        for (int i = 0; i < SIZE; i++)
+        {
+            result &= (source[i] == dest[i]);
+        }
+
+        return (result ? 100 : -1);
+    }
+}

--- a/tests/src/JIT/opt/Inline/tests/UnsafeBlockCopy.csproj
+++ b/tests/src/JIT/opt/Inline/tests/UnsafeBlockCopy.csproj
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+    <NoLogo>True</NoLogo>
+    <NoStandardLib>True</NoStandardLib>
+    <Noconfig>True</Noconfig>
+    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="UnsafeBlockCopy.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)extra\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)extra\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)extra\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Allow jit to inline methods with the cpblk IL opcode. Add a test case
where such an inline happens.