### PR TITLE
Lower, LSRA and Codegen support for reg optional operands

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1238,8 +1238,13 @@ void CodeGen::genCodeForDivMod(GenTreeOp* treeNode)
     genConsumeOperands(treeNode->AsOp());
     if (varTypeIsFloating(targetType))
     {
-        // divisor is not contained or if contained is a memory op
-        assert(!divisor->isContained() || divisor->isMemoryOp() || divisor->IsCnsFltOrDbl());
+        // divisor is not contained or if contained is a memory op.
+        // Note that a reg optional operand is a treated as a memory op
+        // if no register is allocated to it.
+        assert(!divisor->isContained() || 
+               divisor->isMemoryOp() || 
+               divisor->IsCnsFltOrDbl() ||
+               divisor->IsRegOptional());
 
         // Floating point div/rem operation
         assert(oper == GT_DIV || oper == GT_MOD);
@@ -1357,7 +1362,10 @@ void CodeGen::genCodeForBinary(GenTree* treeNode)
     if (op1->isContained())
     {
         assert(treeNode->OperIsCommutative());
-        assert(op1->isMemoryOp() || op1->IsCnsNonZeroFltOrDbl() || op1->IsIntCnsFitsInI32());
+        assert(op1->isMemoryOp() || 
+               op1->IsCnsNonZeroFltOrDbl() || 
+               op1->IsIntCnsFitsInI32() ||
+               op1->IsRegOptional());
 
         op1 = treeNode->gtGetOp2();
         op2 = treeNode->gtGetOp1();
@@ -2203,8 +2211,8 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             bool isUnsignedMultiply    = ((treeNode->gtFlags & GTF_UNSIGNED) != 0);
             bool requiresOverflowCheck = treeNode->gtOverflowEx();
     
-            GenTree *op1 = treeNode->gtOp.gtOp1;
-            GenTree *op2 = treeNode->gtOp.gtOp2;
+            GenTree* op1 = treeNode->gtGetOp1();
+            GenTree* op2 = treeNode->gtGetOp2();
 
             // there are 3 forms of x64 multiply:
             // 1-op form with 128 result:  RDX:RAX = RAX * rm
@@ -4958,6 +4966,18 @@ void CodeGen::genConsumeRegs(GenTree* tree)
             // Now we need to consume the operands of the GT_AND node.
             genConsumeOperands(tree->AsOp());
         }
+        else if (tree->OperGet() == GT_LCL_VAR)
+        {
+            // A contained lcl var must be living on stack and marked as reg optional.
+            unsigned varNum = tree->AsLclVarCommon()->GetLclNum();
+            LclVarDsc* varDsc = compiler->lvaTable + varNum;
+
+            noway_assert(varDsc->lvRegNum == REG_STK);
+            noway_assert(tree->IsRegOptional());
+
+            // Update the life of reg optional lcl var.
+            genUpdateLife(tree);
+        }
         else
         {
             assert(tree->OperIsLeaf());
@@ -5488,10 +5508,15 @@ void CodeGen::genStoreInd(GenTreePtr node)
                     rmwDst = data->gtGetOp2();
                     rmwSrc = data->gtGetOp1();
                 }
+
+                genConsumeRegs(rmwSrc);
             }
             else
             {
-                // For unary RMW ops, src and dst of RMW memory op is the same.
+                // *(p) = oper *(p): Here addr = p, rmwsrc=rmwDst = *(p) i.e. GT_IND(p)
+                // For unary RMW ops, src and dst of RMW memory op is the same.  Lower
+                // clears operand counts on rmwSrc and we don't need to perform a
+                // genConsumeReg() on it.
                 assert(storeInd->IsRMWDstOp1());
                 rmwSrc = data->gtGetOp1();
                 rmwDst = data->gtGetOp1();
@@ -5500,9 +5525,7 @@ void CodeGen::genStoreInd(GenTreePtr node)
 
             assert(rmwSrc != nullptr);
             assert(rmwDst != nullptr);
-            assert(Lowering::IndirsAreEquivalent(rmwDst, storeInd));
-
-            genConsumeRegs(rmwSrc);
+            assert(Lowering::IndirsAreEquivalent(rmwDst, storeInd));             
         }
         else
         {

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2845,17 +2845,22 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
 {
     // dst can only be a reg or modrm
     assert(!dst->isContained() ||
-           dst->isContainedIndir() ||
-           dst->isContainedLclField() ||
+           dst->isContainedMemoryOp() ||
            instrIs3opImul(ins)); // dst on these isn't really the dst
 
+#ifdef DEBUG
     // src can be anything but both src and dst cannot be addr modes
     // or at least cannot be contained addr modes
-    if (dst->isContainedIndir())
-        assert(!src->isContainedIndir());
+    if (dst->isContainedMemoryOp())
+    {
+        assert(!src->isContainedMemoryOp());
+    }
 
-    if (src->isContainedLclField())
-        assert(!dst->isContained());
+    if (src->isContainedMemoryOp())
+    {
+        assert(!dst->isContainedMemoryOp());
+    }
+#endif
 
     // find which operand is a memory op (if any)
     // and what its base is
@@ -2890,7 +2895,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     }
     
     // find local field if any
-    GenTreeLclFld* lclField = nullptr;
+    GenTreeLclFld* lclField = nullptr;    
     if (src->isContainedLclField())
     {
         lclField = src->AsLclFld();
@@ -2900,9 +2905,22 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
         lclField = dst->AsLclFld();
     }
 
+    // find contained lcl var if any
+    GenTreeLclVar* lclVar = nullptr;
+    if (src->isContainedLclVar())
+    {
+        assert(src->IsRegOptional());
+        lclVar = src->AsLclVar();
+    }
+    else if (dst->isContainedLclVar())
+    {
+        assert(dst->IsRegOptional());
+        lclVar = dst->AsLclVar();
+    }
+
     // First handle the simple non-memory cases
     //
-    if ((mem == nullptr) && (lclField == nullptr))
+    if ((mem == nullptr) && (lclField == nullptr) && (lclVar == nullptr))
     {
         if (intConst != nullptr)
         {
@@ -2938,15 +2956,27 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
         return dst->gtRegNum;
     }
 
-    // Next handle the cases where we have a stack based local memory operand
+    // Next handle the cases where we have a stack based local memory operand.
     //
-    if (lclField)
-    {
-        unsigned offset = lclField->gtLclFld.gtLclOffs;
-        unsigned varNum = lclField->gtLclVarCommon.gtLclNum;
+    unsigned varNum = BAD_VAR_NUM;
+    unsigned offset = (unsigned) -1;
 
+    if (lclField != nullptr)
+    {
+        varNum = lclField->AsLclVarCommon()->GetLclNum();
+        offset = lclField->gtLclFld.gtLclOffs;
+    }
+    else if (lclVar != nullptr)
+    {
+        varNum = lclVar->AsLclVarCommon()->GetLclNum();
+        offset = 0;
+    }
+
+    if (varNum != BAD_VAR_NUM)
+    {
         // Is the memory op in the source position?
-        if (src->isContainedLclField())
+        if (src->isContainedLclField() ||
+            src->isContainedLclVar())
         {
             if (instrHasImplicitRegPairDest(ins))
             {
@@ -2964,6 +2994,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
         else  // The memory op is in the dest position.
         {
             assert(dst->gtRegNum == REG_NA);
+
             // src could be int or reg
             if (src->isContainedIntOrIImmed())
             {

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -12869,6 +12869,19 @@ BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler * comp)
     }
 }
 
+// -------------------------------------------------------------------------
+// IsRegOptional: Returns true if this gentree node is marked by lowering to
+// indicate that codegen can still generate code even if it wasn't allocated
+// a register.
+bool GenTree::IsRegOptional() const
+{
+#ifdef LEGACY_BACKEND
+    return false;
+#else
+    return gtLsraInfo.regOptional;
+#endif
+}
+
 bool GenTree::IsPhiDefn()
 {
     bool res = 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -495,11 +495,16 @@ public:
 
     bool isContainedLclField() const        { return isContained() && isLclField(); }
 
+    bool isContainedLclVar() const          {  return isContained() && (OperGet() == GT_LCL_VAR);  } 
+
     // Indicates whether it is a memory op.
     // Right now it includes Indir and LclField ops.
     bool isMemoryOp() const                 { return isIndir() || isLclField(); }
 
-    bool isContainedMemoryOp() const        { return isContained() && isMemoryOp(); }
+    bool isContainedMemoryOp() const        
+    { 
+        return (isContained() && isMemoryOp()) || isContainedLclVar(); 
+    }
 
     regNumber GetRegNum() const
     {
@@ -1620,6 +1625,11 @@ public:
     // cast operations 
     inline var_types            CastFromType();
     inline var_types&           CastToType();
+
+    // Returns true if this gentree node is marked by lowering to indicate
+    // that codegen can still generate code even if it wasn't allocated a 
+    // register.
+    bool IsRegOptional() const;   
 
     // Returns "true" iff "*this" is an assignment (GT_ASG) tree that defines an SSA name (lcl = phi(...));
     bool IsPhiDefn();

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -145,6 +145,8 @@ private:
     void TreeNodeInfoInit(GenTreePtr* tree, GenTree* parent);
 #if defined(_TARGET_XARCH_)
     void TreeNodeInfoInitSimple(GenTree* tree);
+    void SetRegOptionalForBinOp(GenTree* tree);
+    void TryToSetRegOptional(GenTree* operand);
 #endif // defined(_TARGET_XARCH_)
     void TreeNodeInfoInitReturn(GenTree* tree);
     void TreeNodeInfoInitShiftRotate(GenTree* tree);

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -345,15 +345,16 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
                 // overflow operations aren't supported on float/double types.
                 assert(!tree->gtOverflow());
 
+                op1 = tree->gtGetOp1();
+                op2 = tree->gtGetOp2();
+
                 // No implicit conversions at this stage as the expectation is that
                 // everything is made explicit by adding casts.
-                assert(tree->gtOp.gtOp1->TypeGet() == tree->gtOp.gtOp2->TypeGet());
+                assert(op1->TypeGet() == op2->TypeGet());
 
                 info->srcCount = 2;
                 info->dstCount = 1;              
-
-                op1 = tree->gtOp.gtOp1;
-                op2 = tree->gtOp.gtOp2; 
+ 
                 if (op2->isMemoryOp() || op2->IsCnsNonZeroFltOrDbl())
                 {
                     MakeSrcContained(tree, op2);
@@ -370,6 +371,11 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
                     //      movss op1Reg, [memOp]; addss/sd targetReg, Op2Reg  (if op1Reg == targetReg) OR
                     //      movss op1Reg, [memOp]; movaps targetReg, op1Reg, addss/sd targetReg, Op2Reg  
                     MakeSrcContained(tree, op1);
+                }
+                else
+                {
+                    // If there are no containable operands, we can make an operand reg optional.
+                    SetRegOptionalForBinOp(tree);
                 }
                 break;
             }
@@ -559,9 +565,17 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
                     other = node->gtArrLen;
                 }
 
-                if (other->isMemoryOp() && node->gtIndex->TypeGet() == node->gtArrLen->TypeGet())
+                if (other->isMemoryOp())
                 {
-                    MakeSrcContained(tree, other);
+                    if (node->gtIndex->TypeGet() == node->gtArrLen->TypeGet())
+                    {
+                        MakeSrcContained(tree, other);
+                    }
+                }
+                else
+                {
+                    // since 'other' operand is not contained, we can mark it as reg optional
+                    TryToSetRegOptional(other);
                 }
             }
             break;
@@ -772,10 +786,19 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
         // 
         // Example2: GT_CAST(int <- bool <- int) - here type of GT_CAST node is int and castToType is bool.
         //
+        // Example3: GT_EQ(int, op1 of type ubyte, op2 of type ubyte) - in this case codegen uses
+        // ubyte as the result of comparison and if the result needs to be materialized into a reg
+        // simply zero extend it to TYP_INT size.  Here is an example of generated code:
+        //         cmp dl, byte ptr[addr mode]
+        //         movzx edx, dl
+        //
         // Though this looks conservative in theory, in practice we could not think of a case where
         // the below logic leads to conservative register specification.  In future when or if we find
         // one such case, this logic needs to be fine tuned for that case(s).
-        if (varTypeIsByte(tree) || ((tree->OperGet() == GT_CAST) && varTypeIsByte(tree->CastToType())))
+        if (varTypeIsByte(tree) || 
+            ((tree->OperGet() == GT_CAST) && varTypeIsByte(tree->CastToType())) ||
+            (tree->OperIsCompare() && varTypeIsByte(tree->gtGetOp1()) && varTypeIsByte(tree->gtGetOp2()))
+           )
         {
             regMaskTP regMask;
             if (info->dstCount > 0)
@@ -1950,14 +1973,16 @@ Lowering::TreeNodeInfoInitLogicalOp(GenTree* tree)
     // for GT_ADD(Constant, SomeTree)
     info->srcCount = 2;
     info->dstCount = 1;
-    GenTree* op1 = tree->gtOp.gtOp1;
-    GenTree* op2 = tree->gtOp.gtOp2;            
+
+    GenTree* op1 = tree->gtGetOp1();
+    GenTree* op2 = tree->gtGetOp2();            
 
     // We can directly encode the second operand if it is either a containable constant or a memory-op.
     // In case of memory-op, we can encode it directly provided its type matches with 'tree' type.
     // This is because during codegen, type of 'tree' is used to determine emit Type size. If the types
     // do not match, they get normalized (i.e. sign/zero extended) on load into a register.
     bool directlyEncodable = false;
+    bool binOpInRMW = false;
     GenTreePtr operand = nullptr;
 
     if (IsContainableImmed(tree, op2))
@@ -1965,21 +1990,25 @@ Lowering::TreeNodeInfoInitLogicalOp(GenTree* tree)
         directlyEncodable = true;
         operand = op2;
     }
-    else if (!IsBinOpInRMWStoreInd(tree))
+    else
     {
-        if (op2->isMemoryOp() && tree->TypeGet() == op2->TypeGet())
+        binOpInRMW = IsBinOpInRMWStoreInd(tree);
+        if (!binOpInRMW)
         {
-            directlyEncodable = true;
-            operand = op2;
-        }
-        else if (tree->OperIsCommutative())
-        {
-            if (IsContainableImmed(tree, op1) ||
-                (op1->isMemoryOp() && tree->TypeGet() == op1->TypeGet() && IsSafeToContainMem(tree, op1)))
+            if (op2->isMemoryOp() && tree->TypeGet() == op2->TypeGet())
             {
-                // If it is safe, we can reverse the order of operands of commutative operations for efficient codegen
                 directlyEncodable = true;
-                operand = op1;
+                operand = op2;
+            }
+            else if (tree->OperIsCommutative())
+            {
+                if (IsContainableImmed(tree, op1) ||
+                    (op1->isMemoryOp() && tree->TypeGet() == op1->TypeGet() && IsSafeToContainMem(tree, op1)))
+                {
+                    // If it is safe, we can reverse the order of operands of commutative operations for efficient codegen
+                    directlyEncodable = true;
+                    operand = op1;
+                }
             }
         }
     }
@@ -1988,6 +2017,13 @@ Lowering::TreeNodeInfoInitLogicalOp(GenTree* tree)
     {
         assert(operand != nullptr);
         MakeSrcContained(tree, operand);
+    }
+    else if (!binOpInRMW)
+    {
+        // If this binary op neither has contained operands, nor is a 
+        // Read-Modify-Write (RMW) operation, we can mark its operands
+        // as reg optional.
+        SetRegOptionalForBinOp(tree);
     }
 }
 
@@ -2007,6 +2043,12 @@ Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
     TreeNodeInfo* info = &(tree->gtLsraInfo);
     LinearScan* l = m_lsra;
 
+    GenTree* op1 = tree->gtGetOp1();
+    GenTree* op2 = tree->gtGetOp2();
+
+    info->srcCount = 2;
+    info->dstCount = 1;
+
     switch (tree->OperGet())
     {
     case GT_MOD:
@@ -2015,16 +2057,18 @@ Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
         {   
             // No implicit conversions at this stage as the expectation is that
             // everything is made explicit by adding casts.
-            assert(tree->gtOp.gtOp1->TypeGet() == tree->gtOp.gtOp2->TypeGet());
+            assert(op1->TypeGet() == op2->TypeGet());
 
-            info->srcCount = 2;
-            info->dstCount = 1;
-
-            GenTree* op2 = tree->gtOp.gtOp2;
             if (op2->isMemoryOp() || op2->IsCnsNonZeroFltOrDbl())
             {
                 MakeSrcContained(tree, op2);
             }
+            else
+            {
+                // If there are no containable operands, we can make an operand reg optional.
+                SetRegOptionalForBinOp(tree);
+            }
+
             return;
         }
         break;
@@ -2032,12 +2076,6 @@ Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
     default:
         break;
     }
-
-    info->srcCount = 2;
-    info->dstCount = 1;
-
-    GenTree* op1 = tree->gtOp.gtOp1;
-    GenTree* op2 = tree->gtOp.gtOp2;
 
     // Amd64 Div/Idiv instruction: 
     //    Dividend in RAX:RDX  and computes
@@ -2067,6 +2105,9 @@ Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
     else
     {
         op2->gtLsraInfo.setSrcCandidates(l, l->allRegs(TYP_INT) & ~(RBM_RAX | RBM_RDX));
+
+        // If there are no containable operands, we can make an operand reg optional.
+        SetRegOptionalForBinOp(tree);
     }
 }
 
@@ -2087,7 +2128,7 @@ Lowering::TreeNodeInfoInitIntrinsic(GenTree* tree)
     LinearScan* l = m_lsra;
 
     // Both operand and its result must be of floating point type.
-    GenTree* op1 = tree->gtOp.gtOp1;
+    GenTree* op1 = tree->gtGetOp1();
     assert(varTypeIsFloating(op1));
     assert(op1->TypeGet() == tree->TypeGet());
 
@@ -2100,6 +2141,12 @@ Lowering::TreeNodeInfoInitIntrinsic(GenTree* tree)
         if (op1->isMemoryOp() || op1->IsCnsNonZeroFltOrDbl())
         {
             MakeSrcContained(tree, op1);
+        }
+        else
+        {
+            // Mark the operand as reg optional since codegen can still 
+            // generate code if op1 is on stack.
+            TryToSetRegOptional(op1);
         }
         break;
 
@@ -2430,6 +2477,12 @@ Lowering::TreeNodeInfoInitCast(GenTree* tree)
             if (castOp->isMemoryOp() || castOp->IsCnsNonZeroFltOrDbl())
             {
                 MakeSrcContained(tree, castOp);
+            }
+            else
+            {
+                // Mark castOp as reg optional to indicate codegen
+                // can still generate code if it is on stack.
+                TryToSetRegOptional(castOp);
             }
         }
     }
