### PR TITLE
Make StubHelpers::ProcessByrefValidationList NOTHROW

### DIFF
--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -168,8 +168,16 @@ void StubHelpers::ProcessByrefValidationList()
     }
     EX_CATCH
     {
-        FormatValidationMessage(entry.pMD, errorString);
-        EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, errorString.GetUnicode());
+        EX_TRY
+        {
+            FormatValidationMessage(entry.pMD, errorString);
+            EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, errorString.GetUnicode());
+        }
+        EX_CATCH
+        {
+            EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+        }
+        EX_END_CATCH_UNREACHABLE;
     }
     EX_END_CATCH_UNREACHABLE;
 


### PR DESCRIPTION
This change fixes StubHelpers::ProcessByrefValidationList so that it doesn't throw.
While there was a EX_TRY / EX_CATCH, the catch handler calls FormatValidationMessage
to format the message before aborting the process and that function can throw.

The fix is to wrap the inside of the EX_CATCH in one more EX_TRY / EX_CATCH and
abort the process without message if there is an exception in the FormatValidationMessage.