### PR TITLE
Generic dictionary minor performance improvement and simplification for R2R

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -614,10 +614,10 @@ enum CorInfoHelpFunc
     CORINFO_HELP_MEMSET,                // Init block of memory
     CORINFO_HELP_MEMCPY,                // Copy block of memory
 
-    CORINFO_HELP_RUNTIMEHANDLE_METHOD,  // determine a type/field/method handle at run-time
-    CORINFO_HELP_RUNTIMEHANDLE_METHOD_LOG,// determine a type/field/method handle at run-time, with IBC logging
-    CORINFO_HELP_RUNTIMEHANDLE_CLASS,    // determine a type/field/method handle at run-time
-    CORINFO_HELP_RUNTIMEHANDLE_CLASS_LOG,// determine a type/field/method handle at run-time, with IBC logging
+    CORINFO_HELP_RUNTIMEHANDLE_METHOD,          // determine a type/field/method handle at run-time
+    CORINFO_HELP_RUNTIMEHANDLE_METHOD_LOG,      // determine a type/field/method handle at run-time, with IBC logging
+    CORINFO_HELP_RUNTIMEHANDLE_CLASS,           // determine a type/field/method handle at run-time
+    CORINFO_HELP_RUNTIMEHANDLE_CLASS_LOG,       // determine a type/field/method handle at run-time, with IBC logging
 
     // These helpers are required for MDIL backward compatibility only. They are not used by current JITed code.
     CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE_OBSOLETE, // Convert from a TypeHandle (native structure pointer) to RuntimeTypeHandle at run-time

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -4535,6 +4535,40 @@ PTR_Module ExecutionManager::FindZapModule(TADDR currentData)
 }
 
 /* static */
+PTR_Module ExecutionManager::FindReadyToRunModule(TADDR currentData)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        SO_TOLERANT;
+        MODE_ANY;
+        STATIC_CONTRACT_HOST_CALLS;
+        SUPPORTS_DAC;
+    }
+    CONTRACTL_END;
+
+#ifdef FEATURE_READYTORUN
+    ReaderLockHolder rlh;
+
+    RangeSection * pRS = GetRangeSection(currentData);
+    if (pRS == NULL)
+        return NULL;
+
+    if (pRS->flags & RangeSection::RANGE_SECTION_CODEHEAP)
+        return NULL;
+
+    if (pRS->flags & RangeSection::RANGE_SECTION_READYTORUN)
+        return dac_cast<PTR_Module>(pRS->pHeapListOrZapModule);;
+
+    return NULL;
+#else
+    return NULL;
+#endif
+}
+
+
+/* static */
 PTR_Module ExecutionManager::FindModuleForGCRefMap(TADDR currentData)
 {
     CONTRACTL

--- a/src/vm/codeman.h
+++ b/src/vm/codeman.h
@@ -1298,6 +1298,7 @@ public:
     }
 
     static PTR_Module FindZapModule(TADDR currentData);
+    static PTR_Module FindReadyToRunModule(TADDR currentData);
 
     // FindZapModule flavor to be used during GC to find GCRefMap
     static PTR_Module FindModuleForGCRefMap(TADDR currentData);

--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -305,7 +305,7 @@ void CRemotingServices::DestroyThunk(MethodDesc* pMD)
 }
 #endif
 
-CORINFO_GENERIC_HANDLE JIT_GenericHandleWorker(MethodDesc *  pMD, MethodTable * pMT, LPVOID signature)
+CORINFO_GENERIC_HANDLE JIT_GenericHandleWorker(MethodDesc *  pMD, MethodTable * pMT, LPVOID signature, DWORD dictionaryIndexAndSlot, Module* pModule)
 {
     UNREACHABLE();
 }

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -3994,11 +3994,7 @@ void ClearJitGenericHandleCache(AppDomain *pDomain)
 
 // Factored out most of the body of JIT_GenericHandle so it could be called easily from the CER reliability code to pre-populate the
 // cache.
