### PR TITLE
Fix exceptions in GC

### DIFF
--- a/src/gc/env/gcenv.sync.h
+++ b/src/gc/env/gcenv.sync.h
@@ -128,10 +128,11 @@ public:
 class CLREventStatic
 {
 public:
-    void CreateManualEvent(bool bInitialState);
-    void CreateAutoEvent(bool bInitialState);
-    void CreateOSManualEvent(bool bInitialState);
-    void CreateOSAutoEvent(bool bInitialState);
+    bool CreateAutoEventNoThrow(bool bInitialState);
+    bool CreateManualEventNoThrow(bool bInitialState);
+    bool CreateOSAutoEventNoThrow(bool bInitialState);
+    bool CreateOSManualEventNoThrow(bool bInitialState);
+
     void CloseEvent();
     bool IsValid() const;
     bool Set();

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -156,8 +156,6 @@ inline void FATAL_GC_ERROR()
 #define END_TIMING_CYCLES(x)
 #endif //SYNCHRONIZATION_STATS || STAGE_STATS
 
-#define NO_CATCH_HANDLERS  //to debug gc1, remove the catch handlers
-
 /* End of optional features */
 
 #ifdef GC_CONFIG_DRIVEN

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -11,28 +11,36 @@
 
 EEConfig * g_pConfig;
 
-void CLREventStatic::CreateManualEvent(bool bInitialState)
+bool CLREventStatic::CreateManualEventNoThrow(bool bInitialState)
 {
     m_hEvent = CreateEventW(NULL, TRUE, bInitialState, NULL);
     m_fInitialized = true;
+
+    return IsValid();
 }
 
-void CLREventStatic::CreateAutoEvent(bool bInitialState)
+bool CLREventStatic::CreateAutoEventNoThrow(bool bInitialState)
 {
     m_hEvent = CreateEventW(NULL, FALSE, bInitialState, NULL);
     m_fInitialized = true;
+
+    return IsValid();
 }
 
-void CLREventStatic::CreateOSManualEvent(bool bInitialState)
+bool CLREventStatic::CreateOSManualEventNoThrow(bool bInitialState)
 {
     m_hEvent = CreateEventW(NULL, TRUE, bInitialState, NULL);
     m_fInitialized = true;
+
+    return IsValid();
 }
 
-void CLREventStatic::CreateOSAutoEvent(bool bInitialState)
+bool CLREventStatic::CreateOSAutoEventNoThrow(bool bInitialState)
 {
     m_hEvent = CreateEventW(NULL, FALSE, bInitialState, NULL);
     m_fInitialized = true;
+
+    return IsValid();
 }
 
 void CLREventStatic::CloseEvent()

--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -408,6 +408,31 @@ void Object::SetAppDomain(AppDomain *pDomain)
     _ASSERTE(GetHeader()->GetAppDomainIndex().m_dwIndex != 0);
 }
 
+BOOL Object::SetAppDomainNoThrow()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        SO_INTOLERANT;
+    }
+    CONTRACTL_END;
+
+    BOOL success = FALSE;
+
+    EX_TRY
+    {
+        SetAppDomain();
+        success = TRUE;
+    }
+    EX_CATCH
+    {
+        _ASSERTE (!"Exception happened during Object::SetAppDomain");
+    }
+    EX_END_CATCH(RethrowTerminalExceptions)
+
+    return success;
+}
 
 AppDomain *Object::GetAppDomain()
 {

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -326,6 +326,8 @@ class Object
 #ifndef DACCESS_COMPILE
     // Set app domain of object to current domain.
     void SetAppDomain() { WRAPPER_NO_CONTRACT; SetAppDomain(::GetAppDomain()); }
+    BOOL SetAppDomainNoThrow();
+    
 #endif
 
     // Set app domain of object to given domain - it can only be set once

--- a/src/vm/synch.cpp
+++ b/src/vm/synch.cpp
@@ -60,6 +60,33 @@ void CLREventBase::CreateAutoEvent (BOOL bInitialState  // If TRUE, initial stat
     
 }
 
+BOOL CLREventBase::CreateAutoEventNoThrow (BOOL bInitialState  // If TRUE, initial state is signalled
+                                )
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        SO_TOLERANT;
+        // disallow creation of Crst before EE starts
+        // Can not assert here. ASP.Net uses our Threadpool before EE is started.
+        PRECONDITION((m_handle == INVALID_HANDLE_VALUE)); 
+        PRECONDITION((!IsOSEvent()));
+    }
+    CONTRACTL_END;
+
+    EX_TRY
+    {
+        CreateAutoEvent(bInitialState);
+    }
+    EX_CATCH
+    {
+    }
+    EX_END_CATCH(SwallowAllExceptions);
+
+    return IsValid();
+}
+
 void CLREventBase::CreateManualEvent (BOOL bInitialState  // If TRUE, initial state is signalled
                                 )
 {
@@ -100,6 +127,32 @@ void CLREventBase::CreateManualEvent (BOOL bInitialState  // If TRUE, initial st
     }
 }
 
