### PR TITLE
Fixes for two JIT helpers that should not use the x8 RetBuf argument on ARM64

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2809,15 +2809,37 @@ struct GenTreeCall final : public GenTree
     }
 #endif // !LEGACY_BACKEND
 
-    // Returns true if the call has retBuf argument
-    bool HasRetBufArg() const { return (gtCallMoreFlags & GTF_CALL_M_RETBUFFARG) != 0; }
+    // Returns true if this call uses a retBuf argument and its calling convention
+    bool HasRetBufArg() const
+    {
+         return (gtCallMoreFlags & GTF_CALL_M_RETBUFFARG) != 0;
+    }
+
+    //-------------------------------------------------------------------------
+    // TreatAsHasRetBufArg:
+    //
+    // Arguments:
+    //     compiler, the compiler instance so that we can call eeGetHelperNum
+    //
+    // Return Value:
+    //     Returns true if we treat the call as if it has a retBuf argument
+    //     This method may actually have a retBuf argument 
+    //     or it could be a JIT helper that we are still transforming during 
+    //     the importer phase.
+    //
+    // Notes:
+    //     On ARM64 marking the method with the GTF_CALL_M_RETBUFFARG flag
+    //     will make HasRetBufArg() return true, but will also force the 
+    //     use of register x8 to pass the RetBuf argument.
+    //
+    bool TreatAsHasRetBufArg(Compiler* compiler);
 
     //-----------------------------------------------------------------------------------------
     // HasMultiRegRetVal: whether the call node returns its value in multiple return registers.
     //
     // Arguments:
     //     None
-
+    //
     // Return Value:
     //     True if the call is returning a multi-reg return value. False otherwise.
     //

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1104,7 +1104,7 @@ GenTreePtr Compiler::impAssignStructPtr(GenTreePtr      dest,
 
     if (src->gtOper == GT_CALL)
     {
-        if (src->AsCall()->HasRetBufArg())
+        if (src->AsCall()->TreatAsHasRetBufArg(this))
         {
             // Case of call returning a struct via hidden retbuf arg
 
@@ -7614,7 +7614,7 @@ REDO_RETURN_NODE:
     }
     else if (op->gtOper == GT_CALL)
     {
-        if (op->AsCall()->HasRetBufArg())
+        if (op->AsCall()->TreatAsHasRetBufArg(this))
         {
             // This must be one of those 'special' helpers that don't
             // really have a return buffer, but instead use it as a way
@@ -13081,14 +13081,6 @@ FIELD_DONE:
                     // Don't optimize, just call the helper and be done with it
                 args = gtNewArgList(op2, op1);
                 op1 = gtNewHelperCallNode(helper, (var_types)((helper == CORINFO_HELP_UNBOX)?TYP_BYREF:TYP_STRUCT), callFlags, args);
-
-                if (helper == CORINFO_HELP_UNBOX_NULLABLE)
-                {
-                    // NOTE!  This really isn't a return buffer. On the native side this
-                    // is the first argument, but the trees are prettier this way
-                    // so fake it as a return buffer.
-                    op1->gtCall.gtCallMoreFlags |= GTF_CALL_M_RETBUFFARG;
-                }
             }
 
             assert(helper == CORINFO_HELP_UNBOX          && op1->gtType == TYP_BYREF || // Unbox helper returns a byref.


### PR DESCRIPTION
Fixes these two JIT helpers" CORINFO_HELP_GETFIELDSTRUCT and CORINFO_HELP_UNBOX_NULLABLE
We no longer set GTF_CALL_M_RETBUFFARG for the two special Jit helpers
We insert the extra byref argument in the x0 position for these two JIT helpers