### PR TITLE
Remove GTF_DEAD.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -8280,12 +8280,6 @@ int cTreeFlagsIR(Compiler *comp, GenTree *tree)
                 chars += printf("[IND_NONFAULTING]");
             }
         }
-#if FEATURE_ANYCSE
-        if (tree->gtFlags & GTF_DEAD)
-        {
-            chars += printf("[DEAD]");
-        }
-#endif
         if (tree->gtFlags & GTF_MAKE_CSE)
         {
             chars += printf("[MAKE_CSE]");

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -635,11 +635,14 @@ public:
     #define GTF_GLOB_EFFECT     (GTF_SIDE_EFFECT|GTF_GLOB_REF)
     #define GTF_ALL_EFFECT      (GTF_GLOB_EFFECT|GTF_ORDER_SIDEEFF)
 
-    // The extra flag GTF_DEAD is used to tell the consumer of these flags
-    // that we are calling in the context of performing a CSE, thus we 
+    // The extra flag GTF_IS_IN_CSE is used to tell the consumer of these flags
+    // that we are calling in the context of performing a CSE, thus we
     // should allow the run-once side effects of running a class constructor.
     //
-    #define GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE (GTF_ASG|GTF_CALL|GTF_DEAD)
+    // The only requirement of this flag is that it not overlap any of the
+    // side-effect flags. The actual bit used is otherwise arbitrary.
+    #define GTF_IS_IN_CSE  GTF_MAKE_CSE
+    #define GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE (GTF_ASG|GTF_CALL|GTF_IS_IN_CSE)
 
     // Can any side-effects be observed externally, say by a caller method?
     // For assignments, only assignments to global memory can be observed
@@ -672,10 +675,6 @@ public:
                                             // Use gtSetFlags() to check this flags
 #endif
     #define GTF_IND_NONFAULTING 0x00000800  // An indir that cannot fault.  GTF_SET_FLAGS is not used on indirs
-
-#if FEATURE_ANYCSE
-    #define GTF_DEAD            0x00001000  // this node won't be used any more
-#endif // FEATURE_ANYCSE
 
     #define GTF_MAKE_CSE        0x00002000  // Hoisted Expression: try hard to make this into CSE  (see optPerformHoistExpr)
     #define GTF_DONT_CSE        0x00004000  // don't bother CSE'ing this expr

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6832,8 +6832,7 @@ Compiler::fgWalkResult      Compiler::optRemoveTreeVisitor(GenTreePtr *pTree, fg
             //
             if (tree == op1)
             {
-                // This tree and all of its sub trees are being kept 
-                // so we skip marking with GTF_DEAD, etc...
+                // This tree and all of its sub trees are being kept.
                 return WALK_SKIP_SUBTREES;
             }
 
@@ -6844,8 +6843,7 @@ Compiler::fgWalkResult      Compiler::optRemoveTreeVisitor(GenTreePtr *pTree, fg
         }
         if (tree == keptTree)
         {
-            // This tree and all of its sub trees are being kept 
-            // so we skip marking with GTF_DEAD, etc...
+            // This tree and all of its sub trees are being kept.
             return WALK_SKIP_SUBTREES;
         }
     }


### PR DESCRIPTION
This flag was only used by CSE to mark dead trees s.t. these trees
were not considered during CSE replacement. The same information,
however, can be provided by the gtCSEnum field: a tree with this
field set to NO_CSE is treated identically to a tree marked with
GTF_DEAD. The GTF_DEAD flag is therefore redundant and can be
eliminated.

This is part of #5999.