### PR TITLE
Cleanup hardware exception handling

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4644,7 +4644,7 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex, CONTEXT
     EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
 }
 
-VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex)
+VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHardwareException)
 {
     do
     {
@@ -4653,16 +4653,10 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex)
             // Unwind the context to the first managed frame
             CONTEXT frameContext;
 
-            // See if the exception is a hardware one. In such case, we are either in jitted code
-            // or in a marked jit helper.
-            if (ex.ContextRecord.ContextFlags & CONTEXT_EXCEPTION_ACTIVE)
+            // If the exception is hardware exceptions, we use the exception's context record directly
+            if (isHardwareException)
             {
                 frameContext = ex.ContextRecord;
-                if (IsIPInMarkedJitHelper(GetIP(&frameContext)))
-                {
-                    // Unwind to the managed caller of the helper
-                    PAL_VirtualUnwind(&frameContext, NULL);
-                }
             }
             else
             {
@@ -4700,6 +4694,7 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex)
         }
         catch (PAL_SEHException& ex2)
         {
+            isHardwareException = false;
             ex = ex2;
         }
 
@@ -5098,25 +5093,6 @@ VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
             UNREACHABLE();
         }
 
-        // Create frame necessary for the exception handling
-        FrameWithCookie<FaultingExceptionFrame> fef;
-#if defined(WIN64EXCEPTIONS)
-        *((&fef)->GetGSCookiePtr()) = GetProcessGSCookie();
-#endif // WIN64EXCEPTIONS
-        {
-            GCX_COOP();     // Must be cooperative to modify frame chain.
-            CONTEXT context = ex->ContextRecord;
-            if (IsIPInMarkedJitHelper(controlPc))
-            {
-                // For JIT helpers, we need to set the frame to point to the
-                // managed code that called the helper, otherwise the stack
-                // walker would skip all the managed frames upto the next
-                // explicit frame.
-                Thread::VirtualUnwindLeafCallFrame(&context);
-            }
-            fef.InitAndLink(&context);
-        }
-
 #ifdef _AMD64_
         // It is possible that an overflow was mapped to a divide-by-zero exception. 
         // This happens when we try to divide the maximum negative value of a
@@ -5132,7 +5108,26 @@ VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
         }
 #endif //_AMD64_
 
-        DispatchManagedException(*ex);
+        // Create frame necessary for the exception handling
+        FrameWithCookie<FaultingExceptionFrame> fef;
+#if defined(WIN64EXCEPTIONS)
+        *((&fef)->GetGSCookiePtr()) = GetProcessGSCookie();
+#endif // WIN64EXCEPTIONS
+        {
+            GCX_COOP();     // Must be cooperative to modify frame chain.
+            if (IsIPInMarkedJitHelper(controlPc))
+            {
+                // For JIT helpers, we need to set the frame to point to the
+                // managed code that called the helper, otherwise the stack
+                // walker would skip all the managed frames upto the next
+                // explicit frame.
+                PAL_VirtualUnwind(&ex->ContextRecord, NULL);
+                ex->ExceptionRecord.ExceptionAddress = (PVOID)GetIP(&ex->ContextRecord);
+            }
+            fef.InitAndLink(&ex->ContextRecord);
+        }
+
+        DispatchManagedException(*ex, true /* isHardwareException */);
         UNREACHABLE();
     }
     else

--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -319,7 +319,7 @@ void UnwindAndContinueRethrowHelperInsideCatch(Frame* pEntryFrame, Exception* pE
 VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFrame, Exception* pException);
 
 #ifdef FEATURE_PAL
-VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex);
+VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHardwareException);
 
 #define INSTALL_MANAGED_EXCEPTION_DISPATCHER        \
         PAL_SEHException exCopy;                    \
@@ -335,7 +335,7 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex);
         }                                           \
         if (hasCaughtException)                     \
         {                                           \
-            DispatchManagedException(exCopy);       \
+            DispatchManagedException(exCopy, false);\
         }
 
 // Install trap that catches unhandled managed exception and dumps its stack


### PR DESCRIPTION
Currently, we were checking for the exception address being in a marked jit
helper and unwinding to the caller context if it was there at two places.
Once in the HandleHardwareException to get context for the faulting exception
frame and once in DispatchManagedException to get the first managed frame.
This change modifies the code in HandleHardwareException to update the context
record in the exception itself so that we can leave out the same change in
the DispatchManagedException.
I have also added updating of the exception address in the exception record
so that the exception address is set to be in the managed caller of the helper.