### PR TITLE
ARM64: Fix a GC hole for Indirect Branch

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -4171,7 +4171,7 @@ CodeGen::genTableBasedSwitch(GenTree* treeNode)
     getEmitter()->emitIns_R_L(INS_adr, EA_PTRSIZE, compiler->fgFirstBB, tmpReg);
     getEmitter()->emitIns_R_R_R(INS_add, EA_PTRSIZE, baseReg, baseReg, tmpReg);
 
-    // jmp baseReg
+    // br baseReg
     getEmitter()->emitIns_R(INS_br, emitTypeSize(TYP_I_IMPL), baseReg);
 }
 

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -3291,14 +3291,7 @@ void                emitter::emitIns_R(instruction ins,
     /* Figure out the encoding format of the instruction */
     switch (ins)
     {
-    case INS_blr:
     case INS_br:
-        assert(isGeneralRegister(reg));
-        id = emitNewInstrCns(attr, 0);
-        id->idReg3(reg);
-        fmt = IF_BR_1B;
-        break;
-
     case INS_ret:
         assert(isGeneralRegister(reg));
         id = emitNewInstrSmall(attr);
@@ -3317,7 +3310,6 @@ void                emitter::emitIns_R(instruction ins,
 
     dispIns(id);
     appendToCurIG(id);
-
 }
 
 /*****************************************************************************
@@ -8580,7 +8572,7 @@ size_t              emitter::emitOutputInstr(insGroup  *ig,
 
     case IF_BR_1A:    // BR_1A   ................ ......nnnnn.....         Rn
         assert(insOptsNone(id->idInsOpt()));
-        assert(ins == INS_ret);
+        assert((ins == INS_ret) || (ins == INS_br));
         code  = emitInsCode(ins, fmt);
         code |= insEncodeReg_Rn(id->idReg1());               // nnnnn
 
@@ -8589,7 +8581,7 @@ size_t              emitter::emitOutputInstr(insGroup  *ig,
 
     case IF_BR_1B:    // BR_1B   ................ ......nnnnn.....         Rn
         assert(insOptsNone(id->idInsOpt()));
-        assert(ins != INS_ret);
+        assert((ins == INS_br_tail) || (ins == INS_blr));
         code = emitInsCode(ins, fmt);
         code |= insEncodeReg_Rn(id->idReg3());               // nnnnn
 

--- a/src/jit/instrsarm64.h
+++ b/src/jit/instrsarm64.h
@@ -600,14 +600,14 @@ INST1(bl_local,"bl",     0, 0, IF_BI_0A,  0x94000000)
 INST1(bl,      "bl",     0, 0, IF_BI_0C,  0x94000000)
                                    //  bl      simm26               BI_0C  100101iiiiiiiiii iiiiiiiiiiiiiiii   9400 0000   simm26:00
 
-INST1(br,      "br",     0, 0, IF_BR_1B,  0xD61F0000)
-                                   //  br      Rn                   BR_1B  1101011000011111 000000nnnnn00000   D61F 0000
+INST1(br,      "br",     0, 0, IF_BR_1A,  0xD61F0000)
+                                   //  br      Rn                   BR_1A  1101011000011111 000000nnnnn00000   D61F 0000, an indirect branch like switch expansion
 
 INST1(br_tail, "br",     0, 0, IF_BR_1B,  0xD61F0000)
-                                   //  br      Rn                   BR_1B  1101011000011111 000000nnnnn00000   D61F 0000, same as br representing a tail call of blr.
+                                   //  br      Rn                   BR_1B  1101011000011111 000000nnnnn00000   D61F 0000, same as br representing a tail call of blr. Encode target with Reg3.
 
 INST1(blr,     "blr",    0, 0, IF_BR_1B,  0xD63F0000)
-                                   //  blr     Rn                   BR_1B  1101011000111111 000000nnnnn00000   D63F 0000
+                                   //  blr     Rn                   BR_1B  1101011000111111 000000nnnnn00000   D63F 0000, Encode target with Reg3.
 
 INST1(ret,     "ret",    0, 0, IF_BR_1A,  0xD65F0000)
                                    //  ret     Rn                   BR_1A  1101011001011111 000000nnnnn00000   D65F 0000


### PR DESCRIPTION
`br reg` was handled like a regular call under `IF_BR_1B` resulting in
`emitOutputCall` which updates GC vars/regs.
This is only true when this branch is used for a tail-call.
We used the same logic for indirect jump for switch expansion, which is
incorrect.
The fix is to correct instruction category so that such indirect jump is
handled same as an normal instruction under `IF_BR_1A`.

This fixes a part of https://github.com/dotnet/coreclr/issues/4877.
The failing point from the description is now passed, but still another
consistency failure far later on after tests are discovered/started.