### PR TITLE
Fix backwards compatibility bug: RC2 dbgshim debugging RTM runtime.

### DIFF
--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1438,10 +1438,10 @@ static bool IsCoreClrModule(const char* pModulePath)
 // Keep 31 length for Core 1.0 RC2 compatibility
 #if defined(__NetBSD__)
 static const char* RuntimeStartupSemaphoreName = "/clrst%08llx";
-static const char* RuntimeContinueSemaphoreName = "/clrct%08llx";
+static const char* RuntimeContinueSemaphoreName = "/clrco%08llx";
 #else
 static const char* RuntimeStartupSemaphoreName = "/clrst%08x%016llx";
-static const char* RuntimeContinueSemaphoreName = "/clrct%08x%016llx";
+static const char* RuntimeContinueSemaphoreName = "/clrco%08x%016llx";
 #endif
 
 #if defined(__NetBSD__)


### PR DESCRIPTION
Issue #5569

Debugging the RTM runtime with the current VSCode C# extension (RC2 dbgshim) is broken. The target app just runs to completion and any initial breakpoints are not hit.

If we do NOT take this then:
• On the day of RTM, anyone installing VS Code or VS Docker tooling will instantly find that it has stopped working for any existing RC projects until they update to RTM.
• It will not be possible to launch using VS Code until we are ready to start producing RTM builds (when tooling goes into escrow). Folks who want this in that time window can manually get things working by copying over their dbgshim.

The fix is to change the name of the "continue" semaphore used in the launch/attach handshake by the RTM runtime to match the one the RC2 dbgshim creates.