### PR TITLE
Fix SBCG in value-numbering constant assertprop

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/DevDiv_216571/DevDiv_216571.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_216571/DevDiv_216571.il
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Optimizations that attempt to track values that are reinterpreted
+// in different types require special handling.
+
+.assembly extern legacy library mscorlib { }
+.assembly DevDiv_216571
+{
+}
+
+.method assembly static int32  main() cil managed
+{
+  .entrypoint
+  .maxstack  3
+  .locals (float32 V_2,
+           uint32 V_6)
+  IL_0000:  ldc.i4     0x3f000000
+  IL_0005:  stloc.s    V_6
+
+  IL_000e:  ldloca.s   V_2
+  IL_0010:  ldloca.s   V_6
+  IL_0012:  ldc.i4.4
+  IL_0013:  unaligned. 4
+  IL_0016:  cpblk
+
+  IL_0020:  ldloc.s    V_2              // 0.5 in FP representation
+  IL_0021:  ldc.i4     0x3f000000
+  IL_0022:  conv.r4                     // 1056964608 in integer representation
+  IL_0023:  ceq
+  IL_0024:  brtrue     IL_0031          // should not be equivalent
+
+  IL_0027:  ldc.i4.s   100
+  IL_0028:  ret
+
+  IL_0031:  ldc.i4.s   101
+  IL_0032:  ret
+
+} // end of global method main

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_216571/DevDiv_216571.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_216571/DevDiv_216571.ilproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_216571.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_216571/app.config
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_216571/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Value-numbering can assign the same value number to nodes
of different type as long as they have the same bit-representation.
However when substituting a constant into a tree node of different
type, we want the bit-exact representation and not the same value.
Assertion prop should reinterpret int/float value changes rather
than coercing them.

Add an il test that exposes a bug in assertionprop when doing
value-numbering based constant propagation. A cpblk can be used
to copy a scalar value between differing types but for which there
is no change in bit representation.

@schellap @briansull 
/cc @dotnet/jit-contrib 