### PR TITLE
Fix for generic unboxing stub with x8 return buffer argument

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -5989,7 +5989,14 @@ var_types  Compiler::impImportCall(OPCODE                  opcode,
         // assume the worst-case.
         mflags  = (calliSig.callConv & CORINFO_CALLCONV_HASTHIS) ? 0 : CORINFO_FLG_STATIC;
 
-
+#ifdef DEBUG
+        if (verbose)
+        {
+            unsigned structSize = (callRetTyp == TYP_STRUCT) ? info.compCompHnd->getClassSize(calliSig.retTypeSigClass) : 0;
+            printf("\nIn Compiler::impImportCall: opcode is %s, kind=%d, callRetType is %s, structSize is %d\n", 
+                   opcodeNames[opcode], callInfo->kind, varTypeName(callRetTyp), structSize);
+        }
+#endif
         //This should be checked in impImportBlockCode.
         assert(!compIsForInlining()
                || !(impInlineInfo->inlineCandidateInfo->dwRestrictions & INLINE_RESPECT_BOUNDARY));
@@ -6021,6 +6028,14 @@ var_types  Compiler::impImportCall(OPCODE                  opcode,
 
         mflags   = callInfo->methodFlags;
 
+#ifdef DEBUG
+        if (verbose)
+        {
+            unsigned structSize = (callRetTyp == TYP_STRUCT) ? info.compCompHnd->getClassSize(sig->retTypeSigClass) : 0;
+            printf("\nIn Compiler::impImportCall: opcode is %s, kind=%d, callRetType is %s, structSize is %d\n", 
+                   opcodeNames[opcode], callInfo->kind, varTypeName(callRetTyp), structSize);
+        }
+#endif
         if (compIsForInlining())
         {
             /* Does this call site have security boundary restrictions? */

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3683,24 +3683,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             assert(size == 1);
 #endif
 #endif
-            // If 'expectRetBuffArg' is true then the next argument is the RetBufArg
-            // and we may need to change nextRegNum to the theFixedRetBuffReg
-            //
-            if (expectRetBuffArg)
-            {
-                assert(passUsingFloatRegs == false);
-              
-                if (hasFixedRetBuffReg())
-                {
-                    // Change the register used to pass the next argument to the fixed return buffer register
-                    nextRegNum = theFixedRetBuffReg();
-                    // Note that later in this method we don't increment intArgRegNum when we 
-                    // have setup nextRegRun to be the fixed retrurn buffer register
-                }
-
-                // We no longer are expecting the RetBufArg
-                expectRetBuffArg = false;
-            }
 
 #ifndef LEGACY_BACKEND
             // If there are nonstandard args (outside the calling convention) they were inserted above
@@ -3734,6 +3716,25 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             if (nonStandardFound)
                 continue;
 #endif // !LEGACY_BACKEND
+
+            // If 'expectRetBuffArg' is true then the next argument is the RetBufArg
+            // and we may need to change nextRegNum to the theFixedRetBuffReg
+            //
+            if (expectRetBuffArg)
+            {
+                assert(passUsingFloatRegs == false);
+
+                if (hasFixedRetBuffReg())
+                {
+                    // Change the register used to pass the next argument to the fixed return buffer register
+                    nextRegNum = theFixedRetBuffReg();
+                    // Note that later in this method we don't increment intArgRegNum when we 
+                    // have setup nextRegRun to be the fixed retrurn buffer register
+                }
+
+                // We no longer are expecting the RetBufArg
+                expectRetBuffArg = false;
+            }
 
             if (!lateArgsComputed)
             {


### PR DESCRIPTION
When we have nonstandard args we have to handle them before
we setup to expect the return buffer arg.

Added additional JitDump information about the call and its return type in impImportCall.

All of the ARM64 EXPECTED_PASS tests will now pass when hasFixedRerBufReg is enabled.
 (with the VM changes from Rahul)
Additional changes are needed for the IL_STUB_PInvoke to get the Interop tests to pass
But these tests are currently already in the EXPECTED_FAIL catagory.