### PR TITLE
Fix for issue  #5467: [R2R] InvalidCastException in timer tests.

### DIFF
--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -2112,8 +2112,8 @@ FCIMPL3(void, COMDelegate::DelegateConstruct, Object* refThisUNSAFE, Object* tar
                                 {
                                     pMeth = MethodDesc::FindOrCreateAssociatedMethodDesc(
                                         pDispatchSlotMD,
-                                        pDispatchSlotMD->GetMethodTable(),
-                                        (!pDispatchSlotMD->IsStatic() && pDispatchSlotMD->GetMethodTable()->IsValueType()),
+                                        pMTTarg,
+                                        (!pDispatchSlotMD->IsStatic() && pMTTarg->IsValueType()),
                                         pMeth->GetMethodInstantiation(),
                                         FALSE /* allowInstParam */);
                                 }


### PR DESCRIPTION
We were not using the correct MethodTable pointer when constructing delegate objects to interface methods

@jkotas PTAL
cc @JohnChen0 @gkhanna79 