### PR TITLE
make all public properties of DebuggableAttribute visible outside mscorelib

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -1660,6 +1660,12 @@
     <Type Name="System.Diagnostics.DebuggableAttribute">
       <Member Name="#ctor(System.Boolean,System.Boolean)" />
       <Member Name="#ctor(System.Diagnostics.DebuggableAttribute+DebuggingModes)" />
+      <Member Name="get_IsJITTrackingEnabled" />
+      <Member Name="get_IsJITOptimizerDisabled" />
+      <Member Name="get_DebuggingFlags" />
+      <Member MemberType="Property" Name="IsJITTrackingEnabled" />
+      <Member MemberType="Property" Name="IsJITOptimizerDisabled" />
+      <Member MemberType="Property" Name="DebuggingFlags" />
     </Type>
     <Type Name="System.Diagnostics.DebuggableAttribute+DebuggingModes">
       <Member MemberType="Field" Name="Default" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -4476,6 +4476,9 @@ namespace System.Diagnostics
             IgnoreSymbolStoreSequencePoints = 2,
             None = 0,
         }
+        public bool IsJITTrackingEnabled { get { return default(bool); } }
+        public bool IsJITOptimizerDisabled { get { return default(bool); } }
+        public DebuggingModes DebuggingFlags { get { return default(DebuggingModes); } }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class Debugger


### PR DESCRIPTION
Hello everybody!

I am writing a [code](https://github.com/PerfDotNet/BenchmarkDotNet) that needs to check whether given dll was optimized or not. The best way to do it in classic desktop clr is to check if given assembly has attribute `DebuggableAttribute` with  `IsJITOptimizerDisabled == false`.

The problem is that System.Runtime does not expose this public property, which [is implemented anyway](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Diagnostics/DebuggerAttributes.cs/#L93=L111)

Could you expose this methods? If so then is my PR enough to get it working?

