### PR TITLE
Enable GT_CALL with long ret types for x86 RyuJIT

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2728,8 +2728,8 @@ protected :
     GenTreePtr          impFixupCallStructReturn(GenTreePtr           call,
                                                  CORINFO_CLASS_HANDLE retClsHnd);
 
-    GenTreePtr          impFixupCallLongReturn(GenTreePtr           call,
-                                               CORINFO_CLASS_HANDLE retClsHnd);
+    GenTreePtr          impInitCallReturnTypeDesc(GenTreePtr           call,
+                                                  CORINFO_CLASS_HANDLE retClsHnd);
 
     GenTreePtr          impFixupStructReturnType(GenTreePtr       op,
                                                  CORINFO_CLASS_HANDLE retClsHnd);
@@ -4703,6 +4703,7 @@ private:
     GenTreePtr          fgAssignStructInlineeToVar(GenTreePtr child, CORINFO_CLASS_HANDLE retClsHnd);
     void                fgAttachStructInlineeToAsg(GenTreePtr tree, GenTreePtr child, CORINFO_CLASS_HANDLE retClsHnd);
 #endif // defined(FEATURE_HFA) || defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
+
     static fgWalkPreFn  fgUpdateInlineReturnExpressionPlaceHolder;
 
 #ifdef DEBUG
@@ -7988,13 +7989,22 @@ public :
     // TODO-ARM64: Does this apply for ARM64 too?
     bool                compMethodReturnsMultiRegRetType() 
     {       
-#if FEATURE_MULTIREG_RET && (defined(FEATURE_UNIX_AMD64_STRUCT_PASSING) || defined(_TARGET_ARM_))
+#if FEATURE_MULTIREG_RET 
+
+#if (defined(FEATURE_UNIX_AMD64_STRUCT_PASSING) || defined(_TARGET_ARM_))
         // Methods returning a struct in two registers is considered having a return value of TYP_STRUCT.
         // Such method's compRetNativeType is TYP_STRUCT without a hidden RetBufArg
         return varTypeIsStruct(info.compRetNativeType) && (info.compRetBuffArg == BAD_VAR_NUM);
-#else 
+#elif defined(_TARGET_X86_)
+        // Longs are returned in two registers on x86
+        return varTypeIsLong(info.compRetNativeType);
+#else
+        unreached();
+#endif
+
+#else
         return false;
-#endif // FEATURE_MULTIREG_RET && (defined(FEATURE_UNIX_AMD64_STRUCT_PASSING) || defined(_TARGET_ARM_))
+#endif // FEATURE_MULTIREG_RET
 
     }
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6826,7 +6826,7 @@ GenTreePtr          Compiler::gtCloneExpr(GenTree * tree,
         }
         copy->gtCall.gtRetClsHnd = tree->gtCall.gtRetClsHnd;
 
-#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+#if FEATURE_MULTIREG_RET
         copy->gtCall.gtReturnTypeDesc = tree->gtCall.gtReturnTypeDesc;
 #endif
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7185,7 +7185,7 @@ DONE_CALL:
             }
             else if (varTypeIsLong(callRetTyp))
             {
-                call = impFixupCallLongReturn(call, sig->retTypeClass);
+                call = impInitCallReturnTypeDesc(call, sig->retTypeClass);
             }
 
             if ((call->gtFlags & GTF_CALL_INLINE_CANDIDATE) != 0)
