### PR TITLE
Making the fix of runtime suspension check complete

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -550,7 +550,7 @@ void LogSpewAlways(const char *fmt, ...);
 
 void StompWriteBarrierEphemeral(bool isRuntimeSuspended);
 void StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck);
-bool IsSuspendEEThread();
+bool IsGCThread();
 
 class CLRConfig
 {

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -7221,7 +7221,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
 
             // Either this thread was the thread that did the suspension which means we are suspended; or this is called
             // from a GC thread which means we are in a blocking GC and also suspended.
-            BOOL is_runtime_suspended = IsSuspendEEThread() || IsGCSpecialThread();
+            BOOL is_runtime_suspended = IsGCThread();
             if (!is_runtime_suspended)
             {
                 // Note on points where the runtime is suspended anywhere in this function. Upon an attempt to suspend the
@@ -7268,7 +7268,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
             // to be changed, so we are doing this after all global state has
             // been updated. See the comment above suspend_EE() above for more
             // info.
-            StompWriteBarrierResize(!!IsSuspendEEThread(), la != saved_g_lowest_address);
+            StompWriteBarrierResize(!!IsGCThread(), la != saved_g_lowest_address);
         }
 
         // We need to make sure that other threads executing checked write barriers
@@ -15321,7 +15321,7 @@ void gc_heap::gc1()
     if (!settings.concurrent)
 #endif //BACKGROUND_GC
     {
-        adjust_ephemeral_limits(!!IsSuspendEEThread());
+        adjust_ephemeral_limits(!!IsGCThread());
     }
 
 #ifdef BACKGROUND_GC
@@ -16168,7 +16168,7 @@ BOOL gc_heap::expand_soh_with_minimal_gc()
         dd_gc_new_allocation (dynamic_data_of (max_generation)) -= ephemeral_size;
         dd_new_allocation (dynamic_data_of (max_generation)) = dd_gc_new_allocation (dynamic_data_of (max_generation));
 
-        adjust_ephemeral_limits(!!IsSuspendEEThread());
+        adjust_ephemeral_limits(!!IsGCThread());
         return TRUE;
     }
     else

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -249,7 +249,7 @@ void StompWriteBarrierResize(bool /* isRuntimeSuspended */, bool /*bReqUpperBoun
 {
 }
 
-bool IsSuspendEEThread()
+bool IsGCThread()
 {
     return false;
 }


### PR DESCRIPTION
My last fix of checking whether the runtime was suspended was incomplete.

I needed to check at the 3 other places. In fact before the software write watch implementation, this check was done in the write barrier code itself and was doing the right thing. So I am just using the same thing (ie, IsGCThread, which is IsGCSpecialThread () || IsSuspendEEThread ()) to check whether the runtime is suspended.