### PR TITLE
Avoid string concat array allocation in ActivityTracker

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/ActivityTracker.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/ActivityTracker.cs
@@ -328,10 +328,7 @@ namespace System.Diagnostics.Tracing
 
             public override string ToString()
             {
-                string dead = "";
-                if (m_stopped != 0)
-                    dead = ",DEAD";
-                return m_name + "(" + Path(this) + dead + ")";
+                return m_name + "(" + Path(this) + (m_stopped != 0 ? ",DEAD)" : ")");
             }
 
             public static string LiveActivities(ActivityInfo list)


### PR DESCRIPTION
`ActivityTracker+ActivityInfo.ToString()` currently uses `string.Concat(string[])` which requires a `string[]` allocation.

The `string[]` allocation can be avoided by modifying the code slightly.