### PR TITLE
Fix race condition in Loader regression 523654 test

### DIFF
--- a/tests/src/Loader/classloader/regressions/523654/test532654_b.cs
+++ b/tests/src/Loader/classloader/regressions/523654/test532654_b.cs
@@ -46,7 +46,7 @@ public class A
 	public void meth<T>()
 	{
 		Console.WriteLine(Thread.CurrentThread.Name + ": Inside meth<int>");
-		++i;
+        Interlocked.Increment(ref i);
 	}
 }
 


### PR DESCRIPTION
This should resolve https://github.com/dotnet/coreclr/issues/5880.

Before this change, I was able to produce a test failure 3/100 times when running this test. After this change, I was able to run the test 100 times without failure.

CC @sergiy-k @RussKeldorph 