### PR TITLE
Tests dnxcore50 -> netcoreapp1.0

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -11,7 +11,7 @@ set /P BUILDTOOLS_VERSION=< "%~dp0BuildToolsVersion.txt"
 set BUILD_TOOLS_PATH=%PACKAGES_DIR%Microsoft.DotNet.BuildTools\%BUILDTOOLS_VERSION%\lib\
 set PROJECT_JSON_PATH=%TOOLRUNTIME_DIR%\%BUILDTOOLS_VERSION%
 set PROJECT_JSON_FILE=%PROJECT_JSON_PATH%\project.json
-set PROJECT_JSON_CONTENTS={ "dependencies": { "Microsoft.DotNet.BuildTools": "%BUILDTOOLS_VERSION%" , "Microsoft.DotNet.BuildTools.Coreclr": "1.0.4-prerelease"}, "frameworks": { "dnxcore50": { } } }
+set PROJECT_JSON_CONTENTS={ "dependencies": { "Microsoft.DotNet.BuildTools": "%BUILDTOOLS_VERSION%" , "Microsoft.DotNet.BuildTools.Coreclr": "1.0.4-prerelease"}, "frameworks": { "netcoreapp1.0": { "imports": "dnxcore50" } } }
 set BUILD_TOOLS_SEMAPHORE=%PROJECT_JSON_PATH%\init-tools.completed
 set TOOLS_INIT_RETURN_CODE=0
 

--- a/src/.nuget/init/project.json
+++ b/src/.nuget/init/project.json
@@ -3,8 +3,11 @@
       "Microsoft.NETCore.Platforms": "1.0.2-beta-24224-02",
     },
     "frameworks": {
-      "dnxcore50": {
-        "imports": "portable-net45+win8"
+      "netcoreapp1.0": {
+        "imports": [
+          "dnxcore50",
+          "portable-net45+win8"
+        ]
       }
-    },
+    }
 }

--- a/tests/publishdependency.targets
+++ b/tests/publishdependency.targets
@@ -3,8 +3,8 @@
 
   <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <ItemGroup>
-    <TestTargetFramework Include="DNXCore,Version=v5.0">
-      <Folder>dnxcore50</Folder>
+    <TestTargetFramework Include=".NETCoreApp,Version=v1.0">
+      <Folder>netcoreapp1.0</Folder>
     </TestTargetFramework>
   </ItemGroup>
 

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -371,7 +371,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
     "Microsoft.NETCore.TestHost": "1.0.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "$(TestNugetRuntimeId)":{}

--- a/tests/setup-runtime-dependencies.cmd
+++ b/tests/setup-runtime-dependencies.cmd
@@ -80,7 +80,7 @@ echo { ^
     "dependencies": { ^
     "runtime.win7-%__Arch%.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-*" ^
     }, ^
-    "frameworks": { "dnxcore50": { } } ^
+    "frameworks": { "netcoreapp1.0": { "imports": "dnxcore50" } } ^
     } > "%__JsonFilePath%"
 
 echo JSON file: %__JsonFilePath%

