### PR TITLE
Avoid unnecessary allocations in Encoding.EncodingName

### DIFF
--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -722,7 +722,7 @@ namespace System.Text
         {
             get
             {
-                return (Environment.GetResourceString("Globalization.cp_" + m_codePage));
+                return Environment.GetResourceString("Globalization.cp_" + m_codePage.ToString());
             }
         }
 


### PR DESCRIPTION
`Encoding.EncodingName` concatenates a `string` with an `int` via `string.Concat(object, object)`, which results in the `int` being boxed.

This change avoids the box by calling `int.ToString()`, allowing `string.Concat(string, string)` to be used.