### PR TITLE
Modify Crypto benchmark so it uses a fixed random seed

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
+++ b/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
@@ -34,7 +34,7 @@
 
 // Comment this out to use a fixed random number seed.
 
-#define USE_RANDOM_SEED
+// #define USE_RANDOM_SEED
 
 // The code has been adapted for use as a benchmark by Microsoft.
 


### PR DESCRIPTION
Fix seed so benchmark behavior doesn't vary randomly from run to run.