### PR TITLE
Fix CFI annotation of AMD64 assembler helpers on Unix

### DIFF
--- a/src/pal/inc/unixasmmacrosamd64.inc
+++ b/src/pal/inc/unixasmmacrosamd64.inc
@@ -259,6 +259,8 @@ C_FUNC(\Name\()_End):
 // extra locals + padding to qword align
 .macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, stackAllocOnEntry = 0, stackAllocSpill1, stackAllocSpill2, stackAllocSpill3
 
+        set_cfa_register rsp, 8
+        
         __PWTB_FloatArgumentRegisters = \extraLocals
 
         .if ((__PWTB_FloatArgumentRegisters % 16) != 0)


### PR DESCRIPTION
This change fixes annotations of AMD64 assembler helpers on Unix. The helpers that
don't use RBP as a stack frame were missing setting the RSP as a CFA register and
unwinding through them was failing.
This was hit in R2R scenarios, with the DelayLoad_Helper_Obj not being unwindable.