### PR TITLE
Avoid calling prestub through wrong MethodDesc

### DIFF
--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2043,13 +2043,10 @@ EXTERN_C PCODE STDCALL ExternalMethodFixupWorker(TransitionBlock * pTransitionBl
             // Note that we do not want to call code:MethodDesc::IsPointingToPrestub() here. It does not take remoting interception 
             // into account and so it would cause otherwise intercepted methods to be JITed. It is a compat issue if the JITing fails.
             //
-            if (DoesSlotCallPrestub(pCode))
+            if (!DoesSlotCallPrestub(pCode))
             {
-                ETWOnStartup(PrestubWorker_V1, PrestubWorkerEnd_V1);
-                pCode = pMD->DoPrestub(NULL);
+                pCode = PatchNonVirtualExternalMethod(pMD, pCode, pImportSection, pIndirection);
             }
-
-            pCode = PatchNonVirtualExternalMethod(pMD, pCode, pImportSection, pIndirection);
         }
     }
 


### PR DESCRIPTION
(Port PR #5439 / commit  4e4cac8  to release/1.0.0)
While fixing up a call from a Ready-to-Run method, we don't always
have the right implementation MethodDesc for the target of the call.
Thus it is potentially unsafe to DoPrestub using the MethodDesc we have,
causing a test failue (Loader.classloader_regressions_429802_CMain)
in issue #5366. This is fixed by not calling DoPrestub from
ExternalMethodFixupWorker.