### PR TITLE
[WIP]Minor refactoring changes to prepare ground for supporting non-lclvar reg optional operands

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1332,7 +1332,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* treeNode)
         assert(!divisor->isContained() || 
                divisor->isMemoryOp() || 
                divisor->IsCnsFltOrDbl() ||
-               divisor->IsRegOptional());
+               divisor->IsRegOptionalUse());
 
         // Floating point div/rem operation
         assert(oper == GT_DIV || oper == GT_MOD);
@@ -1455,7 +1455,7 @@ void CodeGen::genCodeForBinary(GenTree* treeNode)
         assert(op1->isMemoryOp() || 
                op1->IsCnsNonZeroFltOrDbl() || 
                op1->IsIntCnsFitsInI32() ||
-               op1->IsRegOptional());
+               op1->IsRegOptionalUse());
 
         op1 = treeNode->gtGetOp2();
         op2 = treeNode->gtGetOp1();
@@ -5091,7 +5091,7 @@ void CodeGen::genConsumeRegs(GenTree* tree)
             LclVarDsc* varDsc = compiler->lvaTable + varNum;
 
             noway_assert(varDsc->lvRegNum == REG_STK);
-            noway_assert(tree->IsRegOptional());
+            noway_assert(tree->IsRegOptionalUse());
 
             // Update the life of reg optional lcl var.
             genUpdateLife(tree);

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2909,12 +2909,12 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     GenTreeLclVar* lclVar = nullptr;
     if (src->isContainedLclVar())
     {
-        assert(src->IsRegOptional());
+        assert(src->IsRegOptionalUse());
         lclVar = src->AsLclVar();
     }
     else if (dst->isContainedLclVar())
     {
-        assert(dst->IsRegOptional());
+        assert(dst->IsRegOptionalUse());
         lclVar = dst->AsLclVar();
     }
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -12952,16 +12952,16 @@ BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler * comp)
     }
 }
 
-// -------------------------------------------------------------------------
-// IsRegOptional: Returns true if this gentree node is marked by lowering to
-// indicate that codegen can still generate code even if it wasn't allocated
-// a register.
-bool GenTree::IsRegOptional() const
+// -----------------------------------------------------------------------------
+// IsRegOptionalUse:  Returns true if this gentree node is marked by lowering to
+// indicate that codegen can still generate code for parent of this node even if
+// this operand wasn't allocated a register.
+bool GenTree::IsRegOptionalUse() const
 {
 #ifdef LEGACY_BACKEND
     return false;
 #else
-    return gtLsraInfo.regOptional;
+    return gtLsraInfo.isRegOptionalUse;
 #endif
 }
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1625,9 +1625,9 @@ public:
     inline var_types&           CastToType();
 
     // Returns true if this gentree node is marked by lowering to indicate
-    // that codegen can still generate code even if it wasn't allocated a 
-    // register.
-    bool IsRegOptional() const;   
+    // that codegen can still generate code for parent of this node even if
+    // this operand wasn't allocated a register.
+    bool IsRegOptionalUse() const;   
 
     // Returns "true" iff "*this" is an assignment (GT_ASG) tree that defines an SSA name (lcl = phi(...));
     bool IsPhiDefn();

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -3178,7 +3178,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
             // if one of them is on stack.
             TryToSetRegOptional(op2);
 
-            if (!op2->IsRegOptional())
+            if (!op2->IsRegOptionalUse())
             {
                 TryToSetRegOptional(op1);
             }
@@ -3884,7 +3884,7 @@ void Lowering::TryToSetRegOptional(GenTree* tree)
 {
     if (tree->OperGet() == GT_LCL_VAR)
     {
-        tree->gtLsraInfo.regOptional = true;
+        tree->gtLsraInfo.isRegOptionalUse = true;
     }
 }
 
@@ -3919,7 +3919,7 @@ void Lowering::SetRegOptionalForBinOp(GenTree* tree)
         TryToSetRegOptional(op2);
     }
 
