### PR TITLE
Inliner: make ModelPolicy available in release builds

### DIFF
--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -11,13 +11,13 @@
 //
 // LegalPolicy         - partial class providing common legality checks
 // LegacyPolicy        - policy that provides legacy inline behavior
+// DiscretionaryPolicy - legacy variant with uniform size policy
+// ModelPolicy         - policy based on statistical modelling
 //
 // These experimental policies are available only in
 // DEBUG or release+INLINE_DATA builds of the jit.
 //
 // RandomPolicy        - randomized inlining
-// DiscretionaryPolicy - legacy variant with uniform size policy
-// ModelPolicy         - policy based on statistical modelling
 // FullPolicy          - inlines everything up to size and depth limits
 // SizePolicy          - tries not to increase method sizes
 
@@ -198,8 +198,6 @@ private:
 
 #endif // DEBUG
 
-#if defined(DEBUG) || defined(INLINE_DATA)
-
 // DiscretionaryPolicy is a variant of the legacy policy.  It differs
 // in that there is no ALWAYS_INLINE class, there is no IL size limit,
 // and in prejit mode, discretionary failures do not set the "NEVER"
@@ -227,12 +225,17 @@ public:
     // Policy estimates
     int CodeSizeEstimate() override;
 
+#if defined(DEBUG) || defined(INLINE_DATA)
+
     // Externalize data
     void DumpData(FILE* file) const override;
     void DumpSchema(FILE* file) const override;
 
     // Miscellaneous
     const char* GetName() const override { return "DiscretionaryPolicy"; }
+
+#endif // defined(DEBUG) || defined(INLINE_DATA)
+
 
 protected:
 
@@ -297,9 +300,19 @@ public:
     // Policy determinations
     void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) override;
 
+    // Policy policies
+    bool PropagateNeverToRuntime() const override { return true; }
+
+#if defined(DEBUG) || defined(INLINE_DATA)
+
     // Miscellaneous
     const char* GetName() const override { return "ModelPolicy"; }
+
+#endif // defined(DEBUG) || defined(INLINE_DATA)
+
 };
+
+#if defined(DEBUG) || defined(INLINE_DATA)
 
 // FullPolicy is an experimental policy that will always inline if
 // possible, subject to externally settable depth and size limits.

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -195,13 +195,14 @@ CONFIG_INTEGER(JitInlineDumpData, W("JitInlineDumpData"), 0)
 CONFIG_INTEGER(JitInlineDumpXml, W("JitInlineDumpXml"), 0)   // 1 = full xml (all methods), 2 = minimal xml (only method with inlines)
 CONFIG_INTEGER(JitInlineLimit, W("JitInlineLimit"), -1)
 CONFIG_INTEGER(JitInlinePolicyDiscretionary, W("JitInlinePolicyDiscretionary"), 0)
-CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)
 CONFIG_INTEGER(JitInlinePolicyFull, W("JitInlinePolicyFull"), 0)
 CONFIG_INTEGER(JitInlinePolicySize, W("JitInlinePolicySize"), 0)
 CONFIG_INTEGER(JitInlinePolicyReplay, W("JitInlinePolicyReplay"), 0)
 CONFIG_STRING(JitNoInlineRange, W("JitNoInlineRange"))
 CONFIG_STRING(JitInlineReplayFile, W("JitInlineReplayFile"))
 #endif // defined(DEBUG) || defined(INLINE_DATA)
+
+CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)
 
 #undef CONFIG_INTEGER
 #undef CONFIG_STRING


### PR DESCRIPTION
Make the ModelPolicy available in release builds of the jit. Enable this
policy by setting:

   COMPLUS_JitInlinePolicyModel=1

This works for either jitting or prejitting.

Update the ModelPolicy so callee never inline decisions are always
propagated back to the runtime.