### PR TITLE
Inliner: allow replay log to override force inlines

### DIFF
--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -348,6 +348,9 @@ public:
     // Construct a ReplayPolicy
     ReplayPolicy(Compiler* compiler, bool isPrejitRoot);
 
+    // Policy observations
+    void NoteBool(InlineObservation obs, bool value) override;
+
     // Optional observations
     void NoteContext(InlineContext* context) override
     {
@@ -379,6 +382,7 @@ private:
     static CritSecObject s_XmlReaderLock;
     InlineContext*       m_InlineContext;
     IL_OFFSETX           m_Offset;
+    bool                 m_WasForceInline;
 };
 
 #endif // defined(DEBUG) || defined(INLINE_DATA)


### PR DESCRIPTION
ReplayPolicy only impacts discretionary inlines, so could not control
force inline candidates. This has lead to some confusion during inline
studies.

Since most cases of force inline are performance related, allow replay
to override and control these force inline candidates.

This might be useful down the road to study how likely it is that a force
inline directive is either unnecessary or perhaps even detremental to
performance.