### PR TITLE
Build the TargetingPack package as part of build-packages scripts

### DIFF
--- a/build-packages.cmd
+++ b/build-packages.cmd
@@ -51,6 +51,15 @@ if NOT [!ERRORLEVEL!]==[0] (
   exit /b 1
 )
 
+rem Build the TargetingPack package
+set __msbuildArgs="%__ProjectDir%\src\.nuget\Microsoft.TargetingPack.Private.CoreCLR\Microsoft.TargetingPack.Private.CoreCLR.pkgproj" !allargs! 
+echo msbuild.exe %__msbuildArgs% !options! >> %packagesLog%
+call msbuild.exe %__msbuildArgs% !options!
+if NOT [!ERRORLEVEL!]==[0] (
+  echo ERROR: An error occurred while building packages, see %packagesLog% for more details.
+  exit /b 1
+)
+
 echo Done Building Packages.
 exit /b
 

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -156,6 +156,15 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+    # Build the TargetingPack package
+    $__ProjectRoot/Tools/corerun "$__MSBuildPath" /nologo "$__ProjectRoot/src\.nuget\Microsoft.TargetingPack.Private.CoreCLR\Microsoft.TargetingPack.Private.CoreCLR.pkgproj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$binclashlog" /t:Build /p:__BuildOS=$__BuildOS /p:__BuildArch=$__BuildArch /p:__BuildType=$__BuildType /p:__IntermediatesDir=$__IntermediatesDir /p:BuildNugetPackage=false /p:UseSharedCompilation=false
+
+if [ $? -ne 0 ]; then
+    echo -e "\nAn error occurred. Aborting build-packages.sh ." >> $build_packages_log
+    echo "ERROR: An error occurred while building packages, see $build_packages_log for more details."
+    exit 1
+fi
+
 echo "Done building packages."
 echo -e "\nDone building packages." >> $build_packages_log
 exit 0


### PR DESCRIPTION
Previously, we weren't building this as part of build-packages.cmd/.sh, but the error was invisible because the package got built as part of build.cmd. We have since fixed build.cmd to not build packages when running an orchestrated build, which revealed this error. This change should fix that issue. Should fix https://github.com/dotnet/corefx/issues/10014

CC @ericstj @jhendrixMSFT 