### PR TITLE
Remove need for longgc and gcsimulator tests to have their own build

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1431,13 +1431,9 @@ combinedScenarios.each { scenario ->
                                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} skiptests"
                                         buildCommands += "set __TestIntermediateDir=int&&tests\\buildtest.cmd ${lowerConfiguration} ${arch} ilasmroundtrip"
                                     }
-                                    else if (scenario == 'longgc') {
+                                    else if (isLongGc(scenario)) {
                                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} skiptests"
-                                        buildCommands += "set __TestIntermediateDir=int&&tests\\buildtest.cmd ${lowerConfiguration} ${arch} longgctests"
-                                    }
-                                    else if (scenario == 'gcsimulator') {
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} skiptests"
-                                        buildCommands += "set __TestIntermediateDir=int&&tests\\buildtest.cmd ${lowerConfiguration} ${arch} gcsimulator"
+                                        buildCommands += "set __TestIntermediateDir=int&&tests\\buildtest.cmd ${lowerConfiguration} ${arch}"
                                     }
                                     else {
                                         println("Unknown scenario: ${scenario}")
@@ -1457,6 +1453,7 @@ combinedScenarios.each { scenario ->
                                         def runjitforcerelocsStr = ''
                                         def gcstressStr = ''
                                         def runtestArguments = ''
+                                        def gcTestArguments = ''
 
                                         if (scenario == 'r2r' ||
                                             scenario == 'pri1r2r' ||
@@ -1503,7 +1500,12 @@ combinedScenarios.each { scenario ->
                                         {
                                            gcstressStr = 'gcstresslevel 0xF'
                                         }
-                                         runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr}"
+
+                                        if (isLongGc(scenario)) {
+                                            gcTestArguments = '${scenario} sequential'
+                                        }
+
+                                        runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${gcTestArguments}"
                                         if (Constants.jitStressModeScenarios.containsKey(scenario)) {
                                             if (enableCorefxTesting) {
                                                 // Sync to corefx repo
@@ -1528,31 +1530,15 @@ combinedScenarios.each { scenario ->
                                             }                                            
                                         }
                                         else if (architecture == 'x64') {
-                                            if (isLongGc(scenario)) {
-                                                buildCommands += "tests\\runtest.cmd ${runtestArguments} longgctests sequential"
-                                            } 
-                                            else {
-                                                buildCommands += "tests\\runtest.cmd ${runtestArguments}"
-                                            }
+                                            buildCommands += "tests\\runtest.cmd ${runtestArguments}"
                                         }                                        
                                         else if (architecture == 'x86ryujit') {
                                             def testEnvLocation = "%WORKSPACE%\\tests\\x86\\ryujit_x86_testenv.cmd"
                                             
-                                            if (isLongGc(scenario)) {
-                                                buildCommands += "tests\\runtest.cmd ${runtestArguments} longgctests sequential TestEnv ${testEnvLocation}"
-                                            } 
-                                            else {
-                                                buildCommands += "tests\\runtest.cmd ${runtestArguments} TestEnv ${testEnvLocation}"
-                                            }
+                                            buildCommands += "tests\\runtest.cmd ${runtestArguments} TestEnv ${testEnvLocation}"
                                         }
-
                                         else if (architecture == 'x86lb') {
-                                            if (isLongGc(scenario)) {
-                                                buildCommands += "tests\\runtest.cmd ${runtestArguments} longgctests sequential"
-                                            } 
-                                            else {
-                                                buildCommands += "tests\\runtest.cmd ${runtestArguments} Exclude0 x86_legacy_backend_issues.targets"
-                                            }
+                                            buildCommands += "tests\\runtest.cmd ${runtestArguments} Exclude0 x86_legacy_backend_issues.targets"
                                         }
                                     }
 
@@ -1910,7 +1896,7 @@ combinedScenarios.each { scenario ->
                     if (testBuildScenario == 'coverage' || testBuildScenario == 'pri1r2r'|| testBuildScenario == 'gcstress15_pri1r2r') {
                         testBuildScenario = 'pri1'
                     }
-                    else if ( testBuildScenario == 'r2r'){
+                    else if ( testBuildScenario == 'r2r' || isLongGc(testBuildScenario)) {
                         testBuildScenario = 'default'
                     }
                     def inputWindowTestsBuildName = ''
@@ -1931,6 +1917,11 @@ combinedScenarios.each { scenario ->
                     
                     // Whether or not this test run should run a specific playlist.
                     // Only used for long GC tests.
+
+                    // A note - runtest.sh does have "--long-gc" and "--gcsimulator" options
+                    // for running long GC and GCSimulator tests, respectively. We don't use them
+                    // here because using a playlist file produces much more readable output on the CI machines
+                    // and reduces running time.
                     def playlistString = ''
                      
                     if (os == 'Ubuntu' && isPR){

--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -31,8 +31,6 @@ set __crossgen=
 set __ILAsmRoundtrip=
 set __BuildSequential=
 set __TestPriority=
-set __LongGCTests=
-set __GCSimulatorTests=
 set __msbuildCleanBuildArgs=
 set __msbuildExtraArgs=
 set __verbosity=normal
@@ -65,8 +63,6 @@ if /i "%1" == "crossgen"            (set __crossgen=true&shift&goto Arg_Loop)
 if /i "%1" == "ilasmroundtrip"      (set __ILAsmRoundtrip=true&shift&goto Arg_Loop)
 if /i "%1" == "sequential"          (set __BuildSequential=1&shift&goto Arg_Loop)
 if /i "%1" == "priority"            (set __TestPriority=%2&shift&shift&goto Arg_Loop)
-if /i "%1" == "longgctests"         (set __LongGCTests=1&shift&goto Arg_Loop)
-if /i "%1" == "gcsimulator"         (set __GCSimulatorTests=1&shift&goto Arg_Loop)
 
 if /i "%1" == "verbose"             (set __verbosity=detailed&shift&goto Arg_Loop)
 
@@ -273,16 +269,6 @@ if defined __TestPriority (
     set __msbuildManagedBuildArgs=%__msbuildManagedBuildArgs% /p:CLRTestPriorityToBuild=%__TestPriority%
 )
 
-if defined __LongGCTests (
-    echo Building tests with Long GC tests enabled.
-    set __msbuildManagedBuildArgs=%__msbuildManagedBuildArgs% /p:GCLongRunning=true
-)
-
-if defined __GCSimulatorTests (
-    echo Building GCSimulator tests
-    set __msbuildManagedBuildArgs=%__msbuildManagedBuildArgs% /p:GCSimulatorRun=true
-)
-
 set __BuildLogRootName=Tests_Managed
 call :msbuild "%__ProjectFilesDir%\build.proj" %__msbuildManagedBuildArgs%
 if errorlevel 1 exit /b 1
@@ -370,8 +356,6 @@ echo     1: Build all tests with priority 0 and 1
 echo     666: Build all tests with priority 0, 1 ... 666
 echo sequential: force a non-parallel build ^(default is to build in parallel
 echo     using all processors^).
-echo longgctests: Build tests so that runtests.cmd will do a long-running GC test.
-echo gcsimulator: Build tests so that runtests.cmd will do a GCSimulator test run.
 echo IlasmRoundTrip: enables ilasm round trip build and run of the tests before executing them.
 echo verbose: enables detailed file logging for the msbuild tasks into the msbuild log file.
 exit /b 1

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -29,6 +29,7 @@ set __Exclude0=%~dp0\issues.targets
 set __Sequential=
 set __msbuildExtraArgs=
 set __LongGCTests=
+set __GCSimulatorTests=
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -56,7 +57,8 @@ if /i "%1" == "Exclude0"              (set __Exclude0=%2&shift&shift&goto Arg_Lo
 if /i "%1" == "TestEnv"               (set __TestEnv=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "sequential"            (set __Sequential=1&shift&goto Arg_Loop)
 if /i "%1" == "crossgen"              (set __DoCrossgen=1&shift&goto Arg_Loop)
-if /i "%1" == "longgctests"           (set __LongGCTests=1&shift&goto Arg_Loop)
+if /i "%1" == "longgc"                (set __LongGCTests=1&shift&goto Arg_Loop)
+if /i "%1" == "gcsimulator"           (set __GCSimulatorTests=1&shift&goto Arg_Loop)
 if /i "%1" == "jitstress"             (set COMPlus_JitStress=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "jitstressregs"         (set COMPlus_JitStressRegs=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "jitminopts"            (set COMPlus_JITMinOpts=1&shift&shift&goto Arg_Loop)
@@ -317,10 +319,19 @@ if "%CORE_ROOT%" == "" (
 
 :: Long GC tests take about 10 minutes per test on average, so
 :: they often bump up against the default 10 minute timeout.
-:: 30 minutes is more than enough time for a test to complete successfully.
+:: 20 minutes is more than enough time for a test to complete successfully.
 if defined __LongGCTests (
-    echo Running Long GC tests, extending timeout to 30 minutes
-    set __TestTimeout=1800000
+    echo Running Long GC tests, extending timeout to 20 minutes
+    set __TestTimeout=1200000
+    set RunningLongGCTests=1
+)
+
+:: GCSimulator tests can take up to an hour to complete. They are run twice a week in the
+:: CI, so it's fine if they take a long time.
+if defined __GCSimulatorTests (
+    echo Running GCSimulator tests, extending timeout to one hour
+    set __TestTimeout=3600000
+    set RunningGCSimulatorTests=1
 )
 
 set __BuildLogRootName=Tests_GenerateRuntimeLayout

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -54,6 +54,8 @@ function print_usage {
     echo '    0: None                                1: GC on all allocs and 'easy' places'
     echo '    2: GC on transitions to preemptive GC  4: GC on every allowable JITed instr'
     echo '    8: GC on every allowable NGEN instr   16: GC only on a unique stack trace'
+    echo '  --long-gc                        : Runs the long GC tests'
+    echo '  --gcsimulator                    : Runs the GCSimulator tests'
     echo '  --show-time                      : Print execution sequence and running time for each test'
     echo '  --no-lf-conversion               : Do not execute LF conversion before running test script'
     echo ''
@@ -762,6 +764,8 @@ testEnv=
 playlistFile=
 showTime=
 noLFConversion=
+gcsimulator=
+longgc=
 
 ((disableEventLogging = 0))
 ((serverGC = 0))
@@ -837,6 +841,12 @@ do
         --useServerGC)
             ((serverGC = 1))
             ;;
+        --long-gc)
+            ((longgc = 1))
+            ;;
+        --gcsimulator)
+            ((gcsimulator = 1))
+            ;;
         --playlist=*)
             playlistFile=${i#*=}
             ;;
@@ -895,6 +905,16 @@ if [ -z "$mscorlibDir" ]; then
 fi
 if [ -d $mscorlibDir/bin ]; then
     cp $mscorlibDir/bin/* $mscorlibDir
+fi
+
+if [ ! -z "$longgc"]; then
+    echo "Running Long GC tests"
+    export RunningLongGCTests=1
+fi
+
+if [ ! -z "$gcsimulator"]; then
+    echo "Running GC simulator tests"
+    export RunningGCSimulatorTests=1
 fi
 
 # If this is a coverage run, make sure the appropriate args have been passed

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -120,14 +120,7 @@ then
   exit 0
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
-      <BashCLRTestGCSimulatorSkipCondition Condition="$(GCSimulatorRun) != 'true' And '$(IsGCSimulatorTest)' == 'true'"><![CDATA[
-echo "Skipping execution because GCSimulator tests are not enabled"
-exit 0
-      ]]></BashCLRTestGCSimulatorSkipCondition>
-      <BashCLRTestGCLongTestSkipCondition Condition="$(GCLongRunning) != 'true' And '$(IsLongRunningGCTest)' == 'true'"><![CDATA[
-echo "Skipping execution because long-running GC tests are not enabled"
-exit 0
-      ]]></BashCLRTestGCLongTestSkipCondition>
+
       <BashCLRTestExitCodePrep Condition="$(_CLRTestNeedsToRun)">
 <![CDATA[
 if [ -z ${CLRTestExpectedExitCode+x} ]%3B then export CLRTestExpectedExitCode=$(CLRTestExitCode)%3B fi
@@ -306,9 +299,6 @@ $(BashEnvironmentVariables)
 $(BashCLRTestEnvironmentCompatibilityCheck)
 $(BashCLRTestArgPrep)
 $(BashCLRTestExitCodePrep)
-# Long-running GC test checks
-$(BashCLRTestGCSimulatorSkipCondition)
-$(BashCLRTestGCLongTestSkipCondition)
 # IlasmRoundTrip Script
 $(IlasmRoundTripBashScript)
 # PreCommands

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -114,22 +114,7 @@ IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMi
   Exit /b 0
 :Compatible1
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
-      <BatchCLRTestGCLongTestSkipCondition Condition="$(GCLongRunning) == 'true' And '$(IsLongRunningGCTest)' != 'true'"><![CDATA[
-echo Skipping execution because this is not a long-running GC test
-Exit /b 0
-      ]]></BatchCLRTestGCLongTestSkipCondition>
-      <BatchCLRTestGCLongTestSkipCondition Condition="$(GCLongRunning) != 'true' And '$(IsLongRunningGCTest)' == 'true'"><![CDATA[
-echo Skipping execution because long-running GC tests are not enabled
-Exit /b 0
-      ]]></BatchCLRTestGCLongTestSkipCondition>
-      <BatchCLRTestGCSimulatorSkipCondition Condition="$(GCSimulatorRun) == 'true' And '$(IsGCSimulatorTest)' != 'true'"><![CDATA[
-echo Skipping execution because this is not a GCSimulator test
-Exit /b 0
-      ]]></BatchCLRTestGCSimulatorSkipCondition>
-      <BatchCLRTestGCSimulatorSkipCondition Condition="$(GCSimulatorRun) != 'true' And '$(IsGCSimulatorTest)' == 'true'"><![CDATA[
-echo Skipping execution because GCSimulator tests are not enabled
-Exit /b 0
-      ]]></BatchCLRTestGCSimulatorSkipCondition>
+      
       <BatchCLRTestExitCodePrep Condition="$(_CLRTestNeedsToRun)">
         <![CDATA[
 if not defined CLRTestExpectedExitCode (set CLRTestExpectedExitCode=$(CLRTestExitCode))
@@ -337,12 +322,6 @@ $(BatchCLRTestEnvironmentCompatibilityCheck)
 
 REM IlasmRoundTrip Script
 $(IlasmRoundTripBatchScript)
-
-REM Long GC Tests Script (when /p:GCLongRunning=true)
-$(BatchCLRTestGCLongTestSkipCondition)
-
-REM GCSimulator Tests Script (when /p:GCSimulatorRun=true)
-$(BatchCLRTestGCSimulatorSkipCondition)
 
 REM Precommands
 $(CLRTestBatchPreCommands)

--- a/tests/src/CLRTest.Execute.targets
+++ b/tests/src/CLRTest.Execute.targets
@@ -106,6 +106,7 @@ This file contains the logic for providing Execution Script generation.
   </PropertyGroup>
  
   <Import Project="CLRTest.CrossGen.targets" />
+  <Import Project="CLRTest.GC.targets" />
   <Import Project="CLRTest.Execute.*.targets" />
   
   <Target Name="GenerateExecutionScriptsInternal"

--- a/tests/src/CLRTest.GC.targets
+++ b/tests/src/CLRTest.GC.targets
@@ -1,0 +1,90 @@
+<!--
+***********************************************************************************************
+CLRTest.Execute.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+This file contains the logic for generating command scripts for special GC tests.
+
+WARNING:   When setting properties based on their current state (for example:
+           <Foo Condition="'$(Foo)'==''>Bar</Foo>).  Be very careful.  Another script generation
+           target might be trying to do the same thing.  It's better to avoid this by instead setting a new property.
+           
+           Additionally, be careful with itemgroups.  Include will propagate outside of the target too!
+
+***********************************************************************************************
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <GCLongGCTestBashScript Condition="'$(IsLongRunningGCTest)' != 'true'"><![CDATA[
+# Long GC script
+if [ ! -z $RunningLongGCTests ]
+then
+    echo "Skipping execution because this is not a long-running GC test"
+    exit 0
+fi
+        ]]></GCLongGCTestBashScript>
+        <GCLongGCTestBashScript Condition="'$(IsLongRunningGCTest)' == 'true'"><![CDATA[
+# Long GC script
+if [ -z $RunningLongGCTests ]
+then
+    echo "Skipping execution because long-running GC tests are not enabled"
+    exit 0
+fi
+        ]]></GCLongGCTestBashScript>
+
+
+        <GCSimulatorTestBashScript Condition="'$(IsGCSimulatorTest)' != 'true'"><![CDATA[
+# GCSimulator script
+if [ ! -z $RunningGCSimulatorTests ]
+then
+    echo "Skipping execution because this is not a GCSimulator test"
+    exit 0
+fi
+        ]]></GCSimulatorTestBashScript>
+        <GCSimulatorTestBashScript Condition="'$(IsGCSimulatorTest)' == 'true'"><![CDATA[
+# GCSimulator script
+if [ -z $RunningGCSimulatorTests ]
+then
+    echo "Skipping execution because GCSimulator tests are not enabled"
+    exit 0
+fi
+        ]]></GCSimulatorTestBashScript>
+
+        <BashCLRTestPreCommands>$(BashCLRTestPreCommands);$(GCLongGCTestBashScript);$(GCSimulatorTestBashScript)</BashCLRTestPreCommands>
+        <GCLongGCTestBatchScript Condition="'$(IsLongRunningGCTest)' != 'true'"><![CDATA[
+REM Long GC script
+IF NOT "%RunningLongGCTests%"=="" (
+  echo Skipping execution because this is not a long-running GC test.
+  Exit /b 0
+)
+        ]]></GCLongGCTestBatchScript>
+        <GCLongGCTestBatchScript Condition="'$(IsLongRunningGCTest)' == 'true'"><![CDATA[
+REM Long GC script
+IF "%RunningLongGCTests%"=="" (
+  echo Skipping execution because long-running GC tests are not enabled.
+  Exit /b 0
+)
+        ]]></GCLongGCTestBatchScript>
+      
+      
+        <GCSimulatorTestBatchScript  Condition="'$(IsGCSimulatorTest)' != 'true'"><![CDATA[
+REM GCSimulator script
+IF NOT "%RunningGCSimulatorTests%"=="" (
+  echo Skipping execution because this is not a GCSimulator test.
+  Exit /b 0
+)
+        ]]></GCSimulatorTestBatchScript>
+        <GCSimulatorTestBatchScript  Condition="'$(IsGCSimulatorTest)' == 'true'"><![CDATA[
+REM GCSimulator script
+IF "%RunningGCSimulatorTests%"=="" (
+  echo Skipping execution because GCSimulator tests are not enabled
+  Exit /b 0
+)
+        ]]></GCSimulatorTestBatchScript >
+
+        <CLRTestBatchPreCommands>$(CLRTestBatchPreCommands);$(GCLongGCTestBatchScript);$(GCSimulatorTestBatchScript)</CLRTestBatchPreCommands>
+    </PropertyGroup>
+</Project> 


### PR DESCRIPTION
Fixes #5083. This removes the dependency of long GC tests and GCSimulator tests on separate test builds.