### PR TITLE
JapaneseCalendar: Use Registry.LocalMachine instead of RegistryKey.GetBaseKey(RegistryKey.HKEY_LOCAL_MACHINE)

### DIFF
--- a/src/mscorlib/src/System/Globalization/JapaneseCalendar.cs
+++ b/src/mscorlib/src/System/Globalization/JapaneseCalendar.cs
@@ -172,7 +172,7 @@ namespace System.Globalization {
                 PermissionSet permSet = new PermissionSet(PermissionState.None);
                 permSet.AddPermission(new RegistryPermission(RegistryPermissionAccess.Read, c_japaneseErasHivePermissionList));
                 permSet.Assert();
-                RegistryKey key = RegistryKey.GetBaseKey(RegistryKey.HKEY_LOCAL_MACHINE).OpenSubKey(c_japaneseErasHive, false);
+                RegistryKey key = Registry.LocalMachine.OpenSubKey(c_japaneseErasHive, writable: false);
 
                 // Abort if we didn't find anything
                 if (key == null) return null;


### PR DESCRIPTION
Minor cleanup: `JapaneseCalendar` is the only code outside of the Registry code that calls `RegistryKey.GetBaseKey(RegistryKey.HKEY_LOCAL_MACHINE)` to get a `RegistryKey` instance for the local machine hive. Everywhere else uses `Registry.LocalMachine` or one of the other static fields on `Registry`. Update `JapaneseCalendar` to match, which also avoids the unnecessary `RegistryKey`/`SafeRegistryHandle` allocations.

cc: @jkotas 