### PR TITLE
Disabling NativeResourceCompile Target for Managed libraries

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -30,7 +30,6 @@
     <HighEntropyVA>true</HighEntropyVA>
     <ErrorReport>prompt</ErrorReport>
     <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
-    <GenerateNativeVersionInfo Condition="'$(OsEnvironment)'=='Windows_NT'">true</GenerateNativeVersionInfo>
     <CLSCompliant>true</CLSCompliant>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/src/mscorlib/mscorlib.csproj
+++ b/src/mscorlib/mscorlib.csproj
@@ -30,7 +30,6 @@
     <HighEntropyVA>true</HighEntropyVA>
     <ErrorReport>prompt</ErrorReport>
     <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
-    <GenerateNativeVersionInfo Condition="'$(OsEnvironment)'=='Windows_NT'">true</GenerateNativeVersionInfo>
     <CLSCompliant>true</CLSCompliant>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/src/mscorlib/ref/mscorlib.csproj
+++ b/src/mscorlib/ref/mscorlib.csproj
@@ -23,7 +23,6 @@
     
     <ErrorReport>prompt</ErrorReport>
     <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
-    <GenerateNativeVersionInfo Condition="'$(OsEnvironment)'=='Windows_NT'">true</GenerateNativeVersionInfo>
     <CLSCompliant>true</CLSCompliant>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>


### PR DESCRIPTION
Today we define the assembly metadata for our managed assemblies both in assemblyInfo.cs and with version.h because NativeResourceCompile is on. Because of this, we are sometimes overriding and getting the wrong metadata for some libraries. Managed Libraries should always just use assemblyInfo.cs which is why I'm disabling the NativeResourceCompile in here.

cc: @gkhanna79 @weshaggard @AlexGhiondea 

related: #5397 