### PR TITLE
Add the `<Serviceable>` attribute to codegen packages.

### DIFF
--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,6 +9,7 @@
     <PackagePlatforms>x64;x86;arm</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,6 +9,7 @@
     <PackagePlatforms>x64;x86;arm</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
@@ -9,6 +9,7 @@
     <PackagePlatforms>x64;x86;arm</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
+    <Serviceable>true</Serviceable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This includes Microsoft.NETCore.{ILAsm,ILDAsm,Jit}.