### PR TITLE
Fix Issue #5542

### DIFF
--- a/src/vm/arm/exceparm.cpp
+++ b/src/vm/arm/exceparm.cpp
@@ -54,6 +54,38 @@ FaultingExceptionFrame *GetFrameFromRedirectedStubStackFrame (T_DISPATCHER_CONTE
     return (FaultingExceptionFrame*)((TADDR)pDispatcherContext->ContextRecord->R4);
 }
 
+//Return TRUE if pContext->Pc is in VirtualStub
+BOOL IsIPinVirtualStub(PCODE f_IP)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    Thread * pThread = GetThread();
+
+    // We may not have a managed thread object. Example is an AV on the helper thread.
+    // (perhaps during StubManager::IsStub)
+    if (pThread == NULL)
+    {
+        return FALSE;
+    }
+
+    VirtualCallStubManager::StubKind sk;
+    VirtualCallStubManager::FindStubManager(f_IP, &sk);
+
+    if (sk == VirtualCallStubManager::SK_DISPATCH)
+    {
+        return TRUE;
+    }
+    else if (sk == VirtualCallStubManager::SK_RESOLVE)
+    {
+        return TRUE;
+    }
+
+    else {
+        return FALSE;
+    }
+}
+
+
 // Returns TRUE if caller should resume execution.
 BOOL
 AdjustContextForVirtualStub(

--- a/src/vm/arm/excepcpu.h
+++ b/src/vm/arm/excepcpu.h
@@ -46,5 +46,6 @@ PCODE GetAdjustedCallAddress(PCODE returnAddress)
 }
 
 BOOL AdjustContextForVirtualStub(EXCEPTION_RECORD *pExceptionRecord, T_CONTEXT *pContext);
+BOOL IsIPinVirtualStub(PCODE f_IP);
 
 #endif // __excepcpu_h__


### PR DESCRIPTION
This PR is for fixing #5542 
On arm32, AV exception on dispatch stub is not handled on DispatchManagedException.
Therefore, AV should be signaled before entering dispatch stub.
