### PR TITLE
Resolve Python2.7 when executable is not called 'python'.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 
-PYTHON=${PYTHON:-python}
+# resolve python-version to use
+if [ "$PYTHON" == "" ] ; then
+    if which python >/dev/null 2>&1
+    then
+       PYTHON=python
+    elif which python2 >/dev/null 2>&1
+    then
+       PYTHON=python2
+    elif which python2.7 >/dev/null 2>&1
+    then
+       PYTHON=python2.7
+    else
+       echo "Unable to locate build-dependency python2.x!" 1>&2
+       exit 1
+    fi
+fi
+
+# validate python-dependency
+# useful in case of explicitly set option.
+if ! which $PYTHON > /dev/null 2>&1
+then
+   echo "Unable to locate build-dependency python2.x ($PYTHON)!" 1>&2
+   exit 1
+fi
 
 usage()
 {


### PR DESCRIPTION
On FreeBSD 10.2, the python executable is by default called `python2.7` and there's no default `python` to invoke. This breaks the build unless the user manually creates a python symlink in his `~/bin` folder.

Having no simple `python` executable may become standard on more systems in the future as more and more code is migrated towards python 3.0.

For now, we should try to resolve python2.7 manually when the defaults options does not result in the system resolving an executable.

This may address some issues reported in  https://github.com/dotnet/coreclr/issues/6115