### PR TITLE
Remove set -x from tests/setup-runtime-dependencies.sh.

### DIFF
--- a/tests/setup-runtime-dependencies.cmd
+++ b/tests/setup-runtime-dependencies.cmd
@@ -46,7 +46,7 @@ set __DotNetCmd=%__DotNetToolDir%\dotnetcli\dotnet.exe
 set __PackageDir=%__ThisScriptPath%..\Packages
 set __TmpDir=%Temp%\coreclr_gcstress_%RANDOM%
 
-REM Check if donet cli exists
+REM Check if dotnet cli exists
 if not exist "%__DotNetToolDir%" (
     echo Directory containing dotnet CLI does not exist: %__DotNetToolDir%
     goto Fail
@@ -67,7 +67,7 @@ if exist "%__TmpDir%" (
 mkdir %__TmpDir%
 
 REM Project.json path
-set __JasonFilePath=%__TmpDir%\project.json
+set __JsonFilePath=%__TmpDir%\project.json
 
 REM =========================================================================================
 REM ===
@@ -81,14 +81,14 @@ echo { ^
     "runtime.win7-%__Arch%.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-*" ^
     }, ^
     "frameworks": { "dnxcore50": { } } ^
-    } > "%__JasonFilePath%"
+    } > "%__JsonFilePath%"
 
-echo Jason file: %__JasonFilePath%
-type "%__JasonFilePath%"
+echo JSON file: %__JsonFilePath%
+type "%__JsonFilePath%"
 
 REM Download the package
 echo Downloading CoreDisTools package
-set DOTNETCMD="%__DotNetCmd%" restore "%__JasonFilePath%" --source https://dotnet.myget.org/F/dotnet-core/ --packages "%__PackageDir%"
+set DOTNETCMD="%__DotNetCmd%" restore "%__JsonFilePath%" --source https://dotnet.myget.org/F/dotnet-core/ --packages "%__PackageDir%"
 echo %DOTNETCMD%
 call %DOTNETCMD%
 if errorlevel 1 goto Fail
@@ -131,7 +131,7 @@ REM ============================================================================
 
 :Usage
 echo.
-echo Download coredistool for GC stress testing
+echo Download coredistools for GC stress testing
 echo.
 echo Usage:
 echo     %__ThisScriptShort% /arch ^<TargetArch^> /outputdir ^<coredistools_lib_install_path^>

--- a/tests/setup-runtime-dependencies.sh
+++ b/tests/setup-runtime-dependencies.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -x
+# set -x
+
 #
 # Constants
 #
@@ -11,7 +12,7 @@ readonly EXIT_CODE_SUCCESS=0
 
 function print_usage {
     echo ''
-    echo 'Download coredistool for GC stress testing'
+    echo 'Download coredistools for GC stress testing'
     echo ''
     echo 'Command line:'
     echo ''
@@ -96,7 +97,7 @@ if [ ! -e $dotnetToolsDir ]; then
     exit_with_error 1 'Directory containing dotnet commandline does not exist:'$dotnetToolsDir 
 fi
 if [ ! -e $dotnetCmd ]; then
-    exit_with_error 1 'donet commandline does not exist:'$dotnetCmd
+    exit_with_error 1 'dotnet commandline does not exist:'$dotnetCmd
 fi
 
 # make package directory


### PR DESCRIPTION
I hadn't run runtest.sh in a while. It looks like it's now calling this script which is adding a bunch of noise to the output.

@sejongoh Please let me know if there is any reason you left the `set -x` in.