### PR TITLE
[ARM64/Linux] Fix 'error: 109 enumeration values not handled in switch'

### DIFF
--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1005,6 +1005,8 @@ protected:
                                                                 size = 8;
                                                             }
                                                             break;
+                                                        default:
+                                                            break;
                                                     }
 
                                                     return size;


### PR DESCRIPTION
This fixes ARM64 Linux compilation error
```
/home/sjlee/git/coreclr/src/jit/emit.h:988:61: error: 109 enumeration
values not handled in switch: 'IF_NONE', 'IF_LABEL', 'IF_EN9'...
[-Werror,-Wswitch]
```