### PR TITLE
Pass --build-id=sha1 to linker explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,7 +363,9 @@ elseif (CLR_CMAKE_PLATFORM_UNIX)
 endif(WIN32)
 
 if(CLR_CMAKE_PLATFORM_LINUX)  
-  set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")  
+  set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=sha1")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=sha1")
 endif(CLR_CMAKE_PLATFORM_LINUX)  
 
 #------------------------------------


### PR DESCRIPTION
On some platforms, a build-id was not being added to native artifacts
and we would like it to be present. Explicitly pass --build-id=sha1 to
the linker.

Fixes #5796