### PR TITLE
Correctly resolve binding from Resolving event for static load

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -14319,6 +14319,11 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
 
                 // Make the call
                 _gcRefs.oRefLoadedAssembly = (ASSEMBLYREF) methLoadAssembly.Call_RetOBJECTREF(args);
+                if (_gcRefs.oRefLoadedAssembly != NULL)
+                {
+                    // Set the flag indicating we found the assembly
+                    fResolvedAssembly = true;
+                }
             }
             
             if (fResolvedAssembly && !fResolvedAssemblyViaTPALoadContext)


### PR DESCRIPTION
Add missing check to allow assembly bound using the Resolving event to be used during static binding scenario. 

Fixes https://github.com/dotnet/coreclr/issues/5837

@jkotas PTAL