### PR TITLE
Provide KeyValuePair.Create static factory method

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -683,6 +683,9 @@
       <Member Name="#ctor(System.String)" />
       <Member Name="#ctor(System.String,System.Exception)" />
     </Type>
+    <Type Name="System.Collections.Generic.KeyValuePair">
+      <Member Name="Create&lt;TKey,TValue&gt;(TKey,TValue)" />
+    </Type>
     <Type Name="System.Collections.Generic.KeyValuePair&lt;TKey,TValue&gt;">
       <Member Name="#ctor(TKey,TValue)" />
       <Member Name="get_Key" />

--- a/src/mscorlib/src/System/Collections/Generic/KeyValuePair.cs
+++ b/src/mscorlib/src/System/Collections/Generic/KeyValuePair.cs
@@ -18,6 +18,16 @@ namespace System.Collections.Generic {
     using System;
     using System.Text;
 
+    // Provides the Create factory method for KeyValuePair<TKey, TValue>.
+    public static class KeyValuePair
+    {
+        // Creates a new KeyValuePair<TKey, TValue> from the given values.
+        public static KeyValuePair<TKey, TValue> Create<TKey, TValue>(TKey key, TValue value)
+        {
+            return new KeyValuePair<TKey, TValue>(key, value);
+        }
+    }
+
     // A KeyValuePair holds a key and a value from a dictionary.
     // It is used by the IEnumerable<T> implementation for both IDictionary<TKey, TValue>
     // and IReadOnlyDictionary<TKey, TValue>.


### PR DESCRIPTION
Just like Tuple.Create cuts down the noise and annoyance
of having to specify all the Ts when you already have typed
values to provide, a similarly designed KeyValuePair.Create
factory method would make code that creates those pairs
(i.e. public APIs that expose IEnumerable{KeyValuePair}
significantly more concise and readable.

Fixes dotnet/corefx#2127