### PR TITLE
Introduce the method fullIntArgRegMask() to replace many uses of RBM_ARG_REGS

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1609,7 +1609,7 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         break;
 
     case GT_PINVOKE_PROLOG:
-        noway_assert(((gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur) & ~RBM_ARG_REGS) == 0);
+        noway_assert(((gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur) & ~fullIntArgRegMask()) == 0);
 
         // the runtime side requires the codegen here to be consistent
         emit->emitDisableRandomNops();

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3271,7 +3271,7 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         break;
 
     case GT_PINVOKE_PROLOG:
-        noway_assert(((gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur) & ~RBM_ARG_REGS) == 0);
+        noway_assert(((gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur) & ~fullIntArgRegMask()) == 0);
 
         // the runtime side requires the codegen here to be consistent
         emit->emitDisableRandomNops();

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2640,7 +2640,7 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 #endif
 
     case GT_PINVOKE_PROLOG:
-        noway_assert(((gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur) & ~RBM_ARG_REGS) == 0);
+        noway_assert(((gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur) & ~fullIntArgRegMask()) == 0);
 
         // the runtime side requires the codegen here to be consistent
         emit->emitDisableRandomNops();

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -3243,14 +3243,7 @@ __forceinline regMaskTP genMapArgNumToRegMask(unsigned argNum, var_types type)
 inline
 unsigned           genMapIntRegNumToRegArgNum(regNumber regNum)
 {
-    // First check for the Arm64 fixed return buffer argument register
-    // as it is not in the RBM_ARG_REGS set of registers
-    if (hasFixedRetBuffReg() && (regNum == theFixedRetBuffReg()))
-    {
-        return theFixedRetBuffArgNum();
-    }
-
-    assert (genRegMask(regNum) & RBM_ARG_REGS);
+    assert(genRegMask(regNum) & fullIntArgRegMask());
 
     switch (regNum)
     {
@@ -3277,8 +3270,16 @@ unsigned           genMapIntRegNumToRegArgNum(regNumber regNum)
 #endif
 #endif
     default: 
-        assert(!"invalid register arg register"); 
-        return BAD_VAR_NUM;
+        // Check for the Arm64 fixed return buffer argument register
+        if (hasFixedRetBuffReg() && (regNum == theFixedRetBuffReg()))
+        {
+            return theFixedRetBuffArgNum();
+        }
+        else
+        {
+            assert(!"invalid register arg register");
+            return BAD_VAR_NUM;
+        }
     }
 }
 

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1919,6 +1919,20 @@ inline regNumber    theFixedRetBuffReg()
 }
 
 //-------------------------------------------------------------------------------------------
+// theFixedRetBuffMask: 
+//     Returns the regNumber to use for the fixed return buffer 
+// 
+inline regMaskTP    theFixedRetBuffMask()
+{
+    assert(hasFixedRetBuffReg());   // This predicate should be checked before calling this method
+#ifdef _TARGET_ARM64_
+    return RBM_ARG_RET_BUFF;
+#else
+    return 0;
+#endif
+}
+
+//-------------------------------------------------------------------------------------------
 // theFixedRetBuffArgNum: 
 //     Returns the argNum to use for the fixed return buffer 
 // 
@@ -1933,17 +1947,30 @@ inline unsigned     theFixedRetBuffArgNum()
 }
 
 //-------------------------------------------------------------------------------------------
+// fullIntArgRegMask: 
+//     Returns the full mask of all possible integer registers
+//     Note this includes the fixed return buffer register on Arm64 
+//
+inline regMaskTP       fullIntArgRegMask()
+{    
+    if (hasFixedRetBuffReg())
+    {
+        return RBM_ARG_REGS | theFixedRetBuffMask();
+    }
+    else
+    {
+        return RBM_ARG_REGS;
+    }    
+}
+
+//-------------------------------------------------------------------------------------------
 // isValidIntArgReg: 
 //     Returns true if the register is a valid integer argument register 
 //     Note this method also returns true on Arm64 when 'reg' is the RetBuff register 
 //
 inline bool         isValidIntArgReg(regNumber reg)
 {
-    if (hasFixedRetBuffReg() && (reg == theFixedRetBuffReg()))
-    {
-        return true;
-    }
-    return (genRegMask(reg) & RBM_ARG_REGS) != 0;
+    return (genRegMask(reg) & fullIntArgRegMask()) != 0;
 }
 
 //-------------------------------------------------------------------------------------------


### PR DESCRIPTION
This method returns the full integer argument register mask
this also includes the fixed return buffer argument register.