### PR TITLE
Modify CrossGen test script to work around cmd.exe bug

### DIFF
--- a/tests/src/CLRTest.CrossGen.targets
+++ b/tests/src/CLRTest.CrossGen.targets
@@ -75,16 +75,17 @@ if defined RunCrossGen (
     set COMPlus_ZapRequireList=$(MSBuildProjectName)
     if not exist "$(MSBuildProjectName).ni.exe" (
         call :TakeLock
+        set CrossGenStatus=0
         if not exist "$(MSBuildProjectName).ni.exe" (
             echo "%_DebuggerFullPath% %CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%~dp0 $(MSBuildProjectName).exe
             %_DebuggerFullPath% "%CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%~dp0 $(MSBuildProjectName).exe
-            IF NOT !ERRORLEVEL!==0 (
-            ECHO Crossgen failed with exitcode - !ERRORLEVEL!
-            call :ReleaseLock
+            set CrossGenStatus=!ERRORLEVEL!
+        )
+        call :ReleaseLock
+        IF NOT !CrossGenStatus!==0 (
+            ECHO Crossgen failed with exitcode - !CrossGenStatus!
             Exit /b 1
-            )
-          )
-          call :ReleaseLock
+        )
     )
 ) 
         ]]>


### PR DESCRIPTION
Fixes #5735, which is caused by a bug in cmd.exe. When CrossGen fails in a test script on Windows, the script calls `exit /b 1`. However, the actual exit status returned from cmd.exe to the test harness is 0, not 1. This causes the test harness to incorrectly conclude that the test succeeded.

Here is a simple batch file that demonstrate this cmd.exe bug:

    if 1==1 (
     if 2==2 (
      exit /b 1
     )
     echo Hello
    )

Save the above script in `test.cmd`, and run the following two commands:

    cmd /c test.cmd
    echo %errorlevel%

The second command will show that the first command exited with status 0, instead of the expected status 1. This bug appears to be triggered by the existence of an additional command in the outer `if` command, even though the additional command is not executed. If we remove the line `echo Hello`, then the script works correctly, and `echo %errorlevel%` shows 1, as expected.

Interestingly, running `test.cmd` directly without `cmd /c` always works properly.

To work around this bug, the script is re-structured to make sure no additional statements exist after `exit /b 1` in the outer `if` statement.

cc @jkotas @gkhanna79 