### PR TITLE
JIT: Cleanup code in and around fgFindJumpTargets

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -72,6 +72,7 @@ struct  escapeMapping_t;        // defined in flowgraph.cpp
 class   emitter;                // defined in emit.h
 struct  ShadowParamVarInfo;     // defined in GSChecks.cpp
 struct  InitVarDscInfo;         // defined in register_arg_convention.h
+class   FgStack;                // defined in flowgraph.cpp
 #if FEATURE_STACK_FP_X87
 struct  FlatFPStateX87;         // defined in fp.h
 #endif
@@ -4360,6 +4361,12 @@ protected :
     bool                fgFlowToFirstBlockOfInnerTry(BasicBlock*  blkSrc,
                                                      BasicBlock*  blkDest,
                                                      bool         sibling);
+
+    void                fgObserveInlineConstants(OPCODE opcode,
+                                                 const FgStack& stack,
+                                                 bool isInlining);
+
+    void                fgAdjustForAddressExposedOrWrittenThis();
 
     bool                        fgProfileData_ILSizeMismatch;
     ICorJitInfo::ProfileBuffer *fgProfileBuffer;


### PR DESCRIPTION
Reorder code to remove gotos. Extract two large chunks of logic as
subroutines. Add braces and update comments. Bring `fgStack` class up
to current Jit coding conventions.  Reunite some orphaned comments for
fgFindJumpTargets.

No behavior change expected. No diffs seen via jit-diff tool. No diffs
seen in desktop testing.