### PR TITLE
Add AOT placeholder files to the JIT package.

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Jit/win/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/win/Microsoft.NETCore.Jit.pkgproj
@@ -15,6 +15,11 @@
     </File>
   </ItemGroup>
   <ItemGroup>
+    <!-- prevent accidental inclusion in AOT projects. -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)-aot/native</TargetPath>
+    </File>
+
     <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />


### PR DESCRIPTION
This is intended to prevent accidental inclusion in UWP projects.