### PR TITLE
[WIP] Corerun: Do not override path of the given executable.

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -8470,7 +8470,8 @@ PEAssembly * AppDomain::BindAssemblySpec(
     BOOL                   fRaisePrebindEvents, 
     StackCrawlMark *       pCallerStackMark, 
     AssemblyLoadSecurity * pLoadSecurity,
-    BOOL                   fUseHostBinderIfAvailable)
+    BOOL                   fUseHostBinderIfAvailable,
+    BOOL                   fUseExplicitPath)
 {
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
@@ -8847,7 +8848,7 @@ EndTry2:;
                     // Use CoreClr's fusion alternative
                     CoreBindResult bindResult;
 
-                    pSpec->Bind(this, fThrowOnFileNotFound, &bindResult, FALSE /* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */, pCallerStackMark);
+                    pSpec->Bind(this, fThrowOnFileNotFound, &bindResult, fUseExplicitPath/* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */, pCallerStackMark);
                     hrBindResult = bindResult.GetHRBindResult();
 
                     if (bindResult.Found()) 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -2527,7 +2527,8 @@ public:
         BOOL fRaisePrebindEvents,
         StackCrawlMark *pCallerStackMark = NULL,
         AssemblyLoadSecurity *pLoadSecurity = NULL,
-        BOOL fUseHostBinderIfAvailable = TRUE) DAC_EMPTY_RET(NULL);
+        BOOL fUseHostBinderIfAvailable = TRUE,
+        BOOL fUseExplicitPath = FALSE) DAC_EMPTY_RET(NULL);
 
     HRESULT BindAssemblySpecForHostedBinder(
         AssemblySpec *   pSpec, 

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -1188,7 +1188,7 @@ PEAssembly *AssemblySpec::ResolveAssemblyFile(AppDomain *pDomain, BOOL fPreBind)
 }
 
 
-Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel, AssemblyLoadSecurity *pLoadSecurity, BOOL fThrowOnFileNotFound, BOOL fRaisePrebindEvents, StackCrawlMark *pCallerStackMark)
+Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel, AssemblyLoadSecurity *pLoadSecurity, BOOL fThrowOnFileNotFound, BOOL fRaisePrebindEvents, StackCrawlMark *pCallerStackMark, BOOL fUseExplicitPath)
 {
     CONTRACTL
     {
@@ -1198,7 +1198,7 @@ Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel, AssemblyLoadSecu
     }
     CONTRACTL_END;
  
-    DomainAssembly * pDomainAssembly = LoadDomainAssembly(targetLevel, pLoadSecurity, fThrowOnFileNotFound, fRaisePrebindEvents, pCallerStackMark);
+    DomainAssembly * pDomainAssembly = LoadDomainAssembly(targetLevel, pLoadSecurity, fThrowOnFileNotFound, fRaisePrebindEvents, pCallerStackMark, fUseExplicitPath);
     if (pDomainAssembly == NULL) {
         _ASSERTE(!fThrowOnFileNotFound);
         return NULL;
@@ -1311,7 +1311,8 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
                                                  AssemblyLoadSecurity *pLoadSecurity,
                                                  BOOL fThrowOnFileNotFound,
                                                  BOOL fRaisePrebindEvents,
-                                                 StackCrawlMark *pCallerStackMark)
+                                                 StackCrawlMark *pCallerStackMark,
+                                                 BOOL fUseExplicitPath)
 {
     CONTRACT(DomainAssembly *)
     {
@@ -1464,7 +1465,7 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
     }
 #endif // FEATURE_REFLECTION_ONLY_LOAD
 
-    PEAssemblyHolder pFile(pDomain->BindAssemblySpec(this, fThrowOnFileNotFound, fRaisePrebindEvents, pCallerStackMark, pLoadSecurity));
+    PEAssemblyHolder pFile(pDomain->BindAssemblySpec(this, fThrowOnFileNotFound, fRaisePrebindEvents, pCallerStackMark, pLoadSecurity, TRUE, fUseExplicitPath));
     if (pFile == NULL)
         RETURN NULL;
 
@@ -1499,7 +1500,7 @@ Assembly *AssemblySpec::LoadAssembly(LPCSTR pSimpleName,
 }
 
 /* static */
-Assembly *AssemblySpec::LoadAssembly(LPCWSTR pFilePath)
+Assembly *AssemblySpec::LoadAssembly(LPCWSTR pFilePath, BOOL fUseExplicitPath)
 {
     CONTRACT(Assembly *)
     {
@@ -1514,7 +1515,7 @@ Assembly *AssemblySpec::LoadAssembly(LPCWSTR pFilePath)
 
     AssemblySpec spec;
     spec.SetCodeBase(pFilePath);
-    RETURN spec.LoadAssembly(FILE_LOADED);
+    RETURN spec.LoadAssembly(FILE_LOADED, NULL, TRUE, TRUE, NULL, fUseExplicitPath);
 }
 
 #ifndef  FEATURE_FUSION  

--- a/src/vm/assemblyspec.hpp
+++ b/src/vm/assemblyspec.hpp
@@ -221,12 +221,14 @@ class AssemblySpec  : public BaseAssemblySpec
                            AssemblyLoadSecurity *pLoadSecurity = NULL,
                            BOOL fThrowOnFileNotFound = TRUE,
                            BOOL fRaisePrebindEvents = TRUE,
-                           StackCrawlMark *pCallerStackMark = NULL);
+                           StackCrawlMark *pCallerStackMark = NULL,
+                           BOOL fUseExplicitPath = FALSE);
     DomainAssembly *LoadDomainAssembly(FileLoadLevel targetLevel,
                                        AssemblyLoadSecurity *pLoadSecurity = NULL,
                                        BOOL fThrowOnFileNotFound = TRUE,
                                        BOOL fRaisePrebindEvents = TRUE,
-                                       StackCrawlMark *pCallerStackMark = NULL);
+                                       StackCrawlMark *pCallerStackMark = NULL,
+                                       BOOL fUseExplicitPath = FALSE);
 
     //****************************************************************************************
     //