@@ -2794,6 +2847,12 @@ void Lowering::LowerCmp(GenTreePtr tree)
                 MakeSrcContained(tree, otherOp);
             }
         }
+        else
+        {
+            // Mark otherOp as reg optional to indicate codgen can still generate
+            // code even if otherOp is on stack.
+            TryToSetRegOptional(otherOp);
+        }
 
         return;
     }
@@ -3096,6 +3155,18 @@ void Lowering::LowerCmp(GenTreePtr tree)
 		{
 			MakeSrcContained(tree, op1);
 		}
+        else
+        {
+            // One of op1 or op2 could be marked as reg optional
+            // to indicate that codgen can still generate code 
+            // if one of them is on stack.
+            TryToSetRegOptional(op2);
+
+            if (!op2->IsRegOptional())
+            {
+                TryToSetRegOptional(op1);
+            }
+        }
 
 		if (varTypeIsSmall(op1Type) && varTypeIsUnsigned(op1Type))
 		{
@@ -3613,6 +3684,11 @@ void Lowering::SetMulOpCounts(GenTreePtr tree)
             // generate more efficient code sequence for the case of GT_MUL(op1=memOp, op2=non-memOp)
             MakeSrcContained(tree, op1);
         }
+        else
+        {
+            // If there are no containable operands, we can make an operand reg optional.
+            SetRegOptionalForBinOp(tree);
+        }
         return;
     }
     
