### PR TITLE
Add missing inttypes header for musl-libc

### DIFF
--- a/src/pal/src/safecrt/input.inl
+++ b/src/pal/src/safecrt/input.inl
@@ -258,7 +258,7 @@ static int __check_float_string(size_t nFloatStrUsed,
 #endif  /* ALLOC_TABLE */
 
 #if _INTEGRAL_MAX_BITS >= 64   
-    __uint64_t num64 = 0LL;             /* temp for 64-bit integers          */
+    uint64_t num64 = 0LL;             /* temp for 64-bit integers          */
 #endif  /* _INTEGRAL_MAX_BITS >= 64    */
     void *pointer=NULL;                 /* points to user data receptacle    */
     void *start;                        /* indicate non-empty string         */
@@ -927,7 +927,7 @@ getnum:
                             } /* end of WHILE loop */
 
                             if (negative)
-                                num64 = (__uint64_t )(-(__int64)num64);
+                                num64 = (uint64_t )(-(__int64)num64);
                         }
                         else {
 #endif  /* _INTEGRAL_MAX_BITS >= 64    */
@@ -984,7 +984,7 @@ getnum:
 assign_num:
 #if _INTEGRAL_MAX_BITS >= 64   
                                 if ( integer64 )
-                                    *(__int64 UNALIGNED *)pointer = ( __uint64_t )num64;
+                                    *(__int64 UNALIGNED *)pointer = ( uint64_t )num64;
                                 else
 #endif  /* _INTEGRAL_MAX_BITS >= 64    */
                                 if (longone)

--- a/src/pal/src/safecrt/output.inl
+++ b/src/pal/src/safecrt/output.inl
@@ -1215,7 +1215,7 @@ int __cdecl _output (
                 /* appropriately. */
 
 #if _INTEGRAL_MAX_BITS >= 64       
-                __uint64_t number;    /* number to convert */
+                uint64_t number;    /* number to convert */
                 int digit;              /* ascii value of digit */
                 __int64 l;              /* temp long value */
 #else  /* _INTEGRAL_MAX_BITS >= 64        */

--- a/src/pal/src/safecrt/safecrt_input_s.c
+++ b/src/pal/src/safecrt/safecrt_input_s.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <locale.h>
 #include <stdarg.h>
+#include <inttypes.h>
 
 #include "internal_securecrt.h"
 

--- a/src/pal/src/safecrt/safecrt_output_l.c
+++ b/src/pal/src/safecrt/safecrt_output_l.c
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include "internal_securecrt.h"
 
 #include "mbusafecrt_internal.h"
@@ -1058,7 +1059,7 @@ int __cdecl _output (
 
 #if _INTEGRAL_MAX_BITS >= 64       
 //                unsigned __int64 number;    /* number to convert */
-                __uint64_t number;      /* number to convert */
+                uint64_t number;      /* number to convert */
                 int digit;              /* ascii value of digit */
                 __int64 l;              /* temp long value */
 #else  /* _INTEGRAL_MAX_BITS >= 64        */

--- a/src/pal/src/safecrt/safecrt_output_s.c
+++ b/src/pal/src/safecrt/safecrt_output_s.c
@@ -28,6 +28,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include "internal_securecrt.h"
 
 #include "mbusafecrt_internal.h"

--- a/src/pal/src/safecrt/safecrt_winput_s.c
+++ b/src/pal/src/safecrt/safecrt_winput_s.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <locale.h>
 #include <stdarg.h>
-
+#include <inttypes.h>
 #include "internal_securecrt.h"
 
 #include "mbusafecrt_internal.h"

--- a/src/pal/src/safecrt/safecrt_woutput_s.c
+++ b/src/pal/src/safecrt/safecrt_woutput_s.c
@@ -28,6 +28,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include "internal_securecrt.h"
 
 #include "mbusafecrt_internal.h"


### PR DESCRIPTION
Also replaced the usages of `__unit64_t` and `__int64_t` with
`uint64_t` and `int64_t` respectively.