### PR TITLE
ARM-CI: Prevent creation of job for Checked configuration

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1251,6 +1251,11 @@ combinedScenarios.each { scenario ->
                     // The tuples (LinuxARMEmulator, other architectures) are not handled and control returns
                     def isLinuxEmulatorBuild = false
                     if (os == 'LinuxARMEmulator' && architecture == 'arm') {
+                        // Cross Builds only in Debug and Release modes allowed
+                        if ( configuration == 'Checked' ) {
+                            return
+                        }
+
                         isLinuxEmulatorBuild = true
                         os = 'Ubuntu'
                     } else if (os == 'LinuxARMEmulator') {
@@ -1755,10 +1760,8 @@ combinedScenarios.each { scenario ->
                                         break
                                     }
                                     else {
-                                        // Build only for Debug or Release
-                                        if ( lowerConfiguration != 'debug' && lowerConfiguration != 'release' ) {
-                                            break
-                                        }
+                                        // Make sure the build configuration is either of debug or release
+                                        assert ( lowerConfiguration == 'debug' ) || ( lowerConfiguration == 'release' )
 
                                         // Setup variables to hold emulator folder path and the rootfs mount path
                                         def armemul_path = '/opt/linux-arm-emulator'


### PR DESCRIPTION
Previously we checked if the configuration being built is either of Debug or Release after the job had already been created. This resulted in a job being created for Checked configuration with no build commands to execute (as Checked configuration is not yet supported by Linux ARM Emulator).

We prevent the unnecessary creation of job for the Checked configuration by returning control at the very beginning of the `<LinuxARMEmulator, arm, Checked>` iteration, and just double-check the build configuration while handling the Linux ARM emulator jobs.

Signed-off-by: Prajwal A N <an.prajwal@samsung.com>