### PR TITLE
[SOS] [Linux] Fix incorrect symbol loading from portable pdb

### DIFF
--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -6391,7 +6391,6 @@ public:
             pModuleFilename = pSlash+1;
             pSlash = _wcschr(pModuleFilename, DIRECTORY_SEPARATOR_CHAR_W);
         }
-        return S_OK;
 #ifndef FEATURE_PAL
 
         ImageInfo ii;
@@ -6412,8 +6411,8 @@ public:
         {
             return S_FALSE;
         }
-        return Status;
 #endif // FEATURE_PAL
+        return Status;
     }
 
     HRESULT ResolvePendingNonModuleBoundBreakpoint(__in_z WCHAR* pFilename, DWORD lineNumber, TADDR mod, SymbolReader* pSymbolReader)

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -6412,7 +6412,7 @@ public:
             return S_FALSE;
         }
 #endif // FEATURE_PAL
-        return Status;
+        return S_OK;
     }
 
     HRESULT ResolvePendingNonModuleBoundBreakpoint(__in_z WCHAR* pFilename, DWORD lineNumber, TADDR mod, SymbolReader* pSymbolReader)


### PR DESCRIPTION
Current version of `SymbolReader::LoadSymbolsForModule` doesn't work correctly, because of incorrect `return` operator. As a result, in some cases `bpmd source:line` sos command might not work correctly. This pull request fixes this issue.
CC @mikem8361 @Dmitri-Botcharnikov @seanshpark 