### PR TITLE
Do not use fragile native image content when generating R2R images

### DIFF
--- a/src/vm/clsload.cpp
+++ b/src/vm/clsload.cpp
@@ -100,8 +100,9 @@ PTR_Module ClassLoader::ComputeLoaderModuleWorker(
 
 #ifndef DACCESS_COMPILE
 #ifdef FEATURE_NATIVE_IMAGE_GENERATION
-    // Check we're NGEN'ing
-    if (IsCompilationProcess())
+    // Check we're NGEN'ing. ComputeLoaderModuleForCompilation algorithm assumes that there is fragile
+    // NGen image for CoreLib that is not the case for ReadyToRun compilation.
+    if (IsCompilationProcess() && !IsReadyToRunCompilation())
     {
         RETURN(ComputeLoaderModuleForCompilation(pDefinitionModule, token, classInst, methodInst));
     }


### PR DESCRIPTION
Port https://github.com/dotnet/coreclr/pull/5715 to release/1.0.0 to fix https://github.com/dotnet/coreclr/issues/5720