### PR TITLE
[SOS][Linux] Support of reading local variables from portable PDB

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -138,6 +138,7 @@ else(WIN32)
     dbgutil
     # share the PAL in the dac module
     mscordaccore
+    palrt
   )
 
   set(DEF_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/sos_unixexports.src)

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -11562,12 +11562,10 @@ private:
         IfFailRet(pLocalsEnum->GetCount(&cLocals));
         if (cLocals > 0 && bLocals)
         {
-#ifndef FEATURE_PAL
             bool symbolsAvailable = false;
             SymbolReader symReader;
             if(SUCCEEDED(symReader.LoadSymbols(pMD, pModule)))
                 symbolsAvailable = true;
-#endif
             ExtOut("\nLOCALS:\n");
             for (ULONG i=0; i < cLocals; i++)
             {
@@ -11575,13 +11573,11 @@ private:
                 WCHAR paramName[mdNameLen] = W("\0");
 
                 ToRelease<ICorDebugValue> pValue;
-#ifndef FEATURE_PAL
                 if(symbolsAvailable)
                 {
                     Status = symReader.GetNamedLocalVariable(pILFrame, i, paramName, mdNameLen, &pValue);
                 }
                 else
-#endif
                 {
                     ULONG cArgsFetched;
                     Status = pLocalsEnum->Next(1, &pValue, &cArgsFetched);

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -6383,8 +6383,7 @@ HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDeb
         Status = LoadCoreCLR();
     if (Status != S_OK)
         return Status;
-    // FIXME: we need to find a way to release memory after getting string from managed code.
-    WCHAR *wszParamName = new (std::nothrow) WCHAR[mdNameLen];
+    BSTR wszParamName = SysAllocStringLen(0, mdNameLen);
     if (wszParamName == NULL) {
         return E_OUTOFMEMORY;
     }
@@ -6393,6 +6392,7 @@ HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDeb
     if (ret) {
         wcscpy_s(paramName, _wcslen(wszParamName) + 1, wszParamName);
         paramNameLen = _wcslen(paramName);
+        SysFreeString(wszParamName);
 
         if (SUCCEEDED(pILFrame->GetLocalVariable(localIndex, ppValue)) && (*ppValue != NULL)) {
             return S_OK;
@@ -6401,6 +6401,7 @@ HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDeb
             return E_FAIL;
         }
     }
+    SysFreeString(wszParamName);
     return E_FAIL;
 
 #else

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -52,6 +52,7 @@ PIMAGEHLP_SYMBOL sym = (PIMAGEHLP_SYMBOL) symBuffer;
 void *SymbolReader::coreclrLib;
 ResolveSequencePointDelegate SymbolReader::resolveSequencePointDelegate;
 LoadSymbolsForModuleDelegate SymbolReader::loadSymbolsForModuleDelegate;
+GetLocalVariableName SymbolReader::getLocalVariableNameDelegate;
 #endif // !FEATURE_PAL
 
 const char * const CorElementTypeName[ELEMENT_TYPE_MAX]=
@@ -6284,6 +6285,11 @@ HRESULT SymbolReader::LoadCoreCLR() {
                         SymbolReaderClassName, "LoadSymbolsForModule",
                         (void **)&loadSymbolsForModuleDelegate);
     IfFailRet(Status);
+    Status = CreateDelegate(hostHandle, domainId, SymbolReaderDllName,
+                        SymbolReaderClassName, "GetLocalVariableName",
+                        (void **)&getLocalVariableNameDelegate);
+    IfFailRet(Status);
+
     return Status;
 }
 #endif //FEATURE_PAL
@@ -6363,20 +6369,43 @@ HRESULT SymbolReader::LoadSymbols(IMetaDataImport * pMD, ULONG64 baseAddress, __
     if (Status != S_OK)
         return Status;
 
-    char szName[mdNameLen];
     WideCharToMultiByte(CP_ACP, 0, pModuleName, (int) (_wcslen(pModuleName) + 1),
-            szName, mdNameLen, NULL, NULL);
-    return !loadSymbolsForModuleDelegate(szName);
+            m_szModuleName, mdNameLen, NULL, NULL);
+    return !loadSymbolsForModuleDelegate(m_szModuleName);
 #endif // FEATURE_PAL
 }
 
 HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDebugILFrame * pILFrame, mdMethodDef methodToken, ULONG localIndex, __inout_ecount(paramNameLen) WCHAR* paramName, ULONG paramNameLen, ICorDebugValue** ppValue)
 {
     HRESULT Status = S_OK;
+#ifdef FEATURE_PAL
+    if (getLocalVariableNameDelegate == nullptr)
+        Status = LoadCoreCLR();
+    if (Status != S_OK)
+        return Status;
+    // FIXME: we need to find a way to release memory after getting string from managed code.
+    WCHAR *wszParamName = new (std::nothrow) WCHAR[mdNameLen];
+    if (wszParamName == NULL) {
+        return E_OUTOFMEMORY;
+    }
+    int ret = getLocalVariableNameDelegate(m_szModuleName, methodToken,
+                                       localIndex, &wszParamName);
+    if (ret) {
+        wcscpy_s(paramName, _wcslen(wszParamName) + 1, wszParamName);
+        paramNameLen = _wcslen(paramName);
 
+        if (SUCCEEDED(pILFrame->GetLocalVariable(localIndex, ppValue)) && (*ppValue != NULL)) {
+            return S_OK;
+        } else {
+            *ppValue = NULL;
+            return E_FAIL;
+        }
+    }
+    return E_FAIL;
+
+#else
     if(pScope == NULL)
     {
-#ifndef FEATURE_PAL
         ToRelease<ISymUnmanagedMethod> pSymMethod;
         IfFailRet(m_pSymReader->GetMethod(methodToken, &pSymMethod));
 
@@ -6384,9 +6413,6 @@ HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDeb
         IfFailRet(pSymMethod->GetRootScope(&pScope));
 
         return GetNamedLocalVariable(pScope, pILFrame, methodToken, localIndex, paramName, paramNameLen, ppValue);
-#else
-        return E_FAIL;
-#endif // FEATURE_PAL
     }
     else
     {
@@ -6404,7 +6430,7 @@ HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDeb
                 if(varIndexInMethod != localIndex)
                     continue;
 
-                ULONG32 nameLen = 0; 
+                ULONG32 nameLen = 0;
                 if(FAILED(pLocals[i]->GetName(paramNameLen, &nameLen, paramName)))
                         swprintf_s(paramName, paramNameLen, W("local_%d\0"), localIndex);
 
@@ -6440,7 +6466,9 @@ HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDeb
         for(ULONG j = 0; j < numChildren; j++) pChildren[j]->Release();
 
     }
+
     return E_FAIL;
+#endif // FEATURE_PAL
 }
 
 HRESULT SymbolReader::GetNamedLocalVariable(ICorDebugFrame * pFrame, ULONG localIndex, __inout_ecount(paramNameLen) WCHAR* paramName, ULONG paramNameLen, ICorDebugValue** ppValue)

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -2358,7 +2358,7 @@ private:
 #ifdef FEATURE_PAL
 typedef  int (*ResolveSequencePointDelegate)(const char*, const char*, unsigned int, unsigned int*, unsigned int*);
 typedef  int (*LoadSymbolsForModuleDelegate)(const char*);
