### PR TITLE
Scripts: move intermediate file into intermediate dir

### DIFF
--- a/definitionsconsistencycheck.cmake
+++ b/definitionsconsistencycheck.cmake
@@ -1,11 +1,11 @@
 get_directory_property( DirDefs COMPILE_DEFINITIONS )
 
 # Reset the definition file
-file(WRITE cmake.definitions "")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake.definitions "")
 foreach( d ${DirDefs} )
     if($ENV{VERBOSE})
         message( STATUS "Compiler Definition: " ${d} )
     endif($ENV{VERBOSE})
-    file(APPEND cmake.definitions ${d})
-    file(APPEND cmake.definitions "\n")
+    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/cmake.definitions ${d})
+    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/cmake.definitions "\n")
 endforeach()

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -183,8 +183,9 @@
     <Message Importance="High" Text="============" />
     <PropertyGroup>
       <IgnoreDefineConstants>FEATURE_IMPLICIT_TLS;FEATURE_HIJACK</IgnoreDefineConstants>
+      <CMakeDefinitionSaveFile>$(IntermediateOutputPath)\cmake.definitions</CMakeDefinitionSaveFile>
     </PropertyGroup>
-    <Exec Command='python $(MSBuildThisFileDirectory)../scripts/check-definitions.py $(MSBuildThisFileDirectory)../../cmake.definitions "$(DefineConstants)" "$(IgnoreDefineConstants)" ' />
+    <Exec Command='python $(MSBuildThisFileDirectory)..\scripts\check-definitions.py "$(CMakeDefinitionSaveFile)" "$(DefineConstants)" "$(IgnoreDefineConstants)" ' />
     <Message Importance="High" Text="============" />
   </Target>
 

--- a/src/scripts/check-definitions.py
+++ b/src/scripts/check-definitions.py
@@ -33,7 +33,12 @@ debug = 0
 # For the native part, return the sorted definition array.
 def loadDefinitionFile(filename):
     result = []
-    f = open(filename, 'r')
+    try:
+        f = open(filename, 'r')
+    except:
+        sys.exit(0)
+    # if cmake was not used (because of skipnative or systems that do not use cmake), this script won't work.
+
     for line in f:
         theLine = line.rstrip("\r\n").strip()
         if (len(theLine) > 0):


### PR DESCRIPTION
The intermediate file, cmake.definitions, is moved into
the intermediate directory: bin/obj/OS.Arch.Conf/

Fixes #5976

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>