### PR TITLE
Do not clean tests folder when skiptests option is used along with clean

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -203,8 +203,6 @@ set __msbuildCleanBuildArgs=/t:rebuild
 :: Cleanup the previous output for the selected configuration
 if exist "%__BinDir%"               rd /s /q "%__BinDir%"
 if exist "%__IntermediatesDir%"     rd /s /q "%__IntermediatesDir%"
-if exist "%__TestBinDir%"           rd /s /q "%__TestBinDir%"
-if exist "%__TestIntermediatesDir%" rd /s /q "%__TestIntermediatesDir%"
 if exist "%__LogsDir%"              del /f /q "%__LogsDir%\*_%__BuildOS%__%__BuildArch%__%__BuildType%.*"
 if exist "%__ProjectDir%\Tools"     rd /s /q "%__ProjectDir%\Tools"
 


### PR DESCRIPTION
Currently following command 
build.cmd clean skiptests
deletes bin\test folder contents although it is not going to build test.
After this PR
build.cmd clean -> will delete both product & test binaries
build.cmd clean skiptests -> will only delete product binaries
