### PR TITLE
Refactor debug-only GenTree flags.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -7661,7 +7661,7 @@ int cTreeFlagsIR(Compiler *comp, GenTree *tree)
             }
         }
 #endif // SMALL_TREE_NODES
-        if (tree->gtDebugFlags & GTF_DEBUG_MORPHED)
+        if (tree->gtDebugFlags & GTF_DEBUG_NODE_MORPHED)
         {
             chars += printf("[MORPHED]");
         }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -7643,35 +7643,30 @@ int cTreeFlagsIR(Compiler *comp, GenTree *tree)
 
     if (tree->gtFlags != 0)
     {
-        if (!comp->dumpIRNodes)
-        {
-            if ((tree->gtFlags & (~(GTF_NODE_LARGE|GTF_NODE_SMALL))) == 0)
-            {
-                return chars;
-            }
-        }
-
         chars += printf("flags=");
 
         // Node flags
 
-#if defined(DEBUG) && SMALL_TREE_NODES
+#if defined(DEBUG)
+#if SMALL_TREE_NODES
         if (comp->dumpIRNodes)
         {
-            if (tree->gtFlags & GTF_NODE_LARGE)
+            if (tree->gtDebugFlags & GTF_DEBUG_NODE_LARGE)
             {
                 chars += printf("[NODE_LARGE]");
             }
-            if (tree->gtFlags & GTF_NODE_SMALL)
+            if (tree->gtDebugFlags & GTF_DEBUG_NODE_SMALL)
             {
                 chars += printf("[NODE_SMALL]");
             }
         }
-#endif
-        if (tree->gtFlags & GTF_MORPHED)
+#endif // SMALL_TREE_NODES
+        if (tree->gtDebugFlags & GTF_DEBUG_MORPHED)
         {
             chars += printf("[MORPHED]");
         }
+#endif // defined(DEBUG)
+
         if (tree->gtFlags & GTF_COLON_COND)
         {
             chars += printf("[COLON_COND]");
@@ -7723,10 +7718,12 @@ int cTreeFlagsIR(Compiler *comp, GenTree *tree)
             {
                 chars += printf("[VAR_ARR_INDEX]");
             }
-            if (tree->gtFlags & GTFD_VAR_CSE_REF)
+#if defined(DEBUG)
+            if (tree->gtDebugFlags & GTF_DEBUG_VAR_CSE_REF)
             {
                 chars += printf("[VAR_CSE_REF]");
             }
+#endif
             if (op == GT_REG_VAR)
             {
                 if (tree->gtFlags & GTF_REG_BIRTH)

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -844,6 +844,9 @@ GenTree::GenTree(genTreeOps oper, var_types type DEBUGARG(bool largeNode))
     gtOper     = oper;
     gtType     = type;
     gtFlags    = 0;
+#ifdef DEBUG
+    gtDebugFlags = 0;
+#endif // DEBUG
 #ifdef LEGACY_BACKEND
     gtUsedRegs = 0;
 #endif // LEGACY_BACKEND
@@ -870,11 +873,11 @@ GenTree::GenTree(genTreeOps oper, var_types type DEBUGARG(bool largeNode))
     size_t size = GenTree::s_gtNodeSizes[oper];
     if      (size == TREE_NODE_SZ_SMALL && !largeNode)
     {
-        gtFlags |= GTF_NODE_SMALL;
+        gtDebugFlags |= GTF_DEBUG_NODE_SMALL;
     }
     else if (size == TREE_NODE_SZ_LARGE || largeNode)
     {
-        gtFlags |= GTF_NODE_LARGE;
+        gtDebugFlags |= GTF_DEBUG_NODE_LARGE;
     }
     else
     {
@@ -1308,8 +1311,8 @@ inline unsigned    Compiler::gtSetEvalOrderAndRestoreFPstkLevel(GenTree *      t
 inline
 void                GenTree::SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
 {
-    assert(((gtFlags & GTF_NODE_SMALL) != 0) !=
-           ((gtFlags & GTF_NODE_LARGE) != 0));
+    assert(((gtDebugFlags & GTF_DEBUG_NODE_SMALL) != 0) !=
+           ((gtDebugFlags & GTF_DEBUG_NODE_LARGE) != 0));
 
     /* Make sure the node isn't too small for the new operator */
 
@@ -1318,7 +1321,7 @@ void                GenTree::SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate
     assert(GenTree::s_gtNodeSizes[  oper] == TREE_NODE_SZ_SMALL ||
            GenTree::s_gtNodeSizes[  oper] == TREE_NODE_SZ_LARGE);
 
-    assert(GenTree::s_gtNodeSizes[  oper] == TREE_NODE_SZ_SMALL || (gtFlags & GTF_NODE_LARGE));
+    assert(GenTree::s_gtNodeSizes[  oper] == TREE_NODE_SZ_SMALL || (gtDebugFlags & GTF_DEBUG_NODE_LARGE));
 
     gtOper = oper;
 
@@ -1356,7 +1359,7 @@ void                GenTree::CopyFrom(const GenTree* src, Compiler* comp)
 {
     /* The source may be big only if the target is also a big node */
 
-    assert((gtFlags & GTF_NODE_LARGE) || GenTree::s_gtNodeSizes[src->gtOper] == TREE_NODE_SZ_SMALL);
+    assert((gtDebugFlags & GTF_DEBUG_NODE_LARGE) || GenTree::s_gtNodeSizes[src->gtOper] == TREE_NODE_SZ_SMALL);
     GenTreePtr prev = gtPrev;
     GenTreePtr next = gtNext;
     // The VTable pointer is copied intentionally here

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -20590,7 +20590,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
     {
         // Print the tree so we can see it in the log.
         printf("Missing flags on tree [%X]: ", tree);
-        GenTree::gtDispFlags(chkFlags & ~treeFlags, 0);
+        GenTree::gtDispFlags(chkFlags & ~treeFlags, GTF_DEBUG_NONE);
         printf("\n");
         gtDispTree(tree);
 
@@ -20598,7 +20598,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
 
         // Print the tree again so we can see it right after we hook up the debugger.
         printf("Missing flags on tree [%X]: ", tree);
-        GenTree::gtDispFlags(chkFlags & ~treeFlags, 0);
+        GenTree::gtDispFlags(chkFlags & ~treeFlags, GTF_DEBUG_NONE);
         printf("\n");
         gtDispTree(tree);
     }
@@ -20617,7 +20617,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
         {
             // Print the tree so we can see it in the log.
             printf("Extra GTF_CALL flags on parent tree [%X]: ", tree);
-            GenTree::gtDispFlags(treeFlags & ~chkFlags, 0);
+            GenTree::gtDispFlags(treeFlags & ~chkFlags, GTF_DEBUG_NONE);
             printf("\n");
             gtDispTree(tree);
 
@@ -20625,7 +20625,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
 
             // Print the tree again so we can see it right after we hook up the debugger.
             printf("Extra GTF_CALL flags on parent tree [%X]: ", tree);
-            GenTree::gtDispFlags(treeFlags & ~chkFlags, 0);
+            GenTree::gtDispFlags(treeFlags & ~chkFlags, GTF_DEBUG_NONE);
             printf("\n");
             gtDispTree(tree);
         }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -20590,7 +20590,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
     {
         // Print the tree so we can see it in the log.
         printf("Missing flags on tree [%X]: ", tree);
-        GenTree::gtDispFlags(chkFlags & ~treeFlags);
+        GenTree::gtDispFlags(chkFlags & ~treeFlags, 0);
         printf("\n");
         gtDispTree(tree);
 
@@ -20598,7 +20598,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
 
         // Print the tree again so we can see it right after we hook up the debugger.
         printf("Missing flags on tree [%X]: ", tree);
-        GenTree::gtDispFlags(chkFlags & ~treeFlags);
+        GenTree::gtDispFlags(chkFlags & ~treeFlags, 0);
         printf("\n");
         gtDispTree(tree);
     }
@@ -20617,7 +20617,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
         {
             // Print the tree so we can see it in the log.
             printf("Extra GTF_CALL flags on parent tree [%X]: ", tree);
-            GenTree::gtDispFlags(treeFlags & ~chkFlags);
+            GenTree::gtDispFlags(treeFlags & ~chkFlags, 0);
             printf("\n");
             gtDispTree(tree);
 
@@ -20625,7 +20625,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
 
             // Print the tree again so we can see it right after we hook up the debugger.
             printf("Extra GTF_CALL flags on parent tree [%X]: ", tree);
-            GenTree::gtDispFlags(treeFlags & ~chkFlags);
+            GenTree::gtDispFlags(treeFlags & ~chkFlags, 0);
             printf("\n");
             gtDispTree(tree);
         }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -2915,7 +2915,7 @@ bool                Compiler::gtIsLikelyRegVar(GenTree * tree)
  *         of operands the tree will push on the x87 (coprocessor) stack. Also sets
  *         genFPstkLevel, tmpDoubleSpillMax, and possibly gtFPstLvlRedo.
  *      5. Sometimes sets GTF_ADDRMODE_NO_CSE on nodes in the tree.
- *      6. DEBUG-only: clears GTF_DEBUG_MORPHED.
+ *      6. DEBUG-only: clears GTF_DEBUG_NODE_MORPHED.
  */
 
 #ifdef _PREFAST_
@@ -2928,8 +2928,8 @@ unsigned            Compiler::gtSetEvalOrder(GenTree * tree)
     assert(tree->gtOper != GT_STMT);
 
 #ifdef DEBUG
-    /* Clear the GTF_DEBUG_MORPHED flag as well */
-    tree->gtDebugFlags &= ~GTF_DEBUG_MORPHED;
+    /* Clear the GTF_DEBUG_NODE_MORPHED flag as well */
+    tree->gtDebugFlags &= ~GTF_DEBUG_NODE_MORPHED;
 #endif
 
     /* Is this a FP value? */
@@ -6340,6 +6340,10 @@ GenTreePtr          Compiler::gtClone(GenTree * tree, bool complexOK)
     }
 
     copy->gtFlags |= tree->gtFlags & ~GTF_NODE_MASK;
+#if defined(DEBUG)
+    copy->gtDebugFlags |= tree->gtDebugFlags & ~GTF_DEBUG_NODE_MASK;
+#endif // defined(DEBUG)
+
     return copy;
 }
 
@@ -6751,7 +6755,7 @@ GenTreePtr          Compiler::gtCloneExpr(GenTree * tree,
         }
 
         // We can call gtCloneExpr() before we have called fgMorph when we expand a GT_INDEX node in fgMorphArrayIndex()
-        // The method gtFoldExpr() expects to be run after fgMorph so it will set the GTF_DEBUG_MORPHED
+        // The method gtFoldExpr() expects to be run after fgMorph so it will set the GTF_DEBUG_NODE_MORPHED
         // flag on nodes that it adds/modifies.  Then when we call fgMorph we will assert.
         // We really only will need to fold when this method is used to replace references to 
         // local variable with an integer.
@@ -6959,6 +6963,11 @@ DONE:
 
     /* GTF_COLON_COND should be propagated from 'tree' to 'copy' */
     copy->gtFlags |= (tree->gtFlags & GTF_COLON_COND);
+
+#if defined(DEBUG)
+    // Non-node debug flags should be propagated from 'tree' to 'copy'
+    copy->gtDebugFlags |= (tree->gtDebugFlags & ~GTF_DEBUG_NODE_MASK);
+#endif
 
     /* Make sure to copy back fields that may have been initialized */
 
@@ -7645,7 +7654,7 @@ GenTreePtr GenTree::GetChild(unsigned childNum)
     printf("%c", (flags & GTF_CALL          ) ? 'C' : '-');
     printf("%c", (flags & GTF_EXCEPT        ) ? 'X' : '-');
     printf("%c", (flags & GTF_GLOB_REF      ) ? 'G' : '-');
-    printf("%c", (debugFlags & GTF_DEBUG_MORPHED) ? '+' :     // First print '+' if GTF_DEBUG_MORPHED is set
+    printf("%c", (debugFlags & GTF_DEBUG_NODE_MORPHED) ? '+' :     // First print '+' if GTF_DEBUG_NODE_MORPHED is set
                  (flags & GTF_ORDER_SIDEEFF ) ? 'O' : '-');   // otherwise print 'O' or '-'
     printf("%c", (flags & GTF_COLON_COND    ) ? '?' : '-');
     printf("%c", (flags & GTF_DONT_CSE      ) ? 'N' :         // N is for No cse

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -837,11 +837,13 @@ public:
     //----------------------------------------------------------------
 
 #if defined(DEBUG)
+    #define GTF_DEBUG_NONE            0x00000000  // No debug flags.
+
     #define GTF_DEBUG_NODE_MORPHED    0x00000001  // the node has been morphed (in the global morphing phase)
     #define GTF_DEBUG_NODE_SMALL      0x00000002
     #define GTF_DEBUG_NODE_LARGE      0x00000004
 
-    #define GTF_DEBUG_NODE_MASK       0x00000007  /// These flags are all node (rather than operation) properties.
+    #define GTF_DEBUG_NODE_MASK       0x00000007  // These flags are all node (rather than operation) properties.
 
     #define GTF_DEBUG_VAR_CSE_REF     0x00800000  // GT_LCL_VAR -- This is a CSE LCL_VAR node
 #endif // defined(DEBUG)

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -837,9 +837,11 @@ public:
     //----------------------------------------------------------------
 
 #if defined(DEBUG)
-    #define GTF_DEBUG_MORPHED         0x00000001  // the node has been morphed (in the global morphing phase)
+    #define GTF_DEBUG_NODE_MORPHED    0x00000001  // the node has been morphed (in the global morphing phase)
     #define GTF_DEBUG_NODE_SMALL      0x00000002
     #define GTF_DEBUG_NODE_LARGE      0x00000004
+
+    #define GTF_DEBUG_NODE_MASK       0x00000007  /// These flags are all node (rather than operation) properties.
 
     #define GTF_DEBUG_VAR_CSE_REF     0x00800000  // GT_LCL_VAR -- This is a CSE LCL_VAR node
 #endif // defined(DEBUG)

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -560,7 +560,11 @@ public:
     regMaskTP gtGetRegMask() const;
 
     unsigned            gtFlags;        // see GTF_xxxx below
-    
+
+#if defined(DEBUG)
+    unsigned            gtDebugFlags;   // see GTF_DEBUG_xxx below
+#endif // defined(DEBUG)
+
     ValueNumPair        gtVNPair;
 
     regMaskSmall        gtRsvdRegs;     // set of fixed trashed  registers
@@ -660,16 +664,6 @@ public:
     #define GTF_SPILLED_OP2     0x00000200  //   op2 has been spilled
 #endif // LEGACY_BACKEND
 
-#ifdef DEBUG
-#ifndef LEGACY_BACKEND
-    #define GTF_MORPHED         0x00000200  // the node has been morphed (in the global morphing phase)
-#else // LEGACY_BACKEND
-    // For LEGACY_BACKEND, 0x00000200 is in use, but we can use the same value as GTF_SPILLED since we
-    // don't call gtSetEvalOrder(), which clears GTF_MORPHED, after GTF_SPILLED has been set.
-    #define GTF_MORPHED         0x00000080  // the node has been morphed (in the global morphing phase)
-#endif // LEGACY_BACKEND
-#endif // DEBUG
-
     #define GTF_REDINDEX_CHECK  0x00000100  // Used for redundant range checks. Disjoint from GTF_SPILLED_OPER
 
     #define GTF_ZSF_SET         0x00000400  // the zero(ZF) and sign(SF) flags set to the operand
@@ -687,15 +681,7 @@ public:
     #define GTF_DONT_CSE        0x00004000  // don't bother CSE'ing this expr
     #define GTF_COLON_COND      0x00008000  // this node is conditionally executed (part of ? :)
 
-#if defined(DEBUG) && SMALL_TREE_NODES
-    #define GTF_NODE_LARGE      0x00010000
-    #define GTF_NODE_SMALL      0x00020000
-
-    // Property of the node itself, not the gtOper
-    #define GTF_NODE_MASK       (GTF_COLON_COND | GTF_MORPHED   | GTF_NODE_SMALL | GTF_NODE_LARGE )
-#else
     #define GTF_NODE_MASK       (GTF_COLON_COND)
-#endif
 
     #define GTF_BOOLEAN         0x00040000  // value is known to be 0/1
 
@@ -716,9 +702,7 @@ public:
                                             // code to produce the value.
                                             // It is currently used only on constant nodes.
                                             // It CANNOT be set on var (GT_LCL*) nodes, or on indir (GT_IND or GT_STOREIND) nodes, since
-                                            // 1) it is not needed for lclVars and is highly unlikely to be useful for indir nodes, and
-                                            // 2) it conflicts with GTFD_VAR_CSE_REF for lclVars (though this is debug only, and
-                                            //    GTF_IND_ARR_INDEX for indirs.
+                                            // it is not needed for lclVars and is highly unlikely to be useful for indir nodes
 
     //---------------------------------------------------------------------
     //  The following flags can be used only with a small set of nodes, and
@@ -764,10 +748,6 @@ public:
     #define GTF_CALL_REG_SAVE   0x01000000  // GT_CALL    -- This call preserves all integer regs
                                             // For additional flags for GT_CALL node see GTF_CALL_M_
 
-#ifdef DEBUG
-    #define GTFD_VAR_CSE_REF    0x00800000  // GT_LCL_VAR -- This is a CSE LCL_VAR node
-#endif
-
     #define GTF_NOP_DEATH         0x40000000  // GT_NOP     -- operand dies here
 
     #define GTF_FLD_NULLCHECK     0x80000000  // GT_FIELD -- need to nullcheck the "this" pointer
@@ -785,8 +765,7 @@ public:
     #define GTF_IND_UNALIGNED     0x02000000  // GT_IND   -- the load or store is unaligned (we assume worst case alignment of 1 byte) 
     #define GTF_IND_INVARIANT     0x01000000  // GT_IND   -- the target is invariant (a prejit indirection)
     #define GTF_IND_ARR_LEN       0x80000000  // GT_IND   -- the indirection represents an array length (of the REF contribution to its argument).
-    #define GTF_IND_ARR_INDEX     0x00800000  // GT_IND   -- the indirection represents an (SZ) array index (this shares the same value as GTFD_VAR_CSE_REF,
-                                              //             but is disjoint because a GT_LCL_VAR is never an ind (GT_IND or GT_STOREIND)
+    #define GTF_IND_ARR_INDEX     0x00800000  // GT_IND   -- the indirection represents an (SZ) array index
 
     #define GTF_IND_FLAGS         (GTF_IND_VOLATILE|GTF_IND_REFARR_LAYOUT|GTF_IND_TGTANYWHERE|GTF_IND_NONFAULTING|\
                                    GTF_IND_TLS_REF|GTF_IND_UNALIGNED|GTF_IND_INVARIANT|GTF_IND_ARR_INDEX)
@@ -856,6 +835,14 @@ public:
     #define GTF_STMT_SKIP_LOWER 0x10000000  // GT_STMT    -- Skip lowering if we already lowered an embedded stmt.
 
     //----------------------------------------------------------------
+
+#if defined(DEBUG)
+    #define GTF_DEBUG_MORPHED         0x00000001  // the node has been morphed (in the global morphing phase)
+    #define GTF_DEBUG_NODE_SMALL      0x00000002
+    #define GTF_DEBUG_NODE_LARGE      0x00000004
+
+    #define GTF_DEBUG_VAR_CSE_REF     0x00800000  // GT_LCL_VAR -- This is a CSE LCL_VAR node
+#endif // defined(DEBUG)
 
     GenTreePtr          gtNext;
     GenTreePtr          gtPrev;
@@ -1623,7 +1610,7 @@ public:
     bool                        gtRequestSetFlags   ();
 #ifdef DEBUG
     bool                        gtIsValid64RsltMul  ();
-    static int                  gtDispFlags         (unsigned flags);
+    static int                  gtDispFlags         (unsigned flags, unsigned debugFlags);
 #endif
 
     // cast operations 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5362,7 +5362,7 @@ GenTreePtr          Compiler::fgMorphArrayIndex(GenTreePtr tree)
     addr = gtNewOperNode(GT_ADD, TYP_BYREF, addr, cns);
 
 #if SMALL_TREE_NODES
-    assert(tree->gtFlags & GTF_NODE_LARGE);
+    assert(tree->gtDebugFlags & GTF_DEBUG_NODE_LARGE);
 #endif
 
     // Change the orginal GT_INDEX node into a GT_IND node
@@ -5445,7 +5445,7 @@ GenTreePtr          Compiler::fgMorphArrayIndex(GenTreePtr tree)
         }
     }
 
-    assert(!fgGlobalMorph || (arrElem->gtFlags & GTF_MORPHED));
+    assert(!fgGlobalMorph || (arrElem->gtDebugFlags & GTF_DEBUG_MORPHED));
 
     addr = arrElem->gtOp.gtOp1;
 
@@ -7640,7 +7640,7 @@ NO_TAIL_CALL:
         copyBlk = fgMorphTree(copyBlk);
         GenTree* result = gtNewOperNode(GT_COMMA, TYP_VOID, call, copyBlk);
 #ifdef DEBUG
-        result->gtFlags |= GTF_MORPHED;
+        result->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
         return result;
     }
@@ -8319,7 +8319,7 @@ GenTreePtr          Compiler::fgMorphInitBlock(GenTreePtr tree)
     }
 
 #ifdef DEBUG
-    tree->gtFlags |= GTF_MORPHED;
+    tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
 
     if (verbose)
     {
@@ -8951,7 +8951,7 @@ GenTreePtr          Compiler::fgMorphCopyBlock(GenTreePtr tree)
     }
 
 #ifdef DEBUG
-    tree->gtFlags |= GTF_MORPHED;
+    tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
 
     if (verbose)
     {
@@ -9202,7 +9202,7 @@ GenTreePtr Compiler::fgMorphFieldToSIMDIntrinsicGet(GenTreePtr tree)
         GenTree* op2 = gtNewIconNode(index);   
         tree =  gtNewSIMDNode(baseType, simdStructNode, op2, SIMDIntrinsicGetItem, baseType, simdSize); 
 #ifdef DEBUG
-        tree->gtFlags |= GTF_MORPHED;
+        tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
     }
     return tree;
@@ -9265,7 +9265,7 @@ GenTreePtr  Compiler::fgMorphFieldAssignToSIMDIntrinsicSet(GenTreePtr tree)
                             gtNewIconNode(simdSize),
                             false);
 #ifdef DEBUG
-        tree->gtFlags |= GTF_MORPHED;
+        tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
     }
     
