### PR TITLE
Avoid heap allocating in char.ConvertFromUtf32

### DIFF
--- a/src/mscorlib/src/System/Char.cs
+++ b/src/mscorlib/src/System/Char.cs
@@ -914,6 +914,7 @@ namespace System {
         ** Convert an UTF32 value into a surrogate pair.
         ==============================================================================*/
         
+        [System.Security.SecuritySafeCritical]
         public static String ConvertFromUtf32(int utf32)
         {
             // For UTF32 values from U+00D800 ~ U+00DFFF, we should throw.  They

--- a/src/mscorlib/src/System/Char.cs
+++ b/src/mscorlib/src/System/Char.cs
@@ -932,8 +932,8 @@ namespace System {
             {
                 // This is a sumplementary character.  Convert it to a surrogate pair in UTF-16.
                 utf32 -= UNICODE_PLANE01_START;
-                uint surrogate = 0;
-                char* address = (char*)&surrogate;
+                uint surrogate = 0; // allocate 2 chars worth of stack space
+                char* address = (char*)&surrogate; // we forego using stackalloc here because it's slow; see dotnet/coreclr#5719
                 address[0] = (char)((utf32 / 0x400) + (int)CharUnicodeInfo.HIGH_SURROGATE_START);
                 address[1] = (char)((utf32 % 0x400) + (int)CharUnicodeInfo.LOW_SURROGATE_START);
                 return new string(address, 0, 2);

--- a/src/mscorlib/src/System/Char.cs
+++ b/src/mscorlib/src/System/Char.cs
@@ -933,7 +933,7 @@ namespace System {
                 // This is a supplementary character.  Convert it to a surrogate pair in UTF-16.
                 utf32 -= UNICODE_PLANE01_START;
                 uint surrogate = 0; // allocate 2 chars worth of stack space
-                char* address = (char*)&surrogate; // we forego using stackalloc here because it's slow; see dotnet/coreclr#5719
+                char* address = (char*)&surrogate;
                 address[0] = (char)((utf32 / 0x400) + (int)CharUnicodeInfo.HIGH_SURROGATE_START);
                 address[1] = (char)((utf32 % 0x400) + (int)CharUnicodeInfo.LOW_SURROGATE_START);
                 return new string(address, 0, 2);

--- a/src/mscorlib/src/System/Char.cs
+++ b/src/mscorlib/src/System/Char.cs
@@ -932,10 +932,11 @@ namespace System {
             {
                 // This is a sumplementary character.  Convert it to a surrogate pair in UTF-16.
                 utf32 -= UNICODE_PLANE01_START;
-                char* surrogate = stackalloc char[2];
-                surrogate[0] = (char)((utf32 / 0x400) + (int)CharUnicodeInfo.HIGH_SURROGATE_START);
-                surrogate[1] = (char)((utf32 % 0x400) + (int)CharUnicodeInfo.LOW_SURROGATE_START);
-                return new string(surrogate, 0, 2);
+                uint surrogate = 0;
+                char* address = (char*)&surrogate;
+                address[0] = (char)((utf32 / 0x400) + (int)CharUnicodeInfo.HIGH_SURROGATE_START);
+                address[1] = (char)((utf32 % 0x400) + (int)CharUnicodeInfo.LOW_SURROGATE_START);
+                return new string(address, 0, 2);
             }
         }
 

--- a/src/mscorlib/src/System/Char.cs
+++ b/src/mscorlib/src/System/Char.cs
@@ -927,12 +927,16 @@ namespace System {
                 // This is a BMP character.
                 return (Char.ToString((char)utf32));
             }
-            // This is a sumplementary character.  Convert it to a surrogate pair in UTF-16.
-            utf32 -= UNICODE_PLANE01_START;
-            char[] surrogate = new char[2];
-            surrogate[0] = (char)((utf32 / 0x400) + (int)CharUnicodeInfo.HIGH_SURROGATE_START);
-            surrogate[1] = (char)((utf32 % 0x400) + (int)CharUnicodeInfo.LOW_SURROGATE_START);
-            return (new String(surrogate));
+
+            unsafe
+            {
+                // This is a sumplementary character.  Convert it to a surrogate pair in UTF-16.
+                utf32 -= UNICODE_PLANE01_START;
+                char* surrogate = stackalloc char[2];
+                surrogate[0] = (char)((utf32 / 0x400) + (int)CharUnicodeInfo.HIGH_SURROGATE_START);
+                surrogate[1] = (char)((utf32 % 0x400) + (int)CharUnicodeInfo.LOW_SURROGATE_START);
+                return new string(surrogate, 0, 2);
+            }
         }
 
 

--- a/src/mscorlib/src/System/Char.cs
+++ b/src/mscorlib/src/System/Char.cs
@@ -930,7 +930,7 @@ namespace System {
 
             unsafe
             {
-                // This is a sumplementary character.  Convert it to a surrogate pair in UTF-16.
+                // This is a supplementary character.  Convert it to a surrogate pair in UTF-16.
                 utf32 -= UNICODE_PLANE01_START;
                 uint surrogate = 0; // allocate 2 chars worth of stack space
                 char* address = (char*)&surrogate; // we forego using stackalloc here because it's slow; see dotnet/coreclr#5719


### PR DESCRIPTION
Currently `char.ConvertFromUtf32` creates a new char array of length 2, modifies it, and then creates a string out of that. This is a bit wasteful, since it means an extra heap allocation that won't be used by the caller. This changes that to allocate 2 chars' worth of space on the stack via declaring a local `uint`, then taking the address of that, modifying it, and passing it into the `string(char*, int, int)` constructor.

I didn't use `stackalloc` here since from my benchmarks it seems to be a bit slower than declaring a local variable; see results for [heap](https://gist.github.com/jamesqo/b8d96c106eb1e812d9fcad4c1976ca2f), [stackalloc](https://gist.github.com/jamesqo/82f246d32f1d9ee8646a82656fb3632c), and [local uint](https://gist.github.com/jamesqo/d900057710094fca142709d1f2f05a1d) ([here](https://gist.github.com/jamesqo/26e6453e34eee12640192b81fcf91c6f) is the source code). Also note that since most of the overhead in those timings is probably allocating/calling the string ctor, the differences may be greater than they reflect.

Separated out from #4881 (which should probably be merged sometime)

cc @jkotas