### PR TITLE
Incremental work on ReturnTypeDesc for multiReg return support

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -186,7 +186,7 @@ void                CodeGen::genEmitGSCookieCheck(bool pushReg)
         if (compiler->compMethodReturnsMultiRegRetType())
         {
             ReturnTypeDesc retTypeDesc;
-            retTypeDesc.Initialize(compiler, compiler->info.compMethodInfo->args.retTypeClass);
+            retTypeDesc.InitializeReturnType(compiler, compiler->info.compMethodInfo->args.retTypeClass);
             unsigned regCount = retTypeDesc.GetReturnRegCount();
 
             // Only x86 and x64 Unix ABI allows multi-reg return and
@@ -1516,7 +1516,7 @@ CodeGen::genStructReturn(GenTreePtr treeNode)
         assert(varDsc->lvIsMultiRegArgOrRet);
 
         ReturnTypeDesc retTypeDesc;
-        retTypeDesc.Initialize(compiler, varDsc->lvVerTypeInfo.GetClassHandle());
+        retTypeDesc.InitializeReturnType(compiler, varDsc->lvVerTypeInfo.GetClassHandle());
         unsigned regCount = retTypeDesc.GetReturnRegCount();
         assert(regCount == MAX_RET_REG_COUNT);
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -14082,9 +14082,7 @@ bool GenTree::isCommutativeSIMDIntrinsic()
 // Return Value
 //    None
 //
-// Note:
-//    Right now it is implemented only for x64 unix.
-void ReturnTypeDesc::Initialize(Compiler* comp, CORINFO_CLASS_HANDLE retClsHnd)
+void ReturnTypeDesc::InitializeReturnType(Compiler* comp, CORINFO_CLASS_HANDLE retClsHnd)
 {
     assert(!m_inited);
 
@@ -14096,23 +14094,19 @@ void ReturnTypeDesc::Initialize(Compiler* comp, CORINFO_CLASS_HANDLE retClsHnd)
 
     if (structDesc.passedInRegisters)
     {
-        if (structDesc.eightByteCount == 1)
+        for (int i=0; i<structDesc.eightByteCount; i++)
         {
-            m_regType0 = comp->GetEightByteType(structDesc, 0);
-        }
-        else
-        {
-            assert(structDesc.eightByteCount == 2);
-            m_regType0 = comp->GetEightByteType(structDesc, 0);
-            m_regType1 = comp->GetEightByteType(structDesc, 1);
+            assert(i < MAX_RET_REG_COUNT);
+            m_regType[i] = comp->GetEightByteType(structDesc, i);
         }
     }
 
 #elif defined(_TARGET_X86_)
-    // TODO-X86: Assumes we are only using ReturnTypeDesc for longs on x86. Will
-    // need to be updated in the future to handle other return types
-    m_regType0 = TYP_INT;
-    m_regType1 = TYP_INT;
+    // TODO-X86: Assumes we are only using ReturnTypeDesc for longs on x86.
+    // Will need to be updated in the future to handle other return types
+    assert(MAX_RET_REG_COUNT == 2);
+    m_regType[0] = TYP_INT;
+    m_regType[1] = TYP_INT;
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
 #ifdef DEBUG

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -144,7 +144,7 @@ void                Compiler::lvaInitTypeRef()
         {
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING            
             ReturnTypeDesc retTypeDesc;
-            retTypeDesc.Initialize(this, info.compMethodInfo->args.retTypeClass);
+            retTypeDesc.InitializeReturnType(this, info.compMethodInfo->args.retTypeClass);
 
             if (retTypeDesc.GetReturnRegCount() > 1)
             {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -89,7 +89,7 @@ GenTreePtr          Compiler::fgMorphIntoHelperCall(GenTreePtr      tree,
         GenTreeCall* callNode = tree->AsCall();
         ReturnTypeDesc* retTypeDesc = callNode->GetReturnTypeDesc();
         retTypeDesc->Reset();
-        retTypeDesc->Initialize(this, callNode->gtRetClsHnd);
+        retTypeDesc->InitializeReturnType(this, callNode->gtRetClsHnd);
         callNode->ClearOtherRegs();
         
         NYI("Helper with TYP_LONG return type");


### PR DESCRIPTION
Two items are changed:
 The method Initialize was renamed InitializeReturnType to make it easier to locate in the source code.
 The member variable m_regType is now an array of size MAX_RET_REG_COUNT