### PR TITLE
Fix typo to apply mac build workaround only on OSX

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -69,7 +69,7 @@ esac
 initDistroName $OS
 
 # Work around mac build issue 
-if [ "$OS"=="OSX" ]; then
+if [ "$OS" == "OSX" ]; then
   echo Raising file open limit - otherwise Mac build may fail
   echo ulimit -n 2048
   ulimit -n 2048


### PR DESCRIPTION
init-tools.sh tries to compare strings like this:
` 72 if [ "$OS"=="OSX" ]; then`
` 73   echo Raising file open limit - otherwise Mac build may fail`
` 74   echo ulimit -n 2048`
` 75   ulimit -n 2048`
` 76 fi`

What it actually does is different to what it looks like:
`$ echo $OS`
`$ if [ "$OS"=="OSX" ]; then echo EQUAL; fi`
`EQUAL`
`$ if [ "$OS" == "OSX" ]; then echo EQUAL; fi`
`$ `
`$ OS=Linux`
`$ if [ "$OS"=="OSX" ]; then echo EQUAL; fi`
`EQUAL`
`$ if [ "$OS" == "OSX" ]; then echo EQUAL; fi`

This PR fixes the typo and makes OSX workaround run on macs only.