### PR TITLE
Avoid box allocation in ActivityTracker

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/ActivityTracker.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/ActivityTracker.cs
@@ -323,7 +323,7 @@ namespace System.Diagnostics.Tracing
             {
                 if (activityInfo == null)
                     return ("");
-                return Path(activityInfo.m_creator) + "/" + activityInfo.m_uniqueId;
+                return Path(activityInfo.m_creator) + "/" + activityInfo.m_uniqueId.ToString();
             }
 
             public override string ToString()


### PR DESCRIPTION
The current implementation calls `string.Concat(object, object, object)`, which results in a box allocation.

Avoid the box allocation by calling `long.ToString()`, allowing `string.Concat(string, string, string)` to be used.