@@ -3691,12 +3767,21 @@ void Lowering::SetMulOpCounts(GenTreePtr tree)
     // To generate an LEA we need to force memOp into a register
     // so don't allow memOp to be 'contained'
     //
-    if ((memOp != nullptr)                    &&
-        !useLeaEncoding                       &&
-        (memOp->TypeGet() == tree->TypeGet()) &&
-        IsSafeToContainMem(tree, memOp))
+    if (!useLeaEncoding)
     {
-        MakeSrcContained(tree, memOp);
+        if (memOp != nullptr)
+        {
+            if ((memOp->TypeGet() == tree->TypeGet()) &&
+                IsSafeToContainMem(tree, memOp))
+            {
+                MakeSrcContained(tree, memOp);
+            }
+        }
+        else
+        {
+            // If there are no containable operands, we can make an operand reg optional.
+            SetRegOptionalForBinOp(tree);
+        }
     }
 }
 
@@ -3761,6 +3846,69 @@ bool Lowering:: IsContainableImmed(GenTree* parentNode, GenTree* childNode)
     }
 
     return true;
+}
+
+//----------------------------------------------------------------------
+// TryToSetRegOptional - sets a bit to indicate to LSRA that register
+// for a given tree node is optional for codegen purpose.  If no
+// register is allocated to such a tree node, its parent node treats
+// it as a contained memory operand during codegen.
+//
+// Arguments:
+//    tree    -   GenTree node
+//
+// Returns
+//    None
+//
+// Note: Right now a tree node is marked as reg optional only
+// if is it a GT_LCL_VAR.  This routine needs to be modified if
+// in future if lower/codegen needs to support other tree node
+// types.
+void Lowering::TryToSetRegOptional(GenTree* tree)
+{
+    if (tree->OperGet() == GT_LCL_VAR)
+    {
+        tree->gtLsraInfo.regOptional = true;
+    }
+}
+
+// ------------------------------------------------------------------
+// SetRegOptionalBinOp - Indicates which of the operands of a bin-op
+// register requirement is optional. Xarch instruction set allows
+// either of op1 or op2 of binary operation (e.g. add, mul etc) to be
+// a memory operand.  This routine provides info to register allocator
+// which of its operands optionally require a register.  Lsra might not
+// allocate a register to RefTypeUse positions of such operands if it
+// is beneficial. In such a case codegen will treat them as memory
+// operands.
+//
+// Arguments:
+//     tree  -  Gentree of a bininary operation.
+//
+// Returns 
+//     None.
+// 
+// Note: On xarch at most only one of the operands will be marked as
+// reg optional, even when both operands could be considered register
+// optional.
+void Lowering::SetRegOptionalForBinOp(GenTree* tree)
+{
+    assert(GenTree::OperIsBinary(tree->OperGet()));
+
+    GenTree* op1 = tree->gtGetOp1();
+    GenTree* op2 = tree->gtGetOp2();
+
+    if (tree->TypeGet() == op2->TypeGet())
+    {
+        TryToSetRegOptional(op2);
+    }
+
+    if (!op2->IsRegOptional() &&
+        tree->OperIsCommutative() &&
+        tree->TypeGet() == op1->TypeGet())
+    {
+        TryToSetRegOptional(op1);
+    }
 }
 
 #endif // _TARGET_XARCH_

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -538,6 +538,22 @@ private:
     LsraSpill                   getLsraSpill()                  { return (LsraSpill) (lsraStressMask & LSRA_SPILL_MASK); }
     bool                        spillAlways()                   { return getLsraSpill() == LSRA_SPILL_ALWAYS; }
 
