### PR TITLE
Fix allocation failure handling

### DIFF
--- a/src/pal/src/include/pal/stackstring.hpp
+++ b/src/pal/src/include/pal/stackstring.hpp
@@ -149,8 +149,12 @@ public:
     //Always preserves the existing content
     T * OpenStringBuffer(SIZE_T count)
     {
-        Resize(count);
-        return (T *)m_buffer;
+        T * result = NULL;
+        if (Resize(count))
+        {
+            result = (T *)m_buffer;
+        }
+        return result;
     }
 
     //count should not include the terminating null

--- a/src/pal/src/map/map.cpp
+++ b/src/pal/src/map/map.cpp
@@ -1442,8 +1442,11 @@ CorUnix::InternalMapViewOfFile(
         }
     }
     
-    TRACE( "Added %p to the list.\n", pvBaseAddress );
-    *ppvBaseAddress = pvBaseAddress;
+    if (NO_ERROR == palError)
+    {
+        TRACE( "Added %p to the list.\n", pvBaseAddress );
+        *ppvBaseAddress = pvBaseAddress;
+    }
 
 InternalMapViewOfFileLeaveCriticalSection:
 


### PR DESCRIPTION
While investigating OOM related issues, I have hit two places where we were
not handling correctly the case when memory allocation failed.
In the StackString::OpenStringBuffer, when the Resize failed to allocate
properly sized buffer, we were returning the small internal buffer instead
of NULL. So the caller expected that the full requested size was prepared
and filled it with data, overwriting memory.
In CorUnix::InternalMapViewOfFile, when we have failed to allocate the
PMAPPED_VIEW_LIST to hold information on the mapping, we have unmapped
the memory again, but we have still returned the address of the now
unmapped mapping. The caller, MapViewOfFileEx, then returned this
address to its caller, since it didn't expect the CorUnix::InternalMapViewOfFile
to set its output parameter in the case of failure.