### PR TITLE
Specialize IndexOf, LastIndexOf for the enum equality comparers

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Comparer.cs
@@ -139,7 +139,7 @@ namespace System.Collections.Generic
     [Serializable]
     internal sealed class NullableComparer<T> : Comparer<T?> where T : struct, IComparable<T>
     {
-        public override int Compare(Nullable<T> x, Nullable<T> y) {
+        public override int Compare(T? x, T? y) {
             if (x.HasValue) {
                 if (y.HasValue) return x.value.CompareTo(y.value);
                 return 1;

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -131,7 +131,7 @@ namespace System.Collections.Generic
     // The methods in this class look identical to the inherited methods, but the calls
     // to Equal bind to IEquatable<T>.Equals(T) instead of Object.Equals(Object)
     [Serializable]
-    internal sealed class GenericEqualityComparer<T>: EqualityComparer<T> where T: IEquatable<T>
+    internal class GenericEqualityComparer<T>: EqualityComparer<T> where T: IEquatable<T>
     {
         [Pure]
         public override bool Equals(T x, T y) {

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -144,10 +144,7 @@ namespace System.Collections.Generic
         }
 
         [Pure]
-        public override int GetHashCode(T obj) {
-            if (obj == null) return 0;
-            return obj.GetHashCode();
-        }
+        public override int GetHashCode(T obj) => obj?.GetHashCode() ?? 0;
 
         internal override int IndexOf(T[] array, T value, int startIndex, int count) {
             int endIndex = startIndex + count;
@@ -179,15 +176,12 @@ namespace System.Collections.Generic
             return -1;
         }
 
-        // Equals method for the comparer itself. 
-        public override bool Equals(Object obj){
-            GenericEqualityComparer<T> comparer = obj as GenericEqualityComparer<T>;
-            return comparer != null;
-        }
+        // Equals method for the comparer itself.
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
 
-        public override int GetHashCode() {
-            return this.GetType().GetHashCode();
-        }
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
     }
 
     [Serializable]
@@ -236,15 +230,12 @@ namespace System.Collections.Generic
             return -1;
         }
 
-        // Equals method for the comparer itself. 
-        public override bool Equals(Object obj){
-            NullableEqualityComparer<T> comparer = obj as NullableEqualityComparer<T>;
-            return comparer != null;
-        }        
+        // Equals method for the comparer itself.
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
 
-        public override int GetHashCode() {
-            return this.GetType().GetHashCode();
-        }                                
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
     }
 
     [Serializable]
@@ -261,10 +252,7 @@ namespace System.Collections.Generic
         }
 
         [Pure]
-        public override int GetHashCode(T obj) {
-            if (obj == null) return 0;
-            return obj.GetHashCode();
-        }
+        public override int GetHashCode(T obj) => obj?.GetHashCode() ?? 0;
 
         internal override int IndexOf(T[] array, T value, int startIndex, int count) {
             int endIndex = startIndex + count;
@@ -296,15 +284,12 @@ namespace System.Collections.Generic
             return -1;
         }
 
-        // Equals method for the comparer itself. 
-        public override bool Equals(Object obj){
-            ObjectEqualityComparer<T> comparer = obj as ObjectEqualityComparer<T>;
-            return comparer != null;
-        }        
+        // Equals method for the comparer itself.
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
 
-        public override int GetHashCode() {
-            return this.GetType().GetHashCode();
-        }                                
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
     }
 
 #if FEATURE_CORECLR
@@ -375,15 +360,12 @@ namespace System.Collections.Generic
             return -1;
         }
 
-        // Equals method for the comparer itself. 
-        public override bool Equals(Object obj){
-            ByteEqualityComparer comparer = obj as ByteEqualityComparer;
-            return comparer != null;
-        }        
+        // Equals method for the comparer itself.
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
 
-        public override int GetHashCode() {
-            return this.GetType().GetHashCode();
-        }                                
+        public override int GetHashCode() =>
+            GetType().GetHashCode();      
     }
 
     [Serializable]
@@ -415,15 +397,12 @@ namespace System.Collections.Generic
             }
         }
 
-        // Equals method for the comparer itself. 
-        public override bool Equals(Object obj){
-            EnumEqualityComparer<T> comparer = obj as EnumEqualityComparer<T>;
-            return comparer != null;
-        }
+        // Equals method for the comparer itself.
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
 
-        public override int GetHashCode() {
-            return this.GetType().GetHashCode();
-        }
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
 
         internal override int IndexOf(T[] array, T value, int startIndex, int count)
         {
@@ -496,15 +475,12 @@ namespace System.Collections.Generic
             return x_final.GetHashCode();
         }
 
-        // Equals method for the comparer itself. 
-        public override bool Equals(Object obj){
-            LongEnumEqualityComparer<T> comparer = obj as LongEnumEqualityComparer<T>;
-            return comparer != null;
-        }
+        // Equals method for the comparer itself.
+        public override bool Equals(Object obj) =>
+            obj != null && GetType() == obj.GetType();
 
