### PR TITLE
Fix statement insertion point in GT_STORE_LCL_VAR decomposition

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -318,30 +318,49 @@ void Lowering::DecomposeNode(GenTreePtr* pTree, Compiler::fgWalkData* data)
                 nextTree->gtPrev = hiStore;
             }
             nextTree = hiRhs;
-            GenTreeStmt* stmt;
             GenTreeStmt* currStmt = comp->compCurStmt->AsStmt();
             bool isEmbeddedStmt = !currStmt->gtStmtIsTopLevel();
             if (!isEmbeddedStmt)
             {
                 tree->gtNext = nullptr;
                 hiRhs->gtPrev = nullptr;
-                stmt = comp->fgNewStmtFromTree(hiStore);
-                comp->fgInsertStmtAfter(comp->compCurBB, comp->compCurStmt, stmt);
             }
-            else
+
+            // TODO-Cleanup: DecomposeStoreInd contains identical code, 
+            // this should be moved to a common function
+            if (isEmbeddedStmt)
             {
+                // Find a parent statment containing storeIndHigh.
                 GenTree* parentStmt = currStmt;
                 while ((parentStmt != nullptr) && (!parentStmt->AsStmt()->gtStmtIsTopLevel()))
                 {
                     parentStmt = parentStmt->gtPrev;
                 }
                 assert(parentStmt);
-                stmt = comp->fgMakeEmbeddedStmt(comp->compCurBB, hiStore, parentStmt);
-            }
-            stmt->gtStmtILoffsx = comp->compCurStmt->gtStmt.gtStmtILoffsx;
+
+                GenTreeStmt* stmt = comp->fgMakeEmbeddedStmt(comp->compCurBB, hiStore, parentStmt);
+                stmt->gtStmtILoffsx = comp->compCurStmt->gtStmt.gtStmtILoffsx;
 #ifdef DEBUG
-            stmt->gtStmtLastILoffs = comp->compCurStmt->gtStmt.gtStmtLastILoffs;
+                stmt->gtStmtLastILoffs = comp->compCurStmt->gtStmt.gtStmtLastILoffs;
 #endif // DEBUG
+            }
+            else
+            {
+                GenTreeStmt* stmt = comp->fgNewStmtFromTree(hiStore);
+                stmt->gtStmtILoffsx = comp->compCurStmt->gtStmt.gtStmtILoffsx;
+#ifdef DEBUG
+                stmt->gtStmtLastILoffs = comp->compCurStmt->gtStmt.gtStmtLastILoffs;
+#endif // DEBUG
+
+                // Find an insert point. Skip all embedded statements.
+                GenTree* insertPt = currStmt;
+                while ((insertPt->gtNext != nullptr) && (!insertPt->gtNext->AsStmt()->gtStmtIsTopLevel()))
+                {
+                    insertPt = insertPt->gtNext;
+                }
+
+                comp->fgInsertStmtAfter(comp->compCurBB, insertPt, stmt);
+            }
         }
         break;
     case GT_CAST:

--- a/tests/src/JIT/Regression/JitBlue/GitHub_5696/GitHub_5696.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_5696/GitHub_5696.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This test tries to produce a TYP_LONG GT_STORE_LCL_VAR tree that contains an embedded statement:
+// 
+// *  stmtExpr  void  (top level) (IL 0x000...0x00B)
+// |           /--*  lclVar    int    V01 arg1
+// |           +--*  const     int    4
+// |        /--*  +         int
+// |        |  {  *  stmtExpr  void  (embedded)
+// |        |  {  |        /--*  lclVar    ref    V00 this
+// |        |  {  |        +--*  const     int    4 field offset Fseq[i]
+// |        |  {  |     /--*  +         byref
+// |        |  {  |  /--*  indir     int
+// |        |  {  \--*  st.lclVar int    V03 cse0
+// |        +--*  lclVar    int    V03 cse0
+// |     /--*  -         int 
+// |  /--*  cast      long <- ulong <- uint
+// \--*  st.lclVar long   V02 loc0
+// 
+// This requires decomposition of GT_STORE_LCL_VAR to properly detect the insertion point 
+// for a statment it creates.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    uint i;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    ulong Test(uint h)
+    {
+        uint x = h + 4;
+        ulong f = checked((ulong)unchecked(x - i));
+        if (i > h)
+            return 0;
+        return f;
+    }
+
+    static int Main()
+    {
+        const int Pass = 100;
+        const int Fail = -1;
+
+        if (new Program().Test(42) == 46)
+        {
+            Console.WriteLine("Passed");
+            return Pass;
+        }
+        else
+        {
+            Console.WriteLine("Failed");
+            return Fail;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_5696/GitHub_5696.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_5696/GitHub_5696.csproj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>project.json</ProjectJson>
+    <ProjectLockJson>project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_5696/app.config
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_5696/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_5696/project.json
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_5696/project.json
@@ -1,0 +1,45 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-24117-00",
+    "System.Collections": "4.0.10",
+    "System.Collections.NonGeneric": "4.0.1-rc3-24117-00",
+    "System.Collections.Specialized": "4.0.1-rc3-24117-00",
+    "System.ComponentModel": "4.0.1-rc3-24117-00",
+    "System.Console": "4.0.0-rc3-24117-00",
+    "System.Diagnostics.Process": "4.1.0-rc3-24117-00",
+    "System.Globalization": "4.0.10",
+    "System.Globalization.Calendars": "4.0.0",
+    "System.IO": "4.0.10",
+    "System.IO.FileSystem": "4.0.1-rc3-24117-00",
+    "System.IO.FileSystem.Primitives": "4.0.0",
+    "System.Linq": "4.1.0-rc3-24117-00",
+    "System.Linq.Queryable": "4.0.1-rc3-24117-00",
+    "System.Reflection": "4.1.0-rc3-24117-00",
+    "System.Reflection.Primitives": "4.0.0",
+    "System.Runtime": "4.1.0-rc3-24117-00",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Runtime.Handles": "4.0.0",
+    "System.Runtime.InteropServices": "4.1.0-rc3-24117-00",
+    "System.Runtime.Loader": "4.0.0-rc3-24117-00",
+    "System.Text.Encoding": "4.0.10",
+    "System.Threading": "4.0.10",
+    "System.Threading.Thread": "4.0.0-rc3-24117-00",
+    "System.Threading.ThreadPool": "4.0.10-rc3-24117-00",
+    "System.Xml.ReaderWriter": "4.0.11-rc3-24117-00",
+    "System.Xml.XDocument": "4.0.11-rc3-24117-00",
+    "System.Xml.XmlDocument": "4.0.1-rc3-24117-00",
+    "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8-x64": {}
+  }
+}


### PR DESCRIPTION
In some cases a newly created statement is inserted between the current statement and its embedded statements instead of being inserted after the current statement and its embedded statements.

Fixes #5696 

In addition to the fix itself I reorganized the code to be similar to the code used by @sejongoh in #5380. We should be able to extract a common function from this when the decomposition story is in a better shape. 