### PR TITLE
Inliner: implement profitabily side of the ModelPolicy

### DIFF
--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -238,6 +238,7 @@ protected:
 
     void ComputeOpcodeBin(OPCODE opcode);
     void EstimateCodeSize();
+    void EstimatePerformanceImpact();
     void MethodInfoObservations(CORINFO_METHOD_INFO* methodInfo);
     enum { MAX_ARGS = 6 };
 
@@ -279,6 +280,7 @@ protected:
     unsigned    m_ThrowCount;
     unsigned    m_CallCount;
     int         m_ModelCodeSizeEstimate;
+    int         m_PerCallInstructionEstimate;
 };
 
 // ModelPolicy is an experimental policy that uses the results


### PR DESCRIPTION
First (and very preliminary) cut at a profitability model, based
on inline data modelling.

ModelPolicy heuristic is updated to use this information to decide
when to inline. The policy has two parameters: one for the local
call site weight and another for the overall size/speed tradeoff
that we find acceptable. The first parameter is temporary as we
should be able to model this weight via observations.

Size/speed tradeoff is a policy decision and is a tuning parameter.
I've set it for now to roughly match the LegacyPolicy behavior, in
aggregate, across the jit perf benchmarks.