@@ -250,7 +252,7 @@ class AssemblySpec  : public BaseAssemblySpec
 #endif
 
     // Load an assembly based on an explicit path
-    static Assembly *LoadAssembly(LPCWSTR pFilePath);
+    static Assembly *LoadAssembly(LPCWSTR pFilePath, BOOL fUseExplicitPath = FALSE);
 
 #ifdef FEATURE_FUSION
     BOOL FindAssemblyFile(AppDomain *pAppDomain, BOOL fThrowOnFileNotFound,

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -7997,7 +7997,8 @@ PEAssembly *CompilationDomain::BindAssemblySpec(
     BOOL fRaisePrebindEvents,
     StackCrawlMark *pCallerStackMark,
     AssemblyLoadSecurity *pLoadSecurity,
-    BOOL fUseHostBinderIfAvailable)
+    BOOL fUseHostBinderIfAvailable,
+    BOOL fUseExplicitPath)
 {
     PEAssembly *pFile = NULL;
     //

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -826,7 +826,8 @@ class CompilationDomain : public AppDomain,
         BOOL fRaisePrebindEvents,
         StackCrawlMark *pCallerStackMark = NULL,
         AssemblyLoadSecurity *pLoadSecurity = NULL,
-        BOOL fUseHostBinderIfAvailable = TRUE) DAC_EMPTY_RET(NULL);
+        BOOL fUseHostBinderIfAvailable = TRUE,
+        BOOL fUseExplicitPath = false) DAC_EMPTY_RET(NULL);
 
     BOOL CanEagerBindToZapFile(Module *targetModule, BOOL limitToHardBindList = TRUE);
 

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -1324,7 +1324,7 @@ HRESULT CorHost2::ExecuteAssembly(DWORD dwAppDomainId,
 
     _ASSERTE (!pThread->PreemptiveGCDisabled());
 
-    Assembly *pAssembly = AssemblySpec::LoadAssembly(pwzAssemblyPath);
+    Assembly *pAssembly = AssemblySpec::LoadAssembly(pwzAssemblyPath, TRUE);
 
 #if defined(FEATURE_MULTICOREJIT)
     pCurDomain->GetMulticoreJitManager().AutoStartProfile(pCurDomain);


### PR DESCRIPTION
Corerun has been trying to load the executable from a directory
where Corerun is supposed to find DLL files even if the user has
given a full path of the executable.

This patch disables such speculation/search process for the
executable name.

Fixes #5631

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>