+BOOL CLREventBase::CreateManualEventNoThrow (BOOL bInitialState  // If TRUE, initial state is signalled
+                                )
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        SO_TOLERANT;
+        // disallow creation of Crst before EE starts
+        // Can not assert here. ASP.Net uses our Threadpool before EE is started.
+        PRECONDITION((m_handle == INVALID_HANDLE_VALUE));
+        PRECONDITION((!IsOSEvent()));
+    }
+    CONTRACTL_END;
+
+    EX_TRY
+    {
+        CreateManualEvent(bInitialState);
+    }
+    EX_CATCH
+    {
+    }
+    EX_END_CATCH(SwallowAllExceptions);
+
+    return IsValid();
+}
 
 void CLREventBase::CreateMonitorEvent(SIZE_T Cookie)
 {
@@ -340,6 +393,29 @@ void CLREventBase::CreateOSAutoEvent (BOOL bInitialState  // If TRUE, initial st
     m_handle = h;
 }
 
+BOOL CLREventBase::CreateOSAutoEventNoThrow (BOOL bInitialState  // If TRUE, initial state is signalled
+                                )
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        // disallow creation of Crst before EE starts
+        PRECONDITION((m_handle == INVALID_HANDLE_VALUE));        
+    }
+    CONTRACTL_END;
+
+    EX_TRY
+    {
+        CreateOSAutoEvent(bInitialState);
+    }
+    EX_CATCH
+    {
+    }
+    EX_END_CATCH(SwallowAllExceptions);
+
+    return IsValid();
+}
 
 void CLREventBase::CreateOSManualEvent (BOOL bInitialState  // If TRUE, initial state is signalled
                                 )
@@ -365,6 +441,29 @@ void CLREventBase::CreateOSManualEvent (BOOL bInitialState  // If TRUE, initial 
     m_handle = h;
 }
 
+BOOL CLREventBase::CreateOSManualEventNoThrow (BOOL bInitialState  // If TRUE, initial state is signalled
+                                )
+{
+    CONTRACTL
+    {
+        NOTHROW; 
+        GC_NOTRIGGER;
+        // disallow creation of Crst before EE starts
+        PRECONDITION((m_handle == INVALID_HANDLE_VALUE));
+    }
+    CONTRACTL_END;
+
+    EX_TRY
+    {
+        CreateOSManualEvent(bInitialState);
+    }
+    EX_CATCH
+    {
+    }
+    EX_END_CATCH(SwallowAllExceptions);
+
+    return IsValid();
+}
 
 void CLREventBase::CloseEvent()
 {

--- a/src/vm/synch.h
+++ b/src/vm/synch.h
@@ -36,6 +36,10 @@ public:
     void CreateAutoEvent(BOOL bInitialState);
     void CreateManualEvent(BOOL bInitialState);
 
+    // Non-throwing variants of the functions above
+    BOOL CreateAutoEventNoThrow(BOOL bInitialState);
+    BOOL CreateManualEventNoThrow(BOOL bInitialState);
+
     void CreateMonitorEvent(SIZE_T Cookie); // robust against initialization races - for exclusive use by AwareLock
 
 #ifdef FEATURE_RWLOCK
@@ -46,6 +50,10 @@ public:
     // Create an Event that is not host aware
     void CreateOSAutoEvent (BOOL bInitialState);
     void CreateOSManualEvent (BOOL bInitialState);
+
+    // Non-throwing variants of the functions above
+    BOOL CreateOSAutoEventNoThrow (BOOL bInitialState);
+    BOOL CreateOSManualEventNoThrow (BOOL bInitialState);
 
     void CloseEvent();
 


### PR DESCRIPTION
The GC code in general doesn't expect exceptions to be thrown from functions
it calls. However, the event creation functions were in fact throwing, so
in case of OOM, exception would be thrown from various places of the code.
This change creates non-throwing versions of the event creation functions
and replaces all usages of the throwing ones in the GC.
In addition, I've removed blocks with PAL_TRY that were under NO_CATCH_HANDLERS
define and also added Object::SetAppDomainNoThrow, which allowed me to removed
EX_TRY from GCHeap::StressHeap where the Object::SetAppDomain was called before.