### PR TITLE
Remove the UseLatestBehaviorWhenTFMNotSpecified compat switch

### DIFF
--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -457,7 +457,6 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
         W("APP_PATHS"),
         W("APP_NI_PATHS"),
         W("NATIVE_DLL_SEARCH_DIRECTORIES"),
-        W("AppDomainCompatSwitch")
     };
     const wchar_t *property_values[] = { 
         // TRUSTED_PLATFORM_ASSEMBLIES
@@ -468,8 +467,6 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
         appNiPath,
         // NATIVE_DLL_SEARCH_DIRECTORIES
         nativeDllSearchDirs,
-        // AppDomainCompatSwitch
-        W("UseLatestBehaviorWhenTFMNotSpecified")
     };
 
 

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -495,7 +495,6 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
         W("APP_PATHS"),
         W("APP_NI_PATHS"),
         W("NATIVE_DLL_SEARCH_DIRECTORIES"),
-        W("AppDomainCompatSwitch"),
         W("APP_LOCAL_WINMETADATA")
     };
     const wchar_t *property_values[] = { 
@@ -507,8 +506,6 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
         appNiPath,
         // NATIVE_DLL_SEARCH_DIRECTORIES
         nativeDllSearchDirs,
-        // AppDomainCompatSwitch
-        W("UseLatestBehaviorWhenTFMNotSpecified"),
         // APP_LOCAL_WINMETADATA
         appLocalWinmetadata
     };

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -340,7 +340,6 @@ int ExecuteManagedAssembly(
                 "APP_PATHS",
                 "APP_NI_PATHS",
                 "NATIVE_DLL_SEARCH_DIRECTORIES",
-                "AppDomainCompatSwitch",
                 "System.GC.Server",
             };
             const char *propertyValues[] = {
@@ -352,8 +351,6 @@ int ExecuteManagedAssembly(
                 appPath.c_str(),
                 // NATIVE_DLL_SEARCH_DIRECTORIES
                 nativeDllSearchDirs.c_str(),
-                // AppDomainCompatSwitch
-                "UseLatestBehaviorWhenTFMNotSpecified",
                 // System.GC.Server
                 useServerGc,
             };

--- a/src/mscorlib/src/System/AppContext/AppContextDefaultValues.cs
+++ b/src/mscorlib/src/System/AppContext/AppContextDefaultValues.cs
@@ -28,26 +28,22 @@ namespace System
         {
             string targetFrameworkMoniker = AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
 
-            // If we don't have a TFM then we should default to the 4.0 behavior where all quirks are turned on.
             if (!TryParseFrameworkName(targetFrameworkMoniker, out identifier, out version, out profile))
             {
 #if FEATURE_CORECLR
-                if (CompatibilitySwitches.UseLatestBehaviorWhenTFMNotSpecified)
-                {
-                    // If we want to use the latest behavior it is enough to set the value of the switch to string.Empty.
-                    // When the get to the caller of this method (PopulateDefaultValuesPartial) we are going to use the 
-                    // identifier we just set to decide which switches to turn on. By having an empty string as the 
-                    // identifier we are simply saying -- don't turn on any switches, and we are going to get the latest
-                    // behavior for all the switches
-                    identifier = string.Empty;
-                }
-                else
+                // If we can't parse the TFM or we don't have a TFM, default to latest behavior for all 
+                // switches (ie. all of them false).
+                // If we want to use the latest behavior it is enough to set the value of the switch to string.Empty.
+                // When the get to the caller of this method (PopulateDefaultValuesPartial) we are going to use the 
+                // identifier we just set to decide which switches to turn on. By having an empty string as the 
+                // identifier we are simply saying -- don't turn on any switches, and we are going to get the latest
+                // behavior for all the switches
+                identifier = string.Empty;
+#else
+                identifier = ".NETFramework";		
+                version = 40000;		
+                profile = string.Empty;
 #endif
-                {
-                    identifier = ".NETFramework";
-                    version = 40000;
-                    profile = string.Empty;
-                }
             }
         }
 

--- a/src/mscorlib/src/System/CompatibilitySwitches.cs
+++ b/src/mscorlib/src/System/CompatibilitySwitches.cs
@@ -39,10 +39,6 @@ namespace System
 
         internal static void InitializeSwitches()
         {
-#if FEATURE_CORECLR
-            s_useLatestBehaviorWhenTFMNotSpecified = IsCompatibilitySwitchSet("UseLatestBehaviorWhenTFMNotSpecified");
-#endif //FEATURE_CORECLR
-
 #if !FEATURE_CORECLR
             s_isNetFx40TimeSpanLegacyFormatMode = IsCompatibilitySwitchSet("NetFx40_TimeSpanLegacyFormatMode");
             s_isNetFx40LegacySecurityPolicy = IsCompatibilitySwitchSet("NetFx40_LegacySecurityPolicy");
@@ -52,19 +48,7 @@ namespace System
             s_AreSwitchesSet = true;
         }
 
-#if FEATURE_CORECLR
-        /// <summary>
-        /// This property returns whether to give the latest behavior when the TFM is missing
-        /// </summary>
-        internal static bool UseLatestBehaviorWhenTFMNotSpecified
-        {
-            get
-            {
-                return s_useLatestBehaviorWhenTFMNotSpecified;
-            }
-        }
-#else //FEATURE_CORECLR
-
+#if !FEATURE_CORECLR
         public static bool IsAppEarlierThanSilverlight4
         {
             get
@@ -89,7 +73,7 @@ namespace System
             }
         }
 
-#endif //FEATURE_CORECLR
+#endif //!FEATURE_CORECLR
 
         public static bool IsNetFx40TimeSpanLegacyFormatMode
         {

--- a/src/mscorlib/src/System/Runtime/Versioning/BinaryCompatibility.cs
+++ b/src/mscorlib/src/System/Runtime/Versioning/BinaryCompatibility.cs
@@ -461,16 +461,7 @@ namespace System.Runtime.Versioning
             int fxVersion = 0;
             if (targetFrameworkName == null)
             {
-#if FEATURE_CORECLR
-                // if we don't have a value for targetFrameworkName we need to figure out if we should give the newest behavior or not.
-                if (CompatibilitySwitches.UseLatestBehaviorWhenTFMNotSpecified)
-                {
-                    fxId = TargetFrameworkId.NetFramework;
-                    fxVersion = 50000; // We are going to default to the latest value for version that we have in our code.
-                }
-                else
-#endif
-                    fxId = TargetFrameworkId.Unspecified;
+                fxId = TargetFrameworkId.Unspecified;
             }
             else if (!ParseTargetFrameworkMonikerIntoEnum(targetFrameworkName, out fxId, out fxVersion))
                 fxId = TargetFrameworkId.Unrecognized;


### PR DESCRIPTION
Fixes #5706.

It should be merged after https://github.com/dotnet/coreclr/pull/5695