--- a/tests/src/Common/CoreCLRTestLibrary/project.json
+++ b/tests/src/Common/CoreCLRTestLibrary/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Common/Coreclr.TestWrapper/project.json
+++ b/tests/src/Common/Coreclr.TestWrapper/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/components/fileversioninfo/project.json
+++ b/tests/src/CoreMangLib/components/fileversioninfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/components/stopwatch/project.json
+++ b/tests/src/CoreMangLib/components/stopwatch/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/action/project.json
+++ b/tests/src/CoreMangLib/cti/system/action/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/activator/project.json
+++ b/tests/src/CoreMangLib/cti/system/activator/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/argumentexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/argumentexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/argumentnullexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/argumentnullexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/argumentoutofrangeexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/argumentoutofrangeexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/arithmeticexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/arithmeticexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/array/project.json
+++ b/tests/src/CoreMangLib/cti/system/array/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/arraytypemismatchexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/arraytypemismatchexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/attribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/attribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/attributetargets/project.json
+++ b/tests/src/CoreMangLib/cti/system/attributetargets/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/attributeusageattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/attributeusageattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/badimageformatexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/badimageformatexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/boolean/project.json
+++ b/tests/src/CoreMangLib/cti/system/boolean/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/byte/project.json
+++ b/tests/src/CoreMangLib/cti/system/byte/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/char/project.json
+++ b/tests/src/CoreMangLib/cti/system/char/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/charenumerator/project.json
+++ b/tests/src/CoreMangLib/cti/system/charenumerator/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/clscompliantattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/clscompliantattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/dictionaryentry/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/dictionaryentry/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/comparer/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/comparer/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/equalitycomparer/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/equalitycomparer/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/icollection/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/icollection/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/ienumerable/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/ienumerable/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/ienumerator/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/ienumerator/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/iequalitycomparer/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/iequalitycomparer/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/ilist/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/ilist/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/keynotfoundexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/keynotfoundexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/keyvaluepair/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/keyvaluepair/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queueenumerator/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queueenumerator/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stackenumerator/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stackenumerator/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/icollection/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/icollection/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/icomparer/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/icomparer/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/idictionary/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/idictionary/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/ienumerator/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/ienumerator/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/collections/ilist/project.json
+++ b/tests/src/CoreMangLib/cti/system/collections/ilist/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/comparison/project.json
+++ b/tests/src/CoreMangLib/cti/system/comparison/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/console/project.json
+++ b/tests/src/CoreMangLib/cti/system/console/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/convert/project.json
+++ b/tests/src/CoreMangLib/cti/system/convert/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/datetime/project.json
+++ b/tests/src/CoreMangLib/cti/system/datetime/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/datetimekind/project.json
+++ b/tests/src/CoreMangLib/cti/system/datetimekind/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/dayofweek/project.json
+++ b/tests/src/CoreMangLib/cti/system/dayofweek/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/decimal/project.json
+++ b/tests/src/CoreMangLib/cti/system/decimal/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/delegate/project.json
+++ b/tests/src/CoreMangLib/cti/system/delegate/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/diagnostics/conditionalattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/diagnostics/conditionalattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/project.json
+++ b/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/dividebyzeroexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/dividebyzeroexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/dllnotfoundexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/dllnotfoundexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/double/project.json
+++ b/tests/src/CoreMangLib/cti/system/double/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/enum/project.json
+++ b/tests/src/CoreMangLib/cti/system/enum/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/environment/project.json
+++ b/tests/src/CoreMangLib/cti/system/environment/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/eventargs/project.json
+++ b/tests/src/CoreMangLib/cti/system/eventargs/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/eventhandler/project.json
+++ b/tests/src/CoreMangLib/cti/system/eventhandler/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/eventhandler_generic/project.json
+++ b/tests/src/CoreMangLib/cti/system/eventhandler_generic/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/exception/project.json
+++ b/tests/src/CoreMangLib/cti/system/exception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/flagsattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/flagsattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/formatexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/formatexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/gc/project.json
+++ b/tests/src/CoreMangLib/cti/system/gc/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/calendarweekrule/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/calendarweekrule/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/compareinfo/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareinfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/cultureinfo/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/cultureinfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/regioninfo/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/regioninfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/textelementenumerator/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/textelementenumerator/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/textinfo/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/textinfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/project.json
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/guid/project.json
+++ b/tests/src/CoreMangLib/cti/system/guid/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/icomparable/project.json
+++ b/tests/src/CoreMangLib/cti/system/icomparable/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/icomparable_generic/project.json
+++ b/tests/src/CoreMangLib/cti/system/icomparable_generic/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/iconvertible/project.json
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/idisposable/project.json
+++ b/tests/src/CoreMangLib/cti/system/idisposable/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/iformatable/project.json
+++ b/tests/src/CoreMangLib/cti/system/iformatable/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/indexoutofrangeexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/indexoutofrangeexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/int/project.json
+++ b/tests/src/CoreMangLib/cti/system/int/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/int16/project.json
+++ b/tests/src/CoreMangLib/cti/system/int16/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/int64/project.json
+++ b/tests/src/CoreMangLib/cti/system/int64/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/intptr/project.json
+++ b/tests/src/CoreMangLib/cti/system/intptr/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/invalidcastexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/invalidcastexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/invalidoperationexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/invalidoperationexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/invalidprogramexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/invalidprogramexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/binarywriter/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/binarywriter/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/directorynotfoundexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/directorynotfoundexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/endofstreamexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/endofstreamexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/fileaccess/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/fileaccess/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/filemode/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/filemode/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/fileshare/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/fileshare/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/filestream/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/filestream/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/ioexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/ioexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/memorystream/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/memorystream/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/pathtoolongexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/pathtoolongexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/seekorigin/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/seekorigin/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/stream/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/stream/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/streamreader/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/streamreader/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/stringwriter/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/stringwriter/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/textreader/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/textreader/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/io/textwriter/project.json
+++ b/tests/src/CoreMangLib/cti/system/io/textwriter/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/math/project.json
+++ b/tests/src/CoreMangLib/cti/system/math/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/memberaccessexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/memberaccessexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/methodaccessexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/methodaccessexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/missingfieldexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/missingfieldexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/missingmemberexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/missingmemberexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/missingmethodexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/missingmethodexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/multicastdelegate/project.json
+++ b/tests/src/CoreMangLib/cti/system/multicastdelegate/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/notimplementedexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/notimplementedexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/notsupportedexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/notsupportedexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/nullable/project.json
+++ b/tests/src/CoreMangLib/cti/system/nullable/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/nullreferenceexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/nullreferenceexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/object/project.json
+++ b/tests/src/CoreMangLib/cti/system/object/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/objectdisposedexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/objectdisposedexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/obsoleteattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/obsoleteattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/outofmemoryexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/outofmemoryexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/overflowexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/overflowexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/paramarrayattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/paramarrayattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/platformnotsupportedexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/platformnotsupportedexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/predicate/project.json
+++ b/tests/src/CoreMangLib/cti/system/predicate/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/random/project.json
+++ b/tests/src/CoreMangLib/cti/system/random/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/rankexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/rankexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/ambiguousmatchexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/ambiguousmatchexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assembly/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assembly/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblyconfigurationattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblyconfigurationattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblydefaultaliasattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblydefaultaliasattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblydelaysignattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblydelaysignattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblydescriptionattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblydescriptionattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblykeyfileattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblykeyfileattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblykeynameattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblykeynameattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblyname/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblyname/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblytitleattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblytitleattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/callingconventions/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/callingconventions/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/constructorinfo/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/constructorinfo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/defaultmemberattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/defaultmemberattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/fieldtoken/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/fieldtoken/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/eventattributes/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/eventattributes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/targetinvocationexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/targetinvocationexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/targetparametercountexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/targetparametercountexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/project.json
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/resources/missingmanifestresourceexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/resources/missingmanifestresourceexception/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/resources/neutralresourceslanguageattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/resources/neutralresourceslanguageattribute/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/resources/resourcemanager/project.json
+++ b/tests/src/CoreMangLib/cti/system/resources/resourcemanager/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/resources/satellitecontractversionattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/resources/satellitecontractversionattribute/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/accessedthroughpropertyattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/accessedthroughpropertyattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/compilationrelaxations/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/compilationrelaxations/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/compilergeneratedattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/compilergeneratedattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/customconstantattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/customconstantattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/indexernameattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/indexernameattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/internalsvisibletoattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/internalsvisibletoattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/methodimploptions/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/methodimploptions/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimecompatibilityattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimecompatibilityattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimehelpers/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimehelpers/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/decimalconstantattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/decimalconstantattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/fixedbufferattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/fixedbufferattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/callingconvention/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/callingconvention/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/charset/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/charset/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/dllimportattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/dllimportattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/fieldoffsetattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/fieldoffsetattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/inattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/inattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/layoutkind/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/layoutkind/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshal/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshal/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/outattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/outattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/preservesigattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/preservesigattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/unmanagedtype/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/unmanagedtype/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtimefieldhandle/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtimefieldhandle/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtimemethodhandle/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtimemethodhandle/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/runtimetypehandle/project.json
+++ b/tests/src/CoreMangLib/cti/system/runtimetypehandle/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/sbyte/project.json
+++ b/tests/src/CoreMangLib/cti/system/sbyte/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/security/securityexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/security/securityexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/single/project.json
+++ b/tests/src/CoreMangLib/cti/system/single/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/string/project.json
+++ b/tests/src/CoreMangLib/cti/system/string/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/stringcompare/project.json
+++ b/tests/src/CoreMangLib/cti/system/stringcompare/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/stringcomparer/project.json
+++ b/tests/src/CoreMangLib/cti/system/stringcomparer/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/stringcomparison/project.json
+++ b/tests/src/CoreMangLib/cti/system/stringcomparison/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/szarrayhelper/project.json
+++ b/tests/src/CoreMangLib/cti/system/szarrayhelper/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/text/decoder/project.json
+++ b/tests/src/CoreMangLib/cti/system/text/decoder/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/text/encoder/project.json
+++ b/tests/src/CoreMangLib/cti/system/text/encoder/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/text/encoding/project.json
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/project.json
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/project.json
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/project.json
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/threading/autoresetevent/project.json
+++ b/tests/src/CoreMangLib/cti/system/threading/autoresetevent/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/project.json
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/threading/manualresetevent/project.json
+++ b/tests/src/CoreMangLib/cti/system/threading/manualresetevent/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/threading/timeout/project.json
+++ b/tests/src/CoreMangLib/cti/system/threading/timeout/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/threading/waithandle/project.json
+++ b/tests/src/CoreMangLib/cti/system/threading/waithandle/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/timeoutexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/timeoutexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/timespan/project.json
+++ b/tests/src/CoreMangLib/cti/system/timespan/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/type/project.json
+++ b/tests/src/CoreMangLib/cti/system/type/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/typecode/project.json
+++ b/tests/src/CoreMangLib/cti/system/typecode/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/typeloadexception/project.json
+++ b/tests/src/CoreMangLib/cti/system/typeloadexception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/uint16/project.json
+++ b/tests/src/CoreMangLib/cti/system/uint16/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/uint32/project.json
+++ b/tests/src/CoreMangLib/cti/system/uint32/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/uint64/project.json
+++ b/tests/src/CoreMangLib/cti/system/uint64/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/uintptr/project.json
+++ b/tests/src/CoreMangLib/cti/system/uintptr/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/valuetype/project.json
+++ b/tests/src/CoreMangLib/cti/system/valuetype/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/version/project.json
+++ b/tests/src/CoreMangLib/cti/system/version/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/cti/system/weakreference/project.json
+++ b/tests/src/CoreMangLib/cti/system/weakreference/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/reflection/assembly/project.json
+++ b/tests/src/CoreMangLib/reflection/assembly/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/buffer/project.json
+++ b/tests/src/CoreMangLib/system/buffer/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/collections/generic/hashset/project.json
+++ b/tests/src/CoreMangLib/system/collections/generic/hashset/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/datetime/project.json
+++ b/tests/src/CoreMangLib/system/datetime/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/delegate/VSD/project.json
+++ b/tests/src/CoreMangLib/system/delegate/VSD/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/delegate/generics/project.json
+++ b/tests/src/CoreMangLib/system/delegate/generics/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/delegate/miscellaneous/project.json
+++ b/tests/src/CoreMangLib/system/delegate/miscellaneous/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/delegate/regressions/devdivbugs/113347/project.json
+++ b/tests/src/CoreMangLib/system/delegate/regressions/devdivbugs/113347/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/delegate/threatmodel/public/project.json
+++ b/tests/src/CoreMangLib/system/delegate/threatmodel/public/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/delegate/threatmodel/tests/project.json
+++ b/tests/src/CoreMangLib/system/delegate/threatmodel/tests/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/exception/project.json
+++ b/tests/src/CoreMangLib/system/exception/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/guid/project.json
+++ b/tests/src/CoreMangLib/system/guid/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/lazyt/project.json
+++ b/tests/src/CoreMangLib/system/lazyt/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/reflection/assembly/project.json
+++ b/tests/src/CoreMangLib/system/reflection/assembly/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/resources/resourcemanager/project.json
+++ b/tests/src/CoreMangLib/system/resources/resourcemanager/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/text/encoding/project.json
+++ b/tests/src/CoreMangLib/system/text/encoding/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/type/project.json
+++ b/tests/src/CoreMangLib/system/type/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/CoreMangLib/system/version/project.json
+++ b/tests/src/CoreMangLib/system/version/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Exceptions/Finalization/project.json
+++ b/tests/src/Exceptions/Finalization/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Exceptions/ForeignThread/project.json
+++ b/tests/src/Exceptions/ForeignThread/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/GC/Performance/Tests/project.json
+++ b/tests/src/GC/Performance/Tests/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/GC/Stress/Framework/project.json
+++ b/tests/src/GC/Stress/Framework/project.json
@@ -33,7 +33,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/GC/Stress/Tests/project.json
+++ b/tests/src/GC/Stress/Tests/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/GC/config/extra/project.json
+++ b/tests/src/GC/config/extra/project.json
@@ -36,7 +36,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/GC/config/minimal/project.json
+++ b/tests/src/GC/config/minimal/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/ArrayMarshalling/BoolArray/project.json
+++ b/tests/src/Interop/ArrayMarshalling/BoolArray/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/ArrayMarshalling/ByValArray/project.json
+++ b/tests/src/Interop/ArrayMarshalling/ByValArray/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/BestFitMapping/project.json
+++ b/tests/src/Interop/BestFitMapping/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/FuncPtrAsDelegateParam/project.json
+++ b/tests/src/Interop/FuncPtrAsDelegateParam/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/ICastable/project.json
+++ b/tests/src/Interop/ICastable/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/Copy/project.json
+++ b/tests/src/Interop/MarshalAPI/Copy/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/FunctionPointer/project.json
+++ b/tests/src/Interop/MarshalAPI/FunctionPointer/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/GetExceptionForHR/project.json
+++ b/tests/src/Interop/MarshalAPI/GetExceptionForHR/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/GetNativeVariantForObject/project.json
+++ b/tests/src/Interop/MarshalAPI/GetNativeVariantForObject/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/GetObjectForNativeVariant/project.json
+++ b/tests/src/Interop/MarshalAPI/GetObjectForNativeVariant/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/GetObjectsForNativeVariants/project.json
+++ b/tests/src/Interop/MarshalAPI/GetObjectsForNativeVariants/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/IUnknown/project.json
+++ b/tests/src/Interop/MarshalAPI/IUnknown/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/Miscellaneous/project.json
+++ b/tests/src/Interop/MarshalAPI/Miscellaneous/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/OffsetOf/project.json
+++ b/tests/src/Interop/MarshalAPI/OffsetOf/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/ReadWrite/project.json
+++ b/tests/src/Interop/MarshalAPI/ReadWrite/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/String/project.json
+++ b/tests/src/Interop/MarshalAPI/String/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/MarshalAPI/UnsafeAddrOfPinnedArrayElement/project.json
+++ b/tests/src/Interop/MarshalAPI/UnsafeAddrOfPinnedArrayElement/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/NativeCallable/project.json
+++ b/tests/src/Interop/NativeCallable/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/PrimitiveMarshalling/Bool/project.json
+++ b/tests/src/Interop/PrimitiveMarshalling/Bool/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/PrimitiveMarshalling/EnumMarshalling/project.json
+++ b/tests/src/Interop/PrimitiveMarshalling/EnumMarshalling/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/PrimitiveMarshalling/UIntPtr/project.json
+++ b/tests/src/Interop/PrimitiveMarshalling/UIntPtr/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/RefCharArray/project.json
+++ b/tests/src/Interop/RefCharArray/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/RefInt/project.json
+++ b/tests/src/Interop/RefInt/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/SimpleStruct/project.json
+++ b/tests/src/Interop/SimpleStruct/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/StringMarshalling/LPSTR/project.json
+++ b/tests/src/Interop/StringMarshalling/LPSTR/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/StringMarshalling/LPTSTR/project.json
+++ b/tests/src/Interop/StringMarshalling/LPTSTR/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/StringMarshalling/UTF8/project.json
+++ b/tests/src/Interop/StringMarshalling/UTF8/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Interop/StructMarshalling/PInvoke/project.json
+++ b/tests/src/Interop/StructMarshalling/PInvoke/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Directed/StructABI/project.json
+++ b/tests/src/JIT/Directed/StructABI/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Directed/TypedReference/project.json
+++ b/tests/src/JIT/Directed/TypedReference/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Methodical/dynamic_methods/project.json
+++ b/tests/src/JIT/Methodical/dynamic_methods/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Methodical/eh/rethrow/project.json
+++ b/tests/src/JIT/Methodical/eh/rethrow/project.json
@@ -2,9 +2,9 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24117-00",
     "System.Console": "4.0.0-rc3-24117-00",
