### PR TITLE
Inliner: observe block weight, update schema and data

### DIFF
--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -155,11 +155,12 @@ INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",        
 
 INLINE_OBSERVATION(CONSTANT_ARG_FEEDS_TEST,   bool,   "constant argument feeds test",  INFORMATION, CALLSITE)
 INLINE_OBSERVATION(DEPTH,                     int,    "depth",                         INFORMATION, CALLSITE)
-INLINE_OBSERVATION(FREQUENCY,                 int,    "execution frequency",           INFORMATION, CALLSITE)
+INLINE_OBSERVATION(FREQUENCY,                 int,    "rough call site frequency",     INFORMATION, CALLSITE)
 INLINE_OBSERVATION(IS_PROFITABLE_INLINE,      bool,   "profitable inline",             INFORMATION, CALLSITE)
 INLINE_OBSERVATION(IS_SIZE_DECREASING_INLINE, bool,   "size decreasing inline",        INFORMATION, CALLSITE)
 INLINE_OBSERVATION(LOG_REPLAY_ACCEPT,         bool,   "accepted by log replay",        INFORMATION, CALLSITE)
 INLINE_OBSERVATION(RANDOM_ACCEPT,             bool,   "random accept",                 INFORMATION, CALLSITE)
+INLINE_OBSERVATION(WEIGHT,                    int,    "call site frequency",           INFORMATION, CALLSITE)
 
 // ------ Final Sentinel ------- 
 

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -1140,6 +1140,7 @@ DiscretionaryPolicy::DiscretionaryPolicy(Compiler* compiler, bool isPrejitRoot)
     , m_LoadAddressCount(0)
     , m_ThrowCount(0)
     , m_CallCount(0)
+    , m_CallSiteWeight(0)
     , m_ModelCodeSizeEstimate(0)
     , m_PerCallInstructionEstimate(0)
 {
@@ -1228,6 +1229,10 @@ void DiscretionaryPolicy::NoteInt(InlineObservation obs, int value)
 
     case InlineObservation::CALLSITE_DEPTH:
         m_Depth = value;
+        break;
+
+    case InlineObservation::CALLSITE_WEIGHT:
+        m_CallSiteWeight = static_cast<unsigned>(value);
         break;
 
     default:
@@ -1794,6 +1799,7 @@ void DiscretionaryPolicy::DumpSchema(FILE* file) const
     fprintf(file, ",LoadAddressCount");
     fprintf(file, ",ThrowCount");
     fprintf(file, ",CallCount");
+    fprintf(file, ",CallSiteWeight");
     fprintf(file, ",IsForceInline");
     fprintf(file, ",IsInstanceCtor");
     fprintf(file, ",IsFromPromotableValueClass");
@@ -1806,6 +1812,7 @@ void DiscretionaryPolicy::DumpSchema(FILE* file) const
     fprintf(file, ",CalleeNativeSizeEstimate");
     fprintf(file, ",CallsiteNativeSizeEstimate");
     fprintf(file, ",ModelCodeSizeEstimate");
+    fprintf(file, ",ModelPerCallInstructionEstimate");
 }
 
 //------------------------------------------------------------------------
@@ -1867,6 +1874,7 @@ void DiscretionaryPolicy::DumpData(FILE* file) const
     fprintf(file, ",%u", m_LoadAddressCount);
     fprintf(file, ",%u", m_ThrowCount);
     fprintf(file, ",%u", m_CallCount);
+    fprintf(file, ",%u", m_CallSiteWeight);
     fprintf(file, ",%u", m_IsForceInline ? 1 : 0);
     fprintf(file, ",%u", m_IsInstanceCtor ? 1 : 0);
     fprintf(file, ",%u", m_IsFromPromotableValueClass ? 1 : 0);
@@ -1879,6 +1887,7 @@ void DiscretionaryPolicy::DumpData(FILE* file) const
     fprintf(file, ",%d", m_CalleeNativeSizeEstimate);
     fprintf(file, ",%d", m_CallsiteNativeSizeEstimate);
     fprintf(file, ",%d", m_ModelCodeSizeEstimate);
+    fprintf(file, ",%d", m_PerCallInstructionEstimate);
 }
 
 //------------------------------------------------------------------------/

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -279,6 +279,7 @@ protected:
     unsigned    m_LoadAddressCount;
     unsigned    m_ThrowCount;
     unsigned    m_CallCount;
+    unsigned    m_CallSiteWeight;
     int         m_ModelCodeSizeEstimate;
     int         m_PerCallInstructionEstimate;
 };


### PR DESCRIPTION
Add block weight as observation. At first blush I suspect this will be
useful only when the jit has IBC data, and even then only in the root
method blocks.

We'll likely need to either build up better profile estimates for the
inliner or else just try and cope without it somehow.

Dump out block weight and the per-call profitability in the observation
schema and data. Among other things this lets us cross-validate how well
the ModelPolicy predictions match the abstract GLMNET models...