### PR TITLE
Stop BclRewriter from trimming serializable metadata

### DIFF
--- a/src/mscorlib/Tools/BclRewriter/BclRewriter.targets
+++ b/src/mscorlib/Tools/BclRewriter/BclRewriter.targets
@@ -24,7 +24,7 @@
       <BclRewriterCommand Condition="'$(BclRewriterCommand)'==''">"$(ToolRuntimePath)$(ToolHost)" "$(ToolsDir)BclRewriter.exe"</BclRewriterCommand>
     </PropertyGroup>
    
-    <Exec Command="$(BclRewriterCommand) -in:&quot;@(AnnotatedAssembly)&quot; -out:&quot;$(BclRewriterOutput)&quot; -include:&quot;$(BclRewriterModelFile)&quot; -platform:$(OSPlatform) -architecture:$(Platform) -flavor:$(_BuildType) -define:&quot;$(DefineConstants)&quot; -keepTempFiles+" StandardOutputImportance="Normal" />
+    <Exec Command="$(BclRewriterCommand) -in:&quot;@(AnnotatedAssembly)&quot; -out:&quot;$(BclRewriterOutput)&quot; -include:&quot;$(BclRewriterModelFile)&quot; -platform:$(OSPlatform) -architecture:$(Platform) -flavor:$(_BuildType) -removeSerializable- -define:&quot;$(DefineConstants)&quot; -keepTempFiles+" StandardOutputImportance="Normal" />
 
     <!-- Update the location of the symbol file-->
     <PropertyGroup>


### PR DESCRIPTION
All of the serializable metadata is being stripped off the assembly by the BclRewriter.  With our adding BinaryFormatter support to corefx, this prevents serializing even basic types, like string.  This commit just tells the rewriter not to remove it.

cc: @jkotas, @danmosemsft 