### PR TITLE
ARM/Linux Regression Fix of Exception Handling

### DIFF
--- a/src/pal/src/arch/arm/exceptionhelper.S
+++ b/src/pal/src/arch/arm/exceptionhelper.S
@@ -22,12 +22,7 @@ LEAF_ENTRY ThrowExceptionFromContextInternal, _TEXT
     ldr	r10,	[r0, #(CONTEXT_R10)]
     ldr	r11,	[r0, #(CONTEXT_R11)]
     ldr	sp,	[r0, #(CONTEXT_Sp)]
-
-    ldr	r2,	[r0, #(CONTEXT_Pc)]
-
-    // Store return address to the stack
-    // Added r7 as a dummy to keep the stack aligned by 8 bytes.
-    push    {r2, r7}
+    ldr	lr,	[r0, #(CONTEXT_Pc)]
 
     // The PAL_SEHException pointer
     mov	r0,	r1


### PR DESCRIPTION
This fixes the regression caused by
594b424e1328135049cf0515bc5fc58b91f07e2a, which
intended to fix #5358 while breaking many of
exception handling unit test cases.

The commit fixing #5358 was an incorrect translation
of x86 assembly code.

Fix #5595, #5358.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>