### PR TITLE
Fix syntax error in sign.builds

### DIFF
--- a/src/sign.builds
+++ b/src/sign.builds
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SkipFileSigning Condition="'$(SkipFileSigning)' == ''" and "'$(BuildArch)' == 'arm64'">true</SkipFileSigning>
+    <SkipFileSigning Condition="'$(SkipFileSigning)' == '' and '$(BuildArch)' == 'arm64'">true</SkipFileSigning>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="ReadSigningRequired" />


### PR DESCRIPTION
This syntax error was introduced when trying to skip signing for arm64.