### PR TITLE
Replace `bc` with the BASH builtin let

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -572,7 +572,7 @@ function finish_test {
 
     if [ "$showTime" == "ON" ]; then
         testEndTime=$(date +%s)
-        testRunningTime=$(echo "$testEndTime - ${testStartTimes[$nextProcessIndex]}" | bc)
+        let "testRunningTime = ${testEndTime} - ${testStartTimes[$nextProcessIndex]}"
         header=$(printf "[%03d:%4.0fs] " "$countTotalTests" "$testRunningTime")
     fi
 


### PR DESCRIPTION
As the elapsed time is integer, it can be computed without using bc
via using the BASH builtin.

This commit tries to fix #5677.