### PR TITLE
Remove unnecessary arg validation in ByteEqualityComaprer.IndexOf

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -341,16 +341,12 @@ namespace System.Collections.Generic
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        internal unsafe override int IndexOf(byte[] array, byte value, int startIndex, int count) {
-            if (array==null)
-                throw new ArgumentNullException("array");
-            if (startIndex < 0)
-                throw new ArgumentOutOfRangeException("startIndex", Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count", Environment.GetResourceString("ArgumentOutOfRange_Count"));
-            if (count > array.Length - startIndex)
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
-            Contract.EndContractBlock();
+        internal unsafe override int IndexOf(byte[] array, byte value, int startIndex, int count)
+        {
+            Contract.Assert(array != null);
+            Contract.Assert(startIndex >= 0 && count >= 0);
+            Contract.Assert(count <= array.Length - startIndex);
+            
             if (count == 0) return -1;
             fixed (byte* pbytes = array) {
                 return Buffer.IndexOfByte(pbytes, value, startIndex, count);


### PR DESCRIPTION
`ByteEqualityComparer.IndexOf` validates its arguments before doing anything to them. Since it doesn't do the same for `LastIndexOf`, and nowhere any else in the file are arguments validated (including other comparers' `IndexOf` methods), I've replaced all of the `throw` clauses with `Contract.Assert` blocks. (These checks are eliminated in Release builds.)

cc @jkotas @hughbe 