### PR TITLE
ARM64/Linux: fix compile error 'cannot be narrowed to type int'

### DIFF
--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1207,11 +1207,13 @@ bool IsGcCoverageInterrupt(LPVOID ip)
     }
 
     // Now it's safe to dereference the IP to check the instruction
-#ifdef _TARGET_ARM_    
+#if defined(_TARGET_ARM64_)
+    UINT32 instructionCode = *reinterpret_cast<UINT32 *>(ip);
+#elif defined(_TARGET_ARM_)
     UINT16 instructionCode = *reinterpret_cast<UINT16 *>(ip);
 #else
     UINT8 instructionCode = *reinterpret_cast<UINT8 *>(ip);
-#endif 
+#endif
     switch (instructionCode)
     {
         case INTERRUPT_INSTR:


### PR DESCRIPTION
This fixes ARM64 Linux compilation error
```
src/vm/gccover.cpp:1219:14: error: case value evaluates to 3134983650,
which cannot be narrowed to type 'int' [-Wc++11-narrowing]
        case INTERRUPT_INSTR_PROTECT_RET:
             ^
src/vm/gccover.h:105:41: note: expanded from macro 'INTERRUPT_INSTR_PROTECT_RET'
```