-CORINFO_GENERIC_HANDLE 
-JIT_GenericHandleWorker(
-    MethodDesc *  pMD, 
-    MethodTable * pMT, 
-    LPVOID        signature)
+CORINFO_GENERIC_HANDLE JIT_GenericHandleWorker(MethodDesc * pMD, MethodTable * pMT, LPVOID signature, DWORD dictionaryIndexAndSlot, Module* pModule)
 {
      CONTRACTL {
         THROWS;
@@ -4009,20 +4005,34 @@ JIT_GenericHandleWorker(
 
     if (pMT != NULL)
     {
-        SigPointer ptr((PCCOR_SIGNATURE)signature);
-
-        ULONG kind; // DictionaryEntryKind
-        IfFailThrow(ptr.GetData(&kind));
-
-        // We need to normalize the class passed in (if any) for reliability purposes. That's because preparation of a code region that
-        // contains these handle lookups depends on being able to predict exactly which lookups are required (so we can pre-cache the
-        // answers and remove any possibility of failure at runtime). This is hard to do if the lookup (in this case the lookup of the
-        // dictionary overflow cache) is keyed off the somewhat arbitrary type of the instance on which the call is made (we'd need to
-        // prepare for every possible derived type of the type containing the method). So instead we have to locate the exactly
-        // instantiated (non-shared) super-type of the class passed in.
-
         ULONG dictionaryIndex = 0;
-        IfFailThrow(ptr.GetData(&dictionaryIndex));
+
+        if (pModule != NULL)
+        {
+#ifdef _DEBUG
+            // Only in R2R mode are the module, dictionary index and dictionary slot provided as an input
+            _ASSERTE(dictionaryIndexAndSlot != -1);
+            _ASSERT(ExecutionManager::FindReadyToRunModule(dac_cast<TADDR>(signature)) == pModule);
+#endif
+            dictionaryIndex = (dictionaryIndexAndSlot >> 16);
+        }
+        else
+        {
+            SigPointer ptr((PCCOR_SIGNATURE)signature);
+
+            ULONG kind; // DictionaryEntryKind
+            IfFailThrow(ptr.GetData(&kind));
+
+            // We need to normalize the class passed in (if any) for reliability purposes. That's because preparation of a code region that
+            // contains these handle lookups depends on being able to predict exactly which lookups are required (so we can pre-cache the
+            // answers and remove any possibility of failure at runtime). This is hard to do if the lookup (in this case the lookup of the
+            // dictionary overflow cache) is keyed off the somewhat arbitrary type of the instance on which the call is made (we'd need to
+            // prepare for every possible derived type of the type containing the method). So instead we have to locate the exactly
+            // instantiated (non-shared) super-type of the class passed in.
+
+            _ASSERTE(dictionaryIndexAndSlot == -1);
+            IfFailThrow(ptr.GetData(&dictionaryIndex));
+        }
 
         pDeclaringMT = pMT;
         for (;;)
@@ -4049,7 +4059,7 @@ JIT_GenericHandleWorker(
     }
 
     DictionaryEntry * pSlot;
-    CORINFO_GENERIC_HANDLE result = (CORINFO_GENERIC_HANDLE)Dictionary::PopulateEntry(pMD, pDeclaringMT, signature, FALSE, &pSlot);
+    CORINFO_GENERIC_HANDLE result = (CORINFO_GENERIC_HANDLE)Dictionary::PopulateEntry(pMD, pDeclaringMT, signature, FALSE, &pSlot, dictionaryIndexAndSlot, pModule);
 
     if (pSlot == NULL)
     {
@@ -4076,10 +4086,12 @@ JIT_GenericHandleWorker(
 
 /*********************************************************************/
 // slow helper to tail call from the fast one
-NOINLINE HCIMPL3(CORINFO_GENERIC_HANDLE, JIT_GenericHandle_Framed,
-         CORINFO_CLASS_HANDLE classHnd,
-         CORINFO_METHOD_HANDLE methodHnd,
-         LPVOID signature)
+NOINLINE HCIMPL5(CORINFO_GENERIC_HANDLE, JIT_GenericHandle_Framed, 
+        CORINFO_CLASS_HANDLE classHnd, 
+        CORINFO_METHOD_HANDLE methodHnd, 
+        LPVOID signature, 
+        DWORD dictionaryIndexAndSlot, 
+        CORINFO_MODULE_HANDLE moduleHnd)
 {
     CONTRACTL {
         FCALL_CHECK;
@@ -4092,11 +4104,12 @@ NOINLINE HCIMPL3(CORINFO_GENERIC_HANDLE, JIT_GenericHandle_Framed,
 
     MethodDesc * pMD = GetMethod(methodHnd);
     MethodTable * pMT = TypeHandle(classHnd).AsMethodTable();
+    Module * pModule = GetModule(moduleHnd);
 
     // Set up a frame
     HELPER_METHOD_FRAME_BEGIN_RET_0();
 
-    result = JIT_GenericHandleWorker(pMD, pMT, signature);
+    result = JIT_GenericHandleWorker(pMD, pMT, signature, dictionaryIndexAndSlot, pModule);
 
     HELPER_METHOD_FRAME_END();
 
@@ -4125,7 +4138,27 @@ HCIMPL2(CORINFO_GENERIC_HANDLE, JIT_GenericHandleMethod, CORINFO_METHOD_HANDLE  
 
     // Tailcall to the slow helper
     ENDFORBIDGC();
-    return HCCALL3(JIT_GenericHandle_Framed, NULL, methodHnd, signature);
+    return HCCALL5(JIT_GenericHandle_Framed, NULL, methodHnd, signature, -1, NULL);
+}
+HCIMPLEND
+
+HCIMPL2(CORINFO_GENERIC_HANDLE, JIT_GenericHandleMethodWithSlotAndModule, CORINFO_METHOD_HANDLE  methodHnd, GenericHandleArgs * pArgs)
+{
+    CONTRACTL{
+        FCALL_CHECK;
+        PRECONDITION(CheckPointer(methodHnd));
+        PRECONDITION(GetMethod(methodHnd)->IsRestored());
+        PRECONDITION(CheckPointer(pArgs));
+    } CONTRACTL_END;
+
+    JitGenericHandleCacheKey key(NULL, methodHnd, pArgs->signature);
+    HashDatum res;
+    if (g_pJitGenericHandleCache->GetValueSpeculative(&key, &res))
+        return (CORINFO_GENERIC_HANDLE)(DictionaryEntry)res;
+
+    // Tailcall to the slow helper
+    ENDFORBIDGC();
+    return HCCALL5(JIT_GenericHandle_Framed, NULL, methodHnd, pArgs->signature, pArgs->dictionaryIndexAndSlot, pArgs->module);
 }
 HCIMPLEND
 #include <optdefault.h>
@@ -4149,7 +4182,7 @@ HCIMPL2(CORINFO_GENERIC_HANDLE, JIT_GenericHandleMethodLogging, CORINFO_METHOD_H
 
     // Tailcall to the slow helper
     ENDFORBIDGC();
-    return HCCALL3(JIT_GenericHandle_Framed, NULL, methodHnd, signature);
+    return HCCALL5(JIT_GenericHandle_Framed, NULL, methodHnd, signature, -1, NULL);
 }
 HCIMPLEND
 
@@ -4171,7 +4204,27 @@ HCIMPL2(CORINFO_GENERIC_HANDLE, JIT_GenericHandleClass, CORINFO_CLASS_HANDLE cla
 
     // Tailcall to the slow helper
     ENDFORBIDGC();
-    return HCCALL3(JIT_GenericHandle_Framed, classHnd, NULL, signature);
+    return HCCALL5(JIT_GenericHandle_Framed, classHnd, NULL, signature, -1, NULL);
+}
+HCIMPLEND
+
+HCIMPL2(CORINFO_GENERIC_HANDLE, JIT_GenericHandleClassWithSlotAndModule, CORINFO_CLASS_HANDLE classHnd, GenericHandleArgs * pArgs)
+{
+    CONTRACTL{
+        FCALL_CHECK;
+        PRECONDITION(CheckPointer(classHnd));
+        PRECONDITION(TypeHandle(classHnd).IsRestored());
+        PRECONDITION(CheckPointer(pArgs));
+    } CONTRACTL_END;
+
+    JitGenericHandleCacheKey key(classHnd, NULL, pArgs->signature);
+    HashDatum res;
+    if (g_pJitGenericHandleCache->GetValueSpeculative(&key, &res))
+        return (CORINFO_GENERIC_HANDLE)(DictionaryEntry)res;
+
+    // Tailcall to the slow helper
+    ENDFORBIDGC();
+    return HCCALL5(JIT_GenericHandle_Framed, classHnd, NULL, pArgs->signature, pArgs->dictionaryIndexAndSlot, pArgs->module);
 }
 HCIMPLEND
 #include <optdefault.h>
@@ -4195,7 +4248,7 @@ HCIMPL2(CORINFO_GENERIC_HANDLE, JIT_GenericHandleClassLogging, CORINFO_CLASS_HAN
 
     // Tailcall to the slow helper
     ENDFORBIDGC();
-    return HCCALL3(JIT_GenericHandle_Framed, classHnd, NULL, signature);
+    return HCCALL5(JIT_GenericHandle_Framed, classHnd, NULL, signature, -1, NULL);
 }
 HCIMPLEND
 

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -3064,6 +3064,7 @@ static BOOL IsTypeSpecForTypicalInstantiation(SigPointer sigptr)
 
     return IsSignatureForTypicalInstantiation(sigptr, ELEMENT_TYPE_VAR, ntypars);
 }
+
 void CEEInfo::ComputeRuntimeLookupForSharedGenericToken(DictionaryEntryKind entryKind,
                                                         CORINFO_RESOLVED_TOKEN * pResolvedToken,
                                                         CORINFO_RESOLVED_TOKEN * pConstrainedResolvedToken,
@@ -3081,15 +3082,58 @@ void CEEInfo::ComputeRuntimeLookupForSharedGenericToken(DictionaryEntryKind entr
 
     pResultLookup->lookupKind.needsRuntimeLookup = true;
     pResultLookup->lookupKind.runtimeLookupFlags = 0;
+
+    CORINFO_RUNTIME_LOOKUP *pResult = &pResultLookup->runtimeLookup;
+    pResult->signature = NULL;
+
+    // Unless we decide otherwise, just do the lookup via a helper function
+    pResult->indirections = CORINFO_USEHELPER;
+
+    MethodDesc *pContextMD = GetMethodFromContext(pResolvedToken->tokenContext);
+    MethodTable *pContextMT = pContextMD->GetMethodTable();
+
+    // Do not bother computing the runtime lookup if we are inlining. The JIT is going
+    // to abort the inlining attempt anyway.
+    if (pContextMD != m_pMethodBeingCompiled)
+    {
+        return;
+    }
+
+    // There is a pathological case where invalid IL refereces __Canon type directly, but there is no dictionary availabled to store the lookup. 
+    // All callers of ComputeRuntimeLookupForSharedGenericToken have to filter out this case. We can't do much about it here.
+    _ASSERTE(pContextMD->IsSharedByGenericInstantiations());
+
+    BOOL fInstrument = FALSE;
+
+#ifdef FEATURE_NATIVE_IMAGE_GENERATION
+    // This will make sure that when IBC logging is turned on we will go through a version
+    // of JIT_GenericHandle which logs the access. Note that we still want the dictionaries
+    // to be populated to prepopulate the types at NGen time.
+    if (IsCompilingForNGen() &&
+        GetAppDomain()->ToCompilationDomain()->m_fForceInstrument)
+    {
+        fInstrument = TRUE;
+    }
+#endif // FEATURE_NATIVE_IMAGE_GENERATION
+
+    if (pContextMD->RequiresInstMethodDescArg())
+    {
+        pResultLookup->lookupKind.runtimeLookupKind = CORINFO_LOOKUP_METHODPARAM;
+    }
+    else
+    {
+        if (pContextMD->RequiresInstMethodTableArg())
+            pResultLookup->lookupKind.runtimeLookupKind = CORINFO_LOOKUP_CLASSPARAM;
+        else
+            pResultLookup->lookupKind.runtimeLookupKind = CORINFO_LOOKUP_THISOBJ;
+    }
+
 #ifdef FEATURE_READYTORUN_COMPILER
     if (IsReadyToRunCompilation())
     {
 #if defined(_TARGET_ARM_)
-        // TODO
-        ThrowHR(E_NOTIMPL);
+        ThrowHR(E_NOTIMPL); /* TODO - NYI */
 #endif
-
-
         switch (entryKind)
         {
         case TypeHandleSlot:
@@ -3126,249 +3170,143 @@ void CEEInfo::ComputeRuntimeLookupForSharedGenericToken(DictionaryEntryKind entr
             _ASSERTE(!"Unknown dictionary entry kind!");
             IfFailThrow(E_FAIL);
         }
-    }
-#endif
 
-    CORINFO_RUNTIME_LOOKUP *pResult = &pResultLookup->runtimeLookup;
-    pResult->signature = NULL;
-
-    // Unless we decide otherwise, just do the lookup via a helper function
-    pResult->indirections = CORINFO_USEHELPER;
-
-    MethodDesc *pContextMD = GetMethodFromContext(pResolvedToken->tokenContext);
-    MethodTable *pContextMT = pContextMD->GetMethodTable();
-
-    // Do not bother computing the runtime lookup if we are inlining. The JIT is going
-    // to abort the inlining attempt anyway.
-    if (pContextMD != m_pMethodBeingCompiled)
-    {
+        // For R2R compilations, we don't generate the dictionary lookup signatures (dictionary lookups are done in a 
+        // different way that is more version resilient... plus we can't have pointers to existing MTs/MDs in the sigs)
         return;
     }
-
-    // There is a pathological case where invalid IL refereces __Canon type directly, but there is no dictionary availabled to store the lookup. 
-    // All callers of ComputeRuntimeLookupForSharedGenericToken have to filter out this case. We can't do much about it here.
-    _ASSERTE(pContextMD->IsSharedByGenericInstantiations());
-
-    BOOL fInstrument = FALSE;
-
-#ifdef FEATURE_NATIVE_IMAGE_GENERATION
-    // This will make sure that when IBC logging is turned on we will go through a version
-    // of JIT_GenericHandle which logs the access. Note that we still want the dictionaries
-    // to be populated to prepopulate the types at NGen time.
-    if (IsCompilingForNGen() &&
-        GetAppDomain()->ToCompilationDomain()->m_fForceInstrument)
-    {
-        fInstrument = TRUE;
-    }
-#endif // FEATURE_NATIVE_IMAGE_GENERATION
-
-    DWORD numGenericArgs;
-    DictionaryLayout* pDictionaryLayout;
-    LoaderAllocator* pAllocator;
-
+#endif
+    // If we've got a  method type parameter of any kind then we must look in the method desc arg
     if (pContextMD->RequiresInstMethodDescArg())
     {
-        pAllocator = pContextMD->GetLoaderAllocator();
-        numGenericArgs = pContextMD->GetNumGenericMethodArgs();
-        pDictionaryLayout = pContextMD->GetDictionaryLayout();
-
-        pResultLookup->lookupKind.runtimeLookupKind = CORINFO_LOOKUP_METHODPARAM;
         pResult->helper = fInstrument ? CORINFO_HELP_RUNTIMEHANDLE_METHOD_LOG : CORINFO_HELP_RUNTIMEHANDLE_METHOD;
+
+        if (fInstrument)
+            goto NoSpecialCase;
+
+        // Special cases:
+        // (1) Naked method type variable: look up directly in instantiation hanging off runtime md
+        // (2) Reference to method-spec of current method (e.g. a recursive call) i.e. currentmeth<!0,...,!(n-1)>
+        if ((entryKind == TypeHandleSlot) && (pResolvedToken->tokenType != CORINFO_TOKENKIND_Newarr))
+        {
+            SigPointer sigptr(pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec);
+            CorElementType type;
+            IfFailThrow(sigptr.GetElemType(&type));
+            if (type == ELEMENT_TYPE_MVAR)
+            {
+                pResult->indirections = 2;
+                pResult->testForNull = 0;
+#ifdef FEATURE_PREJIT
+                pResult->testForFixup = 1;
+#else
+                pResult->testForFixup = 0;
+#endif
+                pResult->offsets[0] = offsetof(InstantiatedMethodDesc, m_pPerInstInfo);
+
+                ULONG data;
+                IfFailThrow(sigptr.GetData(&data));
+                pResult->offsets[1] = sizeof(TypeHandle) * data;
+
+                return;
+            }
+        }
+        else if (entryKind == MethodDescSlot)
+        {
+            // It's the context itself (i.e. a recursive call)
+            if (!pTemplateMD->HasSameMethodDefAs(pContextMD))
+                goto NoSpecialCase;
+
+            // Now just check that the instantiation is (!!0, ..., !!(n-1))
+            if (!IsMethodSpecForTypicalInstantation(SigPointer(pResolvedToken->pMethodSpec, pResolvedToken->cbMethodSpec)))
+                goto NoSpecialCase;
+
+            // Type instantiation has to match too if there is one
+            if (pContextMT->HasInstantiation())
+            {
+                TypeHandle thTemplate(pResolvedToken->hClass);
+
+                if (thTemplate.IsTypeDesc() || !thTemplate.AsMethodTable()->HasSameTypeDefAs(pContextMT))
+                    goto NoSpecialCase;
+
+                // This check filters out method instantiation on generic type definition, like G::M<!!0>()
+                // We may not ever get it here. Filter it out just to be sure...
+                if (pResolvedToken->pTypeSpec == NULL)
+                    goto NoSpecialCase;
+
+                if (!IsTypeSpecForTypicalInstantiation(SigPointer(pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec)))
+                    goto NoSpecialCase;
+            }
+
+            // Just use the method descriptor that was passed in!
+            pResult->indirections = 0;
+            pResult->testForNull = 0;
+            pResult->testForFixup = 0;
+
+            return;
+        }
     }
+    // Otherwise we must just have class type variables
     else
     {
-        pAllocator = pContextMT->GetLoaderAllocator();
-        numGenericArgs = pContextMT->GetNumGenericArgs();
-        pDictionaryLayout = pContextMT->GetClass()->GetDictionaryLayout();
+        _ASSERTE(pContextMT->GetNumGenericArgs() > 0);
 
         if (pContextMD->RequiresInstMethodTableArg())
         {
             // If we've got a vtable extra argument, go through that
-            pResultLookup->lookupKind.runtimeLookupKind = CORINFO_LOOKUP_CLASSPARAM;
             pResult->helper = fInstrument ? CORINFO_HELP_RUNTIMEHANDLE_CLASS_LOG : CORINFO_HELP_RUNTIMEHANDLE_CLASS;
         }
         // If we've got an object, go through its vtable
         else
         {
             _ASSERTE(pContextMD->AcquiresInstMethodTableFromThis());
-            pResultLookup->lookupKind.runtimeLookupKind = CORINFO_LOOKUP_THISOBJ;
             pResult->helper = fInstrument ? CORINFO_HELP_RUNTIMEHANDLE_CLASS_LOG : CORINFO_HELP_RUNTIMEHANDLE_CLASS;
         }
-    }
 
-    ComputeRuntimeLookupForSharedGenericTokenStatic(
-        entryKind,
-        pResolvedToken,
-        pConstrainedResolvedToken,
-        pTemplateMD,
-        pAllocator,
-        numGenericArgs,
-        pDictionaryLayout,
-        (pResultLookup->lookupKind.runtimeLookupKind == CORINFO_LOOKUP_METHODPARAM ? 0 : pContextMT->GetNumDicts()),
-        pResultLookup,
-        TRUE,
-        fInstrument,
-        TRUE);
-}
+        if (fInstrument)
+            goto NoSpecialCase;
 
-void CEEInfo::ComputeRuntimeLookupForSharedGenericTokenStatic(DictionaryEntryKind entryKind,
-                                                              CORINFO_RESOLVED_TOKEN * pResolvedToken,
-                                                              CORINFO_RESOLVED_TOKEN * pConstrainedResolvedToken /* for ConstrainedMethodEntrySlot */,
-                                                              MethodDesc * pTemplateMD /* for method-based slots */,
-                                                              LoaderAllocator* pAllocator,
-                                                              DWORD numGenericArgs,
-                                                              DictionaryLayout* pDictionaryLayout,
-                                                              DWORD typeDictionaryIndex,
-                                                              CORINFO_LOOKUP *pResultLookup,
-                                                              BOOL fEnableTypeHandleLookupOptimization,
-                                                              BOOL fInstrument,
-                                                              BOOL fMethodSpecContainsCallingConventionFlag)
-{
-    CONTRACTL{
-        STANDARD_VM_CHECK;
-        PRECONDITION(CheckPointer(pResultLookup));
-    } CONTRACTL_END;
-
-    pResultLookup->lookupKind.needsRuntimeLookup = true;
-
-    CORINFO_RUNTIME_LOOKUP *pResult = &pResultLookup->runtimeLookup;
-    pResult->signature = NULL;
-
-    // Unless we decide otherwise, just do the lookup via a helper function
-    pResult->indirections = CORINFO_USEHELPER;
-
-    // For R2R compilations, we don't generate the dictionary lookup signatures (dictionary lookups are done in a 
-    // different way that is more version resilient... plus we can't have pointers to existing MTs/MDs in the sigs)
-    if (IsReadyToRunCompilation())
-        return;
-
-    if (fEnableTypeHandleLookupOptimization)
-    {
-        MethodDesc *pContextMD = GetMethodFromContext(pResolvedToken->tokenContext);
-        MethodTable *pContextMT = pContextMD->GetMethodTable();
-
-        // There is a pathological case where invalid IL refereces __Canon type directly, but there is no dictionary availabled to store the lookup. 
-        // All callers of ComputeRuntimeLookupForSharedGenericToken have to filter out this case. We can't do much about it here.
-        _ASSERTE(pContextMD->IsSharedByGenericInstantiations());
-
-        // If we've got a  method type parameter of any kind then we must look in the method desc arg
-        if (pContextMD->RequiresInstMethodDescArg())
+        // Special cases:
+        // (1) Naked class type variable: look up directly in instantiation hanging off vtable
+        // (2) C<!0,...,!(n-1)> where C is the context's class and C is sealed: just return vtable ptr
+        if ((entryKind == TypeHandleSlot) && (pResolvedToken->tokenType != CORINFO_TOKENKIND_Newarr))
         {
-            if (fInstrument)
-                goto NoSpecialCase;
-
-            // Special cases:
-            // (1) Naked method type variable: look up directly in instantiation hanging off runtime md
-            // (2) Reference to method-spec of current method (e.g. a recursive call) i.e. currentmeth<!0,...,!(n-1)>
-            if ((entryKind == TypeHandleSlot) && (pResolvedToken->tokenType != CORINFO_TOKENKIND_Newarr))
+            SigPointer sigptr(pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec);
+            CorElementType type;
+            IfFailThrow(sigptr.GetElemType(&type));
+            if (type == ELEMENT_TYPE_VAR)
             {
-                SigPointer sigptr(pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec);
-                CorElementType type;
-                IfFailThrow(sigptr.GetElemType(&type));
-                if (type == ELEMENT_TYPE_MVAR)
-                {
-                    pResult->indirections = 2;
-                    pResult->testForNull = 0;
+                pResult->indirections = 3;
+                pResult->testForNull = 0;
 #ifdef FEATURE_PREJIT
-                    pResult->testForFixup = 1;
+                pResult->testForFixup = 1;
 #else
-                    pResult->testForFixup = 0;
+                pResult->testForFixup = 0;
 #endif
-                    pResult->offsets[0] = offsetof(InstantiatedMethodDesc, m_pPerInstInfo);
+                pResult->offsets[0] = MethodTable::GetOffsetOfPerInstInfo();
+                pResult->offsets[1] = sizeof(TypeHandle*) * (pContextMT->GetNumDicts() - 1);
+                ULONG data;
+                IfFailThrow(sigptr.GetData(&data));
+                pResult->offsets[2] = sizeof(TypeHandle) * data;
 
-                    ULONG data;
-                    IfFailThrow(sigptr.GetData(&data));
-                    pResult->offsets[1] = sizeof(TypeHandle) * data;
-
-                    return;
-                }
+                return;
             }
-            else if (entryKind == MethodDescSlot)
+            else if (type == ELEMENT_TYPE_GENERICINST &&
+                (pContextMT->IsSealed() || pResultLookup->lookupKind.runtimeLookupKind == CORINFO_LOOKUP_CLASSPARAM))
             {
-                // It's the context itself (i.e. a recursive call)
-                if (!pTemplateMD->HasSameMethodDefAs(pContextMD))
+                TypeHandle thTemplate(pResolvedToken->hClass);
+
+                if (thTemplate.IsTypeDesc() || !thTemplate.AsMethodTable()->HasSameTypeDefAs(pContextMT))
                     goto NoSpecialCase;
 
-                // Now just check that the instantiation is (!!0, ..., !!(n-1))
-                if (!IsMethodSpecForTypicalInstantation(SigPointer(pResolvedToken->pMethodSpec, pResolvedToken->cbMethodSpec)))
+                if (!IsTypeSpecForTypicalInstantiation(SigPointer(pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec)))
                     goto NoSpecialCase;
 
-                // Type instantiation has to match too if there is one
-                if (pContextMT->HasInstantiation())
-                {
-                    TypeHandle thTemplate(pResolvedToken->hClass);
-
-                    if (thTemplate.IsTypeDesc() || !thTemplate.AsMethodTable()->HasSameTypeDefAs(pContextMT))
-                        goto NoSpecialCase;
-
-                    // This check filters out method instantiation on generic type definition, like G::M<!!0>()
-                    // We may not ever get it here. Filter it out just to be sure...
-                    if (pResolvedToken->pTypeSpec == NULL)
-                        goto NoSpecialCase;
-
-                    if (!IsTypeSpecForTypicalInstantiation(SigPointer(pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec)))
-                        goto NoSpecialCase;
-                }
-
-                // Just use the method descriptor that was passed in!
+                // Just use the vtable pointer itself!
                 pResult->indirections = 0;
                 pResult->testForNull = 0;
                 pResult->testForFixup = 0;
 
                 return;
-            }
-        }
-        // Otherwise we must just have class type variables
-        else
-        {
-            _ASSERTE(pContextMT->GetNumGenericArgs() > 0);
-
-            if (fInstrument)
-                goto NoSpecialCase;
-
-            // Special cases:
-            // (1) Naked class type variable: look up directly in instantiation hanging off vtable
-            // (2) C<!0,...,!(n-1)> where C is the context's class and C is sealed: just return vtable ptr
-            if ((entryKind == TypeHandleSlot) && (pResolvedToken->tokenType != CORINFO_TOKENKIND_Newarr))
-            {
-                SigPointer sigptr(pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec);
-                CorElementType type;
-                IfFailThrow(sigptr.GetElemType(&type));
-                if (type == ELEMENT_TYPE_VAR)
-                {
-                    pResult->indirections = 3;
-                    pResult->testForNull = 0;
-#ifdef FEATURE_PREJIT
-                    pResult->testForFixup = 1;
-#else
-                    pResult->testForFixup = 0;
-#endif
-                    pResult->offsets[0] = MethodTable::GetOffsetOfPerInstInfo();
-                    pResult->offsets[1] = sizeof(TypeHandle*) * (pContextMT->GetNumDicts() - 1);
-                    ULONG data;
-                    IfFailThrow(sigptr.GetData(&data));
-                    pResult->offsets[2] = sizeof(TypeHandle) * data;
-
-                    return;
-                }
-                else if (type == ELEMENT_TYPE_GENERICINST &&
-                    (pContextMT->IsSealed() || pResultLookup->lookupKind.runtimeLookupKind == CORINFO_LOOKUP_CLASSPARAM))
-                {
-                    TypeHandle thTemplate(pResolvedToken->hClass);
-
-                    if (thTemplate.IsTypeDesc() || !thTemplate.AsMethodTable()->HasSameTypeDefAs(pContextMT))
-                        goto NoSpecialCase;
-
-                    if (!IsTypeSpecForTypicalInstantiation(SigPointer(pResolvedToken->pTypeSpec, pResolvedToken->cbTypeSpec)))
-                        goto NoSpecialCase;
-
-                    // Just use the vtable pointer itself!
-                    pResult->indirections = 0;
-                    pResult->testForNull = 0;
-                    pResult->testForFixup = 0;
-
-                    return;
-                }
             }
         }
     }
@@ -3381,8 +3319,8 @@ NoSpecialCase:
 
     if (pResultLookup->lookupKind.runtimeLookupKind != CORINFO_LOOKUP_METHODPARAM)
     {
-        _ASSERTE(typeDictionaryIndex > 0);
-        sigBuilder.AppendData(typeDictionaryIndex - 1);
+        _ASSERTE(pContextMT->GetNumDicts() > 0);
+        sigBuilder.AppendData(pContextMT->GetNumDicts() - 1);
     }
 
     Module * pModule = (Module *)pResolvedToken->tokenScope;
@@ -3508,14 +3446,11 @@ NoSpecialCase:
             {
                 SigPointer sigptr(pResolvedToken->pMethodSpec, pResolvedToken->cbMethodSpec);
                 
-                if (fMethodSpecContainsCallingConventionFlag)
-                {
-                    BYTE etype;
-                    IfFailThrow(sigptr.GetByte(&etype));
+                BYTE etype;
+                IfFailThrow(sigptr.GetByte(&etype));
 
-                    // Load the generic method instantiation
-                    THROW_BAD_FORMAT_MAYBE(etype == (BYTE)IMAGE_CEE_CS_CALLCONV_GENERICINST, 0, pModule);
-                }
+                // Load the generic method instantiation
+                THROW_BAD_FORMAT_MAYBE(etype == (BYTE)IMAGE_CEE_CS_CALLCONV_GENERICINST, 0, pModule);
                 
                 DWORD nGenericMethodArgs;
                 IfFailThrow(sigptr.GetData(&nGenericMethodArgs));
@@ -3557,10 +3492,15 @@ NoSpecialCase:
         _ASSERTE(false);
     }
 
+    DictionaryEntrySignatureSource signatureSource = (IsCompilationProcess() ? FromZapImage : FromJIT);
+
     // It's a method dictionary lookup
     if (pResultLookup->lookupKind.runtimeLookupKind == CORINFO_LOOKUP_METHODPARAM)
     {
-        if (DictionaryLayout::FindToken(pAllocator, numGenericArgs, pDictionaryLayout, pResult, &sigBuilder, 1))
+        _ASSERTE(pContextMD != NULL);
+        _ASSERTE(pContextMD->HasMethodInstantiation());
+
+        if (DictionaryLayout::FindToken(pContextMD->GetLoaderAllocator(), pContextMD->GetNumGenericMethodArgs(), pContextMD->GetDictionaryLayout(), pResult, &sigBuilder, 1, signatureSource))
         {
             pResult->testForNull = 1;
             pResult->testForFixup = 0;
@@ -3573,7 +3513,7 @@ NoSpecialCase:
     // It's a class dictionary lookup (CORINFO_LOOKUP_CLASSPARAM or CORINFO_LOOKUP_THISOBJ)
     else
     {
-        if (DictionaryLayout::FindToken(pAllocator, numGenericArgs, pDictionaryLayout, pResult, &sigBuilder, 2))
+        if (DictionaryLayout::FindToken(pContextMT->GetLoaderAllocator(), pContextMT->GetNumGenericArgs(), pContextMT->GetClass()->GetDictionaryLayout(), pResult, &sigBuilder, 2, signatureSource))
         {
             pResult->testForNull = 1;
             pResult->testForFixup = 0;
@@ -3582,7 +3522,7 @@ NoSpecialCase:
             pResult->offsets[0] = MethodTable::GetOffsetOfPerInstInfo();
 
             // Next indirect through the dictionary appropriate to this instantiated type
-            pResult->offsets[1] = sizeof(TypeHandle*) * (typeDictionaryIndex - 1);
+            pResult->offsets[1] = sizeof(TypeHandle*) * (pContextMT->GetNumDicts() - 1);
         }
     }
 }

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1151,19 +1151,6 @@ public:
                                                    MethodDesc * pTemplateMD /* for method-based slots */,
                                                    CORINFO_LOOKUP *pResultLookup);
 
-    static void ComputeRuntimeLookupForSharedGenericTokenStatic(DictionaryEntryKind entryKind,
-                                                                CORINFO_RESOLVED_TOKEN * pResolvedToken,
-                                                                CORINFO_RESOLVED_TOKEN * pConstrainedResolvedToken /* for ConstrainedMethodEntrySlot */,
-                                                                MethodDesc * pTemplateMD /* for method-based slots */,
-                                                                LoaderAllocator* pAllocator,
-                                                                DWORD numGenericArgs,
-                                                                DictionaryLayout* pDictionaryLayout,
-                                                                DWORD typeDictionaryIndex,
-                                                                CORINFO_LOOKUP *pResultLookup,
-                                                                BOOL fEnableTypeHandleLookupOptimization,
-                                                                BOOL fInstrument,
-                                                                BOOL fMethodSpecContainsCallingConventionFlag);
-
 protected:
     // NGen provides its own modifications to EE-JIT interface. From technical reason it cannot simply inherit 
     // from code:CEEInfo class (because it has dependencies on VM that NGen does not want).
@@ -1667,9 +1654,21 @@ struct StaticFieldAddressArgs
 FCDECL1(TADDR, JIT_StaticFieldAddress_Dynamic, StaticFieldAddressArgs * pArgs);
 FCDECL1(TADDR, JIT_StaticFieldAddressUnbox_Dynamic, StaticFieldAddressArgs * pArgs);
 
+struct GenericHandleArgs
+{
+    LPVOID signature;
+    CORINFO_MODULE_HANDLE module;
+    DWORD dictionaryIndexAndSlot;
+};
+
+FCDECL2(CORINFO_GENERIC_HANDLE, JIT_GenericHandleMethodWithSlotAndModule, CORINFO_METHOD_HANDLE  methodHnd, GenericHandleArgs * pArgs);
+FCDECL2(CORINFO_GENERIC_HANDLE, JIT_GenericHandleClassWithSlotAndModule, CORINFO_CLASS_HANDLE classHnd, GenericHandleArgs * pArgs);
+
 CORINFO_GENERIC_HANDLE JIT_GenericHandleWorker(MethodDesc   *pMD,
                                                MethodTable  *pMT,
-                                               LPVOID signature);
+                                               LPVOID        signature,
+                                               DWORD         dictionaryIndexAndSlot = -1,
+                                               Module *      pModule = NULL);
 
 void ClearJitGenericHandleCache(AppDomain *pDomain);
 

--- a/src/vm/readytoruninfo.h
+++ b/src/vm/readytoruninfo.h
@@ -138,7 +138,7 @@ public:
     static PCODE CreateReturnIndirConst(LoaderAllocator * pAllocator, TADDR arg, INT8 offset);
     static PCODE CreateHelperWithTwoArgs(LoaderAllocator * pAllocator, TADDR arg, PCODE target);
     static PCODE CreateHelperWithTwoArgs(LoaderAllocator * pAllocator, TADDR arg, TADDR arg2, PCODE target);
-    static PCODE CreateDictionaryLookupHelper(LoaderAllocator * pAllocator, CORINFO_RUNTIME_LOOKUP * pLookup);
+    static PCODE CreateDictionaryLookupHelper(LoaderAllocator * pAllocator, CORINFO_RUNTIME_LOOKUP * pLookup, DWORD dictionaryIndexAndSlot, Module * pModule);
 };
 
 #endif // _READYTORUNINFO_H_

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3487,11 +3487,11 @@ bool ZapInfo::getReadyToRunHelper(CORINFO_RESOLVED_TOKEN * pResolvedToken,
 			pImport = m_pImage->GetImportTable()->GetDictionaryLookupCell(
 				(CORCOMPILE_FIXUP_BLOB_KIND)(ENCODE_DICTIONARY_LOOKUP_METHOD | fAtypicalCallsite), pResolvedToken, pGenericLookupKind);
 		}
-		else if (pGenericLookupKind->runtimeLookupKind == CORINFO_LOOKUP_THISOBJ)
-		{
-			pImport = m_pImage->GetImportTable()->GetDictionaryLookupCell(
-				(CORCOMPILE_FIXUP_BLOB_KIND)(ENCODE_DICTIONARY_LOOKUP_THISOBJ | fAtypicalCallsite), pResolvedToken, pGenericLookupKind);
-}
+        else if (pGenericLookupKind->runtimeLookupKind == CORINFO_LOOKUP_THISOBJ)
+        {
+            pImport = m_pImage->GetImportTable()->GetDictionaryLookupCell(
+                (CORCOMPILE_FIXUP_BLOB_KIND)(ENCODE_DICTIONARY_LOOKUP_THISOBJ | fAtypicalCallsite), pResolvedToken, pGenericLookupKind);
+        }
 		else
 		{
 			_ASSERTE(pGenericLookupKind->runtimeLookupKind == CORINFO_LOOKUP_CLASSPARAM);


### PR DESCRIPTION
A set of refactoring changes to slighly improve the performance of generic dictionary access on R2R images, and simplifying the codebase:
    1) Removing dependency on CEEInfo::ComputeRuntimeLookupForSharedGenericTokenStatic (and deleting the API).
    2) Stop parsing the generic type/method signatures when generating the R2R dictionary lookup assembly stub.
    3) Avoid re-encoding the generic type/method signatures in a new in-memory blob using a SigBuilder  (signatures used directly from the R2R image)
    4) Moved the parsing/loading of type/method signatures to Dictionary::PopulateEntry()
    5) Dictionary index and slot number are now encoded in the generated assembly stub instead of the signature

@jkotas, @JohnChen0  PTAL.

@rahku, we'll need to fix the arm64 assembly stub to pass the 3rd argument to the new JIT helper APIs.