### PR TITLE
Remove obsolete Registry.DynData field from System.Private.CoreLib

### DIFF
--- a/src/mscorlib/src/Microsoft/Win32/Registry.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Registry.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Win32 {
          */
         public static readonly RegistryKey CurrentConfig      = RegistryKey.GetBaseKey(RegistryKey.HKEY_CURRENT_CONFIG);
         
+#if !FEATURE_CORECLR
         /**
          * Dynamic Data Root Key.
          * 
@@ -72,6 +73,7 @@ namespace Microsoft.Win32 {
          */
         [Obsolete("The DynData registry key only works on Win9x, which is no longer supported by the CLR.  On NT-based operating systems, use the PerformanceData registry key instead.")]
         public static readonly RegistryKey DynData            = RegistryKey.GetBaseKey(RegistryKey.HKEY_DYN_DATA);
+#endif
 
         //
         // Following function will parse a keyName and returns the basekey for it.
@@ -114,9 +116,11 @@ namespace Microsoft.Win32 {
                 case "HKEY_CURRENT_CONFIG": 
                     basekey = Registry.CurrentConfig;
                     break;
+#if !FEATURE_CORECLR
                 case "HKEY_DYN_DATA": 
                     basekey = RegistryKey.GetBaseKey(RegistryKey.HKEY_DYN_DATA);
                     break;                    
+#endif
                 default:
                     throw new ArgumentException(Environment.GetResourceString("Arg_RegInvalidKeyName", "keyName"));
             }            

--- a/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
@@ -83,7 +83,9 @@ namespace Microsoft.Win32 {
         Users = unchecked((int)0x80000003),
         PerformanceData = unchecked((int)0x80000004),
         CurrentConfig = unchecked((int)0x80000005),
+#if !FEATURE_CORECLR
         DynData = unchecked((int)0x80000006),
+#endif
     }
 
     /**
@@ -110,7 +112,9 @@ namespace Microsoft.Win32 {
         internal static readonly IntPtr HKEY_USERS                = new IntPtr(unchecked((int)0x80000003));
         internal static readonly IntPtr HKEY_PERFORMANCE_DATA     = new IntPtr(unchecked((int)0x80000004));
         internal static readonly IntPtr HKEY_CURRENT_CONFIG       = new IntPtr(unchecked((int)0x80000005));
+#if !FEATURE_CORECLR
         internal static readonly IntPtr HKEY_DYN_DATA             = new IntPtr(unchecked((int)0x80000006));
+#endif
 
         // Dirty indicates that we have munged data that should be potentially
         // written to disk.
@@ -138,7 +142,9 @@ namespace Microsoft.Win32 {
                 "HKEY_USERS",
                 "HKEY_PERFORMANCE_DATA",
                 "HKEY_CURRENT_CONFIG",
+#if !FEATURE_CORECLR
                 "HKEY_DYN_DATA"
+#endif
                 };
 
         // MSDN defines the following limits for registry key names & values:


### PR DESCRIPTION
`Registry` is internal in System.Private.CoreLib due to being pulled-in by the dependency closure. The obsolete `DynData` field is only valid on Win9X, so there's no need to allocate it and keep it around in CoreCLR. Remove it from System.Private.CoreLib with an ifdef, along with other references to the HKEY_DYN_DATA hive.

cc: @jkotas 