### PR TITLE
Enable GT_CALL with long ret types for x86 RyuJIT

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2885,9 +2885,54 @@ CodeGen::genMultiRegCallStoreToLocal(GenTreePtr treeNode)
 
         varDsc->lvRegNum = REG_STK;
     }
-#else // !FEATURE_UNIX_AMD64_STRUCT_PASSING
+#elif defined(_TARGET_X86_)
+    // Longs are returned in two return registers on x86.
+    assert(varTypeIsLong(treeNode));
+
+    // Assumption: current x86 implementation requires that a multi-reg long
+    // var in 'var = call' is flagged as lvIsMultiRegArgOrRet to prevent it from
+    // being promoted.
+    unsigned lclNum = treeNode->AsLclVarCommon()->gtLclNum;
+    LclVarDsc* varDsc = &(compiler->lvaTable[lclNum]);
+    noway_assert(varDsc->lvIsMultiRegArgOrRet);
+
+    GenTree* op1 = treeNode->gtGetOp1();
+    GenTree* actualOp1 = op1->gtSkipReloadOrCopy();
+    GenTreeCall* call = actualOp1->AsCall();
+    assert(call->HasMultiRegRetVal());
+
+    genConsumeRegs(op1);
+
+    ReturnTypeDesc* retTypeDesc = call->GetReturnTypeDesc();
+    unsigned regCount = retTypeDesc->GetReturnRegCount();
+    assert(regCount == MAX_RET_REG_COUNT);
+
+    // Stack store
+    int offset = 0;
+    for (unsigned i = 0; i < regCount; ++i)
+    {
+        var_types type = retTypeDesc->GetReturnRegType(i);
+        regNumber reg = call->GetRegNumByIdx(i);
+        if (op1->IsCopyOrReload())
+        {
+            // GT_COPY/GT_RELOAD will have valid reg for those positions
+            // that need to be copied or reloaded.
+            regNumber reloadReg = op1->AsCopyOrReload()->GetRegNumByIdx(i);
+            if (reloadReg != REG_NA)
+            {
+                reg = reloadReg;
+            }
+        }
+
+        assert(reg != REG_NA);
+        getEmitter()->emitIns_S_R(ins_Store(type), emitTypeSize(type), reg, lclNum, offset);
+        offset += genTypeSize(type);
+    }
+
+    varDsc->lvRegNum = REG_STK;
+#else // !FEATURE_UNIX_AMD64_STRUCT_PASSING && !_TARGET_X86_
     assert(!"Unreached");
-#endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING
+#endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING && !_TARGET_X86_
 }
 
 // Generate code for division (or mod) by power of two

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7984,7 +7984,9 @@ public :
         // Methods returning a struct in two registers is considered having a return value of TYP_STRUCT.
         // Such method's compRetNativeType is TYP_STRUCT without a hidden RetBufArg
         return varTypeIsStruct(info.compRetNativeType) && (info.compRetBuffArg == BAD_VAR_NUM);
-#else 
+#elif FEATURE_MULTIREG_RET && defined(_TARGET_X86_)
+        return varTypeIsLong(info.compRetNativeType);
+#else
         return false;
 #endif // FEATURE_MULTIREG_RET && (defined(FEATURE_UNIX_AMD64_STRUCT_PASSING) || defined(_TARGET_ARM_))
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6750,7 +6750,7 @@ GenTreePtr          Compiler::gtCloneExpr(GenTree * tree,
         }
         copy->gtCall.gtRetClsHnd = tree->gtCall.gtRetClsHnd;
 