@@ -9684,7 +9684,7 @@ NO_MUL_64RSLT:
             {
                 GenTreePtr zeroNode = gtNewZeroConNode(typ);
 #ifdef DEBUG
-                zeroNode->gtFlags |= GTF_MORPHED;
+                zeroNode->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
                 DEBUG_DESTROY_NODE(tree);
                 return zeroNode;
@@ -11635,7 +11635,7 @@ CM_ADD_OP:
             commaNode->gtType = typ;
             commaNode->gtFlags = (treeFlags & ~GTF_REVERSE_OPS); // Bashing the GT_COMMA flags here is dangerous, clear the GTF_REVERSE_OPS at least.
 #ifdef DEBUG
-            commaNode->gtFlags |= GTF_MORPHED;
+            commaNode->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
             while (commaNode->gtOp.gtOp2->gtOper == GT_COMMA)
             {
@@ -11643,7 +11643,7 @@ CM_ADD_OP:
                 commaNode->gtType = typ;
                 commaNode->gtFlags = (treeFlags & ~GTF_REVERSE_OPS); // Bashing the GT_COMMA flags here is dangerous, clear the GTF_REVERSE_OPS at least.
 #ifdef DEBUG
-                commaNode->gtFlags |= GTF_MORPHED;
+                commaNode->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
             }
             bool wasArrIndex = (tree->gtFlags & GTF_IND_ARR_INDEX) != 0;
@@ -11662,7 +11662,7 @@ CM_ADD_OP:
                 GetArrayInfoMap()->Set(op1, arrInfo);
             }
 #ifdef DEBUG
