### PR TITLE
Avoid unnecessary allocations in LocalVariableInfo.ToString()

### DIFF
--- a/src/mscorlib/src/System/Reflection/MethodBody.cs
+++ b/src/mscorlib/src/System/Reflection/MethodBody.cs
@@ -150,12 +150,7 @@ namespace System.Reflection
         #region Object Overrides
         public override string ToString()
         {
-            string toString = LocalType.ToString() + " (" + LocalIndex + ")";
-            
-            if (IsPinned)
-                toString += " (pinned)";
-
-            return toString;
+            return LocalType.ToString() + " (" + LocalIndex.ToString() + (IsPinned ? ") (pinned)" : ")");
         }
         #endregion
 


### PR DESCRIPTION
`LocalVariableInfo.ToString()` calls `string.Concat(object[])`, which results in an unnecessary `object[]` allocation and `int` box allocation. If `IsPinned` is true, it then additionally calls `string.Concat(string, string)`, resulting in another allocation.

These allocations can be avoided by calling `int.ToString()` to avoid the box allocation and tweaking the code such that `string.Concat(string, string, string, string)` can be used, avoiding the array allocation and additional subsequent string allocation when `IsPinned` is true.