### PR TITLE
Better performance for string.CompareOrdinalHelper

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -483,11 +483,6 @@ namespace System {
                 // if the first two chars the same we can increment by 4 bytes,
                 // leaving us word-aligned on both 32-bit (12 bytes into the string)
                 // and 64-bit (16 bytes) platforms.
-
-                // NOTE: If in the future there is a way to read the second char
-                // without pinning the string (e.g. System.Runtime.CompilerServices.Unsafe
-                // is exposed to mscorlib, or a future version of C# allows inline IL),
-                // then do that and short-circuit before the fixed.
         
                 // For empty strings, the second char will be null due to padding.
                 // The start of the string (not including sync block pointer)
@@ -498,6 +493,11 @@ namespace System {
                 // of 4/8, this will get padded and zeroed out.
                 
                 // For one-char strings the second char will be the null terminator.
+
+                // NOTE: If in the future there is a way to read the second char
+                // without pinning the string (e.g. System.Runtime.CompilerServices.Unsafe
+                // is exposed to mscorlib, or a future version of C# allows inline IL),
+                // then do that and short-circuit before the fixed.
 
                 if (*(a + 1) != *(b + 1))
                 {

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -493,7 +493,7 @@ namespace System {
                 length -= 2; a += 2; b += 2;
 
                 // unroll the loop
-#if WIN64
+#if BIT64
                 while (length >= 12)
                 {
                     if (*(long*)a != *(long*)b) goto DiffOffset0;
@@ -530,7 +530,7 @@ namespace System {
                 // The longer string will be larger.
                 return strA.Length - strB.Length;
                 
-#if WIN64
+#if BIT64
                 DiffOffset8: diffOffset += 4;
                 DiffOffset4: diffOffset += 4;
 #else
@@ -545,7 +545,7 @@ namespace System {
                 
                 DiffOffset0:
                 // If we reached here, we already see a difference in the unrolled loop above
-#if WIN64
+#if BIT64
                 if (*(int*)a == *(int*)b)
                 {
                     a += 2; b += 2;

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -468,7 +468,6 @@ namespace System {
                 "check/short-circuit beforehand if the first char is the same.");
 
             int length = Math.Min(strA.Length, strB.Length);
-            int diffOffset = 0;
 
             fixed (char* ap = &strA.m_firstChar) fixed (char* bp = &strB.m_firstChar)
             {
@@ -537,7 +536,8 @@ namespace System {
                 // always zero terminated and that the terminating zero is not included
                 // in the length. For odd string sizes, the last compare will include
                 // the zero terminator.
-                while (length > 0) {
+                while (length > 0)
+                {
                     if (*(int*)a != *(int*)b) goto DiffNextInt;
                     length -= 2;
                     a += 2; 
@@ -549,17 +549,14 @@ namespace System {
                 return strA.Length - strB.Length;
                 
 #if BIT64
-                DiffOffset8: diffOffset += 4;
-                DiffOffset4: diffOffset += 4;
+                DiffOffset8: a += 4; b += 4;
+                DiffOffset4: a += 4; b += 4;
 #else
-                DiffOffset8: diffOffset += 2;
-                DiffOffset6: diffOffset += 2;
-                DiffOffset4: diffOffset += 2;
-                DiffOffset2: diffOffset += 2;
+                DiffOffset8: a += 2; b += 2;
+                DiffOffset6: a += 2; b += 2;
+                DiffOffset4: a += 2; b += 2;
+                DiffOffset2: a += 2; b += 2;
 #endif
-
-                a += diffOffset;
-                b += diffOffset;
                 
                 DiffOffset0:
                 // If we reached here, we already see a difference in the unrolled loop above

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -471,7 +471,12 @@ namespace System {
         {
             Contract.Assert(strA != null);
             Contract.Assert(strB != null);
-            Contract.Assert(strA.m_firstChar == strB.m_firstChar && strA.m_secondChar == strB.m_secondChar);
+            Contract.Assert(strA.m_firstChar == strB.m_firstChar);
+
+            if (strA.m_secondChar != strB.m_secondChar)
+            {
+                return strA.m_secondChar - strB.m_secondChar;
+            }
 
             int length = Math.Min(strA.Length, strB.Length);
             int diffOffset = 0;
@@ -1874,23 +1879,6 @@ namespace System {
                     {
                         return strA.m_firstChar - strB.m_firstChar;
                     }
-                    
-                    // Also check if the second character is different
-                    // This allows us to align the pointer better in
-                    // CompareOrdinalHelper on 64-bit platforms, since
-                    // if we know the first two chars are the same
-                    // we can increment the starting position by 4,
-                    // which leaves us 8-byte aligned.
-                    
-                    // The reason we don't do this in CompareOrdinalHelper
-                    // itself is because checking here allows us to avoid
-                    // a method call and prematurely pinning the string.
-                    
-                    // Returns false for empty/one-char strings.
-                    if (strA.m_secondChar != strB.m_secondChar)
-                    {
-                        return strA.m_secondChar - strB.m_secondChar;
-                    }
 
                     return CompareOrdinalHelper(strA, strB);
 
@@ -2203,23 +2191,6 @@ namespace System {
             if (strA.m_firstChar != strB.m_firstChar)
             {
                 return strA.m_firstChar - strB.m_firstChar;
-            }
-            
-            // Also check if the second character is different
-            // This allows us to align the pointer better in
-            // CompareOrdinalHelper on 64-bit platforms, since
-            // if we know the first two chars are the same
-            // we can increment the starting position by 4,
-            // which leaves us 8-byte aligned.
-            
-            // The reason we don't do this in CompareOrdinalHelper
-            // itself is because checking here allows us to avoid
-            // a method call and prematurely pinning the string.
-            
-            // Returns false for empty/one-char strings.
-            if (strA.m_secondChar != strB.m_secondChar)
-            {
-                return strA.m_secondChar - strB.m_secondChar;
             }
 
             return CompareOrdinalHelper(strA, strB);

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -568,14 +568,11 @@ namespace System {
 #endif
                 
                 DiffNextInt:
-                if (*a == *b) goto ReturnDifference;
+                if (*a != *b) return *a - *b;
 
                 DiffOffset1:
                 Contract.Assert(*(a + 1) != *(b + 1), "This char must be different if we reach here!");
-                a += 1; b += 1;
-                
-                ReturnDifference:
-                return *a - *b;
+                return *(a + 1) - *(b + 1);
             }
         }
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -515,7 +515,7 @@ namespace System {
                     if (*(long*)(a + 8) != *(long*)(b + 8)) goto DiffOffset8;
                     length -= 12; a += 12; b += 12;
                 }
-#else
+#else // BIT64
                 while (length >= 10)
                 {
                     if (*(int*)a != *(int*)b) goto DiffOffset0;
@@ -525,7 +525,7 @@ namespace System {
                     if (*(int*)(a + 8) != *(int*)(b + 8)) goto DiffOffset8;
                     length -= 10; a += 10; b += 10; 
                 }
-#endif
+#endif // BIT64
 
                 // Fallback loop:
                 // go back to slower code path and do comparison on 4 bytes at a time.
@@ -548,7 +548,7 @@ namespace System {
 #if BIT64
                 DiffOffset8: a += 4; b += 4;
                 DiffOffset4: a += 4; b += 4;
-#else
+#else // BIT64
                 // Use jumps instead of falling through, since
                 // otherwise going to DiffOffset8 will involve
                 // 8 add instructions before getting to DiffNextInt
@@ -556,7 +556,7 @@ namespace System {
                 DiffOffset6: a += 6; b += 6; goto DiffOffset0;
                 DiffOffset4: a += 4; b += 4; goto DiffOffset0;
                 DiffOffset2: a += 2; b += 2;
-#endif
+#endif // BIT64
                 
                 DiffOffset0:
                 // If we reached here, we already see a difference in the unrolled loop above
@@ -565,8 +565,8 @@ namespace System {
                 {
                     a += 2; b += 2;
                 }
-#endif
-                
+#endif // BIT64
+
                 DiffNextInt:
                 if (*a != *b) return *a - *b;
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -523,10 +523,10 @@ namespace System {
                 while (length >= 10)
                 {
                     if (*(int*)a != *(int*)b) goto DiffOffset0;
-                    if (*(int*)(a+2) != *(int*)(b+2)) goto DiffOffset2;
-                    if (*(int*)(a+4) != *(int*)(b+4)) goto DiffOffset4;
-                    if (*(int*)(a+6) != *(int*)(b+6)) goto DiffOffset6;
-                    if (*(int*)(a+8) != *(int*)(b+8)) goto DiffOffset8;
+                    if (*(int*)(a + 2) != *(int*)(b + 2)) goto DiffOffset2;
+                    if (*(int*)(a + 4) != *(int*)(b + 4)) goto DiffOffset4;
+                    if (*(int*)(a + 6) != *(int*)(b + 6)) goto DiffOffset6;
+                    if (*(int*)(a + 8) != *(int*)(b + 8)) goto DiffOffset8;
                     length -= 10; a += 10; b += 10; 
                 }
 #endif

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -541,7 +541,7 @@ namespace System {
                 if ( (order = (int)*a - (int)*b) != 0) {
                     return order;
                 }
-                Contract.Assert( *(a+1) != *(b+1), "This byte must be different if we reach here!");
+                Contract.Assert( *(a+1) != *(b+1), "This char must be different if we reach here!");
                 return ((int)*(a+1) - (int)*(b+1));
 
                 // now go back to slower code path and do comparison on 4 bytes at a time.
@@ -565,7 +565,7 @@ namespace System {
                     if ( (c = (int)*a - (int)*b) != 0) {
                         return c;
                     }
-                    Contract.Assert( *(a+1) != *(b+1), "This byte must be different if we reach here!");
+                    Contract.Assert( *(a+1) != *(b+1), "This char must be different if we reach here!");
                     return ((int)*(a+1) - (int)*(b+1));                                        
                 }
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -537,6 +537,7 @@ namespace System {
                 }
 #endif
                 
+                DiffNextInt:
                 int order;
                 if ( (order = (int)*a - (int)*b) != 0) {
                     return order;
@@ -551,22 +552,10 @@ namespace System {
                 // the zero terminator.
                 FallbackLoop:
                 while (length > 0) {
-                    if (*(int*)a != *(int*)b) {
-                        break;
-                    }
+                    if (*(int*)a != *(int*)b) goto DiffNextInt;
                     length -= 2;
                     a += 2; 
                     b += 2; 
-                }
-
-                if( length > 0) { 
-                    int c;
-                    // found a different int on above loop
-                    if ( (c = (int)*a - (int)*b) != 0) {
-                        return c;
-                    }
-                    Contract.Assert( *(a+1) != *(b+1), "This char must be different if we reach here!");
-                    return ((int)*(a+1) - (int)*(b+1));                                        
                 }
 
                 // At this point, we have compared all the characters in at least one string.

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -52,11 +52,12 @@ namespace System {
         [NonSerialized] private char m_firstChar;
         
         // For empty strings, this will be null due to padding.
-        // The null terminator of an empty string takes up 2
-        // bytes, and the rest of the string object takes up
-        // a multiple of 4 bytes, so there's some left over
-        // to make the size a multiple of 4/8 bytes for
-        // alignment purposes.
+        // The start of the string (not including sync block pointer)
+        // is the method table pointer + string length, which takes up
+        // 8 bytes on 32-bit, 12 on x64. For empty strings the null
+        // terminator immediately follows, leaving us with an object
+        // 10/14 bytes in size. Since everything needs to be a multiple
+        // of 4/8, this will get padded and zeroed out.
         
         // For one-char strings this will be the null terminator.
         [NonSerialized] private char m_secondChar;

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -471,8 +471,21 @@ namespace System {
         {
             Contract.Assert(strA != null);
             Contract.Assert(strB != null);
-            Contract.Assert(strA.m_firstChar == strB.m_firstChar);
 
+            // TODO: This may be subject to change if eliminating the check
+            // in the callers makes them small enough to be inlined by the JIT
+            Contract.Assert(strA.m_firstChar == strB.m_firstChar,
+                "For performance reasons, callers of this method should " +
+                "check/short-circuit beforehand if the first char is the same.");
+
+            // Check if the second chars are different here
+            // The reason we check if m_firstChar is different is because
+            // it's the most common cast and allows us to avoid a method call
+            // to here.
+            // The reason we check if m_secondChar is different is because
+            // if the first two chars the same we can increment by 4 bytes,
+            // leaving us word-aligned on both 32-bit (12 bytes into the string)
+            // and 64-bit (16 bytes) platforms.
             if (strA.m_secondChar != strB.m_secondChar)
             {
                 return strA.m_secondChar - strB.m_secondChar;

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -555,7 +555,7 @@ namespace System {
                 DiffOffset8: a += 8; b += 8; goto DiffOffset0;
                 DiffOffset6: a += 6; b += 6; goto DiffOffset0;
                 DiffOffset4: a += 4; b += 4; goto DiffOffset0;
-                DiffOffset2: a += 2; b += 2; goto DiffOffset0;
+                DiffOffset2: a += 2; b += 2;
 #endif
                 
                 DiffOffset0:

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -554,7 +554,7 @@ namespace System {
                 // 8 add instructions before getting to DiffNextInt
                 DiffOffset8: a += 8; b += 8; goto DiffOffset0;
                 DiffOffset6: a += 6; b += 6; goto DiffOffset0;
-                DiffOffset4: a += 4; b += 4; goto DiffOffset0;
+                DiffOffset4: a += 2; b += 2;
                 DiffOffset2: a += 2; b += 2;
 #endif // BIT64
                 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -34,13 +34,7 @@ namespace System {
     // instance and return the result as a new String. All comparison methods are
     // implemented as a part of String.  As with arrays, character positions
     // (indices) are zero-based.
-    //
-    // When passing a null string into a constructor in VJ and VC, the null should be
-    // explicitly type cast to a String.
-    // For Example:
-    // String s = new String((String)null);
-    // Console.WriteLine(s);
-    //
+    
     [ComVisible(true)]
     [Serializable]
     public sealed class String : IComparable, ICloneable, IConvertible, IEnumerable

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -508,10 +508,15 @@ namespace System {
                 
                 goto FallbackLoop;
                 
+#if WIN64
+                DiffOffset8: diffOffset += 4;
+                DiffOffset4: diffOffset += 4;
+#else
                 DiffOffset8: diffOffset += 2;
                 DiffOffset6: diffOffset += 2;
                 DiffOffset4: diffOffset += 2;
                 DiffOffset2: diffOffset += 2;
+#endif
 
                 a += diffOffset;
                 b += diffOffset;

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -472,7 +472,7 @@ namespace System {
             Contract.Assert(strA != null);
             Contract.Assert(strB != null);
 
-            // TODO: This may be subject to change if eliminating the check
+            // NOTE: This may be subject to change if eliminating the check
             // in the callers makes them small enough to be inlined by the JIT
             Contract.Assert(strA.m_firstChar == strB.m_firstChar,
                 "For performance reasons, callers of this method should " +

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -552,10 +552,13 @@ namespace System {
                 DiffOffset8: a += 4; b += 4;
                 DiffOffset4: a += 4; b += 4;
 #else
-                DiffOffset8: a += 2; b += 2;
-                DiffOffset6: a += 2; b += 2;
-                DiffOffset4: a += 2; b += 2;
-                DiffOffset2: a += 2; b += 2;
+                // Use jumps instead of falling through, since
+                // otherwise going to DiffOffset8 will involve
+                // 8 add instructions before getting to DiffNextInt
+                DiffOffset8: a += 8; b += 8; goto DiffOffset0;
+                DiffOffset6: a += 6; b += 6; goto DiffOffset0;
+                DiffOffset4: a += 4; b += 4; goto DiffOffset0;
+                DiffOffset2: a += 2; b += 2; goto DiffOffset0;
 #endif
                 
                 DiffOffset0:

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -498,10 +498,7 @@ namespace System {
                 // is exposed to mscorlib, or a future version of C# allows inline IL),
                 // then do that and short-circuit before the fixed.
 
-                if (*(a + 1) != *(b + 1))
-                {
-                    return *(a + 1) - *(b + 1);
-                }
+                if (*(a + 1) != *(b + 1)) goto DiffOffset1;
                 
                 // Since we know that the first two chars are the same,
                 // we can increment by 2 here and skip 4 bytes.
@@ -571,12 +568,14 @@ namespace System {
 #endif
                 
                 DiffNextInt:
-                int order;
-                if ( (order = (int)*a - (int)*b) != 0) {
-                    return order;
-                }
-                Contract.Assert( *(a+1) != *(b+1), "This char must be different if we reach here!");
-                return ((int)*(a+1) - (int)*(b+1));
+                if (*a == *b) goto ReturnDifference;
+
+                DiffOffset1:
+                Contract.Assert(*(a + 1) != *(b + 1), "This char must be different if we reach here!");
+                a += 1; b += 1;
+                
+                ReturnDifference:
+                return *a - *b;
             }
         }
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -498,7 +498,8 @@ namespace System {
                 // is exposed to mscorlib, or a future version of C# allows inline IL),
                 // then do that and short-circuit before the fixed.
 
-                if (*(a + 1) != *(b + 1)) goto DiffOffset1;
+                if (*(a + 1) != *(b + 1))
+                    goto Return2ndDifference;
                 
                 // Since we know that the first two chars are the same,
                 // we can increment by 2 here and skip 4 bytes.
@@ -510,19 +511,19 @@ namespace System {
 #if BIT64
                 while (length >= 12)
                 {
-                    if (*(long*)a != *(long*)b) goto DiffOffset0;
-                    if (*(long*)(a + 4) != *(long*)(b + 4)) goto DiffOffset4;
-                    if (*(long*)(a + 8) != *(long*)(b + 8)) goto DiffOffset8;
+                    if (*(long*)a != *(long*)b) goto Check1stWord;
+                    if (*(long*)(a + 4) != *(long*)(b + 4)) goto Check2ndWord;
+                    if (*(long*)(a + 8) != *(long*)(b + 8)) goto Check3rdWord;
                     length -= 12; a += 12; b += 12;
                 }
 #else
                 while (length >= 10)
                 {
-                    if (*(int*)a != *(int*)b) goto DiffOffset0;
-                    if (*(int*)(a + 2) != *(int*)(b + 2)) goto DiffOffset2;
-                    if (*(int*)(a + 4) != *(int*)(b + 4)) goto DiffOffset4;
-                    if (*(int*)(a + 6) != *(int*)(b + 6)) goto DiffOffset6;
-                    if (*(int*)(a + 8) != *(int*)(b + 8)) goto DiffOffset8;
+                    if (*(int*)a != *(int*)b) goto Check1stWord;
+                    if (*(int*)(a + 2) != *(int*)(b + 2)) goto Check2ndWord;
+                    if (*(int*)(a + 4) != *(int*)(b + 4)) goto Check3rdWord;
+                    if (*(int*)(a + 6) != *(int*)(b + 6)) goto Check4thWord;
+                    if (*(int*)(a + 8) != *(int*)(b + 8)) goto Check5thWord;
                     length -= 10; a += 10; b += 10; 
                 }
 #endif
@@ -535,7 +536,7 @@ namespace System {
                 // the zero terminator.
                 while (length > 0)
                 {
-                    if (*(int*)a != *(int*)b) goto DiffNextInt;
+                    if (*(int*)a != *(int*)b) goto Check1stInt;
                     length -= 2;
                     a += 2; 
                     b += 2; 
@@ -546,19 +547,19 @@ namespace System {
                 return strA.Length - strB.Length;
                 
 #if BIT64
-                DiffOffset8: a += 4; b += 4;
-                DiffOffset4: a += 4; b += 4;
+                Check3rdWord: a += 4; b += 4;
+                Check2ndWord: a += 4; b += 4;
 #else
                 // Use jumps instead of falling through, since
-                // otherwise going to DiffOffset8 will involve
-                // 8 add instructions before getting to DiffNextInt
-                DiffOffset8: a += 8; b += 8; goto DiffOffset0;
-                DiffOffset6: a += 6; b += 6; goto DiffOffset0;
-                DiffOffset4: a += 4; b += 4; goto DiffOffset0;
-                DiffOffset2: a += 2; b += 2; goto DiffOffset0;
+                // otherwise going to Check5thWord will involve
+                // 8 add instructions before getting to Check1stWord
+                Check5thWord: a += 8; b += 8; goto Check1stWord;
+                Check4thWord: a += 6; b += 6; goto Check1stWord;
+                Check3rdWord: a += 4; b += 4; goto Check1stWord;
+                Check2ndWord: a += 2; b += 2; goto Check1stWord;
 #endif
                 
-                DiffOffset0:
+                Check1stWord:
                 // If we reached here, we already see a difference in the unrolled loop above
 #if BIT64
                 if (*(int*)a == *(int*)b)
@@ -567,14 +568,16 @@ namespace System {
                 }
 #endif
                 
-                DiffNextInt:
-                if (*a == *b) goto ReturnDifference;
+                Check1stInt:
+                if (*a == *b)
+                    goto Return1stDifference;
 
-                DiffOffset1:
-                Contract.Assert(*(a + 1) != *(b + 1), "This char must be different if we reach here!");
+                Return2ndDifference:
+                Contract.Assert(*(a + 1) != *(b + 1), "These chars must be different if we reach here!");
                 a += 1; b += 1;
                 
-                ReturnDifference:
+                Return1stDifference:
+                Contract.Assert(*a != *b, "These chars must be different if we reach here!");
                 return *a - *b;
             }
         }

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -458,8 +458,8 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         private unsafe static int CompareOrdinalHelper(String strA, String strB)
         {
-            Contract.Assert(strA != null);
-            Contract.Assert(strB != null);
+            Contract.Requires(strA != null);
+            Contract.Requires(strB != null);
 
             // NOTE: This may be subject to change if eliminating the check
             // in the callers makes them small enough to be inlined by the JIT


### PR DESCRIPTION
Right now `string.CompareOrdinal` is fast, but it could be a lot faster. This PR makes the following changes:

- For 64-bit, process a `long` at a time (and 3 longs per iteration of the loop), since it's the largest word size of the processor. This is what other functions, like `EqualsHelper` or `StartsWithOrdinalHelper` do.

- Make sure we perform aligned reads on 64-bit platforms

  - Strings (objects in general?) are allocated on an aligned word boundary (that is, divisible by 4/8). However, the offset to the chars (`OffsetToStringData`) is 12 on 64-bit platforms, meaning that if we read a long from the first char it will *not* be aligned. To fix this, first check for differences in the first/second chars and start the loop from there.

    - Since we were already checking for differences in `m_firstChar` in the callers, I've added a new field to String, `m_secondChar`. This will be the null terminator for one-char strings, and also 0 for empty strings due to padding (see the notes I made above it). I used this to compare the second chars in `CompareOrdinalHelper`.

- Used `goto` within the loop code, so we don't have to keep making jumps in the common case. (I haven't looked at the disassembly, but I'm assuming that's what all of the existing gotos in `*OrdinalHelper` are for.)

- Changed null check in `CompareOrdinalHelper` to `Contract.Assert`, instead of `Contract.Requires`.

I also removed a comment above the `String` class that seems to be outdated (seeing as there is no string constructor that accepts another string).

Perf results: [old](https://gist.github.com/jamesqo/9736acfeae269c30e5a3925b78390ef4) / [new](https://gist.github.com/jamesqo/315c0f8cd63280ad6ef21c1294f06c52) / [test source code](https://gist.github.com/jamesqo/0c98cf76934b51d0737143520a616074)

cc @bbowyersmyth @jkotas @mikedn 

This passes all the CoreFX tests. (I'm planning on adding more shortly to improve coverage.)