### PR TITLE
Drastically reduce memory consumption of Comparer<T> for enums

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Comparer.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 //using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 
 namespace System.Collections.Generic
 {    
@@ -61,6 +62,36 @@ namespace System.Collections.Generic
                     }
                 }
             }
+            else if (t.IsEnum)
+            {
+                // Explicitly call Enum.GetUnderlyingType here. Although GetTypeCode
+                // ends up doing this anyway, we end up avoiding an unnecessary P/Invoke
+                // and virtual method call.
+                TypeCode underlyingTypeCode = Type.GetTypeCode(Enum.GetUnderlyingType(t));
+                
+                // Depending on the enum type, we need to special case the comparers so that we avoid boxing
+                // Specialize differently for signed/unsigned types so we avoid problems with large numbers
+                switch (underlyingTypeCode)
+                {
+                    case TypeCode.SByte:
+                    case TypeCode.Int16:
+                    case TypeCode.Int32:
+                        result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(Int32EnumComparer<int>), t);
+                        break;
+                    case TypeCode.Byte:
+                    case TypeCode.UInt16:
+                    case TypeCode.UInt32:
+                        result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(UInt32EnumComparer<uint>), t);
+                        break;
+                    // 64-bit enums: use UnsafeEnumCastLong
+                    case TypeCode.Int64:
+                        result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(Int64EnumComparer<long>), t);
+                        break;
+                    case TypeCode.UInt64:
+                        result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(UInt64EnumComparer<ulong>), t);
+                        break;
+                }
+            }
             
             return result != null ?
                 (Comparer<T>)result :
@@ -77,9 +108,15 @@ namespace System.Collections.Generic
             return 0;
         }
     }
-
+    
+    // Note: although there is a lot of shared code in the following
+    // comparers, we do not incorporate it into a base class for perf
+    // reasons. Adding another base class (even one with no fields)
+    // means another generic instantiation, which can be costly esp.
+    // for value types.
+    
     [Serializable]
