### PR TITLE
Massage code for clang-format

### DIFF
--- a/src/jit/.clang-format
+++ b/src/jit/.clang-format
@@ -1,0 +1,80 @@
+---
+Language:     Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:   120
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [  ]
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 400
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 500
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 100000
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...

--- a/src/jit/_typeinfo.h
+++ b/src/jit/_typeinfo.h
@@ -416,7 +416,6 @@ public:
     static bool AreEquivalentModuloNativeInt(const typeInfo& verTi, const typeInfo& nodeTi)
     {
         if (AreEquivalent(verTi, nodeTi)) return true;
-        // Otherwise...
 #ifdef _TARGET_64BIT_
         return (nodeTi.IsType(TI_I_IMPL) && tiCompatibleWith(0, verTi, typeInfo::nativeInt(), true)) ||
                (verTi.IsType(TI_I_IMPL) && tiCompatibleWith(0, typeInfo::nativeInt(), nodeTi, true));

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -367,21 +367,16 @@ void                Compiler::optAddCopies()
                     continue;
                 }
 
-                // This block will be the new candidate for the insert point
-                // for the new assignment
-                //
 #ifdef DEBUG
                 if  (verbose)
                     printf("new bestBlock\n");
 #endif
 
+                // This block will be the new candidate for the insert point
+                // for the new assignment
                 bestBlock  = block;
                 bestWeight = block->getBBWeight(this);
             }
-
-            /* If there is a use of the variable in this block */
-            /* then we insert the assignment at the beginning  */
-            /* otherwise we insert the statement at the end    */
 
 #ifdef DEBUG
             if  (verbose)
@@ -393,6 +388,9 @@ void                Compiler::optAddCopies()
             }
 #endif
 
+            // If there is a use of the variable in this block
+            // then we insert the assignment at the beginning
+            // otherwise we insert the statement at the end
             if (BlockSetOps::IsEmpty(this, paramImportantUseDom) || BlockSetOps::IsMember(this, varDsc->lvRefBlks, bestBlock->bbNum))
                 stmt = fgInsertStmtAtBeg(bestBlock, copyAsgn);
             else
