### PR TITLE
ARM64: Change the fixed return buffer argument to be handled as a non-standard argument

### DIFF
--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -101,6 +101,13 @@ public:
         return data[tosIndex - 1 - idx];
     }
 
+    // return a reference to the i'th from the top
+    T& IndexRef(int idx)
+    {
+        assert(tosIndex > idx);
+        return data[tosIndex - 1 - idx];
+    }
+
     int Height()
     {
         return tosIndex;


### PR DESCRIPTION
We already have support for the handling of non-standard arguments and
it is simpler and better to handle the fixed return buffer argument as a non-standard argument.