### PR TITLE
Fix Environment.set_ExitCode to work on coreclr

### DIFF
--- a/src/vm/assembly.cpp
+++ b/src/vm/assembly.cpp
@@ -2495,18 +2495,18 @@ HRESULT RunMain(MethodDesc *pFD ,
     // entrypoint returns an 'int' we take that.  Otherwise we take a latched
     // process exit code.  This can be modified by the app via setting
     // Environment's ExitCode property.
-    //
+#ifndef FEATURE_CORECLR
     // When we're executing the default exe main in the default domain, set the latched exit code to 
     // zero as a default.  If it gets set to something else by user code then that value will be returned. 
-#ifndef FEATURE_CORECLR
+    //
     // StringArgs appears to be non-null only when the main method is explicitly invoked via the hosting api
     // or through creating a subsequent domain and running an exe within it.  In those cases we don't
     // want to reset the (global) latched exit code.
     if (stringArgs == NULL)
-#endif
     {
         SetLatchedExitCode(0);
     }
+#endif
 
     if (!pFD) {
         _ASSERTE(!"Must have a function to call!");
@@ -2600,10 +2600,10 @@ HRESULT RunMain(MethodDesc *pFD ,
             *pParam->piRetVal = (INT32)threadStart.Call_RetArgSlot(&stackVar);
 #ifndef FEATURE_CORECLR
             if (pParam->stringArgs == NULL) 
-#endif
             {
                 SetLatchedExitCode(*pParam->piRetVal);
             }
+#endif
         }
 
         GCPROTECT_END();


### PR DESCRIPTION
I'm not familiar with this area of the code, so I'm not sure if this is the right solution or if it has unexpected and negative consequences, but it appears to work, and with it the tests added in https://github.com/dotnet/corefx/pull/9939 pass.

Fixes #6206
cc: @jkotas