### PR TITLE
Build the GC as part of its own CMake target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/jit32")
   add_subdirectory(jit32)
 endif()
 
+add_subdirectory(gc)
 add_subdirectory(vm)
 add_subdirectory(md)
 add_subdirectory(debug)

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -81,6 +81,7 @@ set(COREDAC_LIBRARIES
     strongname_dac
     utilcode_dac
     unwinder_dac
+    gc_dac
     ${END_LIBRARY_GROUP} # End group of libraries that have circular references
 )
 

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -79,6 +79,7 @@ set(CORECLR_LIBRARIES
     debug-pal
     ${LIB_UNWINDER}
     cee_wks
+    gc_wks
     ${END_LIBRARY_GROUP} # End group of libraries that have circular references
     mdcompiler_wks
     mdruntime_wks

--- a/src/gc/CMakeLists.txt
+++ b/src/gc/CMakeLists.txt
@@ -1,1 +1,45 @@
-add_subdirectory(sample)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}) 
+include_directories(BEFORE ${CLR_DIR}/src/vm)
+include_directories(BEFORE ${CLR_DIR}/src/vm/${ARCH_SOURCES_DIR})
+
+if(CLR_CMAKE_PLATFORM_UNIX)
+  add_compile_options(-fPIC)
+endif(CLR_CMAKE_PLATFORM_UNIX)
+
+if(CMAKE_CONFIGURATION_TYPES)
+  foreach (Config DEBUG CHECKED)  
+     set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:${Config}>:WRITE_BARRIER_CHECK=1>)
+  endforeach (Config)
+else()
+  if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL CHECKED)
+    add_definitions(-DWRITE_BARRIER_CHECK=1)
+  endif(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL CHECKED)
+endif(CMAKE_CONFIGURATION_TYPES)
+
+set( GC_SOURCES_DAC_AND_WKS_COMMON
+  gccommon.cpp
+  gcscan.cpp
+  gcsvr.cpp
+  gcwks.cpp
+  handletable.cpp
+  handletablecore.cpp
+  handletablescan.cpp
+  objecthandle.cpp
+  softwarewritewatch.cpp)
+
+set( GC_SOURCES_WKS
+  ${GC_SOURCES_DAC_AND_WKS_COMMON}
+  gceesvr.cpp
+  gceewks.cpp
+  handletablecache.cpp)
+
+set( GC_SOURCES_DAC
+  ${GC_SOURCES_DAC_AND_WKS_COMMON})
+
+convert_to_absolute_path(GC_SOURCES_WKS ${GC_SOURCES_WKS})
+convert_to_absolute_path(GC_SOURCES_DAC ${GC_SOURCES_DAC})
+
+add_subdirectory(wks)
+add_subdirectory(dac)

--- a/src/gc/dac/CMakeLists.txt
+++ b/src/gc/dac/CMakeLists.txt
@@ -1,0 +1,2 @@
+include(${CLR_DIR}/dac.cmake)
+add_library_clr(gc_dac STATIC ${GC_SOURCES_DAC})

--- a/src/gc/env/common.h
+++ b/src/gc/env/common.h
@@ -9,7 +9,9 @@
 
 #pragma once
 
-#define _CRT_SECURE_NO_WARNINGS
+#ifndef _CRT_SECURE_NO_WARNINGS
+ #define _CRT_SECURE_NO_WARNINGS
+#endif // _CRT_SECURE_NO_WARNINGS
 
 #include <stdint.h>
 #include <stddef.h>

--- a/src/gc/wks/CMakeLists.txt
+++ b/src/gc/wks/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library_clr(gc_wks STATIC ${GC_SOURCES_WKS})

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -63,15 +63,8 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     formattype.cpp
     fptrstubs.cpp
     frames.cpp
-    ../gc/gccommon.cpp
-    ../gc/gcscan.cpp
-    ../gc/gcsvr.cpp
-    ../gc/gcwks.cpp
     genericdict.cpp
     generics.cpp
-    ../gc/handletable.cpp
-    ../gc/handletablecore.cpp
-    ../gc/handletablescan.cpp
     hash.cpp
     hillclimbing.cpp
     ilstubcache.cpp
@@ -86,7 +79,6 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     methoditer.cpp
     methodtable.cpp
     object.cpp
-    ../gc/objecthandle.cpp
     pefile.cpp
     peimage.cpp
     peimagelayout.cpp
@@ -99,7 +91,6 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     securitydescriptorassembly.cpp
     sigformat.cpp
     siginfo.cpp
-    ../gc/softwarewritewatch.cpp
     stackwalk.cpp
     stublink.cpp
     stubmgr.cpp
@@ -177,9 +168,6 @@ set(VM_SOURCES_WKS
     gcenv.os.cpp
     gchelpers.cpp
     genmeth.cpp
-    ../gc/gceesvr.cpp
-    ../gc/gceewks.cpp
-    ../gc/handletablecache.cpp
     hosting.cpp
     ibclogger.cpp
     ilmarshalers.cpp


### PR DESCRIPTION
This PR adds two new CMake libraries that build the garbage collector. The first target, `gc_wks`, builds the parts of the GC that get linked into `coreclr.dll`/`libcoreclr.so` while `gc_dac` builds the parts that are linked into `mscordac`. The build targets themselves produce static archives that are linked in the final step, just as before - the only difference now is that the GC build is a little more decoupled from the build of the rest of the VM.