### PR TITLE
Linux/ARM: Revert -O1 to -O3 for Linux/ARM Release Build.

### DIFF
--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -112,7 +112,7 @@ index 1ed3dbf..c643032 100644
 How to enable -O3 optimization level for ARM/Linux
 ==================================================
 
-Currently, we can build coreclr with -O1 flag of clang in release build mode for Linux/ARM. This instruction is to enable -O3 optimization level of clang on ARM/Linux by fixing the bug of llvm.
+Currently, we can build coreclr with -O1 flag of clang in release build mode for Linux/ARM without any bugfix of llvm-3.6. This instruction is to enable -O3 optimization level of clang on Linux/ARM by fixing the bug of llvm.
 
 First, download latest version from the clang-3.6/llvm-3.6 upstream: 
 ```
@@ -146,7 +146,14 @@ export PATH=$HOME/llvm-3.6.2/bin/:$PATH
 export LD_LIBRARY_PATH=$HOME/llvm-3.6.2/lib:$LD_LIBRARY_PATH
 ```
 
-Finally, let's build coreclr with updated clang/llvm. From now on, you may change the optimization level of coreclr from -O1 to -O3 in ./src/pal/tools/clang-compiler-override.txt. If you meet a lldb related error message at build-time, try to build coreclr with "skipgenerateversion" option. 
+For Ubuntu 14.04 X64 users, they can easily install the fixed clang/llvm3.6 package with "apt-get" command from the "ppa:leemgs/dotnet" Ubuntu repository, without the need to execute the above 1st, 2nd, and 3rd step.
+```
+lgs@ubuntu sudo add-apt-repository ppa:leemgs/dotnet
+lgs@ubuntu sudo apt-get update
+lgs@ubuntu sudo apt-get install clang-3.6 llvm-3.6 lldb-3.6
+```
+
+Finally, let's build coreclr with updated clang/llvm. If you meet a lldb related error message at build-time, try to build coreclr with "skipgenerateversion" option. 
 ```
 lgs@ubuntu time ROOTFS_DIR=/work/dotnet/rootfs-coreclr/arm ./build.sh arm release clean cross 
 ```

--- a/src/pal/tools/clang-compiler-override.txt
+++ b/src/pal/tools/clang-compiler-override.txt
@@ -1,22 +1,15 @@
 SET (CMAKE_C_FLAGS_INIT                "-Wall -std=c11")
 SET (CMAKE_C_FLAGS_DEBUG_INIT          "-g -O0")
 SET (CLR_C_FLAGS_CHECKED_INIT          "-g -O2")
-# Todo: Replace -O1 with -O3 after fixing Clang/LLVM for __thread on Linux/ARM
-if(CMAKE_SYSTEM_NAME STREQUAL Linux AND CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
-    SET (CMAKE_C_FLAGS_RELEASE_INIT        "-g -O1")
-else()
-    SET (CMAKE_C_FLAGS_RELEASE_INIT        "-g -O3")
-endif()
+# Refer to the below instruction to support __thread with -O2/-O3 on Linux/ARM
+# https://github.com/dotnet/coreclr/blob/master/Documentation/building/linux-instructions.md
+SET (CMAKE_C_FLAGS_RELEASE_INIT        "-g -O3")
 SET (CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-g -O2")
 
 SET (CMAKE_CXX_FLAGS_INIT                "-Wall -Wno-null-conversion -std=c++11")
 SET (CMAKE_CXX_FLAGS_DEBUG_INIT          "-g -O0")
 SET (CLR_CXX_FLAGS_CHECKED_INIT          "-g -O2")
-if(CMAKE_SYSTEM_NAME STREQUAL Linux AND CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
-    SET (CMAKE_CXX_FLAGS_RELEASE_INIT        "-g -O1")
-else()
-    SET (CMAKE_CXX_FLAGS_RELEASE_INIT        "-g -O3")
-endif()
+SET (CMAKE_CXX_FLAGS_RELEASE_INIT        "-g -O3")
 SET (CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-g -O2")
 
 SET (CLR_DEFINES_DEBUG_INIT              DEBUG _DEBUG _DBG URTBLDENV_FRIENDLY=Checked BUILDENV_CHECKED=1)


### PR DESCRIPTION
We have completed the bug fix of llvm in order to support thread-local storage(TLS) via  __thread variable with -O3 optimization level of clang. Let's enable the -O3 optimization level of clange for release build on Linux/ARM.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>