### PR TITLE
Fix readytorun tests asking for user input

### DIFF
--- a/tests/src/readytorun/mainv1.csproj
+++ b/tests/src/readytorun/mainv1.csproj
@@ -51,7 +51,7 @@ COPY /Y ..\testv1\test\test.dll test.dll
 ]]></CLRTestBatchPreCommands>
   <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
-rm test.dll
+rm -f test.dll
 cp ../testv1/test/test.dll test.dll
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out test.ni.dll test.dll
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out mainv1.ni.exe mainv1.exe

--- a/tests/src/readytorun/mainv2.csproj
+++ b/tests/src/readytorun/mainv2.csproj
@@ -51,10 +51,10 @@ COPY /Y ..\testv2\test\test.dll test.dll
 ]]></CLRTestBatchPreCommands>
   <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
-rm test.dll
+rm -f test.dll
 cp ../testv1/test/test.dll test.dll
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out mainv2.ni.exe mainv2.exe
-rm test.dll
+rm -f test.dll
 cp ../testv2/test/test.dll test.dll
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out test.ni.dll test.dll
 


### PR DESCRIPTION
'readytorun/mainv1' and 'readytorun/mainv2' tests on Linux wait for human
response asking permission to remove write-protected file:

    rm: remove write-protected regular file 'test.dll'?

'rm' command shall be used with '-f' flag to make it non-interactive.