### PR TITLE
[ARM-softfp/Linux] Get precise type for struct

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1443,6 +1443,10 @@ public:
     GenTreePtr               impAssignMultiRegTypeToVar(GenTreePtr op, CORINFO_CLASS_HANDLE hClass);
 #endif // FEATURE_MULTIREG_RET
 
+#ifdef ARM_SOFTFP
+    bool                     isSingleFloat32Struct(CORINFO_CLASS_HANDLE hClass);
+#endif // ARM_SOFTFP
+
     //-------------------------------------------------------------------------
     // Functions to handle homogeneous floating-point aggregates (HFAs) in ARM.
     // HFAs are one to four element structs where each element is the same

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16010,7 +16010,11 @@ Compiler::fgWalkResult      Compiler::fgMorphLocalField(GenTreePtr tree, fgWalkD
             tree->gtLclFld.SetLclNum(fieldLclIndex);
 
             // We need to keep the types 'compatible'.  If we can switch back to a GT_LCL_VAR
+#ifdef ARM_SOFTFP
+            assert(varTypeIsIntegralOrI(tree->TypeGet()) || varTypeIsFloating(tree->TypeGet()));
+#else
             assert(varTypeIsIntegralOrI(tree->TypeGet()));
+#endif
             if (varTypeCanReg(fldVarDsc->TypeGet()))
             {
                 // If the type is integer-ish, then we can use it as-is


### PR DESCRIPTION
Compiler::argOrReturnTypeForStruct returns TYP_INT for any size-4 value type struct.
On ARM(hardfp), it is processed by HFA, however HFA is off on softfp.
So we need to check if the actual return type is TYPE_INT or TYPE_FLOAT.
Otherwise struct types with single float32 get into problems.

Check is done in Compiler::argOrReturnTypeForStruct, by IsSingleFloat32Struct.
The implementation is almost same `IsHfa` and `GetHfaType` because the logic is very similar.

Fix #6051