### PR TITLE
CoreDisTools Package: Make minor version generic

### DIFF
--- a/tests/setup-runtime-dependencies.cmd
+++ b/tests/setup-runtime-dependencies.cmd
@@ -78,7 +78,7 @@ REM ============================================================================
 REM Write dependency information to project.json
 echo { ^
     "dependencies": { ^
-    "runtime.win7-%__Arch%.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001" ^
+    "runtime.win7-%__Arch%.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-*" ^
     }, ^
     "frameworks": { "dnxcore50": { } } ^
     } > "%__JasonFilePath%"

--- a/tests/setup-runtime-dependencies.sh
+++ b/tests/setup-runtime-dependencies.sh
@@ -119,7 +119,7 @@ fi
 packageName='runtime.'$rid'.Microsoft.NETCore.CoreDisTools'
 echo {  \
     \"dependencies\": { \
-    \"$packageName\": \"1.0.1-prerelease-00001\" \
+    \"$packageName\": \"1.0.1-prerelease-*\" \
     }, \
     \"frameworks\": { \"dnxcore50\": { } } \
     } > $jsonFilePath


### PR DESCRIPTION
Change the version requirement of CoreDisTools package
from 1.0.1-prerelease-00001 to 1.0.1-prerelease-*
so that the test infrastructure picks up the latest
available version.

If only the 1.0.1-prerelease-xxxxx number changes,
there is no change in the library API. There may be
a change in the implementation.

The current need for this change is that we need to pick up
a new version of the CoreDisTools package (with an
implementation fix) for X86 testing.