### PR TITLE
Use LEAF_END_MARKED instead of LEAF_END for ARM64 debugbreak.S

### DIFF
--- a/src/pal/src/arch/arm64/debugbreak.S
+++ b/src/pal/src/arch/arm64/debugbreak.S
@@ -7,5 +7,5 @@
 LEAF_ENTRY DBG_DebugBreak, _TEXT
     EMIT_BREAKPOINT
     ret
-LEAF_END DBG_DebugBreak, _TEXT
+LEAF_END_MARKED DBG_DebugBreak, _TEXT
 


### PR DESCRIPTION
This commit applies the changes in #5847 (which fixes #5845) for ARM64, too.