### PR TITLE
Added 2 configs for Server GC

### DIFF
--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -2892,6 +2892,9 @@ public:
 
 #ifdef MULTIPLE_HEAPS
     PER_HEAP_ISOLATED
+    bool gc_thread_no_affinitize_p;
+
+    PER_HEAP_ISOLATED
     CLREvent gc_start_event;
 
     PER_HEAP_ISOLATED

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -353,6 +353,8 @@ RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_HeapVerify, W("HeapVerify"), 
 RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_SetupGcCoverage, W("SetupGcCoverage"), "This doesn't appear to be a config flag", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCNumaAware, W("GCNumaAware"), 1, "Specifies if to enable GC NUMA aware")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_GCCpuGroup, W("GCCpuGroup"), 0, "Specifies if to enable GC to support CPU groups")
+RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCHeapCount, W("GCHeapCount"), 0, "")
+RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCNoAffinitize, W("GCNoAffinitize"), 0, "")
 
 //
 // IBC

--- a/src/vm/eeconfig.cpp
+++ b/src/vm/eeconfig.cpp
@@ -240,6 +240,8 @@ HRESULT EEConfig::Init()
     iGCForceCompact = 0;
     iGCHoardVM = 0;
     iGCLOHCompactionMode = 0;
+    iGCHeapCount = 0;
+    iGCNoAffinitize = 0;
 
 #ifdef GCTRIMCOMMIT
     iGCTrimCommit = 0;
@@ -973,6 +975,9 @@ HRESULT EEConfig::sync()
 #endif
 
     iGCForceCompact     =  GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_gcForceCompact, iGCForceCompact);
+    iGCNoAffinitize = Configuration::GetKnobBooleanValue(W("System.GC.NoAffinitize"), 
+                                                         CLRConfig::UNSUPPORTED_GCNoAffinitize);
+    iGCHeapCount = Configuration::GetKnobDWORDValue(W("System.GC.HeapCount"), CLRConfig::UNSUPPORTED_GCHeapCount);
 
     fStressLog        =  GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_StressLog, fStressLog) != 0;
     fForceEnc         =  GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_ForceEnc, fForceEnc) != 0;

--- a/src/vm/eeconfig.h
+++ b/src/vm/eeconfig.h
@@ -692,6 +692,8 @@ public:
     int     GetGCForceCompact()             const {LIMITED_METHOD_CONTRACT; return iGCForceCompact; }
     int     GetGCRetainVM ()                const {LIMITED_METHOD_CONTRACT; return iGCHoardVM;}
     int     GetGCLOHCompactionMode()        const {LIMITED_METHOD_CONTRACT; return iGCLOHCompactionMode;}
+    int     GetGCHeapCount()                const {LIMITED_METHOD_CONTRACT; return iGCHeapCount;}
+    int     GetGCNoAffinitize ()            const {LIMITED_METHOD_CONTRACT; return iGCNoAffinitize;}
 
 #ifdef GCTRIMCOMMIT
 
@@ -1077,6 +1079,8 @@ private: //----------------------------------------------------------------
     int  iGCForceCompact;
     int  iGCHoardVM;
     int  iGCLOHCompactionMode;
+    int  iGCHeapCount;
+    int  iGCNoAffinitize;
 
 #ifdef GCTRIMCOMMIT
 


### PR DESCRIPTION
complus var GCNoAffinitize or project.json System.GC.NoAffinitize - specify 1/true to disable hard affinity of Server GC threads to CPUs
complus var GCHeapCount or project.json System.GC.HeapCount - specify the # of Server GC threads/heaps, must be smaller than the # of logical CPUs the process is allowed to run on, ie, if you don't specifically affinitize your process it means the # of total logical CPUs on the machine; otherwise this is the # of logical CPUs you affinitized your process to.