### PR TITLE
Fix SOS bpmd for windows

### DIFF
--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -7116,9 +7116,13 @@ DECLARE_API(bpmd)
         // did we get dll and type name or file:line#? Search for a colon in the first arg
         // to see if it is in fact a file:line#
         CHAR* pColon = strchr(DllName.data, ':');
+#ifndef FEATURE_PAL 
+        if (FAILED(g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_MODULE_NAME_A, 0, NULL, NULL))) {
+#else
         if (FAILED(g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_DLL_NAME_A, 0, NULL, NULL))) {
-            ExtOut("File name:Line number not supported\n");
-           fBadParam = true;
+#endif
+           ExtOut("%s not loaded yet\n", MAIN_CLR_DLL_NAME_A);
+           return Status;
         }
 
         if(NULL != pColon)


### PR DESCRIPTION
SOS for windows x64 seems to have stopped working after commit #5688
In particular !bpmd command no longer works. It always prints the following message.
0:000> !bpmd a.exe Program.Main
File name:Line number not supported
Usage: !bpmd -md 
Usage: !bpmd [-nofuturemodule] []
Usage: !bpmd :
Usage: !bpmd -list
Usage: !bpmd -clear 
Usage: !bpmd -clearall
See "!help bpmd" for more details.

https://github.com/dotnet/coreclr/blob/master/src/ToolBox/SOS/Strike/strike.cpp#L7119 is the cause of the error. It seems we are calling g_ExtSymbols->GetModuleByModuleName with module name as coreclr.dll Otherplaces where the api is called it does not append .dll to the name such as here
https://github.com/dotnet/coreclr/blob/master/src/ToolBox/SOS/Strike/dllsext.cpp#L72

Changing MAIN_CLR_DLL_NAME_A to MAIN_CLR_MODULE_NAME_A fixes the problem on windows x64. Linux however expects full name of library. Also report correct error message.