-            op1->gtFlags |= GTF_MORPHED;
+            op1->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
             commaNode->gtOp.gtOp2 = op1;
             return tree;
@@ -11745,7 +11745,7 @@ CM_ADD_OP:
             {
                 commaNode->gtType = op1->gtType; commaNode->gtFlags |= op1->gtFlags;
 #ifdef DEBUG
-                commaNode->gtFlags |= GTF_MORPHED;
+                commaNode->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
                 commaNode = commaNode->gtOp.gtOp2;
             }
@@ -12743,7 +12743,7 @@ GenTree* Compiler::fgMorphModByConst(GenTreeOp* tree)
     GenTree* sub = gtNewOperNode(GT_SUB, type, numerator, mul);
 
 #ifdef DEBUG
-    sub->gtFlags |= GTF_MORPHED;
+    sub->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
 
     return sub;
@@ -12797,7 +12797,7 @@ GenTree* Compiler::fgMorphModToSubMulDiv(GenTreeOp* tree)
     GenTree* sub = gtNewOperNode(GT_SUB, type, gtCloneExpr(numerator), mul);
 
 #ifdef DEBUG
-    sub->gtFlags |= GTF_MORPHED;
+    sub->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
 
     return sub;
@@ -12883,7 +12883,7 @@ GenTree* Compiler::fgMorphDivByConst(GenTreeOp* tree)
     DISPTREE(result);
 
 #ifdef DEBUG