-    if (!op2->IsRegOptional() &&
+    if (!op2->IsRegOptionalUse() &&
         tree->OperIsCommutative() &&
         tree->TypeGet() == op1->TypeGet())
     {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -752,6 +752,7 @@ LinearScan::newRefPosition(regNumber reg,
     newRP->registerAssignment = mask;
 
     newRP->setMultiRegIdx(0);
+    newRP->setAllocateIfProfitable(0);
 
     associateRefPosWithInterval(newRP);
 
@@ -835,6 +836,7 @@ LinearScan::newRefPosition(Interval* theInterval,
     newRP->registerAssignment = mask;
 
     newRP->setMultiRegIdx(multiRegIdx);
+    newRP->setAllocateIfProfitable(0);
 
     associateRefPosWithInterval(newRP);
 
@@ -3216,6 +3218,8 @@ LinearScan::buildRefPositionsForNode(GenTree *tree,
             prefSrcInterval = i;
         }
 
+        bool useIsRegOptional = useNode->IsRegOptionalUse();
+
         bool isLastUse = true;
         if (isCandidateLocalRef(useNode))
         {
@@ -3260,7 +3264,15 @@ LinearScan::buildRefPositionsForNode(GenTree *tree,
             pos->delayRegFree = true;
         }
 
-        if (isLastUse) pos->lastUse = true;
+        if (isLastUse)
+        {
+            pos->lastUse = true;
+        }
+
+        if (useIsRegOptional)
+        {
+            pos->setAllocateIfProfitable(1);
+        }
     }
     JITDUMP("\n");
     

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1321,10 +1321,10 @@ public:
 
     Referenceable * referent;
 
-    Interval *getInterval() { assert (!isPhysRegRef); return (Interval *) referent; }
+    Interval *getInterval() { assert(!isPhysRegRef); return (Interval *)referent; }
     void setInterval(Interval *i) { referent = i; isPhysRegRef = false; }
 
-    RegRecord *getReg() { assert (isPhysRegRef); return (RegRecord *) referent; }
+    RegRecord *getReg() { assert(isPhysRegRef); return (RegRecord *)referent; }
     void setReg(RegRecord *r) { referent = r; isPhysRegRef = true; registerAssignment = genRegMask(r->regNum); }
 
     // nextRefPosition is the next in code order.
@@ -1344,13 +1344,13 @@ public:
     LsraLocation    nodeLocation;
     regMaskTP       registerAssignment;
 
-    regNumber       assignedReg() { 
+    regNumber       assignedReg() {
         if (registerAssignment == RBM_NONE)
         {
             return REG_NA;
         }
 
-        return genRegNumFromMask(registerAssignment); 
+        return genRegNumFromMask(registerAssignment);
     }
 
     RefType         refType;
@@ -1358,36 +1358,43 @@ public:
     // Returns true if it is a reference on a gentree node.
     bool            IsActualRef()
     {
-        return (refType == RefTypeDef || 
-                refType == RefTypeUse);
+        return (refType == RefTypeDef ||
+            refType == RefTypeUse);
     }
 
     bool            RequiresRegister()
     {
         return (IsActualRef()
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-                || refType == RefTypeUpperVectorSaveDef
-                || refType == RefTypeUpperVectorSaveUse
+            || refType == RefTypeUpperVectorSaveDef
+            || refType == RefTypeUpperVectorSaveUse
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-               ) && !AllocateIfProfitable();
+            ) && !AllocateIfProfitable();
     }
 
-    // Returns true whether this ref position is to be allocated
-    // a reg only if it is profitable.  Currently these are the
+    // Indicates whether this ref position is to be allocated
+    // a reg only if profitable. Currently these are the
     // ref positions that lower/codegen has indicated as reg
     // optional and is considered a contained memory operand if
     // no reg is allocated.
-    bool           AllocateIfProfitable()
+    unsigned        allocRegIfProfitable : 1;
+
+    void            setAllocateIfProfitable(unsigned val)
+    {
+        allocRegIfProfitable = val;
+    }
+
+    // Returns true whether this ref position is to be allocated
+    // a reg only if it is profitable. 
+    bool            AllocateIfProfitable()
     {
         // TODO-CQ: Right now if a ref position is marked as
         // copyreg or movereg, then it is not treated as
         // 'allocate if profitable'. This is an implementation
         // limitation that needs to be addressed.
-        return (refType == RefTypeUse) &&
+        return  allocRegIfProfitable &&
                 !copyReg &&
-                !moveReg &&
-                (treeNode != nullptr) &&
-                treeNode->IsRegOptional();
+                !moveReg;
     }
 
     // Used by RefTypeDef/Use positions of a multi-reg call node.

--- a/src/jit/nodeinfo.h
+++ b/src/jit/nodeinfo.h
@@ -31,7 +31,7 @@ public:
         isDelayFree           = false;
         hasDelayFreeSrc       = false;
         isTgtPref             = false;
-        regOptional           = false;
+        isRegOptionalUse      = false;
     }
 
     // dst
@@ -121,7 +121,7 @@ public:
     // in the same register as op1.
     unsigned char isTgtPref:1;
     // Whether a spilled second src can be treated as a contained operand
-    unsigned char regOptional:1;
+    unsigned char isRegOptionalUse:1;
 
 public:
 


### PR DESCRIPTION
Mainly two changes

1) Rename IsRegOptional() to IsRegOptionalUse() - to explicitly indicate that the use of gentree is considered reg optional.  In future if we need to support def position of a gentree to be reg, we can add IsRegOptionalDef().

2) Add a bit in RefPosition to indicate whether it is 'allocate if profitable'.  Earlier it was getting accessed from GenTreeNodePtr->gtLsraInfo if the ref position is refTypeUse.  RefUse positions of lclVar nodes contain a non-null GenTree node.  But, while building non-lclVar refUse positions, LSRA doesn't store a non-null tree node, since nothing needs to be written back. Hence to know whether refUse position of a non-lclVar tree node is 'allocate if profitable' we need to store it in its ref position.  

There were no asm diffs due to these changes.