### PR TITLE
Port: Fix problem with virtual memory commit in OOM scenario on Linux

### DIFF
--- a/src/pal/src/map/virtual.cpp
+++ b/src/pal/src/map/virtual.cpp
@@ -1197,15 +1197,7 @@ static LPVOID VIRTUALCommitMemory(
         if (allocationType != MEM_COMMIT)
         {
             // Commit the pages
-            void * pRet = MAP_FAILED;
-#if MMAP_DOESNOT_ALLOW_REMAP
             if (mprotect((void *) StartBoundary, MemSize, PROT_WRITE | PROT_READ) == 0)
-                pRet = (void *)StartBoundary;
-#else // MMAP_DOESNOT_ALLOW_REMAP
-            pRet = mmap((void *) StartBoundary, MemSize, PROT_WRITE | PROT_READ,
-                     MAP_ANON | MAP_FIXED | MAP_PRIVATE, -1, 0);
-#endif // MMAP_DOESNOT_ALLOW_REMAP
-            if (pRet != MAP_FAILED)
             {
 #if MMAP_DOESNOT_ALLOW_REMAP
                 SIZE_T i;
@@ -1226,7 +1218,7 @@ static LPVOID VIRTUALCommitMemory(
             }
             else
             {
-                ERROR("mmap() failed! Error(%d)=%s\n", errno, strerror(errno));
+                ERROR("mprotect() failed! Error(%d)=%s\n", errno, strerror(errno));
                 goto error;
             }
             VIRTUALSetAllocState(MEM_COMMIT, runStart, runLength, pInformation);


### PR DESCRIPTION
A stress tests have uncovered a mysterious issue with virtual memory committing on
Linux. During some stress tests, all of a sudden, segments of GC heap got unmapped
or virtual allocator has reserved a block of memory twice.
It turned out that the issue was caused by a strange behavior of mmap in the OOM case.
When we commit a subrange of previously reserved memory (reservation uses mmap with
PROT_NONE, commit uses mmap with PROT_READ | PROT_WRITE) and the mmap fails due to
OOM, it ends up leaving the whole range that was supposed to be committed completely
unmapped. A later attempt to reserve virtual memory finds this block as a free one
and happily reserves a block in it. But our VM allocator is not aware of this issue.

The fix is to use another way to commit pages in a reserved range - using mprotect
to change their protection from the initial PROT_NONE to PROT_READ | PROT_WRITE.
This way doesn't have the problem. I've verified that it works on OSX too, so
I am switching to that way unconditionally.
Decommit still uses mmap so that we don't have to keep track of dirty pages and
so that the pages are really returned to the system in decommit.