### PR TITLE
ARM-CI: Change result archiving from emulated to cross build

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1768,7 +1768,7 @@ combinedScenarios.each { scenario ->
                                         buildCommands += "./tests/scripts/arm32_ci_script.sh ${armemul_path} ${armrootfs_mountpath} ${lowerConfiguration}"
 
                                         // Basic archiving of the build, no pal tests
-                                        Utilities.addArchival(newJob, "/opt/linux-arm-emulator-root/home/coreclr/bin/Product/**")
+                                        Utilities.addArchival(newJob, "/bin/Product/**")
                                         break
                                     }
                                 default:


### PR DESCRIPTION
Previous PR assumed emulated build and thus archived the binaries inside the emulator.
But since cross build produces binaries inside the source folder, change the result path

Signed-off-by: Prajwal A N <an.prajwal@samsung.com>