+    // This controls whether RefPositions that require a register optionally should
+    // be allocated a reg at all.
+    enum LsraRegOptionalControl     { LSRA_REG_OPTIONAL_DEFAULT          = 0,
+                                      LSRA_REG_OPTIONAL_NO_ALLOC         = 0x1000,
+                                      LSRA_REG_OPTIONAL_MASK             = 0x1000 };
+
+    LsraRegOptionalControl      getLsraRegOptionalControl()            
+    { 
+        return (LsraRegOptionalControl) (lsraStressMask & LSRA_REG_OPTIONAL_MASK); 
+    }
+
+    bool                        regOptionalNoAlloc()     
+    { 
+        return getLsraRegOptionalControl() == LSRA_REG_OPTIONAL_NO_ALLOC;
+    }
+
     // Dump support
     void            lsraDumpIntervals(const char* msg);
     void            dumpRefPositions(const char *msg);
@@ -743,6 +759,8 @@ private:
 
     void associateRefPosWithRegister(RefPosition *rp);
 
+    unsigned getWeight(RefPosition* refPos);
+
     /*****************************************************************************
      * Register management
      ****************************************************************************/
@@ -750,7 +768,7 @@ private:
     regNumber tryAllocateFreeReg(Interval *current, RefPosition *refPosition);
     RegRecord* findBestPhysicalReg(RegisterType regType, LsraLocation endLocation,
                                   regMaskTP candidates, regMaskTP preferences);