@@ -7471,18 +7471,17 @@ GenTreePtr                Compiler::impFixupCallStructReturn(GenTreePtr     call
 
 
 //-----------------------------------------------------------------------------------
-//  impFixupCallLongReturn: For a call node that returns a long type, force the call
-//  to always be in the IR form tmp = call
+//  impInitCallReturnTypeDesc: Initialize the ReturnTypDesc for a call node
 //
 //  Arguments:
 //    call       -  GT_CALL GenTree node
 //    retClsHnd  -  Class handle of return type of the call
 //
 //  Return Value:
-//    Returns new GenTree node after fixing long return of call node
+//    Returns new GenTree node after initializing the ReturnTypeDesc of call node
 //
-GenTreePtr                Compiler::impFixupCallLongReturn(GenTreePtr     call,
-                                                           CORINFO_CLASS_HANDLE retClsHnd)
+GenTreePtr                Compiler::impInitCallReturnTypeDesc(GenTreePtr     call,
+                                                              CORINFO_CLASS_HANDLE retClsHnd)
 {
 #if defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
     // LEGACY_BACKEND does not use multi reg returns for calls with long return types
@@ -7507,17 +7506,6 @@ GenTreePtr                Compiler::impFixupCallLongReturn(GenTreePtr     call,
     unsigned retRegCount = retTypeDesc->GetReturnRegCount();
     // must be a long returned in two registers
     assert(retRegCount == 2);
-
-    if ((!callNode->CanTailCall()) && (!callNode->IsInlineCandidate()))
-    {
-        // Force a call returning multi-reg long to be always of the IR form
-        //   tmp = call
-        //
-        // No need to assign a multi-reg long to a local var if:
-        //  - It is a tail call or 
-        //  - The call is marked for in-lining later
-        return impAssignMultiRegTypeToVar(call, retClsHnd);
-    }
 #endif // _TARGET_X86_ && !LEGACY_BACKEND
 
     return call;
@@ -14002,8 +13990,6 @@ GenTreePtr Compiler::impAssignMultiRegTypeToVar(GenTreePtr op, CORINFO_CLASS_HAN
     assert(IsMultiRegReturnedType(hClass));
 
     // Mark the var so that fields are not promoted and stay together.
-    lvaTable[tmpNum].lvIsMultiRegArgOrRet = true;
-#elif defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
     lvaTable[tmpNum].lvIsMultiRegArgOrRet = true;
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1747,7 +1747,7 @@ void   Compiler::lvaPromoteLongVars()
          lclNum++)
     {
         LclVarDsc *  varDsc = &lvaTable[lclNum];
-        if(!varTypeIsLong(varDsc) || varDsc->lvDoNotEnregister || (varDsc->lvRefCnt == 0))
+        if(!varTypeIsLong(varDsc) || varDsc->lvDoNotEnregister || varDsc->lvIsMultiRegArgOrRet || (varDsc->lvRefCnt == 0))
         {
             continue;
         }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -83,6 +83,19 @@ GenTreePtr          Compiler::fgMorphIntoHelperCall(GenTreePtr      tree,
     tree->gtCall.gtEntryPoint.addr = nullptr;
 #endif
 
+#if defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
+    if (varTypeIsLong(tree))
+    {
+        GenTreeCall* callNode = tree->AsCall();
+        ReturnTypeDesc* retTypeDesc = callNode->GetReturnTypeDesc();
+        retTypeDesc->Reset();
+        retTypeDesc->Initialize(this, callNode->gtRetClsHnd);
+        callNode->ClearOtherRegs();
+        
+        NYI("Helper with TYP_LONG return type");
+    }
+#endif
+
     /* Perform the morphing */
 
     tree = fgMorphArgs(tree->AsCall());


### PR DESCRIPTION
1) Enables genMultiRegCallStoreToLocal for x86 RyuJIT. Forces long return
types to be stored to the stack after returning from a call.

2) Update lvaPromoteLongVars to not promote a long if it is a multi reg
arg or ret.

3) Adds NYI for call arguments that are longs and contain adds or
subtracts. We are currently producing the wrong order of operations so
that we can push the argument immediately after performing the arithmetic.
We will do the hi adc/sbb before the carry bit has been set by doing the
lo operation.

4) Adds an NYI for morphing a node into a call node if the call will have
a long return type.

5) Moves the logic for forcing var = call() for calls with long return
types to lower::DecomposeNode().