-    result->gtFlags |= GTF_MORPHED;
+    result->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
 
     return result;
@@ -13401,7 +13401,7 @@ GenTreePtr          Compiler::fgMorphTree(GenTreePtr tree, MorphAddrContext* mac
     if (fgGlobalMorph)
     {
         /* Ensure that we haven't morphed this node already */
-        assert(((tree->gtFlags & GTF_MORPHED) == 0) && "ERROR: Already morphed this node!");
+        assert(((tree->gtDebugFlags & GTF_DEBUG_MORPHED) == 0) && "ERROR: Already morphed this node!");
 
 #if LOCAL_ASSERTION_PROP
         /* Before morphing the tree, we try to propagate any active assertions */
@@ -13607,7 +13607,7 @@ void                Compiler::fgKillDependentAssertions(unsigned lclNum
  *
  *  This function is called to complete the morphing of a tree node
  *  It should only be called once for each node.
- *  If DEBUG is defined the flag GTF_MORPHED is checked and updated,
+ *  If DEBUG is defined the flag GTF_DEBUG_MORPHED is checked and updated,
  *  to enforce the invariant that each node is only morphed once.
  *  If LOCAL_ASSERTION_PROP is enabled the result tree may be replaced
  *  by an equivalent tree.
@@ -13633,7 +13633,7 @@ void                Compiler::fgMorphTreeDone(GenTreePtr tree,
     if ((oldTree != NULL) && (oldTree != tree))
     {
         /* Ensure that we have morphed this node */
-        assert((tree->gtFlags & GTF_MORPHED) && "ERROR: Did not morph this node!");
+        assert((tree->gtDebugFlags & GTF_DEBUG_MORPHED) && "ERROR: Did not morph this node!");
 
 #ifdef DEBUG
         TransferTestDataToNode(oldTree, tree);
@@ -13642,7 +13642,7 @@ void                Compiler::fgMorphTreeDone(GenTreePtr tree,
     else
     {
         // Ensure that we haven't morphed this node already 
-        assert(((tree->gtFlags & GTF_MORPHED) == 0) && "ERROR: Already morphed this node!");
+        assert(((tree->gtDebugFlags & GTF_DEBUG_MORPHED) == 0) && "ERROR: Already morphed this node!");
     }
 
     if (tree->OperKind() & GTK_CONST)
@@ -13676,7 +13676,7 @@ DONE:;
 
 #ifdef DEBUG
     /* Mark this node as being morphed */
-    tree->gtFlags |= GTF_MORPHED;
+    tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
 }
 
@@ -14249,7 +14249,7 @@ void                Compiler::fgMorphStmts(BasicBlock * block,
                but the flag still got set, clear it here...  */
 
 #ifdef DEBUG
-            tree->gtFlags &= ~GTF_MORPHED;
+            tree->gtDebugFlags &= ~GTF_DEBUG_MORPHED;
 #endif
             noway_assert(compTailCallUsed);
             noway_assert((tree->gtOper == GT_CALL) && tree->AsCall()->IsTailCall());

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5445,7 +5445,7 @@ GenTreePtr          Compiler::fgMorphArrayIndex(GenTreePtr tree)
         }
     }
 
-    assert(!fgGlobalMorph || (arrElem->gtDebugFlags & GTF_DEBUG_MORPHED));
+    assert(!fgGlobalMorph || (arrElem->gtDebugFlags & GTF_DEBUG_NODE_MORPHED));
 
     addr = arrElem->gtOp.gtOp1;
 
@@ -7640,7 +7640,7 @@ NO_TAIL_CALL:
         copyBlk = fgMorphTree(copyBlk);
         GenTree* result = gtNewOperNode(GT_COMMA, TYP_VOID, call, copyBlk);
 #ifdef DEBUG
-        result->gtDebugFlags |= GTF_DEBUG_MORPHED;
+        result->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
         return result;
     }
@@ -8319,7 +8319,7 @@ GenTreePtr          Compiler::fgMorphInitBlock(GenTreePtr tree)
     }
 
 #ifdef DEBUG
-    tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
+    tree->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 
     if (verbose)
     {
@@ -8951,7 +8951,7 @@ GenTreePtr          Compiler::fgMorphCopyBlock(GenTreePtr tree)
     }
 
 #ifdef DEBUG
-    tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
+    tree->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 
     if (verbose)
     {
@@ -9202,7 +9202,7 @@ GenTreePtr Compiler::fgMorphFieldToSIMDIntrinsicGet(GenTreePtr tree)
         GenTree* op2 = gtNewIconNode(index);   
         tree =  gtNewSIMDNode(baseType, simdStructNode, op2, SIMDIntrinsicGetItem, baseType, simdSize); 
 #ifdef DEBUG
-        tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
+        tree->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
     }
     return tree;
@@ -9265,7 +9265,7 @@ GenTreePtr  Compiler::fgMorphFieldAssignToSIMDIntrinsicSet(GenTreePtr tree)
                             gtNewIconNode(simdSize),
                             false);
 #ifdef DEBUG
-        tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
+        tree->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
     }
     