-    regNumber allocateBusyReg(Interval *current, RefPosition *refPosition);
+    regNumber allocateBusyReg(Interval* current, RefPosition* refPosition, bool allocationOptional);
     regNumber assignCopyReg(RefPosition * refPosition);
 
     void checkAndAssignInterval(RegRecord * regRec, Interval * interval);
@@ -1326,15 +1344,24 @@ public:
     LsraLocation    nodeLocation;
     regMaskTP       registerAssignment;
 
-    regNumber       assignedReg() { return genRegNumFromMask(registerAssignment); }
+    regNumber       assignedReg() { 
+        if (registerAssignment == RBM_NONE)
+        {
+            return REG_NA;
+        }
+
+        return genRegNumFromMask(registerAssignment); 
+    }
 
     RefType         refType;
 
-    bool            RequiresRegister()
+    bool            IsActualRef()
     {
-        return (refType == RefTypeDef || refType == RefTypeUse
+        return (refType == RefTypeDef || 
+                refType == RefTypeUse
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-               || refType == RefTypeUpperVectorSaveDef || refType == RefTypeUpperVectorSaveUse
+                || refType == RefTypeUpperVectorSaveDef 
+                || refType == RefTypeUpperVectorSaveUse
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
                );
     }
@@ -1353,6 +1380,23 @@ public:
     }
 
     unsigned        getMultiRegIdx() { return multiRegIdx;  }
