### PR TITLE
Disable perf_codequality_math_functions under x86

### DIFF
--- a/tests/x86_jit32_issues.targets
+++ b/tests/x86_jit32_issues.targets
@@ -455,5 +455,8 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_468598\Test_HndIndex_10_Reordered\Test_HndIndex_10_Reordered.cmd">
             <Issue>5286</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Math\Functions\Functions\Functions.cmd">
+            <Issue>5430</Issue>
+        </ExcludeList>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
abssingle relies on a certain level of floating point precision and fails if the diff is outside of that precision.

skip ci please