### PR TITLE
ARM64: Fix WriteBarrier

### DIFF
--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -303,7 +303,7 @@ NotInHeap
 ;
     WRITE_BARRIER_ENTRY JIT_WriteBarrier
         dmb      ST
-        str      x15, [x14], 8
+        str      x15, [x14]
 
         ; Branch to Exit if the reference is not in the Gen0 heap
         ;
@@ -332,6 +332,7 @@ UpdateCardTable
         mov      x12, 0xFF 
         strb     w12, [x15]
 Exit
+        add      x14, x14, 8
         ret      lr          
     WRITE_BARRIER_END JIT_WriteBarrier
 

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -2412,7 +2412,7 @@ RelativePath=baseservices\threading\interlocked\compareexchange\CompareExchangeT
 WorkingDir=baseservices\threading\interlocked\compareexchange\CompareExchangeTClass
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=NEW;EXPECTED_FAIL;UNSTABLE
+Categories=NEW;EXPECTED_PASS
 HostStyle=0
 [CompareExchangeTClass_1.cmd_345]
 RelativePath=baseservices\threading\interlocked\compareexchange\CompareExchangeTClass_1\CompareExchangeTClass_1.cmd
@@ -20850,14 +20850,14 @@ RelativePath=GC\Scenarios\BinTree\thdtreegrowingobj\thdtreegrowingobj.cmd
 WorkingDir=GC\Scenarios\BinTree\thdtreegrowingobj
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=NEW;EXPECTED_FAIL;UNSTABLE
+Categories=NEW;EXPECTED_PASS
 HostStyle=0
 [thdtreelivingobj.cmd_2992]
 RelativePath=GC\Scenarios\BinTree\thdtreelivingobj\thdtreelivingobj.cmd
 WorkingDir=GC\Scenarios\BinTree\thdtreelivingobj
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=NEW;EXPECTED_FAIL
+Categories=NEW;EXPECTED_PASS
 HostStyle=0
 [arrcpy.cmd_2993]
 RelativePath=GC\Scenarios\Boxing\arrcpy\arrcpy.cmd


### PR DESCRIPTION
I think this finally fixes most of long outstanding GC issues that appear in different
forms so far that include #4877, #4879, #4890 and more.

The issues was WriteBarrier implementation.
When we update card table, the address has been already incremented by 8.

With this fix, all corefx tests seem to run on xunit framework without
crashing. I verified this with an out-of-date build locally, so there are not found
assembly errors like System.Runtime.Extensions with different versions,
though. These are what I tested so far that safely finished all runs with very high percentage of pass. 
System.Collections.Tests
System.Dynamic.Runtime.Tests
System.Linq.Expressions.Tests

Potentially more coreclr tests will pass. I will update them as tests go.