### PR TITLE
GC ETW fixes

### DIFF
--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -2072,6 +2072,12 @@ protected:
 
     PER_HEAP
     void pin_object (uint8_t* o, uint8_t** ppObject, uint8_t* low, uint8_t* high);
+
+#if defined(ENABLE_PERF_COUNTERS) || defined(FEATURE_EVENT_TRACE)
+    PER_HEAP_ISOLATED
+    size_t get_total_pinned_objects();
+#endif //ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
+
     PER_HEAP
     void reset_mark_stack ();
     PER_HEAP
@@ -3006,10 +3012,15 @@ protected:
     mark*       mark_stack_array;
 
     PER_HEAP
-    BOOL       verify_pinned_queue_p;
+    BOOL        verify_pinned_queue_p;
 
     PER_HEAP
-    uint8_t*       oldest_pinned_plug;
+    uint8_t*    oldest_pinned_plug;
+
+#if defined(ENABLE_PERF_COUNTERS) || defined(FEATURE_EVENT_TRACE)
+    PER_HEAP
+    size_t      num_pinned_objects;
+#endif //ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
 
 #ifdef FEATURE_LOH_COMPACTION
     PER_HEAP

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -353,8 +353,9 @@ OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF obje
     // store the reference
     HndAssignHandle(handle, object);
 
-    // update perf-counters: track number of handles
-    COUNTER_ONLY(GetPerfCounters().m_GC.cHandles ++);
+#if defined(ENABLE_PERF_COUNTERS) || defined(FEATURE_EVENT_TRACE)
+    g_dwHandles++;
+#endif // ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
 
 #ifdef GC_PROFILING
     {
@@ -503,8 +504,9 @@ void HndDestroyHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTHANDLE handle)
     }        
 #endif //GC_PROFILING
 
-    // update perf-counters: track number of handles
-    COUNTER_ONLY(GetPerfCounters().m_GC.cHandles --);
+#if defined(ENABLE_PERF_COUNTERS) || defined(FEATURE_EVENT_TRACE)
+    g_dwHandles--;
+#endif // ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
 
     // sanity check the type index
     _ASSERTE(uType < pTable->uTypeCount);
@@ -583,8 +585,9 @@ uint32_t HndCreateHandles(HHANDLETABLE hTable, uint32_t uType, OBJECTHANDLE *pHa
         uSatisfied += TableAllocHandlesFromCache(pTable, uType, pHandles + uSatisfied, uCount - uSatisfied);
     }
 
-    // update perf-counters: track number of handles
-    COUNTER_ONLY(GetPerfCounters().m_GC.cHandles += uSatisfied);
+#if defined(ENABLE_PERF_COUNTERS) || defined(FEATURE_EVENT_TRACE)
+    g_dwHandles += uSatisfied;
+#endif // ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
 
 #ifdef GC_PROFILING
     {
@@ -629,8 +632,9 @@ void HndDestroyHandles(HHANDLETABLE hTable, uint32_t uType, const OBJECTHANDLE *
     }
 #endif
 
-    // update perf-counters: track number of handles
-    COUNTER_ONLY(GetPerfCounters().m_GC.cHandles -= uCount);
+#if defined(ENABLE_PERF_COUNTERS) || defined(FEATURE_EVENT_TRACE)
+    g_dwHandles -= uCount;
+#endif // ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
 
     // is this a small number of handles?
     if (uCount <= SMALL_ALLOC_COUNT)

--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -1055,7 +1055,6 @@ SyncBlock *SyncBlockCache::GetNextFreeSyncBlock()
     SyncBlock       *psb;
     SLink           *plst = m_FreeBlockList;
 
-    COUNTER_ONLY(GetPerfCounters().m_GC.cSinkBlocks ++);
     m_ActiveCount++;
 
     if (plst)
@@ -1311,8 +1310,6 @@ void    SyncBlockCache::DeleteSyncBlockMemory(SyncBlock *psb)
     }
     CONTRACTL_END
 
-    COUNTER_ONLY(GetPerfCounters().m_GC.cSinkBlocks --);
-
     m_ActiveCount--;
     m_FreeCount++;
 
@@ -1336,9 +1333,6 @@ void SyncBlockCache::GCDeleteSyncBlock(SyncBlock *psb)
     // Destruct the SyncBlock, but don't reclaim its memory.  (Overridden
     // operator delete).
     delete psb;
-
-    COUNTER_ONLY(GetPerfCounters().m_GC.cSinkBlocks --);
-
 
     m_ActiveCount--;
     m_FreeCount++;

--- a/src/vm/syncblk.h
+++ b/src/vm/syncblk.h
@@ -1028,6 +1028,11 @@ class SyncBlockCache
         return m_bSyncBlockCleanupInProgress;
     }
 
+    DWORD GetActiveCount()
+    {
+        return m_ActiveCount;
+    }
+
     // Encapsulate a CrstHolder, so that clients of our lock don't have to know
     // the details of our implementation.
     class LockHolder : public CrstHolder

--- a/src/vm/vars.cpp
+++ b/src/vm/vars.cpp
@@ -110,6 +110,10 @@ GPTR_IMPL(Thread,g_pSuspensionThread);
 // Global SyncBlock cache
 GPTR_IMPL(SyncTableEntry,g_pSyncTable);
 
+#if defined(ENABLE_PERF_COUNTERS) || defined(FEATURE_EVENT_TRACE)
+DWORD g_dwHandles = 0;
+#endif // ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
+
 #ifdef STRESS_LOG
 GPTR_IMPL_INIT(StressLog, g_pStressLog, &StressLog::theLog);
 #endif

--- a/src/vm/vars.hpp
+++ b/src/vm/vars.hpp
@@ -472,6 +472,12 @@ GPTR_DECL(Thread,g_pSuspensionThread);
 typedef DPTR(SyncTableEntry) PTR_SyncTableEntry;
 GPTR_DECL(SyncTableEntry, g_pSyncTable);
 
+#if defined(ENABLE_PERF_COUNTERS) || defined(FEATURE_EVENT_TRACE)
+// Note this is not updated in a thread safe way so the value may not be accurate. We get
+// it accurately in full GCs if the handle count is requested.
+extern DWORD g_dwHandles;
+#endif // ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
+
 #ifdef FEATURE_COMINTEROP
 // Global RCW cleanup list
 typedef DPTR(RCWCleanupList) PTR_RCWCleanupList;


### PR DESCRIPTION
The code for getting data for ETW and perf counter was written by different folks at different times and was very intertwined. For full CLR we always have both defined but for coreclr perf counters are not enabled so some things for ETW were just 0. Need to make sure when one is not defined the rest are still getting the data they need.