### PR TITLE
Avoid box allocation in TypeBuilder.DefineDataHelper

### DIFF
--- a/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -852,7 +852,7 @@ namespace System.Reflection.Emit {
             ThrowIfCreated();
 
             // form the value class name
-            strValueClassName = ModuleBuilderData.MULTI_BYTE_VALUE_CLASS + size;
+            strValueClassName = ModuleBuilderData.MULTI_BYTE_VALUE_CLASS + size.ToString();
 
             // Is this already defined in this module?
             Type temp = m_module.FindTypeBuilderWithName(strValueClassName, false);


### PR DESCRIPTION
The current implementation calls `string.Concat(object, object)`, which results in a box allocation.

Avoid the box allocation by calling `int.ToString()`, allowing `string.Concat(string, string)` to be used.