### PR TITLE
Add config switch to selectively disable R2R images

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -1023,6 +1023,7 @@ RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ReadyToRun, W("ReadyToRun"), 1, "Enable/disabl
 #else
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ReadyToRun, W("ReadyToRun"), 0, "Enable/disable use of ReadyToRun native code") // Off by default for desktop
 #endif
+RETAIL_CONFIG_STRING_INFO(EXTERNAL_ReadyToRunExcludeList, W("ReadyToRunExcludeList"), "List of assemblies that cannot use Ready to Run images")
 
 #if defined(FEATURE_EVENT_TRACE) || defined(FEATURE_EVENTSOURCE_XPLAT)
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableEventLog, W("EnableEventLog"), 0, "Enable/disable use of EnableEventLogging mechanism ") // Off by default 

--- a/src/vm/eeconfig.cpp
+++ b/src/vm/eeconfig.cpp
@@ -512,6 +512,9 @@ HRESULT EEConfig::Cleanup()
     if (pRequireZapsExcludeList)
         delete pRequireZapsExcludeList;
 
+    if (pReadyToRunExcludeList)
+        delete pReadyToRunExcludeList;
+
 #ifdef _DEBUG
     if (pForbidZapsList)
         delete pForbidZapsList;
@@ -997,6 +1000,14 @@ HRESULT EEConfig::sync()
             if (wszZapRequireExcludeList)
                 pRequireZapsExcludeList = new AssemblyNamesList(wszZapRequireExcludeList);
         }
+    }
+
+    if (ReadyToRunInfo::IsReadyToRunEnabled())
+    {
+        NewArrayHolder<WCHAR> wszReadyToRunExcludeList;
+        IfFailRet(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_ReadyToRunExcludeList, &wszReadyToRunExcludeList));
+        if (wszReadyToRunExcludeList)
+            pReadyToRunExcludeList = new AssemblyNamesList(wszReadyToRunExcludeList);
     }
 
 #ifdef _DEBUG
@@ -1872,6 +1883,16 @@ bool EEConfig::ForbidZap(LPCUTF8 assemblyName) const
     return false;
 }
 #endif
+
+bool EEConfig::ExcludeReadyToRun(LPCUTF8 assemblyName) const
+{
+    LIMITED_METHOD_CONTRACT;
+
+    if (pReadyToRunExcludeList != NULL && pReadyToRunExcludeList->IsInList(assemblyName))
+        return true;
+
+    return false;
+}
 
 #ifdef _TARGET_AMD64_
 bool EEConfig::DisableNativeImageLoad(LPCUTF8 assemblyName) const

--- a/src/vm/eeconfig.h
+++ b/src/vm/eeconfig.h
@@ -760,6 +760,7 @@ public:
 #ifdef _DEBUG
     bool    ForbidZap(LPCUTF8 assemblyName) const;
 #endif
+    bool    ExcludeReadyToRun(LPCUTF8 assemblyName) const;
 
 #ifdef _TARGET_AMD64_
     bool    DisableNativeImageLoad(LPCUTF8 assemblyName) const;
@@ -1117,6 +1118,9 @@ private: //----------------------------------------------------------------
     // This is only used if iRequireZaps!=REQUIRE_ZAPS_NONE
     // This overrides pRequireZapsList.
     AssemblyNamesList * pRequireZapsExcludeList;
+
+    // Assemblies which cannot use Ready to Run images.
+    AssemblyNamesList * pReadyToRunExcludeList;
 
 #ifdef _DEBUG
     // Exact opposite of require zaps

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -345,7 +345,7 @@ PTR_BYTE ReadyToRunInfo::GetDebugInfo(PTR_RUNTIME_FUNCTION pRuntimeFunction)
 
 BOOL ReadyToRunInfo::IsReadyToRunEnabled()
 {
-    STANDARD_VM_CONTRACT;
+    WRAPPER_NO_CONTRACT;
 
     static ConfigDWORD configReadyToRun;
     return configReadyToRun.val(CLRConfig::EXTERNAL_ReadyToRun);
@@ -369,6 +369,9 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
 
     if (!IsReadyToRunEnabled())
+        return NULL;
+
+    if (g_pConfig->ExcludeReadyToRun(pModule->GetSimpleName()))
         return NULL;
 
     if (!pLayout->IsNativeMachineFormat())


### PR DESCRIPTION
New config switch ReadyToRunExcludeList can be used to specify a
list of assembly simple names (separated by ';') that cannot use
Ready to Run images.