### PR TITLE
Pass --long-gc and --gcsimulator to long GC and GCSimulator CI jobs, respectively

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2001,10 +2001,10 @@ combinedScenarios.each { scenario ->
                         // going to be run. The GCSimulator playlist contains all of
                         // the GC simulator tests.
                         if (scenario == 'longgc') {
-                            playlistString = '--playlist=./tests/longRunningGcTests.txt'
+                            playlistString = '--long-gc --playlist=./tests/longRunningGcTests.txt'
                         }
                         else if (scenario == 'gcsimulator') {
-                            playlistString = '--playlist=./tests/gcSimulatorTests.txt'
+                            playlistString = '--gcsimulator --playlist=./tests/gcSimulatorTests.txt'
                         }
                     }
                     


### PR DESCRIPTION
Omitting these flags causes the CI jobs to not behave correctly for these jobs.