### PR TITLE
Fix issue #5642

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4893,9 +4893,9 @@ void                Compiler::fgFixupStructReturn(GenTreePtr     callNode)
 
     if (!callHasRetBuffArg && varTypeIsStruct(call))
     {
-#ifdef FEATURE_HFA
+#if FEATURE_MULTIREG_RET
         if (call->gtCall.IsVarargs() || !IsHfa(call))
-#endif 
+#endif // FEATURE_MULTIREG_RET
         {
             // Now that we are past the importer, re-type this node so the register predictor does
             // the right thing

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -64215,7 +64215,7 @@ RelativePath=JIT\SIMD\VectorReturn_ro\VectorReturn_ro.cmd
 WorkingDir=JIT\SIMD\VectorReturn_ro
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_PASS;R2R_FAIL;ISSUE_5642
+Categories=Pri0;EXPECTED_PASS;ISSUE_5642
 HostStyle=0
 [VectorSet_r.cmd_9294]
 RelativePath=JIT\SIMD\VectorSet_r\VectorSet_r.cmd


### PR DESCRIPTION
Only consider hfa types when multireg return is enabled for the target
Update Test.Lst with new passing test