+
+    // Returns true if codegen has indicated that the tree node
+    // referred to by RefPosition can be treated as a contained
+    // memory operand if no register was allocated.
+    bool           IsRegOptional()
+    {
+        // TODO-CQ: Right now if a ref position is marked as
+        // copyreg or movereg, then it is always allocated a
+        // register, though it is marked as reg optional.
+        // This is an implementation limitation that needs to 
+        // be addressed.
+        return (refType == RefTypeUse) &&
+               !copyReg &&
+               !moveReg &&
+               (treeNode != nullptr) &&
+               treeNode->IsRegOptional();
+    }  
 
     // Last Use - this may be true for multiple RefPositions in the same Interval
     bool            lastUse      : 1;

--- a/src/jit/nodeinfo.h
+++ b/src/jit/nodeinfo.h
@@ -31,6 +31,7 @@ public:
         isDelayFree           = false;
         hasDelayFreeSrc       = false;
         isTgtPref             = false;
+        regOptional           = false;
     }
 
     // dst
@@ -119,7 +120,8 @@ public:
     // isTgtPref is set to true when we have a rmw op, where we would like the result to be allocated
     // in the same register as op1.
     unsigned char isTgtPref:1;
-
+    // Whether a spilled second src can be treated as a contained operand
+    unsigned char regOptional:1;
 
 public:
 


