### PR TITLE
Avoid repeated virtual method calls in List.Contains

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -310,22 +310,19 @@ namespace System.Collections.Generic {
     
         // Contains returns true if the specified element is in the List.
         // It does a linear, O(n) search.  Equality is determined by calling
-        // item.Equals().
-        //
-        public bool Contains(T item) {
-            if ((Object) item == null) {
-                for(int i=0; i<_size; i++)
-                    if ((Object) _items[i] == null)
-                        return true;
-                return false;
-            }
-            else {
-                EqualityComparer<T> c = EqualityComparer<T>.Default;
-                for(int i=0; i<_size; i++) {
-                    if (c.Equals(_items[i], item)) return true;
-                }
-                return false;
-            }
+        // EqualityComparer<T>.Default.Equals().
+
+        public bool Contains(T item)
+        {
+            // PERF: IndexOf calls Array.IndexOf, which internally
+            // calls EqualityComparer<T>.Default.IndexOf, which
+            // is specialized for different types. This
+            // boosts performance since instead of making a
+            // virtual method call each iteration of the loop,
+            // via EqualityComparer<T>.Default.Equals, we
+            // only make one virtual call to EqualityComparer.IndexOf.
+
+            return _size != 0 && IndexOf(item) != -1;
         }
 
         bool System.Collections.IList.Contains(Object item)


### PR DESCRIPTION
Right now `List.Contains` calls `EqualityComparer.Default.Equals` in a loop to check if the list contains the item, which will result in N virtual method calls to `Equals` if there are N items in the list. A more efficient way to do this is to call `Array.IndexOf` and check if it's -1, since internally that calls `EqualityComparer.IndexOf`, which is an internal virtual method in `EqualityComparer` specialized for all the default comparers. This way, we only make 1 virtual call (to `EqualityComparer.IndexOf`) instead of N.

Similar to: dotnet/corefx#9947, which applies this optimization for Stack.

### Performance results

[old](https://gist.github.com/jamesqo/5583d7ccf1a70e254ec2e879f1fce75e) / [new](https://gist.github.com/jamesqo/f963ec77bd0b46dbe22f4b5ea9dd7d7b) / [test source code](https://gist.github.com/jamesqo/9857aaa8b1e03d7d7c5afa6adea142e2)

As with the other PR, if the element is found in the first item of the list the new implementation is slightly slower. If it's found at the 2nd or 3rd position the times are about the same, the new impl is about 1.5x faster for the 10th position, and in extreme cases (or not depending on how big 'typical lists' are) the new implementation can be more than 4x faster.

I've pre-tested this with CoreFX and everything is passing in `System.Collections.Tests`.

@jkotas @stephentoub PTAL

**edit:** Note that this will not result in too big of a performance degradation for null items (e.g. if you do `list.Contains(null)` you won't be making virtual calls in a loop where you hadn't before), since each of the specialized implementations of `IndexOf` for each of the equality comparers [check for null / HasValue](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs#L154) and still do plain `if (array[i] == null)` if the parameter is null, as opposed to calling `Equals`.