### PR TITLE
Increase inlineability of String.Equals

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -561,10 +561,7 @@ namespace System {
                 return true;
 
             string str = obj as string;
-            if (str == null)
-                return false;
-
-            if (this.Length != str.Length)
+            if (str == null || this.Length != str.Length)
                 return false;
 
             return EqualsHelper(this, str);
@@ -585,10 +582,7 @@ namespace System {
             // If either side of an == comparison between strings
             // is null, Roslyn generates a simple ceq instruction
             // instead of calling string.op_Equality.
-            if (value == null)
-                return false;
-            
-            if (this.Length != value.Length)
+            if (value == null || this.Length != value.Length)
                 return false;
 
             return EqualsHelper(this, value);

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -572,6 +572,7 @@ namespace System {
         // Determines whether two strings match.
         [Pure]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(String value)
         {
 #if !FEATURE_CORECLR
@@ -649,6 +650,7 @@ namespace System {
 
         // Determines whether two Strings match.
         [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Equals(String a, String b) {
             if ((Object)a==(Object)b) {
                 return true;

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -554,8 +554,10 @@ namespace System {
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         public override bool Equals(Object obj)
         {
+#if !FEATURE_CORECLR
             if (this == null)                        // this is necessary to guard against reverse-pinvokes and
                 throw new NullReferenceException();  // other callers who do not use the callvirt instruction
+#endif
 
             if (object.ReferenceEquals(this, obj))
                 return true;
@@ -572,8 +574,10 @@ namespace System {
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         public bool Equals(String value)
         {
+#if !FEATURE_CORECLR
             if (this == null)                        // this is necessary to guard against reverse-pinvokes and
                 throw new NullReferenceException();  // other callers who do not use the callvirt instruction
+#endif
 
             if (object.ReferenceEquals(this, value))
                 return true;


### PR DESCRIPTION
Currently, `string.Equals` isn't getting inlined by the JIT. This means that a new method call has to be made every time someone does something like `"foo" == "blah"`. This is in spite of the fact that the body of `string.Equals` itself is pretty small in terms of code size; all it really does is two pointer comparisons and a length check before calling `EqualsHelper`. This means that for different-length strings, we are wasting a method call every time we call `string.Equals`.

This pull request makes the following changes:

- Omits compiling the `this == null` check on CoreCLR. Since the check and the `throw new NullReferenceException` clause bloated the compiled output significantly, I removed it for .NET Core. This is only going to cause different behavior if someone handwrites IL manually/does a reverse PInvoke (as the comment notes), compiles that app for .NET Core, *and* passes null as a parameter to one of the `Equals` functions. Since for 99.99% percent of cases this won't happen and removing it will speed up apps significantly, I decided to only compile it for the framework.

- Aggregated two `if (...) return false` conditionals into an or statement, so we won't generate duplicate code to return false (and thus decrease method size).

- Added `AggressiveInlining` attributes to the `string.Equals` methods. (I didn't do it for the object-based overload, since it's more code + most of the time it's going to be done as a virtual method call, which can't be inlined anyway.)

## Perf impact

- [Test app 1](https://gist.github.com/jamesqo/90fd6e580f1dbbfe4f8d0c5e4cf98d49) (for getting JIT output)
- [Old disassembly](https://gist.github.com/jamesqo/02b3f73cd5efc105a442e68dcd4adcd6)
- [New disassembly](https://gist.github.com/jamesqo/70488223f34c7fd46e7150b6f6cb1e6e) (the JIT is able to optimize the method down to basically nothing)
- [Test app 2](https://gist.github.com/jamesqo/aa17f8e4b5a0b91a9713aab56a0d713c) (for benchmarking)
- [Old results](https://gist.github.com/jamesqo/8fb59c768683d86010ff5c336389bd3f)
- [New results](https://gist.github.com/jamesqo/85e41481c44e56d394722509f4a25a71)

cc: @jkotas @AlexGhiondea @hughbe @ellismg 