### PR TITLE
Do not invoke endlocal when skipping native build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -377,10 +377,10 @@ if errorlevel 1 (
     exit /b 1
 )
 
-:SkipNativeBuild
-
 REM endlocal to rid us of environment changes from vcvarsall.bat
 endlocal
+
+:SkipNativeBuild
 
 REM =========================================================================================
 REM ===


### PR DESCRIPTION
I was suddenly getting an error today when invoking `build.cmd`. I did a `set __echo=1` and got this output: https://gist.github.com/jamesqo/e0195f02941360e4e9a87b512fa80264

After I did a bit more investigating, I found out that the `__VSToolsRoot` (as well as all the other variables in the script) was getting unset after `endlocal` was called. Since we don't call `vcvarsall` anyways unless building for native, I moved it to before the `SkipNativeBuild` label so we only call it if building for native too.

cc @jkotas, @joperezr 