### PR TITLE
ARM64: Fix Fold Type For optOptimizeBools

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -7962,7 +7962,11 @@ void                Compiler::optOptimizeBools()
                 continue;
             if (genTypeSize(t1->TypeGet()) != genTypeSize(t2->TypeGet()))
                 continue;
-
+#ifdef _TARGET_ARMARCH_
+            // Skip the small operand which we cannot encode.
+            if (varTypeIsSmall(c1->TypeGet()))
+                continue;
+#endif
             /* The second condition must not contain side effects */
 
             if  (c2->gtFlags & GTF_GLOB_EFFECT)


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/5955

When merging two boolean operations (cmp/jmp) in optOptimizeBools, JIT
creates type based on operand instead of tree.
Since there is case the operand is bool (1 byte) while tree type is int (4
byte), we should abide by tree type when creating a merged tree.
This passes all 1375 tests in System.Net.Http.Unit.Tests.