### PR TITLE
Use BIT64 define for 64-bit specific code.

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -57,20 +57,20 @@
     <PlatformTarget>x64</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
     <BaseAddress>0x180000000</BaseAddress>
-    <DefineConstants>WIN64;AMD64;$(DefineConstants)</DefineConstants>
+    <DefineConstants>BIT64;AMD64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
     <PlatformTarget>x86</PlatformTarget>
     <BaseAddress>0x10000000</BaseAddress>
-    <DefineConstants>WIN32;$(DefineConstants)</DefineConstants>
+    <DefineConstants>BIT32;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'arm'">
     <PlatformTarget>arm</PlatformTarget>
-    <DefineConstants>WIN32;ARM;$(DefineConstants)</DefineConstants>
+    <DefineConstants>BIT32;ARM;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'arm64'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DefineConstants>WIN64;ARM64;$(DefineConstants)</DefineConstants>
+    <DefineConstants>BIT64;ARM64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   
   <!-- Configuration specific properties -->

--- a/src/mscorlib/src/System/BCLDebug.cs
+++ b/src/mscorlib/src/System/BCLDebug.cs
@@ -408,20 +408,20 @@ namespace System {
 #endif
         }
 
-#if WIN32
+#if !BIT64 // 32
         [SecuritySafeCritical]
 #endif
         internal static bool CorrectnessEnabled()
         {
-#if WIN32
+#if BIT64
+            return false;
+#else // 32
             if (AppDomain.CurrentDomain.IsUnloadingForcedFinalize())
                 return false;
             if (!m_registryChecked)
                 CheckRegistry();
             return m_correctnessWarnings;  
-#else 
-            return false;
-#endif // WIN32
+#endif // BIT64
         }
 
         // Whether SafeHandles include a stack trace showing where they 

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -264,7 +264,7 @@ namespace System {
         // This method has different signature for x64 and other platforms and is done for performance reasons.
         [System.Security.SecurityCritical]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#if WIN64
+#if BIT64
         internal unsafe static void Memmove(byte* dest, byte* src, ulong len)
 #else
         internal unsafe static void Memmove(byte* dest, byte* src, uint len)
@@ -272,7 +272,7 @@ namespace System {
         {
             // P/Invoke into the native version when the buffers are overlapping and the copy needs to be performed backwards
             // This check can produce false positives for lengths greater than Int32.MaxInt. It is fine because we want to use PInvoke path for the large lengths anyway.
-#if WIN64
+#if BIT64
             if ((ulong)dest - (ulong)src < len) goto PInvoke;
 #else
             if (((uint)dest - (uint)src) < len) goto PInvoke;
@@ -315,7 +315,7 @@ namespace System {
                 *(dest + 6) = *(src + 6);
                 return;
             case 8:
-#if WIN64
+#if BIT64
                 *(long*)dest = *(long*)src;
 #else
                 *(int*)dest = *(int*)src;
@@ -323,7 +323,7 @@ namespace System {
 #endif
                 return;
             case 9:
-#if WIN64
+#if BIT64
                 *(long*)dest = *(long*)src;
 #else
                 *(int*)dest = *(int*)src;
@@ -332,7 +332,7 @@ namespace System {
                 *(dest + 8) = *(src + 8);
                 return;
             case 10:
-#if WIN64
+#if BIT64
                 *(long*)dest = *(long*)src;
 #else
                 *(int*)dest = *(int*)src;
@@ -341,7 +341,7 @@ namespace System {
                 *(short*)(dest + 8) = *(short*)(src + 8);
                 return;
             case 11:
-#if WIN64
+#if BIT64
                 *(long*)dest = *(long*)src;
 #else
                 *(int*)dest = *(int*)src;
@@ -351,7 +351,7 @@ namespace System {
                 *(dest + 10) = *(src + 10);
                 return;
             case 12:
-#if WIN64
+#if BIT64
                 *(long*)dest = *(long*)src;
 #else
                 *(int*)dest = *(int*)src;
@@ -360,7 +360,7 @@ namespace System {
                 *(int*)(dest + 8) = *(int*)(src + 8);
                 return;
             case 13:
-#if WIN64
+#if BIT64
                 *(long*)dest = *(long*)src;
 #else
                 *(int*)dest = *(int*)src;
@@ -370,7 +370,7 @@ namespace System {
                 *(dest + 12) = *(src + 12);
                 return;
             case 14:
-#if WIN64
+#if BIT64
                 *(long*)dest = *(long*)src;
 #else
                 *(int*)dest = *(int*)src;
@@ -380,7 +380,7 @@ namespace System {
                 *(short*)(dest + 12) = *(short*)(src + 12);
                 return;
             case 15:
-#if WIN64
+#if BIT64
                 *(long*)dest = *(long*)src;
 #else
                 *(int*)dest = *(int*)src;
@@ -391,7 +391,7 @@ namespace System {
                 *(dest + 14) = *(src + 14);
                 return;
             case 16:
-#if WIN64
+#if BIT64
                 *(long*)dest = *(long*)src;
                 *(long*)(dest + 8) = *(long*)(src + 8);
 #else
@@ -426,7 +426,7 @@ namespace System {
             Aligned: ;
             }
 
-#if WIN64
+#if BIT64
             if (((int)dest & 4) != 0)
             {
                 *(int *)dest = *(int *)src;
@@ -436,14 +436,14 @@ namespace System {
             }
 #endif
 
-#if WIN64
+#if BIT64
             ulong count = len / 16;
 #else
             uint count = len / 16;
 #endif
             while (count > 0)
             {
-#if WIN64
+#if BIT64
                 ((long*)dest)[0] = ((long*)src)[0];
                 ((long*)dest)[1] = ((long*)src)[1];
 #else
@@ -459,7 +459,7 @@ namespace System {
 
             if ((len & 8) != 0)
             {
-#if WIN64
+#if BIT64
                 ((long*)dest)[0] = ((long*)src)[0];
 #else
                 ((int*)dest)[0] = ((int*)src)[0];
@@ -495,7 +495,7 @@ namespace System {
         [SecurityCritical]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-#if WIN64
+#if BIT64
         private unsafe static void _Memmove(byte* dest, byte* src, ulong len)
 #else
         private unsafe static void _Memmove(byte* dest, byte* src, uint len)
@@ -508,7 +508,7 @@ namespace System {
         [SuppressUnmanagedCodeSecurity]
         [SecurityCritical]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#if WIN64
+#if BIT64
         extern private unsafe static void __Memmove(byte* dest, byte* src, ulong len);
 #else
         extern private unsafe static void __Memmove(byte* dest, byte* src, uint len);
@@ -526,11 +526,11 @@ namespace System {
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.sourceBytesToCopy);
             }
-#if WIN64
+#if BIT64
             Memmove((byte*)destination, (byte*)source, checked((ulong) sourceBytesToCopy));
 #else
             Memmove((byte*)destination, (byte*)source, checked((uint)sourceBytesToCopy));
-#endif // WIN64
+#endif // BIT64
         }
 
 
@@ -545,11 +545,11 @@ namespace System {
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.sourceBytesToCopy);
             }
-#if WIN64
+#if BIT64
             Memmove((byte*)destination, (byte*)source, sourceBytesToCopy);
 #else
             Memmove((byte*)destination, (byte*)source, checked((uint)sourceBytesToCopy));
-#endif // WIN64
+#endif // BIT64
         }
     }
 }

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -1324,10 +1324,10 @@ namespace System {
 
         public static bool Is64BitProcess {
             get {
-#if WIN32
-                    return false;
-#else
+#if BIT64
                     return true;
+#else // 32
+                    return false;
 #endif
             }
         }
@@ -1335,14 +1335,14 @@ namespace System {
         public static bool Is64BitOperatingSystem {
             [System.Security.SecuritySafeCritical]
             get {
-#if WIN32
+#if BIT64
+                    // 64-bit programs run only on 64-bit
+                    return true;
+#else // 32
                     bool isWow64; // WinXP SP2+ and Win2k3 SP1+
                     return Win32Native.DoesWin32MethodExist(Win32Native.KERNEL32, "IsWow64Process")
                         && Win32Native.IsWow64Process(Win32Native.GetCurrentProcess(), out isWow64)
                         && isWow64;
-#else
-                    // 64-bit programs run only on 64-bit
-                    return true;
 #endif
             }
         }

--- a/src/mscorlib/src/System/Globalization/CharUnicodeInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CharUnicodeInfo.cs
@@ -256,7 +256,7 @@ namespace System.Globalization {
             index = s_pNumericLevel1Index[index + ((ch >> 4) & 0x000f)];
             byte* pBytePtr = (byte*)&(s_pNumericLevel1Index[index]);
             // Get the result from the 0 -3 bit of ch.
-#if WIN64
+#if BIT64
             // To get around the IA64 alignment issue.  Our double data is aligned in 8-byte boundary, but loader loads the embeded table starting
             // at 4-byte boundary.  This cause a alignment issue since double is 8-byte.
             byte* pSourcePtr = &(s_pNumericValues[pBytePtr[(ch & 0x000f)] * sizeof(double)]);

--- a/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
@@ -323,7 +323,7 @@ namespace System.IO {
                 Contract.EndContractBlock();
                 if (!CanSeek) __Error.StreamIsClosed();
                 
-#if WIN32
+#if !BIT64
                 unsafe {
                     // On 32 bit machines, ensure we don't wrap around.
                     if (value > (long) Int32.MaxValue || _mem + value < _mem)

--- a/src/mscorlib/src/System/IntPtr.cs
+++ b/src/mscorlib/src/System/IntPtr.cs
@@ -45,10 +45,10 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public unsafe IntPtr(int value)
         {
-            #if WIN32
-                m_value = (void *)value;
-            #else
+            #if BIT64
                 m_value = (void *)(long)value;
+            #else // !BIT64 (32)
+                m_value = (void *)value;
             #endif
         }
     
@@ -57,10 +57,10 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public unsafe IntPtr(long value)
         {
-            #if WIN32
-                m_value = (void *)checked((int)value);
-            #else
+            #if BIT64
                 m_value = (void *)value;
+            #else // !BIT64 (32)
+                m_value = (void *)checked((int)value);
             #endif
         }
 
@@ -91,10 +91,10 @@ namespace System {
                 throw new ArgumentNullException("info");
             }
             Contract.EndContractBlock();
-            #if WIN32
-                info.AddValue("value", (long)((int)m_value));
-            #else
+            #if BIT64
                 info.AddValue("value", (long)(m_value));
+            #else // !BIT64 (32)
+                info.AddValue("value", (long)((int)m_value));
             #endif
         }
 #endif
@@ -110,11 +110,11 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override int GetHashCode() {
 #if FEATURE_CORECLR
-    #if WIN32
-            return unchecked((int)m_value);
-    #else
+    #if BIT64
             long l = (long)m_value;
             return (unchecked((int)l) ^ (int)(l >> 32));
+    #else // !BIT64 (32)
+            return unchecked((int)m_value);
     #endif
 #else
             return unchecked((int)((long)m_value));
@@ -125,11 +125,11 @@ namespace System {
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [System.Runtime.Versioning.NonVersionable]
         public unsafe int ToInt32() {
-            #if WIN32
-                return (int)m_value;
-            #else
+            #if BIT64
                 long l = (long)m_value;
                 return checked((int)l);
+            #else // !BIT64 (32)
+                return (int)m_value;
             #endif
         }
 
@@ -137,19 +137,19 @@ namespace System {
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [System.Runtime.Versioning.NonVersionable]
         public unsafe long ToInt64() {
-            #if WIN32
-                return (long)(int)m_value;
-            #else
+            #if BIT64
                 return (long)m_value;
+            #else // !BIT64 (32)
+                return (long)(int)m_value;
             #endif
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override String ToString() {
-            #if WIN32
-                return ((int)m_value).ToString(CultureInfo.InvariantCulture);
-            #else
+            #if BIT64
                 return ((long)m_value).ToString(CultureInfo.InvariantCulture);
+            #else // !BIT64 (32)
+                return ((int)m_value).ToString(CultureInfo.InvariantCulture);
             #endif
         }
 
@@ -158,10 +158,10 @@ namespace System {
         {
             Contract.Ensures(Contract.Result<String>() != null);
 
-            #if WIN32
-                return ((int)m_value).ToString(format, CultureInfo.InvariantCulture);
-            #else
+            #if BIT64
                 return ((long)m_value).ToString(format, CultureInfo.InvariantCulture);
+            #else // !BIT64 (32)
+                return ((int)m_value).ToString(format, CultureInfo.InvariantCulture);
             #endif
         }
 
@@ -200,11 +200,11 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public unsafe static explicit operator int (IntPtr  value) 
         {
-            #if WIN32
-                return (int)value.m_value;
-            #else
+            #if BIT64
                 long l = (long)value.m_value;
                 return checked((int)l);
+            #else // !BIT64 (32)
+                return (int)value.m_value;
             #endif
         }
 
@@ -212,10 +212,10 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public unsafe static explicit operator long (IntPtr  value) 
         {
-            #if WIN32
-                return (long)(int)value.m_value;
-            #else
+            #if BIT64
                 return (long)value.m_value;
+            #else // !BIT64 (32)
+                return (long)(int)value.m_value;
             #endif
         }
 
@@ -246,10 +246,10 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public static IntPtr operator +(IntPtr pointer, int offset) 
         {
-            #if WIN32
-                return new IntPtr(pointer.ToInt32() + offset);
-            #else
+            #if BIT64
                 return new IntPtr(pointer.ToInt64() + offset);
+            #else // !BIT64 (32)
+                return new IntPtr(pointer.ToInt32() + offset);
             #endif
         }
 
@@ -262,10 +262,10 @@ namespace System {
         [ReliabilityContract(Consistency.MayCorruptInstance, Cer.MayFail)]
         [System.Runtime.Versioning.NonVersionable]
         public static IntPtr operator -(IntPtr pointer, int offset) {
-            #if WIN32
-                return new IntPtr(pointer.ToInt32() - offset);
-            #else
+            #if BIT64
                 return new IntPtr(pointer.ToInt64() - offset);
+            #else // !BIT64 (32)
+                return new IntPtr(pointer.ToInt32() - offset);
             #endif
         }
 
@@ -276,10 +276,10 @@ namespace System {
             [System.Runtime.Versioning.NonVersionable]
             get
             {
-                #if WIN32
-                    return 4;
-                #else
+                #if BIT64
                     return 8;
+                #else // !BIT64 (32)
+                    return 4;
                 #endif
             }
         }

--- a/src/mscorlib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -171,11 +171,11 @@ namespace System.Runtime.CompilerServices {
                 // after the sync block, so don't count that.  
                 // This property allows C#'s fixed statement to work on Strings.
                 // On 64 bit platforms, this should be 12 (8+4) and on 32 bit 8 (4+4).
-#if WIN32
-                return 8;
-#else
+#if BIT64
                 return 12;
-#endif // WIN32
+#else // 32
+                return 8;
+#endif // BIT64
             }
         }
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/GcHandle.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/GcHandle.cs
@@ -119,10 +119,10 @@ namespace System.Runtime.InteropServices
                     s_cookieTable.RemoveHandleIfPresent(handle);
 #endif
 
-#if WIN32
-                InternalFree((IntPtr)(((int)handle) & ~1));
-#else
+#if BIT64
                 InternalFree((IntPtr)(((long)handle) & ~1L));
+#else // BIT64 (32)
+                InternalFree((IntPtr)(((int)handle) & ~1));
 #endif
             }
             else
@@ -267,28 +267,28 @@ namespace System.Runtime.InteropServices
 
         internal IntPtr GetHandleValue()
         {
-#if WIN32
-            return new IntPtr(((int)m_handle) & ~1);
-#else
+#if BIT64
             return new IntPtr(((long)m_handle) & ~1L);
+#else // !BIT64 (32)
+            return new IntPtr(((int)m_handle) & ~1);
 #endif
         }
 
         internal bool IsPinned()
         {
-#if WIN32
-            return (((int)m_handle) & 1) != 0;
-#else
+#if BIT64
             return (((long)m_handle) & 1) != 0;
+#else // !BIT64 (32)
+            return (((int)m_handle) & 1) != 0;
 #endif
         }
 
         internal void SetIsPinned()
         {
-#if WIN32
-            m_handle = new IntPtr(((int)m_handle) | 1);
-#else
+#if BIT64
             m_handle = new IntPtr(((long)m_handle) | 1L);
+#else // !BIT64 (32)
+            m_handle = new IntPtr(((int)m_handle) | 1);
 #endif
         }
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -568,10 +568,10 @@ namespace System.Runtime.InteropServices
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         public static IntPtr ReadIntPtr([MarshalAs(UnmanagedType.AsAny),In] Object ptr, int ofs)
         {
-            #if WIN32
-                return (IntPtr) ReadInt32(ptr, ofs);
-            #else
+            #if BIT64
                 return (IntPtr) ReadInt64(ptr, ofs);
+            #else // 32
+                return (IntPtr) ReadInt32(ptr, ofs);
             #endif
         }
 
@@ -579,10 +579,10 @@ namespace System.Runtime.InteropServices
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         public static IntPtr ReadIntPtr(IntPtr ptr, int ofs)
         {
-            #if WIN32
-                return (IntPtr) ReadInt32(ptr, ofs);
-            #else
+            #if BIT64
                 return (IntPtr) ReadInt64(ptr, ofs);
+            #else // 32
+                return (IntPtr) ReadInt32(ptr, ofs);
             #endif
         }
     
@@ -590,10 +590,10 @@ namespace System.Runtime.InteropServices
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         public static IntPtr ReadIntPtr(IntPtr ptr)
         {
-            #if WIN32
-                return (IntPtr) ReadInt32(ptr, 0);
-            #else
+            #if BIT64
                 return (IntPtr) ReadInt64(ptr, 0);
+            #else // 32
+                return (IntPtr) ReadInt32(ptr, 0);
             #endif
         }
 
@@ -798,30 +798,30 @@ namespace System.Runtime.InteropServices
         [System.Security.SecurityCritical]  // auto-generated_required
         public static void WriteIntPtr(IntPtr ptr, int ofs, IntPtr val)
         {
-            #if WIN32
-                WriteInt32(ptr, ofs, (int)val);
-            #else
+            #if BIT64
                 WriteInt64(ptr, ofs, (long)val);
+            #else // 32
+                WriteInt32(ptr, ofs, (int)val);
             #endif
         }
         
         [System.Security.SecurityCritical]  // auto-generated_required
         public static void WriteIntPtr([MarshalAs(UnmanagedType.AsAny),In,Out] Object ptr, int ofs, IntPtr val)
         {
-            #if WIN32
-                WriteInt32(ptr, ofs, (int)val);
-            #else
+            #if BIT64
                 WriteInt64(ptr, ofs, (long)val);
+            #else // 32
+                WriteInt32(ptr, ofs, (int)val);
             #endif
         }
         
         [System.Security.SecurityCritical]  // auto-generated_required
         public static void WriteIntPtr(IntPtr ptr, IntPtr val)
         {
-            #if WIN32
-                WriteInt32(ptr, 0, (int)val);
-            #else
+            #if BIT64
                 WriteInt64(ptr, 0, (long)val);
+            #else // 32
+                WriteInt32(ptr, 0, (int)val);
             #endif
         }
 
@@ -1218,10 +1218,10 @@ namespace System.Runtime.InteropServices
             // though I couldn't reproduce that.  In either case, that means we should continue
             // throwing an OOM instead of an ArgumentOutOfRangeException for "negative" amounts of memory.
             UIntPtr numBytes;
-#if WIN32
-            numBytes = new UIntPtr(unchecked((uint)cb.ToInt32()));
-#else
+#if BIT64
             numBytes = new UIntPtr(unchecked((ulong)cb.ToInt64()));
+#else // 32
+            numBytes = new UIntPtr(unchecked((uint)cb.ToInt32()));
 #endif
 
             IntPtr pNewMem = Win32Native.LocalAlloc_NoSafeHandle(LMEM_FIXED, unchecked(numBytes));

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/NativeMethods.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/NativeMethods.cs
@@ -10,7 +10,7 @@ using System.Security;
 
 namespace System.Runtime.InteropServices.WindowsRuntime
 {
-#if WIN64
+#if BIT64
     [StructLayout(LayoutKind.Explicit, Size = 24)]
 #else
     [StructLayout(LayoutKind.Explicit, Size = 20)]

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -169,7 +169,7 @@ namespace System {
         }
 
 
-#if WIN64
+#if BIT64
         private const int charPtrAlignConst = 3;
         private const int alignConst        = 7;
 #else
@@ -358,7 +358,7 @@ namespace System {
                 char* a = ap;
                 char* b = bp;
 
-#if WIN64
+#if BIT64
                 // Single int read aligns pointers for the following long reads
                 // PERF: No length check needed as there is always an int32 worth of string allocated
                 //       This read can also include the null terminator which both strings will have
@@ -420,7 +420,7 @@ namespace System {
                 char* a = ap;
                 char* b = bp;
 
-#if WIN64
+#if BIT64
                 // Single int read aligns pointers for the following long reads
                 // No length check needed as this method is called when length >= 2
                 Contract.Assert(length >= 2);
@@ -868,14 +868,24 @@ namespace System {
                     Contract.Assert(src[this.Length] == '\0', "src[this.Length] == '\\0'");
                     Contract.Assert( ((int)src)%4 == 0, "Managed string should start at 4 bytes boundary");
 
-#if WIN32
-                    int hash1 = (5381<<16) + 5381;
-#else
+#if BIT64
                     int hash1 = 5381;
+#else // !BIT64 (32)
+                    int hash1 = (5381<<16) + 5381;
 #endif
                     int hash2 = hash1;
-
-#if WIN32
+#if BIT64
+                    int     c;
+                    char *s = src;
+                    while ((c = s[0]) != 0) {
+                        hash1 = ((hash1 << 5) + hash1) ^ c;
+                        c = s[1];
+                        if (c == 0)
+                            break;
+                        hash2 = ((hash2 << 5) + hash2) ^ c;
+                        s += 2;
+                    }
+#else // !BIT64 (32)
                     // 32 bit machines.
                     int* pint = (int *)src;
                     int len = this.Length;
@@ -890,17 +900,6 @@ namespace System {
                     if (len > 0)
                     {
                         hash1 = ((hash1 << 5) + hash1 + (hash1 >> 27)) ^ pint[0];
-                    }
-#else
-                    int     c;
-                    char *s = src;
-                    while ((c = s[0]) != 0) {
-                        hash1 = ((hash1 << 5) + hash1) ^ c;
-                        c = s[1];
-                        if (c == 0)
-                            break;
-                        hash2 = ((hash2 << 5) + hash2) ^ c;
-                        s += 2;
                     }
 #endif
 #if DEBUG
@@ -924,15 +923,25 @@ namespace System {
                 fixed (char* src = &m_firstChar) {
                     Contract.Assert(src[this.Length] == '\0', "src[this.Length] == '\\0'");
                     Contract.Assert( ((int)src)%4 == 0, "Managed string should start at 4 bytes boundary");
-
-#if WIN32
-                    int hash1 = (5381<<16) + 5381;
-#else
+#if BIT64
                     int hash1 = 5381;
+#else // !BIT64 (32)
+                    int hash1 = (5381<<16) + 5381;
 #endif
                     int hash2 = hash1;
 
-#if WIN32
+#if BIT64
+                    int     c;
+                    char *s = src;
+                    while ((c = s[0]) != 0) {
+                        hash1 = ((hash1 << 5) + hash1) ^ c;
+                        c = s[1];
+                        if (c == 0)
+                            break;
+                        hash2 = ((hash2 << 5) + hash2) ^ c;
+                        s += 2;
+                    }
+#else // !BIT64 (32)
                     // 32 bit machines.
                     int* pint = (int *)src;
                     int len = this.Length;
@@ -947,17 +956,6 @@ namespace System {
                     if (len > 0)
                     {
                         hash1 = ((hash1 << 5) + hash1 + (hash1 >> 27)) ^ pint[0];
-                    }
-#else
-                    int     c;
-                    char *s = src;
-                    while ((c = s[0]) != 0) {
-                        hash1 = ((hash1 << 5) + hash1) ^ c;
-                        c = s[1];
-                        if (c == 0)
-                            break;
-                        hash2 = ((hash2 << 5) + hash2) ^ c;
-                        s += 2;
                     }
 #endif
 #if DEBUG

--- a/src/mscorlib/src/System/StubHelpers.cs
+++ b/src/mscorlib/src/System/StubHelpers.cs
@@ -1575,7 +1575,7 @@ namespace  System.StubHelpers {
         // but on ARM it will allow us to correctly determine the layout of native argument lists containing
         // VARIANTs). Note that the field names here don't matter: none of the code refers to these fields,
         // the structure just exists to provide size information to the IL marshaler.
-#if WIN64
+#if BIT64
         IntPtr data1;
         IntPtr data2;
 #else
@@ -1583,7 +1583,7 @@ namespace  System.StubHelpers {
 #endif
     }  // struct NativeVariant
 
-#if !WIN64 && !FEATURE_CORECLR
+#if !BIT64 && !FEATURE_CORECLR
     // Structure filled by IL stubs if copy constructor(s) and destructor(s) need to be called
     // on value types pushed on the stack. The structure is stored in s_copyCtorStubDesc by
     // SetCopyCtorCookieChain and fetched by CopyCtorCallStubWorker. Must be stack-allocated.
@@ -1619,7 +1619,7 @@ namespace  System.StubHelpers {
         public IntPtr m_pCookie;
         public IntPtr m_pTarget;
     }  // struct CopyCtorStubDes
-#endif // !WIN64 && !FEATURE_CORECLR
+#endif // !BIT64 && !FEATURE_CORECLR
 
     // Aggregates SafeHandle and the "owned" bit which indicates whether the SafeHandle
     // has been successfully AddRef'ed. This allows us to do realiable cleanup (Release)
@@ -1679,7 +1679,7 @@ namespace  System.StubHelpers {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         static internal extern IntPtr GetDelegateTarget(Delegate pThis, ref IntPtr pStubArg);
 
-#if !WIN64 && !FEATURE_CORECLR
+#if !BIT64 && !FEATURE_CORECLR
         // Written to by a managed stub helper, read by CopyCtorCallStubWorker in VM.
         [ThreadStatic]
         static CopyCtorStubDesc s_copyCtorStubDesc;
@@ -1695,7 +1695,7 @@ namespace  System.StubHelpers {
         // Returns the final unmanaged stub target, ignores interceptors.
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         static internal extern IntPtr GetFinalStubTarget(IntPtr pStubArg, IntPtr pUnmngThis, int dwStubFlags);
-#endif // !FEATURE_CORECLR && !WIN64
+#endif // !FEATURE_CORECLR && !BIT64
 
 #if !FEATURE_CORECLR
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -1934,10 +1934,10 @@ namespace  System.StubHelpers {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         static internal extern IntPtr GetStubContext();
 
-#if WIN64
+#if BIT64
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         static internal extern IntPtr GetStubContextAddr();
-#endif // WIN64
+#endif // BIT64
 
 #if MDA_SUPPORTED
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -633,7 +633,7 @@ namespace System.Text
                     byteCount++;
                 }
 
-#if WIN64
+#if BIT64
                 // check for overflow
                 if (byteCount < 0) {
                     break;
@@ -666,7 +666,7 @@ namespace System.Text
                     break;
                 }
 
-#if WIN64
+#if BIT64
                 // make sure that we won't get a silent overflow inside the fast loop
                 // (Fall out to slow loop if we have this many characters)
                 availableChars &= 0x0FFFFFFF;
@@ -801,7 +801,7 @@ namespace System.Text
                 ch = 0;
             }
 
-#if WIN64
+#if BIT64
             // check for overflow
             if (byteCount < 0) {
                 throw new ArgumentException(

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -499,7 +499,7 @@ namespace System.Text
                     if ( !bigEndian &&
 #endif // BIGENDIAN
 
-#if WIN64           // 64 bit CPU needs to be long aligned for this to work.
+#if BIT64           // 64 bit CPU needs to be long aligned for this to work.
                           charLeftOver == 0 && (unchecked((long)chars) & 7) == 0)
 #else
                           charLeftOver == 0 && (unchecked((int)chars) & 3) == 0)
@@ -782,11 +782,11 @@ namespace System.Text
 #else
                     if ( !bigEndian &&
 #endif // BIGENDIAN
-#if WIN64           // 64 bit CPU needs to be long aligned for this to work, 32 bit CPU needs to be 32 bit aligned
+#if BIT64           // 64 bit CPU needs to be long aligned for this to work, 32 bit CPU needs to be 32 bit aligned
                         (unchecked((long)chars) & 7) == 0 && (unchecked((long)bytes) & 7) == 0 &&
 #else
                         (unchecked((int)chars) & 3) == 0 && (unchecked((int)bytes) & 3) == 0 &&
-#endif // WIN64
+#endif // BIT64
                         charLeftOver == 0)
                     {
                         // Need -1 to check 2 at a time.  If we have an even #, longChars will go
@@ -868,11 +868,11 @@ namespace System.Text
                         !bigEndian &&
 #endif // BIGENDIAN
 
-#if WIN64
+#if BIT64
                         (unchecked((long)chars) & 7) != (unchecked((long)bytes) & 7) &&  // Only do this if chars & bytes are out of line, otherwise faster loop'll be faster next time
 #else
                         (unchecked((int)chars) & 3) != (unchecked((int)bytes) & 3) &&  // Only do this if chars & bytes are out of line, otherwise faster loop'll be faster next time
-#endif // WIN64
+#endif // BIT64
                         (unchecked((int)(bytes)) & 1) == 0 )
                     {
                         // # to use
@@ -1204,11 +1204,11 @@ namespace System.Text
 #else // BIGENDIAN
                 if (!bigEndian &&
 #endif // BIGENDIAN
-#if WIN64 // win64 has to be long aligned
+#if BIT64 // win64 has to be long aligned
                     (unchecked((long)bytes) & 7) == 0 &&
 #else
                     (unchecked((int)bytes) & 3) == 0 &&
-#endif // WIN64
+#endif // BIT64
                     lastByte == -1 && lastChar == 0)
                 {
                     // Need new char* so we can check 4 at a time
@@ -1531,11 +1531,11 @@ namespace System.Text
 #else // BIGENDIAN
                 if (!bigEndian &&
 #endif // BIGENDIAN
-#if WIN64 // win64 has to be long aligned
+#if BIT64 // win64 has to be long aligned
                     (unchecked((long)chars) & 7) == 0 && (unchecked((long)bytes) & 7) == 0 &&
 #else
                     (unchecked((int)chars) & 3) == 0 && (unchecked((int)bytes) & 3) == 0 &&
-#endif // WIN64
+#endif // BIT64
                     lastByte == -1 && lastChar == 0)
                 {
                     // Need -1 to check 2 at a time.  If we have an even #, longChars will go

--- a/src/mscorlib/src/System/Threading/Volatile.cs
+++ b/src/mscorlib/src/System/Threading/Volatile.cs
@@ -113,7 +113,7 @@ namespace System.Threading
             return value;
         }
 
-#if WIN64
+#if BIT64
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [System.Runtime.Versioning.NonVersionable]
         public static long Read(ref long location)
@@ -317,7 +317,7 @@ namespace System.Threading
             location = value;
         }
 
-#if WIN64
+#if BIT64
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [System.Runtime.Versioning.NonVersionable]
         public static void Write(ref long location, long value)

--- a/src/mscorlib/src/System/UIntPtr.cs
+++ b/src/mscorlib/src/System/UIntPtr.cs
@@ -41,10 +41,10 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public unsafe UIntPtr(ulong value)
         {
-#if WIN32
-            m_value = (void*)checked((uint)value);
-#else
+#if BIT64
             m_value = (void *)value;
+#else // 32
+            m_value = (void*)checked((uint)value);
 #endif
         }
 
@@ -90,11 +90,11 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override int GetHashCode() {
 #if FEATURE_CORECLR
-    #if WIN32
-            return unchecked((int)m_value);
-    #else
+    #if BIT64
             ulong l = (ulong)m_value;
             return (unchecked((int)l) ^ (int)(l >> 32));
+    #else // 32
+            return unchecked((int)m_value);
     #endif
 #else
             return unchecked((int)((long)m_value)) & 0x7fffffff;
@@ -104,10 +104,10 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.Versioning.NonVersionable]
         public unsafe uint ToUInt32() {
-#if WIN32
-            return (uint)m_value;
-#else
+#if BIT64
             return checked((uint)m_value);
+#else // 32
+            return (uint)m_value;
 #endif
         }
 
@@ -121,10 +121,10 @@ namespace System {
         public unsafe override String ToString() {
             Contract.Ensures(Contract.Result<String>() != null);
 
-#if WIN32
-            return ((uint)m_value).ToString(CultureInfo.InvariantCulture);
-#else
+#if BIT64
             return ((ulong)m_value).ToString(CultureInfo.InvariantCulture);
+#else // 32
+            return ((uint)m_value).ToString(CultureInfo.InvariantCulture);
 #endif
         }
 
@@ -144,10 +144,10 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public unsafe static explicit operator uint(UIntPtr value)
         {
-#if WIN32
-            return (uint)value.m_value;
-#else
+#if BIT64
             return checked((uint)value.m_value);
+#else // 32
+            return (uint)value.m_value;
 #endif
         }   
 
@@ -197,10 +197,10 @@ namespace System {
 
         [System.Runtime.Versioning.NonVersionable]
         public static UIntPtr operator +(UIntPtr pointer, int offset) {
-            #if WIN32
-                return new UIntPtr(pointer.ToUInt32() + (uint)offset);
-            #else
+            #if BIT64
                 return new UIntPtr(pointer.ToUInt64() + (ulong)offset);
+            #else // 32
+                return new UIntPtr(pointer.ToUInt32() + (uint)offset);
             #endif
         }
 
@@ -211,10 +211,10 @@ namespace System {
 
         [System.Runtime.Versioning.NonVersionable]
         public static UIntPtr operator -(UIntPtr pointer, int offset) {
-            #if WIN32
-                return new UIntPtr(pointer.ToUInt32() - (uint)offset);
-            #else
+            #if BIT64
                 return new UIntPtr(pointer.ToUInt64() - (ulong)offset);
+            #else // 32
+                return new UIntPtr(pointer.ToUInt32() - (uint)offset);
             #endif
         }
 
@@ -223,10 +223,10 @@ namespace System {
             [System.Runtime.Versioning.NonVersionable]
             get
             {
-#if WIN32
-                return 4;
-#else
+#if BIT64
                 return 8;
+#else // 32
+                return 4;
 #endif
             }
         }


### PR DESCRIPTION
Using WIN32/WIN64 for 32/64-bit architecture dependent code confuses
developers especially those who develop coreclr for non-Windows
systems. Therefore, such definitions are modified to BIT64.

Fixes #4737

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>