### PR TITLE
Fix EventSource deserializing of byte[]s

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -1836,7 +1836,7 @@ namespace System.Diagnostics.Tracing
                 dataPointer = data->DataPointer;
                 data++;
                 for (int i = 0; i < cbSize; ++i)
-                    blob[i] = *((byte*)dataPointer);
+                    blob[i] = *((byte*)(dataPointer + i));
                 return blob;
             }
             else if (dataType == typeof(byte*))


### PR DESCRIPTION
It's incorrectly repeating the first element for all elements.

Fixes https://github.com/dotnet/coreclr/issues/5881
cc: @davmason, @vancem 