-#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+#if FEATURE_MULTIREG_RET
         copy->gtCall.gtReturnTypeDesc = tree->gtCall.gtReturnTypeDesc;
 #endif
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1747,7 +1747,7 @@ void   Compiler::lvaPromoteLongVars()
          lclNum++)
     {
         LclVarDsc *  varDsc = &lvaTable[lclNum];
-        if(!varTypeIsLong(varDsc) || varDsc->lvDoNotEnregister || (varDsc->lvRefCnt == 0))
+        if(!varTypeIsLong(varDsc) || varDsc->lvDoNotEnregister || varDsc->lvIsMultiRegArgOrRet || (varDsc->lvRefCnt == 0))
         {
             continue;
         }

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -265,7 +265,7 @@ void Lowering::DecomposeNode(GenTreePtr* pTree, Compiler::fgWalkData* data)
         {
             GenTree* nextTree = tree->gtNext;
             GenTree* rhs = tree->gtGetOp1();
-            if (rhs->OperGet() == GT_PHI)
+            if (rhs->OperGet() == GT_PHI || rhs->OperGet() == GT_CALL)
             {
                 break;
             }
@@ -372,17 +372,16 @@ void Lowering::DecomposeNode(GenTreePtr* pTree, Compiler::fgWalkData* data)
         }
         break;
     case GT_CALL:
-        NYI("Call with TYP_LONG return value");
         break;
     case GT_RETURN:
-        assert(tree->gtOp.gtOp1->OperGet() == GT_LONG);
+        assert(tree->gtOp.gtOp1->OperGet() == GT_LONG || tree->gtOp.gtOp1->OperGet() == GT_CALL);
         break;
     case GT_STOREIND:
-        assert(tree->gtOp.gtOp2->OperGet() == GT_LONG);
+        assert(tree->gtOp.gtOp2->OperGet() == GT_LONG || tree->gtOp.gtOp2->OperGet() == GT_CALL);
         NYI("StoreInd of of TYP_LONG");
         break;
     case GT_STORE_LCL_FLD:
-        assert(tree->gtOp.gtOp1->OperGet() == GT_LONG);
+        assert(tree->gtOp.gtOp1->OperGet() == GT_LONG || tree->gtOp.gtOp1->OperGet() == GT_CALL);
         NYI("st.lclFld of of TYP_LONG");
         break;
     case GT_IND:
@@ -1504,6 +1503,8 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
             GenTreePtr argLo = arg->gtGetOp1();
             GenTreePtr argHi = arg->gtGetOp2();
 
+            NYI_IF(argHi->OperGet() == GT_ADD_HI || argHi->OperGet() == GT_SUB_HI, "Hi and Lo cannot be reordered");
+            
             GenTreePtr putArgLo = NewPutArg(call, argLo, info, type);
             GenTreePtr putArgHi = NewPutArg(call, argHi, info, type);
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -223,6 +223,22 @@ GenTreePtr          Compiler::fgMorphIntoHelperCall(GenTreePtr      tree,
 
     tree = fgMorphArgs(tree->AsCall());
 
+#if defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
+    if (varTypeIsLong(tree))
+    {
+        GenTreeCall* callNode = tree->AsCall();
+        ReturnTypeDesc* retTypeDesc = callNode->GetReturnTypeDesc();
+        retTypeDesc->Reset();
+        retTypeDesc->Initialize(this, callNode->gtRetClsHnd);
+        
+        NYI("Helper with TYP_LONG return type");
+
+        // For helpers that return longs, we need to make sure they are converted
+        // to tmp = call like we do in the importer for other calls with long
+        // return types.
+    }
+#endif
+
     return tree;
 }
 


### PR DESCRIPTION
1) Enables genMultiRegCallStoreToLocal for x86 RyuJIT. Forces long return
types to be stored to the stack after returning from a call.

2) Update lvaPromoteLongVars to not promote a long if it is a multi reg
arg or ret.

3) Adds NYI for call arguments that are longs and contain adds or
subtracts. We are currently producing the wrong order of operations so
that we can push the argument immediately after performing the arithmetic.
We will do the hi adc/sbb before the carry bit has been set by doing the
lo operation.

4) Adds an NYI for morphing a node into a call node if the call will have
a long return type. We need to force these new calls to be in the form var
= call.