### PR TITLE
More Blk Op Refactoring

### DIFF
--- a/src/jit/codegenclassic.h
+++ b/src/jit/codegenclassic.h
@@ -314,6 +314,9 @@ protected:
                                                              regMaskTP  destReg,
                                                              regMaskTP  bestReg);
 
+    void                genCodeForCopyObj                   (GenTreePtr tree,
+                                                             regMaskTP  destReg);
+
     void                genCodeForBlkOp                     (GenTreePtr tree,
                                                              regMaskTP  destReg);
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -8031,15 +8031,15 @@ int cTreeFlagsIR(Compiler *comp, GenTree *tree)
         case GT_INITBLK:
         case GT_COPYOBJ:
 
-            if (tree->gtFlags & GTF_BLK_HASGCPTR)
+            if (tree->AsBlkOp()->HasGCPtr())
             {
                 chars += printf("[BLK_HASGCPTR]");
             }
-            if (tree->gtFlags & GTF_BLK_VOLATILE)
+            if (tree->AsBlkOp()->IsVolatile())
             {
                 chars += printf("[BLK_VOLATILE]");
             }
-            if (tree->gtFlags & GTF_BLK_UNALIGNED)
+            if (tree->AsBlkOp()->IsUnaligned())
             {
                 chars += printf("[BLK_UNALIGNED]");
             }

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4265,12 +4265,14 @@ public:
     void                fgDebugCheckFlags           (GenTreePtr   tree);
 #endif
 
+#ifdef LEGACY_BACKEND
     static void         fgOrderBlockOps   (GenTreePtr   tree,
                                            regMaskTP    reg0,
                                            regMaskTP    reg1,
                                            regMaskTP    reg2,
                                            GenTreePtr * opsPtr,   // OUT
                                            regMaskTP  * regsPtr); // OUT
+#endif // LEGACY_BACKEND
 
     static GenTreeStmt* fgFindTopLevelStmtBackwards(GenTreeStmt* stmt);
     static GenTreePtr   fgGetFirstNode      (GenTreePtr tree);

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4829,29 +4829,13 @@ inline GenTreePtr Compiler::fgGetLastTopLevelStmt(BasicBlock *block)
     return fgFindTopLevelStmtBackwards(block->bbTreeList->gtPrev->AsStmt());
 }
 
-// Creates an InitBlk or CpBlk node.
-// Parameters
-//     oper          - GT_COPYBLK, GT_INITBLK or GT_COPYOBJ
-//     dst           - Destination or target to copy to / initialize the buffer.
-//     srcOrFillVall - Either the source to copy from or the byte value to fill the buffer.
-//     sizeOrClsTok  - The size of the buffer or a class token (in the case of CpObj).
-//     volatil       - Whether this is a volatile memory operation or not.
-inline GenTreeBlkOp* Compiler::gtNewBlkOpNode(genTreeOps oper, GenTreePtr dst, 
-                                              GenTreePtr srcOrFillVal, GenTreePtr sizeOrClsTok,
-                                              bool volatil)
-{
-    GenTreeBlkOp* result = new (this, oper) GenTreeBlkOp(oper);
-    gtBlockOpInit(result, oper, dst, srcOrFillVal, sizeOrClsTok, volatil);
-    return result;
-}
-
 inline GenTreeBlkOp* Compiler::gtCloneCpObjNode(GenTreeCpObj* source)
 {
     GenTreeCpObj* result = new (this, GT_COPYOBJ) GenTreeCpObj(source->gtGcPtrCount,
                                                                source->gtSlots,
                                                                source->gtGcPtrs);
     gtBlockOpInit(result, GT_COPYOBJ, source->Dest(), source->Source(),
-                  source->ClsTok(), (source->gtFlags & GTF_BLK_VOLATILE) != 0);
+                  source->ClsTok(), source->IsVolatile());
     return result;
 }
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8848,6 +8848,7 @@ void                Compiler::fgFindOperOrder()
         {
             /* Recursively process the statement */
 
+            compCurStmt = stmt;
             gtSetStmtInfo(stmt);
         }
     }
