### PR TITLE
Do not inline methods that never return

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2873,6 +2873,7 @@ struct GenTreeCall final : public GenTree
                                                        // know when these flags are set.
 
 #define     GTF_CALL_M_R2R_REL_INDIRECT        0x2000  // GT_CALL -- ready to run call is indirected through a relative address
+#define     GTF_CALL_M_DOES_NOT_RETURN         0x4000  // GT_CALL -- call does not return
 
     bool IsUnmanaged()       const { return (gtFlags & GTF_CALL_UNMANAGED) != 0; }
     bool NeedsNullCheck()    const { return (gtFlags & GTF_CALL_NULLCHECK) != 0; }
@@ -2992,6 +2993,8 @@ struct GenTreeCall final : public GenTree
 #endif // FEATURE_READYTORUN_COMPILER
 
     bool IsVarargs() const                  { return (gtCallMoreFlags & GTF_CALL_M_VARARGS) != 0; }
+
+    bool IsNoReturn() const                 { return (gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) != 0; }
 
     unsigned short  gtCallMoreFlags;        // in addition to gtFlags
     

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -75,6 +75,7 @@ INLINE_OBSERVATION(ARG_FEEDS_RANGE_CHECK,     bool,   "argument feeds range chec
 INLINE_OBSERVATION(BEGIN_OPCODE_SCAN,         bool,   "prepare to look at opcodes",    INFORMATION, CALLEE)
 INLINE_OBSERVATION(BELOW_ALWAYS_INLINE_SIZE,  bool,   "below ALWAYS_INLINE size",      INFORMATION, CALLEE)
 INLINE_OBSERVATION(CLASS_PROMOTABLE,          bool,   "promotable value class",        INFORMATION, CALLEE)
+INLINE_OBSERVATION(DOES_NOT_RETURN,           bool,   "does not return",               INFORMATION, CALLEE)
 INLINE_OBSERVATION(END_OPCODE_SCAN,           bool,   "done looking at opcodes",       INFORMATION, CALLEE)
 INLINE_OBSERVATION(HAS_SIMD,                  bool,   "has SIMD arg, local, or ret",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                    INFORMATION, CALLEE)

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -563,7 +563,7 @@ struct InlineInfo
     bool              hasSIMDTypeArgLocalOrReturn;
 #endif // FEATURE_SIMD
 
-    GenTree         * iciCall;       // The GT_CALL node to be inlined.
+    GenTreeCall     * iciCall;       // The GT_CALL node to be inlined.
     GenTree         * iciStmt;       // The statement iciCall is in.
     BasicBlock      * iciBlock;      // The basic block iciStmt is in.
 };

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -156,6 +156,35 @@ protected:
     bool                    m_MethodIsMostlyLoadStore :1;
 };
 
+// EnhancedLegacyPolicy extends the legacy policy by rejecting
+// inlining of methods that never return because they throw.
+
+class EnhancedLegacyPolicy : public LegacyPolicy
+{
+public:
+    EnhancedLegacyPolicy(Compiler* compiler, bool isPrejitRoot)
+        : LegacyPolicy(compiler, isPrejitRoot)
+        , m_IsNoReturn(false)
+        , m_IsNoReturnKnown(false)
+    {
+        // empty
+    }
+
+    // Policy observations
+    void NoteBool(InlineObservation obs, bool value) override;
+    void NoteInt(InlineObservation obs, int value) override;
+
+    // Policy policies
+    bool PropagateNeverToRuntime() const override;
+    bool IsLegacyPolicy() const override { return false; }
+
+protected:
+
+    // Data members
+    bool m_IsNoReturn :1;
+    bool m_IsNoReturnKnown :1;
+};
+
 #ifdef DEBUG
 
 // RandomPolicy implements a policy that inlines at random.

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -203,6 +203,7 @@ CONFIG_STRING(JitNoInlineRange, W("JitNoInlineRange"))
 CONFIG_STRING(JitInlineReplayFile, W("JitInlineReplayFile"))
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 
+CONFIG_INTEGER(JitInlinePolicyLegacy, W("JitInlinePolicyLegacy"), 0)
 CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)
 
 #undef CONFIG_INTEGER

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+using System.Collections.Generic;
+using Xunit;
+
+[assembly: OptimizeForBenchmarks]
+[assembly: MeasureInstructionsRetired]
+
+public static class NoThrowInline
+{
+#if DEBUG
+    public const int Iterations = 1;
+#else
+    public const int Iterations = 100000000;
+#endif
+
+    static void ThrowIfNull(string s)
+    {
+        if (s == null)
+            ThrowArgumentNullException();
+    }
+
+    static void ThrowArgumentNullException()
+    {
+        throw new ArgumentNullException();
+    }
+
+    //
+    // We expect ThrowArgumentNullException to not be inlined into Bench, the throw code is pretty
+    // large and throws are extremly slow. However, we need to be careful not to degrade the 
+    // non-exception path performance by preserving registers across the call. For this the compiler
+    // will have to understand that ThrowArgumentNullException never returns and omit the register
+    // preservation code.
+    //
+    // For example, the Bench method below has 4 arguments (all passed in registers on x64) and fairly
+    // typical argument validation code. If the compiler does not inline ThrowArgumentNullException
+    // and does not make use of the "no return" information then all 4 register arguments will have
+    // to be spilled and then reloaded. That would add 8 unnecessary memory accesses.
+    //
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Bench(string a, string b, string c, string d)
+    {
+        ThrowIfNull(a);
+        ThrowIfNull(b);
+        ThrowIfNull(c);
+        ThrowIfNull(d);
+
+        return a.Length + b.Length + c.Length + d.Length;
+    }
+
+    [Benchmark]
+    public static void Test()
+    {
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                Bench("a", "bc", "def", "ghij");
+            }
+        }
+    }
+
+    public static int Main()
+    {
+        return (Bench("a", "bc", "def", "ghij") == 10) ? 100 : -1;
+    }
+}

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.csproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)benchmark\project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NoThrowInline.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)benchmark\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)benchmark\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Methods that do not contain return blocks can't ever exit normally, they either throw or loop indefinitely. Inlining is not beneficial in such cases as it increases the code size without providing any speed benefits. In the particular case of throws the inlined code can easily be 10 times larger than the call site.

The call to `fgMoreThanOneReturnBlock` has been replaced with code that does the same thing but also detects the existence of at least one return block. This avoids walking the basic block list twice.

Note that `BBJ_RETURN` blocks are also generated for `CEE_JMP`. Methods exiting via `CEE_JMP` instead of `CEE_RET` will continue to be inlined (assuming they were inlined before this change).