### PR TITLE
ARM-CI: Prevent creation of job for Checked configuration (rebased over #5961)

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1257,6 +1257,11 @@ combinedScenarios.each { scenario ->
                     // The tuples (LinuxARMEmulator, other architectures) are not handled and control returns
                     def isLinuxEmulatorBuild = false
                     if (os == 'LinuxARMEmulator' && architecture == 'arm') {
+                        // Cross Builds only in Debug and Release modes allowed
+                        if ( configuration == 'Checked' ) {
+                            return
+                        }
+
                         isLinuxEmulatorBuild = true
                         os = 'Ubuntu'
                     } else if (os == 'LinuxARMEmulator') {
@@ -1761,10 +1766,8 @@ combinedScenarios.each { scenario ->
                                         break
                                     }
                                     else {
-                                        // Build only for Debug or Release
-                                        if ( lowerConfiguration != 'debug' && lowerConfiguration != 'release' ) {
-                                            break
-                                        }
+                                        // Make sure the build configuration is either of debug or release
+                                        assert ( lowerConfiguration == 'debug' ) || ( lowerConfiguration == 'release' )
 
                                         // Setup variables to hold emulator folder path and the rootfs mount path
                                         def armemul_path = '/opt/linux-arm-emulator'


### PR DESCRIPTION
Previously we checked if the configuration being built is either of Debug or Release
after the job had already been created. This resulted in a job being created for
Checked configuration with no commands to execute (for this job).
We prevent the unnecessary creation of job for the Checked configuration by
returning control at the very beginning of the <LinuxARMEmulator, arm, Checked> iteration

This PR is the same as #5945 but rebased over PR #5961 

Signed-off-by: Prajwal A N <an.prajwal@samsung.com>