@@ -18155,6 +18156,7 @@ void                Compiler::fgSetBlockOrder(BasicBlock* block)
     }
 }
 
+#ifdef LEGACY_BACKEND
 /*****************************************************************************
  *
  * For GT_INITBLK and GT_COPYBLK, the tree looks like this :
@@ -18231,6 +18233,7 @@ void            Compiler::fgOrderBlockOps(GenTreePtr   tree,
     regsPtr[1]  = regs[ order[1] ];
     regsPtr[2]  = regs[ order[2] ];
 }
+#endif // LEGACY_BACKEND
 
 //------------------------------------------------------------------------
 // fgFindTopLevelStmtBackwards: Find the nearest top-level statement to 'stmt', walking the gtPrev links.

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6149,6 +6149,53 @@ GenTreeBlkOp* Compiler::gtNewCpObjNode(GenTreePtr dst,
     return result;
 }
 
+//------------------------------------------------------------------------
+// FixupInitBlkValue: Fixup the init value for an initBlk operation
+//
+// Arguments:
+//    asgType - The type of assignment that the initBlk is being transformed into
+//
+// Return Value:
+//    Modifies the constant value on this node to be the appropriate "fill"
+//    value for the initblk.
+//
+// Notes:
+//    The initBlk MSIL instruction takes a byte value, which must be
+//    extended to the size of the assignment when an initBlk is transformed
+//    to an assignment of a primitive type.
+//    This performs the appropriate extension.
+
+void
+GenTreeIntCon::FixupInitBlkValue(var_types asgType)
+{
+    assert(varTypeIsIntegralOrI(asgType));
+    unsigned size = genTypeSize(asgType);
+    if (size > 1)
+    {
+        size_t cns = gtIconVal;
+        cns  = cns & 0xFF;
+        cns |= cns << 8;
+        if (size >= 4)
+        {
+            cns |= cns << 16;
+#ifdef _TARGET_64BIT_
+            if (size == 8)
+            {
+                cns |= cns << 32;
+            }
+#endif // _TARGET_64BIT_
+
+            // Make the type used in the GT_IND node match for evaluation types.
+            gtType = asgType;
+
+            // if we are using an GT_INITBLK on a GC type the value being assigned has to be zero (null).
+            assert(!varTypeIsGC(asgType) || (cns == 0));
+        }
+
+        gtIconVal = cns;
+    }
+}
+
 // Initializes a BlkOp GenTree
 // Preconditions:
 //     - Result is a GenTreeBlkOp that is newly constructed by gtNewCpObjNode or gtNewBlkOpNode
@@ -6311,6 +6358,31 @@ void Compiler::gtBlockOpInit(GenTreePtr result,
         
     }
 #endif //FEATURE_SIMD
+}
+
+//------------------------------------------------------------------------
+// gtNewBlkOpNode: Creates an InitBlk or CpBlk node.
+//
+// Arguments:
+//    oper          - GT_COPYBLK, GT_INITBLK or GT_COPYOBJ
+//    dst           - Destination or target to copy to / initialize the buffer.
+//    srcOrFillVall - Either the source to copy from or the byte value to fill the buffer.
+//    sizeOrClsTok  - The size of the buffer or a class token (in the case of CpObj).
+//    isVolatile    - Whether this is a volatile memory operation or not.
+//
+// Return Value:
+//    Returns the newly constructed and initialized block operation.
+
+GenTreeBlkOp*
+Compiler::gtNewBlkOpNode(genTreeOps oper,
+                         GenTreePtr dst, 
+                         GenTreePtr srcOrFillVal,
+                         GenTreePtr sizeOrClsTok,
+                         bool isVolatile)
+{
+    GenTreeBlkOp* result = new (this, oper) GenTreeBlkOp(oper);
+    gtBlockOpInit(result, oper, dst, srcOrFillVal, sizeOrClsTok, isVolatile);
+    return result;
 }
 
 /*****************************************************************************
@@ -13042,6 +13114,39 @@ bool GenTree::DefinesLocalAddr(Compiler* comp, unsigned width, GenTreeLclVarComm
     }
     // Otherwise...
     return false;
+}
+
+//------------------------------------------------------------------------
+// IsLocalExpr: Determine if this is a LclVarCommon node and return some
+//              additional info about it in the two out parameters.
+//
+// Arguments:
+//    comp        - The Compiler instance
+//    pLclVarTree - An "out" argument that returns the local tree as a
+//                  LclVarCommon, if it is indeed local.
+//    pFldSeq     - An "out" argument that returns the value numbering field
+//                  sequence for the node, if any.
+//
+// Return Value:
+//    Returns true, and sets the out arguments accordingly, if this is
+//    a LclVarCommon node.
+
+bool GenTree::IsLocalExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, FieldSeqNode** pFldSeq)
+{
+    if (IsLocal())  // Note that this covers "GT_LCL_FLD." 
+    {
+        *pLclVarTree = AsLclVarCommon();
+        if (OperGet() == GT_LCL_FLD)
+        {
+            // Otherwise, prepend this field to whatever we've already accumulated outside in.
+            *pFldSeq = comp->GetFieldSeqStore()->Append(AsLclFld()->gtFieldSeq, *pFldSeq);
+        }
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 // If this tree evaluates some sum of a local address and some constants,

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -982,15 +982,10 @@ public:
         return (gtOper == GT_LEA);
     }
 
-    bool            OperIsBlkOp() const
-    {
-        return OperIsBlkOp(OperGet());
-    }
-
-    bool            OperIsCopyBlkOp() const
-    {
-        return OperIsCopyBlkOp(OperGet());
-    }
+    bool            OperIsBlkOp() const;
+    bool            OperIsCopyBlkOp() const;
+    bool            OperIsInitBlkOp() const;
+    bool            OperIsDynBlkOp();
 
     bool            OperIsPutArgStk() const
     {
@@ -1467,6 +1462,10 @@ public:
     // Simpler variant of the above which just returns the local node if this is an expression that 
     // yields an address into a local
     GenTreeLclVarCommon* IsLocalAddrExpr();
+
+    // Determine if this is a LclVarCommon node and return some additional info about it in the
+    // two out parameters.
+    bool IsLocalExpr(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, FieldSeqNode** pFldSeq);
 
     // Determine whether this is an assignment tree of the form X = X (op) Y,
     // where Y is an arbitrary tree, and X is a lclVar.
@@ -1950,6 +1949,8 @@ struct GenTreeIntCon: public GenTreeIntConCommon
         {
             assert(fields != NULL);
         }
+
+    void FixupInitBlkValue(var_types asgType);
 
 #ifdef _TARGET_64BIT_
     void TruncateOrSignExtend32()
@@ -3269,8 +3270,14 @@ public:
                                 return gtOp1->gtOp.gtOp1;
                               }
 
+    // Return true iff the object being copied contains one or more GC pointers.
+    bool        HasGCPtr();
+
     // True if this BlkOpNode is a volatile memory operation.
     bool IsVolatile() const { return (gtFlags & GTF_BLK_VOLATILE) != 0; }
+
+    // True if this BlkOpNode is a volatile memory operation.
+    bool IsUnaligned() const { return (gtFlags & GTF_BLK_UNALIGNED) != 0; }
 
     // Instruction selection: during codegen time, what code sequence we will be using
     // to encode this operation.
@@ -4100,6 +4107,28 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
 // be defined already.
 //------------------------------------------------------------------------
 
+inline bool            GenTree::OperIsBlkOp() const
+{
+    return (gtOper == GT_INITBLK ||
+            gtOper == GT_COPYBLK ||
+            gtOper == GT_COPYOBJ);
+}
+
+inline bool            GenTree::OperIsDynBlkOp()
+{
+    return (OperIsBlkOp() && !gtGetOp2()->IsCnsIntOrI());
+}
+
+inline bool            GenTree::OperIsCopyBlkOp() const
+{
+    return (gtOper == GT_COPYOBJ || gtOper == GT_COPYBLK);
+}
+
+inline bool GenTree::OperIsInitBlkOp() const
+{
+    return (gtOper == GT_INITBLK);
+}
+
 //------------------------------------------------------------------------
 // IsFPZero: Checks whether this is a floating point constant with value 0.0
 //
@@ -4434,6 +4463,29 @@ inline bool GenTree::IsHelperCall() { return OperGet() == GT_CALL && gtCall.gtCa
 
 inline var_types GenTree::CastFromType() { return this->gtCast.CastOp()->TypeGet(); }
 inline var_types& GenTree::CastToType()  { return this->gtCast.gtCastType; }
+
+//-----------------------------------------------------------------------------------
+// HasGCPtr: determine whether this block op involves GC pointers
+//
+// Arguments:
+//     None
+//
+// Return Value:
+//    Returns true iff the object being copied contains one or more GC pointers.
+//
+// Notes:
+//    Of the block ops only GT_COPYOBJ is allowed to have GC pointers.
+// 
+inline bool
+GenTreeBlkOp::HasGCPtr()
+{
+    if (gtFlags & GTF_BLK_HASGCPTR)
+    {
+        assert((gtOper == GT_COPYOBJ) && (AsCpObj()->gtGcPtrCount != 0));
+        return true;
+    }
+    return false;
+}
 
 
 /*****************************************************************************/

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1202,7 +1202,7 @@ Lowering::TreeNodeInfoInitBlockStore(GenTreeBlkOp* blkNode)
         // handle this case.
         assert(classSize == blkSize);
         assert((blkSize / TARGET_POINTER_SIZE) == slots);
