### PR TITLE
Clean up fgMorphArgs

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1140,6 +1140,7 @@ struct fgArgTabEntry
     SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structDesc;
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 
+#ifdef _TARGET_ARM_
     void SetIsHfaRegArg(bool hfaRegArg)
     {
         isHfaRegArg = hfaRegArg;
@@ -1150,10 +1151,26 @@ struct fgArgTabEntry
         isBackFilled = backFilled;
     }
 
-    bool IsBackFilled()
+    bool IsBackFilled() const
     {
         return isBackFilled;
     }
+#else // !_TARGET_ARM_
+    // To make the callers easier, we allow these calls (and the isHfaRegArg and isBackFilled data members) for all platforms.
+    void SetIsHfaRegArg(bool hfaRegArg)
+    {
+    }
+
+    void SetIsBackFilled(bool backFilled)
+    {
+    }
+
+    bool IsBackFilled() const
+    {
+        return false;
+    }
+#endif // !_TARGET_ARM_
+
 #ifdef DEBUG
     void Dump();
 #endif

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1034,7 +1034,7 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
                     argNode = argNode->gtEffectiveVal();
                 }
 
-                // If the struct arg is wraped in CPYBLK the type of the param will be TYP_VOID.
+                // If the struct arg is wrapped in CPYBLK the type of the param will be TYP_VOID.
                 // Use the curArgTabEntry's isStruct to get whether the param is a struct.
                 if (varTypeIsStruct(argNode)
                     FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY(|| curArgTabEntry->isStruct))


### PR DESCRIPTION
Simplify a lot of the coding, especially related to non-standard arg and SysV struct arg handling.

Specifically,

1. Added more details to `fgArgTabEntry::Dump()`
2. Adding non-standard args is always (and already) done under `!lateArgsComputed`, so delete that condition.
3. Standardize on `if (lateArgsComputed) { } else { }` pattern; reverse existing `!lateArgsComputed` cases.
4. Delete unneeded `nonRegPassableStruct` variable.
5. Merge `argIndex++` into loop structure (avoids distributing this to various `continue` cases).
6. Delete some dead code related to `passUsingIntRegs` for `UNIX_AMD64_ABI`.
7. Simplify UNIX `structFloatRegs`/`structIntRegs` counting, and reduce scope of these counters.
8. Simplify `passedInRegisters` condition, and get rid of this temp.
9. Simplify UNIX `nextRegNum`/`nextOtherRegNum` calculation.
10. Simplify non-standard args handling: eliminate one `AddArgReg()` call.
11. Removed `#ifdefs` in code by making `SetIsBackFilled()` unconditional, but creating a do-nothing non-ARM version.
12. lowerxarch.cpp: unrelated: just fix a typo.
