### PR TITLE
Initial support of breakpoint setting by source file + line on Linux using portable pdb reader

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -44,6 +44,8 @@ remove_definitions(-D_UNICODE)
 include_directories(BEFORE ${VM_DIR})
 include_directories(${CLR_DIR}/src/gcdump)
 include_directories(${CLR_DIR}/src/debug/shim)
+include_directories(${CLR_DIR}/src/coreclr/hosts/unixcoreruncommon)
+include_directories(${CLR_DIR}/src/coreclr/hosts/inc)
 
 if(WIN32)
   include_directories(inc)
@@ -123,6 +125,12 @@ else(WIN32)
     sos.cpp
     util.cpp
   )
+  if(CLR_CMAKE_PLATFORM_DARWIN)
+    set(SOS_SOURCES
+      ${SOS_SOURCES}
+      ../../../coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+    )
+  endif(CLR_CMAKE_PLATFORM_DARWIN)
 
   set(SOS_LIBRARY
     corguids

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -7117,7 +7117,7 @@ DECLARE_API(bpmd)
         // did we get dll and type name or file:line#? Search for a colon in the first arg
         // to see if it is in fact a file:line#
         CHAR* pColon = strchr(DllName.data, ':');
-        if (!SUCCEEDED(g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_DLL_NAME_A, 0, NULL, NULL))) {
+        if (FAILED(g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_DLL_NAME_A, 0, NULL, NULL))) {
             ExtOut("File name:Line number not supported\n");
            fBadParam = true;
         }

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -6368,7 +6368,6 @@ public:
 
     HRESULT LoadSymbolsForModule(TADDR mod, SymbolReader* pSymbolReader)
     {
-#ifndef FEATURE_PAL
         HRESULT Status = S_OK;
         ToRelease<IXCLRDataModule> module;
         IfFailRet(g_sos->GetModule(mod, &module));
@@ -6392,6 +6391,8 @@ public:
             pModuleFilename = pSlash+1;
             pSlash = _wcschr(pModuleFilename, DIRECTORY_SEPARATOR_CHAR_W);
         }
+        return S_OK;
+#ifndef FEATURE_PAL
 
         ImageInfo ii;
         if(FAILED(Status = GetClrModuleImages(module, CLRDATA_MODULE_PE_FILE, &ii)))
@@ -6406,8 +6407,13 @@ public:
             ExtOut("SOS warning: No symbols for module %S, source line breakpoints in this module will not bind hr=0x%x\n", wszNameBuffer, Status);
             return S_FALSE; // not finding symbols is a typical case
         }
+#else
+        if(FAILED(Status = pSymbolReader->LoadSymbols(pMDImport, 0, pModuleFilename, FALSE)))
+        {
+            return S_FALSE;
+        }
+        return Status;
 #endif // FEATURE_PAL
-        return S_OK;
     }
 
     HRESULT ResolvePendingNonModuleBoundBreakpoint(__in_z WCHAR* pFilename, DWORD lineNumber, TADDR mod, SymbolReader* pSymbolReader)
@@ -6418,7 +6424,7 @@ public:
 
         mdMethodDef methodDef;
         ULONG32 ilOffset;
-        if(FAILED(Status = pSymbolReader->ResolveSequencePoint(pFilename, lineNumber, &methodDef, &ilOffset)))
+        if(FAILED(Status = pSymbolReader->ResolveSequencePoint(pFilename, lineNumber, mod, &methodDef, &ilOffset)))
         {
             return S_FALSE; // not binding in a module is typical
         }
@@ -7033,7 +7039,8 @@ DECLARE_API(bpmd)
         ExtOut("!bpmd is not supported on a dump file.\n");
         return Status;
     }
-    
+
+
     // We keep a list of managed breakpoints the user wants to set, and display pending bps
     // bpmd. If you call bpmd <module name> <method> we will set or update an existing bp.
     // bpmd acts as a feeder of breakpoints to bp when the time is right.
@@ -7110,9 +7117,13 @@ DECLARE_API(bpmd)
         // did we get dll and type name or file:line#? Search for a colon in the first arg
         // to see if it is in fact a file:line#
         CHAR* pColon = strchr(DllName.data, ':');
+        if (!SUCCEEDED(g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_DLL_NAME_A, 0, NULL, NULL))) {
+            ExtOut("File name:Line number not supported\n");
+           fBadParam = true;
+        }
+
         if(NULL != pColon)
         {
-#ifndef FEATURE_PAL
             fIsFilename = true;
             *pColon = '\0';
             pColon++;
@@ -7127,9 +7138,13 @@ DECLARE_API(bpmd)
                 fBadParam = true;
             }
             if(nArg != 1) fBadParam = 1;
-#else
-        ExtOut("File name:Line number not supported\n");
-        fBadParam = true;
+#ifdef FEATURE_PAL
+            if (!SymbolReader::SymbolReaderDllExists())
+            {
+                ExtOut("Can't find dll for symbol reader.");
+                ExtOut("File name:Line number not supported\n");
+                fBadParam = true;
+            }
 #endif // FEATURE_PAL
         }
     }
@@ -7245,7 +7260,7 @@ DECLARE_API(bpmd)
                     // if we have symbols then get the function name so we can lookup the MethodDescs
                     mdMethodDef methodDefToken;
                     ULONG32 ilOffset;
-                    if(SUCCEEDED(symbolReader.ResolveSequencePoint(Filename, lineNumber, &methodDefToken, &ilOffset)))
+                    if(SUCCEEDED(symbolReader.ResolveSequencePoint(Filename, lineNumber, moduleList[iModule], &methodDefToken, &ilOffset)))
                     {
                         ToRelease<IXCLRDataMethodDefinition> pMethodDef = NULL;
                         if (SUCCEEDED(ModDef->GetMethodDefinitionByToken(methodDefToken, &pMethodDef)))

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -22,8 +22,9 @@
 #include "coreruncommon.h"
 #include "coreclrhost.h"
 #include <unistd.h>
-
+#ifndef SUCCEEDED
 #define SUCCEEDED(Status) ((Status) >= 0)
+#endif // !SUCCEEDED
 
 // Name of the environment variable controlling server GC.
 // If set to 1, server GC is enabled on startup. If 0, server GC is


### PR DESCRIPTION
This pull request enables `bpmd source:line` SOS command on Linux platform using portable pdb reader from pull request https://github.com/dotnet/corefx/pull/9281.
We have to put `System.Diagnostics.Debug.SymbolReader.dll` to the directory with debuggee application.
Also, we have to build application with portable pdb using `/debug:portable` option and put pdb file to the directory with debuggee application.
This feature was tested on Ubuntu 14.04 Linux x64.
Related issue: #4798
CC: @mikem8361, @janvorli, @Dmitri-Botcharnikov, @seanshpark, @chunseoklee, @kvochko, @sam-baravy
