### PR TITLE
Fix WeakReference tests depending on JIT not extending lifetimes

### DIFF
--- a/tests/src/GC/API/WeakReference/IsAlive_neg.cs
+++ b/tests/src/GC/API/WeakReference/IsAlive_neg.cs
@@ -16,6 +16,12 @@ public class Test {
     public static void CreateArray() {
         array = new int[50];
     }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public static WeakReference CreateArrayWeakReference()
+    {
+        return new WeakReference(array);
+    }
     
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void DestroyArray() {
@@ -25,7 +31,7 @@ public class Test {
     public static int Main() {
         CreateArray();
 
-        WeakReference weak = new WeakReference(array); // array has ONLY a weakreference
+        WeakReference weak = CreateArrayWeakReference(); // array has ONLY a weakreference
 
         // ensuring that GC happens even with /debug mode
         DestroyArray();

--- a/tests/src/GC/API/WeakReference/Target.cs
+++ b/tests/src/GC/API/WeakReference/Target.cs
@@ -32,6 +32,12 @@ public class Test
     }
     
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public static WeakReference CreateArrayWeakReference()
+    {
+        return new WeakReference(array);
+    }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void DestroyArrays() 
     {
         array = null;
@@ -41,7 +47,7 @@ public class Test
     public bool GetTargetTest()
     {
         CreateArrays();
-        WeakReference weakarray = new WeakReference(array); // array has only weak reference
+        WeakReference weakarray = CreateArrayWeakReference(); // array has only weak reference
 
         // obj has both strong and weak ref and so should not get collected
 


### PR DESCRIPTION
Target and IsAlive_neg are failing in some cases when JIT optimization is
disabled because the JIT (legally) generates code that holds a reference
to an object longer than expected.  Instead of forcing optimization on for
these tests, I'm using the pattern of moving the problematic object
reference to a non-inlined helper method.

Fixes #5555