### PR TITLE
ARM-CI: Use CI cross build script in emulator

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1763,24 +1763,9 @@ combinedScenarios.each { scenario ->
                                         // Setup variables to hold emulator folder path and the rootfs mount path
                                         def armemul_path = '/opt/linux-arm-emulator'
                                         def armrootfs_mountpath = '/opt/linux-arm-emulator-root'
-                                        // Create the mount path directory if not present already
-                                        buildCommands += "if [ ! -d ${armrootfs_mountpath} ]; then sudo mkdir ${armrootfs_mountpath}; fi;"
 
-                                        // Unmount previously mounted rootfs and mount the Linux ARM emulator rootfs at /opt/linux-arm-emulator-root/
-                                        buildCommands += "if grep -qs ${armrootfs_mountpath} /proc/mounts; then sudo umount ${armrootfs_mountpath}; fi ; sudo mount ${armemul_path}/platform/rootfs-t30.ext4 ${armrootfs_mountpath}"
-
-                                        // Export LINUX_ARM_INCPATH to hold the include paths to be used by CPLUS_INCLUDE_PATH environment variable
-                                        // Apply the changes needed to the library search paths to build for the emulator rootfs
-                                        buildCommands += """echo \"Exporting LINUX_ARM_INCPATH environment variable\"
-                                                            source ${armrootfs_mountpath}/dotnet/setenv/setenv_incpath.sh ${armrootfs_mountpath}
-
-                                                            echo \"Applying cross build patch to suit Linux ARM emulator rootfs\"
-                                                            git am < ${armrootfs_mountpath}/dotnet/setenv/coreclr_cross.patch
-
-                                                            ROOTFS_DIR=${armrootfs_mountpath} CPLUS_INCLUDE_PATH=\$LINUX_ARM_INCPATH CXXFLAGS=\$LINUX_ARM_CXXFLAGS ./build.sh arm-softfp clean cross verbose skipmscorlib clang3.5 ${lowerConfiguration}
-
-                                                            echo \"Rewinding HEAD to master code\"
-                                                            git reset --hard HEAD^"""
+                                        // Call the ARM emulator build script to cross build using the ARM emulator rootfs
+                                        buildCommands += "./tests/scripts/arm32_ci_script.sh ${armemul_path} ${armrootfs_mountpath} ${lowerConfiguration}"
 
                                         // Basic archiving of the build, no pal tests
                                         Utilities.addArchival(newJob, "/opt/linux-arm-emulator-root/home/coreclr/bin/Product/**")

--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+usage() {
+	echo "Usage: $0 <emulator folder path> <rootfs mount path> <build configuration>"
+	echo "		emulator folder path: The path to the emulator directory"
+	echo "		rootfs mount path: The target path for mounting the emulator rootfs"
+	echo "				   This path needs to exist, else the mount command will fail"
+	echo "		build configuration: Debug or Release (argument is must)"
+	echo "	     Both the emulator directory path and the target mount path should not end in /"
+	echo "	     This script should be called from inside the coreclr source directory"
+	echo "	     All 3 arguments are a must"
+	exit 1
+}
+
+if [ $# -ne 3 ]
+then
+	usage
+fi
+
+set -x
+
+armemul_path=$1 ; armrootfs_mountpath=$2 ; build_config=$3
+
+if [ ! -d $armrootfs_mountpath ]; then sudo mkdir $armrootfs_mountpath; fi;
+
+if grep -qs $armrootfs_mountpath /proc/mounts; then sudo umount $armrootfs_mountpath; fi ; sudo mount $armemul_path/platform/rootfs-t30.ext4 $armrootfs_mountpath
+
+echo "Exporting LINUX_ARM_INCPATH environment variable"
+source $armrootfs_mountpath/dotnet/setenv/setenv_incpath.sh $armrootfs_mountpath
+
+echo "Applying cross build patch to suit Linux ARM emulator rootfs"
+git am < $armrootfs_mountpath/dotnet/setenv/coreclr_cross.patch
+
+ROOTFS_DIR=$armrootfs_mountpath CPLUS_INCLUDE_PATH=$LINUX_ARM_INCPATH CXXFLAGS=$LINUX_ARM_CXXFLAGS ./build.sh arm-softfp clean cross verbose skipmscorlib clang3.5 $build_config
+
+echo "Rewinding HEAD to master code"
+git reset --hard HEAD^


### PR DESCRIPTION
Previous PRs added the build commands to the groovy script.
But this did not work for various reasons.
The current patch makes the CI system execute the bash script
that does the cross build. The bash script is already supplied with the emulator

Signed-off-by: Prajwal A N <an.prajwal@samsung.com>