### PR TITLE
Use top level PreReleaseLabel

### DIFF
--- a/src/.nuget/Microsoft.NETCore.ILAsm/dir.props
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/dir.props
@@ -4,7 +4,6 @@
 
   <!-- Packaging properties -->
   <PropertyGroup>
-    <PreReleaseLabel>rc4</PreReleaseLabel>
     <PackageDescriptionFile>$(MSBuildThisFileDirectory)descriptions.json</PackageDescriptionFile>
 
     <!-- NOTE: for various required properties, we use the values from the imported dir.props. -->

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/dir.props
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/dir.props
@@ -4,7 +4,6 @@
 
   <!-- Packaging properties -->
   <PropertyGroup>
-    <PreReleaseLabel>rc4</PreReleaseLabel>
     <PackageDescriptionFile>$(MSBuildThisFileDirectory)descriptions.json</PackageDescriptionFile>
 
     <!-- NOTE: for various required properties, we use the values from the imported dir.props. -->

--- a/src/.nuget/Microsoft.NETCore.Jit/dir.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/dir.props
@@ -4,7 +4,6 @@
 
   <!-- Packaging properties -->
   <PropertyGroup>
-    <PreReleaseLabel>rc3</PreReleaseLabel>
     <PackageDescriptionFile>$(MSBuildThisFileDirectory)descriptions.json</PackageDescriptionFile>
 
     <!-- NOTE: for various required properties, we use the values from the imported dir.props. -->


### PR DESCRIPTION
Some projects were overriding PreReleaseLabel instead of inheriting the
parent one in the top level dir.props. In addition, some projects had
the value set to 'rc4' instead of 'rc3'.

Clean this up so we always use the label in the root dir.props