### PR TITLE
Fix test runner batch file to provide correct TPA path

### DIFF
--- a/tests/src/CLRTest.CrossGen.targets
+++ b/tests/src/CLRTest.CrossGen.targets
@@ -77,8 +77,8 @@ if defined RunCrossGen (
         call :TakeLock
         set CrossGenStatus=0
         if not exist "$(MSBuildProjectName).ni.exe" (
-            echo "%_DebuggerFullPath% %CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%~dp0 $(MSBuildProjectName).exe
-            %_DebuggerFullPath% "%CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%~dp0 $(MSBuildProjectName).exe
+            echo "%_DebuggerFullPath% %CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%25cd%25 $(MSBuildProjectName).exe
+            %_DebuggerFullPath% "%CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%25cd%25 $(MSBuildProjectName).exe
             set CrossGenStatus=!ERRORLEVEL!
         )
         call :ReleaseLock


### PR DESCRIPTION
Bacth fails for certain R2R tests because the path provided in Platform_Assemblies_Paths is incorrect. %~dp0 will not point to the batch file path as batch file calls "shift" which changes %~dp0 to point someother location.