### PR TITLE
Need to filter addresses not in the heap range in NextObj

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -33846,6 +33846,14 @@ BOOL    GCHeap::IsEphemeral (Object* object)
 Object * GCHeap::NextObj (Object * object)
 {
     uint8_t* o = (uint8_t*)object;
+
+#ifndef FEATURE_BASICFREEZE
+    if (!((o < g_highest_address) && (o >= g_lowest_address)))
+    {
+        return NULL;
+    }
+#endif //!FEATURE_BASICFREEZE
+
     heap_segment * hs = gc_heap::find_segment (o, FALSE);
     if (!hs)
     {


### PR DESCRIPTION
NextObj is a function that can be called with addresses outside of the heap range. It requires the same filtering as IsHeapPointer.