-        public override int GetHashCode() {
-            return this.GetType().GetHashCode();
-        }
+        public override int GetHashCode() =>
+            GetType().GetHashCode();
 
         public LongEnumEqualityComparer() { }
 

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -131,7 +131,7 @@ namespace System.Collections.Generic
     // The methods in this class look identical to the inherited methods, but the calls
     // to Equal bind to IEquatable<T>.Equals(T) instead of Object.Equals(Object)
     [Serializable]
-    internal class GenericEqualityComparer<T>: EqualityComparer<T> where T: IEquatable<T>
+    internal sealed class GenericEqualityComparer<T>: EqualityComparer<T> where T: IEquatable<T>
     {
         [Pure]
         public override bool Equals(T x, T y) {
@@ -191,7 +191,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    internal class NullableEqualityComparer<T> : EqualityComparer<Nullable<T>> where T : struct, IEquatable<T>
+    internal sealed class NullableEqualityComparer<T> : EqualityComparer<Nullable<T>> where T : struct, IEquatable<T>
     {
         [Pure]
         public override bool Equals(Nullable<T> x, Nullable<T> y) {
@@ -250,7 +250,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    internal class ObjectEqualityComparer<T>: EqualityComparer<T>
+    internal sealed class ObjectEqualityComparer<T>: EqualityComparer<T>
     {
         [Pure]
         public override bool Equals(T x, T y) {
@@ -340,7 +340,7 @@ namespace System.Collections.Generic
     // Performance of IndexOf on byte array is very important for some scenarios.
     // We will call the C runtime function memchr, which is optimized.
     [Serializable]
-    internal class ByteEqualityComparer: EqualityComparer<byte>
+    internal sealed class ByteEqualityComparer: EqualityComparer<byte>
     {
         [Pure]
         public override bool Equals(byte x, byte y) {

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -426,6 +426,30 @@ namespace System.Collections.Generic
         public override int GetHashCode() {
             return this.GetType().GetHashCode();
         }
+
+        internal override int IndexOf(T[] array, T value, int startIndex, int count)
+        {
+            int toFind = JitHelpers.UnsafeEnumCast(value);
+            int endIndex = startIndex + count;
+            for (int i = startIndex; i < endIndex; i++)
+            {
+                int current = JitHelpers.UnsafeEnumCast(array[i]);
+                if (toFind == current) return i;
+            }
+            return -1;
+        }
+
+        internal override int LastIndexOf(T[] array, T value, int startIndex, int count)
+        {
+            int toFind = JitHelpers.UnsafeEnumCast(value);
+            int endIndex = startIndex - count + 1;
+            for (int i = startIndex; i >= endIndex; i--)
+            {
+                int current = JitHelpers.UnsafeEnumCast(array[i]);
+                if (toFind == current) return i;
+            }
+            return -1;
+        }
     }
 
     [Serializable]
@@ -495,6 +519,30 @@ namespace System.Collections.Generic
             // The LongEnumEqualityComparer does not exist on 4.0 so we need to serialize this comparer as ObjectEqualityComparer
             // to allow for roundtrip between 4.0 and 4.5.
             info.SetType(typeof(ObjectEqualityComparer<T>));
+        }
+
+        internal override int IndexOf(T[] array, T value, int startIndex, int count)
+        {
+            long toFind = JitHelpers.UnsafeEnumCastLong(value);
+            int endIndex = startIndex + count;
+            for (int i = startIndex; i < endIndex; i++)
+            {
+                long current = JitHelpers.UnsafeEnumCastLong(array[i]);
+                if (toFind == current) return i;
+            }
+            return -1;
+        }
+
+        internal override int LastIndexOf(T[] array, T value, int startIndex, int count)
+        {
+            long toFind = JitHelpers.UnsafeEnumCastLong(value);
+            int endIndex = startIndex - count + 1;
+            for (int i = startIndex; i >= endIndex; i--)
+            {
+                long current = JitHelpers.UnsafeEnumCastLong(array[i]);
+                if (toFind == current) return i;
+            }
+            return -1;
         }
     }
 

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -191,10 +191,10 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    internal sealed class NullableEqualityComparer<T> : EqualityComparer<Nullable<T>> where T : struct, IEquatable<T>
+    internal sealed class NullableEqualityComparer<T> : EqualityComparer<T?> where T : struct, IEquatable<T>
     {
         [Pure]
-        public override bool Equals(Nullable<T> x, Nullable<T> y) {
+        public override bool Equals(T? x, T? y) {
             if (x.HasValue) {
                 if (y.HasValue) return x.value.Equals(y.value);
                 return false;
@@ -204,11 +204,9 @@ namespace System.Collections.Generic
         }
 
         [Pure]
-        public override int GetHashCode(Nullable<T> obj) {
-            return obj.GetHashCode();
-        }
+        public override int GetHashCode(T? obj) => obj.GetHashCode();
 
-        internal override int IndexOf(Nullable<T>[] array, Nullable<T> value, int startIndex, int count) {
+        internal override int IndexOf(T?[] array, T? value, int startIndex, int count) {
             int endIndex = startIndex + count;
             if (!value.HasValue) {
                 for (int i = startIndex; i < endIndex; i++) {
@@ -223,7 +221,7 @@ namespace System.Collections.Generic
             return -1;
         }
 
-        internal override int LastIndexOf(Nullable<T>[] array, Nullable<T> value, int startIndex, int count) {
+        internal override int LastIndexOf(T?[] array, T? value, int startIndex, int count) {
             int endIndex = startIndex - count + 1;
             if (!value.HasValue) {
                 for (int i = startIndex; i >= endIndex; i--) {

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -186,7 +186,7 @@ namespace System.Collections.Generic
         }
 
         public override int GetHashCode() {
-            return this.GetType().Name.GetHashCode();
+            return this.GetType().GetHashCode();
         }
     }
 
@@ -245,7 +245,7 @@ namespace System.Collections.Generic
         }        
 
         public override int GetHashCode() {
-            return this.GetType().Name.GetHashCode();
+            return this.GetType().GetHashCode();
         }                                
     }
 
@@ -305,7 +305,7 @@ namespace System.Collections.Generic
         }        
 
         public override int GetHashCode() {
-            return this.GetType().Name.GetHashCode();
+            return this.GetType().GetHashCode();
         }                                
     }
 
@@ -384,7 +384,7 @@ namespace System.Collections.Generic
         }        
 
         public override int GetHashCode() {
-            return this.GetType().Name.GetHashCode();
+            return this.GetType().GetHashCode();
         }                                
     }
 
@@ -424,7 +424,7 @@ namespace System.Collections.Generic
         }
 
         public override int GetHashCode() {
-            return this.GetType().Name.GetHashCode();
+            return this.GetType().GetHashCode();
         }
     }
 
@@ -481,7 +481,7 @@ namespace System.Collections.Generic
         }
 
         public override int GetHashCode() {
-            return this.GetType().Name.GetHashCode();
+            return this.GetType().GetHashCode();
         }
 
         public LongEnumEqualityComparer() { }
@@ -552,7 +552,7 @@ namespace System.Collections.Generic
         }
 
         public override int GetHashCode() {
-            return (this.GetType().Name.GetHashCode() ^ ((int) (_entropy & 0x7FFFFFFF))); 
+            return (this.GetType().GetHashCode() ^ ((int) (_entropy & 0x7FFFFFFF))); 
         }
 
 
@@ -604,7 +604,7 @@ namespace System.Collections.Generic
         }
 
         public override int GetHashCode() {
-            return (this.GetType().Name.GetHashCode() ^ ((int) (_entropy & 0x7FFFFFFF))); 
+            return (this.GetType().GetHashCode() ^ ((int) (_entropy & 0x7FFFFFFF))); 
         }
 
         IEqualityComparer IWellKnownStringEqualityComparer.GetRandomizedEqualityComparer() {


### PR DESCRIPTION
Overrides the internal `IndexOf`/`LastIndexOf` methods for `EqualityComparer`, so only one virtual method call is made as opposed to however many elements are in the array. I also made some other changes to bring the code in line with what I did in #5503, namely using `sealed` where applicable and not calling `Name` for `GetHashCode`.

### Performance impact

Test code:

```cs
using System;
using System.Collections.Generic;
using System.Diagnostics;
using System.Reflection;

namespace ConsoleApplication
{
    public class Program
    {
        const int Index = Length / 2;
        const int Length = 5000;
        const int Iterations = 100000;
        const int OuterIterations = 5;
        
        public static void Main(string[] args)
        {
            var array = new StringSplitOptions[Length];
            array[Index] = StringSplitOptions.RemoveEmptyEntries;

            for (int i = 0; i < OuterIterations; i++)
            {
                var watch = Stopwatch.StartNew();
                for (int j = 0; j < Iterations; j++)
                    Array.IndexOf(array, StringSplitOptions.RemoveEmptyEntries);
                watch.Stop();
                Console.WriteLine(watch.Elapsed);
            }

            Console.WriteLine();

            for (int i = 0; i < OuterIterations; i++)
            {
                var watch = Stopwatch.StartNew();
                for (int j = 0; j < Iterations; j++)
                    Array.LastIndexOf(array, StringSplitOptions.RemoveEmptyEntries);
                watch.Stop();
                Console.WriteLine(watch.Elapsed);
            }
        }
    }
}
```

Before:

```
00:00:01.0684618
00:00:01.0321808
00:00:01.5014109
00:00:01.9096960
00:00:01.1151452

00:00:01.0152761
00:00:01.2019504
00:00:01.0269755
00:00:01.1227927
00:00:01.2432870
```

After (5x speedup):

```
00:00:00.3152865
00:00:00.2413720
00:00:00.2654954
00:00:00.2776022
00:00:00.2525021

00:00:00.2897419
00:00:00.2840207
00:00:00.2761021
00:00:00.3039447
00:00:00.2753199
```

@jkotas @omariom