### PR TITLE
Add check for sys/sysctl.h

### DIFF
--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -16,7 +16,9 @@
 #include <string>
 #include <string.h>
 #include <sys/stat.h>
+#ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
+#endif
 #include "coreruncommon.h"
 #include "coreclrhost.h"
 #include <unistd.h>

--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -18,6 +18,7 @@
 #cmakedefine01 HAVE_LIBUUID_H
 #cmakedefine01 HAVE_BSD_UUID_H
 #cmakedefine01 HAVE_RUNETYPE_H
+#cmakedefine01 HAVE_SYS_SYSCTL_H
 
 #cmakedefine01 HAVE_KQUEUE
 #cmakedefine01 HAVE_GETPWUID_R

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -35,6 +35,7 @@ check_include_files(libunwind.h HAVE_LIBUNWIND_H)
 check_include_files(runetype.h HAVE_RUNETYPE_H)
 check_include_files(lttng/tracepoint.h HAVE_LTTNG_TRACEPOINT_H)
 check_include_files(uuid/uuid.h HAVE_LIBUUID_H)
+check_include_files(sys/sysctl.h HAVE_SYS_SYSCTL_H)
 
 check_function_exists(kqueue HAVE_KQUEUE)
 check_function_exists(getpwuid_r HAVE_GETPWUID_R)


### PR DESCRIPTION
On some operating systems `<sys/sysctl.h>`is not present yet `sysct`
function in available. One example is Alpine Linux which uses musl-libc
as opposed to GNU libc.

Ref: dotnet/corefx#6253