### PR TITLE
Fix LLDB search order

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -41,7 +41,8 @@ if(NOT ENABLE_LLDBPLUGIN)
 endif()
 
 # Check for LLDB library
-find_library(LLDB NAMES LLDB lldb lldb-3.8 lldb-3.6 lldb-3.5 PATHS "${WITH_LLDB_LIBS}" PATH_SUFFIXES llvm)
+find_library(LLDB NAMES LLDB lldb lldb-3.8 lldb-3.6 lldb-3.5 PATHS "${WITH_LLDB_LIBS}" PATH_SUFFIXES llvm NO_DEFAULT_PATH)
+find_library(LLDB NAMES LLDB lldb lldb-3.8 lldb-3.6 lldb-3.5 PATH_SUFFIXES llvm)
 if(LLDB STREQUAL LLDB-NOTFOUND)
     if(REQUIRE_LLDBPLUGIN)
         message(FATAL_ERROR "Cannot find lldb-3.5, lldb-3.6 or lldb-3.8. Try installing lldb-3.6-dev (or the appropriate package for your platform)")
@@ -55,7 +56,8 @@ message(STATUS "LLDB: ${LLDB}")
 
 # Check for LLDB headers
 
-find_path(LLDB_H "lldb/API/LLDB.h" PATHS "${WITH_LLDB_INCLUDES}")
+find_path(LLDB_H "lldb/API/LLDB.h" PATHS "${WITH_LLDB_INCLUDES}" NO_DEFAULT_PATH)
+find_path(LLDB_H "lldb/API/LLDB.h")
 if(LLDB_H STREQUAL LLDB_H-NOTFOUND)
     find_path(LLDB_H "lldb/API/LLDB.h" PATHS "/usr/lib/llvm-3.8/include")
     if(LLDB_H STREQUAL LLDB_H-NOTFOUND)


### PR DESCRIPTION
By default `cmake`'s `find_library`  without `NO_DEFAULT_PATH` keyword searches first in default locations specified by `${CMAKE_SYSTEM_PREFIX_PATH}` and only then in locations specified via `PATHS` keyword (`${WITH_LLDB_LIBS}` in our case). As result it always picks-up default LLDB ignoring the one explicitly specified via `${WITH_LLDB_LIBS}`.

This change modifies search order giving priority to `${WITH_LLDB_LIBS}` and `${WITH_LLDB_INCLUDES}` over default locations.