### PR TITLE
Fix 'unicode/uchar.h' file not found on MacOS

### DIFF
--- a/Documentation/building/osx-instructions.md
+++ b/Documentation/building/osx-instructions.md
@@ -38,7 +38,12 @@ dotnet-mbp:~ richlander$ brew install cmake
 
 ICU
 ---
-ICU (International Components for Unicode) is also required to build and run. It can be obtained via [Homebrew](http://brew.sh/) with `brew install icu4c`.
+ICU (International Components for Unicode) is also required to build and run. It can be obtained via [Homebrew](http://brew.sh/).
+
+```sh
+brew install icu4c
+brew link --force icu4c
+```
 
 OpenSSL
 -------


### PR DESCRIPTION
The latest version of Homebrew does not set up the include path for `icu4c` so we have to force the creation of symbolic links like this is done for OpenSSL.