### PR TITLE
Revert "Less conservative gt obj"

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -17725,7 +17725,7 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
                                             fieldSize,
                                             fieldVarDsc->lvRegNum,
                                             compiler->lvaOutgoingArgSpaceVar,
-                                            argOffset + fieldArgOffset);
+                                            fieldArgOffset);
 
                     if (fieldVarDsc->lvExactSize == 8) 
                     {
@@ -17751,7 +17751,7 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
                                                         fieldSize,
                                                         regTmp,
                                                         compiler->lvaOutgoingArgSpaceVar,
-                                                        argOffset + fieldArgOffset + TARGET_POINTER_SIZE);
+                                                        fieldArgOffset + TARGET_POINTER_SIZE);
                             }
                             else
                             {
@@ -17759,7 +17759,7 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
                                                         fieldSize,
                                                         fieldVarDsc->lvOtherReg,
                                                         compiler->lvaOutgoingArgSpaceVar,
-                                                        argOffset + fieldArgOffset + TARGET_POINTER_SIZE);
+                                                        fieldArgOffset + TARGET_POINTER_SIZE);
                             }
                         }
                         // Record the fact that we filled in an extra register slot
@@ -17823,7 +17823,7 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
                                             fieldSize,
                                             regTmp,
                                             compiler->lvaOutgoingArgSpaceVar,
-                                            argOffset + fieldArgOffset);
+                                            fieldArgOffset);
                     // We overwrote "regTmp", so erase any previous value we recorded that it contained.
                     regTracker.rsTrackRegTrash(regTmp);
 
@@ -17838,7 +17838,7 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
                                                 fieldSize,
                                                 regTmp,
                                                 compiler->lvaOutgoingArgSpaceVar,
-                                                argOffset + fieldArgOffset + TARGET_POINTER_SIZE);
+                                                fieldArgOffset + TARGET_POINTER_SIZE);
                         // Record the fact that we filled in an extra stack slot
                         filledExtraSlot = true;
                     }
@@ -17885,8 +17885,6 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
                 {
                     if (curRegNum != MAX_REG_ARG)
                     {
-                        // We are going to write to the lvaPromotedStructAssemblyScratchVar, at the offset
-                        // of this field within the current slot.
                         noway_assert(compiler->lvaPromotedStructAssemblyScratchVar != BAD_VAR_NUM);
 
                         getEmitter()->emitIns_S_R(ins_Store(fieldTypeForInstr),
@@ -17902,7 +17900,7 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
                                                 fieldSize,
                                                 fieldVarDsc->lvRegNum,
                                                 compiler->lvaOutgoingArgSpaceVar,
-                                                argOffset + fieldArgOffset);
+                                                fieldArgOffset);
                     }
                 }
                 else
@@ -17922,8 +17920,6 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
 
                     if (curRegNum != MAX_REG_ARG)
                     {                    
-                        // We are going to write to the lvaPromotedStructAssemblyScratchVar, at the offset
-                        // of this field within the current slot.
                         noway_assert(compiler->lvaPromotedStructAssemblyScratchVar != BAD_VAR_NUM);
 
                         getEmitter()->emitIns_S_R(ins_Store(fieldTypeForInstr),
@@ -17938,7 +17934,7 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
                                                 fieldSize,
                                                 regTmp,
                                                 compiler->lvaOutgoingArgSpaceVar,
-                                                argOffset + fieldArgOffset);
+                                                fieldArgOffset);
                     }
                 }
                 // Go to the next field.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6824,7 +6824,7 @@ public :
 #endif // _TARGET_ARM_
 
     // If "tree" is a indirection (GT_IND, or GT_OBJ) whose arg is an ADDR, whose arg is a LCL_VAR, return that LCL_VAR node, else NULL.
-    static GenTreePtr   fgIsIndirOfAddrOfLocal(GenTreePtr tree);
+    GenTreePtr          fgIsIndirOfAddrOfLocal(GenTreePtr tree);
 
     // This is indexed by GT_OBJ nodes that are address of promoted struct variables, which
     // have been annotated with the GTF_VAR_DEATH flag.  If such a node is *not* mapped in this

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -6756,7 +6756,7 @@ bool                Compiler::fgIsCommaThrow(GenTreePtr tree,
     return false;
 }
 
