### PR TITLE
Expose remaining Environment.* public surface area from System.Private.Corelib

### DIFF
--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -73,9 +73,11 @@ FCIMPLEND;
 
 
 
-#ifndef FEATURE_CORECLR
 INT64 QCALLTYPE SystemNative::GetWorkingSet()
 {
+#if PLATFORM_UNIX
+    return 0; // TODO: Implement in PAL
+#else
     QCALL_CONTRACT;
 
     DWORD memUsage = 0;
@@ -85,8 +87,8 @@ INT64 QCALLTYPE SystemNative::GetWorkingSet()
     END_QCALL;
     
     return memUsage;
+#endif
 }
-#endif // !FEATURE_CORECLR
 
 VOID QCALLTYPE SystemNative::Exit(INT32 exitcode)
 {

--- a/src/classlibnative/bcltype/system.h
+++ b/src/classlibnative/bcltype/system.h
@@ -76,10 +76,8 @@ public:
     static FCDECL1(FC_BOOL_RET, GetOSVersion, OSVERSIONINFOObject *osVer);
     static FCDECL1(FC_BOOL_RET, GetOSVersionEx, OSVERSIONINFOEXObject *osVer);
 
-#ifndef FEATURE_CORECLR
     static
     INT64 QCALLTYPE GetWorkingSet();
-#endif // !FEATURE_CORECLR
 
     static
     void QCALLTYPE Exit(INT32 exitcode);

--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -59,6 +59,7 @@ GetStdHandle
 GetSystemInfo
 GetTempFileNameW
 GetTempPathW
+GetUserNameW
 LocalAlloc
 LocalReAlloc
 LocalFree

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -1793,31 +1793,122 @@
       <Member Name="TryParse&lt;TEnum&gt;(System.String,TEnum@)" />
       <Member Name="TryParse&lt;TEnum&gt;(System.String,System.Boolean,TEnum@)" />
     </Type>
+    <Type Name="System.EnvironmentVariableTarget">
+      <Member MemberType="Field" Name="Process" />
+      <Member MemberType="Field" Name="User" />
+      <Member MemberType="Field" Name="Machine" />
+    </Type>
+    <Type Name="System.Environment+SpecialFolderOption">
+      <Member MemberType="Field" Name="None" />
+      <Member MemberType="Field" Name="Create" />
+      <Member MemberType="Field" Name="DoNotVerify" />
+    </Type>
+    <Type Name="System.Environment+SpecialFolder">
+      <Member MemberType="Field" Name="ApplicationData" />
+      <Member MemberType="Field" Name="CommonApplicationData" />
+      <Member MemberType="Field" Name="LocalApplicationData" />
+      <Member MemberType="Field" Name="Cookies" />
+      <Member MemberType="Field" Name="Desktop" />
+      <Member MemberType="Field" Name="Favorites" />
+      <Member MemberType="Field" Name="History" />
+      <Member MemberType="Field" Name="InternetCache" />
+      <Member MemberType="Field" Name="Programs" />
+      <Member MemberType="Field" Name="MyComputer" />
+      <Member MemberType="Field" Name="MyMusic" />
+      <Member MemberType="Field" Name="MyPictures" />
+      <Member MemberType="Field" Name="MyVideos" />
+      <Member MemberType="Field" Name="Recent" />
+      <Member MemberType="Field" Name="SendTo" />
+      <Member MemberType="Field" Name="StartMenu" />
+      <Member MemberType="Field" Name="Startup" />
+      <Member MemberType="Field" Name="System" />
+      <Member MemberType="Field" Name="Templates" />
+      <Member MemberType="Field" Name="DesktopDirectory" />
+      <Member MemberType="Field" Name="Personal" />
+      <Member MemberType="Field" Name="MyDocuments" />
+      <Member MemberType="Field" Name="ProgramFiles" />
+      <Member MemberType="Field" Name="CommonProgramFiles" />
+      <Member MemberType="Field" Name="AdminTools" />
+      <Member MemberType="Field" Name="CDBurning" />
+      <Member MemberType="Field" Name="CommonAdminTools" />
+      <Member MemberType="Field" Name="CommonDocuments" />
+      <Member MemberType="Field" Name="CommonMusic" />
+      <Member MemberType="Field" Name="CommonOemLinks" />
+      <Member MemberType="Field" Name="CommonPictures" />
+      <Member MemberType="Field" Name="CommonStartMenu" />
+      <Member MemberType="Field" Name="CommonPrograms" />
+      <Member MemberType="Field" Name="CommonStartup" />
+      <Member MemberType="Field" Name="CommonDesktopDirectory" />
+      <Member MemberType="Field" Name="CommonTemplates" />
+      <Member MemberType="Field" Name="CommonVideos" />
+      <Member MemberType="Field" Name="Fonts" />
+      <Member MemberType="Field" Name="NetworkShortcuts" />
+      <Member MemberType="Field" Name="PrinterShortcuts" />
+      <Member MemberType="Field" Name="UserProfile" />
+      <Member MemberType="Field" Name="CommonProgramFilesX86" />
+      <Member MemberType="Field" Name="ProgramFilesX86" />
+      <Member MemberType="Field" Name="Resources" />
+      <Member MemberType="Field" Name="LocalizedResources" />
+      <Member MemberType="Field" Name="SystemX86" />
+      <Member MemberType="Field" Name="Windows" />
+    </Type>
     <Type Name="System.Environment">
+      <Member Name="get_CommandLine"  />
+      <Member Name="get_CurrentDirectory"  />
       <Member Name="get_CurrentManagedThreadId"  />
+      <Member Name="get_ExitCode"  />
+      <Member Name="get_HasShutdownStarted"  />
+      <Member Name="get_Is64BitProcess"  />
+      <Member Name="get_Is64BitOperatingSystem"  />
       <Member Name="get_MachineName"  />
+      <Member Name="get_NewLine"  />
       <Member Name="get_OSVersion" />
       <Member Name="get_ProcessorCount" />      
       <Member Name="get_StackTrace" />
-      <Member Name="GetEnvironmentVariable(System.String)" />
-      <Member Name="GetEnvironmentVariables" />
-      <Member Name="GetCommandLineArgs" />
-      <Member Name="SetEnvironmentVariable(System.String,System.String)" />
-      <Member Name="ExpandEnvironmentVariables(System.String)" />
+      <Member Name="get_SystemDirectory"  />
+      <Member Name="get_SystemPageSize"  />
+      <Member Name="get_TickCount"  />
+      <Member Name="get_UserDomainName"  />
+      <Member Name="get_UserInteractive"  />
+      <Member Name="get_UserName"  />
+      <Member Name="get_Version"  />
+      <Member Name="get_WorkingSet"  />
+      <Member MemberType="Property" Name="CommandLine"  />
+      <Member MemberType="Property" Name="CurrentDirectory"  />
+      <Member MemberType="Property" Name="CurrentManagedThreadId"  />
+      <Member MemberType="Property" Name="ExitCode" />
+      <Member MemberType="Property" Name="HasShutdownStarted" />
+      <Member MemberType="Property" Name="Is64BitProcess" />
+      <Member MemberType="Property" Name="Is64BitOperatingSystem" />
+      <Member MemberType="Property" Name="MachineName" />
+      <Member MemberType="Property" Name="NewLine" />
       <Member MemberType="Property" Name="OSVersion" />
       <Member MemberType="Property" Name="ProcessorCount" />
-      <Member MemberType="Property" Name="CurrentManagedThreadId"  />
-      <Member MemberType="Property" Name="HasShutdownStarted" />
-      <Member MemberType="Property" Name="NewLine" />
       <Member MemberType="Property" Name="StackTrace" />
+      <Member MemberType="Property" Name="SystemDirectory"  />
+      <Member MemberType="Property" Name="SystemPageSize"  />
       <Member MemberType="Property" Name="TickCount" />
+      <Member MemberType="Property" Name="UserInteractive" />
+      <Member MemberType="Property" Name="UserDomainName" />
+      <Member MemberType="Property" Name="UserName" />
       <Member MemberType="Property" Name="Version" />
-      <Member MemberType="Property" Name="ExitCode" />
-      <Member Status="ImplRoot" Name="GetResourceStringLocal(System.String)" />
-      <Member Status="ImplRoot" Name="SetCommandLineArgs(System.String[])" />
+      <Member MemberType="Property" Name="WorkingSet" />
+      <Member Name="Exit(System.Int32)" />
+      <Member Name="ExpandEnvironmentVariables(System.String)" />
       <Member Name="FailFast(System.String)"  />
       <Member Name="FailFast(System.String,System.Exception)"  />
-      <Member Name="Exit(System.Int32)" />
+      <Member Name="GetCommandLineArgs" />
+      <Member Name="GetFolderPath(System.Environment+SpecialFolder)" />
+      <Member Name="GetFolderPath(System.Environment+SpecialFolder,System.Environment+SpecialFolderOption)" />
+      <Member Name="GetEnvironmentVariable(System.String)" />
+      <Member Name="GetEnvironmentVariable(System.String,System.EnvironmentVariableTarget)" />
+      <Member Name="GetEnvironmentVariables" />
+      <Member Name="GetEnvironmentVariables(System.EnvironmentVariableTarget)" />
+      <Member Name="GetLogicalDrives" />
+      <Member Name="SetEnvironmentVariable(System.String,System.String)" />
+      <Member Name="SetEnvironmentVariable(System.String,System.String,System.EnvironmentVariableTarget)" />
+      <Member Status="ImplRoot" Name="GetResourceStringLocal(System.String)" />
+      <Member Status="ImplRoot" Name="SetCommandLineArgs(System.String[])" />
     </Type>
     <Type Name="System.EventArgs">
       <Member MemberType="Field" Name="Empty" />

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -701,14 +701,15 @@ namespace Microsoft.Win32 {
         internal const String OLE32    = "ole32.dll";
         internal const String OLEAUT32 = "oleaut32.dll";
         internal const String NTDLL    = "ntdll.dll";
+        internal const String ADVAPI32 = "advapi32.dll";
 #else //FEATURE_PAL
         internal const String KERNEL32 = "libcoreclr";
         internal const String USER32   = "libcoreclr";
         internal const String OLE32    = "libcoreclr";
         internal const String OLEAUT32 = "libcoreclr";
         internal const String NTDLL    = "libcoreclr";
+        internal const String ADVAPI32 = "libcoreclr";
 #endif //FEATURE_PAL         
-        internal const String ADVAPI32 = "advapi32.dll";
         internal const String SHELL32  = "shell32.dll";
         internal const String SHIM     = "mscoree.dll";
         internal const String CRYPT32  = "crypt32.dll";

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -34,10 +34,8 @@ namespace System {
     [ComVisible(true)]
     public enum EnvironmentVariableTarget {
         Process = 0,
-#if FEATURE_WIN32_REGISTRY            
         User = 1,
         Machine = 2,
-#endif        
     }
 
     [ComVisible(true)]
@@ -323,12 +321,15 @@ namespace System {
             [SecuritySafeCritical]
             get { return GetIsCLRHosted(); }
         }
+#endif // !FEATURE_CORECLR
 
         public static String CommandLine {
             [System.Security.SecuritySafeCritical]  // auto-generated
-            get {
+            get
+            {
+#if !FEATURE_CORECLR
                 new EnvironmentPermission(EnvironmentPermissionAccess.Read, "Path").Demand();
-
+#endif
                 String commandLine = null;
                 GetCommandLine(JitHelpers.GetStringHandleOnStack(ref commandLine));
                 return commandLine;
@@ -338,7 +339,6 @@ namespace System {
         [System.Security.SecurityCritical]  // auto-generated
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode), SuppressUnmanagedCodeSecurity]
         private static extern void GetCommandLine(StringHandleOnStack retString);
-#endif // !FEATURE_CORECLR
 
         /*===============================CurrentDirectory===============================
         **Action:  Provides a getter and setter for the current directory.  The original
@@ -369,6 +369,9 @@ namespace System {
             [System.Security.SecuritySafeCritical]  // auto-generated
 #endif
             get {
+#if PLATFORM_UNIX
+                return Path.DirectorySeparatorCharAsString; // TODO: anything better to return?
+#else
                 StringBuilder sb = new StringBuilder(Path.MaxPath);
                 int r = Win32Native.GetSystemDirectory(sb, Path.MaxPath);
                 Contract.Assert(r < Path.MaxPath, "r < Path.MaxPath");
@@ -381,6 +384,7 @@ namespace System {
 #endif
 
                 return path;
+#endif // !PLATFORM_UNIX
             }
         }
 
@@ -557,7 +561,9 @@ namespace System {
         public static int SystemPageSize {
             [System.Security.SecuritySafeCritical]  // auto-generated
             get {
+#if !FEATURE_CORECLR
                 (new EnvironmentPermission(PermissionState.Unrestricted)).Demand();
+#endif
                 Win32Native.SYSTEM_INFO info = new Win32Native.SYSTEM_INFO();
                 Win32Native.GetSystemInfo(ref info);
                 return info.dwPageSize;
@@ -574,7 +580,6 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public static String[] GetCommandLineArgs()
         {
-            new EnvironmentPermission(EnvironmentPermissionAccess.Read, "Path").Demand();
 #if FEATURE_CORECLR
             /*
              * There are multiple entry points to a hosted app.
@@ -591,6 +596,8 @@ namespace System {
              */
             if(s_CommandLineArgs != null)
                 return (string[])s_CommandLineArgs.Clone();
+#else
+            new EnvironmentPermission(EnvironmentPermissionAccess.Read, "Path").Demand();
 #endif
             return GetCommandLineArgsNative();
         }
@@ -672,7 +679,14 @@ namespace System {
                 return GetEnvironmentVariable(variable);
             }
 
-#if FEATURE_WIN32_REGISTRY
+#if PLATFORM_UNIX
+            else if (target == EnvironmentVariableTarget.Machine ||
+                     target == EnvironmentVariableTarget.User)
+            {
+                return null;
+            }
+            else
+#elif FEATURE_WIN32_REGISTRY
             (new EnvironmentPermission(PermissionState.Unrestricted)).Demand();
 
             if( target == EnvironmentVariableTarget.Machine) {
@@ -864,8 +878,14 @@ namespace System {
             if( target == EnvironmentVariableTarget.Process) {
                 return GetEnvironmentVariables();
             }
-
-#if FEATURE_WIN32_REGISTRY
+#if PLATFORM_UNIX
+            else if (target == EnvironmentVariableTarget.Machine ||
+                     target == EnvironmentVariableTarget.User)
+            {
+                return new Hashtable(0);
+            }
+            else
+#elif FEATURE_WIN32_REGISTRY
             (new EnvironmentPermission(PermissionState.Unrestricted)).Demand();
 
             if( target == EnvironmentVariableTarget.Machine) {
@@ -883,7 +903,7 @@ namespace System {
             }
             else 
 #endif // FEATURE_WIN32_REGISTRY                
-                {
+            {
                 throw new ArgumentException(Environment.GetResourceString("Arg_EnumIllegalVal", (int)target));
             }
         }
@@ -970,12 +990,24 @@ namespace System {
                 throw new ArgumentException(Environment.GetResourceString("Argument_LongEnvVarName"));
             }
 
+#if PLATFORM_UNIX
+            if (target == EnvironmentVariableTarget.Machine ||
+                target == EnvironmentVariableTarget.User)
+            {
+                return;
+            }
+#endif
+
+#if !FEATURE_CORECLR
             new EnvironmentPermission(PermissionState.Unrestricted).Demand();
+#endif
+
+#if FEATURE_WIN32_REGISTRY
             // explicitly null out value if is the empty string. 
             if (String.IsNullOrEmpty(value) || value[0] == '\0') {
                 value = null;
             }
-#if FEATURE_WIN32_REGISTRY
+
             if( target == EnvironmentVariableTarget.Machine) {
                 using (RegistryKey environmentKey = 
                        Registry.LocalMachine.OpenSubKey(@"System\CurrentControlSet\Control\Session Manager\Environment", true)) {
@@ -1029,8 +1061,10 @@ namespace System {
         ==============================================================================*/
         [System.Security.SecuritySafeCritical]  // auto-generated
         public static String[] GetLogicalDrives() {
+#if !PLATFORM_UNIX
+#if !FEATURE_CORECLR
             new EnvironmentPermission(PermissionState.Unrestricted).Demand();
-                                 
+#endif
             int drives = Win32Native.GetLogicalDrives();
             if (drives==0)
                 __Error.WinIOError();
@@ -1052,8 +1086,27 @@ namespace System {
                 root[0]++;
             }
             return result;
+#else // PLATFORM_UNIX
+            // Use reflection to access the unix implementation in System.IO.FileSystem.DriveInfo.dll
+            Type driveInfoType = Type.GetType(
+                "System.IO.DriveInfo, System.IO.FileSystem.DriveInfo, Version=4.0.0.0, Culture=neutral, PublicKeyToken=" + AssemblyRef.MicrosoftPublicKeyToken,
+                throwOnError: false);
+            Array drives = (Array)driveInfoType?.GetMethod("GetDrives")?.Invoke(null, null) as Array;
+            if (drives != null)
+            {
+                string[] logicalDrives = new string[drives.Length];
+                int i = 0;
+                foreach (object drive in drives)
+                {
+                    logicalDrives[i++] = drive.ToString();
+                }
+                return logicalDrives;
+            }
+
+            throw new PlatformNotSupportedException();
+#endif // PLATFORM_UNIX
         }
-        
+
         /*===================================NewLine====================================
         **Action: A property which returns the appropriate newline string for the given
         **        platform.
@@ -1104,7 +1157,9 @@ namespace System {
         public static long WorkingSet {
             [System.Security.SecuritySafeCritical]  // auto-generated
             get {
+#if !FEATURE_CORECLR
                 new EnvironmentPermission(PermissionState.Unrestricted).Demand();
+#endif
                 return GetWorkingSet();
             }
         }
@@ -1225,8 +1280,9 @@ namespace System {
             [System.Security.SecuritySafeCritical]  // auto-generated
             get {
                 Contract.Ensures(Contract.Result<String>() != null);
-
+#if !FEATURE_CORECLR
                 new EnvironmentPermission(PermissionState.Unrestricted).Demand();
+#endif
                 return GetStackTrace(null, true);
             }
         }
@@ -1338,6 +1394,8 @@ namespace System {
 #if BIT64
                     // 64-bit programs run only on 64-bit
                     return true;
+#elif PLATFORM_UNIX
+                    return IntPtr.Size == 8; // TODO: use uname and match utsname.machine?
 #else // 32
                     bool isWow64; // WinXP SP2+ and Win2k3 SP1+
                     return Win32Native.DoesWin32MethodExist(Win32Native.KERNEL32, "IsWow64Process")
@@ -1363,8 +1421,9 @@ namespace System {
         public static string UserName {
             [System.Security.SecuritySafeCritical]  // auto-generated
             get {
+#if !FEATURE_CORECLR
                 new EnvironmentPermission(EnvironmentPermissionAccess.Read,"UserName").Demand();
-
+#endif
                 StringBuilder sb = new StringBuilder(256);
                 int size = sb.Capacity;
                 if (Win32Native.GetUserName(sb, ref size))
@@ -1437,6 +1496,11 @@ namespace System {
         [System.Security.SecurityCritical]
         private static string InternalGetFolderPath(SpecialFolder folder, SpecialFolderOption option, bool suppressSecurityChecks = false)
         {
+            // TODO: FEATURE_CORESYSTEM is set when compiling FEATURE_CORECLR.  On Windows we want to
+            // take the path that calls SHGetFolderPath, and on Unix we want to either do so as well and
+            // put SHGetFolderPath in the PAL, or provide a PLATFORM_UNIX implementation of it here. (For
+            // Unix many of the folders will simply return empty string or throw PlatformNotSupportedException, 
+            // but some can be supported well.)
 #if FEATURE_CORESYSTEM
             // This is currently customized for Windows Phone since CoreSystem doesn't support
             // SHGetFolderPath. The allowed folder values are based on the version of .NET CF WP7 was using.
@@ -1519,8 +1583,11 @@ namespace System {
         {
             [System.Security.SecuritySafeCritical]  // auto-generated
             get {
+#if PLATFORM_UNIX
+                return MachineName;
+#elif !FEATURE_CORECLR
                 new EnvironmentPermission(EnvironmentPermissionAccess.Read,"UserDomain").Demand();
-
+#endif
                 byte[] sid = new byte[1024];
                 int sidLen = sid.Length;
                 StringBuilder domainName = new StringBuilder(1024);
@@ -1659,7 +1726,6 @@ namespace System {
             //     Represents the folder for components that are shared across applications. 
             //  
             CommonProgramFiles =  Win32Native.CSIDL_PROGRAM_FILES_COMMON,            
-#if !FEATURE_CORECLR
             //
             //      <user name>\Start Menu\Programs\Administrative Tools
             //
@@ -1752,7 +1818,6 @@ namespace System {
             //      GetWindowsDirectory()
             //
             Windows                = Win32Native.CSIDL_WINDOWS,
-#endif // !FEATURE_CORECLR
         }
 
         public static int CurrentManagedThreadId

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -291,11 +291,13 @@ FCFuncStart(gEnvironmentFuncs)
     FCFuncElement("get_ExitCode", SystemNative::GetExitCode)
     FCFuncElement("get_HasShutdownStarted", SystemNative::HasShutdownStarted)
     QCFuncElement("GetProcessorCount", SystemNative::GetProcessorCount)
-#ifndef FEATURE_CORECLR
     QCFuncElement("GetWorkingSet", SystemNative::GetWorkingSet)
+#ifndef FEATURE_CORECLR
     FCFuncElement("nativeGetEnvironmentVariable", SystemNative::_GetEnvironmentVariable)
     FCFuncElement("GetCompatibilityFlag", SystemNative::_GetCompatibilityFlag)
+#endif // !FEATURE_CORECLR
     QCFuncElement("GetCommandLine", SystemNative::_GetCommandLine)
+#ifndef FEATURE_CORECLR
     FCFuncElement("GetResourceFromDefault", GetResourceFromDefault)
 #endif // !FEATURE_CORECLR
     FCFuncElement("GetCommandLineArgsNative", SystemNative::GetCommandLineArgs)


### PR DESCRIPTION
Known issues to address subsequently (I'll open issues for them):
- Environment.WorkingSet returns 0 on Unix.  We should put that in the PAL and provide a real implementation.
- Environment.SystemDirectory returns "/" on Unix.  Not sure if there's a better answer.
- Environment.Is64BitOperatingSystem returns IntPtr.Size == 8 on Unix, which isn't necessarily correct.  We should come up with a better solution, such as querying uname.
- Environment.GetFolderPath on both Windows and Unix is currently taking the code path written for Windows Phone, such that only SpecialFolder.System is implemented and everything else throws PlatformNotSupportedException.
- Environment.CommandLine on Unix appears to be returning only argv[0].
- Plus the relevant ref file needs to be updated in corefx and tests added there.  My testing thus far was limited to a few calls to each method via reflection.

cc: @jkotas, @danmosemsft, @weshaggard 
