### PR TITLE
Remove JIT_FEATURE_SSA_SKIP_DEFS.

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4756,11 +4756,7 @@ void Compiler::optAssertionPropMain()
         fgRemoveRestOfBlock = false;
 
         // Walk the statement trees in this basic block
-#if JIT_FEATURE_SSA_SKIP_DEFS
         GenTreePtr stmt = block->FirstNonPhiDef();
-#else
-        GenTreePtr stmt = block->bbTreeList;
-#endif
         while (stmt)
         {
             noway_assert(stmt->gtOper == GT_STMT);

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -523,11 +523,7 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
     // trees *except* PHI definitions.
     bool isEmpty()
     {
-#if JIT_FEATURE_SSA_SKIP_DEFS
         return (this->FirstNonPhiDef() == nullptr);
-#else
-        return (this->bbTreeList == nullptr);
-#endif
     }
 
     // Returns "true" iff "this" is the first block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair --
@@ -932,11 +928,9 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
 
     bool endsWithTailCallConvertibleToLoop(Compiler *comp, GenTree** tailCall);
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
     // Returns the first statement in the statement list of "this" that is
     // not an SSA definition (a lcl = phi(...) assignment).
     GenTreeStmt* FirstNonPhiDef();
-#endif // JIT_FEATURE_SSA_SKIP_DEFS
     GenTree* FirstNonPhiDefOrCatchArgAsg();
 
     BasicBlock() :

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -351,11 +351,7 @@ void                CodeGen::genCodeForBBlist()
 
         if (handlerGetsXcptnObj(block->bbCatchTyp))
         {
-#if JIT_FEATURE_SSA_SKIP_DEFS
             GenTreePtr firstStmt = block->FirstNonPhiDef();
-#else
-            GenTreePtr firstStmt = block->bbTreeList;
-#endif
             if (firstStmt != NULL)
             {
                 GenTreePtr firstTree = firstStmt->gtStmt.gtStmtExpr;
@@ -491,11 +487,7 @@ void                CodeGen::genCodeForBBlist()
         }
 #endif // FEATURE_EH_FUNCLETS
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
         for (GenTreePtr stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
-#else
-        for (GenTreePtr stmt = block->bbTreeList; stmt; stmt = stmt->gtNext)
-#endif
         {
             noway_assert(stmt->gtOper == GT_STMT);
 

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1619,11 +1619,7 @@ void                CodeGen::genCodeForBBlist()
 
         if (handlerGetsXcptnObj(block->bbCatchTyp))
         {
-#if JIT_FEATURE_SSA_SKIP_DEFS
             GenTreePtr firstStmt = block->FirstNonPhiDef();
-#else
-            GenTreePtr firstStmt = block->bbTreeList;
-#endif
             if (firstStmt != NULL)
             {
                 GenTreePtr firstTree = firstStmt->gtStmt.gtStmtExpr;

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -12845,11 +12845,7 @@ void                CodeGen::genCodeForBBlist()
 
         if (handlerGetsXcptnObj(block->bbCatchTyp))
         {
-#if JIT_FEATURE_SSA_SKIP_DEFS
             GenTreePtr firstStmt = block->FirstNonPhiDef(); 
-#else
-            GenTreePtr firstStmt = block->bbTreeList; 
-#endif
             if (firstStmt != NULL)
             {
                 GenTreePtr firstTree = firstStmt->gtStmt.gtStmtExpr;
@@ -13000,11 +12996,7 @@ void                CodeGen::genCodeForBBlist()
         }
 #endif // FEATURE_EH_FUNCLETS
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
         for (GenTreePtr stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
-#else
-        for (GenTreePtr stmt = block->bbTreeList; stmt; stmt = stmt->gtNext)
-#endif
         {
             noway_assert(stmt->gtOper == GT_STMT);
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -527,11 +527,7 @@ void                CodeGen::genCodeForBBlist()
 
         if (handlerGetsXcptnObj(block->bbCatchTyp))
         {
-#if JIT_FEATURE_SSA_SKIP_DEFS
             GenTreePtr firstStmt = block->FirstNonPhiDef();
-#else
-            GenTreePtr firstStmt = block->bbTreeList;
-#endif
             if (firstStmt != NULL)
             {
                 GenTreePtr firstTree = firstStmt->gtStmt.gtStmtExpr;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5770,11 +5770,7 @@ Compiler::NodeToIntMap* Compiler::FindReachableNodesInNodeTestData()
          block != NULL;
          block =  block->bbNext)
     {
-#if JIT_FEATURE_SSA_SKIP_DEFS
         for (GenTreePtr stmt = block->FirstNonPhiDef();
-#else
-        for (GenTreePtr stmt = block->bbTreeList;
-#endif
              stmt != NULL;
              stmt = stmt->gtNext)
         {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8809,11 +8809,7 @@ void Compiler::fgSimpleLowering()
         // Walk the statement trees in this basic block, converting ArrLength nodes.
         compCurBB = block; // Used in fgRngChkTarget.
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
         for (GenTreeStmt* stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNextStmt)
-#else
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
-#endif
         {
             for (GenTreePtr tree = stmt->gtStmtList; tree; tree = tree->gtNext)
             {
@@ -9994,7 +9990,6 @@ void                Compiler::fgUnreachableBlock(BasicBlock* block)
     /* Make the block publicly available */
     compCurBB = block;
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
     // TODO-Cleanup: I'm not sure why this happens -- if the block is unreachable, why does it have phis?
     // Anyway, remove any phis.
     GenTreePtr firstNonPhi = block->FirstNonPhiDef();
@@ -10006,7 +10001,6 @@ void                Compiler::fgUnreachableBlock(BasicBlock* block)
         }
         block->bbTreeList = firstNonPhi;
     }
-#endif // JIT_FEATURE_SSA_SKIP_DEFS
 
     for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
     {
@@ -18585,12 +18579,7 @@ unsigned Compiler::fgGetCodeEstimate(BasicBlock* block)
         break;
     }
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
     GenTreePtr  tree = block->FirstNonPhiDef();
-#else
-    GenTreePtr  tree = block->bbTreeList;
-#endif
-
     if  (tree)
     {
         do
@@ -20645,11 +20634,7 @@ void Compiler::fgDebugCheckNodeLinks(BasicBlock* block, GenTree* node)
                 // The GT_CATCH_ARG should always have GTF_ORDER_SIDEEFF set
                 noway_assert(tree->gtFlags & GTF_ORDER_SIDEEFF);
                 // The GT_CATCH_ARG has to be the first thing evaluated
-#if JIT_FEATURE_SSA_SKIP_DEFS
                 noway_assert(stmt == block->FirstNonPhiDef());
-#else
-                noway_assert(stmt == block->bbTreeList);
-#endif
                 noway_assert(stmt->gtStmtList->gtOper == GT_CATCH_ARG);
                 // The root of the tree should have GTF_ORDER_SIDEEFF set
                 noway_assert(stmt->gtStmtExpr->gtFlags & GTF_ORDER_SIDEEFF);
@@ -20743,11 +20728,7 @@ unsigned Compiler::fgDebugCheckLinearTree(BasicBlock* block,
             // The GT_CATCH_ARG should always have GTF_ORDER_SIDEEFF set
             noway_assert(tree->gtFlags & GTF_ORDER_SIDEEFF);
             // The GT_CATCH_ARG has to be the first thing evaluated
-#if JIT_FEATURE_SSA_SKIP_DEFS
             noway_assert(stmt == block->FirstNonPhiDef());
-#else
-            noway_assert(stmt == block->bbTreeList);
-#endif
             noway_assert(stmt->gtStmt.gtStmtList->gtOper == GT_CATCH_ARG);
             // The root of the tree should have GTF_ORDER_SIDEEFF set
             noway_assert(stmt->gtStmt.gtStmtExpr->gtFlags & GTF_ORDER_SIDEEFF);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -12463,7 +12463,6 @@ bool BasicBlock::containsStatement(GenTree *statement)
     return curr != NULL;
 }
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
 GenTreeStmt* BasicBlock::FirstNonPhiDef()
 {
     GenTreePtr stmt = bbTreeList;
@@ -12478,15 +12477,10 @@ GenTreeStmt* BasicBlock::FirstNonPhiDef()
     }
     return stmt->AsStmt();
 }
-#endif // JIT_FEATURE_SSA_SKIP_DEFS
 
 GenTreePtr BasicBlock::FirstNonPhiDefOrCatchArgAsg()
 {
-#if JIT_FEATURE_SSA_SKIP_DEFS
     GenTreePtr stmt = FirstNonPhiDef();
-#else // !JIT_FEATURE_SSA_SKIP_DEFS
-    GenTreePtr stmt = bbTreeList;
-#endif // !JIT_FEATURE_SSA_SKIP_DEFS
     if (stmt == nullptr) return nullptr;
     GenTreePtr tree = stmt->gtStmt.gtStmtExpr;
     if ((tree->OperGet() == GT_ASG && tree->gtOp.gtOp2->OperGet() == GT_CATCH_ARG)

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -421,7 +421,6 @@ typedef ptrdiff_t   ssize_t;
 #define DUMP_GC_TABLES      DEBUG
 #define VERIFY_GC_TABLES    0
 #define REARRANGE_ADDS      1
-#define JIT_FEATURE_SSA_SKIP_DEFS 1
 
 #define FUNC_INFO_LOGGING   1   // Support dumping function info to a file. In retail, only NYIs, with no function name, are dumped.
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3185,11 +3185,7 @@ void                Compiler::lvaMarkLocalVars(BasicBlock * block)
                block->bbNum, refCntWtd2str(lvaMarkRefsWeight));
 #endif
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
     for (GenTreePtr tree = block->FirstNonPhiDef(); tree; tree = tree->gtNext)
-#else
-    for (GenTreePtr tree = block->bbTreeList; tree; tree = tree->gtNext)
-#endif
     {
         noway_assert(tree->gtOper == GT_STMT);
         

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -560,11 +560,7 @@ void                Compiler::fgPerBlockLocalVarLiveness()
 
         compCurBB   = block;
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
         for (stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
-#else
-        for (stmt = block->bbTreeList; stmt; stmt = stmt->gtNext)
-#endif
         {
             noway_assert(stmt->gtOper == GT_STMT);
 
@@ -2738,7 +2734,6 @@ void                Compiler::fgInterBlockLocalVarLiveness()
 
         /* Get the first statement in the block */
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
         GenTreePtr      firstStmt = block->FirstNonPhiDef();
 
         if (!firstStmt)
@@ -2747,16 +2742,6 @@ void                Compiler::fgInterBlockLocalVarLiveness()
         /* Walk all the statements of the block backwards - Get the LAST stmt */
 
         GenTreePtr      nextStmt = block->bbTreeList->gtPrev;
-#else // !JIT_FEATURE_SSA_SKIP_DEFS
-        GenTreePtr      firstStmt = block->bbTreeList;
-
-        if (!firstStmt)
-            continue;
-
-        /* Walk all the statements of the block backwards - Get the LAST stmt */
-
-        GenTreePtr      nextStmt = firstStmt->gtPrev;
-#endif // !JIT_FEATURE_SSA_SKIP_DEFS
 
         do
         {

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -634,11 +634,7 @@ unsigned            Compiler::optValnumCSE_Locate()
         noway_assert((block->bbFlags & (BBF_VISITED|BBF_MARKED)) == 0);           
 
         /* Walk the statement trees in this basic block */
-#if JIT_FEATURE_SSA_SKIP_DEFS
         for (stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
-#else
-        for (stmt = block->bbTreeList; stmt; stmt = stmt->gtNext)
-#endif
         {
             noway_assert(stmt->gtOper == GT_STMT);
 
@@ -893,11 +889,7 @@ void            Compiler::optValnumCSE_Availablity()
 
         /* Walk the statement trees in this basic block */
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
         for (stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
-#else
-        for (stmt = block->bbTreeList; stmt; stmt = stmt->gtNext)
-#endif
         {
             noway_assert(stmt->gtOper == GT_STMT);
 
@@ -2411,11 +2403,7 @@ void                Compiler::optCleanupCSEs()
         GenTreePtr  stmt;
 
         // Initialize 'stmt' to the first non-Phi statement
-#if JIT_FEATURE_SSA_SKIP_DEFS
         stmt = block->FirstNonPhiDef(); 
-#else
-        stmt = block->bbTreeList;
-#endif
 
         for (; stmt; stmt = stmt->gtNext)
         {
@@ -2449,11 +2437,7 @@ void                Compiler::optEnsureClearCSEInfo()
         GenTreePtr  stmt;
 
         // Initialize 'stmt' to the first non-Phi statement
-#if JIT_FEATURE_SSA_SKIP_DEFS
         stmt = block->FirstNonPhiDef(); 
-#else
-        stmt = block->bbTreeList;
-#endif
 
         for (; stmt; stmt = stmt->gtNext)
         {

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -5160,11 +5160,7 @@ int                 Compiler::optIsSetAssgLoop(unsigned            lnum,
         {
             noway_assert(beg);
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
             for (GenTreeStmt* stmt = beg->FirstNonPhiDef(); stmt; stmt = stmt->gtNextStmt)
-#else
-            for (GenTreeStmt* stmt = beg->firstStmt(); stmt; stmt = stmt->gtNextStmt)
-#endif
             {
                 noway_assert(stmt->gtOper == GT_STMT);
                 fgWalkTreePre(&stmt->gtStmtExpr, optIsVarAssgCB, &desc);
@@ -5741,11 +5737,7 @@ void Compiler::optHoistLoopExprsForBlock(BasicBlock* blk,
          return;
      }
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
     for (GenTreeStmt* stmt = blk->FirstNonPhiDef(); stmt; stmt = stmt->gtNextStmt)
-#else
-    for (GenTreeStmt* stmt = blk->firstStmt(); stmt; stmt = stmt->gtNextStmt)
-#endif
     {
         GenTreePtr stmtTree = stmt->gtStmtExpr;
         bool hoistable;

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -6523,11 +6523,7 @@ void               Compiler::rpPredictRegUse()
 
             compCurBB = block;
 
-#if JIT_FEATURE_SSA_SKIP_DEFS
             for (stmt =  block->FirstNonPhiDef();
-#else
-            for (stmt =  block->bbTreeList;
-#endif
                  stmt != NULL;
                  stmt =  stmt->gtNext)
             {

--- a/src/jit/stackfp.cpp
+++ b/src/jit/stackfp.cpp
@@ -4089,11 +4089,7 @@ void Compiler::raEnregisterVarsPrePassStackFP            ()
         }
         
         VARSET_TP VARSET_INIT(this, liveSet, block->bbLiveIn);
-#if JIT_FEATURE_SSA_SKIP_DEFS
         for (GenTreePtr stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
-#else
-        for (GenTreePtr stmt = block->bbTreeList; stmt; stmt = stmt->gtNext)
-#endif
         {
             assert(stmt->gtOper == GT_STMT);
 
@@ -4291,11 +4287,7 @@ void Compiler::raEnregisterVarsPostPassStackFP       ()
 
         
         VARSET_TP VARSET_INIT(this, lastlife, block->bbLiveIn);
-#if JIT_FEATURE_SSA_SKIP_DEFS
         for (GenTreePtr stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
-#else
-        for (GenTreePtr stmt = block->bbTreeList; stmt; stmt = stmt->gtNext)
-#endif
         {
             assert(stmt->gtOper == GT_STMT);
             


### PR DESCRIPTION
This symbol is always defined to `1`. Remove it and its associated
dead code.