### PR TITLE
Fix Latest.txt update when all nupkgs stable

### DIFF
--- a/UpdatePublishedVersions.ps1
+++ b/UpdatePublishedVersions.ps1
@@ -123,7 +123,8 @@ foreach ($package in $packages)
 
 if (!$prereleaseVersion)
 {
-    throw "Could not find a Prerelease version in '$newPackages'"
+    # value here is no longer needed, use "stable" to indicate that prerelease is no longer valid and a human will have to do the update to stable.
+    $prereleaseVersion = "stable"
 }
 
 $versionFilePath = "$versionsRepoPath/Latest.txt"


### PR DESCRIPTION
The update script was bailing when it couldn't find a prerelease
version in any of the packages.  No prerelease is expected since we're
building stable packages.  The latest.txt won't help in the stable
transition so I've just set the value to "stable" to indicate what
happened.

/cc @eerhardt @dagood 