-        assert((cpObjNode->gtFlags & GTF_BLK_HASGCPTR) != 0);
+        assert(cpObjNode->HasGCPtr());
 #endif
 
         // We don't need to materialize the struct size but we still need

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1533,7 +1533,7 @@ Lowering::TreeNodeInfoInitBlockStore(GenTreeBlkOp* blkNode)
         // handle this case.
         assert(classSize == blkSize);
         assert((blkSize / TARGET_POINTER_SIZE) == slots);
-        assert((cpObjNode->gtFlags & GTF_BLK_HASGCPTR) != 0);
+        assert(cpObjNode->HasGCPtr());
 #endif
 
         bool IsRepMovsProfitable = false;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8075,29 +8075,9 @@ _DoneSrc:;
         }
         else // (oper == GT_INITBLK)
         {
-            if (size > 1)
-            {
-                size_t cns = src->gtIntCon.gtIconVal;
-                cns  = cns & 0xFF;
-                cns |= cns << 8;
-                if (size >= 4)
-                {
-                    cns |= cns << 16;
-#ifdef _TARGET_64BIT_
-                    if (size == 8)
-                    {
-                        cns |= cns << 32;
-                    }
-#endif // _TARGET_64BIT_
-
-                    src->gtType = type;   // Make the type used in the GT_IND node match for TYP_REF
-
-                    // if we are using an GT_INITBLK on a GC type the value being assigned has to be zero (null)
-                    assert(!varTypeIsGC(type) || (cns == 0));
-                }
-
-                src->gtIntCon.gtIconVal = cns;
-            }
+            // This will mutate the integer constant, in place, to be the correct
+            // value for the type were are using in the assignment.
+            src->AsIntCon()->FixupInitBlkValue(type);
         }
 
         /* Create the assignment node */

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -1694,7 +1694,7 @@ regMaskTP           Compiler::rpPredictBlkAsgRegUse(GenTreePtr    tree,
 
     size_t         blkSize        = 0;
 
-    hasGCpointer = ((tree->gtFlags & GTF_BLK_HASGCPTR) != 0);
+    hasGCpointer = (blkNode->HasGCPtr());
 
     bool isCopyBlk = tree->OperIsCopyBlkOp();
     bool isCopyObj = (tree->OperGet() == GT_COPYOBJ);


### PR DESCRIPTION
Code refactoring in preparation for 1st Class Structs:
Factor out the legacy code generation for CpObj.
Abstract some functionality to member methods.
Move some block-related method definitions.
Make fgOrderBlockOps legacy-only (it is unused in RyuJIT).
Factor out the code to create a block init value.
Add a new IsLocalExpr() method.
Change some variable names to distinguish between objects and their addresses.