### PR TITLE
Switch to double-quotes for interpolated string in netci.groovy

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1523,7 +1523,7 @@ combinedScenarios.each { scenario ->
                                         }
 
                                         if (isLongGc(scenario)) {
-                                            gcTestArguments = '${scenario} sequential'
+                                            gcTestArguments = "${scenario} sequential"
                                         }
 
                                         runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${gcTestArguments}"


### PR DESCRIPTION
Groovy only interpolates double or triple-quoted strings, so the "scenario" variable here was not getting interpolated. This fixes the long GC Windows CI runs.