### PR TITLE
Mark KeepAliveRecur as GCStressIncompatible

### DIFF
--- a/tests/src/GC/API/GC/KeepAliveRecur.csproj
+++ b/tests/src/GC/API/GC/KeepAliveRecur.csproj
@@ -31,6 +31,7 @@
     <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="KeepAliveRecur.cs" />


### PR DESCRIPTION
The test seems to make assumptions of the lifetime of an object,
which may not be necessarily true in GCStress.

@swgillespie @RussKeldorph ptal