### PR TITLE
Fix platform logic in symbol stripping code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if (PYTHON STREQUAL "PYTHON-NOTFOUND")
 endif()
 
 # Ensure other tools are present
-if(WIN32)
+if (WIN32)
     enable_language(ASM_MASM)
 
     # Ensure that MC is present
@@ -41,7 +41,7 @@ if(WIN32)
         message(FATAL_ERROR "MC not found")
     endif()
 
-    if(CLR_CMAKE_HOST_ARCH STREQUAL arm64)
+    if (CLR_CMAKE_HOST_ARCH STREQUAL arm64)
       # CMAKE_CXX_COMPILER will default to the compiler installed with 
       # Visual studio. Overwrite it to the compiler on the path. 
       # TODO, remove when cmake generator supports Arm64 as a target.  
@@ -50,7 +50,8 @@ if(WIN32)
       message("Overwriting the CMAKE_CXX_COMPILER.") 
       message(CMAKE_CXX_COMPILER found:${CMAKE_CXX_COMPILER}) 
     endif()
-else()
+
+else (WIN32)
     enable_language(ASM)
 
     # Ensure that awk is present
@@ -61,21 +62,22 @@ else()
  
     if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
-      # Ensure that dsymutil and strip is present
+      # Ensure that dsymutil and strip are present
       find_program(DSYMUTIL dsymutil)
       if (DSYMUTIL STREQUAL "DSYMUTIL-NOTFOUND")
           message(FATAL_ERROR "dsymutil not found")
       endif()
+
       find_program(STRIP strip)
       if (STRIP STREQUAL "STRIP-NOTFOUND")
           message(FATAL_ERROR "strip not found")
       endif()
-    elseif (CMAKE_SYSTEM_NAME STREQUAL Linux)
+
+    else (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
       # Ensure that objcopy is present
-      if(DEFINED ENV{CROSSCOMPILE})
-        if(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
-          find_program(OBJCOPY ${TOOLCHAIN}-objcopy) 
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
+      if (DEFINED ENV{CROSSCOMPILE})
+        if (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
           find_program(OBJCOPY ${TOOLCHAIN}-objcopy)
         else()
           clr_unknown_arch()
@@ -83,10 +85,12 @@ else()
       else()
         find_program(OBJCOPY objcopy)
       endif()
+
       if (OBJCOPY STREQUAL "OBJCOPY-NOTFOUND")
           message(FATAL_ERROR "objcopy not found")
       endif()
-    endif ()
+
+    endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif(WIN32)
 
 #----------------------------------------

--- a/functions.cmake
+++ b/functions.cmake
@@ -93,19 +93,19 @@ function(add_precompiled_header header cppFile targetSources)
 endfunction()
 
 function(strip_symbols targetName outputFilename)
-  if(CLR_CMAKE_PLATFORM_UNIX)
-    if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+  if (CLR_CMAKE_PLATFORM_UNIX)
+    if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
 
       # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
       # generator expression doesn't work correctly returning the wrong path and on
       # the newer cmake versions the LOCATION property isn't supported anymore.
-      if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
+      if (CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
           set(strip_source_file $<TARGET_FILE:${targetName}>)
       else()
           get_property(strip_source_file TARGET ${targetName} PROPERTY LOCATION)
       endif()
 
-      if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
         set(strip_destination_file ${strip_source_file}.dwarf)
 
         add_custom_command(
@@ -116,7 +116,7 @@ function(strip_symbols targetName outputFilename)
           COMMAND ${STRIP} -S ${strip_source_file}
           COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
         )
-      elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+      else (CMAKE_SYSTEM_NAME STREQUAL Darwin)
         set(strip_destination_file ${strip_source_file}.dbg)
 
         add_custom_command(
@@ -128,7 +128,7 @@ function(strip_symbols targetName outputFilename)
           COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
           COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
         )
-      endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
       set(${outputFilename} ${strip_destination_file} PARENT_SCOPE)
     endif(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)


### PR DESCRIPTION
_Testing, do not merge yet._

Looks like https://github.com/dotnet/coreclr/pull/3944 changed the logic for stripping debug information so it only applies to Darwin and Linux platforms.
