### PR TITLE
Set b14364 as gcstress incompat

### DIFF
--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b14364/b14364.ilproj
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b14364/b14364.ilproj
@@ -14,6 +14,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This test is set to be excluded to in internal testing under gc stress.
Add that information here as well. @RussKeldorph @dotnet/jit-contrib ptal