### PR DESCRIPTION
Xarch allows one of the operands of a binary operation like add, mul etc to be a memory operand.  Right now lower/codegen takes advantage of it by marking memory operands as contained.  During Lower reg specification time we may not know whether a certain non-memory operand can end up in memory (i.e. on stack) because it was spilled by LSRA.

For example say we have gt_add(a, b) where a and b are two lcl vars.

 a =...
b =..
..
spill b
use b
...
gt_add(a,b)

At the point of gt_add, b is on stack.  Currently, LSRA would allocate a new reg to b and codegen would generate the following code.  If there are no free regs available, LSRA would spill some other interval and hence it would also have the side effect of spill and reload of some other interval.

mov reg1, [b's stack addr]
add a's reg, reg1

In some cases it might be beneficial if no register was allocated to use of b in gt_add, if there are more important variables currently occupying registers. In such a case, it would be CQ beneficial to generate the following:

mov a's reg,  [b's stack addr]

In the above example, use position of operand b is reg optional i.e codegen can still generate code even if b is allocated no register and on stack.  On Xarch, commutative binary operations like add/mul/and/or, either of op1 or op2 could be reg optional.  In case of non-commutative operations like sub/div, only op2 can be reg optional.

This PR aims to add support for reg optional operands.  This is the phase 1 implementation that supports marking only lcl vars as reg optional operands.  Supporting non-lcl var gentree nodes as reg optional operands will be done in a separate work item.

