### PR TITLE
Fix exceptions in GC wave 2

### DIFF
--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -128,8 +128,6 @@ inline void FATAL_GC_ERROR()
 //#define TRACE_GC          //debug trace gc operation
 //#define SIMPLE_DPRINTF
 
-//#define CATCH_GC          //catches exception during GC
-
 //#define TIME_GC           //time allocation and garbage collection
 //#define TIME_WRITE_WATCH  //time GetWriteWatch and ResetWriteWatch calls
 //#define COUNT_CYCLES  //Use cycle counter for timing

--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -250,28 +250,6 @@ LONG WINAPI CLRVectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo);
 // Actual UEF worker prototype for use by GCUnhandledExceptionFilter.
 extern LONG InternalUnhandledExceptionFilter_Worker(PEXCEPTION_POINTERS pExceptionInfo);
 
-// This function is the filter function for the "__except" setup in "gc1()"
-// in gc.cpp to handle exceptions that happen during GC.
-inline LONG CheckException(EXCEPTION_POINTERS* pExceptionPointers, PVOID pv)
-{
-    WRAPPER_NO_CONTRACT;
-
-    LONG result = CLRVectoredExceptionHandler(pExceptionPointers);
-    if (result != EXCEPTION_EXECUTE_HANDLER)
-        return result;
-
-#ifdef _DEBUG_IMPL
-    _ASSERTE(!"Unexpected Exception");
-#else
-    FreeBuildDebugBreak();
-#endif
-
-    // Set the debugger to break on AV and return a value of EXCEPTION_CONTINUE_EXECUTION (-1)
-    // here and you will bounce back to the point of the AV.
-    return EXCEPTION_EXECUTE_HANDLER;
-
-}
-
 //==========================================================================
 // Installs a handler to unwind exception frames, but not catch the exception
 //==========================================================================

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -585,7 +585,7 @@ void GCToEEInterface::GcStartWork (int condemned, int max_gen)
 {
     CONTRACTL
     {
-        THROWS; // StubHelpers::ProcessByrefValidationList throws
+        NOTHROW;
         GC_NOTRIGGER;
     }
     CONTRACTL_END;
@@ -660,7 +660,7 @@ void GCToEEInterface::GcBeforeBGCSweepWork()
 {
     CONTRACTL
     {
-        THROWS; // StubHelpers::ProcessByrefValidationList throws
+        NOTHROW;
         GC_NOTRIGGER;
     }
     CONTRACTL_END;

--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -143,7 +143,7 @@ void StubHelpers::ProcessByrefValidationList()
 {
     CONTRACTL
     {
-        THROWS;
+        NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;           
     }


### PR DESCRIPTION
I've removed blocks with PAL_TRY that were under CATCH_GC. I also had to
fix contract problem in GCToEEInterface::GcStartWork that was marked as
THROWS due to StubHelpers::ProcessByrefValidationList being marked as
THROWS, but the StubHelpers::ProcessByrefValidationList in fact doesn't
throw since it has body wrapped in EX_TRY / EX_CATCH. 
I have also removed the CheckException which is not used anywhere after this 
change.

This also fixes a problem that started to appear after my previous exceptions
fix change.