### PR TITLE
Refactor TreeNodeInfoInit(): extract lots of functions

### DIFF
--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -143,20 +143,27 @@ private:
 
     void TreeNodeInfoInit(GenTree* stmt);
     void TreeNodeInfoInit(GenTreePtr* tree, GenTree* parent);
-#ifdef _TARGET_ARM_
-    void TreeNodeInfoInitCall(GenTreePtr tree, TreeNodeInfo &info, int &srcCount, int &dstCount);
-#endif // _TARGET_ARM_
-    void TreeNodeInfoInitStructArg(GenTreePtr structArg);
+#if defined(_TARGET_XARCH_)
+    void TreeNodeInfoInitSimple(GenTree* tree);
+#endif // defined(_TARGET_XARCH_)
+    void TreeNodeInfoInitReturn(GenTree* tree);
+    void TreeNodeInfoInitShiftRotate(GenTree* tree);
+    void TreeNodeInfoInitCall(GenTreeCall* call);
     void TreeNodeInfoInitBlockStore(GenTreeBlkOp* blkNode);
+    void TreeNodeInfoInitLogicalOp(GenTree* tree);
+    void TreeNodeInfoInitModDiv(GenTree* tree);
+    void TreeNodeInfoInitIntrinsic(GenTree* tree);
 #ifdef FEATURE_SIMD
-    void TreeNodeInfoInitSIMD(GenTree* tree, LinearScan* lsra);
+    void TreeNodeInfoInitSIMD(GenTree* tree);
 #endif // FEATURE_SIMD
+    void TreeNodeInfoInitCast(GenTree* tree);
 #ifdef _TARGET_ARM64_
     void TreeNodeInfoInitPutArgStk(GenTree* argNode, fgArgTabEntryPtr info);
 #endif // _TARGET_ARM64_
-#if defined(_TARGET_XARCH_)
-    void TreeNodeInfoInitSimple(GenTree* tree, TreeNodeInfo* info, unsigned kind);
-#endif // defined(_TARGET_XARCH_)
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+    void TreeNodeInfoInitPutArgStk(GenTree* tree);
+#endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
+    void TreeNodeInfoInitLclHeap(GenTree* tree);
 
     void SpliceInUnary(GenTreePtr parent, GenTreePtr* ppChild, GenTreePtr newNode);
     void DumpNodeInfoMap();

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -45,14 +45,6 @@ void Lowering::LowerRotate(GenTreePtr tree)
     NYI_ARM("ARM Lowering for ROL and ROR");
 }
 
-void Lowering::TreeNodeInfoInitCall(GenTree *tree, TreeNodeInfo &info, 
-                                    int &srcCount, // out 
-                                    int &dstCount  // out
-    )
-{
-    NYI_ARM("ARM TreeNodeInfoInit for Call");
-}
-
 Compiler::fgWalkResult Lowering::TreeInfoInitHelper(GenTreePtr* pTree, Compiler::fgWalkData* data)
 {
     Lowering* lower = (Lowering*)data->pCallbackData;

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -392,7 +392,7 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
 
 #ifdef FEATURE_SIMD
         case GT_SIMD:
-            TreeNodeInfoInitSIMD(tree, l);
+            TreeNodeInfoInitSIMD(tree);
             break;
 #endif // FEATURE_SIMD
 
@@ -1293,11 +1293,12 @@ Lowering::TreeNodeInfoInitBlockStore(GenTreeBlkOp* blkNode)
 //    None.
 
 void
-Lowering::TreeNodeInfoInitSIMD(GenTree* tree, LinearScan* lsra)
+Lowering::TreeNodeInfoInitSIMD(GenTree* tree)
 {
     NYI("TreeNodeInfoInitSIMD");
     GenTreeSIMD* simdTree = tree->AsSIMD();
     TreeNodeInfo* info = &(tree->gtLsraInfo);
+    LinearScan* lsra = m_lsra;
     info->dstCount = 1;
     switch(simdTree->gtSIMDIntrinsicID)
     {


### PR DESCRIPTION
The TreeNodeInfoInit() function for xarch was getting exceedingly large, and some of the individual cases, like for GT_CALL, were upwards of 400 lines of code. I extracted all the large cases out into functions.

@dotnet/jit-contrib PTAL.