-// static
+
 GenTreePtr          Compiler::fgIsIndirOfAddrOfLocal(GenTreePtr tree)
 {
     GenTreePtr res = nullptr;
@@ -20592,7 +20592,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
     if (chkFlags & ~treeFlags)
     {
         // Print the tree so we can see it in the log.
-        printf("Missing flags on tree [%06d]: ", dspTreeID(tree));
+        printf("Missing flags on tree [%X]: ", tree);
         GenTree::gtDispFlags(chkFlags & ~treeFlags, GTF_DEBUG_NONE);
         printf("\n");
         gtDispTree(tree);
@@ -20600,7 +20600,7 @@ void                Compiler::fgDebugCheckFlags(GenTreePtr tree)
         noway_assert(!"Missing flags on tree");
 
         // Print the tree again so we can see it right after we hook up the debugger.
-        printf("Missing flags on tree [%06d]: ", dspTreeID(tree));
+        printf("Missing flags on tree [%X]: ", tree);
         GenTree::gtDispFlags(chkFlags & ~treeFlags, GTF_DEBUG_NONE);
         printf("\n");
         gtDispTree(tree);
@@ -22330,11 +22330,9 @@ GenTreePtr      Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
                     !(argSingleUseNode->gtFlags & GTF_VAR_CLONED) &&
                     !inlArgInfo[argNum].argHasLdargaOp)
                 {
-                    // Change the temp in-place to the actual argument.
-                    // We currently do not support this for struct arguments, so it must not be a GT_OBJ.
-                    GenTree* argNode = inlArgInfo[argNum].argNode;
-                    assert(argNode->gtOper != GT_OBJ);
-                    argSingleUseNode->CopyFrom(argNode, this);
+                    /* Change the temp in-place to the actual argument */
+
+                    argSingleUseNode->CopyFrom(inlArgInfo[argNum].argNode, this);
                     continue;
                 }
                 else

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5313,14 +5313,12 @@ bool                GenTree::OperMayThrow()
 
         break;
 
-    case GT_OBJ:
-        return !Compiler::fgIsIndirOfAddrOfLocal(this);
-
     case GT_ARR_BOUNDS_CHECK:
     case GT_ARR_ELEM:
     case GT_ARR_INDEX:
     case GT_CATCH_ARG:
     case GT_ARR_LENGTH:
+    case GT_OBJ:
     case GT_LCLHEAP:
     case GT_CKFINITE:
     case GT_NULLCHECK:
@@ -6047,16 +6045,7 @@ GenTreeObj* Compiler::gtNewObjNode(CORINFO_CLASS_HANDLE structHnd, GenTree* addr
 {
     var_types nodeType   = impNormStructType(structHnd);
     assert(varTypeIsStruct(nodeType));
-    GenTreeObj *objNode = new (this, GT_OBJ) GenTreeObj(nodeType, addr, structHnd);
-    // An Obj is not a global reference, if it is known to be a local struct.
-    GenTreeLclVarCommon* lclNode = addr->IsLocalAddrExpr();
-    if ((lclNode != nullptr) &&
-        !lvaIsImplicitByRefLocal(lclNode->gtLclNum) &&
-        !lvaTable[lclNode->gtLclNum].lvAddrExposed)
-    {
-        objNode->gtFlags &= ~GTF_GLOB_REF;
-    }
-    return objNode;
+    return new (this, GT_OBJ) GenTreeObj(nodeType, addr, structHnd);
 }
 
 // Creates a new CpObj node.
@@ -14278,8 +14267,6 @@ bool FieldSeqNode::IsPseudoField()
 #ifdef FEATURE_SIMD
 GenTreeSIMD* Compiler::gtNewSIMDNode(var_types type, GenTreePtr op1, SIMDIntrinsicID simdIntrinsicID, var_types baseType, unsigned size)
 {   
-    // TODO-CQ: An operand may be a GT_OBJ(GT_ADDR(GT_LCL_VAR))), in which case it should be
-    // marked lvUsedInSIMDIntrinsic.
     assert(op1 != nullptr);
     if (op1->OperGet() == GT_LCL_VAR)
     {
@@ -14293,8 +14280,6 @@ GenTreeSIMD* Compiler::gtNewSIMDNode(var_types type, GenTreePtr op1, SIMDIntrins
 
 GenTreeSIMD* Compiler::gtNewSIMDNode(var_types type, GenTreePtr op1, GenTreePtr op2, SIMDIntrinsicID simdIntrinsicID, var_types baseType, unsigned size)
 {
-    // TODO-CQ: An operand may be a GT_OBJ(GT_ADDR(GT_LCL_VAR))), in which case it should be
-    // marked lvUsedInSIMDIntrinsic.
     assert(op1 != nullptr);
     if (op1->OperIsLocal())
     {

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3329,8 +3329,7 @@ struct GenTreeObj: public GenTreeUnOp
         GenTreeUnOp(GT_OBJ, type, addr),
         gtClass(cls)
         {
-            // By default, an OBJ is assumed to be a global reference.
-            gtFlags |= GTF_GLOB_REF;
+            gtFlags |= GTF_GLOB_REF; // An Obj is always a global reference.
         }
 
 #if DEBUGGABLE_GENTREE

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1498,7 +1498,7 @@ GenTreePtr      Compiler::impNormStructVal(GenTreePtr    structVal,
 
     // Normalize it by wraping it in an OBJ
 
-    GenTreePtr structAddr = impGetStructAddr(structVal, structHnd, curLevel, !forceNormalization); // get the addr of struct
+    GenTreePtr structAddr  = impGetStructAddr(structVal, structHnd, curLevel, !forceNormalization); // get the addr of struct
     GenTreePtr structObj = new (this, GT_OBJ) GenTreeObj(structType, structAddr, structHnd);
 
     if (structAddr->gtOper == GT_ADDR)
@@ -1512,10 +1512,9 @@ GenTreePtr      Compiler::impNormStructVal(GenTreePtr    structVal,
     {
         // A OBJ on a ADDR(LCL_VAR) can never raise an exception
         // so we don't set GTF_EXCEPT here.
-        if (!lvaIsImplicitByRefLocal(structVal->AsLclVarCommon()->gtLclNum))
-        {
-            structObj->gtFlags &= ~GTF_GLOB_REF;
-        }
+        //
+        // TODO-CQ: Clear the GTF_GLOB_REF flag on structObj as well
+        //          but this needs additional work when inlining.
     }
     else  
     {
@@ -16799,17 +16798,15 @@ GenTreePtr  Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo *inlArgInfo,
             inlArgInfo[lclNum].argHasTmp = true;
             inlArgInfo[lclNum].argTmpNum = tmpNum;
             
-            // If we require strict exception order, then arguments must
-            // be evaluated in sequence before the body of the inlined method.
-            // So we need to evaluate them to a temp.
-            // Also, if arguments have global references, we need to
-            // evaluate them to a temp before the inlined body as the
-            // inlined body may be modifying the global ref.
-            // TODO-1stClassStructs: We currently do not reuse an existing lclVar
-            // if it is a struct, because it requires some additional handling.
+            /* If we require strict exception order then, arguments must
+            be evaulated in sequence before the body of the inlined
+            method. So we need to evaluate them to a temp.
+            Also, if arguments have global references, we need to
+            evaluate them to a temp before the inlined body as the
+            inlined body may be modifying the global ref.
+            */
             
-            if (!varTypeIsStruct(lclTyp) &&
-                (!inlArgInfo[lclNum].argHasSideEff) &&
+            if ((!inlArgInfo[lclNum].argHasSideEff) &&
                 (!inlArgInfo[lclNum].argHasGlobRef))
             {
                 /* Get a *LARGE* LCL_VAR node */

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -4683,7 +4683,7 @@ HANDLE_SHIFT_COUNT:
                     }
                 }
 
-                if ((promotedStructLocal != NULL) && (curArgMask != RBM_NONE))
+                if (promotedStructLocal != NULL)
                 {
                     // All or a portion of this struct will be placed in the argument registers indicated by "curArgMask".
                     // We build in knowledge of the order in which the code is generated here, so that the second arg to be evaluated


### PR DESCRIPTION
Reverts dotnet/coreclr#6021 to fix #6179 