### PR TITLE
Improve performance, drastically reduce misfires for new string(char*) on 64-bit

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1789,6 +1789,7 @@ namespace System {
                 if (end[3] == 0) goto EndAt3;
 
                 // if we reached here, it was a false positive-- just continue
+                end += 4;
             }
 
             EndAt3: end++;

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1699,7 +1699,7 @@ namespace System {
             // First make sure our pointer is aligned on a word boundary
             int alignment = IntPtr.Size - 1;
 
-            // If ptr is at an odd address, this loop will simply iterate all the way
+            // If ptr is at an odd address (e.g. 0x5), this loop will simply iterate all the way
             while (((uint)end & (uint)alignment) != 0)
             {
                 if (*end == 0) goto FoundZero;

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1696,9 +1696,6 @@ namespace System {
         {
             char *end = ptr;
             
-            // TODO: Test to see if switching to something like
-            // the 64-bit version would be beneficial on x86 as well
-
             // First make sure our pointer is aligned on a word boundary
             int alignment = IntPtr.Size - 1;
 
@@ -1710,18 +1707,6 @@ namespace System {
             }
 
 #if !BIT64
-            // TODO: The following code is typically fast (1 and operation),
-            // but it can generate many false positives which lead to falling
-            // back and checking each char individually. For example,
-            // "?@" causes a misfire, [space] + any control char, etc. since
-            // they share no bits.
-
-            // Investigate doing the same thing we do in the x64 version, namely
-            // adding 0x7fff7fff and seeing if any high bits aren't set. This
-            // should limit the misfires to chars > 0x8000.
-
-            // Original comments:
-
             // The following code is (somewhat surprisingly!) significantly faster than a naive loop,
             // at least on x86 and the current jit.
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1696,7 +1696,6 @@ namespace System {
         {
             char *end = ptr;
             
-            // x64 implementation is based on glibc's strlen
             // TODO: Test to see if switching to something like
             // the 64-bit version would be beneficial on x86 as well
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1718,6 +1718,16 @@ namespace System {
 
             if (*end != 0) {
 #if !BIT64
+                // TODO: The following code is typically fast (1 and operation),
+                // but it can generate many false positives which lead to falling
+                // back and checking each char individually. For example,
+                // "?@" causes a misfire, [space] + any control char, etc. since
+                // they share no bits.
+
+                // Investigate doing the same thing we do in the x64 version, namely
+                // subtracting 0x00010001 and seeing if any high bits are set. This
+                // should limit the misfires to chars > 0x8000.
+
                 // The following code is (somewhat surprisingly!) significantly faster than a naive loop,
                 // at least on x86 and the current jit.
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1704,8 +1704,7 @@ namespace System {
             // the 64-bit version would be beneficial on x86 as well
 
             // First make sure our pointer is aligned on a word boundary
-            int wordSize = IntPtr.Size;
-            int alignment = wordSize - 1;
+            int alignment = IntPtr.Size - 1;
 
             // If ptr is at an odd address, this loop will simply iterate all the way
             while (((uint)end & alignment) != 0 && *end != 0)
@@ -1743,7 +1742,7 @@ namespace System {
                 // NOTE: We can access a long a time since the ptr is aligned,
                 // and therefore we're only accessing the same word/page.
                 
-                const long HighMask = 0x8080808080808080;
+                const long HighMask = 0x8000800080008000;
                 const long LowMask = 0x0001000100010001;
 
                 while (true)
@@ -1770,10 +1769,6 @@ namespace System {
                     if (end[1] == 0) break;
                     if (end[2] == 0) break;
                     if (end[3] == 0) break;
-                    if (end[4] == 0) break;
-                    if (end[5] == 0) break;
-                    if (end[6] == 0) break;
-                    if (end[7] == 0) break;
                 }
 #endif // !BIT64
             }

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1704,6 +1704,15 @@ namespace System {
             int alignment = IntPtr.Size - 1;
 
             // If ptr is at an odd address, this loop will simply iterate all the way
+            // TODO: See if it would be beneficial for performance to have something like
+            //
+            // while (((uint)end & alignment) != 0)
+            // {
+            //     if (*end == 0) goto FoundZero; // FoundZero is just before we calculate the count
+            //     end++;
+            // }
+            //
+            // This way we avoid the if (*end != 0) check below.
             while (((uint)end & alignment) != 0 && *end != 0)
                 end++;
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1695,9 +1695,6 @@ namespace System {
         private static unsafe int wcslen(char *ptr)
         {
             char *end = ptr;
-
-            // The following code is (somewhat surprisingly!) significantly faster than a naive loop,
-            // at least on x86 and the current jit.
             
             // x64 implementation is based on glibc's strlen
             // TODO: Test to see if switching to something like
@@ -1712,6 +1709,9 @@ namespace System {
 
             if (*end != 0) {
 #if !BIT64
+                // The following code is (somewhat surprisingly!) significantly faster than a naive loop,
+                // at least on x86 and the current jit.
+
                 // The loop condition below works because if "end[0] & end[1]" is non-zero, that means
                 // neither operand can have been zero. If is zero, we have to look at the operands individually,
                 // but we hope this going to fairly rare.


### PR DESCRIPTION
In the `new string(char*)` constructor, we don't know how long the character buffer pointed to by the `char*` is, so we have to roll our own function, `wcslen`, to find the first 0 in the buffer. Instead of naively looping through each char in the buffer, `wcslen` does something different. It first 4-byte aligns the pointer, and then in a loop ANDs the next two chars together. If one of them is equal to zero, the result will be 0 and it will exit the loop. This can be very fast, as it is only 1 instruction (and).

Unfortunately, this approach has some downsides. Just because `(a & b) == 0` doesn't necessarily mean that either a or b has to be 0, it just means they don't share any bits (though it could be likely that one of them is zero). This means that chars like `@` or ` ` (space), which only contain 1 bit, are *very* prone to misfires and we have to fall back to checking each char individually for 0. This is especially true of non-ASCII characters too (which have at least one of bits 1..9 set), since there are a lot more of them that don't share bits with ASCII chars. Also, it doesn't take advantage of the fact that 4 chars can fit into a word on x64, which means it's best to process 4 (instead of 2) chars at a time.

<s>I've introduced a new implementation for `wcslen` on 64-bit, based on [glibc's strlen implementation](http://tsunanet.net/~tsuna/strlen.c.html). It's a little different since the sizeof a `char` in .NET is 2 rather than 1, but the basic concept is the same. It reads a word from the string (1 long), and subtracts the magic constant `0x0001000100010001`. This will subtract 1 from every char in the long, so if a zero is present it will turn to `0xffff`. It then ANDs this with `0x8000800080008000` to check if the high bit is set in any of the chars. If it is, it checks each char individually for 0 then exits the loop.</s> (see commentary below)

Note that this approach is also prone to misfires; any char > 0x8000 will still have its high bit set when subtracted 1 from, so this is going to be slower if the string contains any of those. However, I'm assuming those aren't going to be as common as ASCII chars, so I optimized for the common case.

I ran performance tests before posting this: [old](https://gist.github.com/jamesqo/e7e2a763a83bd6ff0aab4f4e67ebb777) / [new](https://gist.github.com/jamesqo/3de048580abc570031651a238bf08ec9) / [source code](https://gist.github.com/jamesqo/479a2e1cdf7297e2b2a613d9b9ebc1cc)

It looks like there is a slight slowdown for very small strings (< 8 in size), which is to be expected since we now 8-align rather than 4-align on 64-bit. However, for larger strings the story is different; even assuming the old algorithm experiences no misfires, it is still ~20% slower than the new one for large strings. I also tested the other extreme; if strings like `?@?@...` are used which causes the old one to constantly misfire, the new one can be 2x as fast. Also, the new algorithm doesn't seem to slow down too badly; even when fed a constant stream of chars > 0x8000, it's only ~30% slower than the old one with no misfires.

I ran the CoreFX test suite on this, and will be adding more tests shortly to cover strings like `?@` or `\u8000`.

cc @jkotas @bbowyersmyth @mikedn 

**edit:** I added yet another test case to the performance tests that read in the text of the `.cs` source file and tested `wcslen` on it. It looks like the new implementation is 2x-2.5x faster here.