### PR TITLE
Update the header string in runtest.sh

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -572,10 +572,14 @@ function finish_test {
     local testRunningTime=
     local header=
 
+    if ((verbose == 1)); then
+        header=$(printf "[%4d]" $countTotalTests)
+    fi
+
     if [ "$showTime" == "ON" ]; then
         testEndTime=$(date +%s)
-        testRunningTime=$(echo "$testEndTime - ${testStartTimes[$nextProcessIndex]}" | bc)
-        header=$(printf "[%03d:%4.0fs] " "$countTotalTests" "$testRunningTime")
+        testRunningTime=$(( $testEndTime - ${testStartTimes[$nextProcessIndex]} ))
+        header=$header$(printf "[%4ds]" $testRunningTime)
     fi
 
     local xunitTestResult


### PR DESCRIPTION
Replace 'bc' with the bash expr.
Add the countTotalTests numbers to headers depends on verbose option.

Fix #5677

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>