### PR TITLE
Add back some surface area to thinned corelib

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -1877,7 +1877,11 @@
       <Member Status="ImplRoot" Name="TryGetRestrictedLanguageErrorObject(System.Object@)" Condition="FEATURE_COMINTEROP" />
 
     </Type>
-    <Type Name="System.ExecutionEngineException" />
+    <Type Name="System.ExecutionEngineException">
+      <Member Name="#ctor" />
+      <Member Name="#ctor(System.String)" />
+      <Member Name="#ctor(System.String,System.Exception)" />
+    </Type>
     <Type Name="System.FieldAccessException">
       <Member Name="#ctor" />
       <Member Name="#ctor(System.String)" />
@@ -3247,8 +3251,11 @@
     </Type>
     <Type Name="System.NotFiniteNumberException">
       <Member Name="#ctor" />
+      <Member Name="#ctor(System.Double)" />
       <Member Name="#ctor(System.String)" />
+      <Member Name="#ctor(System.String,System.Double)" />
       <Member Name="#ctor(System.String,System.Exception)" />
+      <Member Name="#ctor(System.String,System.Double,System.Exception)" />
     </Type>
     <Type Name="System.NotImplementedException">
       <Member Name="#ctor" />
@@ -5820,6 +5827,7 @@
       <Member Name="#ctor" />
       <Member Name="#ctor(System.String)" />
       <Member Name="#ctor(System.String,System.Exception)" />
+      <Member Name="#ctor(System.String,System.Int32)" />
       <Member Name="get_ErrorCode" />
       <Member MemberType="Property" Name="ErrorCode" />
     </Type>

--- a/src/vm/wks/CMakeLists.txt
+++ b/src/vm/wks/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 add_custom_command(
     # The AsmConstants.inc will be built in the pre-build phase of the cee_wks build
     TARGET cee_wks PRE_BUILD 
-    COMMAND ${POWERSHELL} -NoProfile -ExecutionPolicy Bypass \"& \"\"${VM_DIR}/h2inc.ps1\"\"\" \"\"\"${VM_DIR}/${ARCH_SOURCES_DIR}/asmconstants.h\"\"\" >"${CMAKE_CURRENT_BINARY_DIR}/AsmConstants.tmp"
+    COMMAND ${POWERSHELL} -NoProfile -ExecutionPolicy Bypass -NonInteractive \"& \"\"${VM_DIR}/h2inc.ps1\"\"\" \"\"\"${VM_DIR}/${ARCH_SOURCES_DIR}/asmconstants.h\"\"\" >"${CMAKE_CURRENT_BINARY_DIR}/AsmConstants.tmp"
     COMMAND ${CMAKE_CXX_COMPILER} ${DEFINITIONS} /EP "${CMAKE_CURRENT_BINARY_DIR}/AsmConstants.tmp" >"${CMAKE_CURRENT_BINARY_DIR}/AsmConstants.inc"
 )
 


### PR DESCRIPTION
We are working on expsosing some existing exception types from
System.Runtime in CoreFX. The implementations will facade over
System.Private.CoreLib, but we need to make sure all the members we expect
to expose from the contract are present in the implementation assembly.

Expose the missing members for ExecutionEngineException,
NotFiniteNumberException and ExternalException.