### PR TITLE
Strip debugging symbol table entries on OS X Release builds.

### DIFF
--- a/functions.cmake
+++ b/functions.cmake
@@ -113,7 +113,7 @@ function(strip_symbols targetName outputFilename)
           POST_BUILD
           VERBATIM 
           COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
-          COMMAND ${STRIP} -u -r ${strip_source_file}
+          COMMAND ${STRIP} -S ${strip_source_file}
           COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
         )
       elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)


### PR DESCRIPTION
_Porting #5586 to release/1.0.0_

This changes the way we strip symbols from binaries on OS X Release builds to match what we do on Linux. We'll strip the debugging symbol table entries, but keep enough that we can have some information like function names available at a small size increase. After this change, libcoreclr.dylib is ~76% of its original size rather than ~62%, but the diagnostic experience with Release binaries is greatly improved.

@mikem8361 @sergiy-k 

Addresses #5608