### PR TITLE
ARM64:Similar to arm, in order to preserve volatile semantics MemoryB…

### DIFF
--- a/src/inc/volatile.h
+++ b/src/inc/volatile.h
@@ -90,9 +90,9 @@
 // notice.
 //
 #define VOLATILE_MEMORY_BARRIER() asm volatile ("" : : : "memory")
-#endif // !_ARM_
-#elif defined(_ARM_) && _ISO_VOLATILE
-// ARM has a very weak memory model and very few tools to control that model. We're forced to perform a full
+#endif // _ARM_ || _ARM64_
+#elif (defined(_ARM_) || defined(_ARM64_)) && _ISO_VOLATILE
+// ARM & ARM64 have a very weak memory model and very few tools to control that model. We're forced to perform a full
 // memory barrier to preserve the volatile semantics. Technically this is only necessary on MP systems but we
 // currently don't have a cheap way to determine the number of CPUs from this header file. Revisit this if it
 // turns out to be a performance issue for the uni-proc case.
@@ -104,7 +104,7 @@
 // targeted by VC++ with /iso_volatile-.
 //
 #define VOLATILE_MEMORY_BARRIER()
-#endif
+#endif // __GNUC__
 
 //
 // VolatileLoad loads a T from a pointer to T.  It is guaranteed that this load will not be optimized

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -683,7 +683,7 @@ RelativePath=baseservices\exceptions\regressions\V1\SEH\VJ\ExternalException\Ext
 WorkingDir=baseservices\exceptions\regressions\V1\SEH\VJ\ExternalException
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=NEW;EXPECTED_PASS;GCSTRESS_FAIL;ISSUE_6143
+Categories=NEW;EXPECTED_PASS
 HostStyle=0
 [HandlerException.cmd_98]
 RelativePath=baseservices\exceptions\regressions\V1\SEH\VJ\HandlerException\HandlerException.cmd
@@ -61107,7 +61107,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1.1-M1-Beta1\b143840\b143840\b143840.cm
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1.1-M1-Beta1\b143840\b143840
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_PASS;GC_GEN0;GCSTRESS_FAIL;ISSUE_6143
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [b102879.cmd_8847]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b102879\b102879\b102879.cmd


### PR DESCRIPTION
Similar to arm, in order to preserve volatile semantics MemoryBarrier instructions needs to be inserted. Otherwise writes to memory locations can be re-ordered. For eg. In function leave_spin_lock() we set holding_thread to -1 and then set pSpinLock->lock to -1. Without memorybarrier it is possible for different threads to see pSpinLock->lock new value of -1 and old value of holding_thread. This causes assertion pSpinLock->holding_thread == (Thread*)-1 in function enter_spin_lock() to fire