@@ -9684,7 +9684,7 @@ NO_MUL_64RSLT:
             {
                 GenTreePtr zeroNode = gtNewZeroConNode(typ);
 #ifdef DEBUG
-                zeroNode->gtDebugFlags |= GTF_DEBUG_MORPHED;
+                zeroNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
                 DEBUG_DESTROY_NODE(tree);
                 return zeroNode;
@@ -11635,7 +11635,7 @@ CM_ADD_OP:
             commaNode->gtType = typ;
             commaNode->gtFlags = (treeFlags & ~GTF_REVERSE_OPS); // Bashing the GT_COMMA flags here is dangerous, clear the GTF_REVERSE_OPS at least.
 #ifdef DEBUG
-            commaNode->gtDebugFlags |= GTF_DEBUG_MORPHED;
+            commaNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
             while (commaNode->gtOp.gtOp2->gtOper == GT_COMMA)
             {
@@ -11643,7 +11643,7 @@ CM_ADD_OP:
                 commaNode->gtType = typ;
                 commaNode->gtFlags = (treeFlags & ~GTF_REVERSE_OPS); // Bashing the GT_COMMA flags here is dangerous, clear the GTF_REVERSE_OPS at least.
 #ifdef DEBUG
-                commaNode->gtDebugFlags |= GTF_DEBUG_MORPHED;
+                commaNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
             }
             bool wasArrIndex = (tree->gtFlags & GTF_IND_ARR_INDEX) != 0;
@@ -11662,7 +11662,7 @@ CM_ADD_OP:
                 GetArrayInfoMap()->Set(op1, arrInfo);
             }
 #ifdef DEBUG
