### PR TITLE
Release/1.0.0 port: Partial revert "Fix problem with virtual memory commit in OOM scenario on Linux (#5609)"

### DIFF
--- a/src/pal/src/map/virtual.cpp
+++ b/src/pal/src/map/virtual.cpp
@@ -1197,7 +1197,17 @@ static LPVOID VIRTUALCommitMemory(
         if (allocationType != MEM_COMMIT)
         {
             // Commit the pages
+            void * pRet = MAP_FAILED;
+#ifndef __APPLE__
             if (mprotect((void *) StartBoundary, MemSize, PROT_WRITE | PROT_READ) == 0)
+                pRet = (void *)StartBoundary;
+#else // __APPLE__
+            // Using mprotect above on MacOS is suspect to cause intermittent crashes
+            // https://github.com/dotnet/coreclr/issues/5672
+            pRet = mmap((void *) StartBoundary, MemSize, PROT_WRITE | PROT_READ,
+                     MAP_ANON | MAP_FIXED | MAP_PRIVATE, -1, 0);
+#endif // __APPLE__
+            if (pRet != MAP_FAILED)
             {
 #if MMAP_DOESNOT_ALLOW_REMAP
                 SIZE_T i;


### PR DESCRIPTION
#5609 is suspect to cause intermittent crashes on OS X. Keep the fix for Linux, but revert to using the original code on OS X.