### PR TITLE
Consolidate much of the duplicated code across Encoding implementations

### DIFF
--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -982,6 +982,7 @@
     <TextSources Include="$(BclSourcesRoot)\System\Text\EncoderFallback.cs" />
     <TextSources Include="$(BclSourcesRoot)\System\Text\EncoderReplacementFallback.cs" />
     <TextSources Include="$(BclSourcesRoot)\System\Text\Encoding.cs" />
+    <TextSources Include="$(BclSourcesRoot)\System\Text\EncodingForwarder.cs" />
     <TextSources Include="$(BclSourcesRoot)\System\Text\EncodingInfo.cs" />
     <TextSources Include="$(BclSourcesRoot)\System\Text\EncodingNLS.cs" />
     <TextSources Include="$(BclSourcesRoot)\System\Text\EncodingProvider.cs" />

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -83,18 +83,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
-            // Validate Parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            // Call it with empty encoder
-            return GetByteCount(chars, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
         // Parent method is safe.

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -154,7 +154,7 @@ namespace System.Text
             return EncodingForwarder.GetString(this, bytes, byteIndex, byteCount);
         }
         
-        // End of overriden methods which use EncodingForwarder
+        // End of overridden methods which use EncodingForwarder
 
         // GetByteCount
         // Note: We start by assuming that the output will be the same as count.  Having

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -141,29 +141,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetCharCount(byte[] bytes, int index, int count)
+        public override int GetCharCount(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input just return 0, fixed doesn't like 0 length arrays
-            if (count == 0)
-                return 0;
-
-            // Just call pointer version
-            fixed (byte* pBytes = bytes)
-                return GetCharCount(pBytes + index, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -164,43 +164,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? "byteIndex" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if ( bytes.Length - byteIndex < byteCount)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (charIndex < 0 || charIndex > chars.Length)
-                throw new ArgumentOutOfRangeException("charIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0 & avoid fixed problem
-            if (byteCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int charCount = chars.Length - charIndex;
-
-            // Fixed doesn't like empty char arrays
-            if (chars.Length == 0)
-                chars = new char[1];
-
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
-                    // Remember that charCount is # to decode, not size of array
-                    return GetChars(pBytes + byteIndex, byteCount,
-                                    pChars + charIndex, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -56,29 +56,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetByteCount(char[] chars, int index, int count)
+        public override int GetByteCount(char[] chars, int index, int count)
         {
-            // Validate input parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - index < count)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0, avoid fixed empty array problem
-            if (count == 0)
-                return 0;
-
-            // Just call the pointer version
-            fixed (char* pChars = chars)
-                return GetByteCount(pChars + index, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -114,43 +114,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetBytes(char[] chars, int charIndex, int charCount,
+        public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
-            // Validate parameters
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                     Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If nothing to encode return 0, avoid fixed problem
-            if (charCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like empty byte arrays
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
-                    // Remember that byteCount is # to decode, not size of array.
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -155,17 +155,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetCharCount(bytes, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -191,29 +191,11 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe String GetString(byte[] bytes, int byteIndex, int byteCount)
+        public override String GetString(byte[] bytes, int byteIndex, int byteCount)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex < 0 ? "byteIndex" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-
-            if (bytes.Length - byteIndex < byteCount)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // Avoid problems with empty input buffer
-            if (byteCount == 0) return String.Empty;
-
-            fixed (byte* pBytes = bytes)
-                return String.CreateStringFromEncoding(
-                    pBytes + byteIndex, byteCount, this);
+            // NOTE: If the byteIndex/byteCount parameters are invalid, this will
+            // throw an ArgumentOutOfRange for "index" or "count" instead of those names.
+            return EncodingForwarder.GetString(this, bytes, byteIndex, byteCount);
         }
 
         //

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -36,35 +36,32 @@ namespace System.Text
             this.decoderFallback = DecoderFallback.ReplacementFallback;
         }
 
-        //
         // WARNING: GetByteCount(string chars), GetBytes(string chars,...), and GetString(byte[] byteIndex...)
         // WARNING: have different variable names than EncodingNLS.cs, so this can't just be cut & pasted,
         // WARNING: or it'll break VB's way of calling these.
-        //
-        // The following methods are copied from EncodingNLS.cs.
-        // Unfortunately EncodingNLS.cs is internal and we're public, so we have to reimpliment them here.
-        // These should be kept in sync for the following classes:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        //
 
+        // NOTE: Many methods in this class forward to EncodingForwarder for
+        // validating arguments/wrapping the unsafe methods in this class 
+        // which do the actual work. That class contains
+        // shared logic for doing this which is used by
+        // ASCIIEncoding, EncodingNLS, UnicodeEncoding, UTF32Encoding,
+        // UTF7Encoding, and UTF8Encoding.
+        // The reason the code is separated out into a static class, rather
+        // than a base class which overrides all of these methods for us
+        // (which is what EncodingNLS is for internal Encodings) is because
+        // that's really more of an implementation detail so it's internal.
+        // At the same time, C# doesn't allow a public class subclassing an
+        // internal/private one, so we end up having to re-override these
+        // methods in all of the public Encodings + EncodingNLS.
+        
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String chars)
@@ -74,10 +71,6 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
         [System.Runtime.InteropServices.ComVisible(false)]
@@ -85,11 +78,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
-
-        // Parent method is safe.
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(String chars, int charIndex, int charCount,
@@ -107,11 +95,6 @@ namespace System.Text
         // Alternatively, the GetMaxByteCount method can be used to
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
@@ -119,10 +102,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -134,21 +113,12 @@ namespace System.Text
 
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -158,21 +128,12 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
-
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
             return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -184,11 +145,6 @@ namespace System.Text
 
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String GetString(byte[] bytes, int byteIndex, int byteCount)
@@ -197,10 +153,8 @@ namespace System.Text
             // throw an ArgumentOutOfRange for "index" or "count" instead of those names.
             return EncodingForwarder.GetString(this, bytes, byteIndex, byteCount);
         }
-
-        //
-        // End of standard methods copied from EncodingNLS.cs
-        //
+        
+        // End of overriden methods which use EncodingForwarder
 
         // GetByteCount
         // Note: We start by assuming that the output will be the same as count.  Having

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -92,36 +92,11 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetBytes(String chars, int charIndex, int charCount,
+        public override int GetBytes(String chars, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like empty byte arrays
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = chars)
-                fixed ( byte* pBytes = bytes)
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            // NOTE: Will throw ArgumentNull of "s" is chars is null.
+            return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
 
         // Encodes a range of characters in a character array into a range of bytes

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -67,15 +67,11 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetByteCount(String chars)
+        public override int GetByteCount(String chars)
         {
-            // Validate input
-            if (chars==null)
-                throw new ArgumentNullException("chars");
-            Contract.EndContractBlock();
-
-            fixed (char* pChars = chars)
-                return GetByteCount(pChars, chars.Length, null);
+            // NOTE: If chars is null, this will throw an ArgumentNullException
+            // with the parameter name "s" rather than "chars"
+            return EncodingForwarder.GetByteCount(this, chars);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -179,17 +179,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetChars(bytes, byteCount, chars, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteCount, chars, charCount);
         }
 
         // Returns a string containing the decoded representation of a range of

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -57,13 +57,11 @@ namespace System.Text
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String chars)
         {
             return EncodingForwarder.GetByteCount(this, chars);
@@ -77,7 +75,6 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(String chars, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
@@ -93,7 +90,6 @@ namespace System.Text
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
@@ -111,7 +107,6 @@ namespace System.Text
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
@@ -125,7 +120,6 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
@@ -143,7 +137,6 @@ namespace System.Text
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override String GetString(byte[] bytes, int byteIndex, int byteCount)
         {
             return EncodingForwarder.GetString(this, bytes, byteIndex, byteCount);

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -66,8 +66,6 @@ namespace System.Text
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String chars)
         {
-            // NOTE: If chars is null, this will throw an ArgumentNullException
-            // with the parameter name "s" rather than "chars"
             return EncodingForwarder.GetByteCount(this, chars);
         }
 
@@ -83,7 +81,6 @@ namespace System.Text
         public override int GetBytes(String chars, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
-            // NOTE: Will throw ArgumentNull of "s" is chars is null.
             return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
 
@@ -149,8 +146,6 @@ namespace System.Text
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String GetString(byte[] bytes, int byteIndex, int byteCount)
         {
-            // NOTE: If the byteIndex/byteCount parameters are invalid, this will
-            // throw an ArgumentOutOfRange for "index" or "count" instead of those names.
             return EncodingForwarder.GetString(this, bytes, byteIndex, byteCount);
         }
         

--- a/src/mscorlib/src/System/Text/ASCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ASCIIEncoding.cs
@@ -129,17 +129,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetBytes(chars, charCount, bytes, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charCount, bytes, byteCount);
         }
 
         // Returns the number of characters produced by decoding a range of bytes

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -52,6 +52,7 @@ namespace System.Text
 
         public unsafe static int GetByteCount(Encoding encoding, string s)
         {
+            Contract.Assert(encoding != null);
             if (s == null)
             {
                 throw new ArgumentNullException("s");
@@ -68,6 +69,23 @@ namespace System.Text
 
             fixed (char* pChars = s)
                 return encoding.GetByteCount(pChars, s.Length, encoder: null);
+        }
+
+        public unsafe static int GetByteCount(Encoding encoding, char* chars, int count)
+        {
+            Contract.Assert(encoding != null);
+            if (chars == null)
+            {
+                throw new ArgumentNullException("chars", Environment.GetResourceString("ArgumentNull_Array"));
+            }
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+            Contract.EndContractBlock();
+
+            // Call the internal version, with an empty encoder
+            return encoding.GetByteCount(chars, count, encoder: null);
         }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -87,5 +87,41 @@ namespace System.Text
             // Call the internal version, with an empty encoder
             return encoding.GetByteCount(chars, count, encoder: null);
         }
+
+        public unsafe static int GetBytes(Encoding encoding, string s, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        {
+            Contract.Assert(encoding != null);
+            if (s == null || bytes == null)
+            {
+                throw new ArgumentNullException(s == null ? "s" : "bytes", Environment.GetResourceString("ArgumentNull_Array"));
+            }
+            if (charIndex < 0 || charCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(charIndex < 0 ? "charIndex" : "charCount", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+            if (s.Length - charIndex < charCount)
+            {
+                throw new ArgumentOutOfRangeException("s", Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
+            }
+            if (byteIndex < 0 || byteIndex > bytes.Length)
+            {
+                throw new ArgumentOutOfRangeException("byteIndex", Environment.GetResourceString("ArgumentOutOfRange_Index"));
+            }
+            Contract.EndContractBlock();
+
+            int byteCount = bytes.Length - byteIndex;
+
+            // Fixed doesn't like empty arrays
+            // TODO: Consider just throwing an
+            // exception here instead of allocating
+            // a new array, if (byteCount == 0)
+            if (bytes.Length == 0)
+                bytes = new byte[1];
+            
+            fixed (char* pChars = s) fixed (byte* pBytes = bytes)
+            {
+                return encoding.GetBytes(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, encoder: null);
+            }
+        }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Contracts;
+
+namespace System.Text
+{
+    // Shared implementations for commonly overriden Encoding methods
+
+    internal static class EncodingForwarder
+    {
+        // We normally have to duplicate a lot of code between UTF8Encoding,
+        // UTF7Encoding, EncodingNLS, etc. because we want to override many
+        // of the methods in all of those classes to just forward to the unsafe
+        // version. (e.g. GetBytes(char[]))
+        // Ideally, everything would just derive from EncodingNLS, but that's
+        // not exposed in the public API, and C# prohibits a public class from
+        // inheriting from an internal one. So, we have to override each of the
+        // methods in question and repeat the argument validation/logic.
+
+        // These set of methods exist so instead of duplicating code, we can
+        // simply have those overriden methods call here to do the actual work.
+
+        public unsafe static int GetByteCount(Encoding encoding, char[] chars, int index, int count)
+        {
+            // Validate parameters
+
+            Contract.Assert(encoding != null); // this parameter should only be affected internally, so just do a debug check here
+            if (chars == null)
+            {
+                throw new ArgumentNullException("chars", Environment.GetResourceString("ArgumentNull_Array"));
+            }
+            if (index < 0 || count < 0)
+            {
+                throw new ArgumentOutOfRangeException(index < 0 ? "index" : "count", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+            if (chars.Length - index < count)
+            {
+                throw new ArgumentOutOfRangeException("chars", Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
+            }
+            Contract.EndContractBlock();
+
+            // If no input, return 0, avoid fixed empty array problem
+            if (count == 0)
+                return 0;
+
+            // Just call the pointer version
+            fixed (char* pChars = chars)
+                return encoding.GetByteCount(pChars + index, count, null);
+        }
+    }
+}

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -179,5 +179,31 @@ namespace System.Text
 
             return encoding.GetBytes(chars, charCount, bytes, byteCount, encoder: null);
         }
+
+        public unsafe static int GetCharCount(Encoding encoding, byte[] bytes, int index, int count)
+        {
+            Contract.Assert(encoding != null);
+            if (bytes == null)
+            {
+                throw new ArgumentNullException("bytes", Environment.GetResourceString("ArgumentNull_Array"));
+            }
+            if (index < 0 || count < 0)
+            {
+                throw new ArgumentOutOfRangeException(index < 0 ? "index" : "count", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+            if (bytes.Length - index < count)
+            {
+                throw new ArgumentOutOfRangeException("bytes", Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
+            }
+            Contract.EndContractBlock();
+
+            // If no input just return 0, fixed doesn't like 0 length arrays.
+            if (count == 0)
+                return 0;
+
+            // Just call pointer version
+            fixed (byte* pBytes = bytes)
+                return encoding.GetCharCount(pBytes + index, count, decoder: null);
+        }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -22,6 +22,14 @@ namespace System.Text
         // These set of methods exist so instead of duplicating code, we can
         // simply have those overriden methods call here to do the actual work.
 
+        // NOTE: This class should ONLY be called from Encodings that override
+        // the internal methods which accept an Encoder/DecoderNLS. The reason
+        // for this is that by default, those methods just call the same overload
+        // except without the encoder/decoder parameter. If an overriden method
+        // without that parameter calls this class, which calls the overload with
+        // the parameter, it will call the same method again, which will eventually
+        // lead to a StackOverflowException.
+
         public unsafe static int GetByteCount(Encoding encoding, char[] chars, int index, int count)
         {
             // Validate parameters
@@ -204,6 +212,22 @@ namespace System.Text
             // Just call pointer version
             fixed (byte* pBytes = bytes)
                 return encoding.GetCharCount(pBytes + index, count, decoder: null);
+        }
+
+        public unsafe static int GetCharCount(Encoding encoding, byte* bytes, int count)
+        {
+            Contract.Assert(encoding != null);
+            if (bytes == null)
+            {
+                throw new ArgumentNullException("bytes", Environment.GetResourceString("ArgumentNull_Array"));
+            }
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+            Contract.EndContractBlock();
+
+            return encoding.GetCharCount(bytes, count, decoder: null);
         }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -130,9 +130,6 @@ namespace System.Text
             int byteCount = bytes.Length - byteIndex;
 
             // Fixed doesn't like empty arrays
-            // TODO: Consider just throwing an
-            // exception here instead of allocating
-            // a new array, if (byteCount == 0)
             if (bytes.Length == 0)
                 bytes = new byte[1];
             

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -64,6 +64,7 @@ namespace System.Text
             if (s == null)
             {
                 string paramName = encoding is ASCIIEncoding ? "chars" : "s"; // ASCIIEncoding calls the string chars
+                // UTF8Encoding does this as well, but it originally threw an ArgumentNull for "s" so don't check for that
                 throw new ArgumentNullException(paramName);
             }
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.Contracts;
+using System.Security;
 
 namespace System.Text
 {
@@ -30,6 +31,7 @@ namespace System.Text
         // the parameter, it will call the same method again, which will eventually
         // lead to a StackOverflowException.
 
+        [SecuritySafeCritical]
         public unsafe static int GetByteCount(Encoding encoding, char[] chars, int index, int count)
         {
             // Validate parameters
@@ -58,6 +60,7 @@ namespace System.Text
                 return encoding.GetByteCount(pChars + index, count, encoder: null);
         }
 
+        [SecuritySafeCritical]
         public unsafe static int GetByteCount(Encoding encoding, string s)
         {
             Contract.Assert(encoding != null);
@@ -81,6 +84,7 @@ namespace System.Text
                 return encoding.GetByteCount(pChars, s.Length, encoder: null);
         }
 
+        [SecurityCritical]
         public unsafe static int GetByteCount(Encoding encoding, char* chars, int count)
         {
             Contract.Assert(encoding != null);
@@ -98,6 +102,7 @@ namespace System.Text
             return encoding.GetByteCount(chars, count, encoder: null);
         }
 
+        [SecuritySafeCritical]
         public unsafe static int GetBytes(Encoding encoding, string s, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             Contract.Assert(encoding != null);
@@ -137,6 +142,7 @@ namespace System.Text
             }
         }
 
+        [SecuritySafeCritical]
         public unsafe static int GetBytes(Encoding encoding, char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
             Contract.Assert(encoding != null);
@@ -177,6 +183,7 @@ namespace System.Text
             }
         }
 
+        [SecurityCritical]
         public unsafe static int GetBytes(Encoding encoding, char* chars, int charCount, byte* bytes, int byteCount)
         {
             Contract.Assert(encoding != null);
@@ -193,6 +200,7 @@ namespace System.Text
             return encoding.GetBytes(chars, charCount, bytes, byteCount, encoder: null);
         }
 
+        [SecuritySafeCritical]
         public unsafe static int GetCharCount(Encoding encoding, byte[] bytes, int index, int count)
         {
             Contract.Assert(encoding != null);
@@ -219,6 +227,7 @@ namespace System.Text
                 return encoding.GetCharCount(pBytes + index, count, decoder: null);
         }
 
+        [SecurityCritical]
         public unsafe static int GetCharCount(Encoding encoding, byte* bytes, int count)
         {
             Contract.Assert(encoding != null);
@@ -235,6 +244,7 @@ namespace System.Text
             return encoding.GetCharCount(bytes, count, decoder: null);
         }
 
+        [SecuritySafeCritical]
         public unsafe static int GetChars(Encoding encoding, byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
         {
             Contract.Assert(encoding != null);
@@ -273,6 +283,7 @@ namespace System.Text
             }
         }
 
+        [SecurityCritical]
         public unsafe static int GetChars(Encoding encoding, byte* bytes, int byteCount, char* chars, int charCount)
         {
             Contract.Assert(encoding != null);
@@ -289,6 +300,7 @@ namespace System.Text
             return encoding.GetChars(bytes, byteCount, chars, charCount, decoder: null);
         }
 
+        [SecuritySafeCritical]
         public unsafe static string GetString(Encoding encoding, byte[] bytes, int index, int count)
         {
             Contract.Assert(encoding != null);

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -163,5 +163,21 @@ namespace System.Text
                 return encoding.GetBytes(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, encoder: null);
             }
         }
+
+        public unsafe static int GetBytes(Encoding encoding, char* chars, int charCount, byte* bytes, int byteCount)
+        {
+            Contract.Assert(encoding != null);
+            if (bytes == null || chars == null)
+            {
+                throw new ArgumentNullException(bytes == null ? "bytes" : "chars", Environment.GetResourceString("ArgumentNull_Array"));
+            }
+            if (charCount < 0 || byteCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(charCount < 0 ? "charCount" : "byteCount", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+            Contract.EndContractBlock();
+
+            return encoding.GetBytes(chars, charCount, bytes, byteCount, encoder: null);
+        }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -63,7 +63,8 @@ namespace System.Text
             Contract.Assert(encoding != null);
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                string paramName = encoding is ASCIIEncoding ? "chars" : "s"; // ASCIIEncoding calls the string chars
+                throw new ArgumentNullException(paramName);
             }
             Contract.EndContractBlock();
 
@@ -101,7 +102,8 @@ namespace System.Text
             Contract.Assert(encoding != null);
             if (s == null || bytes == null)
             {
-                throw new ArgumentNullException(s == null ? "s" : "bytes", Environment.GetResourceString("ArgumentNull_Array"));
+                string stringName = encoding is ASCIIEncoding ? "chars" : "s"; // ASCIIEncoding calls the first parameter chars
+                throw new ArgumentNullException(s == null ? stringName : "bytes", Environment.GetResourceString("ArgumentNull_Array"));
             }
             if (charIndex < 0 || charCount < 0)
             {
@@ -109,7 +111,9 @@ namespace System.Text
             }
             if (s.Length - charIndex < charCount)
             {
-                throw new ArgumentOutOfRangeException("s", Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
+                string stringName = encoding is ASCIIEncoding ? "chars" : "s"; // ASCIIEncoding calls the first parameter chars
+                // Duplicate the above check since we don't want the overhead of a type check on the general path
+                throw new ArgumentOutOfRangeException(stringName, Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
             }
             if (byteIndex < 0 || byteIndex > bytes.Length)
             {
@@ -293,7 +297,11 @@ namespace System.Text
             }
             if (index < 0 || count < 0)
             {
-                throw new ArgumentOutOfRangeException(index < 0 ? "index" : "count", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                // ASCIIEncoding has different names for its parameters here (byteIndex, byteCount)
+                bool ascii = encoding is ASCIIEncoding;
+                string indexName = ascii ? "byteIndex" : "index";
+                string countName = ascii ? "byteCount" : "count";
+                throw new ArgumentOutOfRangeException(index < 0 ? indexName : countName, Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             }
             if (bytes.Length - index < count)
             {

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -123,5 +123,45 @@ namespace System.Text
                 return encoding.GetBytes(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, encoder: null);
             }
         }
+
+        public unsafe static int GetBytes(Encoding encoding, char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        {
+            Contract.Assert(encoding != null);
+            if (chars == null || bytes == null)
+            {
+                throw new ArgumentNullException(chars == null ? "chars" : "bytes", Environment.GetResourceString("ArgumentNull_Array"));
+            }
+            if (charIndex < 0 || charCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(charIndex < 0 ? "charIndex" : "charCount", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+            if (chars.Length - charIndex < charCount)
+            {
+                throw new ArgumentOutOfRangeException("chars", Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
+            }
+            if (byteIndex < 0 || byteIndex > bytes.Length)
+            {
+                throw new ArgumentOutOfRangeException("byteIndex", Environment.GetResourceString("ArgumentOutOfRange_Index"));
+            }
+            Contract.EndContractBlock();
+
+            // If nothing to encode return 0, avoid fixed problem
+            if (charCount == 0)
+                return 0;
+
+            // Note that this is the # of bytes to decode,
+            // not the size of the array
+            int byteCount = bytes.Length - byteIndex;
+
+            // Fixed doesn't like 0 length arrays.
+            if (bytes.Length == 0)
+                bytes = new byte[1];
+            
+            // Just call the (internal) pointer version
+            fixed (char* pChars = chars) fixed (byte* pBytes = bytes)
+            {
+                return encoding.GetBytes(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, encoder: null);
+            }
+        }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -267,5 +267,21 @@ namespace System.Text
                 return encoding.GetChars(pBytes + byteIndex, byteCount, pChars + charIndex, charCount, decoder: null);
             }
         }
+
+        public unsafe static int GetChars(Encoding encoding, byte* bytes, int byteCount, char* chars, int charCount)
+        {
+            Contract.Assert(encoding != null);
+            if (bytes == null || chars == null)
+            {
+                throw new ArgumentNullException(bytes == null ? "bytes" : "chars", Environment.GetResourceString("ArgumentNull_Array"));
+            }
+            if (charCount < 0 || byteCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(charCount < 0 ? "charCount" : "byteCount", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+            Contract.EndContractBlock();
+
+            return encoding.GetChars(bytes, byteCount, chars, charCount, decoder: null);
+        }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -229,5 +229,43 @@ namespace System.Text
 
             return encoding.GetCharCount(bytes, count, decoder: null);
         }
+
+        public unsafe static int GetChars(Encoding encoding, byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+        {
+            Contract.Assert(encoding != null);
+            if (bytes == null || chars == null)
+            {
+                throw new ArgumentNullException(bytes == null ? "bytes" : "chars", Environment.GetResourceString("ArgumentNull_Array"));
+            }
+            if (byteIndex < 0 || byteCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(byteIndex < 0 ? "byteIndex" : "byteCount", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+            if (bytes.Length - byteIndex < byteCount)
+            {
+                throw new ArgumentOutOfRangeException("bytes", Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
+            }
+            if (charIndex < 0 || charIndex > chars.Length)
+            {
+                throw new ArgumentOutOfRangeException("charIndex", Environment.GetResourceString("ArgumentOutOfRange_Index"));
+            }
+            Contract.EndContractBlock();
+
+            if (byteCount == 0)
+                return 0;
+
+            // NOTE: This is the # of chars we can decode,
+            // not the size of the array
+            int charCount = chars.Length - charIndex;
+
+            // Fixed doesn't like 0 length arrays.
+            if (chars.Length == 0)
+                chars = new char[1];
+
+            fixed (byte* pBytes = bytes) fixed (char* pChars = chars)
+            {
+                return encoding.GetChars(pBytes + byteIndex, byteCount, pChars + charIndex, charCount, decoder: null);
+            }
+        }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -63,7 +63,7 @@ namespace System.Text
             // null strings/empty char arrays. See
             // http://stackoverflow.com/q/37757751/4077294
             // Regardless, we may still want to check
-            // for if (chars.Length == 0) in the future
+            // for if (s.Length == 0) in the future
             // and short-circuit as an optimization (TODO).
 
             fixed (char* pChars = s)

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -45,9 +45,29 @@ namespace System.Text
             if (count == 0)
                 return 0;
 
-            // Just call the pointer version
+            // Just call the (internal) pointer version
             fixed (char* pChars = chars)
-                return encoding.GetByteCount(pChars + index, count, null);
+                return encoding.GetByteCount(pChars + index, count, encoder: null);
+        }
+
+        public unsafe static int GetByteCount(Encoding encoding, string s)
+        {
+            if (s == null)
+            {
+                throw new ArgumentNullException("s");
+            }
+            Contract.EndContractBlock();
+
+            // NOTE: The behavior of fixed *is* defined by
+            // the spec for empty strings, although not for
+            // null strings/empty char arrays. See
+            // http://stackoverflow.com/q/37757751/4077294
+            // Regardless, we may still want to check
+            // for if (chars.Length == 0) in the future
+            // and short-circuit as an optimization (TODO).
+
+            fixed (char* pChars = s)
+                return encoding.GetByteCount(pChars, s.Length, encoder: null);
         }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -71,36 +71,10 @@ namespace System.Text
         // So if you fix this, fix the others.  Currently those include:
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         [System.Security.SecuritySafeCritical] // overrides public transparent member
-        public override unsafe int GetBytes(String s, int charIndex, int charCount,
+        public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
-            if (s == null || bytes == null)
-                throw new ArgumentNullException((s == null ? "s" : "bytes"), 
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"), 
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (s.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("s",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex", 
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like empty arrays
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = s)
-                fixed ( byte* pBytes = bytes)
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, s, charIndex, charCount, bytes, byteIndex);
         }
     
         // Encodes a range of characters in a character array into a range of bytes

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -14,18 +14,7 @@ namespace System.Text
     using Win32Native = Microsoft.Win32.Win32Native;
     
     // This class overrides Encoding with the things we need for our NLS Encodings
-    //
-    // All of the GetBytes/Chars GetByte/CharCount methods are just wrappers for the pointer
-    // plus decoder/encoder method that is our real workhorse.  Note that this is an internal
-    // class, so our public classes cannot derive from this class.  Because of this, all of the
-    // GetBytes/Chars GetByte/CharCount wrapper methods are duplicated in all of our public
-    // encodings, which currently include:
-    //
-    //      EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, & UnicodeEncoding
-    //
-    // So if you change the wrappers in this class, you must change the wrappers in the other classes
-    // as well because they should have the same behavior.
-    //
+    
     [System.Runtime.InteropServices.ComVisible(true)]
     [Serializable]
     internal abstract class EncodingNLS : Encoding
@@ -34,42 +23,41 @@ namespace System.Text
         {
         }
 
+        // NOTE: Many methods in this class forward to EncodingForwarder for
+        // validating arguments/wrapping the unsafe methods in this class 
+        // which do the actual work. That class contains
+        // shared logic for doing this which is used by
+        // ASCIIEncoding, EncodingNLS, UnicodeEncoding, UTF32Encoding,
+        // UTF7Encoding, and UTF8Encoding.
+        // The reason the code is separated out into a static class, rather
+        // than a base class which overrides all of these methods for us
+        // (which is what EncodingNLS is for internal Encodings) is because
+        // that's really more of an implementation detail so it's internal.
+        // At the same time, C# doesn't allow a public class subclassing an
+        // internal/private one, so we end up having to re-override these
+        // methods in all of the public Encodings + EncodingNLS.
+
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
-        // 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
+
         [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
+        
         [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetByteCount(String s)
         {
             return EncodingForwarder.GetByteCount(this, s);
-        }       
+        }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetByteCount(char* chars, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
-        // Parent method is safe.
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
@@ -85,11 +73,7 @@ namespace System.Text
         // Alternatively, the GetMaxByteCount method can be used to
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
-        // 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
+        
         [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
@@ -97,9 +81,6 @@ namespace System.Text
             return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
@@ -108,30 +89,19 @@ namespace System.Text
 
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
-        // 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
+        
         [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }        
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
         [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
@@ -139,9 +109,6 @@ namespace System.Text
             return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         [System.Security.SecurityCritical]  // auto-generated
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
@@ -150,11 +117,7 @@ namespace System.Text
     
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
-        // 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
+        
         [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override String GetString(byte[] bytes, int index, int count)
         {

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -103,17 +103,7 @@ namespace System.Text
         [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"), 
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetBytes(chars, charCount, bytes, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charCount, bytes, byteCount);
         }                                              
 
         // Returns the number of characters produced by decoding a range of bytes

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -114,29 +114,9 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         // parent method is safe
         [System.Security.SecuritySafeCritical] // overrides public transparent member
-        public override unsafe int GetCharCount(byte[] bytes, int index, int count)
+        public override int GetCharCount(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes", 
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), 
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-                                   
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input just return 0, fixed doesn't like 0 length arrays
-            if (count == 0)
-                return 0;
-
-            // Just call pointer version
-            fixed (byte* pBytes = bytes)
-                return GetCharCount(pBytes + index, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -133,43 +133,10 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         // parent method is safe
         [System.Security.SecuritySafeCritical] // overrides public transparent member
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? "byteIndex" : "byteCount"), 
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if ( bytes.Length - byteIndex < byteCount)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (charIndex < 0 || charIndex > chars.Length)
-                throw new ArgumentOutOfRangeException("charIndex", 
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0 & avoid fixed problem
-            if (byteCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int charCount = chars.Length - charIndex;
-
-            // Fixed doesn't like empty arrays
-            if (chars.Length == 0)
-                chars = new char[1];
-
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
-                    // Remember that charCount is # to decode, not size of array
-                    return GetChars(pBytes + byteIndex, byteCount,
-                                    pChars + charIndex, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -91,43 +91,10 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         // parent method is safe
         [System.Security.SecuritySafeCritical] // overrides public transparent member
-        public override unsafe int GetBytes(char[] chars, int charIndex, int charCount,
+        public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
-            // Validate parameters
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"), 
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"), 
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                     Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If nothing to encode return 0, avoid fixed problem
-            if (charCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like empty arrays
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
-                    // Remember that byteCount is # to decode, not size of array.
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);            
+            return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -42,29 +42,9 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         // parent method is safe
         [System.Security.SecuritySafeCritical] // overrides public transparent member
-        public override unsafe int GetByteCount(char[] chars, int index, int count)
+        public override int GetByteCount(char[] chars, int index, int count)
         {
-            // Validate input parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars", 
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), 
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - index < count)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0, avoid fixed empty array problem
-            if (count == 0)
-                return 0;
-
-            // Just call the pointer version
-            fixed (char* pChars = chars)
-                return GetByteCount(pChars + index, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -63,18 +63,7 @@ namespace System.Text
         [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetByteCount(char* chars, int count)
         {
-            // Validate Parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars", 
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count", 
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-            
-            // Call it with empty encoder
-            return GetByteCount(chars, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
         // Parent method is safe.

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -156,28 +156,9 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         // parent method is safe
         [System.Security.SecuritySafeCritical] // overrides public transparent member
-        public override unsafe String GetString(byte[] bytes, int index, int count)
+        public override String GetString(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), 
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // Avoid problems with empty input buffer
-            if (count == 0) return String.Empty;
-            
-            fixed (byte* pBytes = bytes)
-                return String.CreateStringFromEncoding(
-                    pBytes + index, count, this);
+            return EncodingForwarder.GetString(this, bytes, index, count);
         }
 
         public override Decoder GetDecoder()

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -125,17 +125,7 @@ namespace System.Text
         [System.Security.SecurityCritical]  // auto-generated
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes", 
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count", 
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-            
-            return GetCharCount(bytes, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, count);
         }        
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -40,13 +40,11 @@ namespace System.Text
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
 
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
         
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetByteCount(String s)
         {
             return EncodingForwarder.GetByteCount(this, s);
@@ -58,7 +56,6 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
@@ -74,7 +71,6 @@ namespace System.Text
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
         
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
@@ -90,7 +86,6 @@ namespace System.Text
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
         
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
@@ -102,7 +97,6 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }        
 
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
@@ -118,7 +112,6 @@ namespace System.Text
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
         
-        [System.Security.SecuritySafeCritical] // overrides public transparent member
         public override String GetString(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetString(this, bytes, index, count);

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -145,17 +145,7 @@ namespace System.Text
         [System.Security.SecurityCritical]  // auto-generated
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"), 
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-            
-            return GetChars(bytes, byteCount, chars, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteCount, chars, charCount);
         }
     
         // Returns a string containing the decoded representation of a range of

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -52,15 +52,9 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
         // parent method is safe
         [System.Security.SecuritySafeCritical] // overrides public transparent member
-        public override unsafe int GetByteCount(String s)
+        public override int GetByteCount(String s)
         {
-            // Validate input
-            if (s==null)
-                throw new ArgumentNullException("s");
-            Contract.EndContractBlock();
-
-            fixed (char* pChars = s)
-                return GetByteCount(pChars, s.Length, null);
+            return EncodingForwarder.GetByteCount(this, s);
         }       
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -106,15 +106,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetByteCount(String s)
+        public override int GetByteCount(String s)
         {
-            // Validate input
-            if (s==null)
-                throw new ArgumentNullException("s");
-            Contract.EndContractBlock();
-
-            fixed (char* pChars = s)
-                return GetByteCount(pChars, s.Length, null);
+            return EncodingForwarder.GetByteCount(this, s);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -197,43 +197,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? "byteIndex" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if ( bytes.Length - byteIndex < byteCount)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (charIndex < 0 || charIndex > chars.Length)
-                throw new ArgumentOutOfRangeException("charIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0 & avoid fixed problem
-            if (byteCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int charCount = chars.Length - charIndex;
-
-            // Fix our input array if 0 length because fixed doesn't like 0 length arrays
-            if (chars.Length == 0)
-                chars = new char[1];
-
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
-                    // Remember that charCount is # to decode, not size of array
-                    return GetChars(pBytes + byteIndex, byteCount,
-                                    pChars + charIndex, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -95,13 +95,11 @@ namespace System.Text
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String s)
         {
             return EncodingForwarder.GetByteCount(this, s);
@@ -114,7 +112,6 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
@@ -130,7 +127,6 @@ namespace System.Text
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
@@ -147,7 +143,6 @@ namespace System.Text
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
@@ -160,7 +155,6 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
@@ -177,7 +171,6 @@ namespace System.Text
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override String GetString(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetString(this, bytes, index, count);

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -163,17 +163,7 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetBytes(chars, charCount, bytes, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charCount, bytes, byteCount);
         }
 
         // Returns the number of characters produced by decoding a range of bytes

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -188,17 +188,7 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetCharCount(bytes, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -78,21 +78,22 @@ namespace System.Text
             }
         }
 
-
-        //
-        // The following methods are copied from EncodingNLS.cs.
-        // Unfortunately EncodingNLS.cs is internal and we're public, so we have to reimpliment them here.
-        // These should be kept in sync for the following classes:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        //
+        // NOTE: Many methods in this class forward to EncodingForwarder for
+        // validating arguments/wrapping the unsafe methods in this class 
+        // which do the actual work. That class contains
+        // shared logic for doing this which is used by
+        // ASCIIEncoding, EncodingNLS, UnicodeEncoding, UTF32Encoding,
+        // UTF7Encoding, and UTF8Encoding.
+        // The reason the code is separated out into a static class, rather
+        // than a base class which overrides all of these methods for us
+        // (which is what EncodingNLS is for internal Encodings) is because
+        // that's really more of an implementation detail so it's internal.
+        // At the same time, C# doesn't allow a public class subclassing an
+        // internal/private one, so we end up having to re-override these
+        // methods in all of the public Encodings + EncodingNLS.
 
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
@@ -100,20 +101,11 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
-
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String s)
         {
             return EncodingForwarder.GetByteCount(this, s);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -121,11 +113,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
-
-        // Parent method is safe.
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(String s, int charIndex, int charCount,
@@ -142,11 +129,6 @@ namespace System.Text
         // Alternatively, the GetMaxByteCount method can be used to
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
@@ -154,10 +136,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -168,21 +146,12 @@ namespace System.Text
 
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -191,21 +160,12 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
-
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
             return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -216,21 +176,14 @@ namespace System.Text
 
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String GetString(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetString(this, bytes, index, count);
         }
-
-        //
-        // End of standard methods copied from EncodingNLS.cs
-        //
+        
+        // End of overridden methods which use EncodingForwarder
 
         [System.Security.SecurityCritical]  // auto-generated
         internal override unsafe int GetByteCount(char *chars, int count, EncoderNLS encoder)

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -119,18 +119,7 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
-            // Validate Parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            // Call it with empty encoder
-            return GetByteCount(chars, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
         // Parent method is safe.

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -223,28 +223,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe String GetString(byte[] bytes, int index, int count)
+        public override String GetString(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // Avoid problems with empty input buffer
-            if (count == 0) return String.Empty;
-
-            fixed (byte* pBytes = bytes)
-                return String.CreateStringFromEncoding(
-                    pBytes + index, count, this);
+            return EncodingForwarder.GetString(this, bytes, index, count);
         }
 
         //

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -211,17 +211,7 @@ namespace System.Text
         [CLSCompliant(false)]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetChars(bytes, byteCount, chars, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteCount, chars, charCount);
         }
 
         // Returns a string containing the decoded representation of a range of

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -128,36 +128,10 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetBytes(String s, int charIndex, int charCount,
+        public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
-            if (s == null || bytes == null)
-                throw new ArgumentNullException((s == null ? "s" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (s.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("s",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fix our input array if 0 length because fixed doesn't like 0 length arrays
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = s)
-                fixed ( byte* pBytes = bytes)
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, s, charIndex, charCount, bytes, byteIndex);
         }
 
         // Encodes a range of characters in a character array into a range of bytes

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -149,43 +149,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetBytes(char[] chars, int charIndex, int charCount,
+        public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
-            // Validate parameters
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                     Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If nothing to encode return 0, avoid fixed problem
-            if (charCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fix our input array if 0 length because fixed doesn't like 0 length arrays
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
-                    // Remember that byteCount is # to decode, not size of array.
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -175,29 +175,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetCharCount(byte[] bytes, int index, int count)
+        public override int GetCharCount(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input just return 0, fixed doesn't like 0 length arrays.
-            if (count == 0)
-                return 0;
-
-            // Just call pointer version
-            fixed (byte* pBytes = bytes)
-                return GetCharCount(pBytes + index, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -95,29 +95,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetByteCount(char[] chars, int index, int count)
+        public override int GetByteCount(char[] chars, int index, int count)
         {
-            // Validate input parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - index < count)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0, avoid fixed empty array problem
-            if (count == 0)
-                return 0;
-
-            // Just call the pointer version
-            fixed (char* pChars = chars)
-                return GetByteCount(pChars + index, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -161,29 +161,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetByteCount(char[] chars, int index, int count)
+        public override int GetByteCount(char[] chars, int index, int count)
         {
-            // Validate input parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - index < count)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0, avoid fixed empty array problem
-            if (count == 0)
-                return 0;
-
-            // Just call the pointer version
-            fixed (char* pChars = chars)
-                return GetByteCount(pChars + index, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -233,17 +233,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetBytes(chars, charCount, bytes, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charCount, bytes, byteCount);
         }
 
         // Returns the number of characters produced by decoding a range of bytes

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -259,17 +259,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetCharCount(bytes, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -145,31 +145,28 @@ namespace System.Text
             return this.CodePage + this.EncoderFallback.GetHashCode() + this.DecoderFallback.GetHashCode();
         }
 
-        //
-        // The following methods are copied from EncodingNLS.cs.
-        // Unfortunately EncodingNLS.cs is internal and we're public, so we have to reimpliment them here.
-        // These should be kept in sync for the following classes:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        //
+        // NOTE: Many methods in this class forward to EncodingForwarder for
+        // validating arguments/wrapping the unsafe methods in this class 
+        // which do the actual work. That class contains
+        // shared logic for doing this which is used by
+        // ASCIIEncoding, EncodingNLS, UnicodeEncoding, UTF32Encoding,
+        // UTF7Encoding, and UTF8Encoding.
+        // The reason the code is separated out into a static class, rather
+        // than a base class which overrides all of these methods for us
+        // (which is what EncodingNLS is for internal Encodings) is because
+        // that's really more of an implementation detail so it's internal.
+        // At the same time, C# doesn't allow a public class subclassing an
+        // internal/private one, so we end up having to re-override these
+        // methods in all of the public Encodings + EncodingNLS.
 
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
@@ -178,10 +175,6 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, s);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
         [System.Runtime.InteropServices.ComVisible(false)]
@@ -189,11 +182,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
-
-        // Parent method is safe.
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
@@ -211,11 +199,6 @@ namespace System.Text
         // Alternatively, the GetMaxByteCount method can be used to
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
@@ -223,10 +206,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -238,21 +217,12 @@ namespace System.Text
 
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -262,21 +232,12 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
-
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
             return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -288,11 +249,6 @@ namespace System.Text
 
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
@@ -300,10 +256,8 @@ namespace System.Text
         {
             return EncodingForwarder.GetString(this, bytes, index, count);
         }
-
-        //
-        // End of standard methods copied from EncodingNLS.cs
-        //
+        
+        // End of overridden methods which use EncodingForwarder
 
         [System.Security.SecurityCritical]  // auto-generated
         internal override unsafe int GetByteCount(char* chars, int count, EncoderNLS baseEncoder)

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -245,29 +245,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetCharCount(byte[] bytes, int index, int count)
+        public override int GetCharCount(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input just return 0, fixed doesn't like 0 length arrays.
-            if (count == 0)
-                return 0;
-
-            // Just call pointer version
-            fixed (byte* pBytes = bytes)
-                return GetCharCount(pBytes + index, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -296,28 +296,9 @@ namespace System.Text
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
-        public override unsafe String GetString(byte[] bytes, int index, int count)
+        public override String GetString(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // Avoid problems with empty input buffer
-            if (count == 0) return String.Empty;
-
-            fixed (byte* pBytes = bytes)
-                return String.CreateStringFromEncoding(
-                    pBytes + index, count, this);
+            return EncodingForwarder.GetString(this, bytes, index, count);
         }
 
         //

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -283,17 +283,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetChars(bytes, byteCount, chars, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteCount, chars, charCount);
         }
 
         // Returns a string containing the decoded representation of a range of

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -218,43 +218,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetBytes(char[] chars, int charIndex, int charCount,
+        public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
-            // Validate parameters
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                     Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If nothing to encode return 0, avoid fixed problem
-            if (charCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like empty arrays
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
-                    // Remember that byteCount is # to decode, not size of array.
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -187,18 +187,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
-            // Validate Parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            // Call it with empty encoder
-            return GetByteCount(chars, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
         // Parent method is safe.

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -173,15 +173,9 @@ namespace System.Text
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
-        public override unsafe int GetByteCount(String s)
+        public override int GetByteCount(String s)
         {
-            // Validate input
-            if (s==null)
-                throw new ArgumentNullException("s");
-            Contract.EndContractBlock();
-
-            fixed (char* pChars = s)
-                return GetByteCount(pChars, s.Length, null);
+            return EncodingForwarder.GetByteCount(this, s);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -197,36 +197,10 @@ namespace System.Text
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
-        public override unsafe int GetBytes(String s, int charIndex, int charCount,
+        public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
-            if (s == null || bytes == null)
-                throw new ArgumentNullException((s == null ? "s" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (s.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("s",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like empty arrays
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = s)
-                fixed ( byte* pBytes = bytes)
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, s, charIndex, charCount, bytes, byteIndex);
         }
 
         // Encodes a range of characters in a character array into a range of bytes

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -268,43 +268,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? "byteIndex" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if ( bytes.Length - byteIndex < byteCount)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (charIndex < 0 || charIndex > chars.Length)
-                throw new ArgumentOutOfRangeException("charIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0 & avoid fixed problem
-            if (byteCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int charCount = chars.Length - charIndex;
-
-            // Fixed doesn't like empty arrays
-            if (chars.Length == 0)
-                chars = new char[1];
-
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
-                    // Remember that charCount is # to decode, not size of array
-                    return GetChars(pBytes + byteIndex, byteCount,
-                                    pChars + charIndex, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -162,13 +162,11 @@ namespace System.Text
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
         public override int GetByteCount(String s)
         {
@@ -183,7 +181,6 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
         public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
@@ -200,7 +197,6 @@ namespace System.Text
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
@@ -218,7 +214,6 @@ namespace System.Text
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
@@ -232,7 +227,6 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
@@ -250,7 +244,6 @@ namespace System.Text
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
         public override String GetString(byte[] bytes, int index, int count)
         {

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -176,43 +176,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetBytes(char[] chars, int charIndex, int charCount,
+        public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
-            // Validate parameters
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                     Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If nothing to encode return 0, avoid fixed problem
-            if (charCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like 0 length arrays.
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
-                    // Remember that byteCount is # to decode, not size of array.
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -146,18 +146,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
-            // Validate Parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            // Call it with empty encoder
-            return GetByteCount(chars, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
         // Parent method is safe.

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -119,29 +119,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetByteCount(char[] chars, int index, int count)
+        public override int GetByteCount(char[] chars, int index, int count)
         {
-            // Validate input parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - index < count)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0, avoid fixed empty array problem
-            if (count == 0)
-                return 0;
-
-            // Just call the pointer version
-            fixed (char* pChars = chars)
-                return GetByteCount(pChars + index, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -115,13 +115,11 @@ namespace System.Text
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String chars)
         {
             return EncodingForwarder.GetByteCount(this, chars);
@@ -135,7 +133,6 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
@@ -151,7 +148,6 @@ namespace System.Text
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
@@ -169,7 +165,6 @@ namespace System.Text
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
@@ -183,7 +178,6 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
@@ -201,7 +195,6 @@ namespace System.Text
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
         public override String GetString(byte[] bytes, int index, int count)
         {

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -98,36 +98,28 @@ namespace System.Text
             }
         }
 
-
-        //
-        // WARNING: GetByteCount(string chars)
-        // WARNING: has different variable names than EncodingNLS.cs, so this can't just be cut & pasted,
-        // WARNING: otherwise it'll break VB's way of declaring these.
-        //
-        // The following methods are copied from EncodingNLS.cs.
-        // Unfortunately EncodingNLS.cs is internal and we're public, so we have to reimpliment them here.
-        // These should be kept in sync for the following classes:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        //
+        // NOTE: Many methods in this class forward to EncodingForwarder for
+        // validating arguments/wrapping the unsafe methods in this class 
+        // which do the actual work. That class contains
+        // shared logic for doing this which is used by
+        // ASCIIEncoding, EncodingNLS, UnicodeEncoding, UTF32Encoding,
+        // UTF7Encoding, and UTF8Encoding.
+        // The reason the code is separated out into a static class, rather
+        // than a base class which overrides all of these methods for us
+        // (which is what EncodingNLS is for internal Encodings) is because
+        // that's really more of an implementation detail so it's internal.
+        // At the same time, C# doesn't allow a public class subclassing an
+        // internal/private one, so we end up having to re-override these
+        // methods in all of the public Encodings + EncodingNLS.
 
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String chars)
@@ -137,10 +129,6 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
         [System.Runtime.InteropServices.ComVisible(false)]
@@ -148,11 +136,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
-
-        // Parent method is safe.
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(String s, int charIndex, int charCount,
@@ -169,11 +152,6 @@ namespace System.Text
         // Alternatively, the GetMaxByteCount method can be used to
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
@@ -181,10 +159,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -196,21 +170,12 @@ namespace System.Text
 
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -220,21 +185,12 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
-
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
             return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -246,11 +202,6 @@ namespace System.Text
 
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
@@ -258,10 +209,8 @@ namespace System.Text
         {
             return EncodingForwarder.GetString(this, bytes, index, count);
         }
-
-        //
-        // End of standard methods copied from EncodingNLS.cs
-        //
+        
+        // End of overridden methods which use EncodingForwarder
 
         // To simplify maintenance, the structure of GetByteCount and GetBytes should be
         // kept the same as much as possible

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -155,36 +155,10 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetBytes(String s, int charIndex, int charCount,
+        public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
-            if (s == null || bytes == null)
-                throw new ArgumentNullException((s == null ? "s" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (s.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("s",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like 0 length arrays.
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = s)
-                fixed ( byte* pBytes = bytes)
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, s, charIndex, charCount, bytes, byteIndex);
         }
 
         // Encodes a range of characters in a character array into a range of bytes

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -124,8 +124,6 @@ namespace System.Text
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String chars)
         {
-            // NOTE: If chars is null, this will throw an ArgumentNullException
-            // with the parameter name "s" rather than "chars"
             return EncodingForwarder.GetByteCount(this, chars);
         }
 

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -203,29 +203,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetCharCount(byte[] bytes, int index, int count)
+        public override int GetCharCount(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input just return 0, fixed doesn't like 0 length arrays.
-            if (count == 0)
-                return 0;
-
-            // Just call pointer version
-            fixed (byte* pBytes = bytes)
-                return GetCharCount(pBytes + index, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -130,15 +130,11 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetByteCount(String chars)
+        public override int GetByteCount(String chars)
         {
-            // Validate input
-            if (chars==null)
-                throw new ArgumentNullException("s");
-            Contract.EndContractBlock();
-
-            fixed (char* pChars = chars)
-                return GetByteCount(pChars, chars.Length, null);
+            // NOTE: If chars is null, this will throw an ArgumentNullException
+            // with the parameter name "s" rather than "chars"
+            return EncodingForwarder.GetByteCount(this, chars);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -217,17 +217,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetCharCount(bytes, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -254,28 +254,9 @@ namespace System.Text
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
-        public override unsafe String GetString(byte[] bytes, int index, int count)
+        public override String GetString(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // Avoid problems with empty input buffer
-            if (count == 0) return String.Empty;
-
-            fixed (byte* pBytes = bytes)
-                return String.CreateStringFromEncoding(
-                    pBytes + index, count, this);
+            return EncodingForwarder.GetString(this, bytes, index, count);
         }
 
         //

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -191,17 +191,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetBytes(chars, charCount, bytes, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charCount, bytes, byteCount);
         }
 
         // Returns the number of characters produced by decoding a range of bytes

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -226,43 +226,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? "byteIndex" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if ( bytes.Length - byteIndex < byteCount)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (charIndex < 0 || charIndex > chars.Length)
-                throw new ArgumentOutOfRangeException("charIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0 & avoid fixed problem
-            if (byteCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int charCount = chars.Length - charIndex;
-
-            // Fixed doesn't like 0 length arrays.
-            if (chars.Length == 0)
-                chars = new char[1];
-
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
-                    // Remember that charCount is # to decode, not size of array
-                    return GetChars(pBytes + byteIndex, byteCount,
-                                    pChars + charIndex, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -241,17 +241,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetChars(bytes, byteCount, chars, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteCount, chars, charCount);
         }
 
         // Returns a string containing the decoded representation of a range of

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -94,13 +94,11 @@ namespace System.Text
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String s)
         {
             return EncodingForwarder.GetByteCount(this, s);
@@ -114,7 +112,6 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
@@ -130,7 +127,6 @@ namespace System.Text
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
@@ -148,7 +144,6 @@ namespace System.Text
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
@@ -162,7 +157,6 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
@@ -180,7 +174,6 @@ namespace System.Text
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
         public override String GetString(byte[] bytes, int index, int count)
         {

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -93,29 +93,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetByteCount(char[] chars, int index, int count)
+        public override int GetByteCount(char[] chars, int index, int count)
         {
-            // Validate input parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - index < count)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0, avoid fixed empty array problem
-            if (count == 0)
-                return 0;
-
-            // Just call the pointer version
-            fixed (char* pChars = chars)
-                return GetByteCount(pChars + index, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -189,17 +189,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetCharCount(bytes, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -175,29 +175,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetCharCount(byte[] bytes, int index, int count)
+        public override int GetCharCount(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // If no input just return 0, fixed doesn't like 0 length arrays
-            if (count == 0)
-                return 0;
-
-            // Just call pointer version
-            fixed (byte* pBytes = bytes)
-                return GetCharCount(pBytes + index, count, null);
+            return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -213,17 +213,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetChars(bytes, byteCount, chars, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteCount, chars, charCount);
         }
 
         // Returns a string containing the decoded representation of a range of

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -198,43 +198,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? "byteIndex" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if ( bytes.Length - byteIndex < byteCount)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (charIndex < 0 || charIndex > chars.Length)
-                throw new ArgumentOutOfRangeException("charIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If no input, return 0 & avoid fixed problem
-            if (byteCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int charCount = chars.Length - charIndex;
-
-            // Fixed doesn't like 0 length arrays.
-            if (chars.Length == 0)
-                chars = new char[1];
-
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
-                    // Remember that charCount is # to decode, not size of array
-                    return GetChars(pBytes + byteIndex, byteCount,
-                                    pChars + charIndex, charCount, null);
+            return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -118,18 +118,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
-            // Validate Parameters
-            if (chars == null)
-                throw new ArgumentNullException("chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count",
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            // Call it with empty encoder
-            return GetByteCount(chars, count, null);
+            return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
         // Parent method is safe.

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -226,28 +226,9 @@ namespace System.Text
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
-        public override unsafe String GetString(byte[] bytes, int index, int count)
+        public override String GetString(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException("bytes",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException("bytes",
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-            Contract.EndContractBlock();
-
-            // Avoid problems with empty input buffer
-            if (count == 0) return String.Empty;
-
-            fixed (byte* pBytes = bytes)
-                return String.CreateStringFromEncoding(
-                    pBytes + index, count, this);
+            return EncodingForwarder.GetString(this, bytes, index, count);
         }
 
         //

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -104,15 +104,9 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetByteCount(String s)
+        public override int GetByteCount(String s)
         {
-            // Validate input
-            if (s==null)
-                throw new ArgumentNullException("s");
-            Contract.EndContractBlock();
-
-            fixed (char* pChars = s)
-                return GetByteCount(pChars, s.Length, null);
+            return EncodingForwarder.GetByteCount(this, s);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -77,20 +77,22 @@ namespace System.Text
             }
         }
 
-        //
-        // The following methods are copied from EncodingNLS.cs.
-        // Unfortunately EncodingNLS.cs is internal and we're public, so we have to reimpliment them here.
-        // These should be kept in sync for the following classes:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        //
+        // NOTE: Many methods in this class forward to EncodingForwarder for
+        // validating arguments/wrapping the unsafe methods in this class 
+        // which do the actual work. That class contains
+        // shared logic for doing this which is used by
+        // ASCIIEncoding, EncodingNLS, UnicodeEncoding, UTF32Encoding,
+        // UTF7Encoding, and UTF8Encoding.
+        // The reason the code is separated out into a static class, rather
+        // than a base class which overrides all of these methods for us
+        // (which is what EncodingNLS is for internal Encodings) is because
+        // that's really more of an implementation detail so it's internal.
+        // At the same time, C# doesn't allow a public class subclassing an
+        // internal/private one, so we end up having to re-override these
+        // methods in all of the public Encodings + EncodingNLS.
 
         // Returns the number of bytes required to encode a range of characters in
         // a character array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(char[] chars, int index, int count)
@@ -98,20 +100,11 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
-
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetByteCount(String s)
         {
             return EncodingForwarder.GetByteCount(this, s);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -120,11 +113,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
-
-        // Parent method is safe.
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(String s, int charIndex, int charCount,
@@ -141,11 +129,6 @@ namespace System.Text
         // Alternatively, the GetMaxByteCount method can be used to
         // determine the maximum number of bytes that will be produced for a given
         // number of characters, regardless of the actual character values.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetBytes(char[] chars, int charIndex, int charCount,
@@ -153,10 +136,6 @@ namespace System.Text
         {
             return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -168,21 +147,12 @@ namespace System.Text
 
         // Returns the number of characters produced by decoding a range of bytes
         // in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, index, count);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -192,21 +162,12 @@ namespace System.Text
             return EncodingForwarder.GetCharCount(this, bytes, count);
         }
 
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
-
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
             return EncodingForwarder.GetChars(this, bytes, byteIndex, byteCount, chars, charIndex);
         }
-
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecurityCritical]  // auto-generated
         [CLSCompliant(false)]
@@ -218,11 +179,6 @@ namespace System.Text
 
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
-        //
-        // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)
-        // So if you fix this, fix the others.  Currently those include:
-        // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
-        // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.InteropServices.ComVisible(false)]
@@ -230,10 +186,8 @@ namespace System.Text
         {
             return EncodingForwarder.GetString(this, bytes, index, count);
         }
-
-        //
-        // End of standard methods copied from EncodingNLS.cs
-        //
+        
+        // End of overridden methods which use EncodingForwarder
 
         [System.Security.SecurityCritical]  // auto-generated
         internal override unsafe int GetByteCount(char* chars, int count, EncoderNLS encoder)

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -148,43 +148,10 @@ namespace System.Text
         // parent method is safe
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetBytes(char[] chars, int charIndex, int charCount,
+        public override int GetBytes(char[] chars, int charIndex, int charCount,
                                                byte[] bytes, int byteIndex)
         {
-            // Validate parameters
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? "chars" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (chars.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("chars",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                     Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            // If nothing to encode return 0, avoid fixed problem
-            if (charCount == 0)
-                return 0;
-
-            // Just call pointer version
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like 0 length arrays.
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
-                    // Remember that byteCount is # to decode, not size of array.
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charIndex, charCount, bytes, byteIndex);
         }
 
         // All of our public Encodings that don't use EncodingNLS must have this (including EncodingNLS)

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -163,17 +163,7 @@ namespace System.Text
         [System.Runtime.InteropServices.ComVisible(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
-            // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? "bytes" : "chars",
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            Contract.EndContractBlock();
-
-            return GetBytes(chars, charCount, bytes, byteCount, null);
+            return EncodingForwarder.GetBytes(this, chars, charCount, bytes, byteCount);
         }
 
         // Returns the number of characters produced by decoding a range of bytes

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -127,36 +127,10 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public override unsafe int GetBytes(String s, int charIndex, int charCount,
+        public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
-            if (s == null || bytes == null)
-                throw new ArgumentNullException((s == null ? "s" : "bytes"),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (s.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException("s",
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
-
-            if (byteIndex < 0 || byteIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException("byteIndex",
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-            Contract.EndContractBlock();
-
-            int byteCount = bytes.Length - byteIndex;
-
-            // Fixed doesn't like 0 length arrays.
-            if (bytes.Length == 0)
-                bytes = new byte[1];
-
-            fixed (char* pChars = s)
-                fixed ( byte* pBytes = bytes)
-                    return GetBytes(pChars + charIndex, charCount,
-                                    pBytes + byteIndex, byteCount, null);
+            return EncodingForwarder.GetBytes(this, s, charIndex, charCount, bytes, byteIndex);
         }
 
         // Encodes a range of characters in a character array into a range of bytes


### PR DESCRIPTION
(Note: This PR is best reviewed on a commit-by-commit basis.)

Many of the unsafe methods of `Encoding` which take pointers were introduced after the overloads which take arrays. So the pointer-based overloads had to be defined in terms of arrays, which means allocating a new array and copying all of the data (since there is no way to reinterpret a pointer as an array). This is undesirable for performance, so all the types in mscorlib which subclass `Encoding` switch it around and define the array-based overloads in terms of pointers. (They also override the pointer-based ones, to call the overload with `EncoderNLS`/`DecoderNLS`.) To do this, 11 methods need to be overridden consistently in each class that subclasses `Encoding`.

`EncodingNLS` subclasses `Encoding` and overrides all of these methods for convenience, so any class that inherits from it doesn't have to worry about that. However, the public Encodings (ASCIIEncoding, UTF8Encoding, etc.) can't do that since it is an internal class and public classes can't derive from internal classes, so they all have to re-duplicate the logic.

Originally, all of this code (which is +1,000 lines) was just copied-and-pasted around the 6 classes. I've changed it so that they call a static method in a new class, `EncodingForwarder`, passing all of their parameters and `this` to it. The methods in `EncodingForwarder` do all the argument validation/checks and call the unsafe overload on the `Encoding`.

I've also updated/removed many of the comments in the classes that say "if you change something in here, change it in the other 5 classes as well..." since the implementation is now shared among all the classes, and added a note about `EncodingForwarder` to the top of each class to explain the whole thing.

cc @tarekgh @jkotas @AlexGhiondea 