-            op1->gtDebugFlags |= GTF_DEBUG_MORPHED;
+            op1->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
             commaNode->gtOp.gtOp2 = op1;
             return tree;
@@ -11745,7 +11745,7 @@ CM_ADD_OP:
             {
                 commaNode->gtType = op1->gtType; commaNode->gtFlags |= op1->gtFlags;
 #ifdef DEBUG
-                commaNode->gtDebugFlags |= GTF_DEBUG_MORPHED;
+                commaNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
                 commaNode = commaNode->gtOp.gtOp2;
             }
@@ -12743,7 +12743,7 @@ GenTree* Compiler::fgMorphModByConst(GenTreeOp* tree)
     GenTree* sub = gtNewOperNode(GT_SUB, type, numerator, mul);
 
 #ifdef DEBUG
-    sub->gtDebugFlags |= GTF_DEBUG_MORPHED;
+    sub->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
 
     return sub;
@@ -12797,7 +12797,7 @@ GenTree* Compiler::fgMorphModToSubMulDiv(GenTreeOp* tree)
     GenTree* sub = gtNewOperNode(GT_SUB, type, gtCloneExpr(numerator), mul);
 
 #ifdef DEBUG
-    sub->gtDebugFlags |= GTF_DEBUG_MORPHED;
+    sub->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
 
     return sub;
