### PR TITLE
Use LEAF_END_MARKED instead of LEAF_END for DBG_DebugBreak

### DIFF
--- a/src/pal/src/arch/arm/debugbreak.S
+++ b/src/pal/src/arch/arm/debugbreak.S
@@ -10,5 +10,5 @@
 LEAF_ENTRY DBG_DebugBreak, _TEXT
     EMIT_BREAKPOINT
     bx lr
-LEAF_END DBG_DebugBreak, _TEXT
+LEAF_END_MARKED DBG_DebugBreak, _TEXT
 


### PR DESCRIPTION
This commit tries to fix #5845