### PR TITLE
Short-circuit on the count, not the array length, in common Encoding methods

### DIFF
--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -73,7 +73,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0, avoid fixed empty array problem
-            if (chars.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call the pointer version
@@ -196,7 +196,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If nothing to encode return 0, avoid fixed problem
-            if (chars.Length == 0)
+            if (charCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -261,7 +261,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input just return 0, fixed doesn't like 0 length arrays
-            if (bytes.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call pointer version
@@ -319,7 +319,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0 & avoid fixed problem
-            if (bytes.Length == 0)
+            if (byteCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -385,7 +385,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // Avoid problems with empty input buffer
-            if (bytes.Length == 0) return String.Empty;
+            if (byteCount == 0) return String.Empty;
 
             fixed (byte* pBytes = bytes)
                 return String.CreateStringFromEncoding(

--- a/src/mscorlib/src/System/Text/Decoder.cs
+++ b/src/mscorlib/src/System/Text/Decoder.cs
@@ -101,7 +101,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public virtual void Reset()
         {
-            byte[] byteTemp = {};
+            byte[] byteTemp = Array.Empty<byte>();
             char[] charTemp = new char[GetCharCount(byteTemp, 0, 0, true)];
             GetChars(byteTemp, 0, 0, charTemp, 0, true);
             if (m_fallbackBuffer != null)

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -59,7 +59,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0, avoid fixed empty array problem
-            if (chars.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call the pointer version
@@ -176,7 +176,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If nothing to encode return 0, avoid fixed problem
-            if (chars.Length == 0)
+            if (charCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -237,7 +237,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input just return 0, fixed doesn't like 0 length arrays
-            if (bytes.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call pointer version
@@ -291,7 +291,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0 & avoid fixed problem
-            if (bytes.Length == 0)
+            if (byteCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -352,7 +352,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // Avoid problems with empty input buffer
-            if (bytes.Length == 0) return String.Empty;
+            if (count == 0) return String.Empty;
             
             fixed (byte* pBytes = bytes)
                 return String.CreateStringFromEncoding(

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -112,7 +112,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0, avoid fixed empty array problem
-            if (chars.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call the pointer version
@@ -234,7 +234,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If nothing to encode return 0, avoid fixed problem
-            if (chars.Length == 0)
+            if (charCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -298,7 +298,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input just return 0, fixed doesn't like 0 length arrays.
-            if (bytes.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call pointer version
@@ -355,7 +355,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0 & avoid fixed problem
-            if (bytes.Length == 0)
+            if (byteCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -419,7 +419,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // Avoid problems with empty input buffer
-            if (bytes.Length == 0) return String.Empty;
+            if (count == 0) return String.Empty;
 
             fixed (byte* pBytes = bytes)
                 return String.CreateStringFromEncoding(

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -178,7 +178,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0, avoid fixed empty array problem
-            if (chars.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call the pointer version
@@ -303,7 +303,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If nothing to encode return 0, avoid fixed problem
-            if (chars.Length == 0)
+            if (charCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -368,7 +368,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input just return 0, fixed doesn't like 0 length arrays.
-            if (bytes.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call pointer version
@@ -426,7 +426,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0 & avoid fixed problem
-            if (bytes.Length == 0)
+            if (byteCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -492,7 +492,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // Avoid problems with empty input buffer
-            if (bytes.Length == 0) return String.Empty;
+            if (count == 0) return String.Empty;
 
             fixed (byte* pBytes = bytes)
                 return String.CreateStringFromEncoding(

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -136,7 +136,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0, avoid fixed empty array problem
-            if (chars.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call the pointer version
@@ -259,7 +259,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If nothing to encode return 0, avoid fixed problem
-            if (chars.Length == 0)
+            if (charCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -324,7 +324,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input just return 0, fixed doesn't like 0 length arrays.
-            if (bytes.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call pointer version
@@ -382,7 +382,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0 & avoid fixed problem
-            if (bytes.Length == 0)
+            if (byteCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -448,7 +448,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // Avoid problems with empty input buffer
-            if (bytes.Length == 0) return String.Empty;
+            if (count == 0) return String.Empty;
 
             fixed (byte* pBytes = bytes)
                 return String.CreateStringFromEncoding(

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -110,7 +110,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0, avoid fixed empty array problem
-            if (chars.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call the pointer version
@@ -233,7 +233,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If nothing to encode return 0, avoid fixed problem
-            if (chars.Length == 0)
+            if (charCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -298,7 +298,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input just return 0, fixed doesn't like 0 length arrays
-            if (bytes.Length == 0)
+            if (count == 0)
                 return 0;
 
             // Just call pointer version
@@ -356,7 +356,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // If no input, return 0 & avoid fixed problem
-            if (bytes.Length == 0)
+            if (byteCount == 0)
                 return 0;
 
             // Just call pointer version
@@ -422,7 +422,7 @@ namespace System.Text
             Contract.EndContractBlock();
 
             // Avoid problems with empty input buffer
-            if (bytes.Length == 0) return String.Empty;
+            if (count == 0) return String.Empty;
 
             fixed (byte* pBytes = bytes)
                 return String.CreateStringFromEncoding(


### PR DESCRIPTION
Methods like `Encoding.GetByteCount` once short-circuited and returned 0 if the input buffer was empty. However, they did not short-circuit if the `count` was 0, but the input buffer wasn't empty. e.g. this:

```cs
var bytes = new byte[1];
Encoding.UTF8.GetChars(bytes, 0, count: 0);
```
wouldn't short-circuit.

Due to argument validation if `bytes.Length` is 0, then `count` must always be zero, since the code checks that `bytes.Length - index < count`. Therefore, this won't impact the codepath of existing code that passes in an empty buffer.

cc @jkotas @AlexGhiondea 

(note: Since it was very tedious to go through each file and make the same changes again, I will soon be submitting another pull request that aggregates most of the logic into a static helper class.)

(self note: port to corert if this gets merged)