### PR TITLE
Fix GC profiling on arm-softfp

### DIFF
--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -227,9 +227,9 @@ struct ScanContext
 #ifdef GC_PROFILING
         pMD = NULL;
 #endif //GC_PROFILING
-#ifdef FEATURE_EVENT_TRACE
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
         dwEtwRootKind = kEtwGCRootKindOther;
-#endif // FEATURE_EVENT_TRACE
+#endif // GC_PROFILING || FEATURE_EVENT_TRACE
     }
 };
 


### PR DESCRIPTION
This PR resolves #5918 by initializing dwEtwRootKind field of ScanContext when GC_PROFILING is defined while FEATURE_EVENT_TRACE is not. This happens to all platforms except win32 and linux/amd64.
```
src/pal/CMakeLists.txt:
if (WIN32)
  set(FEATURE_EVENT_TRACE 1)
endif()
if(CLR_CMAKE_PLATFORM_LINUX AND CLR_CMAKE_PLATFORM_ARCH_AMD64)
  set(FEATURE_EVENT_TRACE 1)
endif()
```