@@ -12883,7 +12883,7 @@ GenTree* Compiler::fgMorphDivByConst(GenTreeOp* tree)
     DISPTREE(result);
 
 #ifdef DEBUG
-    result->gtDebugFlags |= GTF_DEBUG_MORPHED;
+    result->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
 
     return result;
@@ -13401,7 +13401,7 @@ GenTreePtr          Compiler::fgMorphTree(GenTreePtr tree, MorphAddrContext* mac
     if (fgGlobalMorph)
     {
         /* Ensure that we haven't morphed this node already */
-        assert(((tree->gtDebugFlags & GTF_DEBUG_MORPHED) == 0) && "ERROR: Already morphed this node!");
+        assert(((tree->gtDebugFlags & GTF_DEBUG_NODE_MORPHED) == 0) && "ERROR: Already morphed this node!");
 
 #if LOCAL_ASSERTION_PROP
         /* Before morphing the tree, we try to propagate any active assertions */
@@ -13607,7 +13607,7 @@ void                Compiler::fgKillDependentAssertions(unsigned lclNum
  *
  *  This function is called to complete the morphing of a tree node
  *  It should only be called once for each node.
- *  If DEBUG is defined the flag GTF_DEBUG_MORPHED is checked and updated,
+ *  If DEBUG is defined the flag GTF_DEBUG_NODE_MORPHED is checked and updated,
  *  to enforce the invariant that each node is only morphed once.
  *  If LOCAL_ASSERTION_PROP is enabled the result tree may be replaced
  *  by an equivalent tree.
@@ -13633,7 +13633,7 @@ void                Compiler::fgMorphTreeDone(GenTreePtr tree,
     if ((oldTree != NULL) && (oldTree != tree))
     {
         /* Ensure that we have morphed this node */
-        assert((tree->gtDebugFlags & GTF_DEBUG_MORPHED) && "ERROR: Did not morph this node!");
+        assert((tree->gtDebugFlags & GTF_DEBUG_NODE_MORPHED) && "ERROR: Did not morph this node!");
 
 #ifdef DEBUG
         TransferTestDataToNode(oldTree, tree);
@@ -13642,7 +13642,7 @@ void                Compiler::fgMorphTreeDone(GenTreePtr tree,
     else
     {
         // Ensure that we haven't morphed this node already 
-        assert(((tree->gtDebugFlags & GTF_DEBUG_MORPHED) == 0) && "ERROR: Already morphed this node!");
+        assert(((tree->gtDebugFlags & GTF_DEBUG_NODE_MORPHED) == 0) && "ERROR: Already morphed this node!");
     }
 
     if (tree->OperKind() & GTK_CONST)
@@ -13676,7 +13676,7 @@ DONE:;
 
 #ifdef DEBUG
     /* Mark this node as being morphed */
-    tree->gtDebugFlags |= GTF_DEBUG_MORPHED;
+    tree->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
 }
 
@@ -14249,7 +14249,7 @@ void                Compiler::fgMorphStmts(BasicBlock * block,
                but the flag still got set, clear it here...  */
 
 #ifdef DEBUG
-            tree->gtDebugFlags &= ~GTF_DEBUG_MORPHED;
+            tree->gtDebugFlags &= ~GTF_DEBUG_NODE_MORPHED;
 #endif
             noway_assert(compTailCallUsed);
             noway_assert((tree->gtOper == GT_CALL) && tree->AsCall()->IsTailCall());

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -1766,7 +1766,7 @@ public:
                 cse = m_pCompiler->gtNewLclvNode(cseLclVarNum, cseLclVarTyp);
                 cse->gtVNPair = exp->gtVNPair;  // assign the proper Value Numbers 
 #ifdef DEBUG
-                cse->gtFlags |= GTFD_VAR_CSE_REF;
+                cse->gtDebugFlags |= GTF_DEBUG_VAR_CSE_REF;
 #endif // DEBUG
 
                 // If we have side effects then we need to create a GT_COMMA tree instead

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -4849,7 +4849,7 @@ bool                Compiler::optNarrowTree(GenTreePtr     tree,
                         assert(tree->gtType == TYP_INT);
                         op1 = gtNewCastNode(TYP_INT, op1, TYP_INT);
 #ifdef DEBUG
-                        op1->gtFlags |= GTF_MORPHED;
+                        op1->gtDebugFlags |= GTF_DEBUG_MORPHED;
 #endif
                         tree->gtOp.gtOp1 = op1;
                     }

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -4849,7 +4849,7 @@ bool                Compiler::optNarrowTree(GenTreePtr     tree,
                         assert(tree->gtType == TYP_INT);
                         op1 = gtNewCastNode(TYP_INT, op1, TYP_INT);
 #ifdef DEBUG
-                        op1->gtDebugFlags |= GTF_DEBUG_MORPHED;
+                        op1->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif
                         tree->gtOp.gtOp1 = op1;
                     }


### PR DESCRIPTION
Move the four debug-only GenTree flags into their own field. This frees
up two bits across both the RyuJIT and the legacy backend.