-typedef  int (*GetLocalVariableName)(const char*, int, int, WCHAR**);
+typedef  int (*GetLocalVariableName)(const char*, int, int, BSTR*);
 static const char *SymbolReaderDllName = "System.Diagnostics.Debug.SymbolReader";
 static const char *SymbolReaderClassName = "System.Diagnostics.Debug.SymbolReader.SymbolReader";
 #endif //FEATURE_PAL

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -2358,6 +2358,7 @@ private:
 #ifdef FEATURE_PAL
 typedef  int (*ResolveSequencePointDelegate)(const char*, const char*, unsigned int, unsigned int*, unsigned int*);
 typedef  int (*LoadSymbolsForModuleDelegate)(const char*);
+typedef  int (*GetLocalVariableName)(const char*, int, int, WCHAR**);
 static const char *SymbolReaderDllName = "System.Diagnostics.Debug.SymbolReader";
 static const char *SymbolReaderClassName = "System.Diagnostics.Debug.SymbolReader.SymbolReader";
 #endif //FEATURE_PAL
@@ -2368,8 +2369,10 @@ private:
     ISymUnmanagedReader* m_pSymReader;
 #ifdef FEATURE_PAL
     static void *coreclrLib;
+    char m_szModuleName[mdNameLen];
     static ResolveSequencePointDelegate resolveSequencePointDelegate;
     static LoadSymbolsForModuleDelegate loadSymbolsForModuleDelegate;
+    static GetLocalVariableName getLocalVariableNameDelegate;
 #endif
 
 private:


### PR DESCRIPTION
This pull request implements initial support of reading local variables from portable PDB for `clrstack -i` command. To read variables we need `System.Diagnostics.Debug.SymbolReader.dll` with method `GetLocalVariableName` form the issue: https://github.com/dotnet/corefx/issues/9570.
Please pay in attention on FIXME  [src/ToolBox/SOS/Strike/util.cpp:6386](https://github.com/dotnet/coreclr/compare/master...lucenticus:clrstack_local_vars_portable_pdb_reader?expand=1#diff-7736cd46ff4108fe7193cfd677070cb0R6386): if we trying to release memory, then we get `SIGABRT` ("free(): invalid pointer"). @mikem8361, @janvorli could you advise the best way to  release memory from managed code?
Related issue: https://github.com/dotnet/coreclr/issues/5809
CC @Dmitri-Botcharnikov @seanshpark @chunseoklee 