### PR TITLE
Properly handle uname -p output that contains spaces

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -358,7 +358,7 @@ __ProjectRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Use uname to determine what the CPU is.
 CPUName=$(uname -p)
 # Some Linux platforms report unknown for platform, but the arch for machine.
-if [ $CPUName == "unknown" ]; then
+if [ "$CPUName" == "unknown" ]; then
     CPUName=$(uname -m)
 fi
 


### PR DESCRIPTION
e.g. Intel(R) Xeon(R) CPU E5-2603 0 @ 1.80GHz