### PR TITLE
Fix RyuJIT/x86 P/Invoke inlining

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -686,6 +686,13 @@ regMaskTP Compiler::compHelperCallKillSet(CorInfoHelpFunc helper)
     case CORINFO_HELP_STOP_FOR_GC:
         return RBM_STOP_FOR_GC_TRASH;
 
+#ifdef _TARGET_X86_
+    case CORINFO_HELP_INIT_PINVOKE_FRAME:
+        // On x86, this helper has a custom calling convention that takes EDI as argument
+        // (but doesn't trash it), trashes EAX, and returns ESI.
+        return RBM_PINVOKE_SCRATCH | RBM_PINVOKE_TCB;
+#endif // _TARGET_X86_
+
     default:
         return RBM_CALLEE_TRASH;
     }

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -6063,6 +6063,16 @@ void CodeGen::genCallInstruction(GenTreePtr node)
             }
             else
             {                
+#ifdef _TARGET_X86_
+                if ((call->gtCallType == CT_HELPER) && (call->gtCallMethHnd == compiler->eeFindHelper(CORINFO_HELP_INIT_PINVOKE_FRAME)))
+                {
+                    // The x86 CORINFO_HELP_INIT_PINVOKE_FRAME helper uses a custom calling convention that returns with
+                    // TCB in REG_PINVOKE_TCB. AMD64/ARM64 use the standard calling convention. fgMorphCall() sets the
+                    // correct argument registers.
+                    returnReg = REG_PINVOKE_TCB;
+                }
+                else
+#endif // _TARGET_X86_
                 if (varTypeIsFloating(returnType))
                 {
                     returnReg = REG_FLOATRET;

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -903,6 +903,16 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
             }
 
             // Set destination candidates for return value of the call.
+#ifdef _TARGET_X86_
+            if ((tree->gtCall.gtCallType == CT_HELPER) && (tree->gtCall.gtCallMethHnd == compiler->eeFindHelper(CORINFO_HELP_INIT_PINVOKE_FRAME)))
+            {
+                // The x86 CORINFO_HELP_INIT_PINVOKE_FRAME helper uses a custom calling convention that returns with
+                // TCB in REG_PINVOKE_TCB. AMD64/ARM64 use the standard calling convention. fgMorphCall() sets the
+                // correct argument registers.
+                info->setDstCandidates(l, RBM_PINVOKE_TCB);
+            }
+            else
+#endif // _TARGET_X86_
             if (hasMultiRegRetVal)
             {
                 assert(retTypeDesc != nullptr);

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -584,11 +584,11 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define PREDICT_REG_VIRTUAL_STUB_PARAM  PREDICT_REG_EAX
 
   // Registers used by PInvoke frame setup
-  #define REG_PINVOKE_FRAME        REG_EDI
+  #define REG_PINVOKE_FRAME        REG_EDI      // EDI is p/invoke "Frame" pointer argument to CORINFO_HELP_INIT_PINVOKE_FRAME helper
   #define RBM_PINVOKE_FRAME        RBM_EDI
-  #define REG_PINVOKE_TCB          REG_ESI
+  #define REG_PINVOKE_TCB          REG_ESI      // ESI is set to Thread Control Block (TCB) on return from CORINFO_HELP_INIT_PINVOKE_FRAME helper
   #define RBM_PINVOKE_TCB          RBM_ESI
-  #define REG_PINVOKE_SCRATCH      REG_EAX
+  #define REG_PINVOKE_SCRATCH      REG_EAX      // EAX is trashed by CORINFO_HELP_INIT_PINVOKE_FRAME helper
   #define RBM_PINVOKE_SCRATCH      RBM_EAX
 
 #ifdef LEGACY_BACKEND


### PR DESCRIPTION
Enable RyuJIT/x86 PInvoke lowering

Fixes #4181 "NYI_X86: Implement PInvoke frame init inlining for x86"

The main work here is to handle the custom calling convention for the
x86 CORINFO_HELP_INIT_PINVOKE_FRAME helper call: it takes EDI as an argument,
trashes only EAX, and returns the TCB in ESI.

The code changes are as follows:
1. Lowering::InsertPInvokeMethodProlog(): don't pass the "secret stub param" for x86.
Also, don't store the InlinedCallFrame.m_pCallSiteSP in the prolog: for x86 this is done
at the call site, due to the floating stack pointer.
2. LinearScan::getKillSetForNode(): for helper calls, call compHelperCallKillSet() to get the killMask,
to account for non-standard kill sets.
3. Morph.cpp::fgMorphArgs(): set non-standard arguments for CORINFO_HELP_INIT_PINVOKE_FRAME.
4. compHelperCallKillSet(): set the correct kill set for CORINFO_HELP_INIT_PINVOKE_FRAME.
5. codegenxarch.cpp::genCallInstruction(): set the ABI return register for CORINFO_HELP_INIT_PINVOKE_FRAME.
6. lowerxarch.cpp::TreeNodeInfoInit(): set the GT_CALL dstCandidates for CORINFO_HELP_INIT_PINVOKE_FRAME.

5 & 6 are both needed to avoid a copy.

With this change, the `#1` NYI with 18415 hits over the tests is gone.
The total number of NYI is now 29516.