-    "System.IO": "4.0.10",
+    "System.IO": "4.1.0-rc3-24117-00",
     "System.Runtime": "4.1.0-rc3-24117-00",
-    "System.Runtime.Extensions": "4.0.10",
+    "System.Runtime.Extensions": "4.1.0-rc3-24117-00",
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {

--- a/tests/src/JIT/Methodical/eh/rethrow/project.json
+++ b/tests/src/JIT/Methodical/eh/rethrow/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Methodical/structs/systemvbringup/project.json
+++ b/tests/src/JIT/Methodical/structs/systemvbringup/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M10/b06811/project.json
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M10/b06811/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51875/Desktop/project.json
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51875/Desktop/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/project.json
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/project.json
@@ -10,7 +10,7 @@
     "System.Threading.Timer": "4.0.0"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Regression/Dev11/External/dev11_149090/project.json
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_149090/project.json
@@ -9,7 +9,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Regression/JitBlue/GitHub_4115/project.json
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_4115/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/Regression/JitBlue/GitHub_5696/project.json
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_5696/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/SIMD/project.json
+++ b/tests/src/JIT/SIMD/project.json
@@ -14,7 +14,7 @@
     "System.IO.FileSystem": "4.0.1-rc3-24117-00",
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/config/benchmark+roslyn/project.json
+++ b/tests/src/JIT/config/benchmark+roslyn/project.json
@@ -26,9 +26,10 @@
     "xunit.runner.utility": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
+    "netcoreapp1.0": {
       "imports": [
         "netstandard1.6",
+        "dnxcore50",
         "portable-net45+win8"
       ]
     }

--- a/tests/src/JIT/config/benchmark+serialize/project.json
+++ b/tests/src/JIT/config/benchmark+serialize/project.json
@@ -23,8 +23,11 @@
     "xunit.runner.utility": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8"
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {

--- a/tests/src/JIT/config/benchmark/project.json
+++ b/tests/src/JIT/config/benchmark/project.json
@@ -26,8 +26,11 @@
     "xunit.runner.utility": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8"
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {

--- a/tests/src/JIT/config/empty/project.json
+++ b/tests/src/JIT/config/empty/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/config/extra/project.json
+++ b/tests/src/JIT/config/extra/project.json
@@ -18,7 +18,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/config/minimal/project.json
+++ b/tests/src/JIT/config/minimal/project.json
@@ -7,7 +7,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/config/minimal/project.json
+++ b/tests/src/JIT/config/minimal/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24117-00",
     "System.Console": "4.0.0-rc3-24117-00",
     "System.Runtime": "4.1.0-rc3-24117-00",
-    "System.Runtime.Extensions": "4.0.10",
+    "System.Runtime.Extensions": "4.1.0-rc3-24117-00",
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {

--- a/tests/src/JIT/config/threading+thread/project.json
+++ b/tests/src/JIT/config/threading+thread/project.json
@@ -9,7 +9,7 @@
     "System.Threading.Thread": "4.0.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/config/threading/project.json
+++ b/tests/src/JIT/config/threading/project.json
@@ -7,7 +7,7 @@
     "System.Threading": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/jit64/eh/basics/project.json
+++ b/tests/src/JIT/jit64/eh/basics/project.json
@@ -8,7 +8,7 @@
     "System.Runtime.InteropServices": "4.1.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/NativeLibs/project.json
+++ b/tests/src/Loader/NativeLibs/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/binding/assemblies/assemblybugs/102140/project.json
+++ b/tests/src/Loader/binding/assemblies/assemblybugs/102140/project.json
@@ -7,7 +7,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/binding/assemblies/assemblybugs/177066w/project.json
+++ b/tests/src/Loader/binding/assemblies/assemblybugs/177066w/project.json
@@ -7,7 +7,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/binding/assemblies/assemblybugs/203962w/project.json
+++ b/tests/src/Loader/binding/assemblies/assemblybugs/203962w/project.json
@@ -7,7 +7,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/binding/assemblies/assemblyversion/project.json
+++ b/tests/src/Loader/binding/assemblies/assemblyversion/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/project.json
+++ b/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/project.json
@@ -7,7 +7,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/binding/assemblies/generics/arilistienum/methods/project.json
+++ b/tests/src/Loader/binding/assemblies/generics/arilistienum/methods/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/PrivateInterfaceImpl/project.json
+++ b/tests/src/Loader/classloader/PrivateInterfaceImpl/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/Statics/ComplexScenarios/project.json
+++ b/tests/src/Loader/classloader/Statics/ComplexScenarios/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/Statics/Misc/project.json
+++ b/tests/src/Loader/classloader/Statics/Misc/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/TSAmbiguities/CollapsedMethods/InterfaceImplementation/project.json
+++ b/tests/src/Loader/classloader/TSAmbiguities/CollapsedMethods/InterfaceImplementation/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/TypeForwarding/UnitTest/project.json
+++ b/tests/src/Loader/classloader/TypeForwarding/UnitTest/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/TypeInitialization/CctorsWithSideEffects/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/CctorsWithSideEffects/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/TypeInitialization/CoreCLR/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/CoreCLR/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/TypeInitialization/Inlining/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/Inlining/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/TypeInitialization/ThisNulllPointer/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/ThisNulllPointer/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/TypeInitialization/backpatching/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/backpatching/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/explicitlayout/Regressions/298006/project.json
+++ b/tests/src/Loader/classloader/explicitlayout/Regressions/298006/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/explicitlayout/Regressions/369794/project.json
+++ b/tests/src/Loader/classloader/explicitlayout/Regressions/369794/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/explicitlayout/misc/project.json
+++ b/tests/src/Loader/classloader/explicitlayout/misc/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/project.json
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Constraints/General/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/General/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Constraints/Recursion/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Recursion/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Constraints/Regressions/532403/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Regressions/532403/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Constraints/Regressions/ddb62403/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Regressions/ddb62403/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Constraints/Regressions/dev10_512868/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Regressions/dev10_512868/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Constraints/Regressions/vsw609874/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Regressions/vsw609874/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/GenericMethods/project.json
+++ b/tests/src/Loader/classloader/generics/GenericMethods/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Instantiation/Negative/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Negative/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Instantiation/Nesting/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Nesting/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Instantiation/Positive/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Positive/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Instantiation/Recursion/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Recursion/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Instantiation/Regressions/607/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Regressions/607/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Layout/General/project.json
+++ b/tests/src/Loader/classloader/generics/Layout/General/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Layout/Specific/project.json
+++ b/tests/src/Loader/classloader/generics/Layout/Specific/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Misc/project.json
+++ b/tests/src/Loader/classloader/generics/Misc/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Statics/Regressions/524571/project.json
+++ b/tests/src/Loader/classloader/generics/Statics/Regressions/524571/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/VSD/project.json
+++ b/tests/src/Loader/classloader/generics/VSD/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Variance/CoreCLR/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/CoreCLR/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Variance/Delegates/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/Delegates/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Variance/IL/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/IL/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Variance/Interfaces/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/Interfaces/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Variance/Methods/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/Methods/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/Visibility/project.json
+++ b/tests/src/Loader/classloader/generics/Visibility/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/123712/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/123712/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/137310/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/137310/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/188892/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/188892/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/237932/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/237932/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/334376/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/334376/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/341477/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/341477/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/395780/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/395780/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/433497/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/433497/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/448208/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/448208/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/515341/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/515341/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/536564/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/536564/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/DD117522/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/DD117522/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/dd95372/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/dd95372/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/ddb3422/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/ddb3422/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/vsw237932/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/vsw237932/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/vsw514968/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/vsw514968/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/vsw524571/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/vsw524571/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/generics/regressions/vsw578898/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/vsw578898/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/methodoverriding/regressions/549411/project.json
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/549411/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/methodoverriding/regressions/576621/project.json
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/576621/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/methodoverriding/regressions/577403/project.json
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/577403/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/methodoverriding/regressions/593884/project.json
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/593884/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/methodoverriding/regressions/dev10_432038/project.json
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/dev10_432038/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/nesting/Regressions/dev10_602978/project.json
+++ b/tests/src/Loader/classloader/nesting/Regressions/dev10_602978/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/nesting/Tests/project.json
+++ b/tests/src/Loader/classloader/nesting/Tests/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/nesting/coreclr/project.json
+++ b/tests/src/Loader/classloader/nesting/coreclr/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/101682/project.json
+++ b/tests/src/Loader/classloader/regressions/101682/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/101904/project.json
+++ b/tests/src/Loader/classloader/regressions/101904/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/106647/project.json
+++ b/tests/src/Loader/classloader/regressions/106647/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/111021/project.json
+++ b/tests/src/Loader/classloader/regressions/111021/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/123413/project.json
+++ b/tests/src/Loader/classloader/regressions/123413/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/144257/project.json
+++ b/tests/src/Loader/classloader/regressions/144257/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/14610/project.json
+++ b/tests/src/Loader/classloader/regressions/14610/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/208900/project.json
+++ b/tests/src/Loader/classloader/regressions/208900/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/245191/project.json
+++ b/tests/src/Loader/classloader/regressions/245191/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/307137/project.json
+++ b/tests/src/Loader/classloader/regressions/307137/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/347422/project.json
+++ b/tests/src/Loader/classloader/regressions/347422/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/348842/project.json
+++ b/tests/src/Loader/classloader/regressions/348842/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/359519/project.json
+++ b/tests/src/Loader/classloader/regressions/359519/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/405223/project.json
+++ b/tests/src/Loader/classloader/regressions/405223/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/434481/project.json
+++ b/tests/src/Loader/classloader/regressions/434481/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/451034/project.json
+++ b/tests/src/Loader/classloader/regressions/451034/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/523654/project.json
+++ b/tests/src/Loader/classloader/regressions/523654/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/529206/project.json
+++ b/tests/src/Loader/classloader/regressions/529206/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/583649/project.json
+++ b/tests/src/Loader/classloader/regressions/583649/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/91888/project.json
+++ b/tests/src/Loader/classloader/regressions/91888/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/Dev12_518401/project.json
+++ b/tests/src/Loader/classloader/regressions/Dev12_518401/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dd116295/project.json
+++ b/tests/src/Loader/classloader/regressions/dd116295/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dd52/project.json
+++ b/tests/src/Loader/classloader/regressions/dd52/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_398410/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_398410/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_526434/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_526434/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_568786/4_Misc/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_568786/4_Misc/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_630250/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_630250/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_724989/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_724989/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_794943/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_794943/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_813331/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_813331/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_851479/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_851479/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_889822/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_889822/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev10_897464/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_897464/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev11_256384/project.json
+++ b/tests/src/Loader/classloader/regressions/dev11_256384/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev11_38348/project.json
+++ b/tests/src/Loader/classloader/regressions/dev11_38348/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev11_383846/project.json
+++ b/tests/src/Loader/classloader/regressions/dev11_383846/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/dev11_95728/project.json
+++ b/tests/src/Loader/classloader/regressions/dev11_95728/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/vsw111021/project.json
+++ b/tests/src/Loader/classloader/regressions/vsw111021/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/vsw307137/project.json
+++ b/tests/src/Loader/classloader/regressions/vsw307137/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/vsw529206/project.json
+++ b/tests/src/Loader/classloader/regressions/vsw529206/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/regressions/vsw531159/project.json
+++ b/tests/src/Loader/classloader/regressions/vsw531159/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/v1/Beta1/Layout/Matrix/cs/project.json
+++ b/tests/src/Loader/classloader/v1/Beta1/Layout/Matrix/cs/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/v1/M10/Acceptance/project.json
+++ b/tests/src/Loader/classloader/v1/M10/Acceptance/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/classloader/v1/Stress/Beta1/CLStressA/project.json
+++ b/tests/src/Loader/classloader/v1/Stress/Beta1/CLStressA/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/lowlevel/regress/105736/project.json
+++ b/tests/src/Loader/lowlevel/regress/105736/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/multimodule/project.json
+++ b/tests/src/Loader/multimodule/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/regressions/classloader/project.json
+++ b/tests/src/Loader/regressions/classloader/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/regressions/polyrec/project.json
+++ b/tests/src/Loader/regressions/polyrec/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Loader/versioning/coverage/project.json
+++ b/tests/src/Loader/versioning/coverage/project.json
@@ -6,7 +6,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/assemblyref/project.json
+++ b/tests/src/Regressions/assemblyref/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/common/project.json
+++ b/tests/src/Regressions/common/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0014/project.json
+++ b/tests/src/Regressions/coreclr/0014/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0018/project.json
+++ b/tests/src/Regressions/coreclr/0018/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0028/project.json
+++ b/tests/src/Regressions/coreclr/0028/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0041/project.json
+++ b/tests/src/Regressions/coreclr/0041/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0044/project.json
+++ b/tests/src/Regressions/coreclr/0044/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0046/project.json
+++ b/tests/src/Regressions/coreclr/0046/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0069/project.json
+++ b/tests/src/Regressions/coreclr/0069/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0075/project.json
+++ b/tests/src/Regressions/coreclr/0075/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0077/project.json
+++ b/tests/src/Regressions/coreclr/0077/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0080/project.json
+++ b/tests/src/Regressions/coreclr/0080/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0099/project.json
+++ b/tests/src/Regressions/coreclr/0099/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0138/project.json
+++ b/tests/src/Regressions/coreclr/0138/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0149/project.json
+++ b/tests/src/Regressions/coreclr/0149/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0198/project.json
+++ b/tests/src/Regressions/coreclr/0198/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0202/project.json
+++ b/tests/src/Regressions/coreclr/0202/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0211/project.json
+++ b/tests/src/Regressions/coreclr/0211/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0275/project.json
+++ b/tests/src/Regressions/coreclr/0275/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0308/project.json
+++ b/tests/src/Regressions/coreclr/0308/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0341/project.json
+++ b/tests/src/Regressions/coreclr/0341/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0342/project.json
+++ b/tests/src/Regressions/coreclr/0342/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0416/project.json
+++ b/tests/src/Regressions/coreclr/0416/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0433/project.json
+++ b/tests/src/Regressions/coreclr/0433/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0487/project.json
+++ b/tests/src/Regressions/coreclr/0487/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0570/project.json
+++ b/tests/src/Regressions/coreclr/0570/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0576/project.json
+++ b/tests/src/Regressions/coreclr/0576/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0582/project.json
+++ b/tests/src/Regressions/coreclr/0582/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0583/project.json
+++ b/tests/src/Regressions/coreclr/0583/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0584/project.json
+++ b/tests/src/Regressions/coreclr/0584/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0694/project.json
+++ b/tests/src/Regressions/coreclr/0694/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0792/project.json
+++ b/tests/src/Regressions/coreclr/0792/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0828/project.json
+++ b/tests/src/Regressions/coreclr/0828/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0829/project.json
+++ b/tests/src/Regressions/coreclr/0829/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0857/project.json
+++ b/tests/src/Regressions/coreclr/0857/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0939/project.json
+++ b/tests/src/Regressions/coreclr/0939/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/0968/project.json
+++ b/tests/src/Regressions/coreclr/0968/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1307/project.json
+++ b/tests/src/Regressions/coreclr/1307/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1333/project.json
+++ b/tests/src/Regressions/coreclr/1333/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1337/project.json
+++ b/tests/src/Regressions/coreclr/1337/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1380/project.json
+++ b/tests/src/Regressions/coreclr/1380/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1386/project.json
+++ b/tests/src/Regressions/coreclr/1386/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1402/project.json
+++ b/tests/src/Regressions/coreclr/1402/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1514/project.json
+++ b/tests/src/Regressions/coreclr/1514/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1534/project.json
+++ b/tests/src/Regressions/coreclr/1534/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1535/project.json
+++ b/tests/src/Regressions/coreclr/1535/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/1549/project.json
+++ b/tests/src/Regressions/coreclr/1549/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/coreclr/72162/project.json
+++ b/tests/src/Regressions/coreclr/72162/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/Regressions/expl_double/project.json
+++ b/tests/src/Regressions/expl_double/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/compilerservices/dynamicobjectproperties/project.json
+++ b/tests/src/baseservices/compilerservices/dynamicobjectproperties/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/AccessViolationException/project.json
+++ b/tests/src/baseservices/exceptions/AccessViolationException/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/StackTracePreserve/project.json
+++ b/tests/src/baseservices/exceptions/StackTracePreserve/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/generics/project.json
+++ b/tests/src/baseservices/exceptions/generics/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/Dev11/147911/project.json
+++ b/tests/src/baseservices/exceptions/regressions/Dev11/147911/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/Dev11/154243/project.json
+++ b/tests/src/baseservices/exceptions/regressions/Dev11/154243/project.json
@@ -32,7 +32,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/COOL/project.json
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/COOL/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/project.json
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/coverage/project.json
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/coverage/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/v1.0/project.json
+++ b/tests/src/baseservices/exceptions/regressions/v1.0/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/v4.0/640474/project.json
+++ b/tests/src/baseservices/exceptions/regressions/v4.0/640474/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/v4.0/706099/project.json
+++ b/tests/src/baseservices/exceptions/regressions/v4.0/706099/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/whidbeyM3.2/project.json
+++ b/tests/src/baseservices/exceptions/regressions/whidbeyM3.2/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/whidbeybeta2/349379/project.json
+++ b/tests/src/baseservices/exceptions/regressions/whidbeybeta2/349379/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/whidbeybeta2/366085/project.json
+++ b/tests/src/baseservices/exceptions/regressions/whidbeybeta2/366085/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/whidbeym3.3/106011/project.json
+++ b/tests/src/baseservices/exceptions/regressions/whidbeym3.3/106011/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/whidbeym3.3/293674/project.json
+++ b/tests/src/baseservices/exceptions/regressions/whidbeym3.3/293674/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/regressions/whidbeym3.3/302680/project.json
+++ b/tests/src/baseservices/exceptions/regressions/whidbeym3.3/302680/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/sharedexceptions/emptystacktrace/project.json
+++ b/tests/src/baseservices/exceptions/sharedexceptions/emptystacktrace/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/simple/project.json
+++ b/tests/src/baseservices/exceptions/simple/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/exceptions/unittests/project.json
+++ b/tests/src/baseservices/exceptions/unittests/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/finalization/project.json
+++ b/tests/src/baseservices/finalization/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/ilasm_ildasm/regression/dd130885/project.json
+++ b/tests/src/baseservices/ilasm_ildasm/regression/dd130885/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey267905/project.json
+++ b/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey267905/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey305155/project.json
+++ b/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey305155/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey395914/project.json
+++ b/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey395914/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/multidimmarray/project.json
+++ b/tests/src/baseservices/multidimmarray/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/regression/v1/assembly/vos/cool/helloworld/project.json
+++ b/tests/src/baseservices/regression/v1/assembly/vos/cool/helloworld/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/regression/v1/assembly/vos/cool/multipleassembly/project.json
+++ b/tests/src/baseservices/regression/v1/assembly/vos/cool/multipleassembly/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/regression/v1/seh/vc/chain/project.json
+++ b/tests/src/baseservices/regression/v1/seh/vc/chain/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/regression/v1/threads/functional/thread/project.json
+++ b/tests/src/baseservices/regression/v1/threads/functional/thread/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_support/project.json
+++ b/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_support/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_threadpoolnullchecks/project.json
+++ b/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_threadpoolnullchecks/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/regression/v1/threads/hostedscenario/apunload/project.json
+++ b/tests/src/baseservices/regression/v1/threads/hostedscenario/apunload/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/regression/v1/threads/hostedscenario/apunloadtwo/project.json
+++ b/tests/src/baseservices/regression/v1/threads/hostedscenario/apunloadtwo/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/commitstackonlyasneeded/project.json
+++ b/tests/src/baseservices/threading/commitstackonlyasneeded/project.json
@@ -32,7 +32,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/coverage/Nullref/project.json
+++ b/tests/src/baseservices/threading/coverage/Nullref/project.json
@@ -33,7 +33,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/currentculture/project.json
+++ b/tests/src/baseservices/threading/currentculture/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/delegate/project.json
+++ b/tests/src/baseservices/threading/delegate/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/events/AutoResetEvent/project.json
+++ b/tests/src/baseservices/threading/events/AutoResetEvent/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/events/EventWaitHandle/AutoReset/project.json
+++ b/tests/src/baseservices/threading/events/EventWaitHandle/AutoReset/project.json
@@ -32,7 +32,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/events/EventWaitHandle/ManualReset/project.json
+++ b/tests/src/baseservices/threading/events/EventWaitHandle/ManualReset/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/events/EventWaitHandle/unit/project.json
+++ b/tests/src/baseservices/threading/events/EventWaitHandle/unit/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/events/ManualResetEvent/project.json
+++ b/tests/src/baseservices/threading/events/ManualResetEvent/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/generics/Monitor/project.json
+++ b/tests/src/baseservices/threading/generics/Monitor/project.json
@@ -32,7 +32,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/generics/TimerCallback/project.json
+++ b/tests/src/baseservices/threading/generics/TimerCallback/project.json
@@ -32,7 +32,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/generics/WaitCallback/project.json
+++ b/tests/src/baseservices/threading/generics/WaitCallback/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/generics/syncdelegate/project.json
+++ b/tests/src/baseservices/threading/generics/syncdelegate/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/generics/threadstart/project.json
+++ b/tests/src/baseservices/threading/generics/threadstart/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/interlocked/add/project.json
+++ b/tests/src/baseservices/threading/interlocked/add/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/interlocked/checkreturn/project.json
+++ b/tests/src/baseservices/threading/interlocked/checkreturn/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/interlocked/compareexchange/project.json
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/interlocked/ctorchk/project.json
+++ b/tests/src/baseservices/threading/interlocked/ctorchk/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/interlocked/decrement/project.json
+++ b/tests/src/baseservices/threading/interlocked/decrement/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/interlocked/exchange/project.json
+++ b/tests/src/baseservices/threading/interlocked/exchange/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/interlocked/increment/project.json
+++ b/tests/src/baseservices/threading/interlocked/increment/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/interlocked/read/project.json
+++ b/tests/src/baseservices/threading/interlocked/read/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/monitor/ctorchk/project.json
+++ b/tests/src/baseservices/threading/monitor/ctorchk/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/monitor/enter/project.json
+++ b/tests/src/baseservices/threading/monitor/enter/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/monitor/exit/project.json
+++ b/tests/src/baseservices/threading/monitor/exit/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/monitor/isentered/project.json
+++ b/tests/src/baseservices/threading/monitor/isentered/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/monitor/pulse/project.json
+++ b/tests/src/baseservices/threading/monitor/pulse/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/monitor/pulseall/project.json
+++ b/tests/src/baseservices/threading/monitor/pulseall/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/monitor/tryenter/project.json
+++ b/tests/src/baseservices/threading/monitor/tryenter/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/monitor/unownedlock/project.json
+++ b/tests/src/baseservices/threading/monitor/unownedlock/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/monitor/wait/project.json
+++ b/tests/src/baseservices/threading/monitor/wait/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/mutex/abandonedmutex/project.json
+++ b/tests/src/baseservices/threading/mutex/abandonedmutex/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/mutex/misc/project.json
+++ b/tests/src/baseservices/threading/mutex/misc/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/mutex/openexisting/project.json
+++ b/tests/src/baseservices/threading/mutex/openexisting/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/paramthreadstart/project.json
+++ b/tests/src/baseservices/threading/paramthreadstart/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/13662/project.json
+++ b/tests/src/baseservices/threading/regressions/13662/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/17360/project.json
+++ b/tests/src/baseservices/threading/regressions/17360/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/269336/project.json
+++ b/tests/src/baseservices/threading/regressions/269336/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/30032/project.json
+++ b/tests/src/baseservices/threading/regressions/30032/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/576463/project.json
+++ b/tests/src/baseservices/threading/regressions/576463/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/6906/project.json
+++ b/tests/src/baseservices/threading/regressions/6906/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/beta1/project.json
+++ b/tests/src/baseservices/threading/regressions/beta1/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/beta2/project.json
+++ b/tests/src/baseservices/threading/regressions/beta2/project.json
@@ -32,7 +32,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/devdiv489437/project.json
+++ b/tests/src/baseservices/threading/regressions/devdiv489437/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/regressions/whidbey_m3/project.json
+++ b/tests/src/baseservices/threading/regressions/whidbey_m3/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/semaphore/ctoropen/project.json
+++ b/tests/src/baseservices/threading/semaphore/ctoropen/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/semaphore/unit/project.json
+++ b/tests/src/baseservices/threading/semaphore/unit/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/stress/sudoku/project.json
+++ b/tests/src/baseservices/threading/stress/sudoku/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/threadpool/bindhandle/project.json
+++ b/tests/src/baseservices/threading/threadpool/bindhandle/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/threadpool/ctorchk/project.json
+++ b/tests/src/baseservices/threading/threadpool/ctorchk/project.json
@@ -32,7 +32,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/threadpool/unregister/project.json
+++ b/tests/src/baseservices/threading/threadpool/unregister/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/threadstatic/project.json
+++ b/tests/src/baseservices/threading/threadstatic/project.json
@@ -31,7 +31,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/waithandle/misc/project.json
+++ b/tests/src/baseservices/threading/waithandle/misc/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/waithandle/waitall/project.json
+++ b/tests/src/baseservices/threading/waithandle/waitall/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/waithandle/waitany/project.json
+++ b/tests/src/baseservices/threading/waithandle/waitany/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/threading/waithandle/waitone/project.json
+++ b/tests/src/baseservices/threading/waithandle/waitone/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/tools/roundtrip/dlls/project.json
+++ b/tests/src/baseservices/tools/roundtrip/dlls/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/baseservices/visibility/project.json
+++ b/tests/src/baseservices/visibility/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/hosting/coreclr/activation/sxshost/project.json
+++ b/tests/src/hosting/coreclr/activation/sxshost/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/hosting/samples/hosting/usercode/project.json
+++ b/tests/src/hosting/samples/hosting/usercode/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/hosting/samples/resolveevent/usercodedependency/project.json
+++ b/tests/src/hosting/samples/resolveevent/usercodedependency/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/hosting/stress/testset1/project.json
+++ b/tests/src/hosting/stress/testset1/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/managed/Compilation/project.json
+++ b/tests/src/managed/Compilation/project.json
@@ -2,30 +2,31 @@
   "dependencies": {
     "Microsoft.CodeAnalysis.Compilers": "1.1.1",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24117-00",
-    "System.Collections": "4.0.10",
-    "System.Collections.Concurrent": "4.0.10",
+    "System.Collections": "4.0.11-rc3-24117-00",
+    "System.Collections.Concurrent": "4.0.12-rc3-24117-00",
     "System.Collections.Immutable": "1.1.37",
     "System.Console": "4.0.0-rc3-24117-00",
     "System.Dynamic.Runtime": "4.0.11-rc3-24117-00",
-    "System.IO": "4.0.10",
+    "System.IO": "4.1.0-rc3-24117-00",
     "System.IO.FileSystem": "4.0.1-rc3-24117-00",
-    "System.IO.FileSystem.Primitives": "4.0.0",
+    "System.IO.FileSystem.Primitives": "4.0.1-rc3-24117-00",
     "System.Linq": "4.1.0-rc3-24117-00",
     "System.Runtime": "4.1.0-rc3-24117-00",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Runtime.Handles": "4.0.0",
-    "System.Text.Encoding": "4.0.10",
-    "System.Threading": "4.0.10",
-    "System.Threading.Overlapped": "4.0.0",
-    "System.Threading.Tasks": "4.0.10",
+    "System.Runtime.Extensions": "4.1.0-rc3-24117-00",
+    "System.Runtime.Handles": "4.0.1-rc3-24117-00",
+    "System.Text.Encoding": "4.0.11-rc3-24117-00",
+    "System.Threading": "4.0.11-rc3-24117-00",
+    "System.Threading.Overlapped": "4.0.1-rc3-24117-00",
+    "System.Threading.Tasks": "4.0.11-rc3-24117-00",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "System.Threading.ThreadPool": "4.0.10-rc3-24117-00",
     "System.Security.Cryptography.Algorithms": "4.2.0-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {
+    "netcoreapp1.0": {
       "imports": [
         "netstandard1.6",
+        "dnxcore50",
         "portable-net45+win8"
       ]
     }

--- a/tests/src/performance/perflab/project.json
+++ b/tests/src/performance/perflab/project.json
@@ -15,8 +15,11 @@
     "xunit.runner.utility": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8"
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {

--- a/tests/src/readytorun/genericsload/project.json
+++ b/tests/src/readytorun/genericsload/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/readytorun/project.json
+++ b/tests/src/readytorun/project.json
@@ -32,7 +32,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/readytorun/testv1/project.json
+++ b/tests/src/readytorun/testv1/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/readytorun/testv2/project.json
+++ b/tests/src/readytorun/testv2/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/reflection/regression/dev10bugs/project.json
+++ b/tests/src/reflection/regression/dev10bugs/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/reflection/regression/reflectionrepromasterforsl/project.json
+++ b/tests/src/reflection/regression/reflectionrepromasterforsl/project.json
@@ -30,7 +30,7 @@
     "System.Xml.XmlSerializer": "4.0.11-rc3-24117-00"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/runtime/project.json
+++ b/tests/src/runtime/project.json
@@ -33,7 +33,7 @@
     "System.Xml.XDocument": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "netcoreapp1.0": { "imports": "dnxcore50" }
   },
   "runtimes": {
     "win7-x86": {},


### PR DESCRIPTION
Currently the build produces a vast amount of warnings in the output about the wrong framework being referenced.

> warning : Your project is not referencing the ".NETCoreApp,Version=v1.0" framework. Add a reference to ".NETCoreApp,Version=v1.0" in the "frameworks" section of your project.json, and then re-run NuGet restore.