### PR TITLE
Fix for issue 5795

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1174,6 +1174,8 @@ class  fgArgInfo
     unsigned              stkLevel;     // Stack depth when we make this call (for x86)
 
     unsigned              argTableSize; // size of argTable array (equal to the argCount when done with fgMorphArgs)
+    bool                  hasRegArgs;   // true if we have one or more register arguments
+    bool                  hasStackArgs; // true if we have one or more stack arguments
     bool                  argsComplete; // marker for state
     bool                  argsSorted;   // marker for state
     fgArgTabEntryPtr *    argTable;     // variable sized array of per argument descrption: (i.e. argTable[argTableSize])
@@ -1247,6 +1249,8 @@ public:
     unsigned            ArgCount ()      { return argCount; }
     fgArgTabEntryPtr *  ArgTable ()      { return argTable; }
     unsigned            GetNextSlotNum() { return nextSlotNum; }
+    bool                HasRegArgs()     { return hasRegArgs; } 
+    bool                HasStackArgs()   { return hasStackArgs; }
 
 };
 


### PR DESCRIPTION
We incorrectly pass the ret buf arg in x9 instead of x8 in some cases

It is required that we call SortArgs and EvalArgsToTemps whenever we have any register arguments
We were not doing that when we only had a retBufArg argument in x8.

Fix for UNIX_AMD64 structs