@@ -2251,9 +2249,9 @@ GenTreePtr Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTreePtr stmt,
 #ifdef _TARGET_64BIT_
             if (vnStore->IsVNHandle(vnCns))
             {
+#ifdef RELOC_SUPPORT
                 // Don't perform constant folding that involves a handle that needs
                 // to be recorded as a relocation with the VM.
-#ifdef RELOC_SUPPORT
                 if (!opts.compReloc)
 #endif
                 {
@@ -2322,9 +2320,9 @@ GenTreePtr Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTreePtr stmt,
 #ifndef _TARGET_64BIT_
             if (vnStore->IsVNHandle(vnCns))
             {
+#ifdef RELOC_SUPPORT
                 // Don't perform constant folding that involves a handle that needs
                 // to be recorded as a relocation with the VM.
-#ifdef RELOC_SUPPORT
                 if (!opts.compReloc)
 #endif
                 {
@@ -2475,8 +2473,10 @@ GenTreePtr Compiler::optConstantAssertionProp(AssertionDsc* curAssertion, GenTre
     if (!optLocalAssertionProp)
     {
         assert(newTree->OperIsConst());                       // We should have a simple Constant node for newTree
-        assert(vnStore->IsVNConstant(curAssertion->op2.vn));  // The value number stored for op2 should be a valid VN representing the constant
-        newTree->gtVNPair.SetBoth(curAssertion->op2.vn);      // Set the ValueNumPair to the constant VN from op2 of the assertion
+        assert(vnStore->IsVNConstant(curAssertion->op2.vn));  // The value number stored for op2 should be a valid
+                                                              // VN representing the constant
+        newTree->gtVNPair.SetBoth(curAssertion->op2.vn);      // Set the ValueNumPair to the constant VN from op2
+                                                              // of the assertion
     }
 
 #ifdef  DEBUG
@@ -2708,8 +2708,8 @@ GenTreePtr Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, const 
  *  op1Kind and lclNum, op2Kind and the constant value and is either equal or
  *  not equal assertion.
  */
-Compiler::AssertionIndex Compiler::optLocalAssertionIsEqualOrNotEqual(optOp1Kind op1Kind, unsigned lclNum, optOp2Kind  op2Kind,
-                                                      ssize_t cnsVal, ASSERT_VALARG_TP assertions)
+Compiler::AssertionIndex Compiler::optLocalAssertionIsEqualOrNotEqual(optOp1Kind op1Kind, unsigned lclNum,
+        optOp2Kind  op2Kind, ssize_t cnsVal, ASSERT_VALARG_TP assertions)
 {
     noway_assert((op1Kind == O1K_LCLVAR) || (op1Kind == O1K_EXACT_TYPE) || (op1Kind == O1K_SUBTYPE));
     noway_assert((op2Kind == O2K_CONST_INT) || (op2Kind == O2K_IND_CNS_INT));

--- a/src/jit/bitset.cpp
+++ b/src/jit/bitset.cpp
@@ -12,10 +12,12 @@
 #include "bitsetasshortlong.h"
 #include "bitsetasuint64inclass.h"
 
+// clang-format off
 unsigned BitSetSupport::BitCountTable[16] = { 0, 1, 1, 2, 
                                               1, 2, 2, 3, 
                                               1, 2, 2, 3, 
                                               2, 3, 3, 4 };
+// clang-format on
 
 #ifdef DEBUG
 template<typename BitSetType, 

--- a/src/jit/bitset.h
+++ b/src/jit/bitset.h
@@ -137,9 +137,10 @@ unsigned BitSetSupport::CountBitsInIntegral<unsigned>(unsigned c)
 //      An "adapter" class that provides methods that retrieves things from the Env:
 //        static IAllocator* GetAllococator(Env):   yields an "IAllocator*" that the BitSet implementation can use.
 //        static unsigned    GetSize(Env):          the current size (= # of bits) of this bitset type.
-//        static unsigned    GetArrSize(Env, unsigned elemSize):  The number of "elemSize" chunks sufficient to hold "GetSize".
-//                                                                A given BitSet implementation must call this with only one constant value.
-//                                                                Thus, and "Env" may compute this result when GetSize changes.
+//        static unsigned    GetArrSize(Env, unsigned elemSize):  The number of "elemSize" chunks sufficient to hold
+//                                                                "GetSize". A given BitSet implementation must call
+//                                                                this with only one constant value. Thus, and "Env"
+//                                                                may compute this result when GetSize changes.
 //                                    
 //        static unsigned    GetEpoch(Env):         the current epoch.
 //
@@ -149,7 +150,8 @@ unsigned BitSetSupport::CountBitsInIntegral<unsigned>(unsigned c)
 // In addition to implementing the method signatures here, an instantiation of BitSetOps must also export a
 // BitSetOps::Iter type, which supports the following operations:
 //      Iter(BitSetValueArgType):        a constructor
-//      bool NextElem(unsigned* pElem):  returns true if the iteration is not complete, and sets *pElem to the next yielded member.
+//      bool NextElem(unsigned* pElem):  returns true if the iteration is not complete, and sets *pElem to the next
+//                                       yielded member.
 //
 // Finally, it should export two further types:
 // 
@@ -166,12 +168,13 @@ template<typename BitSetType,
          typename BitSetTraits>
 class BitSetOps
 {
+#if 0
     // Below are the set of methods that an instantiation of BitSetOps should provide.  This is
     // #if'd out because it doesn't make any difference; C++ has no mechanism for checking that
     // the methods of an instantiation are consistent with these signatures, other than the expectations
     // embodied in the program that uses the instantiation(s).  But it's useful documentation, and
     // we should try to keep it up to date.
-#if 0
+
   public:
 
     // The uninitialized value -- not a real bitset (if possible).

--- a/src/jit/bitsetasuint64inclass.h
+++ b/src/jit/bitsetasuint64inclass.h
@@ -63,12 +63,12 @@ private:
             ;
     }
 
+#ifndef DEBUG
     // In debug we also want the default copy constructor to be private, to make inadvertent
     // default initializations illegal.  Debug builds therefore arrange to use the
     // non-default constructor defined below that takes an extra argument where one would
     // otherwise use a copy constructor.  In non-debug builds, we don't pass the extra dummy
     // int argument, and just make copy constructor defined here visible.
-#ifndef DEBUG
 public:
 #endif
     BitSetUint64(const BitSetUint64& bs) : m_bits(bs.m_bits)

--- a/src/jit/bitvec.h
+++ b/src/jit/bitvec.h
@@ -37,8 +37,8 @@ typedef  BitSetShortLongRep BitVec;
 typedef   BitVecOps::ValArgType BitVec_ValArg_T;
 typedef   BitVecOps::RetValType BitVec_ValRet_T;
 
-// Initialize "_varName" to "_initVal."  Copies contents, not references; if "_varName" is uninitialized, allocates a set
-// for it (using "_traits" for any necessary allocation), and copies the contents of "_initVal" into it.
+// Initialize "_varName" to "_initVal."  Copies contents, not references; if "_varName" is uninitialized, allocates a
+// set for it (using "_traits" for any necessary allocation), and copies the contents of "_initVal" into it.
 #define BITVEC_INIT(_traits, _varName, _initVal) _varName(BitVecOps::MakeCopy(_traits, _initVal))
 
 // Initializes "_varName" to "_initVal", without copying: if "_initVal" is an indirect representation, copies its

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -142,7 +142,8 @@ enum ThisInitState
 
 struct EntryState
 {
-    ThisInitState   thisInitialized : 8;        // used to track whether the this ptr is initialized (we could use fewer bits here)
+    ThisInitState   thisInitialized : 8;        // used to track whether the this ptr is initialized (we could use
+                                                // fewer bits here)
     unsigned        esStackDepth    : 24;       // size of esStack
     StackEntry*     esStack;                    // ptr to  stack
 };
@@ -319,22 +320,25 @@ struct BasicBlock
 #define BBF_HAS_NEWOBJ      0x00800000  // BB contains 'new' of an object type. 
 
 #if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
-#define BBF_FINALLY_TARGET  0x01000000  // BB is the target of a finally return: where a finally will return during non-exceptional flow.
-                                        // Because the ARM calling sequence for calling a finally explicitly sets the return address to
-                                        // the finally target and jumps to the finally, instead of using a call instruction, ARM needs this
-                                        // to generate correct code at the finally target, to allow for proper stack unwind from within a
-                                        // non-exceptional call to a finally.
+#define BBF_FINALLY_TARGET  0x01000000  // BB is the target of a finally return: where a finally will return during
+                                        // non-exceptional flow. Because the ARM calling sequence for calling a
+                                        // finally explicitly sets the return address to the finally target and jumps
+                                        // to the finally, instead of using a call instruction, ARM needs this to
+                                        // generate correct code at the finally target, to allow for proper stack
+                                        // unwind from within a non-exceptional call to a finally.
 #endif // FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
 #define BBF_BACKWARD_JUMP   0x02000000  // BB is surrounded by a backward jump/switch arc
-#define BBF_RETLESS_CALL    0x04000000  // BBJ_CALLFINALLY that will never return (and therefore, won't need a paired BBJ_ALWAYS); see isBBCallAlwaysPair().
+#define BBF_RETLESS_CALL    0x04000000  // BBJ_CALLFINALLY that will never return (and therefore, won't need a paired
+                                        // BBJ_ALWAYS); see isBBCallAlwaysPair().
 #define BBF_LOOP_PREHEADER  0x08000000  // BB is a loop preheader block
 
 #define BBF_COLD            0x10000000  // BB is cold
 #define BBF_PROF_WEIGHT     0x20000000  // BB weight is computed from profile data
 #define BBF_FORWARD_SWITCH  0x40000000  // Aux flag used in FP codegen to know if a jmptable entry has been forwarded
-#define BBF_KEEP_BBJ_ALWAYS 0x80000000  // A special BBJ_ALWAYS block, used by EH code generation. Keep the jump kind as BBJ_ALWAYS.
-                                        // Used for the paired BBJ_ALWAYS block following the BBJ_CALLFINALLY block, as well as, on x86,
-                                        // the final step block out of a finally.
+#define BBF_KEEP_BBJ_ALWAYS 0x80000000  // A special BBJ_ALWAYS block, used by EH code generation. Keep the jump kind
+                                        // as BBJ_ALWAYS. Used for the paired BBJ_ALWAYS block following the
+                                        // BBJ_CALLFINALLY block, as well as, on x86, the final step block out of a
+                                        // finally.
 
     bool      isRunRarely()             { return ((bbFlags & BBF_RUN_RARELY) != 0); }
     bool      isLoopHead()              { return ((bbFlags & BBF_LOOP_HEAD)  != 0); }
@@ -586,8 +590,8 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
     // analysis that is tracking the contents of local variables might want to consider *all* successors,
     // and would pass the current Compiler object.
     //
-    // Similarly, BBJ_EHFILTERRET blocks are assumed to have no successors if "comp" is null; if non-null, NumSucc/GetSucc
-    // yields the first block of the try blocks handler.
+    // Similarly, BBJ_EHFILTERRET blocks are assumed to have no successors if "comp" is null; if non-null,
+    // NumSucc/GetSucc yields the first block of the try blocks handler.
     //
     // Also, the behavior for switches changes depending on the value of "comp". If it is null, then all
     // switch successors are returned. If it is non-null, then only unique switch successors are returned;
@@ -621,8 +625,8 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
 
 #define MAX_XCPTN_INDEX (USHRT_MAX - 1)
 
-    // It would be nice to make bbTryIndex and bbHndIndex private, but there is still code that uses them directly, especially
-    // Compiler::fgNewBBinRegion() and friends.
+    // It would be nice to make bbTryIndex and bbHndIndex private, but there is still code that uses them directly,
+    // especially Compiler::fgNewBBinRegion() and friends.
 
     // index, into the compHndBBtab table, of innermost 'try' clause containing the BB (used for raising exceptions).
     // Stored as index + 1; 0 means "no try index".
@@ -632,13 +636,13 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
     // Stored as index + 1; 0 means "no handler index".
     unsigned short      bbHndIndex;
 
-    // Given two EH indices that are either bbTryIndex or bbHndIndex (or related), determine if index1 might be more deeply
-    // nested than index2. Both index1 and index2 are in the range [0..compHndBBtabCount], where 0 means "main function"
-    // and otherwise the value is an index into compHndBBtab[]. Note that "sibling" EH regions will have a numeric
-    // index relationship that doesn't indicate nesting, whereas a more deeply nested region must have a lower index
-    // than the region it is nested within. Note that if you compare a single block's bbTryIndex and bbHndIndex, there
-    // is guaranteed to be a nesting relationship, since that block can't be simultaneously in two sibling EH regions.
-    // In that case, "maybe" is actually "definitely".
+    // Given two EH indices that are either bbTryIndex or bbHndIndex (or related), determine if index1 might be more
+    // deeply nested than index2. Both index1 and index2 are in the range [0..compHndBBtabCount], where 0 means
+    // "main function" and otherwise the value is an index into compHndBBtab[]. Note that "sibling" EH regions will
+    // have a numeric index relationship that doesn't indicate nesting, whereas a more deeply nested region must have
+    // a lower index than the region it is nested within. Note that if you compare a single block's bbTryIndex and
+    // bbHndIndex, there is guaranteed to be a nesting relationship, since that block can't be simultaneously in two
+    // sibling EH regions. In that case, "maybe" is actually "definitely".
     static bool ehIndexMaybeMoreNested(unsigned index1, unsigned index2)
     {
         if (index1 == 0)
@@ -725,8 +729,9 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
 #endif
 
     IL_OFFSET           bbCodeOffs;    // IL offset of the beginning of the block
-    IL_OFFSET           bbCodeOffsEnd; // IL offset past the end of the block. Thus, the [bbCodeOffs..bbCodeOffsEnd) range is not inclusive of the end offset.
-                                       // The count of IL bytes in the block is bbCodeOffsEnd - bbCodeOffs, assuming neither are BAD_IL_OFFSET.
+    IL_OFFSET           bbCodeOffsEnd; // IL offset past the end of the block. Thus, the [bbCodeOffs..bbCodeOffsEnd)
+                                       // range is not inclusive of the end offset. The count of IL bytes in the block
+                                       // is bbCodeOffsEnd - bbCodeOffs, assuming neither are BAD_IL_OFFSET.
 
 #ifdef DEBUG
     void                dspBlockILRange();  // Display the block's IL range as [XXX...YYY), where XXX and YYY might be "???" for BAD_IL_OFFSET.
@@ -744,8 +749,9 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
     unsigned            bbHeapDef: 1;
     unsigned            bbHeapLiveIn: 1;
     unsigned            bbHeapLiveOut: 1;
-    unsigned            bbHeapHavoc: 1;    // If true, at some point the block does an operation that leaves the heap in an unknown state.
-                                           // (E.g., unanalyzed call, store through unknown pointer...)
+    unsigned            bbHeapHavoc: 1;    // If true, at some point the block does an operation that leaves the heap
+                                           // in an unknown state. (E.g., unanalyzed call, store through unknown
+                                           // pointer...)
 
     // We want to make phi functions for the special implicit var "Heap".  But since this is not a real
     // lclVar, and thus has no local #, we can't use a GenTreePhiArg.  Instead, we use this struct.
@@ -778,10 +784,12 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
 
         void* operator new(size_t sz, class Compiler* comp);
     };
-    static HeapPhiArg*  EmptyHeapPhiDef;   // Special value (0x1, FWIW) to represent a to-be-filled in Phi arg list for Heap.
+    static HeapPhiArg*  EmptyHeapPhiDef;   // Special value (0x1, FWIW) to represent a to-be-filled in Phi arg list
+                                           // for Heap.
     HeapPhiArg*         bbHeapSsaPhiFunc;  // If the "in" Heap SSA var is not a phi definition, this value is NULL.
-                                           // Otherwise, it is either the special value EmptyHeapPhiDefn, to indicate that Heap needs a phi
-                                           // definition on entry, or else it is the linked list of the phi arguments.
+                                           // Otherwise, it is either the special value EmptyHeapPhiDefn, to indicate
+                                           // that Heap needs a phi definition on entry, or else it is the linked list
+                                           // of the phi arguments.
     unsigned            bbHeapSsaNumIn;    // The SSA # of "Heap" on entry to the block.
     unsigned            bbHeapSsaNumOut;   // The SSA # of "Heap" on exit from the block.
 
@@ -849,14 +857,14 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
 
     /* The following fields used for loop detection */
 
+    static const unsigned NOT_IN_LOOP = UCHAR_MAX;
+
 #ifdef DEBUG
     // This is the label a loop gets as part of the second, reachability-based
     // loop discovery mechanism.  This is apparently only used for debugging.
     // We hope we'll eventually just have one loop-discovery mechanism, and this will go away.
     unsigned char       bbLoopNum;   // set to 'n' for a loop #n header
 #endif // DEBUG
-
-    static const unsigned NOT_IN_LOOP = UCHAR_MAX;
 
     unsigned char       bbNatLoopNum;  // Index, in optLoopTable, of most-nested loop that contains this block,
                                        // or else NOT_IN_LOOP if this block is not in a loop.
@@ -881,7 +889,7 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
     }
 
     // Given an the edge b1 -> b2, calculate the slop fraction by
-    //  using the higher of the two block weights
+    // using the higher of the two block weights
     static weight_t     GetSlopFraction(BasicBlock* b1, BasicBlock* b2)
     {
         return GetSlopFraction(max(b1->bbWeight, b2->bbWeight));

--- a/src/jit/blockset.h
+++ b/src/jit/blockset.h
@@ -60,8 +60,8 @@ typedef  BitSetShortLongRep BlockSet;
 typedef   BlockSetOps::ValArgType BlockSet_ValArg_T;
 typedef   BlockSetOps::RetValType BlockSet_ValRet_T;
 
-// Initialize "_varName" to "_initVal."  Copies contents, not references; if "_varName" is uninitialized, allocates a var set
-// for it (using "_comp" for any necessary allocation), and copies the contents of "_initVal" into it.
+// Initialize "_varName" to "_initVal."  Copies contents, not references; if "_varName" is uninitialized, allocates a
+// var set for it (using "_comp" for any necessary allocation), and copies the contents of "_initVal" into it.
 #define BLOCKSET_INIT(_comp, _varName, _initVal) _varName(BlockSetOps::MakeCopy(_comp, _initVal))
 
 // Initializes "_varName" to "_initVal", without copying: if "_initVal" is an indirect representation, copies its

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -211,9 +211,9 @@ void                CodeGen::genCodeForBBlist()
 
     regSet.rsSpillBeg();
 
+#ifdef DEBUGGING_SUPPORT
     /* Initialize the line# tracking logic */
 
-#ifdef DEBUGGING_SUPPORT
     if (compiler->opts.compScopeInfo)
     {
         siInit();
@@ -362,10 +362,10 @@ void                CodeGen::genCodeForBBlist()
             }
         }
 
-        /* Start a new code output block */
-
 #if FEATURE_EH_FUNCLETS
 #if defined(_TARGET_ARM_)
+        /* Start a new code output block */
+
         // If this block is the target of a finally return, we need to add a preceding NOP, in the same EH region,
         // so the unwinder doesn't get confused by our "movw lr, xxx; movt lr, xxx; b Lyyy" calling convention that
         // calls the funclet during non-exceptional control flow.
@@ -373,18 +373,17 @@ void                CodeGen::genCodeForBBlist()
         {
             assert(block->bbFlags & BBF_JMP_TARGET);
 
-            // Create a label that we'll use for computing the start of an EH region, if this block is
-            // at the beginning of such a region. If we used the existing bbEmitCookie as is for
-            // determining the EH regions, then this NOP would end up outside of the region, if this
-            // block starts an EH region. If we pointed the existing bbEmitCookie here, then the NOP
-            // would be executed, which we would prefer not to do.
-
 #ifdef  DEBUG
             if (compiler->verbose)
             {
                 printf("\nEmitting finally target NOP predecessor for BB%02u\n", block->bbNum);
             }
 #endif
+            // Create a label that we'll use for computing the start of an EH region, if this block is
+            // at the beginning of such a region. If we used the existing bbEmitCookie as is for
+            // determining the EH regions, then this NOP would end up outside of the region, if this
+            // block starts an EH region. If we pointed the existing bbEmitCookie here, then the NOP
+            // would be executed, which we would prefer not to do.
 
             block->bbUnwindNopEmitCookie = getEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur,
                                                                       gcInfo.gcRegGCrefSetCur,
@@ -474,18 +473,18 @@ void                CodeGen::genCodeForBBlist()
         bool    firstMapping = true;
 #endif // DEBUGGING_SUPPORT
 
-        /*---------------------------------------------------------------------
-         *
-         *  Generate code for each statement-tree in the block
-         *
-         */
-
 #if FEATURE_EH_FUNCLETS
         if (block->bbFlags & BBF_FUNCLET_BEG)
         {
             genReserveFuncletProlog(block);
         }
 #endif // FEATURE_EH_FUNCLETS
+
+        /*---------------------------------------------------------------------
+         *
+         *  Generate code for each statement-tree in the block
+         *
+         */
 
         for (GenTreePtr stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
         {

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -173,17 +173,19 @@ void CodeGen::genStackPointerAdjustment(ssize_t spDelta, regNumber tmpReg, bool*
 }
 
 //------------------------------------------------------------------------
-// genPrologSaveRegPair: Save a pair of general-purpose or floating-point/SIMD registers in a function or funclet prolog.
-// If possible, we use pre-indexed addressing to adjust SP and store the registers with a single instruction.
-// The caller must ensure that we can use the STP instruction, and that spOffset will be in the legal range for that instruction.
+// genPrologSaveRegPair: Save a pair of general-purpose or floating-point/SIMD registers in a function or funclet
+// prolog. If possible, we use pre-indexed addressing to adjust SP and store the registers with a single instruction.
+// The caller must ensure that we can use the STP instruction, and that spOffset will be in the legal range for that
+// instruction.
 //
 // Arguments:
 //    reg1                     - First register of pair to save.
 //    reg2                     - Second register of pair to save.
 //    spOffset                 - The offset from SP to store reg1 (must be positive or zero).
-//    spDelta                  - If non-zero, the amount to add to SP before the register saves (must be negative or zero).
-//    lastSavedWasPreviousPair - True if the last prolog instruction was to save the previous register pair. This allows us to
-//                               emit the "save_next" unwind code.
+//    spDelta                  - If non-zero, the amount to add to SP before the register saves (must be negative or
+//                               zero).
+//    lastSavedWasPreviousPair - True if the last prolog instruction was to save the previous register pair. This
+//                               allows us to emit the "save_next" unwind code.
 //    tmpReg                   - An available temporary register. Needed for the case of large frames.
 //    pTmpRegIsZero            - If we use tmpReg, and pTmpRegIsZero is non-null, we set *pTmpRegIsZero to 'false'.
 //                               Otherwise, we don't touch it.
@@ -202,7 +204,8 @@ void CodeGen::genPrologSaveRegPair(regNumber reg1,
     assert(spOffset >= 0);
     assert(spDelta <= 0);
     assert((spDelta % 16) == 0); // SP changes must be 16-byte aligned
-    assert(genIsValidFloatReg(reg1) == genIsValidFloatReg(reg2)); // registers must be both general-purpose, or both FP/SIMD
+    assert(genIsValidFloatReg(reg1) == genIsValidFloatReg(reg2)); // registers must be both general-purpose, or both
+                                                                  // FP/SIMD
 
     bool needToSaveRegs = true;
     if (spDelta != 0)
@@ -246,16 +249,18 @@ void CodeGen::genPrologSaveRegPair(regNumber reg1,
 }
 
 //------------------------------------------------------------------------
-// genPrologSaveReg: Like genPrologSaveRegPair, but for a single register. Save a single general-purpose or floating-point/SIMD register
-// in a function or funclet prolog. Note that if we wish to change SP (i.e., spDelta != 0), then spOffset must be 8. This is because
-// otherwise we would create an alignment hole above the saved register, not below it, which we currently don't support. This restriction
-// could be loosened if the callers change to handle it (and this function changes to support using pre-indexed STR addressing).
-// The caller must ensure that we can use the STR instruction, and that spOffset will be in the legal range for that instruction.
+// genPrologSaveReg: Like genPrologSaveRegPair, but for a single register. Save a single general-purpose or
+// floating-point/SIMD register in a function or funclet prolog. Note that if we wish to change SP (i.e., spDelta != 0),
+// then spOffset must be 8. This is because otherwise we would create an alignment hole above the saved register, not
+// below it, which we currently don't support. This restriction could be loosened if the callers change to handle it
+// (and this function changes to support using pre-indexed STR addressing). The caller must ensure that we can use the
+// STR instruction, and that spOffset will be in the legal range for that instruction.
 //
 // Arguments:
 //    reg1                     - Register to save.
 //    spOffset                 - The offset from SP to store reg1 (must be positive or zero).
-//    spDelta                  - If non-zero, the amount to add to SP before the register saves (must be negative or zero).
+//    spDelta                  - If non-zero, the amount to add to SP before the register saves (must be negative or
+//                               zero).
 //    tmpReg                   - An available temporary register. Needed for the case of large frames.
 //    pTmpRegIsZero            - If we use tmpReg, and pTmpRegIsZero is non-null, we set *pTmpRegIsZero to 'false'.
 //                               Otherwise, we don't touch it.
@@ -294,7 +299,8 @@ void CodeGen::genPrologSaveReg(regNumber reg1,
 //    reg1                     - First register of pair to restore.
 //    reg2                     - Second register of pair to restore.
 //    spOffset                 - The offset from SP to load reg1 (must be positive or zero).
-//    spDelta                  - If non-zero, the amount to add to SP after the register restores (must be positive or zero).
+//    spDelta                  - If non-zero, the amount to add to SP after the register restores (must be positive or
+//                               zero).
 //    tmpReg                   - An available temporary register. Needed for the case of large frames.
 //    pTmpRegIsZero            - If we use tmpReg, and pTmpRegIsZero is non-null, we set *pTmpRegIsZero to 'false'.
 //                               Otherwise, we don't touch it.
@@ -348,7 +354,8 @@ void CodeGen::genEpilogRestoreRegPair(regNumber reg1,
 // Arguments:
 //    reg1                     - Register to restore.
 //    spOffset                 - The offset from SP to restore reg1 (must be positive or zero).
-//    spDelta                  - If non-zero, the amount to add to SP after the register restores (must be positive or zero).
+//    spDelta                  - If non-zero, the amount to add to SP after the register restores (must be positive or
+//                               zero).
 //    tmpReg                   - An available temporary register. Needed for the case of large frames.
 //    pTmpRegIsZero            - If we use tmpReg, and pTmpRegIsZero is non-null, we set *pTmpRegIsZero to 'false'.
 //                               Otherwise, we don't touch it.
@@ -400,7 +407,8 @@ void CodeGen::genEpilogRestoreReg(regNumber reg1,
 //    lowestCalleeSavedOffset - The offset from SP that is the beginning of the callee-saved register area. Note that
 //                              if non-zero spDelta, then this is the offset of the first save *after* that
 //                              SP adjustment.
-//    spDelta                 - If non-zero, the amount to add to SP before the register saves (must be negative or zero).
+//    spDelta                 - If non-zero, the amount to add to SP before the register saves (must be negative or
+//                              zero).
 //
 // Return Value:
 //    None.
@@ -424,7 +432,8 @@ void CodeGen::genSaveCalleeSavedRegistersHelp(regMaskTP   regsToSaveMask,
 
     assert((spDelta % 16) == 0);
     assert((regsToSaveMask & RBM_FP) == 0); // we never save FP here
-    assert(regsToSaveCount <= genCountBits(RBM_CALLEE_SAVED | RBM_LR)); // We also save LR, even though it is not in RBM_CALLEE_SAVED.
+    assert(regsToSaveCount <= genCountBits(RBM_CALLEE_SAVED | RBM_LR)); // We also save LR, even though it is not in
+                                                                        // RBM_CALLEE_SAVED.
 
     regMaskTP maskSaveRegsFloat = regsToSaveMask & RBM_ALLFLOAT;
     regMaskTP maskSaveRegsInt   = regsToSaveMask & ~maskSaveRegsFloat;
@@ -469,8 +478,8 @@ void CodeGen::genSaveCalleeSavedRegistersHelp(regMaskTP   regsToSaveMask,
 
             genPrologSaveRegPair(reg1, reg2, spOffset, spDelta, lastSavedWasPair, REG_IP0, nullptr);
 
-            // TODO-ARM64-CQ: this code works in the prolog, but it's a bit weird to think about "next" when generating this epilog, to
-            // get the codes to match. Turn this off until that is better understood.
+            // TODO-ARM64-CQ: this code works in the prolog, but it's a bit weird to think about "next" when generating
+            // this epilog, to get the codes to match. Turn this off until that is better understood.
             // lastSavedWasPair = true;
 
             spOffset += 2 * REGSIZE_BYTES;
@@ -521,8 +530,8 @@ void CodeGen::genSaveCalleeSavedRegistersHelp(regMaskTP   regsToSaveMask,
 
             genPrologSaveRegPair(reg1, reg2, spOffset, spDelta, lastSavedWasPair, REG_IP0, nullptr);
 
-            // TODO-ARM64-CQ: this code works in the prolog, but it's a bit weird to think about "next" when generating this epilog, to
-            // get the codes to match. Turn this off until that is better understood.
+            // TODO-ARM64-CQ: this code works in the prolog, but it's a bit weird to think about "next" when generating
+            // this epilog, to get the codes to match. Turn this off until that is better understood.
             // lastSavedWasPair = true;
 
             spOffset += 2 * FPSAVE_REGSIZE_BYTES;
@@ -551,7 +560,8 @@ void CodeGen::genSaveCalleeSavedRegistersHelp(regMaskTP   regsToSaveMask,
 // Arguments:
 //    regsToRestoreMask       - The mask of callee-saved registers to restore. If empty, this function does nothing.
 //    lowestCalleeSavedOffset - The offset from SP that is the beginning of the callee-saved register area.
-//    spDelta                 - If non-zero, the amount to add to SP after the register restores (must be positive or zero).
+//    spDelta                 - If non-zero, the amount to add to SP after the register restores (must be positive or
+//                              zero).
 //
 // Here's an example restore sequence:
 //      ldp     x27, x28, [sp,#96]
@@ -568,8 +578,8 @@ void CodeGen::genSaveCalleeSavedRegistersHelp(regMaskTP   regsToSaveMask,
 //      ldp     x21, x22, [sp,#16]
 //      ldp     x19, x20, [sp], #80
 //
-// Note you call the unwind functions specifying the prolog operation that is being un-done. So, for example, when generating
-// a post-indexed load, you call the unwind function for specifying the corresponding preindexed store.
+// Note you call the unwind functions specifying the prolog operation that is being un-done. So, for example, when
+// generating a post-indexed load, you call the unwind function for specifying the corresponding preindexed store.
 //
 // Return Value:
 //    None.
@@ -717,7 +727,7 @@ void CodeGen::genRestoreCalleeSavedRegistersHelp(regMaskTP   regsToRestoreMask,
     assert(intRegsToRestoreCount == 0);
 }
 
-
+// clang-format off
 /*****************************************************************************
  *
  *  Generates code for an EH funclet prolog.
@@ -900,6 +910,7 @@ void CodeGen::genRestoreCalleeSavedRegistersHelp(regMaskTP   regsToRestoreMask,
  *      |       | downward      |         
  *              V
  */
+// clang-format on
 
 void                CodeGen::genFuncletProlog(BasicBlock* block)
 {
@@ -1125,7 +1136,8 @@ void                CodeGen::genCaptureFuncletPrologEpilogInfo()
         return;
 
     assert(isFramePointerUsed());
-    assert(compiler->lvaDoneFrameLayout == Compiler::FINAL_FRAME_LAYOUT); // The frame size and offsets must be finalized
+    assert(compiler->lvaDoneFrameLayout == Compiler::FINAL_FRAME_LAYOUT); // The frame size and offsets must be
+                                                                          // finalized
 
     genFuncletInfo.fiFunction_CallerSP_to_FP_delta = genCallerSPtoFPdelta();
 
@@ -1448,9 +1460,9 @@ void                CodeGen::genCodeForBBlist()
 
     regSet.rsSpillBeg();
 
+#ifdef DEBUGGING_SUPPORT
     /* Initialize the line# tracking logic */
 
-#ifdef DEBUGGING_SUPPORT
     if (compiler->opts.compScopeInfo)
     {
         siInit();
@@ -1539,9 +1551,9 @@ void                CodeGen::genCodeForBBlist()
         genUpdateLife(block->bbLiveIn);
 
         // Even if liveness didn't change, we need to update the registers containing GC references.
-        // genUpdateLife will update the registers live due to liveness changes. But what about registers that didn't change?
-        // We cleared them out above. Maybe we should just not clear them out, but update the ones that change here.
-        // That would require handling the changes in recordVarLocationsAtStartOfBB().
+        // genUpdateLife will update the registers live due to liveness changes. But what about registers that didn't
+        // change? We cleared them out above. Maybe we should just not clear them out, but update the ones that change
+        // here. That would require handling the changes in recordVarLocationsAtStartOfBB().
 
         regMaskTP newLiveRegSet = RBM_NONE;
         regMaskTP newRegGCrefSet = RBM_NONE;
@@ -3175,7 +3187,8 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         break;
 
     case GT_PUTARG_REG:
-        assert(targetType != TYP_STRUCT);  // Any TYP_STRUCT register args should have been removed by fgMorphMultiregStructArg
+        assert(targetType != TYP_STRUCT);  // Any TYP_STRUCT register args should have been removed by
+                                           // fgMorphMultiregStructArg
         // We have a normal non-Struct targetType
         {
             GenTree *op1 = treeNode->gtOp.gtOp1;
@@ -3498,7 +3511,8 @@ CodeGen::genLclHeap(GenTreePtr tree)
     //      Nothing needs to popped off from stack nor relocated.
     if  (compiler->lvaOutgoingArgSpaceSize > 0)
     {
-        assert((compiler->lvaOutgoingArgSpaceSize % STACK_ALIGN) == 0); // This must be true for the stack to remain aligned
+        assert((compiler->lvaOutgoingArgSpaceSize % STACK_ALIGN) == 0); // This must be true for the stack to remain
+                                                                        // aligned
         inst_RV_IV(INS_add, REG_SPBASE, compiler->lvaOutgoingArgSpaceSize, EA_PTRSIZE);
         stackAdjustment += compiler->lvaOutgoingArgSpaceSize;
     }
@@ -3765,9 +3779,9 @@ void CodeGen::genCodeForInitBlk(GenTreeInitBlk* initBlkNode)
     assert(!initVal->isContained());
     assert(!blockSize->isContained());
 
+#if 0
     // TODO-ARM64-CQ: When initblk loop unrolling is implemented
     //                put this assert back on.
-#if 0
     if (blockSize->IsCnsIntOrI())
     {
         assert(blockSize->gtIntCon.gtIconVal >= INITBLK_UNROLL_LIMIT);
@@ -4026,9 +4040,10 @@ void CodeGen::genCodeForCpBlk(GenTreeCpBlk* cpBlkNode)
     assert(!srcAddr->isContained());
     assert(!blockSize->isContained());
 
-    // Enable this when we support cpblk loop unrolling.
 #if 0
 #ifdef DEBUG
+    // Enable this when we support cpblk loop unrolling.
+
     if (blockSize->IsCnsIntOrI())
     {
         assert(blockSize->gtIntCon.gtIconVal >= CPBLK_UNROLL_LIMIT);
@@ -5991,8 +6006,9 @@ CodeGen::genFloatToFloatCast(GenTreePtr treeNode)
 
         getEmitter()->emitIns_R_R(INS_fcvt, emitTypeSize(treeNode), treeNode->gtRegNum, op1->gtRegNum, cvtOption);
     }
-    else if (treeNode->gtRegNum != op1->gtRegNum) // If double to double cast or float to float cast. Emit a move instruction.
+    else if (treeNode->gtRegNum != op1->gtRegNum)
     {
+        // If double to double cast or float to float cast. Emit a move instruction.
         getEmitter()->emitIns_R_R(INS_mov, emitTypeSize(treeNode), treeNode->gtRegNum, op1->gtRegNum);
     }
 
@@ -6970,6 +6986,7 @@ void                CodeGen::genArm64EmitterUnitTests()
 
     emitter*  theEmitter = getEmitter();
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     // We use this:
     //      genDefineTempLabel(genCreateTempLabel());
     // to create artificial labels to help separate groups of tests.
@@ -6977,8 +6994,6 @@ void                CodeGen::genArm64EmitterUnitTests()
     //
     // Loads/Stores basic general register
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7037,11 +7052,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // Compares 
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7072,11 +7086,9 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
-
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     // R_R
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7095,11 +7107,11 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_I
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7149,11 +7161,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7187,11 +7198,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_I_I
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7209,11 +7219,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_I
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7320,11 +7329,11 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_I cmp/txt
     //
 
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     // cmp
     theEmitter->emitIns_R_R_I(INS_cmp,    EA_8BYTE, REG_R8, REG_R9, 0);
     theEmitter->emitIns_R_R_I(INS_cmp,    EA_4BYTE, REG_R8, REG_R9, 0);
@@ -7382,11 +7391,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7438,11 +7446,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_I_I
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7472,11 +7479,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R_I
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7580,11 +7586,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R_I  -- load/store pair
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     theEmitter->emitIns_R_R_R_I(INS_ldnp,    EA_8BYTE, REG_R8, REG_R9, REG_R10, 0);
     theEmitter->emitIns_R_R_R_I(INS_stnp,    EA_8BYTE, REG_R8, REG_R9, REG_R10, 0);
@@ -7629,11 +7634,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R_Ext    -- load/store shifted/extend
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7757,11 +7761,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R_R
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7781,10 +7784,9 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     // R_COND
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // cset reg, cond
     theEmitter->emitIns_R_COND(INS_cset, EA_8BYTE, REG_R9, INS_COND_EQ); // eq
@@ -7820,10 +7822,9 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     // R_R_COND
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // cinc reg, reg, cond
     // cinv reg, reg, cond
@@ -7845,10 +7846,9 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     // R_R_R_COND
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // csel  reg, reg, reg, cond
     // csinc reg, reg, reg, cond
@@ -7871,10 +7871,9 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     // R_R_FLAGS_COND
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // ccmp reg1, reg2, nzcv, cond
     theEmitter->emitIns_R_R_FLAGS_COND(INS_ccmp, EA_8BYTE, REG_R9, REG_R3, INS_FLAGS_V,    INS_COND_EQ); // eq
@@ -7958,11 +7957,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // Branch to register
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -7973,11 +7971,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // Misc
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -8002,6 +7999,7 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     ////////////////////////////////////////////////////////////////////////////////
     //
     // SIMD and Floating point
@@ -8011,8 +8009,6 @@ void                CodeGen::genArm64EmitterUnitTests()
     //
     // Load/Stores vector register
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -8179,11 +8175,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R   mov and aliases for mov
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // mov vector to vector
     theEmitter->emitIns_R_R(INS_mov, EA_8BYTE,  REG_V0,  REG_V1);
@@ -8262,11 +8257,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_I   movi and mvni
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // movi  imm8  (vector)
     theEmitter->emitIns_R_I(INS_movi, EA_8BYTE,   REG_V0,  0x00,       INS_OPTS_8B);
@@ -8334,11 +8328,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_I   orr/bic vector immediate
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     theEmitter->emitIns_R_I(INS_orr, EA_8BYTE,   REG_V0,  0x0022,     INS_OPTS_4H);
     theEmitter->emitIns_R_I(INS_orr, EA_8BYTE,   REG_V1,  0x2200,     INS_OPTS_4H);  // LSL  8
@@ -8372,11 +8365,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_F   cmp/fmov immediate
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // fmov  imm8  (scalar)
     theEmitter->emitIns_R_F(INS_fmov, EA_8BYTE,  REG_V14,  1.0);
@@ -8414,11 +8406,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R   fmov/fcmp/fcvt
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // fmov to vector to vector
     theEmitter->emitIns_R_R(INS_fmov, EA_8BYTE,  REG_V0,  REG_V2);
@@ -8456,11 +8447,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R   floating point conversions
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // fcvtas scalar
     theEmitter->emitIns_R_R(INS_fcvtas, EA_4BYTE,  REG_V0,  REG_V1);
@@ -8654,11 +8644,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R   floating point operations, one dest, one source
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // fabs scalar
     theEmitter->emitIns_R_R(INS_fabs,  EA_4BYTE,  REG_V0,  REG_V1);
@@ -8769,11 +8758,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R   floating point round to int, one dest, one source
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     // frinta scalar
     theEmitter->emitIns_R_R(INS_frinta, EA_4BYTE,  REG_V0,  REG_V1);
@@ -8840,11 +8828,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R   floating point operations, one dest, two source
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -8916,11 +8903,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_I  vector operations, one dest, one source reg, one immed
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -9161,11 +9147,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R   vector operations, one dest, two source
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -9265,11 +9250,10 @@ void                CodeGen::genArm64EmitterUnitTests()
     
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R  vector multiply
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -9327,11 +9311,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R   floating point operations, one source/dest, and two source
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     genDefineTempLabel(genCreateTempLabel());
 
@@ -9357,11 +9340,10 @@ void                CodeGen::genArm64EmitterUnitTests()
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
     //
     // R_R_R_R   floating point operations, one dest, and three source
     //
-
-#ifdef ALL_ARM64_EMITTER_UNIT_TESTS
 
     theEmitter->emitIns_R_R_R_R(INS_fmadd,   EA_4BYTE, REG_V0, REG_V8,  REG_V16, REG_V24);
     theEmitter->emitIns_R_R_R_R(INS_fmsub,   EA_4BYTE, REG_V1, REG_V9,  REG_V17, REG_V25);

--- a/src/jit/codegenclassic.h
+++ b/src/jit/codegenclassic.h
@@ -68,12 +68,12 @@ protected:
 
     void                genPInvokeMethodEpilog();    
 
-    regNumber           genPInvokeCallProlog(LclVarDsc *    varDsc,
+    regNumber           genPInvokeCallProlog(LclVarDsc*     varDsc,
                                              int            argSize,
                                       CORINFO_METHOD_HANDLE methodToken,
-                                             BasicBlock *   returnLabel);
+                                             BasicBlock*    returnLabel);
 
-    void                genPInvokeCallEpilog(LclVarDsc *    varDsc,
+    void                genPInvokeCallEpilog(LclVarDsc*     varDsc,
                                              regMaskTP      retVal);
 
     regNumber           genLclHeap          (GenTreePtr     size);
@@ -147,7 +147,7 @@ protected:
                                              bool           forLea,
                                              regMaskTP      regMask,
                                              RegSet::KeepReg        keepReg,
-                                             regMaskTP *    useMaskPtr,
+                                             regMaskTP*     useMaskPtr,
                                              bool           deferOp = false);
 
     regMaskTP           genMakeRvalueAddressable(GenTreePtr tree,
@@ -195,7 +195,7 @@ protected:
                                              RegSet::KeepReg        keptReg);
 
     GenTreePtr          genMakeAddrOrFPstk  (GenTreePtr     tree,
-                                             regMaskTP *    regMaskPtr,
+                                             regMaskTP*     regMaskPtr,
                                              bool           roundResult);
 
     void                genEmitGSCookieCheck(bool           pushReg);
@@ -204,8 +204,8 @@ protected:
 
 
     void                genCondJump         (GenTreePtr     cond,
-                                             BasicBlock *   destTrue  = NULL,
-                                             BasicBlock *   destFalse = NULL,
+                                             BasicBlock*    destTrue  = NULL,
+                                             BasicBlock*    destFalse = NULL,
                                              bool           bStackFPFixup = true);
 
 
@@ -213,28 +213,28 @@ protected:
 
 
     void                genJCC              (genTreeOps     cmp,
-                                             BasicBlock *   block,
+                                             BasicBlock*    block,
                                              var_types      type);
 
     void                genJccLongHi        (genTreeOps     cmp,
-                                             BasicBlock *   jumpTrue,
-                                             BasicBlock *   jumpFalse,
+                                             BasicBlock*    jumpTrue,
+                                             BasicBlock*    jumpFalse,
                                              bool           unsOper = false);
 
     void                genJccLongLo        (genTreeOps     cmp,
-                                             BasicBlock *   jumpTrue,
-                                             BasicBlock *   jumpFalse);
+                                             BasicBlock*    jumpTrue,
+                                             BasicBlock*    jumpFalse);
 
     void                genCondJumpLng      (GenTreePtr     cond,
-                                             BasicBlock *   jumpTrue,
-                                             BasicBlock *   jumpFalse,
+                                             BasicBlock*    jumpTrue,
+                                             BasicBlock*    jumpFalse,
                                              bool bFPTransition = false);
 
     bool                genUse_fcomip();
 
     void                genTableSwitch      (regNumber      reg,
                                              unsigned       jumpCnt,
-                                             BasicBlock **  jumpTab);
+                                             BasicBlock**  jumpTab);
 
     regMaskTP           WriteBarrier        (GenTreePtr     tgt,
                                              GenTreePtr     assignVal,
@@ -321,7 +321,7 @@ protected:
                                              regMaskTP      destReg,
                                              regMaskTP      bestReg = RBM_NONE);
 
-    regNumber           genIntegerCast(GenTree *tree, regMaskTP needReg, regMaskTP bestReg);
+    regNumber           genIntegerCast(GenTree* tree, regMaskTP needReg, regMaskTP bestReg);
     
     void                genCodeForNumericCast(GenTreePtr     tree,
                                               regMaskTP      destReg,
@@ -417,8 +417,8 @@ protected:
     void                genCodeForSwitch      (GenTreePtr     tree);
 
     regMaskTP           genPushRegs         (regMaskTP      regs,
-                                             regMaskTP *    byrefRegs,
-                                             regMaskTP *    noRefRegs);
+                                             regMaskTP*     byrefRegs,
+                                             regMaskTP*     noRefRegs);
     void                genPopRegs          (regMaskTP      regs,
                                              regMaskTP      byrefRegs,
                                              regMaskTP      noRefRegs);
@@ -470,7 +470,7 @@ protected:
                                                       LclVarDsc* promotedStructLocalVarDesc, 
                                                       emitAttr fieldSize,
                                                       unsigned* pNextPromotedStructFieldVar,         // IN/OUT
-                                                      unsigned *pBytesOfNextSlotOfCurPromotedStruct, // IN/OUT
+                                                      unsigned* pBytesOfNextSlotOfCurPromotedStruct, // IN/OUT
                                                       regNumber* pCurRegNum,                         // IN/OUT
                                                       int argOffset,
                                                       int fieldOffsetOfFirstStackSlot,
@@ -502,7 +502,7 @@ protected:
     GenTreePtr          genGetAddrModeBase  (GenTreePtr     tree);
 
     GenTreePtr          genIsAddrMode       (GenTreePtr     tree,
-                                             GenTreePtr *   indxPtr);
+                                             GenTreePtr*    indxPtr);
 private:
 
     bool                genIsLocalLastUse   (GenTreePtr     tree);
@@ -551,25 +551,25 @@ private:
     void            genCodeForTreeStackFP_Cast               (GenTreePtr tree);
     void            genCodeForTreeStackFP                    (GenTreePtr tree);
     void            genCondJumpFltStackFP                    (GenTreePtr     cond,
-                                                             BasicBlock *   jumpTrue,
-                                                             BasicBlock *   jumpFalse,
+                                                             BasicBlock*    jumpTrue,
+                                                             BasicBlock*    jumpFalse,
                                                              bool bDoTransition = true);
     void            genCondJumpFloat                         (GenTreePtr     cond,
-                                                             BasicBlock *   jumpTrue,
-                                                             BasicBlock *   jumpFalse);
+                                                             BasicBlock*    jumpTrue,
+                                                             BasicBlock*    jumpFalse);
     void            genCondJumpLngStackFP                    (GenTreePtr     cond,
-                                                             BasicBlock *   jumpTrue,
-                                                             BasicBlock *   jumpFalse);
+                                                             BasicBlock*    jumpTrue,
+                                                             BasicBlock*    jumpFalse);
 
-    void            genFloatConst(GenTree *tree, RegSet::RegisterPreference *pref);
-    void            genFloatLeaf(GenTree *tree, RegSet::RegisterPreference *pref);
-    void            genFloatSimple(GenTree *tree, RegSet::RegisterPreference *pref);
-    void            genFloatMath(GenTree *tree, RegSet::RegisterPreference *pref);
-    void            genFloatCheckFinite(GenTree *tree, RegSet::RegisterPreference *pref);
+    void            genFloatConst(GenTree* tree, RegSet::RegisterPreference* pref);
+    void            genFloatLeaf(GenTree* tree, RegSet::RegisterPreference* pref);
+    void            genFloatSimple(GenTree* tree, RegSet::RegisterPreference* pref);
+    void            genFloatMath(GenTree* tree, RegSet::RegisterPreference* pref);
+    void            genFloatCheckFinite(GenTree* tree, RegSet::RegisterPreference* pref);
     void            genLoadFloat(GenTreePtr tree, regNumber reg);
-    void            genFloatAssign(GenTree *tree);
-    void            genFloatArith(GenTree *tree, RegSet::RegisterPreference *pref);
-    void            genFloatAsgArith(GenTree *tree);
+    void            genFloatAssign(GenTree* tree);
+    void            genFloatArith(GenTree* tree, RegSet::RegisterPreference* pref);
+    void            genFloatAsgArith(GenTree* tree);
 
     regNumber       genAssignArithFloat(genTreeOps oper, 
                                         GenTreePtr dst, regNumber dstreg, 
@@ -577,11 +577,11 @@ private:
 
 
     GenTreePtr      genMakeAddressableFloat(GenTreePtr tree, 
-                                            regMaskTP *  regMaskIntPtr, regMaskTP *  regMaskFltPtr, 
+                                            regMaskTP*   regMaskIntPtr, regMaskTP*   regMaskFltPtr, 
                                             bool bCollapseConstantDoubles = true);
 
     void            genCodeForTreeFloat(GenTreePtr tree,
-                                        RegSet::RegisterPreference *pref = NULL);
+                                        RegSet::RegisterPreference* pref = NULL);
 
     void            genCodeForTreeFloat(GenTreePtr tree,
                                         regMaskTP  needReg, regMaskTP bestReg);
@@ -590,10 +590,10 @@ private:
                                    GenTreePtr dst, regNumber dstreg, 
                                    GenTreePtr src, regNumber srcreg, 
                                    bool bReverse);
-    void            genCodeForTreeCastFloat(GenTreePtr tree, RegSet::RegisterPreference *pref);
-    void            genCodeForTreeCastToFloat(GenTreePtr tree, RegSet::RegisterPreference *pref);
-    void            genCodeForTreeCastFromFloat(GenTreePtr tree, RegSet::RegisterPreference *pref);
-    void            genKeepAddressableFloat(GenTreePtr tree, regMaskTP * regMaskIntPtr, regMaskTP * regMaskFltPtr);
+    void            genCodeForTreeCastFloat(GenTreePtr tree, RegSet::RegisterPreference* pref);
+    void            genCodeForTreeCastToFloat(GenTreePtr tree, RegSet::RegisterPreference* pref);
+    void            genCodeForTreeCastFromFloat(GenTreePtr tree, RegSet::RegisterPreference* pref);
+    void            genKeepAddressableFloat(GenTreePtr tree, regMaskTP*  regMaskIntPtr, regMaskTP*  regMaskFltPtr);
     void            genDoneAddressableFloat(GenTreePtr tree, regMaskTP addrRegInt, regMaskTP addrRegFlt, RegSet::KeepReg keptReg);
     void            genComputeAddressableFloat(GenTreePtr tree, regMaskTP addrRegInt, regMaskTP addrRegFlt, RegSet::KeepReg keptReg, regMaskTP needReg, RegSet::KeepReg keepReg, bool freeOnly = false);
     void            genRoundFloatExpression(GenTreePtr op, var_types type);
@@ -614,8 +614,8 @@ private:
 
 #endif
 
-    GenTreePtr      genMakeAddressableStackFP               (GenTreePtr tree, regMaskTP *  regMaskIntPtr, regMaskTP *  regMaskFltPtr, bool bCollapseConstantDoubles = true);
-    void            genKeepAddressableStackFP               (GenTreePtr tree, regMaskTP *  regMaskIntPtr, regMaskTP *  regMaskFltPtr);
+    GenTreePtr      genMakeAddressableStackFP               (GenTreePtr tree, regMaskTP*   regMaskIntPtr, regMaskTP*   regMaskFltPtr, bool bCollapseConstantDoubles = true);
+    void            genKeepAddressableStackFP               (GenTreePtr tree, regMaskTP*   regMaskIntPtr, regMaskTP*   regMaskFltPtr);
     void            genDoneAddressableStackFP               (GenTreePtr tree, regMaskTP addrRegInt, regMaskTP addrRegFlt, RegSet::KeepReg keptReg);
 
 
@@ -674,12 +674,12 @@ private:
     regNumber       genArithmStackFP                       (genTreeOps oper, GenTreePtr dst, regNumber dstreg, GenTreePtr src, regNumber srcreg, bool bReverse);
     regNumber       genAsgArithmStackFP                    (genTreeOps oper, GenTreePtr dst, regNumber dstreg, GenTreePtr src, regNumber srcreg);
     void            genCondJmpInsStackFP                   (emitJumpKind   jumpKind,
-                                                            BasicBlock *   jumpTrue,
-                                                            BasicBlock *   jumpFalse,
+                                                            BasicBlock*    jumpTrue,
+                                                            BasicBlock*    jumpFalse,
                                                             bool bDoTransition = true);
     void            genTableSwitchStackFP                  (regNumber      reg,
                                                             unsigned       jumpCnt,
-                                                            BasicBlock **  jumpTab);
+                                                            BasicBlock**   jumpTab);
 
     void            JitDumpFPState                          ();
 #else // !FEATURE_STACK_FP_X87
@@ -705,10 +705,10 @@ private:
 #endif // FEATURE_STACK_FP_X87
 
     // Float spill
-    void            UnspillFloat                           (RegSet::SpillDsc *spillDsc);
+    void            UnspillFloat                           (RegSet::SpillDsc* spillDsc);
     void            UnspillFloat                           (GenTreePtr tree);
-    void            UnspillFloat                           (LclVarDsc * varDsc);
-    void            UnspillFloatMachineDep                 (RegSet::SpillDsc *spillDsc);
+    void            UnspillFloat                           (LclVarDsc*  varDsc);
+    void            UnspillFloatMachineDep                 (RegSet::SpillDsc* spillDsc);
     void            UnspillFloatMachineDep                 (RegSet::SpillDsc* spillDsc, bool useSameReg);
     void            RemoveSpillDsc                         (RegSet::SpillDsc* spillDsc);
 
@@ -726,10 +726,10 @@ protected :
         {}
     };
 
-    void saveLiveness    (genLivenessSet * ls);
-    void restoreLiveness (genLivenessSet * ls);
-    void checkLiveness   (genLivenessSet * ls);
-    void unspillLiveness (genLivenessSet * ls);
+    void saveLiveness    (genLivenessSet*  ls);
+    void restoreLiveness (genLivenessSet*  ls);
+    void checkLiveness   (genLivenessSet*  ls);
+    void unspillLiveness (genLivenessSet*  ls);
 
     //-------------------------------------------------------------------------
     //
@@ -751,3 +751,4 @@ protected :
 #endif // LEGACY_BACKEND
 
 #endif // _CODEGENCLASSIC_H_
+

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -1585,7 +1585,8 @@ bool                CodeGen::genMakeIndAddrMode(GenTreePtr   addr,
             // Maybe I should just set "fold" true in the call to genMakeAddressable above.
             if (scaledIndex != NULL)
             {
-                int scale = 1 << ((int)scaledIndex->gtOp.gtOp2->gtIntCon.gtIconVal);  // If this truncates, that's OK -- multiple of 2^6.
+                int scale = 1 << ((int)scaledIndex->gtOp.gtOp2->gtIntCon.gtIconVal); // If this truncates, that's OK --
+                                                                                     // multiple of 2^6.
                 if (mul == 0)
                 {
                     mul = scale;
@@ -1926,8 +1927,9 @@ void                CodeGen::genRangeCheck(GenTreePtr  oper)
         GenTreeArrLen* arrLenExact = arrLen->AsArrLen();
         lenOffset = arrLenExact->ArrLenOffset();
 
-        // We always load the length into a register on ARM and x64.
 #if !CPU_LOAD_STORE_ARCH && !defined(_TARGET_64BIT_)
+        // We always load the length into a register on ARM and x64.
+
         // 64-bit has to act like LOAD_STORE_ARCH because the array only holds 32-bit
         // lengths, but the index expression *can* be native int (64-bits)
         arrRef = arrLenExact->ArrRef();
@@ -2234,9 +2236,9 @@ regMaskTP           CodeGen::genMakeAddrArrElem(GenTreePtr      arrElem,
 
         genRecoverReg(index, indRegMask, RegSet::KEEP_REG);
 
+#if CPU_LOAD_STORE_ARCH
         /* Subtract the lower bound, and do the range check */
 
-#if CPU_LOAD_STORE_ARCH
         regNumber   valueReg = regSet.rsGrabReg(RBM_ALLINT & ~genRegMask(arrReg) & ~genRegMask(index->gtRegNum));
         getEmitter()->emitIns_R_AR(
                         INS_ldr, EA_4BYTE,
@@ -2984,8 +2986,9 @@ void                CodeGen::genEmitGSCookieCheck(bool pushReg)
 
     if (compiler->gsGlobalSecurityCookieAddr == NULL)
     {
-        // JIT case
 #if CPU_LOAD_STORE_ARCH
+        // JIT case
+
         regNumber reg = regSet.rsGrabReg(RBM_ALLINT);
         getEmitter()->emitIns_R_S(ins_Load(TYP_INT), EA_4BYTE,
                                 reg,
@@ -3105,8 +3108,9 @@ AGAIN:
             else if ((tree->gtFlags & GTF_IND_ARR_INDEX) == 0 &&
                      ((tree->gtFlags & GTF_EXCEPT) | GTF_IND_VOLATILE))
             {
+#if defined(_TARGET_XARCH_)
                 /* Compare against any register to do null-check */
- #if defined(_TARGET_XARCH_)
+
                 inst_TT_RV(INS_cmp, tree, REG_TMP_0, 0, EA_1BYTE);
                 genDoneAddressable(tree, addrReg, RegSet::KEEP_REG);
 #elif CPU_LOAD_STORE_ARCH
@@ -3422,10 +3426,11 @@ regMaskTP           CodeGen::WriteBarrier(GenTreePtr tgt,
     gcInfo.gcMarkRegSetByref(RBM_ARG_0);        // byref in ARG_0 
 
 #ifdef _TARGET_ARM_
+#if NOGC_WRITE_BARRIERS
     // Finally, we may be required to spill whatever is in the further argument registers
     // trashed by the call. The write barrier trashes some further registers --
     // either the standard volatile var set, or, if we're using assembly barriers, a more specialized set.
-#if NOGC_WRITE_BARRIERS
+
     regMaskTP volatileRegsTrashed = RBM_CALLEE_TRASH_NOGC;
 #else
     regMaskTP volatileRegsTrashed = RBM_CALLEE_TRASH;
@@ -3983,9 +3988,9 @@ void                CodeGen::genCondJumpLng(GenTreePtr     cond,
         inst_RV_TT(INS_cmp, genRegPairLo(regPair), op2, 0);
         genJccLongLo(cmp, jumpTrue, jumpFalse);
 
+#if CPU_LOAD_STORE_ARCH
         /* Free up anything that was tied up by either operand */
 
-#if CPU_LOAD_STORE_ARCH
         // Fix 388442 ARM JitStress WP7
         regSet.rsUnlockUsedReg(genRegPairMask(op2->gtRegPair));
         genReleaseRegPair(op2);
@@ -5166,11 +5171,11 @@ void                CodeGen::genCodeForTreeLeaf(GenTreePtr tree,
         break;
 
     case GT_NO_OP:
+        // The VM does certain things with actual NOP instructions
+        // so generate something small that has no effect, but isn't
+        // a typical NOP
         if (tree->gtFlags & GTF_NO_OP_NO)
         {
-            // The VM does certain things with actual NOP instructions
-            // so generate something small that has no effect, but isn't
-            // a typical NOP
 #ifdef _TARGET_XARCH_
             // The VM expects 0x66 0x90 for a 2-byte NOP, not 0x90 0x90
             instGen(INS_nop);
@@ -5373,10 +5378,10 @@ void                CodeGen::genCodeForTreeLeaf_GT_JMP(GenTreePtr tree)
         if (varDsc->lvIsRegArg || !varDsc->lvRegister)
             continue;
 
+#ifndef _TARGET_64BIT_
         /* Argument was passed on the stack, but ended up in a register
          * Store it back to the stack */
 
-#ifndef _TARGET_64BIT_
         if (varDsc->TypeGet() == TYP_LONG)
         {
             /* long - at least the low half must be enregistered */
@@ -5428,9 +5433,8 @@ void                CodeGen::genCodeForTreeLeaf_GT_JMP(GenTreePtr tree)
         noway_assert(isRegParamType(genActualType(varDsc->TypeGet())));
         noway_assert(!varDsc->lvRegister);
 
-        /* Reload it from the stack */
-
 #ifndef _TARGET_64BIT_
+        /* Reload it from the stack */
         if (varDsc->TypeGet() == TYP_LONG)
         {
             /* long - at least the low half must be enregistered */
@@ -5735,14 +5739,15 @@ void                CodeGen::genCodeForQmark(GenTreePtr tree,
     lab_false = genCreateTempLabel();
 
 #if FEATURE_STACK_FP_X87
-    /* Spill any register that hold partial values so that the exit liveness
-       from sides is the same */
 #ifdef DEBUG
     regMaskTP spillMask = regSet.rsMaskUsedFloat | regSet.rsMaskLockedFloat | regSet.rsMaskRegVarFloat;
 
     // spillMask should be the whole FP stack      
     noway_assert(compCurFPState.m_uStackSize == genCountBits(spillMask));
 #endif
+
+    /* Spill any register that hold partial values so that the exit liveness
+       from sides is the same */
 
     SpillTempsStackFP(regSet.rsMaskUsedFloat);
     noway_assert(regSet.rsMaskUsedFloat == 0);
@@ -6089,26 +6094,27 @@ void                CodeGen::genCodeForQmark(GenTreePtr tree,
         /* Generate jmp lab_done */
         lab_done  = genCreateTempLabel();
 
-        // We would like to know here if the else node is really going to generate
-        // code, as if it isn't, we're generating here a jump to the next instruction.
-        // What you would really like is to be able to go back and remove the jump, but
-        // we have no way of doing that right now.
-
 #ifdef DEBUG
         // We will use this to assert we don't emit instructions if we decide not to
         // do the jmp
         unsigned emittedInstructions = getEmitter()->emitInsCount;
         bool bSkippedJump = false;
 #endif
+        // We would like to know here if the else node is really going to generate
+        // code, as if it isn't, we're generating here a jump to the next instruction.
+        // What you would really like is to be able to go back and remove the jump, but
+        // we have no way of doing that right now.
+
         if (
 #if FEATURE_STACK_FP_X87
             !bHasFPUState && // If there is no FPU state, we won't need an x87 transition
 #endif
              genIsEnregisteredIntVariable(thenNode) == reg)
         {
+#ifdef DEBUG
             // For the moment, fix this easy case (enregistered else node), which
             // is the one that happens all the time.
-#ifdef DEBUG
+
             bSkippedJump = true;
 #endif
         }
@@ -6661,9 +6667,8 @@ void                CodeGen::genCodeForTreeSmpBinArithLogOp(GenTreePtr tree,
 
         reg   = regSet.rsPickReg(needReg, bestReg);
 
-        /* Compute the value into the target: reg=op1*op2_icon */
-
 #if LEA_AVAILABLE
+        /* Compute the value into the target: reg=op1*op2_icon */
         if (op2->gtIntCon.gtIconVal == 3 || op2->gtIntCon.gtIconVal == 5 || op2->gtIntCon.gtIconVal == 9)
         {
             regNumber regSrc;
@@ -6681,6 +6686,7 @@ void                CodeGen::genCodeForTreeSmpBinArithLogOp(GenTreePtr tree,
         else
 #endif // LEA_AVAILABLE
         {
+            /* Compute the value into the target: reg=op1*op2_icon */
             inst_RV_TT_IV(INS_MUL, reg, op1, (int)op2->gtIntCon.gtIconVal);
         }
 
@@ -6970,8 +6976,8 @@ DONE_LEA_ADD:
                 inst_RV_IV(INS_AND, reg, and_val, EA_4BYTE, flags);
             }
 
-            /* Update the live set of register variables */
 #ifdef DEBUG
+            /* Update the live set of register variables */
             if (compiler->opts.varNames) genUpdateLife(tree);
 #endif
 
@@ -7472,14 +7478,14 @@ INCDEC_REG:
                 /* Make the target addressable for load/store */
                 addrReg = genMakeAddressable2(op1, needReg, RegSet::KEEP_REG, true, true);
 
-    #if CPU_LOAD_STORE_ARCH
-                // We always load from memory then store to memory 
-    #else
+    #if !CPU_LOAD_STORE_ARCH
+                // For CPU_LOAD_STORE_ARCH, we always load from memory then store to memory
+
                 /* For small types with overflow check, we need to
                     sign/zero extend the result, so we need it in a reg */
 
                 if (ovfl && genTypeSize(treeType) < sizeof(int))
-    #endif // CPU_LOAD_STORE_ARCH
+    #endif // !CPU_LOAD_STORE_ARCH
                 {
                     // Load op1 into a reg
 
@@ -7580,9 +7586,9 @@ INCDEC_REG:
 
         addrReg = genMakeRvalueAddressable(op2, 0, RegSet::KEEP_REG, false);
 
+#if CPU_HAS_BYTE_REGS
         /* Compute the new value into the target register */
 
-#if CPU_HAS_BYTE_REGS
         // Fix 383833 X86 ILGEN
         regNumber  reg2; 
         if ((op2->gtFlags & GTF_REG_VAL) != 0) 
@@ -7741,14 +7747,13 @@ INCDEC_REG:
         addrReg = genMakeAddressable2(op1, 0, RegSet::KEEP_REG, true, true);
         regSet.rsLockUsedReg(addrReg);
 
-#if CPU_LOAD_STORE_ARCH
-        // We always load from memory then store to memory 
-#else
+#if !CPU_LOAD_STORE_ARCH
+        // For CPU_LOAD_STORE_ARCH, we always load from memory then store to memory
         /* For small types with overflow check, we need to
             sign/zero extend the result, so we need it in a reg */
 
         if (ovfl && genTypeSize(treeType) < sizeof(int))
-#endif // CPU_LOAD_STORE_ARCH
+#endif // !CPU_LOAD_STORE_ARCH
         {
             reg = regSet.rsPickReg();
             regSet.rsLockReg(genRegMask(reg));
@@ -7817,14 +7822,14 @@ INCDEC_REG:
         addrReg = genKeepAddressable(op1, addrReg);
         regSet.rsLockUsedReg(addrReg);
 
-#if CPU_LOAD_STORE_ARCH
-        // We always load from memory then store to memory 
-#else
+#if !CPU_LOAD_STORE_ARCH
+        // For CPU_LOAD_STORE_ARCH, we always load from memory then store to memory 
+        
         /* For small types with overflow check, we need to
             sign/zero extend the result, so we need it in a reg */
 
         if (ovfl && genTypeSize(treeType) < sizeof(int))
-#endif // CPU_LOAD_STORE_ARCH
+#endif // !CPU_LOAD_STORE_ARCH
         {
             reg = regSet.rsPickReg();
 
@@ -8550,8 +8555,8 @@ void                CodeGen::genCodeForAsgShift(GenTreePtr tree,
         /* Make sure the address registers are still here */
         addrReg = genKeepAddressable(op1, addrReg, op2Regs);
 
-        /* Perform the shift */
 #ifdef _TARGET_XARCH_
+        /* Perform the shift */
         inst_TT_CL(ins, op1);
 #else
         noway_assert(op2->gtFlags & GTF_REG_VAL);
@@ -8620,12 +8625,12 @@ void                CodeGen::genCodeForShift(GenTreePtr tree,
         noway_assert(op1->gtFlags & GTF_REG_VAL);
         reg = op1->gtRegNum;
 
+#ifndef _TARGET_ARM_
         /* Are we shifting left by 1 bit? (or 2 bits for fast code) */
 
         // On ARM, until proven otherwise by performance numbers, just do the shift.
         // It's no bigger than add (16 bits for low registers, 32 bits for high registers).
         // It's smaller than two "add reg, reg".
-#ifndef _TARGET_ARM_
         if  (oper == GT_LSH)
         {
             emitAttr size = emitActualTypeSize(treeType);
@@ -8715,8 +8720,8 @@ DO_SHIFT_BY_CNS:
         noway_assert(op1->gtFlags & GTF_REG_VAL);
         reg = op1->gtRegNum;
 
-        /* Perform the shift */
 #ifdef _TARGET_ARM_
+        /* Perform the shift */
         getEmitter()->emitIns_R_R(ins, EA_4BYTE, reg, op2->gtRegNum, flags);
 #else
         inst_RV_CL(ins, reg);
@@ -8737,7 +8742,8 @@ DO_SHIFT_BY_CNS:
 
 /*****************************************************************************
  *
- *  Generate code for a top-level relational operator (not one that is part of a GT_JTRUE tree). Handles GT_EQ, GT_NE, GT_LT, GT_LE, GT_GE, GT_GT.
+ *  Generate code for a top-level relational operator (not one that is part of a GT_JTRUE tree).
+ *  Handles GT_EQ, GT_NE, GT_LT, GT_LE, GT_GE, GT_GT.
  */
 
 void                CodeGen::genCodeForRelop(GenTreePtr tree,
@@ -9125,9 +9131,8 @@ void                CodeGen::genCodeForBlkOp(GenTreePtr tree,
                     bTrashedESI = true;
             }
 
-            /* Now take care of the remainder */
-
 #ifdef _TARGET_64BIT_
+            /* Now take care of the remainder */
             if (length > 4)
             {
                 noway_assert(bNeedEvaluateCnst);
@@ -9217,9 +9222,10 @@ void                CodeGen::genCodeForBlkOp(GenTreePtr tree,
 #else // !CPU_USES_BLOCK_MOVE 
 
 #ifndef _TARGET_ARM_
-        // Currently only the ARM implementation is provided
 #error "COPYBLK/INITBLK non-ARM && non-CPU_USES_BLOCK_MOVE"
 #endif
+        // Currently only the ARM implementation is provided
+
         //
         // Is this a fixed size COPYBLK?
         //      or a fixed size INITBLK with a constant init value?
@@ -9713,15 +9719,14 @@ void                CodeGen::genCodeForTreeSmpOp(GenTreePtr tree,
 
             regTracker.rsTrackRegTrash(reg);
 
-            /* Update the live set of register variables */
-
 #ifdef DEBUG
+            /* Update the live set of register variables */
             if (compiler->opts.varNames) genUpdateLife(tree);
 #endif
 
             /* Now we can update the register pointer information */
 
-//          genDoneAddressable(tree, addrReg, RegSet::KEEP_REG);
+            // genDoneAddressable(tree, addrReg, RegSet::KEEP_REG);
             gcInfo.gcMarkRegPtrVal(reg, treeType);
 
             genCodeForTree_DONE_LIFE(tree, reg);
@@ -9869,9 +9874,10 @@ void                CodeGen::genCodeForTreeSmpOp(GenTreePtr tree,
 
             }
 
+#ifdef PROFILING_SUPPORTED
             //The profiling hook does not trash registers, so it's safe to call after we emit the code for
             //the GT_RETURN tree.
-#ifdef PROFILING_SUPPORTED
+
             if (compiler->compCurBB == compiler->genReturnBB)
             {
                 genProfilingLeaveCallback();
@@ -10130,9 +10136,10 @@ void                CodeGen::genCodeForTreeSmpOp(GenTreePtr tree,
                 emitAttr srcType = (varTypeIsGC(srcObj) && !srcIsOnStack) ? EA_BYREF : EA_PTRSIZE;
                 emitAttr dstType = (varTypeIsGC(dstObj) && !dstIsOnStack) ? EA_BYREF : EA_PTRSIZE;
 
-                // Materialize the trees in the order desired
 
 #if CPU_USES_BLOCK_MOVE
+                // Materialize the trees in the order desired
+
                 genComputeReg(treeFirst, genRegMask(regFirst), RegSet::EXACT_REG, RegSet::KEEP_REG, true);
                 genComputeReg(treeSecond, genRegMask(regSecond), RegSet::EXACT_REG, RegSet::KEEP_REG, true);
                 genRecoverReg(treeFirst, genRegMask(regFirst), RegSet::KEEP_REG);
@@ -10189,9 +10196,9 @@ void                CodeGen::genCodeForTreeSmpOp(GenTreePtr tree,
 #else //  !CPU_USES_BLOCK_MOVE
 
 #ifndef _TARGET_ARM_
-                // Currently only the ARM implementation is provided
 #error "COPYBLK for non-ARM && non-CPU_USES_BLOCK_MOVE"
 #endif
+                // Currently only the ARM implementation is provided
 
                 bool         helperUsed;
                 regNumber    regDst;
@@ -11243,7 +11250,7 @@ void                CodeGen::genCodeForTreeSmpOp_GT_ADDR(GenTreePtr tree,
     noway_assert(!(op1->gtFlags & GTF_REG_VAL));
 
     genDoneAddressable(op1, addrReg, RegSet::FREE_REG);
-//    gcInfo.gcMarkRegSetNpt(genRegMask(reg));
+    // gcInfo.gcMarkRegSetNpt(genRegMask(reg));
     noway_assert((gcInfo.gcRegGCrefSetCur & genRegMask(reg)) == 0);
 
     regTracker.rsTrackRegTrash(reg);       // reg does have foldable value in it
@@ -11364,8 +11371,8 @@ void                CodeGen::genStoreFromFltRetRegs(GenTreePtr tree)
     // Generate code for call and copy the return registers into the local.
     regMaskTP retMask = genCodeForCall(op2, true);
 
-    // Ret mask should be contiguously set from s0, up to s3 or starting from d0 upto d3.
 #ifdef DEBUG
+    // Ret mask should be contiguously set from s0, up to s3 or starting from d0 upto d3.
     regMaskTP mask = ((retMask >> REG_FLOATRET) + 1);
     assert((mask & (mask - 1)) == 0);
     assert(mask <= (1 << MAX_HFA_RET_SLOTS));
@@ -11499,13 +11506,13 @@ REG_VAR2:
 
         op1Reg = op1->gtRegVar.gtRegNum;
 
+#ifdef DEBUG
         /* Compute the RHS (hopefully) into the variable's register.
            For debuggable code, op1Reg may already be part of regSet.rsMaskVars,
            as variables are kept alive everywhere. So we have to be
            careful if we want to compute the value directly into
            the variable's register. */
 
-#ifdef DEBUG 
         bool   needToUpdateRegSetCheckLevel;
         needToUpdateRegSetCheckLevel = false;
 #endif   
@@ -11692,10 +11699,9 @@ REG_VAR2:
 
         regGC = WriteBarrier(op1, op2, addrReg);
 
+        // No, assignment was not done by the WriteBarrier
         if  (regGC == RBM_NONE)
         {
-            // No, assignment was not done by the WriteBarrier
-
 #ifdef _TARGET_ARM_
             if (volat)
             {
@@ -11989,9 +11995,8 @@ NOT_SMALL:
                 inst_TT_RV(ins_Store(op1->TypeGet()), op1, op2->gtRegNum);
             }
 
-            /* Update the current liveness info */
-
 #ifdef DEBUG
+            /* Update the current liveness info */
             if (compiler->opts.varNames) genUpdateLife(tree);
 #endif
 
@@ -12107,9 +12112,8 @@ NOT_SMALL:
 
             genReleaseReg(op2);
 
-            /* Update the current liveness info */
-
 #ifdef DEBUG
+            /* Update the current liveness info */
             if (compiler->opts.varNames) genUpdateLife(tree);
 #endif
 
@@ -12260,19 +12264,17 @@ void                CodeGen::genCodeForTreeSpecialOp(GenTreePtr tree,
         {
 #if defined(_TARGET_XARCH_)
             // cmpxchg does not have an [r/m32], imm32 encoding, so we need a register for the value operand
-            //
+            
             // Since this is a "call", evaluate the operands from right to left.  Don't worry about spilling
             // right now, just get the trees evaluated.
 
             // As a friendly reminder.  IL args are evaluated left to right.
-            //
+            
             GenTreePtr location  = tree->gtCmpXchg.gtOpLocation;     // arg1
             GenTreePtr value     = tree->gtCmpXchg.gtOpValue;        // arg2
             GenTreePtr comparand = tree->gtCmpXchg.gtOpComparand;    // arg3
             regMaskTP addrReg;
 
-
-            // This little piggy (on the left) went to market.
             bool isAddr = genMakeIndAddrMode(location,
                                              tree,
                                              false, /* not for LEA */
@@ -12288,21 +12290,18 @@ void                CodeGen::genCodeForTreeSpecialOp(GenTreePtr tree,
                 regSet.rsMarkRegUsed(location);
             }
 
-            // This little piggy (in the middle) went home.
             // We must have a reg for the Value, but it doesn't really matter which register. 
             
             // Try to avoid EAX and the address regsiter if possible.
             genComputeReg(value, regSet.rsNarrowHint(RBM_ALLINT, RBM_EAX | addrReg), RegSet::ANY_REG, RegSet::KEEP_REG);
 
-            // This little piggy (on the right) had roast beef
+#ifdef DEBUG
             // cmpxchg uses EAX as an implicit operand to hold the comparand
             // We're going to destroy EAX in this operation, so we better not be keeping 
             // anything important in it.
-
-#ifdef DEBUG
             if (RBM_EAX & regSet.rsMaskVars)
             {
-                //We have a variable enregistered in EAX.  Make sure it goes dead in this tree.
+                // We have a variable enregistered in EAX.  Make sure it goes dead in this tree.
                 for (unsigned varNum = 0; varNum < compiler->lvaCount; ++varNum)
                 {
                     const LclVarDsc & varDesc = compiler->lvaTable[varNum];
@@ -12314,11 +12313,10 @@ void                CodeGen::genCodeForTreeSpecialOp(GenTreePtr tree,
                         continue;
                     if (varDesc.lvRegNum != REG_EAX)
                         continue;
-                    //I suppose I should technically check lvOtherReg.
+                    // We may need to check lvOtherReg.
 
-                    //OK, finally.  Let's see if this local goes dead.
-                    //If the variable isn't going dead during this tree, we've just trashed a local with
-                    //cmpxchg.
+                    // If the variable isn't going dead during this tree, we've just trashed a local with
+                    // cmpxchg.
                     noway_assert(genContainsVarDeath(value->gtNext, comparand->gtNext, varNum));
 
                     break;
@@ -12326,10 +12324,6 @@ void                CodeGen::genCodeForTreeSpecialOp(GenTreePtr tree,
             }
 #endif
             genComputeReg(comparand, RBM_EAX, RegSet::EXACT_REG, RegSet::KEEP_REG);
-
-            //Oh, no more piggies.
-            //* Author's note.  I believe in bounty and chose to omit the piggy who got none.
-
 
             //By this point we've evaluated everything.  However the odds are that we've spilled something by
             //now.  Let's recover all the registers and force them to stay.
@@ -12377,7 +12371,6 @@ void                CodeGen::genCodeForTreeSpecialOp(GenTreePtr tree,
 
             reg = REG_EAX;
 
-            //Until I try to optimize a cmp after a cmpxchg, just trash the flags for safety's sake.
             genFlagsEqualToNone();
             break;
 #else // not defined(_TARGET_XARCH_)
@@ -12592,9 +12585,9 @@ void                CodeGen::genCodeForBBlist()
 
     regSet.rsSpillBeg();
 
-    /* Initialize the line# tracking logic */
-
 #ifdef DEBUGGING_SUPPORT
+    /* Initialize the line# tracking logic */
+    
     if (compiler->opts.compScopeInfo)
     {
         siInit();
@@ -12854,10 +12847,11 @@ void                CodeGen::genCodeForBBlist()
             }
         }
 
-        /* Start a new code output block */
 
 #if FEATURE_EH_FUNCLETS
 #if defined(_TARGET_ARM_)
+        /* Start a new code output block */
+        
         // If this block is the target of a finally return, we need to add a preceding NOP, in the same EH region,
         // so the unwinder doesn't get confused by our "movw lr, xxx; movt lr, xxx; b Lyyy" calling convention that
         // calls the funclet during non-exceptional control flow.
@@ -12865,18 +12859,17 @@ void                CodeGen::genCodeForBBlist()
         {
             assert(block->bbFlags & BBF_JMP_TARGET);
 
-            // Create a label that we'll use for computing the start of an EH region, if this block is
-            // at the beginning of such a region. If we used the existing bbEmitCookie as is for
-            // determining the EH regions, then this NOP would end up outside of the region, if this
-            // block starts an EH region. If we pointed the existing bbEmitCookie here, then the NOP
-            // would be executed, which we would prefer not to do.
-
 #ifdef  DEBUG
             if (compiler->verbose)
             {
                 printf("\nEmitting finally target NOP predecessor for BB%02u\n", block->bbNum);
             }
 #endif
+            // Create a label that we'll use for computing the start of an EH region, if this block is
+            // at the beginning of such a region. If we used the existing bbEmitCookie as is for
+            // determining the EH regions, then this NOP would end up outside of the region, if this
+            // block starts an EH region. If we pointed the existing bbEmitCookie here, then the NOP
+            // would be executed, which we would prefer not to do.
 
             block->bbUnwindNopEmitCookie = getEmitter()->emitAddLabel(
                                      gcInfo.gcVarPtrSetCur,
@@ -12981,18 +12974,18 @@ void                CodeGen::genCodeForBBlist()
         bool    firstMapping = true;
 #endif // DEBUGGING_SUPPORT
 
-        /*---------------------------------------------------------------------
-         *
-         *  Generate code for each statement-tree in the block
-         *
-         */
-
 #if FEATURE_EH_FUNCLETS
         if (block->bbFlags & BBF_FUNCLET_BEG)
         {
             genReserveFuncletProlog(block);
         }
 #endif // FEATURE_EH_FUNCLETS
+
+        /*---------------------------------------------------------------------
+         *
+         *  Generate code for each statement-tree in the block
+         *
+         */
 
         for (GenTreePtr stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
         {
@@ -13477,9 +13470,9 @@ REG_VAR_LONG:
 
         regPair  = regSet.rsPickRegPair(needReg);
 
+#if !   CPU_HAS_FP_SUPPORT
         /* Load the value into the registers */
 
-#if !   CPU_HAS_FP_SUPPORT
         if  (oper == GT_CNS_DBL)
         {
             noway_assert(sizeof(__int64) == sizeof(double));
@@ -13571,7 +13564,6 @@ REG_VAR_LONG:
             loadIns = ins_Load(TYP_INT);   // INS_ldr
             regLo   = genRegPairLo(regPair);
             regHi   = genRegPairHi(regPair); 
-            // assert(regLo != regHi);  // regpair property
 
 #if CPU_LOAD_STORE_ARCH
             {
@@ -14725,10 +14717,9 @@ SIMPLE_OR_LONG:
             regTracker.rsTrackRegTrash(regLo);
             regTracker.rsTrackRegTrash(regHi);
 
+            /* Unary "neg": negate the value  in the register pair */
             if  (oper == GT_NEG)
             {
-                /* Unary "neg": negate the value  in the register pair */
-
 #ifdef _TARGET_ARM_
 
                 // ARM doesn't have an opcode that sets the carry bit like
@@ -14882,7 +14873,7 @@ SIMPLE_OR_LONG:
                         }
                         else
                         {
-//                          printf("Overlap: needReg = %08X\n", needReg);
+                            // printf("Overlap: needReg = %08X\n", needReg);
 
                             // Reg-prediction won't allow this
                             noway_assert((regSet.rsMaskVars & addrReg) == 0);
@@ -15085,12 +15076,12 @@ USE_SAR_FOR_CAST:
 
                         regPair = gen2regs2pair(regLo, regHi);
 
-                        /* Copy the lo32 bits from regLo to regHi and sign-extend it */
-
 #ifdef _TARGET_ARM_
+                        /* Copy the lo32 bits from regLo to regHi and sign-extend it */
                         // Use one instruction instead of two
                         getEmitter()->emitIns_R_R_I(INS_SHIFT_RIGHT_ARITHM, EA_4BYTE, regHi, regLo, 31);
 #else
+                        /* Copy the lo32 bits from regLo to regHi and sign-extend it */
                         inst_RV_RV(INS_mov, regHi, regLo, TYP_INT);
                         inst_RV_SH(INS_SHIFT_RIGHT_ARITHM, EA_4BYTE, regHi, 31);
 #endif
@@ -15230,12 +15221,10 @@ USE_SAR_FOR_CAST:
             NYI("64-bit return");
 #endif
 
+#ifdef PROFILING_SUPPORTED
             //The profiling hook does not trash registers, so it's safe to call after we emit the code for
             //the GT_RETURN tree.
-#ifdef PROFILING_SUPPORTED
-            /* XXX Thu 7/5/2007
-             * Oh look.  More cloned code from the regular processing of GT_RETURN.
-             */
+
             if (compiler->compCurBB == compiler->genReturnBB)
             {
                 genProfilingLeaveCallback();
@@ -15632,12 +15621,10 @@ void                CodeGen::genCodeForTreeFlt(GenTreePtr tree,
             genPInvokeMethodEpilog();
         }
 
+#ifdef PROFILING_SUPPORTED
         //The profiling hook does not trash registers, so it's safe to call after we emit the code for
         //the GT_RETURN tree.
-#ifdef PROFILING_SUPPORTED
-        /* XXX Thu 7/5/2007
-         * Oh look.  More cloned code from the regular processing of GT_RETURN.
-         */
+
         if (compiler->compCurBB == compiler->genReturnBB)
         {
             genProfilingLeaveCallback();
@@ -15889,8 +15876,8 @@ void        CodeGen::genEmitHelperCall(unsigned    helper,
 
     void * addr = NULL, **pAddr = NULL;
 
-    // Don't ask VM if it hasn't requested ELT hooks 
 #if defined(_TARGET_ARM_) && defined(DEBUG) && defined(PROFILING_SUPPORTED)
+    // Don't ask VM if it hasn't requested ELT hooks 
     if (!compiler->compProfilerHookNeeded && 
         compiler->opts.compJitELTHookEnabled &&
         (helper == CORINFO_HELP_PROF_FCN_ENTER ||
@@ -15994,7 +15981,7 @@ regMaskTP           CodeGen::genPushRegs(regMaskTP regs, regMaskTP * byrefRegs, 
     *byrefRegs = RBM_NONE;
     *noRefRegs = RBM_NONE;
 
-//  noway_assert((regs & regSet.rsRegMaskFree()) == regs); // Don't care. Caller is responsible for all this
+    // noway_assert((regs & regSet.rsRegMaskFree()) == regs); // Don't care. Caller is responsible for all this
 
     if (regs == RBM_NONE)
         return RBM_NONE;
@@ -16072,7 +16059,7 @@ void                CodeGen::genPopRegs(regMaskTP regs, regMaskTP byrefRegs, reg
 
     noway_assert((regs & byrefRegs) == byrefRegs);
     noway_assert((regs & noRefRegs) == noRefRegs);
-//  noway_assert((regs & regSet.rsRegMaskFree()) == regs); // Don't care. Caller is responsible for all this
+    // noway_assert((regs & regSet.rsRegMaskFree()) == regs); // Don't care. Caller is responsible for all this
     noway_assert((regs & (gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur)) == RBM_NONE);
 
     noway_assert(genTypeStSz(TYP_REF)   == genTypeStSz(TYP_INT));
@@ -17137,10 +17124,11 @@ size_t              CodeGen::genPushArgList(GenTreePtr     call)
             /* This is passed as a pointer-sized integer argument */
 
             genCodeForTree(curr, 0);
+            
+            // The arg has been evaluated now, but will be put in a register or pushed on the stack later.
+            
             if (curr->gtFlags & GTF_LATE_ARG)
             {
-                // The arg has been evaluated now, but will be put in a register or pushed on the stack later.
-
 #ifdef _TARGET_ARM_
                 argSize = 0;  // nothing is passed on the stack
 #endif
@@ -17148,7 +17136,7 @@ size_t              CodeGen::genPushArgList(GenTreePtr     call)
             else
             {
                 // The arg is passed in the outgoing argument area of the stack frame
-                //
+                
                 assert(curr->gtOper != GT_ASG);  // GTF_LATE_ARG should be set if this is the case
                 assert(curr->gtFlags & GTF_REG_VAL);  // should be enregistered after genCodeForTree(curr, 0)
                 inst_SA_RV(ins_Store(type), argOffset, curr->gtRegNum, type);
@@ -17272,7 +17260,8 @@ DEFERRED:
                     Compiler::lvaPromotionType promotionType = compiler->lvaGetPromotionType(varDsc);
 
                     if (varDsc->lvPromoted && 
-                        promotionType==Compiler::PROMOTION_TYPE_INDEPENDENT)  // Otherwise it is guaranteed to live on stack.
+                        promotionType == Compiler::PROMOTION_TYPE_INDEPENDENT) // Otherwise it is guaranteed to live
+                                                                               // on stack.
                     {
                         assert(!varDsc->lvAddrExposed);  // Compiler::PROMOTION_TYPE_INDEPENDENT ==> not exposed.  
                         promotedStructLocalVarDesc = varDsc;
@@ -17846,8 +17835,8 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
         {
             // The current slot should contain more than one field.
             // We'll construct a word in memory for the slot, then load it into a register.
-            // (Note that it *may* be possible for the fldOffset to be greater than the largest offset in the current slot,
-            // in which case we'll just skip this loop altogether.)
+            // (Note that it *may* be possible for the fldOffset to be greater than the largest offset in the current
+            // slot, in which case we'll just skip this loop altogether.)
             while (fieldVarDsc != NULL && fieldVarDsc->lvFldOffset < bytesOfNextSlotOfCurPromotedStruct)
             {
                 // If it doesn't fill a slot, it can't overflow the slot (again, because we only promote structs
@@ -17929,8 +17918,8 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
                     fieldVarDsc = &compiler->lvaTable[nextPromotedStructFieldVar];
                 }
             }
-            // Now, if we were accumulating into the first scratch word of the outgoing argument space in order to write to
-            // an argument register, do so.
+            // Now, if we were accumulating into the first scratch word of the outgoing argument space in order to
+            // write to an argument register, do so.
             if (curRegNum != MAX_REG_ARG)
             {
                 noway_assert(compiler->lvaPromotedStructAssemblyScratchVar != BAD_VAR_NUM);
@@ -18161,10 +18150,10 @@ void CodeGen::SetupLateArgs(GenTreePtr call)
             // home stack loc) "promotedStructLocalVarDesc" will be set to point to the local variable
             // table entry for the promoted struct local.  As we fill slots with the contents of a
             // promoted struct, "bytesOfNextSlotOfCurPromotedStruct" will be the number of filled bytes
-            // that indicate another filled slot (if we have a 12-byte struct, it has 3 four byte slots; when we're working
-            // on the second slot, "bytesOfNextSlotOfCurPromotedStruct" will be 8, the point at which we're done),
-            // and "nextPromotedStructFieldVar" will be the local
-            // variable number of the next field variable to be copied.
+            // that indicate another filled slot (if we have a 12-byte struct, it has 3 four byte slots; when we're
+            // working on the second slot, "bytesOfNextSlotOfCurPromotedStruct" will be 8, the point at which we're
+            // done), and "nextPromotedStructFieldVar" will be the local variable number of the next field variable
+            // to be copied.
             LclVarDsc* promotedStructLocalVarDesc = NULL;
             unsigned   bytesOfNextSlotOfCurPromotedStruct = 0;  // Size of slot.
             unsigned   nextPromotedStructFieldVar = BAD_VAR_NUM;
@@ -18285,8 +18274,8 @@ void CodeGen::SetupLateArgs(GenTreePtr call)
                 {
                     nextPromotedStructFieldVar++;
                 }
-                // If we reach the limit, meaning there is no field that goes even partly in the stack, only if the first stack slot is after
-                // the last slot.
+                // If we reach the limit, meaning there is no field that goes even partly in the stack, only if the
+                // first stack slot is after the last slot.
                 assert(nextPromotedStructFieldVar < fieldVarLim|| firstStackSlot >= slots);
             }
                         
@@ -18451,7 +18440,8 @@ void CodeGen::SetupLateArgs(GenTreePtr call)
                 regSet.rsMarkRegFree(genRegMask(regSrc));
             }
             
-            if (regNum != REG_STK && promotedStructLocalVarDesc == NULL)  // If promoted, we already declared the regs used.
+            if (regNum != REG_STK && promotedStructLocalVarDesc == NULL)  // If promoted, we already declared the regs
+                                                                          // used.
             {
                 arg->gtFlags |= GTF_REG_VAL;
                 for (unsigned i = 1; i < firstStackSlot; i++)
@@ -19031,13 +19021,13 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
     args = (call->gtFlags & GTF_CALL_POP_ARGS) ? -int(argSize)
                                                :  argSize;
 
+#ifdef PROFILING_SUPPORTED
+
     /*-------------------------------------------------------------------------
      *  Generate the profiling hooks for the call
      */
 
     /* Treat special cases first */
-
-#ifdef PROFILING_SUPPORTED
 
     /* fire the event at the call site */
     /* alas, right now I can only handle calls via a method handle */
@@ -19047,10 +19037,11 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
     {
         unsigned  saveStackLvl2 = genStackLevel;
 
+#ifdef _TARGET_X86_
         //
         // Push the profilerHandle
         //
-#ifdef _TARGET_X86_
+        
         regMaskTP byrefPushedRegs;
         regMaskTP norefPushedRegs;
         regMaskTP pushedArgRegs = genPushRegs(call->gtCall.gtCallRegUsedMask, &byrefPushedRegs, &norefPushedRegs);
@@ -19084,8 +19075,8 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
         // To make r0 available, we add REG_PROFILER_TAIL_SCRATCH as an additional interference for tail prefixed calls.
         // Here we grab a register to temporarily store r0 and revert it back after we have emitted callback.
         //
-        // By the time we reach this point argument registers are setup (by genPushArgList()), therefore we don't want to disturb them
-        // and hence argument registers are locked here.
+        // By the time we reach this point argument registers are setup (by genPushArgList()), therefore we don't want
+        // to disturb them and hence argument registers are locked here.
         regMaskTP usedMask = RBM_NONE;
         regSet.rsLockReg(RBM_ARG_REGS, &usedMask);
         
@@ -19462,7 +19453,7 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
 
             noway_assert(callType == CT_USER_FUNC);
 
-            vptrReg   = regSet.rsGrabReg(RBM_ALLINT);     // Grab an available register to use for the CALL indirection
+            vptrReg   = regSet.rsGrabReg(RBM_ALLINT); // Grab an available register to use for the CALL indirection
             vptrMask  = genRegMask(vptrReg);
 
             /* The register no longer holds a live pointer value */
@@ -19877,12 +19868,12 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
                     break;
 
                 case IAT_PVALUE: 
+#if CPU_LOAD_STORE_ARCH
                     //------------------------------------------------------
                     // Non-virtual direct calls to addresses accessed by
                     // a single indirection.
                     //
                     // For tailcalls we place the target address in REG_TAILCALL_ADDR
-#if CPU_LOAD_STORE_ARCH
                     {
                         regNumber indReg = REG_TAILCALL_ADDR;    
                         instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, indReg, (ssize_t)addr);
@@ -19897,12 +19888,12 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
                     break;
 
                 case IAT_PPVALUE: 
+#if CPU_LOAD_STORE_ARCH
                     //------------------------------------------------------
                     // Non-virtual direct calls to addresses accessed by
                     // a double indirection.
                     //
                     // For tailcalls we place the target address in REG_TAILCALL_ADDR
-#if CPU_LOAD_STORE_ARCH
                     {
                         regNumber indReg = REG_TAILCALL_ADDR;    
                         instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, indReg, (ssize_t)addr);
@@ -19931,12 +19922,12 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
                     regNumber  indCallReg;
 
                 case IAT_VALUE:   
+#ifdef _TARGET_ARM_
                     //------------------------------------------------------
                     // Non-virtual direct calls to known addressess
                     //
                     // The vast majority of calls end up here....  Wouldn't
                     // it be nice if they all did!
-#ifdef _TARGET_ARM_
                     if (!arm_Valid_Imm_For_BL((ssize_t)addr))
                     {
                         // Load the address into a register and call  through a register
@@ -19978,11 +19969,12 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
                     break;
 
                 case IAT_PVALUE: 
+#if CPU_LOAD_STORE_ARCH
                     //------------------------------------------------------
                     // Non-virtual direct calls to addresses accessed by
                     // a single indirection.
                     //
-#if CPU_LOAD_STORE_ARCH
+
                     // Load the address into a register, load indirect and call  through a register
                     indCallReg = regSet.rsGrabReg(RBM_ALLINT);     // Grab an available register to use for the CALL indirection
 
@@ -20189,10 +20181,10 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
         gcInfo.gcRegByrefSetCur &= ~(curArgMask);
     }
 
+#if !FEATURE_STACK_FP_X87
     //-------------------------------------------------------------------------
     // free up the FP args
 
-#if !FEATURE_STACK_FP_X87
     for (areg = 0; areg < MAX_FLOAT_REG_ARG; areg++)
     {
         regNumber argRegNum  = genMapRegArgNumToRegNum(areg, TYP_FLOAT);
@@ -20272,9 +20264,9 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
 
     genStackLevel = saveStackLvl;
 
+#ifdef  DEBUG
     /* No trashed registers may possibly hold a pointer at this point */
 
-#ifdef  DEBUG
     regMaskTP ptrRegs = (gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur) & (calleeTrashedRegs & RBM_ALLINT) & ~regSet.rsMaskVars & ~vptrMask;
     if  (ptrRegs)
     {
@@ -20404,9 +20396,9 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
 #endif
     }
 
+#if defined(_TARGET_X86_)
     /* Are we supposed to pop the arguments? */
 
-#if defined(_TARGET_X86_)
     if (call->gtFlags & GTF_CALL_UNMANAGED)
     {
         if ((compiler->opts.eeFlags & CORJIT_FLG_PINVOKE_RESTORE_ESP) ||
@@ -20582,8 +20574,8 @@ regMaskTP           CodeGen::genCodeForCall(GenTreePtr  call,
             UnspillFloat(call);
         }
 
-        // Mark as free
 #if FEATURE_STACK_FP_X87
+        // Mark as free
         regSet.SetUsedRegFloat(call, false);
 #endif
     }
@@ -20821,8 +20813,8 @@ regNumber           CodeGen::genLclHeap(GenTreePtr size)
     var_types   type   = genActualType(size->gtType);
     emitAttr    easz   = emitTypeSize(type);
 
-    // Verify ESP
     #ifdef DEBUG
+    // Verify ESP
     if (compiler->opts.compStackCheckOnRet)
     {
         noway_assert(compiler->lvaReturnEspCheck != 0xCCCCCCCC && compiler->lvaTable[compiler->lvaReturnEspCheck].lvDoNotEnregister && compiler->lvaTable[compiler->lvaReturnEspCheck].lvOnFrame);
@@ -20964,9 +20956,9 @@ regNumber           CodeGen::genLclHeap(GenTreePtr size)
 
         if (compiler->info.compInitMem)
         {
+#if ((STACK_ALIGN >> STACK_ALIGN_SHIFT) > 1)
             // regCnt will be the number of pointer-sized words to locAlloc
             // If the shift right won't do the 'and' do it here
-#if ((STACK_ALIGN >> STACK_ALIGN_SHIFT) > 1)
             inst_RV_IV(INS_AND, regCnt, ~(STACK_ALIGN - 1), emitActualTypeSize(type));
 #endif
             // --- shr regCnt, 2 ---
@@ -20984,13 +20976,12 @@ regNumber           CodeGen::genLclHeap(GenTreePtr size)
 
     if (compiler->info.compInitMem)
     {
+#if defined(_TARGET_ARM_)
         // At this point 'regCnt' is set to the number of pointer-sized words to locAlloc
 
         /* Since we have to zero out the allocated memory AND ensure that
            ESP is always valid by tickling the pages, we will just push 0's
            on the stack */
-
-#if defined(_TARGET_ARM_)
         regNumber   regZero1 = regSet.rsGrabReg(RBM_ALLINT & ~genRegMask(regCnt));
         regNumber   regZero2 = regSet.rsGrabReg(RBM_ALLINT & ~genRegMask(regCnt) & ~genRegMask(regZero1));
         // Set 'regZero1' and 'regZero2' to zero
@@ -21026,6 +21017,7 @@ regNumber           CodeGen::genLclHeap(GenTreePtr size)
     }
     else
     {
+#ifdef _TARGET_ARM_
         // At this point 'regCnt' is set to the total number of bytes to locAlloc
 
         /* We don't need to zero out the allocated memory. However, we do have
@@ -21057,7 +21049,7 @@ regNumber           CodeGen::genLclHeap(GenTreePtr size)
                   mov   ESP, REG
              end:
           */
-#ifdef _TARGET_ARM_
+
         inst_RV_RV_RV(INS_sub, regCnt, REG_SPBASE, regCnt, EA_4BYTE, INS_FLAGS_SET);
         inst_JMP(EJ_hs, loop);
 #else
@@ -21077,12 +21069,12 @@ regNumber           CodeGen::genLclHeap(GenTreePtr size)
 
         regNumber   regTemp = regSet.rsPickReg();
 
+#if CPU_LOAD_STORE_ARCH
         // Tickle the decremented value, and move back to ESP,
         // note that it has to be done BEFORE the update of ESP since
         // ESP might already be on the guard page.  It is OK to leave
         // the final value of ESP on the guard page
 
-#if CPU_LOAD_STORE_ARCH
         getEmitter()->emitIns_R_R_I(INS_ldr, EA_4BYTE, regTemp, REG_SPBASE, 0);
 #else
         getEmitter()->emitIns_AR_R(INS_TEST, EA_4BYTE, REG_SPBASE, REG_SPBASE, 0);
@@ -21172,9 +21164,9 @@ void        CodeGen::genSetScopeInfo  (unsigned                 which,
     unsigned ilVarNum = compiler->compMap2ILvarNum(varNum);
     noway_assert((int)ilVarNum != ICorDebugInfo::UNKNOWN_ILNUM);
 
+#ifdef _TARGET_X86_
     // Non-x86 platforms are allowed to access all arguments directly
     // so we don't need this code.
-#ifdef _TARGET_X86_
 
     // Is this a varargs function?
 
@@ -21727,12 +21719,13 @@ regMaskTP           CodeGen::genPInvokeMethodProlog(regMaskTP initRegs)
         regTCB = REG_PINVOKE_TCB;
     }
 
-    /* get TCB,  mov reg, FS:[compiler->info.compEEInfo.threadTlsIndex] */
-
-    // TODO-ARM-CQ: should we inline TlsGetValue here?
 #if !defined(_TARGET_ARM_)
 #define WIN_NT_TLS_OFFSET (0xE10)
 #define WIN_NT5_TLS_HIGHOFFSET (0xf94)
+
+    /* get TCB,  mov reg, FS:[compiler->info.compEEInfo.threadTlsIndex] */
+
+    // TODO-ARM-CQ: should we inline TlsGetValue here?
 
     if (threadTlsIndex < 64)
     {
@@ -22159,9 +22152,9 @@ regNumber          CodeGen::genPInvokeCallProlog(LclVarDsc*            frameList
                               pInfo->inlinedCallFrameInfo.offsetOfCallSiteSP);
 #endif // _TARGET_X86_
 
-    /* mov   dword ptr [frame.callSiteReturnAddress], label */
-    
 #if CPU_LOAD_STORE_ARCH
+    /* mov   dword ptr [frame.callSiteReturnAddress], label */
+
     regNumber tmpReg = regSet.rsGrabReg(RBM_ALLINT & ~genRegMask(tcbReg));
     getEmitter()->emitIns_J_R (INS_adr,
                              EA_PTRSIZE,
@@ -22253,8 +22246,8 @@ void                CodeGen::genPInvokeCallEpilog(LclVarDsc *  frameListRoot,
     }
     else
     {
-        /* mov   reg2, dword ptr [tcb address]    */
 #ifdef _TARGET_ARM_
+        /* mov   reg2, dword ptr [tcb address]    */
         reg2 = REG_R2;
 #else
         reg2 = REG_ECX;

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -356,9 +356,9 @@ void                CodeGen::genCodeForBBlist()
 
     regSet.rsSpillBeg();
 
+#ifdef DEBUGGING_SUPPORT
     /* Initialize the line# tracking logic */
 
-#ifdef DEBUGGING_SUPPORT
     if (compiler->opts.compScopeInfo)
     {
         siInit();
@@ -447,9 +447,9 @@ void                CodeGen::genCodeForBBlist()
         genUpdateLife(block->bbLiveIn);
 
         // Even if liveness didn't change, we need to update the registers containing GC references.
-        // genUpdateLife will update the registers live due to liveness changes. But what about registers that didn't change?
-        // We cleared them out above. Maybe we should just not clear them out, but update the ones that change here.
-        // That would require handling the changes in recordVarLocationsAtStartOfBB().
+        // genUpdateLife will update the registers live due to liveness changes. But what about registers that didn't
+        // change? We cleared them out above. Maybe we should just not clear them out, but update the ones that change
+        // here. That would require handling the changes in recordVarLocationsAtStartOfBB().
 
         regMaskTP newLiveRegSet = RBM_NONE;
         regMaskTP newRegGCrefSet = RBM_NONE;
@@ -604,18 +604,18 @@ void                CodeGen::genCodeForBBlist()
         bool    firstMapping = true;
 #endif // DEBUGGING_SUPPORT
 
-        /*---------------------------------------------------------------------
-         *
-         *  Generate code for each statement-tree in the block
-         *
-         */
-
 #if FEATURE_EH_FUNCLETS
         if (block->bbFlags & BBF_FUNCLET_BEG)
         {
             genReserveFuncletProlog(block);
         }
 #endif // FEATURE_EH_FUNCLETS
+
+        /*---------------------------------------------------------------------
+         *
+         *  Generate code for each statement-tree in the block
+         *
+         */
 
         for (GenTreePtr stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
         {
@@ -3026,7 +3026,8 @@ CodeGen::genLclHeap(GenTreePtr tree)
     //      Nothing to pop off from the stack.
     if  (compiler->lvaOutgoingArgSpaceSize > 0)
     {
-        assert((compiler->lvaOutgoingArgSpaceSize % STACK_ALIGN) == 0); // This must be true for the stack to remain aligned
+        assert((compiler->lvaOutgoingArgSpaceSize % STACK_ALIGN) == 0); // This must be true for the stack to remain
+                                                                        // aligned
         inst_RV_IV(INS_add, REG_SPBASE, compiler->lvaOutgoingArgSpaceSize, EA_PTRSIZE);
         stackAdjustment += compiler->lvaOutgoingArgSpaceSize;
     }
@@ -5058,7 +5059,8 @@ void CodeGen::genConsumePutStructArgStk(GenTreePutArgStk* putArgNode, regNumber 
     // Otherwise load the op1 (GT_ADDR) into the dstReg to copy the struct on the stack by value.
     if (op1->gtRegNum != dstReg)
     {
-        // Generate LEA instruction to load the stack of the outgoing var + SlotNum offset (or the incoming arg area for tail calls) in RDI.
+        // Generate LEA instruction to load the stack of the outgoing var + SlotNum offset (or the incoming arg area
+        // for tail calls) in RDI.
         // Destination is always local (on the stack) - use EA_PTRSIZE.
         getEmitter()->emitIns_R_S(INS_lea, EA_PTRSIZE, dstReg, baseVarNum, putArgNode->getArgOffset());
     }
@@ -6771,8 +6773,8 @@ void        CodeGen::genCompareLong(GenTreePtr  treeNode)
 //
 //    Opcode          Amd64 equivalent         Comment
 //    ------          -----------------        --------
-//    BLT.UN(a,b)      ucomis[s|d] a, b        Jb branches if CF=1, which means either a<b or unordered from the above table.
-//                     jb
+//    BLT.UN(a,b)      ucomis[s|d] a, b        Jb branches if CF=1, which means either a<b or unordered from the above
+//                     jb                      table
 //
 //    BLT(a,b)         ucomis[s|d] b, a        Ja branches if CF=0 and ZF=0, which means b>a that in turn implies a<b
 //                     ja
@@ -7044,10 +7046,9 @@ void CodeGen::genSetRegToCond(regNumber dstReg, GenTreePtr tree)
     }
     else
     {       
+#ifdef DEBUG
         // jmpKind[1] != EJ_NONE implies BEQ and BEN.UN of floating point values.
         // These are represented by two conditions.
-
-#ifdef DEBUG
         if (tree->gtOper == GT_EQ)
         {
             // This must be an ordered comparison.
@@ -8818,6 +8819,8 @@ void                CodeGen::genAmd64EmitterUnitTests()
     // Mark the "fake" instructions in the output.
     printf("*************** In genAmd64EmitterUnitTests()\n");
 
+#ifdef ALL_XARCH_EMITTER_UNIT_TESTS
+#ifdef FEATURE_AVX_SUPPORT
     // We use this:
     //      genDefineTempLabel(genCreateTempLabel());
     // to create artificial labels to help separate groups of tests.
@@ -8825,9 +8828,6 @@ void                CodeGen::genAmd64EmitterUnitTests()
     //
     // Loads
     //
-
-#ifdef ALL_XARCH_EMITTER_UNIT_TESTS
-#ifdef FEATURE_AVX_SUPPORT
     genDefineTempLabel(genCreateTempLabel());
 
     // vhaddpd     ymm0,ymm1,ymm2

--- a/src/jit/compmemkind.h
+++ b/src/jit/compmemkind.h
@@ -10,6 +10,7 @@
 // This list of macro invocations should be used to define the CompMemKind enumeration,
 // and the corresponding array of string names for these enum members.
 
+// clang-format off
 CompMemKindMacro(AssertionProp)
 CompMemKindMacro(ASTNode)
 CompMemKindMacro(InstDesc)
@@ -50,5 +51,6 @@ CompMemKindMacro(Codegen)
 CompMemKindMacro(LoopOpt)
 CompMemKindMacro(LoopHoist)
 CompMemKindMacro(Unknown)
+//clang-format on
 
 #undef CompMemKindMacro

--- a/src/jit/compphases.h
+++ b/src/jit/compphases.h
@@ -18,6 +18,7 @@
 //         (We should never do EndPhase on a phase that has children, only on 'leaf phases.')
 //     "parent" is -1 for leaf phases, otherwise it is the "enumName" of the parent phase.
 
+// clang-format off
 CompPhaseNameMacro(PHASE_PRE_IMPORT,             "Pre-import",                     "PRE-IMP",  false, -1)
 CompPhaseNameMacro(PHASE_IMPORTATION,            "Importation",                    "IMPORT",   false, -1)
 CompPhaseNameMacro(PHASE_POST_IMPORT,            "Post-import",                    "POST-IMP", false, -1)
@@ -84,5 +85,6 @@ CompPhaseNameMacro(PHASE_LINEAR_SCAN_RESOLVE,    "LSRA resolve",                
 CompPhaseNameMacro(PHASE_GENERATE_CODE,          "Generate code",                  "CODEGEN",  false, -1)
 CompPhaseNameMacro(PHASE_EMIT_CODE,              "Emit code",                      "EMIT",     false, -1)
 CompPhaseNameMacro(PHASE_EMIT_GCEH,              "Emit GC+EH tables",              "EMT-GCEH", false, -1)
+// clang-format on
 
 #undef CompPhaseNameMacro

--- a/src/jit/disasm.cpp
+++ b/src/jit/disasm.cpp
@@ -123,7 +123,7 @@ size_t              DisAssembler::disCchAddrMember  (const DIS* pdis,
 
     switch (terminationType)
     {
-//        int disCallSize;
+        // int disCallSize;
 
     case DISX86::trmtaJmpShort:
     case DISX86::trmtaJmpCcShort:
@@ -171,7 +171,7 @@ size_t              DisAssembler::disCchAddrMember  (const DIS* pdis,
         /* find the emitter block and the offset of the call fixup */
         /* for the fixup offset we have to add the opcode size for the call - in the case of a near call is 1 */
 
-//        disCallSize = 1;
+        // disCallSize = 1;
 
         {
             size_t absoluteTarget = (size_t)disGetLinearAddr(disTarget);
@@ -214,7 +214,7 @@ size_t              DisAssembler::disCchAddrMember  (const DIS* pdis,
 
     switch (terminationType)
     {
-//        int disCallSize;
+        // int disCallSize;
 
     case DISARM64::TRMTA::trmtaBra:
     case DISARM64::TRMTA::trmtaBraCase:
@@ -257,7 +257,7 @@ size_t              DisAssembler::disCchAddrMember  (const DIS* pdis,
         /* find the emitter block and the offset of the call fixup */
         /* for the fixup offset we have to add the opcode size for the call - in the case of a near call is 1 */
 
-//        disCallSize = 1;
+        // disCallSize = 1;
 
         {
             size_t absoluteTarget = (size_t)disGetLinearAddr(disTarget);
@@ -1524,8 +1524,8 @@ void    DisAssembler::disAsmCode(BYTE* hotCodePtr, size_t hotCodeSize, BYTE* col
         return;
     }
 
-    // Should we make it diffable?
 #ifdef DEBUG
+    // Should we make it diffable?
     disDiffable = disComp->opts.dspDiffable;
 #else // !DEBUG
     // NOTE: non-debug builds are always diffable!

--- a/src/jit/disasm.h
+++ b/src/jit/disasm.h
@@ -148,7 +148,8 @@ private:
     /* Given a linear offset into the code, find a pointer to the actual code (either in the hot or cold section) */
     const BYTE*     disGetLinearAddr(size_t offset);
 
-    /* Given a linear offset into the code, determine how many bytes are left in the hot or cold buffer the offset points to */
+    /* Given a linear offset into the code, determine how many bytes are left in the hot or cold buffer the offset
+     * points to */
     size_t          disGetBufferSize(size_t offset);
 
     // Map of instruction addresses to call target method handles for normal calls.
@@ -245,7 +246,6 @@ private:
                                       bool           printit         = false,
                                       bool           dispOffs        = false,
                                       bool           dispCodeBytes   = false);
-
 };
 
 

--- a/src/jit/emitfmtsarm.h
+++ b/src/jit/emitfmtsarm.h
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 //////////////////////////////////////////////////////////////////////////////
 
-
+// clang-format off
 #if !defined(_TARGET_ARM_)
   #error Unexpected target type
 #endif
@@ -150,3 +150,4 @@ IF_DEF(INVALID,     IS_NONE,               NONE)     //
 
 #endif // !DEFINE_ID_OPS
 //////////////////////////////////////////////////////////////////////////////
+// clang-format on

--- a/src/jit/emitfmtsarm64.h
+++ b/src/jit/emitfmtsarm64.h
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 //////////////////////////////////////////////////////////////////////////////
 
-
+//clang-format off
 #if !defined(_TARGET_ARM64_)
   #error Unexpected target type
 #endif
@@ -206,3 +206,4 @@ IF_DEF(INVALID,     IS_NONE,               NONE)     //
 
 #endif // !DEFINE_ID_OPS
 //////////////////////////////////////////////////////////////////////////////
+// clang-format on

--- a/src/jit/emitfmtsxarch.h
+++ b/src/jit/emitfmtsxarch.h
@@ -7,6 +7,7 @@
 //  This file was previously known as emitfmts.h
 //
 
+// clang-format off
 #if !defined(_TARGET_XARCH_)
   #error Unexpected target type
 #endif
@@ -236,3 +237,4 @@ IF_DEF(AWR_TRD,     IS_FP_STK|IS_AM_WR,         AMD )     // write [adr], read S
 #endif // DEFINE_IS_OPS
 #endif // DEFINE_ID_OPS
 //////////////////////////////////////////////////////////////////////////////
+// clang-format on

--- a/src/jit/emitjmps.h
+++ b/src/jit/emitjmps.h
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
+// clang-format off
 #ifndef JMP_SMALL
 #error Must define JMP_SMALL macro before including this file
 #endif
@@ -54,3 +54,5 @@ JMP_SMALL(le    , gt    , ble    )  // LE
 /*****************************************************************************/
 #undef JMP_SMALL
 /*****************************************************************************/
+
+// clang-format on

--- a/src/jit/emitpub.h
+++ b/src/jit/emitpub.h
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
     /************************************************************************/
     /*       Overall emitter control (including startup and shutdown)       */
     /************************************************************************/
@@ -171,3 +170,4 @@
     unsigned        emitGetInstructionSize(emitLocation* emitLoc);
 
 #endif // defined(_TARGET_ARM_)
+

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -193,7 +193,7 @@ private:
                                                       insFormat FPld,
                                                       insFormat FPst);
 
-   bool            emitVerifyEncodable(instruction  ins, 
+    bool            emitVerifyEncodable(instruction  ins, 
                                        emitAttr     size,
                                        regNumber    reg1,
                                        regNumber    reg2 = REG_NA);

--- a/src/jit/fp.h
+++ b/src/jit/fp.h
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 #ifndef _JIT_FP
 
 #define _JIT_FP
@@ -12,12 +11,11 @@
 
 enum dummyFPenum
 {
-    #define REGDEF(name, rnum, mask, sname)  dummmy_##name = rnum,
-    #include "registerfp.h"
+#define REGDEF(name, rnum, mask, sname)  dummmy_##name = rnum,
+#include "registerfp.h"
 
     FP_VIRTUALREGISTERS,
 };
-
 
 // FlatFPStateX87 holds the state of the virtual register file. For each
 // virtual register we keep track to which physical register we're 
@@ -42,10 +40,10 @@ public:
     unsigned                Pop                     ();
     void                    Push                    (unsigned uEntry);
     bool                    IsEmpty                 ();
-            
+
     // Debug/test methods
     static bool             AreEqual                (FlatFPStateX87* pSrc, FlatFPStateX87* pDst);
-    #ifdef DEBUG    
+#ifdef DEBUG
     bool                    IsValidEntry            (unsigned uEntry);
     bool                    IsConsistent            ();
     void                    UpdateMappingFromStack  ();
@@ -60,16 +58,16 @@ public:
     {
         m_bIgnoreConsistencyChecks = bIgnore;
     }
-    #else
+#else
     inline void IgnoreConsistencyChecks(bool bIgnore) 
-    {       
-    }    
-    #endif
+    {
+    }
+#endif
 
     unsigned                m_uVirtualMap[FP_VIRTUALREGISTERS];
     unsigned                m_uStack[FP_PHYSICREGISTERS];
     unsigned                m_uStackSize;
-};    
-    
+};
+
 #endif // FEATURE_STACK_FP_X87
 #endif

--- a/src/jit/gcinfo.cpp
+++ b/src/jit/gcinfo.cpp
@@ -414,13 +414,14 @@ void                GCInfo::gcCountForHeader(UNALIGNED unsigned int * untrackedC
             }
             else
             {
+#ifndef LEGACY_BACKEND
                 /* Stack-passed arguments which are not enregistered
                  * are always reported in this "untracked stack
                  * pointers" section of the GC info even if lvTracked==true
                  */
 
                 /* Has this argument been fully enregistered? */
-#ifndef LEGACY_BACKEND
+
                 if (!varDsc->lvOnFrame)
 #else // LEGACY_BACKEND
                 if  (varDsc->lvRegister) 

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// clang-format off
 /*****************************************************************************/
 #ifndef GTNODE
 #error  Define GTNODE before including this file.
@@ -244,3 +245,4 @@ GTNODE(SWAP         , "swap"          ,0,GTK_BINOP)          // op1 and op2 swap
 /*****************************************************************************/
 #undef  GTNODE
 /*****************************************************************************/
+// clang-format on

--- a/src/jit/gtstructs.h
+++ b/src/jit/gtstructs.h
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// clang-format off
 
 /*****************************************************************************/
 
@@ -108,3 +109,5 @@ GTSTRUCT_1(SIMD        , GT_SIMD)
 #undef  GTSTRUCT_4
 #undef  GTSTRUCT_N
 /*****************************************************************************/
+
+// clang-format on

--- a/src/jit/hashbv.cpp
+++ b/src/jit/hashbv.cpp
@@ -1723,7 +1723,7 @@ void hashBv::InorderTraverseTwo(hashBv *other, dualNodeAction a)
       
     }
     delete[] nodesThis;
-    delete[] nodesOther;;
+    delete[] nodesOther;
 }
 
 

--- a/src/jit/hashbv.h
+++ b/src/jit/hashbv.h
@@ -322,6 +322,7 @@ public:
 
 indexType HbvNext(hashBv *bv, Compiler *comp);
 
+// clang-format off
 #define FOREACH_HBV_BIT_SET(index, bv) \
     { \
         for (int hashNum=0; hashNum<(bv)->hashtable_size(); hashNum++) {\
@@ -344,7 +345,7 @@ indexType HbvNext(hashBv *bv, Compiler *comp);
             }\
         }\
     } \
-
+//clang-format on
 
 #ifdef DEBUG
 void SimpleDumpNode(hashBvNode *n);

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -1101,6 +1101,7 @@ void RandomPolicy::DetermineProfitability(CORINFO_METHOD_INFO* methodInfo)
 //    compiler -- compiler instance doing the inlining (root compiler)
 //    isPrejitRoot -- true if this compiler is prejitting the root method
 
+// clang-format off
 DiscretionaryPolicy::DiscretionaryPolicy(Compiler* compiler, bool isPrejitRoot)
     : LegacyPolicy(compiler, isPrejitRoot)
     , m_Depth(0)
@@ -1146,6 +1147,7 @@ DiscretionaryPolicy::DiscretionaryPolicy(Compiler* compiler, bool isPrejitRoot)
 {
     // Empty
 }
+// clang-format on
 
 //------------------------------------------------------------------------
 // NoteBool: handle an observed boolean value
@@ -1675,6 +1677,7 @@ void DiscretionaryPolicy::EstimateCodeSize()
     // R=0.55, MSE=177, MAE=6.59
     //
     // Suspect it doesn't handle factors properly...
+    // clang-format off
     double sizeEstimate =
         -13.532 +
           0.359 * (int) m_CallsiteFrequency +
@@ -1697,6 +1700,7 @@ void DiscretionaryPolicy::EstimateCodeSize()
          -5.357 * m_IsFromPromotableValueClass +
          -7.901 * m_ConstantFeedsConstantTest +
           0.065 * m_CalleeNativeSizeEstimate;
+    // clang-format on
 
     // Scaled up and reported as an integer value.
     m_ModelCodeSizeEstimate = (int) (SIZE_SCALE * sizeEstimate);
@@ -1716,6 +1720,7 @@ void DiscretionaryPolicy::EstimatePerformanceImpact()
 {
     // Performance estimate based on GLMNET model.
     // R=0.24, RMSE=16.1, MAE=8.9.
+    // clang-format off
     double perCallSavingsEstimate =
         -7.35
         + (m_CallsiteFrequency == InlineCallsiteFrequency::BORING ?  0.76 : 0)
@@ -1724,6 +1729,7 @@ void DiscretionaryPolicy::EstimatePerformanceImpact()
         + (m_ArgType[3] == CORINFO_TYPE_BOOL  ? 20.7  : 0)
         + (m_ArgType[4] == CORINFO_TYPE_CLASS ?  0.38 : 0)
         + (m_ReturnType == CORINFO_TYPE_CLASS ?  2.32 : 0);
+    // clang-format on
 
     // Scaled up and reported as an integer value.
     m_PerCallInstructionEstimate = (int) (SIZE_SCALE * perCallSavingsEstimate);

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -32,6 +32,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 const   char *      CodeGen::genInsName(instruction ins)
 {
+// clang-format off
     static
     const char * const insNames[] =
     {
@@ -69,6 +70,8 @@ const   char *      CodeGen::genInsName(instruction ins)
 #error "Unknown _TARGET_"
 #endif
     };
+// clang-format on
+
     assert((unsigned)ins < sizeof(insNames)/sizeof(insNames[0]));
     assert(insNames[ins] != NULL);
 
@@ -122,6 +125,7 @@ void                CodeGen::instInit()
 
 const   char *      CodeGen::genSizeStr(emitAttr attr)
 {
+// clang-format off
     static
     const char * const sizes[] =
     {
@@ -148,6 +152,7 @@ const   char *      CodeGen::genSizeStr(emitAttr attr)
         0, 0, 0, 0, 0, 0, 0,
         "ymmword ptr"
     };
+// clang-format on
 
     unsigned size = EA_SIZE(attr);
 
@@ -1273,8 +1278,8 @@ void                CodeGen::instEmit_indCall(GenTreePtr                        
     }
     else
     {
-        // Force the address into a register
 #ifdef LEGACY_BACKEND
+        // Force the address into a register
         genCodeForTree(addr, RBM_NONE);
 #endif // LEGACY_BACKEND
         assert(addr->gtFlags & GTF_REG_VAL);
@@ -4075,8 +4080,8 @@ void                CodeGen::instGen_Store_Imm_Into_Lcl(var_types   dstType,
         getEmitter()->emitIns_S_I(ins_Store(dstType), sizeAttr, varNum, offs, (int)imm);
     }
 #elif defined(_TARGET_ARMARCH_)
-    // Load imm into a register
 #ifndef LEGACY_BACKEND
+    // Load imm into a register
     regNumber immReg = regToUse;
     assert(regToUse != REG_NA);
 #else // LEGACY_BACKEND

--- a/src/jit/instr.h
+++ b/src/jit/instr.h
@@ -11,6 +11,7 @@
 
 /*****************************************************************************/
 
+// clang-format off
 DECLARE_TYPED_ENUM(instruction,unsigned)
 {
 #if defined(_TARGET_XARCH_)
@@ -293,6 +294,7 @@ enum InstructionSet
 #endif
     InstructionSet_NONE
 };
+// clang-format on
 
 /*****************************************************************************/
 #endif//_INSTR_H_

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -37,7 +37,8 @@
 #endif
 
 #ifdef _MSC_VER
-#define CHECK_STRUCT_PADDING    0   // Set this to '1' to enable warning C4820 "'bytes' bytes padding added after construct 'member_name'" on interesting structs/classes
+#define CHECK_STRUCT_PADDING    0   // Set this to '1' to enable warning C4820 "'bytes' bytes padding added after
+                                    // construct 'member_name'" on interesting structs/classes
 #else
 #define CHECK_STRUCT_PADDING    0   // Never enable it for non-MSFT compilers
 #endif
@@ -422,15 +423,18 @@ typedef ptrdiff_t   ssize_t;
 #define VERIFY_GC_TABLES    0
 #define REARRANGE_ADDS      1
 
-#define FUNC_INFO_LOGGING   1   // Support dumping function info to a file. In retail, only NYIs, with no function name, are dumped.
+#define FUNC_INFO_LOGGING   1   // Support dumping function info to a file. In retail, only NYIs, with no function name,
+                                // are dumped.
 
 /*****************************************************************************/
 /*****************************************************************************/
 /* Set these to 1 to collect and output various statistics about the JIT */
 
 #define CALL_ARG_STATS      0   // Collect stats about calls and call arguments.
-#define COUNT_BASIC_BLOCKS  0   // Create a histogram of basic block sizes, and a histogram of IL sizes in the simple case of single block methods.
-#define COUNT_LOOPS         0   // Collect stats about loops, such as the total number of natural loops, a histogram of the number of loop exits, etc.
+#define COUNT_BASIC_BLOCKS  0   // Create a histogram of basic block sizes, and a histogram of IL sizes in the simple
+                                // case of single block methods.
+#define COUNT_LOOPS         0   // Collect stats about loops, such as the total number of natural loops, a histogram of
+                                // the number of loop exits, etc.
 #define COUNT_RANGECHECKS   0   // Count range checks removed (in lexical CSE?).
 #define DATAFLOW_ITER       0   // Count iterations in lexical CSE and constant folding dataflow.
 #define DISPLAY_SIZES       0   // Display generated code, data, and GC information sizes.

--- a/src/jit/jitgcinfo.h
+++ b/src/jit/jitgcinfo.h
@@ -390,7 +390,6 @@ public:
 #endif // !LEGACY_BACKEND
 };
 
-
 inline
 unsigned char encodeUnsigned(BYTE *dest, unsigned value)
 {

--- a/src/jit/jittelemetry.cpp
+++ b/src/jit/jittelemetry.cpp
@@ -26,7 +26,8 @@
 //         (0xb3864c38, 0x4273, 0x58c5, 0x54, 0x5b, 0x8b, 0x36, 0x08, 0x34, 0x34, 0x71)); // Provider GUID
 //     int main(int argc, char* argv[]) // or DriverEntry for kernel-mode.
 //     {
-//         TraceLoggingRegister(g_hProvider, NULL, NULL, NULL); // NULLs only needed for C. Please do not include the NULLs in C++ code.
+//         TraceLoggingRegister(g_hProvider, NULL, NULL, NULL); // NULLs only needed for C. Please do not include the
+//                                                              // NULLs in C++ code.
 //         TraceLoggingWrite(g_hProvider,
 //            "MyEvent1",
 //            TraceLoggingString(argv[0], "arg0"),
@@ -115,8 +116,10 @@ TRACELOGGING_DEFINE_PROVIDER(g_hClrJitProvider, CLRJIT_PROVIDER_NAME, CLRJIT_PRO
 
 // Threshold to detect if we are hitting too many bad (noway) methods
 // over good methods per process to prevent logging too much data.
-static const double NOWAY_NOISE_RATIO                       = 0.6; // Threshold of (bad / total) beyond which we'd stop logging. We'd restart if the pass rate improves.
-static const unsigned NOWAY_SUFFICIENCY_THRESHOLD           = 25;  // Count of methods beyond which we'd apply percent threshold
+static const double NOWAY_NOISE_RATIO                       = 0.6; // Threshold of (bad / total) beyond which we'd stop
+                                                                   // logging. We'd restart if the pass rate improves.
+static const unsigned NOWAY_SUFFICIENCY_THRESHOLD           = 25;  // Count of methods beyond which we'd apply percent
+                                                                   // threshold
 
 // Initialize Telemetry State
 volatile bool     JitTelemetry::s_fProviderRegistered     = false;

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -87,17 +87,17 @@ void                 Compiler::fgMarkUseDef(GenTreeLclVarCommon *tree, GenTree *
         if  ((tree->gtFlags & GTF_VAR_DEF) != 0 &&
              (tree->gtFlags & (GTF_VAR_USEASG | GTF_VAR_USEDEF)) == 0)
         {
-//          if  (!(fgCurUseSet & bitMask)) printf("V%02u,T%02u def at %08p\n", lclNum, varDsc->lvVarIndex, tree);
+            // if  (!(fgCurUseSet & bitMask)) printf("V%02u,T%02u def at %08p\n", lclNum, varDsc->lvVarIndex, tree);
             VarSetOps::AddElemD(this, fgCurDefSet, varDsc->lvVarIndex);
         }
         else
         {
-//          if  (!(fgCurDefSet & bitMask))
-//          {
-//               printf("V%02u,T%02u use at ", lclNum, varDsc->lvVarIndex);
-//               printTreeID(tree);
-//               printf("\n");
-//          }
+            // if  (!(fgCurDefSet & bitMask))
+            // {
+            //      printf("V%02u,T%02u use at ", lclNum, varDsc->lvVarIndex);
+            //      printTreeID(tree);
+            //      printf("\n");
+            // }
 
             /* We have the following scenarios:
              *   1. "x += something" - in this case x is flagged GTF_VAR_USEASG
@@ -1842,8 +1842,9 @@ SKIP_QMARK:
             }
         }
 
-        // Is this a use/def of a local variable?
 #ifdef LEGACY_BACKEND
+        // Is this a use/def of a local variable?
+
         // Generally, the last use information is associated with the lclVar node.
         // However, for LEGACY_BACKEND, the information must be associated
         // with the OBJ itself for promoted structs.
@@ -2246,6 +2247,13 @@ bool Compiler::fgRemoveDeadStore(GenTree** pTree, LclVarDsc* varDsc, VARSET_TP l
 
         if (asgNode->gtOper != GT_ASG && asgNode->gtOverflowEx())
         {
+#ifdef DEBUG
+            if  (verbose)
+            {
+                printf("\nChanging dead <asgop> ovf to <op> ovf...\n");
+            }
+#endif // DEBUG
+
             // asgNode may be <op_ovf>= (with GTF_OVERFLOW). In that case, we need to keep the <op_ovf>
 
             // Dead <OpOvf>= assignment. We change it to the right operation (taking out the assignment),
@@ -2253,13 +2261,6 @@ bool Compiler::fgRemoveDeadStore(GenTree** pTree, LclVarDsc* varDsc, VARSET_TP l
             // and we start computing life again from the op_ovf node (we go backwards). Note that we
             // don't need to update ref counts because we don't change them, we're only changing the
             // operation.
-
-#ifdef DEBUG
-            if  (verbose)
-            {
-                printf("\nChanging dead <asgop> ovf to <op> ovf...\n");
-            }
-#endif // DEBUG
 
             switch (asgNode->gtOper)
             {
@@ -2501,7 +2502,6 @@ bool Compiler::fgRemoveDeadStore(GenTree** pTree, LclVarDsc* varDsc, VARSET_TP l
             else
             {
             NO_SIDE_EFFECTS:
-                /* No side effects - Remove the interior statement */
 #ifdef DEBUG
                 if (verbose)
                 {
@@ -2512,6 +2512,7 @@ bool Compiler::fgRemoveDeadStore(GenTree** pTree, LclVarDsc* varDsc, VARSET_TP l
                     printf("\n");
                 }
 #endif // DEBUG
+                /* No side effects - Remove the interior statement */
                 fgUpdateRefCntForExtract(asgNode, NULL);
 
                 /* Change the assignment to a GT_NOP node */

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1120,12 +1120,12 @@ Lowering::TreeNodeInfoInitBlockStore(GenTreeBlkOp* blkNode)
         GenTreePtr blockSize = initBlkNode->Size();
         GenTreePtr   initVal = initBlkNode->InitVal();
 
+#if 0
         // TODO-ARM64-CQ: Currently we generate a helper call for every
         // initblk we encounter.  Later on we should implement loop unrolling
         // code sequences to improve CQ.
         // For reference see the code in LowerXArch.cpp.
 
-#if 0
         // If we have an InitBlk with constant block size we can speed this up by unrolling the loop.
         if (blockSize->IsCnsIntOrI() && 
             blockSize->gtIntCon.gtIconVal <= INITBLK_UNROLL_LIMIT &&
@@ -1221,11 +1221,12 @@ Lowering::TreeNodeInfoInitBlockStore(GenTreeBlkOp* blkNode)
         GenTreePtr blockSize = cpBlkNode->Size();
         GenTreePtr   srcAddr = cpBlkNode->Source();
 
+#if 0
         // In case of a CpBlk with a constant size and less than CPBLK_UNROLL_LIMIT size
         // we should unroll the loop to improve CQ.
 
         // TODO-ARM64-CQ: cpblk loop unrolling is currently not implemented.
-#if 0
+
         if (blockSize->IsCnsIntOrI() && blockSize->gtIntCon.gtIconVal <= CPBLK_UNROLL_LIMIT)
         {
             assert(!blockSize->IsIconHandle());

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1071,8 +1071,8 @@ Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
 
     RegisterType registerType = call->TypeGet();
 
-    // Set destination candidates for return value of the call.
 #ifdef _TARGET_X86_
+    // Set destination candidates for return value of the call.
     if ((call->gtCallType == CT_HELPER) && (call->gtCallMethHnd == compiler->eeFindHelper(CORINFO_HELP_INIT_PINVOKE_FRAME)))
     {
         // The x86 CORINFO_HELP_INIT_PINVOKE_FRAME helper uses a custom calling convention that returns with
@@ -1126,11 +1126,11 @@ Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
         }
     }
 
-    // First, count reg args
 #if FEATURE_VARARG
     bool callHasFloatRegArgs = false;
 #endif // !FEATURE_VARARG
     
+    // First, count reg args
     for (GenTreePtr list = call->gtCallLateArgs; list; list = list->MoveNext())
     {
         assert(list->IsList());
@@ -1277,12 +1277,13 @@ Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
             short internalIntCount = 0;
             if (remainingSlots > 0)
             {
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
                 // This TYP_STRUCT argument is also passed in the outgoing argument area
                 // We need a register to address the TYP_STRUCT
-                // And we may need 2
-#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+
                 internalIntCount = 1;
 #else // FEATURE_UNIX_AMD64_STRUCT_PASSING
+                // And we may need 2
                 internalIntCount = 2;
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
             }
@@ -2546,6 +2547,7 @@ void Lowering::SetIndirAddrOpCounts(GenTreePtr indirTree)
     bool rev;
     bool modifiedSources = false;    
 
+#ifdef FEATURE_SIMD
     // If indirTree is of TYP_SIMD12, don't mark addr as contained
     // so that it always get computed to a register.  This would
     // mean codegen side logic doesn't need to handle all possible
@@ -2553,7 +2555,6 @@ void Lowering::SetIndirAddrOpCounts(GenTreePtr indirTree)
     // 
     // TODO-XArch-CQ: handle other addr mode expressions that could be marked
     // as contained.
-#ifdef FEATURE_SIMD
     if (indirTree->TypeGet() == TYP_SIMD12)
     {
         // Vector3 is read/written as two reads/writes: 8 byte and 4 byte.
@@ -2932,9 +2933,9 @@ void Lowering::LowerCmp(GenTreePtr tree)
                             GenTreePtr andOp1 = op1->gtOp.gtOp1;
                             if (andOp1->isMemoryOp())
                             {
-                                // If the type of value memoryOp (andOp1) is not the same as the type of constant (andOp2)
-                                // check to see whether it is safe to mark AndOp1 as contained.  For e.g. in the following
-                                // case it is not safe to mark andOp1 as contained
+                                // If the type of value memoryOp (andOp1) is not the same as the type of constant
+                                // (andOp2) check to see whether it is safe to mark AndOp1 as contained.  For e.g. in
+                                // the following case it is not safe to mark andOp1 as contained
                                 //    AndOp1 = signed byte and andOp2 is an int constant of value 512.
                                 //
                                 // If it is safe, we update the type and value of andOp2 to match with andOp1.

--- a/src/jit/lsra_reftypes.h
+++ b/src/jit/lsra_reftypes.h
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// clang-format off
 //  memberName - enum member name
 //  memberValue - enum member value
 //  shortName - short name string
@@ -19,3 +20,4 @@
     DEF_REFTYPE(RefTypeUpperVectorSaveDef, (0x40 | RefTypeDef), "UVSv"    )
     DEF_REFTYPE(RefTypeUpperVectorSaveUse, (0x40 | RefTypeUse), "UVRs"    )
     DEF_REFTYPE(RefTypeKillGCRefs        , 0x80               , "KlGC"    )
+// clang-format on

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -1503,7 +1503,8 @@ public:
 #endif
                     cse_def_cost = 2;
                     cse_use_cost = 2;
-                    extra_yes_cost = BB_UNITY_WEIGHT * 2;   // Extra cost in case we have to spill/restore a caller saved register  
+                    extra_yes_cost = BB_UNITY_WEIGHT * 2; // Extra cost in case we have to spill/restore a caller
+                                                          // saved register
                 }
             }
             else // Conservative CSE promotion

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -732,8 +732,8 @@ void RangeCheck::MergeEdgeAssertions(GenTreePtr tree, const ASSERT_VALARG_TP ass
     }
 }
 
-// Merge assertions from the pred edges of the block, i.e., check for any assertions about "op's" value numbers for phi arguments.
-// If not a phi argument, check if we assertions about local variables.
+// Merge assertions from the pred edges of the block, i.e., check for any assertions about "op's" value numbers for phi
+// arguments. If not a phi argument, check if we assertions about local variables.
 void RangeCheck::MergeAssertion(BasicBlock* block, GenTreePtr stmt, GenTreePtr op, SearchPath* path, Range* pRange DEBUGARG(int indent))
 {
     JITDUMP("Merging assertions from pred edges of BB%02d for op(%p) $%03x\n", block->bbNum, dspPtr(op), op->gtVNPair.GetConservative());

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -1551,9 +1551,10 @@ void Rationalizer::RewriteObj(GenTreePtr* ppTree, Compiler::fgWalkData* data)
     Compiler* comp = data->compiler;
     GenTreeObj* obj = (*ppTree)->AsObj();
 
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
     // For UNIX struct passing, we can have Obj nodes for arguments.
     // For other cases, we should never see a non-SIMD type here.
-#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+
     if (!varTypeIsSIMD(obj))
     {
         return;
@@ -1842,9 +1843,6 @@ Compiler::fgWalkResult Rationalizer::SimpleTransformHelper(GenTree **ppTree, Com
         GenTree *child = tree->gtOp.gtOp1;
         if (child->IsLocal())
         {
-            // We are changing the child from GT_LCL_VAR TO GT_LCL_VAR_ADDR.
-            // Therefore gtType of the child needs to be changed to a TYP_BYREF
-
 #ifdef DEBUG
             if (child->gtOper == GT_LCL_VAR)
             {
@@ -1856,6 +1854,9 @@ Compiler::fgWalkResult Rationalizer::SimpleTransformHelper(GenTree **ppTree, Com
                 JITDUMP("Rewriting GT_ADDR(GT_LCL_FLD) to GT_LCL_FLD_ADDR:\n");
             }
 #endif // DEBUG
+
+            // We are changing the child from GT_LCL_VAR TO GT_LCL_VAR_ADDR.
+            // Therefore gtType of the child needs to be changed to a TYP_BYREF
 
             Compiler::fgSnipNode(tmpState->root->AsStmt(), tree);
             child->gtOper = addrForm(child->gtOper);

--- a/src/jit/rationalize.h
+++ b/src/jit/rationalize.h
@@ -150,7 +150,7 @@ private:
     static void       DuplicateCommaProcessOneTree (Compiler* comp, Rationalizer* irt, BasicBlock* block, GenTree* tree);
 
     static void       FixupIfCallArg               (GenTreeStack* parentStack,
-                                                    GenTree* oldChild, 
+                                                    GenTree* oldChild,
                                                     GenTree* newChild);
 
     static void       FixupIfSIMDLocal             (Compiler* comp, GenTreeLclVarCommon* tree);
@@ -166,20 +166,20 @@ private:
     Location   RewriteOneQuestion       (BasicBlock* block, GenTree* op, GenTree* stmt, GenTree* dest);
     void       RewriteQuestions         (BasicBlock* block, GenTree* stmt);
     bool       BreakFirstLevelQuestions (BasicBlock* block, GenTree* tree);
-    
+
     // SIMD related transformations
     static void RewriteObj(GenTreePtr* ppTree, Compiler::fgWalkData* data);
     static void RewriteCopyBlk(GenTreePtr* ppTree, Compiler::fgWalkData* data);
     static void RewriteInitBlk(GenTreePtr* ppTree, Compiler::fgWalkData* data);
 
-    // Intrinsic related    
+    // Intrinsic related
     static void RewriteNodeAsCall(GenTreePtr* ppTree, Compiler::fgWalkData* data,
         CORINFO_METHOD_HANDLE callHnd,
 #ifdef FEATURE_READYTORUN_COMPILER
         CORINFO_CONST_LOOKUP entryPoint,
 #endif
         GenTreeArgList* args);
-    static void RewriteIntrinsicAsUserCall(GenTreePtr* ppTree, Compiler::fgWalkData* data);    
+    static void RewriteIntrinsicAsUserCall(GenTreePtr* ppTree, Compiler::fgWalkData* data);
 };
 
 inline Rationalizer::Rationalizer(Compiler* _comp)

--- a/src/jit/register.h
+++ b/src/jit/register.h
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// clang-format off
+
 /*****************************************************************************/
 /*****************************************************************************/
 #ifndef REGDEF
@@ -118,3 +120,5 @@ REGDEF(STK,    16+XMMBASE,  0x0000,       "STK"  )
 #undef  REGALIAS
 #undef  XMMMASK
 /*****************************************************************************/
+
+// clang-format on

--- a/src/jit/register_arg_convention.cpp
+++ b/src/jit/register_arg_convention.cpp
@@ -40,11 +40,12 @@ unsigned InitVarDscInfo::allocRegArg(var_types type, unsigned numRegs /* = 1 */)
 
     if (!isBackFilled)
     {
-        // We didn't back-fill a register (on ARM), so skip the number of registers that we allocated.
-#if defined(_TARGET_AMD64_) && !defined(UNIX_AMD64_ABI) // For System V the reg type counters should be independent.
+#if defined(_TARGET_AMD64_) && !defined(UNIX_AMD64_ABI)
+        // For System V the reg type counters should be independent.
         nextReg(TYP_INT, numRegs);
         nextReg(TYP_FLOAT, numRegs);
 #else
+        // We didn't back-fill a register (on ARM), so skip the number of registers that we allocated.
         nextReg(type, numRegs);
 #endif
     }
@@ -96,7 +97,8 @@ unsigned InitVarDscInfo::alignReg(var_types type, unsigned requiredRegAlignment)
     }
 #endif // _TARGET_ARM_
 
-    assert(regArgNum(type) + cAlignSkipped <= maxRegArgNum(type));  // if equal, then we aligned the last slot, and the arg can't be enregistered
+    assert(regArgNum(type) + cAlignSkipped <= maxRegArgNum(type));  // if equal, then we aligned the last slot, and the
+                                                                    // arg can't be enregistered
     regArgNum(type) += cAlignSkipped;
 
     return cAlignSkipped;

--- a/src/jit/registerarm.h
+++ b/src/jit/registerarm.h
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// clang-format off
+
 /*****************************************************************************/
 /*****************************************************************************/
 #ifndef REGDEF
@@ -80,3 +82,5 @@ REGDEF(STK,  32+FPBASE, 0x0000,      "STK")
 #undef  REGDEF
 #undef  REGALIAS
 /*****************************************************************************/
+
+// clang-format on

--- a/src/jit/registerarm64.h
+++ b/src/jit/registerarm64.h
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// clang-format off
+
 /*****************************************************************************/
 /*****************************************************************************/
 #ifndef REGDEF
@@ -108,3 +110,5 @@ REGDEF(STK,   1+NBASE, 0x0000,    "STK", "STK")
 #undef  REGDEF
 #undef  REGALIAS
 /*****************************************************************************/
+
+// clang-format on

--- a/src/jit/registerxmm.h
+++ b/src/jit/registerxmm.h
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// clang-format off
 /*****************************************************************************/
 /*****************************************************************************/
 #ifndef REGDEF
@@ -43,3 +44,5 @@ REGDEF(XMM15,   15,  XMMMASK(16), "xmm15" )
 /*****************************************************************************/
 #undef  REGDEF
 /*****************************************************************************/
+
+// clang-format on

--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -943,7 +943,7 @@ void                RegSet::rsMarkRegPairUsed(GenTreePtr tree)
 
     /* Can't mark a register pair more than once as used */
 
-//    assert((regMask & rsMaskUsed) == 0);
+    // assert((regMask & rsMaskUsed) == 0);
 
     /* Mark the registers as 'used' */
 
@@ -1016,11 +1016,11 @@ RegSet::SpillDsc *        RegSet::rsGetSpillInfo(GenTreePtr tree,
 #endif // LEGACY_BACKEND
                                                  )
 {
+#ifdef LEGACY_BACKEND
     /* Normally, trees are unspilled in the order of being spilled due to
        the post-order walking of trees during code-gen. However, this will
        not be true for something like a GT_ARR_ELEM node */
- 
-#ifdef LEGACY_BACKEND
+
     SpillDsc* multi = rsSpillDesc[reg];
 #endif // LEGACY_BACKEND
 
@@ -1320,14 +1320,14 @@ void                RegTracker::rsTrackRegLclVar(regNumber reg, unsigned var)
 
 #endif
 
-    /* Record the new value for the register. ptr var needed for
-     * lifetime extension
-     */
-
 #ifdef  DEBUG
     if  (compiler->verbose) 
         printf("\t\t\t\t\t\t\tThe register %s now holds V%02u\n", compiler->compRegVarName(reg), var);
 #endif
+
+    /* Record the new value for the register. ptr var needed for
+     * lifetime extension
+     */
 
     rsRegValues[reg].rvdKind      = RV_LCL_VAR;
 
@@ -3146,8 +3146,8 @@ TempDsc * Compiler::tmpGetTemp(var_types type)
         }
     }
 
-    /* Do we need to allocate a new temp */
 #ifdef DEBUG
+    /* Do we need to allocate a new temp */
     bool isNewTemp = false;    
 #endif // DEBUG
 

--- a/src/jit/regset.h
+++ b/src/jit/regset.h
@@ -30,7 +30,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 */
 
-
 /*****************************************************************************
 *
 *  Keep track of the current state of each register. This is intended to be

--- a/src/jit/sharedfloat.cpp
+++ b/src/jit/sharedfloat.cpp
@@ -250,8 +250,6 @@ void RegSet::SetUsedRegFloat(GenTreePtr tree, bool bValue)
 
     if (bValue)
     {
-        // Mark as used
-
 #ifdef  DEBUG
         if  (m_rsCompiler->verbose)
         {
@@ -262,6 +260,7 @@ void RegSet::SetUsedRegFloat(GenTreePtr tree, bool bValue)
         }
 #endif
 
+        // Mark as used
         assert((rsGetMaskLock() & regMask) == 0);
 
 #if FEATURE_STACK_FP_X87
@@ -285,8 +284,6 @@ void RegSet::SetUsedRegFloat(GenTreePtr tree, bool bValue)
     }
     else
     {
-        // Mark as free
-
 #ifdef DEBUG
         if  (m_rsCompiler->verbose)
         {
@@ -297,6 +294,7 @@ void RegSet::SetUsedRegFloat(GenTreePtr tree, bool bValue)
         }
 #endif
 
+        // Mark as free
         assert((rsGetMaskUsed() & regMask) == regMask);
 
         // Are we freeing a multi-use registers?

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -1166,7 +1166,8 @@ GenTreePtr  Compiler::impSIMDSelect(CORINFO_CLASS_HANDLE typeHnd,
 
     // Select(BitVector vc, va, vb) = (va & vc) | (vb & !vc)
     // Select(op1, op2, op3)        = (op2 & op1) | (op3 & !op1)
-    //                              = SIMDIntrinsicBitwiseOr(SIMDIntrinsicBitwiseAnd(op2, op1), SIMDIntrinsicBitwiseAndNot(op3, op1))
+    //                              = SIMDIntrinsicBitwiseOr(SIMDIntrinsicBitwiseAnd(op2, op1),
+    //                                                       SIMDIntrinsicBitwiseAndNot(op3, op1))
     //
     // If Op1 has side effect, create an assignment to a temp
     GenTree* tmp = op1;
@@ -1577,9 +1578,10 @@ bool Compiler::areArgumentsContiguous(GenTreePtr op1, GenTreePtr op2)
 //      return the address node.
 //
 // TODO-CQ: 
-//      1. Currently just support for GT_FIELD and GT_INDEX, because we can only verify the GT_INDEX node or GT_Field are located contiguously or not.
-//      In future we should support more cases.
-//      2.Though it happens to just work fine front-end phases are not aware of GT_LEA node.  Therefore, convert these to use GT_ADDR .   
+//      1. Currently just support for GT_FIELD and GT_INDEX, because we can only verify the GT_INDEX node or GT_Field
+//         are located contiguously or not. In future we should support more cases.
+//      2. Though it happens to just work fine front-end phases are not aware of GT_LEA node.  Therefore, convert these
+//         to use GT_ADDR.
 GenTreePtr Compiler::createAddressNodeForSIMDInit(GenTreePtr tree, unsigned simdSize)
 {
     assert(tree->OperGet() == GT_FIELD || tree->OperGet() == GT_INDEX);
@@ -1600,11 +1602,12 @@ GenTreePtr Compiler::createAddressNodeForSIMDInit(GenTreePtr tree, unsigned simd
             // so that this sturct won't be promoted.
             // e.g. s.x x is a field, and s is a struct, then we should set the s's lvUsedInSIMDIntrinsic as true.
             // so that s won't be promoted.
-            // Notice that if we have a case like s1.s2.x. s1 s2 are struct, and x is a field, then it is possible that s1 can be promoted, so that s2 can be promoted.
-            // The reason for that is if we don't allow s1 to be promoted, then this will affect the other optimizations which are depend on s1's struct promotion.
+            // Notice that if we have a case like s1.s2.x. s1 s2 are struct, and x is a field, then it is possible that
+            // s1 can be promoted, so that s2 can be promoted. The reason for that is if we don't allow s1 to be
+            // promoted, then this will affect the other optimizations which are depend on s1's struct promotion.
             // TODO-CQ:
-            //  In future, we should optimize this case so that if there is a nested field like s1.s2.x and s1.s2.x's address is used for 
-            //  initializing the vector, then s1 can be promoted but s2 can't. 
+            //  In future, we should optimize this case so that if there is a nested field like s1.s2.x and s1.s2.x's
+            //  address is used for initializing the vector, then s1 can be promoted but s2 can't. 
             if(varTypeIsSIMD(obj) && obj->OperIsLocal())
             {
                 setLclRelatedToSIMDIntrinsic(obj);

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -1326,14 +1326,16 @@ CodeGen::genSIMDIntrinsicDotProduct(GenTreeSIMD* simdNode)
         if (baseType == TYP_FLOAT)
         {
             // v0 = v1 * v2
-            // tmp = v0                                       // v0  = (3, 2, 1, 0) - each element is given by its position
+            // tmp = v0                                       // v0  = (3, 2, 1, 0) - each element is given by its
+            //                                                // position
             // tmp = shuffle(tmp, tmp, Shuffle(2,3,0,1))      // tmp = (2, 3, 0, 1)
             // v0 = v0 + tmp                                  // v0  = (3+2, 2+3, 1+0, 0+1)
             // tmp = v0                                       
             // tmp = shuffle(tmp, tmp, Shuffle(0,1,2,3))      // tmp = (0+1, 1+0, 2+3, 3+2)
             // v0 = v0 + tmp                                  // v0  = (0+1+2+3, 0+1+2+3, 0+1+2+3, 0+1+2+3)
             //                                                // Essentially horizontal addtion of all elements.
-            //                                                // We could achieve the same using SSEv3 instruction HADDPS.
+            //                                                // We could achieve the same using SSEv3 instruction
+            //                                                // HADDPS.
             //
             inst_RV_RV(INS_mulps, targetReg, op2Reg);
             inst_RV_RV(INS_movaps, tmpReg, targetReg);

--- a/src/jit/simdintrinsiclist.h
+++ b/src/jit/simdintrinsiclist.h
@@ -8,6 +8,7 @@
 #endif
 /*****************************************************************************/
 
+// clang-format off
 #ifdef FEATURE_SIMD
 
     /*
@@ -141,3 +142,4 @@ SIMD_INTRINSIC(nullptr,                     false,       Invalid,               
 #endif //!_TARGET_AMD64_
 
 #endif //FEATURE_SIMD
+// clang-format on

--- a/src/jit/smcommon.cpp
+++ b/src/jit/smcommon.cpp
@@ -21,9 +21,9 @@ const char * const  smOpcodeNames[] =
 
 const SM_OPCODE s_CodeSeqs[][MAX_CODE_SEQUENCE_LENGTH] =
 { 
-    // ==== Single opcode states ==== 
 
 #define SMOPDEF(smname,string) {smname, CODE_SEQUENCE_END},
+// ==== Single opcode states ==== 
 #include "smopcode.def"
 #undef SMOPDEF    
     
@@ -68,8 +68,9 @@ const SM_OPCODE s_CodeSeqs[][MAX_CODE_SEQUENCE_LENGTH] =
     {SM_CONV_R4,       SM_MUL,        CODE_SEQUENCE_END},    
     {SM_CONV_R4,       SM_DIV,        CODE_SEQUENCE_END},    
 
-    // {SM_CONV_R8,       SM_ADD,        CODE_SEQUENCE_END},  // Removed since it collides with ldelem.r8 in Math.InternalRound
-    // {SM_CONV_R8,       SM_SUB,        CODE_SEQUENCE_END},  // Just remove the SM_SUB as well.  
+    // {SM_CONV_R8,       SM_ADD,        CODE_SEQUENCE_END},  // Removed since it collides with ldelem.r8 in
+                                                              // Math.InternalRound
+    // {SM_CONV_R8,       SM_SUB,        CODE_SEQUENCE_END},  // Just remove the SM_SUB as well.
     {SM_CONV_R8,       SM_MUL,        CODE_SEQUENCE_END},    
     {SM_CONV_R8,       SM_DIV,        CODE_SEQUENCE_END}, 
 

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -447,7 +447,8 @@ void SsaBuilder::ComputeDominators(BasicBlock** postOrder, int count, BlkToBlkSe
 
 #ifdef SSA_FEATURE_DOMARR
     // Allocate space for constant time computation of (a DOM b?) query.
-    unsigned bbArrSize = m_pCompiler->fgBBNumMax + 1; // We will use 1-based bbNums as indices into these arrays, so add 1.
+    unsigned bbArrSize = m_pCompiler->fgBBNumMax + 1; // We will use 1-based bbNums as indices into these arrays, so
+                                                      // add 1.
     m_pDomPreOrder = jitstd::utility::allocate<int>(m_allocator, bbArrSize);
     m_pDomPostOrder = jitstd::utility::allocate<int>(m_allocator, bbArrSize);
 
@@ -748,17 +749,17 @@ void SsaBuilder::InsertPhiFunctions(BasicBlock** postOrder, int count)
                 // Check if we've already inserted a phi node.
                 if (GetPhiNode(bbInDomFront, lclNum) == NULL)
                 {
-                    // We have a variable i that is defined in block j and live at l, and l belongs to dom frontier of j.
-                    // So insert a phi node at l.
+                    // We have a variable i that is defined in block j and live at l, and l belongs to dom frontier of
+                    // j. So insert a phi node at l.
                     JITDUMP("Inserting phi definition for V%02u at start of BB%02u.\n", lclNum, bbInDomFront->bbNum);
 
                     GenTreePtr phiLhs  = m_pCompiler->gtNewLclvNode(lclNum, m_pCompiler->lvaTable[lclNum].TypeGet());
 
-                    // Create 'phiRhs' as a GT_PHI node for 'lclNum', it will eventually hold a GT_LIST of GT_PHI_ARG nodes.
-                    // However we have to construct this list so for now the gtOp1 of 'phiRhs' is a nullptr.
-                    // It will get replaced with a GT_LIST of GT_PHI_ARG nodes in SsaBuilder::AssignPhiNodeRhsVariables()
-                    // and in SsaBuilder::AddDefToHandlerPhis()
-                    //
+                    // Create 'phiRhs' as a GT_PHI node for 'lclNum', it will eventually hold a GT_LIST of GT_PHI_ARG
+                    // nodes. However we have to construct this list so for now the gtOp1 of 'phiRhs' is a nullptr.
+                    // It will get replaced with a GT_LIST of GT_PHI_ARG nodes in
+                    // SsaBuilder::AssignPhiNodeRhsVariables() and in SsaBuilder::AddDefToHandlerPhis()
+
                     GenTreePtr phiRhs = m_pCompiler->gtNewOperNode(GT_PHI, m_pCompiler->lvaTable[lclNum].TypeGet(), nullptr);
 
                     GenTreePtr phiAsg = m_pCompiler->gtNewAssignNode(phiLhs, phiRhs  DEBUGARG(/*isPhiDefn*/true));
@@ -786,8 +787,8 @@ void SsaBuilder::InsertPhiFunctions(BasicBlock** postOrder, int count)
                 // Check if we've already inserted a phi node.
                 if (bbInDomFront->bbHeapSsaPhiFunc == NULL)
                 {
-                    // We have a variable i that is defined in block j and live at l, and l belongs to dom frontier of j.
-                    // So insert a phi node at l.
+                    // We have a variable i that is defined in block j and live at l, and l belongs to dom frontier of
+                    // j. So insert a phi node at l.
                     JITDUMP("Inserting phi definition for Heap at start of BB%02u.\n", bbInDomFront->bbNum);
                     bbInDomFront->bbHeapSsaPhiFunc = BasicBlock::EmptyHeapPhiDef;
                 }
@@ -1528,8 +1529,8 @@ void SsaBuilder::RenameVariables(BlkToBlkSetMap* domTree, SsaRenameState* pRenam
 
         if (!blockWrk.m_processed)
         {
-            // Push the block back on the stack with "m_processed" true, to record the fact that when its children have been
-            // (recursively) processed, we still need to call BlockPopStacks on it.
+            // Push the block back on the stack with "m_processed" true, to record the fact that when its children have
+            // been (recursively) processed, we still need to call BlockPopStacks on it.
             blocksToDo->push_back(BlockWork(block, true));
 
             // Walk the block give counts to DEFs and give top of stack count for USEs.

--- a/src/jit/ssabuilder.h
+++ b/src/jit/ssabuilder.h
@@ -132,8 +132,8 @@ private:
     // iterated dominance frontiers.  (Recall that the dominance frontier of a block B is the set of blocks
     // B3 such that there exists some B2 s.t. B3 is a successor of B2, and B dominates B2.  Note that this dominance
     // need not be strict -- B2 and B may be the same node.  The iterated dominance frontier is formed by a closure
-    // operation: the IDF of B is the smallest set that includes B's dominance frontier, and also includes the dominance frontier
-    // of all elements of the set.)
+    // operation: the IDF of B is the smallest set that includes B's dominance frontier, and also includes the dominance
+    // frontier of all elements of the set.)
     BlkToBlkSetMap* ComputeIteratedDominanceFrontier(BasicBlock** postOrder, int count);
 
     // Requires "postOrder" to hold the blocks of the flowgraph in topologically sorted order. Requires
@@ -157,9 +157,9 @@ private:
     // Requires "pRenameState" to be non-NULL and be currently used for variables renaming.
     void BlockRenameVariables(BasicBlock* block, SsaRenameState* pRenameState);
 
-    // Requires "tree" (assumed to be a statement in "block") to be searched for defs and uses to assign ssa numbers. Requires "pRenameState"
-    // to be non-NULL and be currently used for variables renaming.  Assumes that "isPhiDefn" implies that any definition occurring within "tree"
-    // is a phi definition.
+    // Requires "tree" (assumed to be a statement in "block") to be searched for defs and uses to assign ssa numbers.
+    // Requires "pRenameState" to be non-NULL and be currently used for variables renaming.  Assumes that "isPhiDefn"
+    // implies that any definition occurring within "tree" is a phi definition.
     void TreeRenameVariables(GenTree* tree, BasicBlock* block, SsaRenameState* pRenameState, bool isPhiDefn);
 
     // Assumes that "block" contains a definition for local var "lclNum", with SSA number "count".

--- a/src/jit/typelist.h
+++ b/src/jit/typelist.h
@@ -30,6 +30,7 @@
 DEF_TP(tn      ,nm        , jitType,     verType, sz,sze,asze, st,al, tf,            howUsed     )
 */
 
+// clang-format off
 DEF_TP(UNDEF   ,"<UNDEF>" , TYP_UNDEF,   TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY,        0           )
 DEF_TP(VOID    ,"void"    , TYP_VOID,    TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY,        0           )
 
@@ -70,6 +71,7 @@ DEF_TP(SIMD32   ,"simd32" , TYP_SIMD32,  TI_STRUCT,32,32, 32,   8,16, VTF_S,    
 #endif // FEATURE_SIMD
 
 DEF_TP(UNKNOWN ,"unknown" ,TYP_UNKNOWN,  TI_ERROR, 0,  0,  0,   0, 0, VTF_ANY,        0           )
+// clang-format on
 
 #undef  GCS
 #undef  BRS

--- a/src/jit/unwind.h
+++ b/src/jit/unwind.h
@@ -35,10 +35,14 @@ const unsigned MAX_EPILOG_SIZE_BYTES = 100;
 #define UW_MAX_EPILOG_START_INDEX           0x3FFU
 #endif // _TARGET_ARM64_
 
-#define UW_MAX_EPILOG_COUNT                 31      // Max number that can be encoded in the "Epilog count" field of the .pdata record
-#define UW_MAX_EXTENDED_CODE_WORDS_COUNT    0xFFU       // Max number that can be encoded in the "Extended Code Words" field of the .pdata record
-#define UW_MAX_EXTENDED_EPILOG_COUNT        0xFFFFU     // Max number that can be encoded in the "Extended Epilog Count" field of the .pdata record
-#define UW_MAX_EPILOG_START_OFFSET          0x3FFFFU    // Max number that can be encoded in the "Epilog Start Offset" field of the .pdata record
+#define UW_MAX_EPILOG_COUNT                 31          // Max number that can be encoded in the "Epilog count" field
+                                                        // of the .pdata record
+#define UW_MAX_EXTENDED_CODE_WORDS_COUNT    0xFFU       // Max number that can be encoded in the "Extended Code Words"
+                                                        // field of the .pdata record
+#define UW_MAX_EXTENDED_EPILOG_COUNT        0xFFFFU     // Max number that can be encoded in the "Extended Epilog Count"
+                                                        // field of the .pdata record
+#define UW_MAX_EPILOG_START_OFFSET          0x3FFFFU    // Max number that can be encoded in the "Epilog Start Offset"
+                                                        // field of the .pdata record
 
 //
 // Forward declaration of class defined in emit.h
@@ -691,7 +695,8 @@ private:
     // set of epilogs, for this function/funclet.
     bool                ufiInProlog;
 
-    static const unsigned UFI_INITIALIZED_PATTERN = 0x0FACADE0;     // Something unlikely to be the fill pattern for uninitialized memory
+    static const unsigned UFI_INITIALIZED_PATTERN = 0x0FACADE0;     // Something unlikely to be the fill pattern for
+                                                                    // uninitialized memory
     unsigned            ufiInitialized;
 
 #endif // DEBUG
@@ -815,7 +820,8 @@ private:
 
 #ifdef DEBUG
 
-    static const unsigned UWI_INITIALIZED_PATTERN = 0x0FACADE1;     // Something unlikely to be the fill pattern for uninitialized memory
+    static const unsigned UWI_INITIALIZED_PATTERN = 0x0FACADE1;     // Something unlikely to be the fill pattern for
+                                                                    // uninitialized memory
     unsigned            uwiInitialized;
 
 #endif // DEBUG

--- a/src/jit/unwindarm.cpp
+++ b/src/jit/unwindarm.cpp
@@ -590,9 +590,10 @@ void            UnwindPrologCodes::SetFinalSize(int headerBytes, int epilogBytes
         // The prolog codes that are already at the end of the array need to get moved to the middle,
         // with space for the non-matching epilog codes to follow.
 
+        // Note that the three UWC_END padding bytes still exist at the end of the array.
+
         memmove_s(&upcMem[upcUnwindBlockSlot + headerBytes], upcMemSize - (upcUnwindBlockSlot + headerBytes), &upcMem[upcCodeSlot], prologBytes);
 
-        // Note that the three UWC_END padding bytes still exist at the end of the array.
 
 #ifdef DEBUG
         // Zero out the epilog codes memory, to ensure we've copied the right bytes. Don't zero the padding bytes.
@@ -925,7 +926,8 @@ void            UnwindFragmentInfo::FinalizeOffset()
 {
     if (ufiEmitLoc == NULL)
     {
-        ufiStartOffset = 0;    // NULL emit location means the beginning of the code. This is to handle the first fragment prolog.
+        // NULL emit location means the beginning of the code. This is to handle the first fragment prolog.
+        ufiStartOffset = 0;
     }
     else
     {
@@ -1069,7 +1071,8 @@ void            UnwindFragmentInfo::MergeCodes()
     assert(ufiInitialized == UFI_INITIALIZED_PATTERN);
 
     unsigned epilogCount = 0;
-    unsigned epilogCodeBytes = 0;   // The total number of unwind code bytes used by epilogs that don't match the prolog codes
+    unsigned epilogCodeBytes = 0;   // The total number of unwind code bytes used by epilogs that don't match the
+                                    // prolog codes
     unsigned epilogIndex = ufiPrologCodes.Size();   // The "Epilog Start Index" for the next non-matching epilog codes
     UnwindEpilogInfo* pEpi;
 
@@ -1155,7 +1158,8 @@ void            UnwindFragmentInfo::MergeCodes()
 
     DWORD finalSize =
         headerBytes
-        + codeBytes;                                    // Size of actual unwind codes, aligned up to 4-byte words, including end padding if necessary
+        + codeBytes;                                    // Size of actual unwind codes, aligned up to 4-byte words,
+                                                        // including end padding if necessary
 
     // Construct the final unwind information.
 
@@ -1387,7 +1391,8 @@ void            UnwindFragmentInfo::Reserve(BOOL isFunclet, bool isHotCode)
 //      funKind:       funclet kind
 //      pHotCode:      hot section code buffer
 //      pColdCode:     cold section code buffer
-//      funcEndOffset: offset of the end of this function/funclet. Used if this fragment is the last one for a function/funclet.
+//      funcEndOffset: offset of the end of this function/funclet. Used if this fragment is the last one for a
+//                     function/funclet.
 //      isHotCode:     are we allocating the unwind info for the hot code section?
 
 void            UnwindFragmentInfo::Allocate(CorJitFuncKind funKind, void* pHotCode, void* pColdCode, UNATIVE_OFFSET funcEndOffset, bool isHotCode)
@@ -1616,7 +1621,8 @@ void            UnwindInfo::Split()
 
     if (uwiFragmentLast->ufiEmitLoc == NULL)
     {
-        startOffset = 0;    // NULL emit location means the beginning of the code. This is to handle the first fragment prolog.
+        // NULL emit location means the beginning of the code. This is to handle the first fragment prolog.
+        startOffset = 0;
     }
     else
     {
@@ -1654,13 +1660,6 @@ void            UnwindInfo::Split()
         return;
     }
 
-    // Now, we're going to commit to splitting the function into "numberOfFragments" fragments,
-    // for the purpose of unwind information. We need to do the actual splits so we can figure out
-    // the size of each piece of unwind data for the call to reserveUnwindInfo(). We won't know
-    // the actual offsets of the splits since we haven't issued the instructions yet, so store
-    // an emitter location instead of an offset, and "finalize" the offset in the unwindEmit() phase,
-    // like we do for the function length and epilog offsets.
-
 #ifdef DEBUG
     if (uwiComp->verbose)
     {
@@ -1670,6 +1669,13 @@ void            UnwindInfo::Split()
             maxFragmentSize);
     }
 #endif // DEBUG
+
+    // Now, we're going to commit to splitting the function into "numberOfFragments" fragments,
+    // for the purpose of unwind information. We need to do the actual splits so we can figure out
+    // the size of each piece of unwind data for the call to reserveUnwindInfo(). We won't know
+    // the actual offsets of the splits since we haven't issued the instructions yet, so store
+    // an emitter location instead of an offset, and "finalize" the offset in the unwindEmit() phase,
+    // like we do for the function length and epilog offsets.
 
     // Call the emitter to do the split, and call us back for every split point it chooses.
     uwiComp->genEmitter->emitSplit(uwiFragmentLast->ufiEmitLoc, uwiEndLoc, maxFragmentSize, (void*)this, EmitSplitCallback);

--- a/src/jit/utils.cpp
+++ b/src/jit/utils.cpp
@@ -22,6 +22,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 #define DECLARE_DATA
 
+// clang-format off
 extern
 const signed char       opcodeSizes[] =
 {
@@ -70,7 +71,7 @@ const signed char       opcodeSizes[] =
     #undef InlineSwitch_size
     #undef InlinePhi_size
 };
-
+// clang-format on
 
 const BYTE          varTypeClassification[] =
 {
@@ -318,8 +319,8 @@ void                dspRegMask(regMaskTP regMask, size_t minSiz)
                 // By default, we're not starting a potential register range.
                 sep = " ";
 
-                // What kind of separator should we use for this range (if it is indeed going to be a range)?
 #if defined(_TARGET_AMD64_)
+                // What kind of separator should we use for this range (if it is indeed going to be a range)?
                 // For AMD64, create ranges for int registers R8 through R15, but not the "old" registers.
                 if (regNum >= REG_R8)
                 {
@@ -349,8 +350,8 @@ void                dspRegMask(regMaskTP regMask, size_t minSiz)
 #error Unsupported or unset target architecture
 #endif // _TARGET_*
             }
-            // We've already printed a register. Is this the end of a range?
 #if defined(_TARGET_ARM64_)
+            // We've already printed a register. Is this the end of a range?
             else if ((regNum == REG_INT_LAST)
                      || (regNum == REG_R17) // last register before TEB
                      || (regNum == REG_R28)) // last register before FP
@@ -498,7 +499,8 @@ dumpSingleInstr(const BYTE* const codeAddr, IL_OFFSET offs, const char* prefix)
 {
     const BYTE  *        opcodePtr = codeAddr + offs;
     const BYTE  *   startOpcodePtr = opcodePtr;
-    const unsigned ALIGN_WIDTH = 3 * 6; // assume 3 characters * (1 byte opcode + 4 bytes data + 1 prefix byte) for most things
+    const unsigned ALIGN_WIDTH = 3 * 6; // assume 3 characters * (1 byte opcode + 4 bytes data + 1 prefix byte) for
+                                        // most things
 
     if (prefix != NULL)
         printf("%s", prefix);

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -170,8 +170,8 @@ private:
     template<typename T>
     static T EvalOp(VNFunc vnf, T v0);
 
-    // If vnf(v0, v1) would raise an exception, sets *pExcSet to the singleton set containing the exception, and returns (T)0.
-    // Otherwise, returns vnf(v0, v1).
+    // If vnf(v0, v1) would raise an exception, sets *pExcSet to the singleton set containing the exception, and
+    // returns (T)0. Otherwise, returns vnf(v0, v1).
     template<typename T>
     T EvalOp(VNFunc vnf, T v0, T v1, ValueNum* pExcSet);
 
@@ -218,8 +218,8 @@ private:
     unsigned m_numMapSels;
 #endif
 
-    // This is the maximum number of MapSelect terms that can be "considered" as part of evaluation of a top-level MapSelect
-    // application.
+    // This is the maximum number of MapSelect terms that can be "considered" as part of evaluation of a top-level
+    // MapSelect application.
     unsigned m_mapSelectBudget;
 
 public:
@@ -440,8 +440,8 @@ public:
     // Get a new, unique value number for an expression that we're not equating to some function.
     ValueNum VNForExpr(var_types typ = TYP_UNKNOWN);
 
-    // This controls extra tracing of the "evaluation" of "VNF_MapSelect" functions.
 #define FEATURE_VN_TRACE_APPLY_SELECTORS 1
+    // This controls extra tracing of the "evaluation" of "VNF_MapSelect" functions.
 
     // Return the value number corresponding to constructing "MapSelect(map, f0)", where "f0" is the
     // (value number of) the first field in "fieldSeq".  (The type of this application will be the type of "f0".)
@@ -502,11 +502,11 @@ public:
     // When "fieldSeqVN" is VNForNotAField, a unique VN is generated using m_uPtrToLocNotAFieldCount.
     ValueNum VNForPtrToLoc(var_types typ, ValueNum lclVarVN, ValueNum fieldSeqVN);
 
-    // If "opA" has a PtrToLoc, PtrToArrElem, or PtrToStatic application as its value numbers, and "opB" is an integer with
-    // a "fieldSeq", returns the VN for the pointer form extended with the field sequence; or else NoVN.
+    // If "opA" has a PtrToLoc, PtrToArrElem, or PtrToStatic application as its value numbers, and "opB" is an integer
+    // with a "fieldSeq", returns the VN for the pointer form extended with the field sequence; or else NoVN.
     ValueNum ExtendPtrVN(GenTreePtr opA, GenTreePtr opB);
-    // If "opA" has a PtrToLoc, PtrToArrElem, or PtrToStatic application as its value numbers, returns the VN for the pointer form
-    // extended with "fieldSeq"; or else NoVN.
+    // If "opA" has a PtrToLoc, PtrToArrElem, or PtrToStatic application as its value numbers, returns the VN for the
+    // pointer form extended with "fieldSeq"; or else NoVN.
     ValueNum ExtendPtrVN(GenTreePtr opA, FieldSeqNode* fieldSeq);
 
     // Queries on value numbers.
@@ -760,8 +760,8 @@ public:
     bool VNIsValid(ValueNum vn);
 
 #ifdef DEBUG
-    // This controls whether we recursively call vnDump on function arguments.
 #define FEATURE_VN_DUMP_FUNC_ARGS 0
+    // This controls whether we recursively call vnDump on function arguments.
 
     // Prints, to standard out, a representation of "vn".
     void vnDump(Compiler* comp, ValueNum vn, bool isPtr = false);
@@ -792,10 +792,11 @@ public:
     static bool        isReservedVN(ValueNum);
 
 #define VALUENUM_SUPPORT_MERGE 0
+#if VALUENUM_SUPPORT_MERGE
     // If we're going to support the Merge operation, and do it right, we really need to use an entire
     // egraph data structure, so that we can do congruence closure, and discover congruences implied
     // by the eq-class merge.
-#if VALUENUM_SUPPORT_MERGE
+
     // It may be that we provisionally give two expressions distinct value numbers, then later discover
     // that the values of the expressions are provably equal.  We allow the two value numbers to be
     // "merged" -- after the merge, they represent the same abstract value.
@@ -848,8 +849,9 @@ private:
     // "m_typ" and "m_attribs".  These properties determine the interpretation of "m_defs", as discussed below.
     struct Chunk
     {
-        // If "m_defs" is non-null, it is an array of size ChunkSize, whose element type is determined by the other members.
-        // The "m_numUsed" field indicates the number of elements of "m_defs" that are already consumed (the next one to allocate).
+        // If "m_defs" is non-null, it is an array of size ChunkSize, whose element type is determined by the other
+        // members. The "m_numUsed" field indicates the number of elements of "m_defs" that are already consumed (the
+        // next one to allocate).
         void*    m_defs;
         unsigned m_numUsed;
 

--- a/src/jit/valuenumfuncs.h
+++ b/src/jit/valuenumfuncs.h
@@ -6,6 +6,7 @@
 // Defines the functions understood by the value-numbering system.
 // ValueNumFuncDef(<name of function>, <arity (1-4)>, <is-commutative (for arity = 2)>, <non-null (for gc functions)>, <is-shared-static>)
 
+// clang-format off
 ValueNumFuncDef(MapStore, 3, false, false, false)
 ValueNumFuncDef(MapSelect, 2, false, false, false)
 
@@ -135,7 +136,7 @@ ValueNumFuncDef(MOD_UN, 2, false, false, false)
 ValueNumFuncDef(StrCns, 2, false, true, false)
 
 ValueNumFuncDef(Unbox, 2, false, true, false)
-
+// clang-format on
 
 
 #undef ValueNumFuncDef

--- a/src/jit/varset.h
+++ b/src/jit/varset.h
@@ -175,9 +175,8 @@ const unsigned lclMAX_ALLSET_TRACKED = UInt64Bits;
 typedef   AllVarSetOps::ValArgType ALLVARSET_VALARG_TP;
 typedef   AllVarSetOps::RetValType ALLVARSET_VALRET_TP;
 
-
-// Initialize "varName" to "initVal."  Copies contents, not references; if "varName" is uninitialized, allocates a var set
-// for it (using "comp" for any necessary allocation), and copies the contents of "initVal" into it.
+// Initialize "varName" to "initVal."  Copies contents, not references; if "varName" is uninitialized, allocates a var
+// set for it (using "comp" for any necessary allocation), and copies the contents of "initVal" into it.
 #define VARSET_INIT(comp, varName, initVal) varName(VarSetOps::MakeCopy(comp, initVal))
 #define ALLVARSET_INIT(comp, varName, initVal) varName(AllVarSetOps::MakeCopy(comp, initVal))
 


### PR DESCRIPTION
This change starts the process of updating the jit code to make it ready
for being formatted by clang-format. Changes mostly include reflowing
comments that go past our column limit and moving comments around ifdefs
so clang-format does not modify the indentation. Additionally, some
header files are manually reformatted for pointer alignment and marked
as clang-format off so that we do not lose the current formatting.