### PR TITLE
Avoid box allocation in DateTimeFormat.FormatCustomized

### DIFF
--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -606,7 +606,7 @@ namespace System {
                                 FormatDigits(result, year % 100, tokenLen);
                             }
                             else {
-                                String fmtPattern = "D" + tokenLen;
+                                String fmtPattern = "D" + tokenLen.ToString();
                                 result.Append(year.ToString(fmtPattern, CultureInfo.InvariantCulture));
                             }
                         }


### PR DESCRIPTION
The current implementation calls `string.Concat(object, object)`, which results in an `int` box allocation.

Avoid the box allocation by calling `int.ToString()`, allowing `string.Concat(string, string)` to be used.