### PR TITLE
Skip reloads and copies in `gcIsWriteBarrierCandidate`.

### DIFF
--- a/src/jit/gcinfo.cpp
+++ b/src/jit/gcinfo.cpp
@@ -656,6 +656,9 @@ GCInfo::WriteBarrierForm GCInfo::gcWriteBarrierFormFromTargetAddress(GenTreePtr 
     while (simplifiedExpr)
     {
         simplifiedExpr = false;
+
+        tgtAddr = tgtAddr->gtSkipReloadOrCopy();
+
         while (tgtAddr->OperGet() == GT_ADDR && tgtAddr->gtOp.gtOp1->OperGet() == GT_IND)
         {
             tgtAddr = tgtAddr->gtOp.gtOp1->gtOp.gtOp1;


### PR DESCRIPTION
The change is actually in `gcWriteBarrierFormFromTargetAddress`. Because copies/reloads
may be placed inside of address-forming trees and because such operations are
transparent w.r.t. the GC-ness of their operand, these nodes should be skipped during
the check for write barriers.

Fixes #5484.