### PR TITLE
Make GetMethods() return methods in declaration order consistantly

### DIFF
--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -3114,6 +3114,24 @@ void EEClass::AddChunk (MethodDescChunk* pNewChunk)
 }
 
 //*******************************************************************************
+// Reverses the linked list of MethodDescChunks.  Used to keep the methods
+// in the same order as the meta-data so that reflection also returns
+// methods in lexical order.  
+void EEClass::ReverseChunks()
+{
+	PTR_MethodDescChunk chunks = GetChunks();
+	PTR_MethodDescChunk reversed = NULL;
+	while (chunks != NULL)
+	{
+		PTR_MethodDescChunk next = chunks->GetNextChunk();
+		chunks->SetNextChunk(reversed);
+		reversed = chunks;
+		chunks = next;
+	}
+	SetChunks(reversed);
+}
+
+//*******************************************************************************
 void EEClass::AddChunkIfItHasNotBeenAdded (MethodDescChunk* pNewChunk)
 {
     STATIC_CONTRACT_NOTHROW;

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -3119,16 +3119,16 @@ void EEClass::AddChunk (MethodDescChunk* pNewChunk)
 // methods in lexical order.  
 void EEClass::ReverseChunks()
 {
-	PTR_MethodDescChunk chunks = GetChunks();
-	PTR_MethodDescChunk reversed = NULL;
-	while (chunks != NULL)
-	{
-		PTR_MethodDescChunk next = chunks->GetNextChunk();
-		chunks->SetNextChunk(reversed);
-		reversed = chunks;
-		chunks = next;
-	}
-	SetChunks(reversed);
+    PTR_MethodDescChunk chunks = GetChunks();
+    PTR_MethodDescChunk reversed = NULL;
+    while (chunks != NULL)
+    {
+        PTR_MethodDescChunk next = chunks->GetNextChunk();
+        chunks->SetNextChunk(reversed);
+        reversed = chunks;
+        chunks = next;
+   }
+    SetChunks(reversed);
 }
 
 //*******************************************************************************

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -1758,6 +1758,7 @@ public:
     }
 #endif // !DACCESS_COMPILE
     void AddChunk (MethodDescChunk* pNewChunk);
+	void ReverseChunks();
 
     void AddChunkIfItHasNotBeenAdded (MethodDescChunk* pNewChunk);
 

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -1758,7 +1758,7 @@ public:
     }
 #endif // !DACCESS_COMPILE
     void AddChunk (MethodDescChunk* pNewChunk);
-	void ReverseChunks();
+    void ReverseChunks();
 
     void AddChunkIfItHasNotBeenAdded (MethodDescChunk* pNewChunk);
 

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -7057,11 +7057,11 @@ VOID MethodTableBuilder::AllocAndInitMethodDescs()
         AllocAndInitMethodDescChunk(startIndex, NumDeclaredMethods() - startIndex, sizeOfMethodDescs);
     }
 
-	// The chunks are a linked list, and naturally for a list that is in reverse order of
-	// the way we iterated meta-data.   Reverse the chunks so that the methods are in
-	// meta-data order.   This makes reflection's GetMethods() routine return them in 
-	// meta-data order.   System.Diagnostics.Tracing.EventSource Depends on this.  
-	GetHalfBakedClass()->ReverseChunks();
+    // The chunks are a linked list, and naturally for a list that is in reverse order of
+    // the way we iterated meta-data.   Reverse the chunks so that the methods are in
+    // meta-data order.   This makes reflection's GetMethods() routine return them in 
+    // meta-data order.   System.Diagnostics.Tracing.EventSource Depends on this.  
+    GetHalfBakedClass()->ReverseChunks();
 }
 
 //*******************************************************************************

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -7056,6 +7056,12 @@ VOID MethodTableBuilder::AllocAndInitMethodDescs()
     {
         AllocAndInitMethodDescChunk(startIndex, NumDeclaredMethods() - startIndex, sizeOfMethodDescs);
     }
+
+	// The chunks are a linked list, and naturally for a list that is in reverse order of
+	// the way we iterated meta-data.   Reverse the chunks so that the methods are in
+	// meta-data order.   This makes reflection's GetMethods() routine return them in 
+	// meta-data order.   System.Diagnostics.Tracing.EventSource Depends on this.  
+	GetHalfBakedClass()->ReverseChunks();
 }
 
 //*******************************************************************************


### PR DESCRIPTION
For classes with less than 64 methods, the GetMethods() call returns the methods in the order
of delcaration.   However internally in the runtime we read methods in chunks and put
them on a linked list, which means that for classes with more than this number of methods
the order gets scrambled.

There are classes like System.Diagnostic.Tracing.EventSource that depend on reflection
returning the methods in order of declaration IN CERTAIN SCENARIOS, and this does work
today for classes with less than 64 methods.     However we are now seeing cases where people
are relying on this scenario with classes of more than 64 methods.

It is pretty trivial to fix this so that we preserve the order of the methods.   Basicaly we
reverse the list of chunks after we have generated it, which restores the order.

This fix can be viewed as a compatibility fix, but in general preserving delclaration order
is a useful, because it is a natural way of resolving conflicts (e.g. last one wins), and
there is no other way to get this information from reflection unless we expose it in
GetMethods().     we are 95% of the way there (it works in chunks), this simple
change pushes us to 100% (for statically declared methods).