-    internal class GenericComparer<T> : Comparer<T> where T: IComparable<T>
+    internal sealed class GenericComparer<T> : Comparer<T> where T : IComparable<T>
     {    
         public override int Compare(T x, T y) {
             if (x != null) {
@@ -91,18 +128,15 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj){
-            GenericComparer<T> comparer = obj as GenericComparer<T>;
-            return comparer != null;
-        }        
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
 
-        public override int GetHashCode() {
-            return this.GetType().Name.GetHashCode();
-        }
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
     }
 
     [Serializable]
-    internal class NullableComparer<T> : Comparer<Nullable<T>> where T : struct, IComparable<T>
+    internal sealed class NullableComparer<T> : Comparer<T?> where T : struct, IComparable<T>
     {
         public override int Compare(Nullable<T> x, Nullable<T> y) {
             if (x.HasValue) {
@@ -114,37 +148,30 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj){
-            NullableComparer<T> comparer = obj as NullableComparer<T>;
-            return comparer != null;
-        }        
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
 
-
-        public override int GetHashCode() {
-            return this.GetType().Name.GetHashCode();
-        }
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
     }
 
     [Serializable]
-    internal class ObjectComparer<T> : Comparer<T>
+    internal sealed class ObjectComparer<T> : Comparer<T>
     {
         public override int Compare(T x, T y) {
             return System.Collections.Comparer.Default.Compare(x, y);
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(Object obj){
-            ObjectComparer<T> comparer = obj as ObjectComparer<T>;
-            return comparer != null;
-        }        
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
 
-        public override int GetHashCode() {
-            return this.GetType().Name.GetHashCode();
-        }
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
     }
 
     [Serializable]
-    internal class ComparisonComparer<T> : Comparer<T>
+    internal sealed class ComparisonComparer<T> : Comparer<T>
     {
         private readonly Comparison<T> _comparison;
 
@@ -154,6 +181,140 @@ namespace System.Collections.Generic
 
         public override int Compare(T x, T y) {
             return _comparison(x, y);
+        }
+    }
+    
+    // Enum comparers (specialized to avoid boxing)
+    // NOTE: Each of these needs to implement ISerializable
+    // and have a SerializationInfo/StreamingContext ctor,
+    // since we want to serialize as ObjectComparer for
+    // back-compat reasons (see below).
+    
+    [Serializable]
+    internal sealed class Int32EnumComparer<T> : Comparer<T>, ISerializable where T : struct
+    {
+        public Int32EnumComparer()
+        {
+            Contract.Assert(typeof(T).IsEnum, "This type is only intended to be used to compare enums!");
+        }
+        
+        // Used by the serialization engine.
+        private Int32EnumComparer(SerializationInfo info, StreamingContext context) { }
+        
+        public override int Compare(T x, T y)
+        {
+            int ix = JitHelpers.UnsafeEnumCast(x);
+            int iy = JitHelpers.UnsafeEnumCast(y);
+            return ix.CompareTo(iy);
+        }
+
+        // Equals method for the comparer itself. 
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
+
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
+        
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            // Previously Comparer<T> was not specialized for enums,
+            // and instead fell back to ObjectComparer which uses boxing.
+            // Set the type as ObjectComparer here so code that serializes
+            // Comparer for enums will not break.
+            info.SetType(typeof(ObjectComparer<T>));
+        }
+    }
+    
+    [Serializable]
+    internal sealed class UInt32EnumComparer<T> : Comparer<T>, ISerializable where T : struct
+    {
+        public UInt32EnumComparer()
+        {
+            Contract.Assert(typeof(T).IsEnum, "This type is only intended to be used to compare enums!");
+        }
+        
+        // Used by the serialization engine.
+        private UInt32EnumComparer(SerializationInfo info, StreamingContext context) { }
+        
+        public override int Compare(T x, T y)
+        {
+            uint ix = (uint)JitHelpers.UnsafeEnumCast(x);
+            uint iy = (uint)JitHelpers.UnsafeEnumCast(y);
+            return ix.CompareTo(iy);
+        }
+
+        // Equals method for the comparer itself. 
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
+
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
+        
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.SetType(typeof(ObjectComparer<T>));
+        }
+    }
+    
+    [Serializable]
+    internal sealed class Int64EnumComparer<T> : Comparer<T>, ISerializable where T : struct
+    {
+        public Int64EnumComparer()
+        {
+            Contract.Assert(typeof(T).IsEnum, "This type is only intended to be used to compare enums!");
+        }
+        
+        // Used by the serialization engine.
+        private Int64EnumComparer(SerializationInfo info, StreamingContext context) { }
+        
+        public override int Compare(T x, T y)
+        {
+            long lx = JitHelpers.UnsafeEnumCastLong(x);
+            long ly = JitHelpers.UnsafeEnumCastLong(y);
+            return lx.CompareTo(ly);
+        }
+
+        // Equals method for the comparer itself. 
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
+
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
+        
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.SetType(typeof(ObjectComparer<T>));
+        }
+    }
+    
+    [Serializable]
+    internal sealed class UInt64EnumComparer<T> : Comparer<T>, ISerializable where T : struct
+    {
+        public UInt64EnumComparer()
+        {
+            Contract.Assert(typeof(T).IsEnum, "This type is only intended to be used to compare enums!");
+        }
+        
+        // Used by the serialization engine.
+        private UInt64EnumComparer(SerializationInfo info, StreamingContext context) { }
+        
+        public override int Compare(T x, T y)
+        {
+            ulong lx = (ulong)JitHelpers.UnsafeEnumCastLong(x);
+            ulong ly = (ulong)JitHelpers.UnsafeEnumCastLong(y);
+            return lx.CompareTo(ly);
+        }
+
+        // Equals method for the comparer itself. 
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
+
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
+        
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.SetType(typeof(ObjectComparer<T>));
         }
     }
 }


### PR DESCRIPTION
This addresses #5314 by specializing `Comparer<T>` if the typeof T can be determined to be an enum. It follows similar logic to what's done in [`EqualityComparer`](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs#L63) today, with the exception that it doesn't attempt to specialize for sbytes/shorts, since we don't have to deal with hash codes.

Additional changes/notes:

- `Enum.GetUnderlyingType` shouldn't be necessary before the call to `Type.GetTypeCode`, as if you do `Type.GetTypeCode(typeof(StringSplitOptions))` it will [print out Int32](https://dotnetfiddle.net/8YLFGA).
- I used the unsigned wrapping trick to check if the enum's `TypeCode` was <= 32 bits without introducing unnecessary branches. I made sure to leave a comment explaining what it was intended to check, and didn't change the version in `EqualityComparer`.
- Added `Serializable` attributes to the new classes, in case anyone expects `Comparer<T>.Default` to always be serializable.

## Perf impact

I made [this](https://gist.github.com/jamesqo/925ae2a97e1edc75bf51753abf7b440f) console app to test the new changes.

- [Old results](https://gist.github.com/jamesqo/3a9043f35de27c5be7fb88e85adaf275)
- [New results](https://gist.github.com/jamesqo/528af5a09f2b9017a13ef7b0cf59e033)

Interestingly, the timings don't seem to be too much affected, regardless of how much I alter the iterations/length of the array. *However* with the old implementation the app consumes ~20K memory in Task Manager, while it consumes ~2K with the new one, so I guess while it may not have much impact in terms of speed it helps a lot with memory usage.

cc: @jkotas @omariom @AlexGhiondea 