### PR TITLE
Use cached empty arrays for "".ToCharArray

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -770,15 +770,21 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         unsafe public char[] ToCharArray() {
             int length = Length;
-            char[] chars = new char[length];
             if (length > 0)
             {
-                fixed (char* src = &this.m_firstChar)
-                    fixed (char* dest = chars) {
-                        wstrcpy(dest, src, length);
-                    }
+                char[] chars = new char[length];
+                fixed (char* src = &this.m_firstChar) fixed (char* dest = chars)
+                {
+                    wstrcpy(dest, src, length);
+                }
+                return chars;
             }
-            return chars;
+            
+#if FEATURE_CORECLR
+            return Array.Empty<char>();
+#else
+            return new char[0];
+#endif
         }
     
         // Returns a substring of this string as an array of characters.
@@ -793,15 +799,21 @@ namespace System {
                 throw new ArgumentOutOfRangeException("length", Environment.GetResourceString("ArgumentOutOfRange_Index"));
             Contract.EndContractBlock();
 
-            char[] chars = new char[length];
-            if(length > 0)
+            if (length > 0)
             {
-                fixed (char* src = &this.m_firstChar)
-                    fixed (char* dest = chars) {
-                        wstrcpy(dest, src + startIndex, length);
-                    }
+                char[] chars = new char[length];
+                fixed (char* src = &this.m_firstChar) fixed (char* dest = chars)
+                {
+                    wstrcpy(dest, src + startIndex, length);
+                }
+                return chars;
             }
-            return chars;
+            
+#if FEATURE_CORECLR
+            return Array.Empty<char>();
+#else
+            return new char[0];
+#endif
         }
 
         [Pure]


### PR DESCRIPTION
Currently, if you do `"".ToCharArray()` it will always allocate a new array. I changed it to use `Array.Empty<char>` for CoreCLR, but fallback to the old behavior of returning a new array each time on the .NET Framework.

As we have to make the length check anyway (for `fixed`) I think this is basically a free perf gain.

cc: @AlexGhiondea @jkotas