### PR TITLE
ARM64: In GetDelegateTarget a portion of the _WIN64 code was under _T…

### DIFF
--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -1245,9 +1245,7 @@ FCIMPL2(void*, StubHelpers::GetDelegateTarget, DelegateObject *pThisUNSAFE, UINT
     UINT_PTR target = (UINT_PTR)orefThis->GetMethodPtrAux();
 
     // The lowest bit is used to distinguish between MD and target on 64-bit.
-#ifdef _TARGET_AMD64_
     target = (target << 1) | 1;
-#endif // _TARGET_AMD64_
 
     // On 64-bit we pass the real target to the stub-for-host through this out argument,
     // see IL code gen in NDirectStubLinker::DoNDirect for details.


### PR DESCRIPTION
ARM64: In GetDelegateTarget a portion of the _WIN64 code was under _TARGET_AMD64_ whereas at other places (like NDirectStubLinker::DoNDirect & InlinedCallFrame::HasFunction ) related code is under _WIN64. Make the code in GetDelegateTarget to be in sync with other functions and remove ifdef _TARGET_ADM64_. Without this change for arm64 InlinedCallFrame::m_datum stores unmanaged target pointer but StackWalker assumes it to be a NDirectMethodDesc and tries to dereference it and crashes.