### PR TITLE
Remove end labels from regular asm procs on Unix

### DIFF
--- a/src/pal/inc/unixasmmacros.inc
+++ b/src/pal/inc/unixasmmacros.inc
@@ -20,9 +20,6 @@
 #define C_PLTFUNC(name) name@PLT
 #endif
 
-.macro LEAF_END Name, Section
-        LEAF_END_MARKED \Name, \Section
-.endm
 
 .macro END_PROLOGUE
 .endm

--- a/src/pal/inc/unixasmmacrosamd64.inc
+++ b/src/pal/inc/unixasmmacrosamd64.inc
@@ -16,10 +16,10 @@
 .macro NESTED_END Name, Section
         LEAF_END \Name, \Section
 #if defined(__APPLE__)
+        .set LOCAL_LABEL(\Name\()_Size), . - C_FUNC(\Name)
         .section __LD,__compact_unwind,regular,debug
         .quad C_FUNC(\Name)
-        .set C_FUNC(\Name\()_Size), C_FUNC(\Name\()_End) - C_FUNC(\Name)
-        .long C_FUNC(\Name\()_Size)
+        .long LOCAL_LABEL(\Name\()_Size)
         .long 0x04000000 # DWARF
         .quad 0
         .quad 0
@@ -42,13 +42,17 @@ C_FUNC(\Name):
         .cfi_startproc
 .endm
 
-.macro LEAF_END_MARKED Name, Section
-C_FUNC(\Name\()_End):
-        .global C_FUNC(\Name\()_End)
+.macro LEAF_END Name, Section
 #if !defined(__APPLE__)
         .size \Name, .-\Name
 #endif
         .cfi_endproc
+.endm
+
+.macro LEAF_END_MARKED Name, Section
+C_FUNC(\Name\()_End):
+        .global C_FUNC(\Name\()_End)
+        LEAF_END \Name, \Section
 .endm
 
 .macro NOP_3_BYTE

--- a/src/pal/inc/unixasmmacrosarm.inc
+++ b/src/pal/inc/unixasmmacrosarm.inc
@@ -27,12 +27,16 @@ C_FUNC(\Name):
 C_FUNC(\Name):
 .endm
 
+.macro LEAF_END Name, Section
+        .size \Name, .-\Name
+        .fnend
+.endm
+
 .macro LEAF_END_MARKED Name, Section
         .thumb_func
         .global C_FUNC(\Name\()_End)
 C_FUNC(\Name\()_End):
-        .size \Name, .-\Name
-        .fnend
+        LEAF_END \Name, \Section
 .endm
 
 .macro PREPARE_EXTERNAL_VAR Name, HelperReg

--- a/src/pal/inc/unixasmmacrosarm64.inc
+++ b/src/pal/inc/unixasmmacrosarm64.inc
@@ -25,11 +25,15 @@ C_FUNC(\Name):
         .cfi_startproc
 .endm
 
+.macro LEAF_END Name, Section
+        .size \Name, .-\Name
+        .cfi_endproc
+.endm
+
 .macro LEAF_END_MARKED Name, Section
         .global C_FUNC(\Name\()_End)
 C_FUNC(\Name\()_End):
-        .size \Name, .-\Name
-        .cfi_endproc
+        LEAF_END \Name, \Section
 .endm
 
 .macro PREPARE_EXTERNAL_VAR Name, HelperReg

--- a/src/pal/src/arch/i386/debugbreak.S
+++ b/src/pal/src/arch/i386/debugbreak.S
@@ -8,5 +8,5 @@
 LEAF_ENTRY DBG_DebugBreak, _TEXT
         int3
         ret
-LEAF_END DBG_DebugBreak, _TEXT
+LEAF_END_MARKED DBG_DebugBreak, _TEXT
 


### PR DESCRIPTION
All ASM proc now unnecessarily have xxx_End label marking
the end of the proc. This causes confusing stack traces in
some cases, especially on OSX, when instead of a name of
an actual function, a name of the previous one with the
_End attached to it is shown.
This change fixes that by modifying the LEAF_END macro to
not to be defined as an equivalent of the LEAF_END_MARKED.