At a conceptual level, Lower reg specification marks the operands as reg optional.  LSRA during reg allocation may not allocate a register to use position of such an operand.  Codegen will treat reg optional operands that live on stack as contained memory operand for codegen purpose.  

Lower.h/Lowerxarch.cpp/gentree.h/gentree.cpp:  These changes are meant to mark a lcl var gentree node as reg optional.  This also contains a bug fix for x86 ryujit that surfaced during testing. The bug is that in case of comparison operations (e.g. GT_EQ) on byte type operands, we need to exclude non-bytable registers from src candidates of its operands and dst candidates of comparison node.

emitxarch.cpp/codegenxarch.cpp - codegen support for treating reg optional operands as contained memory operands for codegen.  

lsra.h/nodeinfo.h/lsra.h/lsra.cpp:
 - allocateRegisters(): though a RefTypeUse position is marked as reg optional, LSRA still attempts to give it a free reg if one available.  If there are no free regs, it will call allocateBusyReg() indicating allocating a reg is optional.  This also contains a change to special putarg_reg case that got exposed due to the changes in allocateBusyReg.
- allocateBusyReg() - if reg allocation is optional, it will check to see if there is a lesser important ref position sitting in a register than the current one.  If so, a reg is allocated by spilling otherwise no reg is allocated.  This routine now uses weight of the ref position as overriding factor and if there is a tie then uses farthest distance to next ref position as tie breaker to select a spill candidate.
- Importance of a ref position is indicated by its weight.  See getWeight() method on how the weight of a refPosition is determined.

Asm Diffs:
CQPerf run indicates the following perf improvements and no regressions
bzip2 - 3.5%
8Queens - 10%
Scimark - 6%

Overall very minor code size improvement.

Testing done:
Apart from github testing, DDR and asm diffs on desktop, also did the following runs without any regressions
- LSRA stress mode runs both on windows and linux
- JIT stress=2 run both on windows and linux
- Corefx run both on windows and linux

Post merging this PR, I will be opening the following github issues
- supporting non-lcl var tree nodes to be marked as reg optional
- address the implementation limitation that if a ref position is marked as copyreg or movereg, then it is always allocated a register even if marked as reg optional




