### PR TITLE
Make Phase::{Pre,Do,Post}Phase protected.

### DIFF
--- a/src/jit/phase.h
+++ b/src/jit/phase.h
@@ -9,13 +9,14 @@
 class Phase
 {
 public:
+    virtual void Run();
+
+protected:
     Phase(Compiler *_comp, 
           const char *_name, 
           Phases _phase=PHASE_NUMBER_OF) 
         : comp(_comp), name(_name), phase(_phase) {}
-    virtual void Run();
 
-protected:
     virtual void PrePhase();
     virtual void DoPhase() = 0;
     virtual void PostPhase();

--- a/src/jit/phase.h
+++ b/src/jit/phase.h
@@ -14,11 +14,12 @@ public:
           Phases _phase=PHASE_NUMBER_OF) 
         : comp(_comp), name(_name), phase(_phase) {}
     virtual void Run();
+
+protected:
     virtual void PrePhase();
     virtual void DoPhase() = 0;
     virtual void PostPhase();
 
-protected:
     Compiler *comp;
     const char *name;
     Phases phase;


### PR DESCRIPTION
These methods are implementation details of a phase and should not be a part
of its public interface.