### PR TITLE
Add more opcodes to x86 stack unwinder

### DIFF
--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -866,6 +866,8 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
                 datasize = b16bit?2:4;
                 goto decodeRM;
 
+            case 0x01:                           // ADD mod/rm
+            case 0x03:
             case 0x29:                           // SUB mod/rm
             case 0x2B:
                 datasize = 0;


### PR DESCRIPTION
(Port PR #5491 / commit 432c2ff to release/1.0.0)
Add x86 opcodes 0x01 and 0x03 (ADD instruction) to stack unwinder.
These instructions are generated by C++ compiler as part of the
JIT_StaticFieldAddress_Dynamic method, triggering issue #5464.