### PR TITLE
Add -DARM_SOFTFP inside compileoptions.cmake

### DIFF
--- a/compileoptions.cmake
+++ b/compileoptions.cmake
@@ -49,7 +49,6 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   # Some architectures (e.g., ARM) assume char type is unsigned while CoreCLR assumes char is signed
   # as x64 does. It has been causing issues in ARM (https://github.com/dotnet/coreclr/issues/4746)
   add_compile_options(-fsigned-char)
-
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 if(CLR_CMAKE_PLATFORM_UNIX_ARM)
@@ -58,6 +57,7 @@ if(CLR_CMAKE_PLATFORM_UNIX_ARM)
    add_compile_options(-mthumb)
    add_compile_options(-mfpu=vfpv3)
    if(ARM_SOFTFP)
+     add_definitions(-DARM_SOFTFP)
      add_compile_options(-mfloat-abi=softfp)
      add_compile_options(-target armv7-linux-gnueabi)
    else()

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -11,9 +11,6 @@ if (CLR_CMAKE_TARGET_ARCH_AMD64)
   add_definitions(-DFEATURE_AVX_SUPPORT) 
 endif ()
 
-if (ARM_SOFTFP)
-  add_definitions(-DARM_SOFTFP)
-endif (ARM_SOFTFP)
 
 if(WIN32)
   set(JIT_RESOURCES Native.rc)

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -12,9 +12,6 @@ add_definitions(-DFEATURE_LEAVE_RUNTIME_HOLDER=1)
 add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)
 
-if (ARM_SOFTFP)
-  add_definitions(-DARM_SOFTFP)
-endif (ARM_SOFTFP)
 
 if(CMAKE_CONFIGURATION_TYPES) # multi-configuration generator?
   foreach (Config DEBUG CHECKED)  


### PR DESCRIPTION
Currently, '-DARM_SOFTFP' is added inside jit/CMakeList.txt and
vm/CMakeLists.txt, and thus the header definition might be inconsistent
across each componenet.

This inconsistency results in some strange behavior discussed in #5629.

This commit tries to enforce the consistent definition of '-DARM_SOFTFP'
for every component via definiing it inside compileoptions.cmake in order
to fix #5629.