### PR TITLE
Fix #4177: RyuJIT/x86 NYI related to lvaArgType()

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -586,7 +586,7 @@ void                Compiler::lvaInitUserArgs(InitVarDscInfo *      varDscInfo)
         }
         if (isHfaArg)
         {
-            // We have an HFA argument, so from here on our treat the type as a float or double.
+            // We have an HFA argument, so from here on out treat the type as a float or double.
             // The orginal struct type is available by using origArgType
             // We also update the cSlots to be the number of float/double fields in the HFA
             argType = hfaType;
@@ -720,7 +720,7 @@ void                Compiler::lvaInitUserArgs(InitVarDscInfo *      varDscInfo)
         }
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
-        // The final home for this incoming register might be our local stack frame
+        // The final home for this incoming register might be our local stack frame.
         // For System V platforms the final home will always be on the local stack frame.
         varDsc->lvOnFrame = true;
 
@@ -2860,8 +2860,10 @@ var_types           LclVarDsc::lvaArgType()
 
         }
     }
+#elif defined(_TARGET_X86_)
+    // Nothing to do; use the type as is.
 #else
-    NYI("unknown target");
+    NYI("lvaArgType");
 #endif //_TARGET_AMD64_
 
     return type;


### PR DESCRIPTION
For x86, this function can simply return the variable type. There is
no need to map struct types. The function actually will never be
called on x86 for struct types because it is only called for register
arguments.

This NYI was only hit in the case of JMP calls. I fixed two cases
in the JMP implementation where FEATURE_VARARGS code assumed AMD64, due
to the Windows AMD64 ABI convention to pass float varargs values in both
integer and floating point registers. I put that under `#ifdef _TARGET_AMD64_`.

This removes 426 NYI.

@adiaaida @briansull PTAL
cc @dotnet/jit-contrib 