### PR TITLE
Add #if FEATURE_SERIALIZATION around customized [Serializable]s

### DIFF
--- a/src/mscorlib/src/System/AccessViolationException.cs
+++ b/src/mscorlib/src/System/AccessViolationException.cs
@@ -17,7 +17,9 @@ namespace System
     using System;
     using System.Runtime.Serialization;
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class AccessViolationException : SystemException 
     {
         public AccessViolationException() 

--- a/src/mscorlib/src/System/AggregateException.cs
+++ b/src/mscorlib/src/System/AggregateException.cs
@@ -29,7 +29,9 @@ namespace System
     /// <see cref="AggregateException"/> is used to consolidate multiple failures into a single, throwable
     /// exception object.
     /// </remarks>
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [DebuggerDisplay("Count = {InnerExceptionCount}")]
     public class AggregateException : Exception
     {

--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -111,15 +111,21 @@ namespace System {
     #if FEATURE_CORECLR
     [System.Security.SecurityCritical] // auto-generated
     #endif
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ComVisible(true)]
     public delegate Assembly ResolveEventHandler(Object sender, ResolveEventArgs args);
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ComVisible(true)]
     public delegate void AssemblyLoadEventHandler(Object sender, AssemblyLoadEventArgs args);
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ComVisible(true)]
     public delegate void AppDomainInitializer(string[] args);
 

--- a/src/mscorlib/src/System/AppDomainUnloadedException.cs
+++ b/src/mscorlib/src/System/AppDomainUnloadedException.cs
@@ -15,8 +15,10 @@ namespace System {
 
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class AppDomainUnloadedException : SystemException {
         public AppDomainUnloadedException() 
             : base(Environment.GetResourceString("Arg_AppDomainUnloadedException")) {

--- a/src/mscorlib/src/System/ApplicationException.cs
+++ b/src/mscorlib/src/System/ApplicationException.cs
@@ -22,8 +22,10 @@ namespace System {
     // ApplicationException extends but adds no new functionality to 
     // RecoverableException.
     // 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ApplicationException : Exception {
         
         // Creates a new ApplicationException with its message string set to

--- a/src/mscorlib/src/System/ArgumentException.cs
+++ b/src/mscorlib/src/System/ArgumentException.cs
@@ -23,8 +23,10 @@ namespace System {
     // the contract of the method.  Ideally it should give a meaningful error
     // message describing what was wrong and which parameter is incorrect.
     // 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ArgumentException : SystemException, ISerializable {
         private String m_paramName;
         

--- a/src/mscorlib/src/System/ArgumentNullException.cs
+++ b/src/mscorlib/src/System/ArgumentNullException.cs
@@ -21,8 +21,11 @@ namespace System {
     // The ArgumentException is thrown when an argument 
     // is null when it shouldn't be.
     // 
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class ArgumentNullException : ArgumentException
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class ArgumentNullException : ArgumentException
     {
         // Creates a new ArgumentNullException with its message 
         // string set to a default message explaining an argument was null.

--- a/src/mscorlib/src/System/ArgumentOutOfRangeException.cs
+++ b/src/mscorlib/src/System/ArgumentOutOfRangeException.cs
@@ -22,8 +22,10 @@ namespace System {
         
     // The ArgumentOutOfRangeException is thrown when an argument 
     // is outside the legal range for that argument.  
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ArgumentOutOfRangeException : ArgumentException, ISerializable {
      
         private static volatile String _rangeMessage;

--- a/src/mscorlib/src/System/ArithmeticException.cs
+++ b/src/mscorlib/src/System/ArithmeticException.cs
@@ -18,8 +18,11 @@ namespace System {
     // The ArithmeticException is thrown when overflow or underflow
     // occurs.
     // 
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class ArithmeticException : SystemException
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class ArithmeticException : SystemException
     {        
         // Creates a new ArithmeticException with its message string set to
         // the empty string, its HRESULT set to COR_E_ARITHMETIC, 

--- a/src/mscorlib/src/System/ArrayTypeMismatchException.cs
+++ b/src/mscorlib/src/System/ArrayTypeMismatchException.cs
@@ -18,8 +18,10 @@ namespace System {
     // The ArrayMismatchException is thrown when an attempt to store
     // an object of the wrong type within an array occurs.
     // 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ArrayTypeMismatchException : SystemException {
         
         // Creates a new ArrayMismatchException with its message string set to

--- a/src/mscorlib/src/System/AsyncCallback.cs
+++ b/src/mscorlib/src/System/AsyncCallback.cs
@@ -10,7 +10,9 @@
 **
 ===========================================================*/
 namespace System {
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public delegate void AsyncCallback(IAsyncResult ar);
 

--- a/src/mscorlib/src/System/BadImageFormatException.cs
+++ b/src/mscorlib/src/System/BadImageFormatException.cs
@@ -21,7 +21,9 @@ namespace System {
     using System.Globalization;
 
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class BadImageFormatException : SystemException {
 
         private String _fileName;  // The name of the corrupt PE file.

--- a/src/mscorlib/src/System/CannotUnloadAppDomainException.cs
+++ b/src/mscorlib/src/System/CannotUnloadAppDomainException.cs
@@ -16,7 +16,9 @@ namespace System {
     using System.Runtime.Serialization;
 
 [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class CannotUnloadAppDomainException : SystemException {
         public CannotUnloadAppDomainException() 
             : base(Environment.GetResourceString("Arg_CannotUnloadAppDomainException")) {

--- a/src/mscorlib/src/System/Collections/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Comparer.cs
@@ -19,9 +19,11 @@ namespace System.Collections {
     using System.Runtime.Serialization;
     using System.Security.Permissions;
     using System.Diagnostics.Contracts;
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class Comparer : IComparer , ISerializable
     {
         private CompareInfo m_compareInfo;   

--- a/src/mscorlib/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/mscorlib/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -39,7 +39,9 @@ namespace System.Collections.Concurrent
     /// concurrently from multiple threads.
     /// </remarks>
 #if !FEATURE_CORECLR
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
 #endif
     [ComVisible(false)]
     [DebuggerTypeProxy(typeof(Mscorlib_DictionaryDebugView<,>))]

--- a/src/mscorlib/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/mscorlib/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -39,7 +39,9 @@ namespace System.Collections.Concurrent
     [DebuggerDisplay("Count = {Count}")]
     [DebuggerTypeProxy(typeof(SystemCollectionsConcurrent_ProducerConsumerCollectionDebugView<>))]
     [HostProtection(Synchronization = true, ExternalThreading = true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ConcurrentQueue<T> : IProducerConsumerCollection<T>, IReadOnlyCollection<T>
     {
         //fields of ConcurrentQueue

--- a/src/mscorlib/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/mscorlib/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -47,7 +47,9 @@ namespace System.Collections.Concurrent
     [DebuggerTypeProxy(typeof(SystemCollectionsConcurrent_ProducerConsumerCollectionDebugView<>))]
     [HostProtection(Synchronization = true, ExternalThreading = true)]
 #if !FEATURE_CORECLR
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
 #endif //!FEATURE_CORECLR
     public class ConcurrentStack<T> : IProducerConsumerCollection<T>, IReadOnlyCollection<T>
     {

--- a/src/mscorlib/src/System/Collections/Generic/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Comparer.cs
@@ -184,14 +184,16 @@ namespace System.Collections.Generic
             return _comparison(x, y);
         }
     }
-    
+
     // Enum comparers (specialized to avoid boxing)
     // NOTE: Each of these needs to implement ISerializable
     // and have a SerializationInfo/StreamingContext ctor,
     // since we want to serialize as ObjectComparer for
     // back-compat reasons (see below).
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class Int32EnumComparer<T> : Comparer<T>, ISerializable where T : struct
     {
         public Int32EnumComparer()
@@ -226,8 +228,10 @@ namespace System.Collections.Generic
             info.SetType(typeof(ObjectComparer<T>));
         }
     }
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class UInt32EnumComparer<T> : Comparer<T>, ISerializable where T : struct
     {
         public UInt32EnumComparer()
@@ -258,8 +262,10 @@ namespace System.Collections.Generic
             info.SetType(typeof(ObjectComparer<T>));
         }
     }
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class Int64EnumComparer<T> : Comparer<T>, ISerializable where T : struct
     {
         public Int64EnumComparer()
@@ -290,8 +296,10 @@ namespace System.Collections.Generic
             info.SetType(typeof(ObjectComparer<T>));
         }
     }
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class UInt64EnumComparer<T> : Comparer<T>, ISerializable where T : struct
     {
         public UInt64EnumComparer()

--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -52,7 +52,9 @@ namespace System.Collections.Generic {
 
     [DebuggerTypeProxy(typeof(Mscorlib_DictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(false)]
     public class Dictionary<TKey,TValue>: IDictionary<TKey,TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>, ISerializable, IDeserializationCallback  {
     

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -388,7 +388,9 @@ namespace System.Collections.Generic
         }                                
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class EnumEqualityComparer<T> : EqualityComparer<T>, ISerializable where T : struct
     {
         [Pure]
@@ -428,7 +430,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class SByteEnumEqualityComparer<T> : EnumEqualityComparer<T>, ISerializable where T : struct
     {
         public SByteEnumEqualityComparer() { }
@@ -443,7 +447,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class ShortEnumEqualityComparer<T> : EnumEqualityComparer<T>, ISerializable where T : struct
     {
         public ShortEnumEqualityComparer() { }
@@ -458,7 +464,9 @@ namespace System.Collections.Generic
         }
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class LongEnumEqualityComparer<T> : EqualityComparer<T>, ISerializable where T : struct
     {
         [Pure]

--- a/src/mscorlib/src/System/Collections/Generic/KeyNotFoundException.cs
+++ b/src/mscorlib/src/System/Collections/Generic/KeyNotFoundException.cs
@@ -19,8 +19,10 @@ namespace System.Collections.Generic {
     using System.Runtime.Remoting;
     using System.Runtime.Serialization;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class KeyNotFoundException  : SystemException, ISerializable {
     
         public KeyNotFoundException () 

--- a/src/mscorlib/src/System/Collections/Hashtable.cs
+++ b/src/mscorlib/src/System/Collections/Hashtable.cs
@@ -70,7 +70,9 @@ namespace System.Collections {
     [DebuggerTypeProxy(typeof(System.Collections.Hashtable.HashtableDebugView))]
     [DebuggerDisplay("Count = {Count}")]
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class Hashtable : IDictionary, ISerializable, IDeserializationCallback, ICloneable {
         /*
           Implementation Notes:
@@ -463,7 +465,7 @@ namespace System.Collections {
             occupancy = 0;
             UpdateVersion();            
             isWriterInProgress = false;    
-#if !FEATURE_CORECLR        
+#if !FEATURE_CORECLR
             Thread.EndCriticalRegion();
 #endif
         }
@@ -764,9 +766,9 @@ namespace System.Collections {
             loadsize = (int)(loadFactor * newsize);
             UpdateVersion();
             isWriterInProgress = false;
-#if !FEATURE_CORECLR            
+#if !FEATURE_CORECLR
             Thread.EndCriticalRegion();   
-#endif         
+#endif
             // minimun size of hashtable is 3 now and maximum loadFactor is 0.72 now.
             Contract.Assert(loadsize < newsize, "Our current implementaion means this is not possible.");
             return;
@@ -915,7 +917,7 @@ namespace System.Collections {
                     // code until the value & key are set appropriately.
 #if !FEATURE_CORECLR
                     Thread.BeginCriticalRegion(); 
-#endif           
+#endif
                     isWriterInProgress = true;                    
                     buckets[bucketNumber].val = nvalue;
                     buckets[bucketNumber].key  = key;
@@ -923,9 +925,9 @@ namespace System.Collections {
                     count++;
                     UpdateVersion();
                     isWriterInProgress = false;   
-#if !FEATURE_CORECLR                                     
+#if !FEATURE_CORECLR
                     Thread.EndCriticalRegion();
-#endif                    
+#endif
 
 #if FEATURE_RANDOMIZED_STRING_HASHING
 #if !FEATURE_CORECLR
@@ -956,14 +958,14 @@ namespace System.Collections {
                     }
 #if !FEATURE_CORECLR
                     Thread.BeginCriticalRegion();
-#endif          
+#endif
                     isWriterInProgress = true;                    
                     buckets[bucketNumber].val = nvalue;
                     UpdateVersion();                    
                     isWriterInProgress = false; 
-#if !FEATURE_CORECLR       
+#if !FEATURE_CORECLR
                     Thread.EndCriticalRegion();   
-#endif                 
+#endif
 
 #if FEATURE_RANDOMIZED_STRING_HASHING
 #if !FEATURE_CORECLR
@@ -1002,7 +1004,7 @@ namespace System.Collections {
                 // code until the value & key are set appropriately.
 #if !FEATURE_CORECLR
                 Thread.BeginCriticalRegion();  
-#endif         
+#endif
                 isWriterInProgress = true;                    
                 buckets[emptySlotNumber].val = nvalue;
                 buckets[emptySlotNumber].key  = key;
@@ -1010,7 +1012,7 @@ namespace System.Collections {
                 count++;
                 UpdateVersion();                
                 isWriterInProgress = false;     
-#if !FEATURE_CORECLR                
+#if !FEATURE_CORECLR
                 Thread.EndCriticalRegion(); 
 #endif
 
@@ -1088,7 +1090,7 @@ namespace System.Collections {
                     KeyEquals (b.key, key)) {
 #if !FEATURE_CORECLR
                     Thread.BeginCriticalRegion();    
-#endif                
+#endif
                     isWriterInProgress = true;
                     // Clear hash_coll field, then key, then value
                     buckets[bn].hash_coll &= unchecked((int)0x80000000);
@@ -1102,9 +1104,9 @@ namespace System.Collections {
                     count--;
                     UpdateVersion();
                     isWriterInProgress = false; 
-#if !FEATURE_CORECLR                   
+#if !FEATURE_CORECLR
                     Thread.EndCriticalRegion();   
-#endif                 
+#endif
                     return;
                 }
                 bn = (int) (((long)bn + incr)% (uint)buckets.Length);                               
@@ -1221,7 +1223,7 @@ namespace System.Collections {
 
 #pragma warning disable 618
             IHashCodeProvider hcp = null;
-#pragma warning restore 618        
+#pragma warning restore 618
 
             Object [] serKeys = null;
             Object [] serValues = null;
@@ -1247,7 +1249,7 @@ namespace System.Collections {
                     case HashCodeProviderName:
 #pragma warning disable 618
                         hcp = (IHashCodeProvider)siInfo.GetValue(HashCodeProviderName, typeof(IHashCodeProvider));
-#pragma warning restore 618        
+#pragma warning restore 618
                         break;
                     case KeysName:
                         serKeys = (Object[])siInfo.GetValue(KeysName, typeof(Object[]));

--- a/src/mscorlib/src/System/ContextMarshalException.cs
+++ b/src/mscorlib/src/System/ContextMarshalException.cs
@@ -20,7 +20,9 @@ namespace System {
 	using System;
 	using System.Runtime.Serialization;
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ContextMarshalException : SystemException {
         public ContextMarshalException() 
             : base(Environment.GetResourceString("Arg_ContextMarshalException")) {

--- a/src/mscorlib/src/System/DBNull.cs
+++ b/src/mscorlib/src/System/DBNull.cs
@@ -12,8 +12,10 @@ namespace System {
     using System.Runtime.Remoting;
     using System.Runtime.Serialization;
     using System.Security.Permissions;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class DBNull : ISerializable, IConvertible {
     
         //Package private constructor

--- a/src/mscorlib/src/System/DataMisalignedException.cs
+++ b/src/mscorlib/src/System/DataMisalignedException.cs
@@ -14,8 +14,10 @@ namespace System
     using System;
     using System.Runtime.Serialization;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class DataMisalignedException : SystemException 
     {
         public DataMisalignedException() 

--- a/src/mscorlib/src/System/DateTime.cs
+++ b/src/mscorlib/src/System/DateTime.cs
@@ -52,7 +52,9 @@ namespace System {
     // 
     // 
     [StructLayout(LayoutKind.Auto)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public struct DateTime : IComparable, IFormattable, IConvertible, ISerializable, IComparable<DateTime>,IEquatable<DateTime> {
     
         // Number of 100ns ticks per time unit

--- a/src/mscorlib/src/System/DateTimeOffset.cs
+++ b/src/mscorlib/src/System/DateTimeOffset.cs
@@ -33,7 +33,9 @@ namespace System {
     // out and for internal readability.
     
     [StructLayout(LayoutKind.Auto)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public struct DateTimeOffset : IComparable, IFormattable, ISerializable, IDeserializationCallback,
                                    IComparable<DateTimeOffset>, IEquatable<DateTimeOffset> {
     

--- a/src/mscorlib/src/System/Decimal.cs
+++ b/src/mscorlib/src/System/Decimal.cs
@@ -56,7 +56,9 @@ namespace System {
     // Decimal throws an OverflowException if the value is not within
     // the range of the Decimal type.
     [StructLayout(LayoutKind.Sequential)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     [System.Runtime.Versioning.NonVersionable] // This only applies to field layout
     public struct Decimal : IFormattable, IComparable, IConvertible, IDeserializationCallback

--- a/src/mscorlib/src/System/Delegate.cs
+++ b/src/mscorlib/src/System/Delegate.cs
@@ -14,7 +14,9 @@ namespace System {
     using System.Runtime.Versioning;
     using System.Diagnostics.Contracts;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ClassInterface(ClassInterfaceType.AutoDual)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public abstract class Delegate : ICloneable, ISerializable 

--- a/src/mscorlib/src/System/DelegateSerializationHolder.cs
+++ b/src/mscorlib/src/System/DelegateSerializationHolder.cs
@@ -13,7 +13,9 @@ using System.Diagnostics.Contracts;
 
 namespace System
 {
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class DelegateSerializationHolder : IObjectReference, ISerializable
     {
         #region Static Members

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSourceException.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSourceException.cs
@@ -19,7 +19,9 @@ namespace System.Diagnostics.Tracing
     /// Exception that is thrown when an error occurs during EventSource operation.
     /// </summary>
 #if (!ES_BUILD_PCL && !PROJECTN)
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
 #endif
     public class EventSourceException : Exception
     {

--- a/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
+++ b/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
@@ -17,12 +17,14 @@ namespace System.Diagnostics {
     using System.Runtime.Serialization;
     using System.Runtime.Versioning;
     using System.Diagnostics.Contracts;
-    
+
     // READ ME:
     // Modifying the order or fields of this object may require other changes 
     // to the unmanaged definition of the StackFrameHelper class, in 
     // VM\DebugDebugger.h. The binder will catch some of these layout problems.
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class StackFrameHelper : IDisposable
     {
         [NonSerialized]
@@ -270,7 +272,9 @@ namespace System.Diagnostics {
 #if !FEATURE_CORECLR
     [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
 #endif
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public class StackTrace
     {
@@ -292,9 +296,9 @@ namespace System.Diagnostics {
 
         // Constructs a stack trace from the current location.
         //
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         public StackTrace(bool fNeedFileInfo)
         {
             m_iNumOfFrames = 0;
@@ -305,9 +309,9 @@ namespace System.Diagnostics {
         // Constructs a stack trace from the current location, in a caller's
         // frame
         //
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         public StackTrace(int skipFrames)
         {
     
@@ -325,9 +329,9 @@ namespace System.Diagnostics {
         // Constructs a stack trace from the current location, in a caller's
         // frame
         //
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         public StackTrace(int skipFrames, bool fNeedFileInfo)
         {
     
@@ -357,9 +361,9 @@ namespace System.Diagnostics {
 
         // Constructs a stack trace from the current location.
         //
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         public StackTrace(Exception e, bool fNeedFileInfo)
         {
             if (e == null)
@@ -374,9 +378,9 @@ namespace System.Diagnostics {
         // Constructs a stack trace from the current location, in a caller's
         // frame
         //
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         public StackTrace(Exception e, int skipFrames)
         {
             if (e == null)
@@ -396,9 +400,9 @@ namespace System.Diagnostics {
         // Constructs a stack trace from the current location, in a caller's
         // frame
         //
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         public StackTrace(Exception e, int skipFrames, bool fNeedFileInfo)
         {
             if (e == null)
@@ -430,9 +434,9 @@ namespace System.Diagnostics {
 
         // Constructs a stack trace for the given thread
         //
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         [Obsolete("This constructor has been deprecated.  Please use a constructor that does not require a Thread parameter.  http://go.microsoft.com/fwlink/?linkid=14202")]
         public StackTrace(Thread targetThread, bool needFileInfo)
         {    
@@ -596,9 +600,9 @@ namespace System.Diagnostics {
             
         // Builds a readable representation of the stack trace, specifying 
         // the format for backwards compatibility.
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         internal String ToString(TraceFormat traceFormat)
         {
             bool displayFilenames = true;   // we'll try, but demand may fail
@@ -754,9 +758,9 @@ namespace System.Diagnostics {
 
         // This helper is called from within the EE to construct a string representation
         // of the current stack trace.
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         private static String GetManagedStackTraceStringHelper(bool fNeedFileInfo)
         {
             // Note all the frames in System.Diagnostics will be skipped when capturing 

--- a/src/mscorlib/src/System/Diagnostics/log.cs
+++ b/src/mscorlib/src/System/Diagnostics/log.cs
@@ -21,7 +21,9 @@ namespace System.Diagnostics {
    // There is also a "built-in" console device which can be enabled
    // programatically, by registry (specifics....) or environment
    // variables.
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [HostProtection(Synchronization=true, ExternalThreading=true)]
     internal delegate void LogMessageEventHandler(LoggingLevels level, LogSwitch category, 
                                                     String message, 
@@ -32,7 +34,9 @@ namespace System.Diagnostics {
    // NOTE: These are NOT triggered when the log switch setting is changed from the 
    // attached debugger.
    // 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal delegate void LogSwitchLevelHandler(LogSwitch ls, LoggingLevels newLevel);
     
     

--- a/src/mscorlib/src/System/DivideByZeroException.cs
+++ b/src/mscorlib/src/System/DivideByZeroException.cs
@@ -16,7 +16,9 @@ namespace System {
     using System;
     using System.Runtime.Serialization;
 [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class DivideByZeroException : ArithmeticException {
         public DivideByZeroException() 
             : base(Environment.GetResourceString("Arg_DivideByZero")) {

--- a/src/mscorlib/src/System/DllNotFoundException.cs
+++ b/src/mscorlib/src/System/DllNotFoundException.cs
@@ -16,8 +16,11 @@ namespace System {
     using System;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class DllNotFoundException : TypeLoadException {
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class DllNotFoundException : TypeLoadException {
         public DllNotFoundException() 
             : base(Environment.GetResourceString("Arg_DllNotFoundException")) {
             SetErrorCode(__HResults.COR_E_DLLNOTFOUND);

--- a/src/mscorlib/src/System/DuplicateWaitObjectException.cs
+++ b/src/mscorlib/src/System/DuplicateWaitObjectException.cs
@@ -20,8 +20,10 @@ namespace System {
     // The DuplicateWaitObjectException is thrown when an object 
     // appears more than once in the list of objects to WaitAll or WaitAny.
     // 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class DuplicateWaitObjectException : ArgumentException {
 
         private static volatile String _duplicateWaitObjectMessage = null;

--- a/src/mscorlib/src/System/Empty.cs
+++ b/src/mscorlib/src/System/Empty.cs
@@ -12,7 +12,9 @@ namespace System {
     using System.Runtime.Remoting;
     using System.Runtime.Serialization;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class Empty : ISerializable
     {
         private Empty() {

--- a/src/mscorlib/src/System/EntryPointNotFoundException.cs
+++ b/src/mscorlib/src/System/EntryPointNotFoundException.cs
@@ -15,8 +15,11 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class EntryPointNotFoundException : TypeLoadException {
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class EntryPointNotFoundException : TypeLoadException {
         public EntryPointNotFoundException() 
             : base(Environment.GetResourceString("Arg_EntryPointNotFoundException")) {
             SetErrorCode(__HResults.COR_E_ENTRYPOINTNOTFOUND);

--- a/src/mscorlib/src/System/EventHandler.cs
+++ b/src/mscorlib/src/System/EventHandler.cs
@@ -5,10 +5,14 @@
 namespace System {
     
     using System;
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public delegate void EventHandler(Object sender, EventArgs e);
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public delegate void EventHandler<TEventArgs>(Object sender, TEventArgs e); // Removed TEventArgs constraint post-.NET 4
 }

--- a/src/mscorlib/src/System/Exception.cs
+++ b/src/mscorlib/src/System/Exception.cs
@@ -29,7 +29,9 @@ namespace System {
 
     [ClassInterface(ClassInterfaceType.None)]
     [ComDefaultInterface(typeof(_Exception))]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ComVisible(true)]
     public class Exception : ISerializable, _Exception
     {
@@ -321,9 +323,9 @@ namespace System {
         // is true.  Note that this requires FileIOPermission(PathDiscovery), and so
         // will usually fail in CoreCLR.  To avoid the demand and resulting
         // SecurityException we can explicitly not even try to get fileinfo.
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         private string GetStackTrace(bool needFileInfo)
         {
             string stackTraceString = _stackTraceString;
@@ -380,9 +382,9 @@ namespace System {
         }
     
         public virtual String Source {
-            #if FEATURE_CORECLR
+#if FEATURE_CORECLR
             [System.Security.SecurityCritical] // auto-generated
-            #endif
+#endif
             get { 
                 if (_source == null)
                 {
@@ -411,9 +413,9 @@ namespace System {
 
                 return _source;
             }
-            #if FEATURE_CORECLR
+#if FEATURE_CORECLR
             [System.Security.SecurityCritical] // auto-generated
-            #endif
+#endif
             set { _source = value; }
         }
 
@@ -425,9 +427,9 @@ namespace System {
             return ToString(true, true);
         }
 
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         private String ToString(bool needFileLineInfo, bool needMessage) {
             String message = (needMessage ? Message : null);
             String s;
@@ -978,7 +980,9 @@ namespace System {
     // The Message field is set to the ToString() output of the original exception.
     //--------------------------------------------------------------------------
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class CrossAppDomainMarshaledException : SystemException 
     {
         public CrossAppDomainMarshaledException(String message, int errorCode) 
@@ -990,9 +994,9 @@ namespace System {
         // Normally, only Telesto's UEF will see these exceptions.
         // This override prints out the original Exception's ToString()
         // output and hides the fact that it is wrapped inside another excepton.
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #endif
+#endif
         internal override String InternalToString()
         {
             return Message;

--- a/src/mscorlib/src/System/ExecutionEngineException.cs
+++ b/src/mscorlib/src/System/ExecutionEngineException.cs
@@ -21,7 +21,9 @@ namespace System {
 	using System.Runtime.Serialization;
     [Obsolete("This type previously indicated an unspecified fatal error in the runtime. The runtime no longer raises this exception so this type is obsolete.")]
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class ExecutionEngineException : SystemException {
         public ExecutionEngineException() 
             : base(Environment.GetResourceString("Arg_ExecutionEngineException")) {

--- a/src/mscorlib/src/System/FieldAccessException.cs
+++ b/src/mscorlib/src/System/FieldAccessException.cs
@@ -13,8 +13,11 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class FieldAccessException : MemberAccessException {
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class FieldAccessException : MemberAccessException {
         public FieldAccessException() 
             : base(Environment.GetResourceString("Arg_FieldAccessException")) {
             SetErrorCode(__HResults.COR_E_FIELDACCESS);

--- a/src/mscorlib/src/System/FormatException.cs
+++ b/src/mscorlib/src/System/FormatException.cs
@@ -15,7 +15,9 @@ namespace System {
     using System;
     using System.Runtime.Serialization;
 [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class FormatException : SystemException {
         public FormatException() 
             : base(Environment.GetResourceString("Arg_FormatException")) {

--- a/src/mscorlib/src/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.cs
@@ -64,9 +64,10 @@ namespace System.Globalization {
     }
 
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
-
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class CompareInfo
 #if FEATURE_SERIALIZATION
     : IDeserializationCallback

--- a/src/mscorlib/src/System/Globalization/CultureInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CultureInfo.cs
@@ -42,7 +42,9 @@ namespace System.Globalization {
     using System.Diagnostics.Contracts;
     using System.Resources;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public class CultureInfo : ICloneable, IFormatProvider {
         //--------------------------------------------------------------------//
@@ -342,7 +344,7 @@ namespace System.Globalization {
         }
 
 
-#if  FEATURE_USE_LCID         
+#if FEATURE_USE_LCID
         public CultureInfo(int culture) : this(culture, true) {
         }
 
@@ -407,7 +409,7 @@ namespace System.Globalization {
         [OnDeserialized]
         private void OnDeserialized(StreamingContext ctx)
         {
-#if  FEATURE_USE_LCID         
+#if FEATURE_USE_LCID
             // Whidbey+ should remember our name
             // but v1 and v1.1 did not store name -- only lcid
             // Whidbey did not store actual alternate sort name in m_name
@@ -428,7 +430,7 @@ namespace System.Globalization {
                     throw new CultureNotFoundException(
                         "m_name", m_name, Environment.GetResourceString("Argument_CultureNotSupported"));
                     
-#if  FEATURE_USE_LCID         
+#if FEATURE_USE_LCID
             }
 #endif
             m_isInherited = (this.GetType() != typeof(System.Globalization.CultureInfo));
@@ -449,7 +451,7 @@ namespace System.Globalization {
             }
         }
 
-#if  FEATURE_USE_LCID         
+#if FEATURE_USE_LCID
         //  A locale ID is a 32 bit value which is the combination of a
         //  language ID, a sort ID, and a reserved area.  The bits are
         //  allocated as follows:
@@ -976,7 +978,7 @@ namespace System.Globalization {
         //  of a customized culture (LCID == LOCALE_CUSTOM_UNSPECIFIED).
         //
         ////////////////////////////////////////////////////////////////////////
-#if FEATURE_USE_LCID    
+#if FEATURE_USE_LCID
         [System.Runtime.InteropServices.ComVisible(false)]
         public virtual int KeyboardLayoutId
         {

--- a/src/mscorlib/src/System/Globalization/CultureNotFoundException.cs
+++ b/src/mscorlib/src/System/Globalization/CultureNotFoundException.cs
@@ -11,7 +11,9 @@ namespace System.Globalization {
     using System.Diagnostics.Contracts;
     
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class CultureNotFoundException : ArgumentException, ISerializable
     {
         private string          m_invalidCultureName; // unrecognized culture name

--- a/src/mscorlib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -54,8 +54,10 @@ namespace System.Globalization {
     }
 
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class DateTimeFormatInfo : ICloneable, IFormatProvider
     {
         //
@@ -384,7 +386,7 @@ namespace System.Globalization {
 #endif
         }
 
-        #region Serialization
+#region Serialization
         // The following fields are defined to keep the serialization compatibility with .NET V1.0/V1.1.
         [OptionalField(VersionAdded = 1)]
         private int    CultureID;

--- a/src/mscorlib/src/System/Globalization/GregorianCalendar.cs
+++ b/src/mscorlib/src/System/Globalization/GregorianCalendar.cs
@@ -22,8 +22,10 @@ namespace System.Globalization {
     // 0 CurrentEra (AD)
     // 1 BeforeCurrentEra (BC)
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class GregorianCalendar : Calendar
     {
         /*

--- a/src/mscorlib/src/System/Globalization/RegionInfo.cs
+++ b/src/mscorlib/src/System/Globalization/RegionInfo.cs
@@ -21,8 +21,10 @@ namespace System.Globalization {
     using System.Runtime.Serialization;
     using System.Diagnostics.Contracts;
 
+#if FEATURE_SERIALIZATION
     [Serializable] 
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class RegionInfo
     {
         //--------------------------------------------------------------------//
@@ -137,7 +139,7 @@ namespace System.Globalization {
         [System.Security.SecurityCritical]  // auto-generated
         private void SetName(string name)
         {
-#if FEATURE_CORECLR      
+#if FEATURE_CORECLR
             // Use the name of the region we found
             this.m_name = this.m_cultureData.SREGIONNAME;
 #else
@@ -163,7 +165,7 @@ namespace System.Globalization {
         [OptionalField(VersionAdded = 2)]
         internal int m_dataItem = 0;
 
-#if !FEATURE_CORECLR            
+#if !FEATURE_CORECLR
         static private readonly int[] IdFromEverettRegionInfoDataItem =
         {
             0x3801, /*  0 */  // AE          ar-AE      Arabic (U.A.E.)
@@ -306,7 +308,7 @@ namespace System.Globalization {
         [OnDeserialized]
         private void OnDeserialized(StreamingContext ctx)
         {
-#if FEATURE_CORECLR            
+#if FEATURE_CORECLR
             // This won't happen anyway since CoreCLR doesn't support serialization
             this.m_cultureData = CultureData.GetCultureData(m_name, true);
 #else

--- a/src/mscorlib/src/System/Globalization/SortKey.cs
+++ b/src/mscorlib/src/System/Globalization/SortKey.cs
@@ -18,8 +18,11 @@ namespace System.Globalization {
     using System.Runtime.Serialization;
     using System.Diagnostics.Contracts;
 
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class SortKey
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class SortKey
     {
         //--------------------------------------------------------------------//
         //                        Internal Information                        //

--- a/src/mscorlib/src/System/Globalization/StringInfo.cs
+++ b/src/mscorlib/src/System/Globalization/StringInfo.cs
@@ -19,9 +19,10 @@ namespace System.Globalization {
     using System.Security.Permissions;
     using System.Diagnostics.Contracts;
 
-
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class StringInfo  
     {
 

--- a/src/mscorlib/src/System/Globalization/TextElementEnumerator.cs
+++ b/src/mscorlib/src/System/Globalization/TextElementEnumerator.cs
@@ -21,8 +21,10 @@ namespace System.Globalization {
     // This is public because GetTextElement() is public.
     //
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class TextElementEnumerator: IEnumerator
     {
         private String str;

--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -27,7 +27,9 @@ namespace System.Globalization {
     using System.Diagnostics.Contracts;
 
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public class TextInfo : ICloneable, IDeserializationCallback
     {
@@ -169,7 +171,7 @@ namespace System.Globalization {
                             m_cultureName = CultureInfo.GetCultureInfo(m_win32LangID).m_cultureData.CultureName;
                         }
                     }
-#endif                
+#endif
                 }
                 
                 // Get the text info name belonging to that culture
@@ -375,7 +377,7 @@ namespace System.Globalization {
                 return (this.m_cultureData.IDEFAULTEBCDICCODEPAGE);
             }
         }
-#endif 
+#endif
 
 
         ////////////////////////////////////////////////////////////////////////
@@ -387,7 +389,7 @@ namespace System.Globalization {
         //
         ////////////////////////////////////////////////////////////////////////
 
-#if FEATURE_USE_LCID 
+#if FEATURE_USE_LCID
         [System.Runtime.InteropServices.ComVisible(false)]
         public int LCID 
         {

--- a/src/mscorlib/src/System/IO/DirectoryNotFoundException.cs
+++ b/src/mscorlib/src/System/IO/DirectoryNotFoundException.cs
@@ -22,7 +22,9 @@ namespace System.IO {
      * the Win32 errorcode-as-HRESULT ERROR_PATH_NOT_FOUND (0x80070003) 
      * and STG_E_PATHNOTFOUND (0x80030003).
      */
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public class DirectoryNotFoundException : IOException {
         public DirectoryNotFoundException() 

--- a/src/mscorlib/src/System/IO/DriveInfo.cs
+++ b/src/mscorlib/src/System/IO/DriveInfo.cs
@@ -40,7 +40,9 @@ namespace System.IO
 
     // Ideally we'll get a better security permission, but possibly
     // not for Whidbey.
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ComVisible(true)]
     public sealed class DriveInfo : ISerializable
     {

--- a/src/mscorlib/src/System/IO/DriveNotFoundException.cs
+++ b/src/mscorlib/src/System/IO/DriveNotFoundException.cs
@@ -16,8 +16,10 @@ using System.Runtime.Serialization;
 namespace System.IO {
 
     //Thrown when trying to access a drive that is not availabe.
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class DriveNotFoundException : IOException {
         public DriveNotFoundException() 
             : base(Environment.GetResourceString("Arg_DriveNotFoundException")) {

--- a/src/mscorlib/src/System/IO/EndOfStreamException.cs
+++ b/src/mscorlib/src/System/IO/EndOfStreamException.cs
@@ -17,8 +17,10 @@ using System;
 using System.Runtime.Serialization;
 
 namespace System.IO {
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class EndOfStreamException : IOException
     {
         public EndOfStreamException() 

--- a/src/mscorlib/src/System/IO/FileLoadException.cs
+++ b/src/mscorlib/src/System/IO/FileLoadException.cs
@@ -26,8 +26,10 @@ using SecurityException = System.Security.SecurityException;
 
 namespace System.IO {
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class FileLoadException : IOException {
 
         private String _fileName;   // the name of the file we could not load.

--- a/src/mscorlib/src/System/IO/FileNotFoundException.cs
+++ b/src/mscorlib/src/System/IO/FileNotFoundException.cs
@@ -22,8 +22,10 @@ using System.Globalization;
 
 namespace System.IO {
     // Thrown when trying to access a file that doesn't exist on disk.
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class FileNotFoundException : IOException {
 
         private String _fileName;  // The name of the file that isn't found.

--- a/src/mscorlib/src/System/IO/FileSystemInfo.cs
+++ b/src/mscorlib/src/System/IO/FileSystemInfo.cs
@@ -25,12 +25,14 @@ using System.Runtime.Versioning;
 using System.Diagnostics.Contracts;
 
 namespace System.IO {
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
 #if !FEATURE_CORECLR
     [FileIOPermissionAttribute(SecurityAction.InheritanceDemand,Unrestricted=true)]
 #endif
     [ComVisible(true)]
-#if FEATURE_REMOTING        
+#if FEATURE_REMOTING
     public abstract class FileSystemInfo : MarshalByRefObject, ISerializable {
 #else // FEATURE_REMOTING
     public abstract class FileSystemInfo : ISerializable {   
@@ -49,7 +51,7 @@ namespace System.IO {
         protected String OriginalPath;      // path passed in by the user
         private String _displayPath = "";   // path that can be displayed to the user
 
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
 #if FEATURE_CORESYSTEM
         [System.Security.SecurityCritical]
 #else
@@ -305,11 +307,11 @@ namespace System.IO {
 
                 return (FileAttributes) _data.fileAttributes;
             }
-            #if FEATURE_CORECLR
+#if FEATURE_CORECLR
             [System.Security.SecurityCritical] // auto-generated
-            #else
+#else
             [System.Security.SecuritySafeCritical]
-            #endif
+#endif
             set {
 #if !FEATURE_CORECLR
                 new FileIOPermission(FileIOPermissionAccess.Write, FullPath).Demand();

--- a/src/mscorlib/src/System/IO/IOException.cs
+++ b/src/mscorlib/src/System/IO/IOException.cs
@@ -18,8 +18,10 @@ using System.Runtime.Serialization;
 
 namespace System.IO {
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class IOException : SystemException
     {
         // For debugging purposes, store the complete path in the IOException

--- a/src/mscorlib/src/System/IO/PathTooLongException.cs
+++ b/src/mscorlib/src/System/IO/PathTooLongException.cs
@@ -19,8 +19,10 @@ using System.Runtime.Serialization;
 
 namespace System.IO {
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class PathTooLongException : IOException
     {
         public PathTooLongException() 

--- a/src/mscorlib/src/System/IndexOutOfRangeException.cs
+++ b/src/mscorlib/src/System/IndexOutOfRangeException.cs
@@ -16,7 +16,9 @@ namespace System {
     using System;
     using System.Runtime.Serialization;
 [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class IndexOutOfRangeException : SystemException {
         public IndexOutOfRangeException() 
             : base(Environment.GetResourceString("Arg_IndexOutOfRangeException")) {

--- a/src/mscorlib/src/System/InsufficientExecutionStackException.cs
+++ b/src/mscorlib/src/System/InsufficientExecutionStackException.cs
@@ -17,7 +17,9 @@ namespace System {
     using System;
     using System.Runtime.Serialization;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class InsufficientExecutionStackException : SystemException 
     {
         public InsufficientExecutionStackException()

--- a/src/mscorlib/src/System/InsufficientMemoryException.cs
+++ b/src/mscorlib/src/System/InsufficientMemoryException.cs
@@ -21,7 +21,9 @@ namespace System {
     using System;
     using System.Runtime.Serialization;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class InsufficientMemoryException : OutOfMemoryException
     {
         public InsufficientMemoryException() 

--- a/src/mscorlib/src/System/IntPtr.cs
+++ b/src/mscorlib/src/System/IntPtr.cs
@@ -21,9 +21,11 @@ namespace System {
     using System.Runtime.ConstrainedExecution;
     using System.Security;
     using System.Diagnostics.Contracts;
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public struct IntPtr : ISerializable
     {
         [SecurityCritical]
@@ -45,11 +47,11 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public unsafe IntPtr(int value)
         {
-            #if BIT64
+#if BIT64
                 m_value = (void *)(long)value;
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 m_value = (void *)value;
-            #endif
+#endif
         }
     
         [System.Security.SecuritySafeCritical]  // auto-generated
@@ -57,11 +59,11 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public unsafe IntPtr(long value)
         {
-            #if BIT64
+#if BIT64
                 m_value = (void *)value;
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 m_value = (void *)checked((int)value);
-            #endif
+#endif
         }
 
         [System.Security.SecurityCritical]
@@ -91,11 +93,11 @@ namespace System {
                 throw new ArgumentNullException("info");
             }
             Contract.EndContractBlock();
-            #if BIT64
+#if BIT64
                 info.AddValue("value", (long)(m_value));
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 info.AddValue("value", (long)((int)m_value));
-            #endif
+#endif
         }
 #endif
 
@@ -110,12 +112,12 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override int GetHashCode() {
 #if FEATURE_CORECLR
-    #if BIT64
+#if BIT64
             long l = (long)m_value;
             return (unchecked((int)l) ^ (int)(l >> 32));
-    #else // !BIT64 (32)
+#else // !BIT64 (32)
             return unchecked((int)m_value);
-    #endif
+#endif
 #else
             return unchecked((int)((long)m_value));
 #endif
@@ -125,32 +127,32 @@ namespace System {
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [System.Runtime.Versioning.NonVersionable]
         public unsafe int ToInt32() {
-            #if BIT64
+#if BIT64
                 long l = (long)m_value;
                 return checked((int)l);
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 return (int)m_value;
-            #endif
+#endif
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [System.Runtime.Versioning.NonVersionable]
         public unsafe long ToInt64() {
-            #if BIT64
+#if BIT64
                 return (long)m_value;
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 return (long)(int)m_value;
-            #endif
+#endif
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override String ToString() {
-            #if BIT64
+#if BIT64
                 return ((long)m_value).ToString(CultureInfo.InvariantCulture);
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 return ((int)m_value).ToString(CultureInfo.InvariantCulture);
-            #endif
+#endif
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
@@ -158,11 +160,11 @@ namespace System {
         {
             Contract.Ensures(Contract.Result<String>() != null);
 
-            #if BIT64
+#if BIT64
                 return ((long)m_value).ToString(format, CultureInfo.InvariantCulture);
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 return ((int)m_value).ToString(format, CultureInfo.InvariantCulture);
-            #endif
+#endif
         }
 
 
@@ -200,23 +202,23 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public unsafe static explicit operator int (IntPtr  value) 
         {
-            #if BIT64
+#if BIT64
                 long l = (long)value.m_value;
                 return checked((int)l);
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 return (int)value.m_value;
-            #endif
+#endif
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [System.Runtime.Versioning.NonVersionable]
         public unsafe static explicit operator long (IntPtr  value) 
         {
-            #if BIT64
+#if BIT64
                 return (long)value.m_value;
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 return (long)(int)value.m_value;
-            #endif
+#endif
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
@@ -246,11 +248,11 @@ namespace System {
         [System.Runtime.Versioning.NonVersionable]
         public static IntPtr operator +(IntPtr pointer, int offset) 
         {
-            #if BIT64
+#if BIT64
                 return new IntPtr(pointer.ToInt64() + offset);
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 return new IntPtr(pointer.ToInt32() + offset);
-            #endif
+#endif
         }
 
         [ReliabilityContract(Consistency.MayCorruptInstance, Cer.MayFail)]
@@ -262,11 +264,11 @@ namespace System {
         [ReliabilityContract(Consistency.MayCorruptInstance, Cer.MayFail)]
         [System.Runtime.Versioning.NonVersionable]
         public static IntPtr operator -(IntPtr pointer, int offset) {
-            #if BIT64
+#if BIT64
                 return new IntPtr(pointer.ToInt64() - offset);
-            #else // !BIT64 (32)
+#else // !BIT64 (32)
                 return new IntPtr(pointer.ToInt32() - offset);
-            #endif
+#endif
         }
 
         public static int Size
@@ -276,11 +278,11 @@ namespace System {
             [System.Runtime.Versioning.NonVersionable]
             get
             {
-                #if BIT64
+#if BIT64
                     return 8;
-                #else // !BIT64 (32)
+#else // !BIT64 (32)
                     return 4;
-                #endif
+#endif
             }
         }
     

--- a/src/mscorlib/src/System/InvalidCastException.cs
+++ b/src/mscorlib/src/System/InvalidCastException.cs
@@ -15,8 +15,10 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class InvalidCastException : SystemException {
         public InvalidCastException() 
             : base(Environment.GetResourceString("Arg_InvalidCastException")) {

--- a/src/mscorlib/src/System/InvalidOperationException.cs
+++ b/src/mscorlib/src/System/InvalidOperationException.cs
@@ -15,8 +15,10 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class InvalidOperationException : SystemException
     {
         public InvalidOperationException() 

--- a/src/mscorlib/src/System/InvalidProgramException.cs
+++ b/src/mscorlib/src/System/InvalidProgramException.cs
@@ -15,8 +15,10 @@ namespace System {
 
     using System;
     using System.Runtime.Serialization;
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class InvalidProgramException : SystemException {
         public InvalidProgramException() 
             : base(Environment.GetResourceString("InvalidProgram_Default")) {

--- a/src/mscorlib/src/System/InvalidTimeZoneException.cs
+++ b/src/mscorlib/src/System/InvalidTimeZoneException.cs
@@ -6,7 +6,9 @@ namespace System {
    using  System.Runtime.Serialization;
    using  System.Runtime.CompilerServices;
 
-   [Serializable]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
    [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
    [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
    public class InvalidTimeZoneException : Exception {

--- a/src/mscorlib/src/System/Lazy.cs
+++ b/src/mscorlib/src/System/Lazy.cs
@@ -46,7 +46,9 @@ namespace System
     /// using parameters to the type's constructors.
     /// </para>
     /// </remarks>
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ComVisible(false)]
 #if !FEATURE_CORECLR
     [HostProtection(Synchronization = true, ExternalThreading = true)]
@@ -56,7 +58,7 @@ namespace System
     public class Lazy<T>
     {
 
-        #region Inner classes
+#region Inner classes
         /// <summary>
         /// wrapper class to box the initialized value, this is mainly created to avoid boxing/unboxing the value each time the value is called in case T is 
         /// a value type
@@ -83,7 +85,7 @@ namespace System
                 m_edi = ExceptionDispatchInfo.Capture(ex);
             }
         }
-        #endregion
+#endregion
 
         // A dummy delegate used as a  :
         // 1- Flag to avoid recursive call to Value in None and ExecutionAndPublication modes in m_valueFactory

--- a/src/mscorlib/src/System/MemberAccessException.cs
+++ b/src/mscorlib/src/System/MemberAccessException.cs
@@ -15,8 +15,10 @@ namespace System {
     // The MemberAccessException is thrown when trying to access a class
     // member fails.
     // 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class MemberAccessException : SystemException {
         
         // Creates a new MemberAccessException with its message string set to

--- a/src/mscorlib/src/System/MethodAccessException.cs
+++ b/src/mscorlib/src/System/MethodAccessException.cs
@@ -13,8 +13,11 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class MethodAccessException : MemberAccessException {
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class MethodAccessException : MemberAccessException {
         public MethodAccessException() 
             : base(Environment.GetResourceString("Arg_MethodAccessException")) {
             SetErrorCode(__HResults.COR_E_METHODACCESS);

--- a/src/mscorlib/src/System/MissingFieldException.cs
+++ b/src/mscorlib/src/System/MissingFieldException.cs
@@ -16,8 +16,10 @@ namespace System {
     using System.Runtime.Serialization;
     using System.Runtime.CompilerServices;
     using System.Globalization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class MissingFieldException : MissingMemberException, ISerializable {
         public MissingFieldException() 
             : base(Environment.GetResourceString("Arg_MissingFieldException")) {

--- a/src/mscorlib/src/System/MissingMemberException.cs
+++ b/src/mscorlib/src/System/MissingMemberException.cs
@@ -23,7 +23,10 @@ namespace System {
     using System.Diagnostics.Contracts;
     
     [System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class MissingMemberException : MemberAccessException, ISerializable {
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class MissingMemberException : MemberAccessException, ISerializable {
         public MissingMemberException() 
             : base(Environment.GetResourceString("Arg_MissingMemberException")) {
             SetErrorCode(__HResults.COR_E_MISSINGMEMBER);

--- a/src/mscorlib/src/System/MissingMethodException.cs
+++ b/src/mscorlib/src/System/MissingMethodException.cs
@@ -18,8 +18,10 @@ namespace System {
     using System.Runtime.Serialization;
     using System.Runtime.CompilerServices;
     using System.Globalization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class MissingMethodException : MissingMemberException, ISerializable {
         public MissingMethodException() 
             : base(Environment.GetResourceString("Arg_MissingMethodException")) {

--- a/src/mscorlib/src/System/MulticastDelegate.cs
+++ b/src/mscorlib/src/System/MulticastDelegate.cs
@@ -11,8 +11,10 @@ namespace System
     using System.Runtime.Serialization;
     using System.Diagnostics.Contracts;
     using System.Reflection.Emit;
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public abstract class MulticastDelegate : Delegate
     {

--- a/src/mscorlib/src/System/MulticastNotSupportedException.cs
+++ b/src/mscorlib/src/System/MulticastNotSupportedException.cs
@@ -11,8 +11,10 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class MulticastNotSupportedException : SystemException {
         
         public MulticastNotSupportedException() 

--- a/src/mscorlib/src/System/NotFiniteNumberException.cs
+++ b/src/mscorlib/src/System/NotFiniteNumberException.cs
@@ -9,8 +9,10 @@ namespace System {
     using System.Security.Permissions;
     using System.Diagnostics.Contracts;
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class NotFiniteNumberException : ArithmeticException {
         private double _offendingNumber;    
     

--- a/src/mscorlib/src/System/NotImplementedException.cs
+++ b/src/mscorlib/src/System/NotImplementedException.cs
@@ -17,8 +17,10 @@ namespace System {
     using System;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class NotImplementedException : SystemException
     {
         public NotImplementedException() 

--- a/src/mscorlib/src/System/NotSupportedException.cs
+++ b/src/mscorlib/src/System/NotSupportedException.cs
@@ -15,8 +15,10 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class NotSupportedException : SystemException
     {
         public NotSupportedException() 

--- a/src/mscorlib/src/System/NullReferenceException.cs
+++ b/src/mscorlib/src/System/NullReferenceException.cs
@@ -15,8 +15,10 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class NullReferenceException : SystemException {
         public NullReferenceException() 
             : base(Environment.GetResourceString("Arg_NullReferenceException")) {

--- a/src/mscorlib/src/System/ObjectDisposedException.cs
+++ b/src/mscorlib/src/System/ObjectDisposedException.cs
@@ -12,8 +12,10 @@ namespace System {
     ///    <para> The exception that is thrown when accessing an object that was
     ///       disposed.</para>
     /// </devdoc>
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ObjectDisposedException : InvalidOperationException {
         private String objectName;
 

--- a/src/mscorlib/src/System/OperatingSystem.cs
+++ b/src/mscorlib/src/System/OperatingSystem.cs
@@ -19,7 +19,9 @@ namespace System {
 
 
     [ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class OperatingSystem : ICloneable , ISerializable
     {
         private Version _version;

--- a/src/mscorlib/src/System/OperationCanceledException.cs
+++ b/src/mscorlib/src/System/OperationCanceledException.cs
@@ -17,7 +17,9 @@ using System.Threading;
 
 namespace System {
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public class OperationCanceledException : SystemException
     {

--- a/src/mscorlib/src/System/OutOfMemoryException.cs
+++ b/src/mscorlib/src/System/OutOfMemoryException.cs
@@ -17,7 +17,9 @@ namespace System {
     using System.Runtime.Serialization;
 
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class OutOfMemoryException : SystemException {
         public OutOfMemoryException() 
             : base(GetMessageFromNativeResources(ExceptionMessageKind.OutOfMemory)) {

--- a/src/mscorlib/src/System/OverflowException.cs
+++ b/src/mscorlib/src/System/OverflowException.cs
@@ -16,8 +16,10 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class OverflowException : ArithmeticException {
         public OverflowException() 
             : base(Environment.GetResourceString("Arg_OverflowException")) {

--- a/src/mscorlib/src/System/PlatformNotSupportedException.cs
+++ b/src/mscorlib/src/System/PlatformNotSupportedException.cs
@@ -16,8 +16,10 @@ namespace System {
     using System;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class PlatformNotSupportedException : NotSupportedException
     {
         public PlatformNotSupportedException() 

--- a/src/mscorlib/src/System/RankException.cs
+++ b/src/mscorlib/src/System/RankException.cs
@@ -16,8 +16,10 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class RankException : SystemException
     {
         public RankException() 

--- a/src/mscorlib/src/System/Reflection/AmbiguousMatchException.cs
+++ b/src/mscorlib/src/System/Reflection/AmbiguousMatchException.cs
@@ -17,8 +17,10 @@ namespace System.Reflection {
     using System;
     using SystemException = System.SystemException;
     using System.Runtime.Serialization;
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class AmbiguousMatchException : SystemException
     {
         

--- a/src/mscorlib/src/System/Reflection/Assembly.cs
+++ b/src/mscorlib/src/System/Reflection/Assembly.cs
@@ -42,12 +42,16 @@ namespace System.Reflection
     using System.Diagnostics.Contracts;
 
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public delegate Module ModuleResolveEventHandler(Object sender, ResolveEventArgs e);
 
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ClassInterface(ClassInterfaceType.None)]
     [ComDefaultInterface(typeof(_Assembly))]
     [System.Runtime.InteropServices.ComVisible(true)]
@@ -56,11 +60,11 @@ namespace System.Reflection
 #pragma warning restore 618
     public abstract class Assembly : _Assembly, IEvidenceFactory, ICustomAttributeProvider, ISerializable
     {
-        #region constructors
+#region constructors
         protected Assembly() {}
-        #endregion
+#endregion
 
-        #region public static methods
+#region public static methods
 
         public static String CreateQualifiedName(String assemblyName, String typeName)
         {
@@ -596,9 +600,9 @@ namespace System.Reflection
             return domainManager.EntryAssembly;
         }
     
-        #endregion // public static methods
+#endregion // public static methods
 
-        #region public methods
+#region public methods
         public virtual event ModuleResolveEventHandler ModuleResolve
         {
             [System.Security.SecurityCritical]  // auto-generated_required
@@ -1069,7 +1073,7 @@ namespace System.Reflection
                 return false;
             }
         }
-        #endregion // public methods
+#endregion // public methods
 
     }
 
@@ -1089,7 +1093,7 @@ namespace System.Reflection
 #endif
     {
 #if !FEATURE_CORECLR
-        #region ICustomQueryInterface
+#region ICustomQueryInterface
         [System.Security.SecurityCritical]
         CustomQueryInterfaceResult ICustomQueryInterface.GetInterface([In]ref Guid iid, out IntPtr ppv)
         {
@@ -1102,7 +1106,7 @@ namespace System.Reflection
             ppv = IntPtr.Zero;
             return CustomQueryInterfaceResult.NotHandled;
         }
-        #endregion
+#endregion
 #endif // !FEATURE_CORECLR
 
 #if FEATURE_APPX
@@ -1122,7 +1126,7 @@ namespace System.Reflection
 
         internal RuntimeAssembly() { throw new NotSupportedException(); }
 
-        #region private data members
+#region private data members
         [method: System.Security.SecurityCritical]
         private event ModuleResolveEventHandler _ModuleResolve;
         private string m_fullname;
@@ -1132,7 +1136,7 @@ namespace System.Reflection
 #if FEATURE_APPX
         private ASSEMBLY_FLAGS m_flags;
 #endif
-        #endregion
+#endregion
 
 #if FEATURE_APPX
         internal int InvocableAttributeCtorToken

--- a/src/mscorlib/src/System/Reflection/AssemblyName.cs
+++ b/src/mscorlib/src/System/Reflection/AssemblyName.cs
@@ -25,10 +25,12 @@ namespace System.Reflection {
     using System.Runtime.Versioning;
     using System.Diagnostics.Contracts;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ClassInterface(ClassInterfaceType.None)]
     [ComDefaultInterface(typeof(_AssemblyName))]
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class AssemblyName : _AssemblyName, ICloneable, ISerializable, IDeserializationCallback
     {
         //
@@ -105,13 +107,13 @@ namespace System.Reflection {
     
         public String CodeBase
         {
-            #if FEATURE_CORECLR
+#if FEATURE_CORECLR
             [System.Security.SecurityCritical] // auto-generated
-            #endif
+#endif
             get { return _CodeBase; }
-            #if FEATURE_CORECLR
+#if FEATURE_CORECLR
             [System.Security.SecurityCritical] // auto-generated
-            #endif
+#endif
             set { _CodeBase = value; }
         }
     
@@ -309,7 +311,7 @@ namespace System.Reflection {
             info.AddValue("_Name", _Name);
             info.AddValue("_PublicKey", _PublicKey, typeof(byte[]));
             info.AddValue("_PublicKeyToken", _PublicKeyToken, typeof(byte[]));
-#if FEATURE_USE_LCID            
+#if FEATURE_USE_LCID
             info.AddValue("_CultureInfo", (_CultureInfo == null) ? -1 :_CultureInfo.LCID);
 #endif
             info.AddValue("_CodeBase", _CodeBase);
@@ -335,7 +337,7 @@ namespace System.Reflection {
             int lcid = (int)m_siInfo.GetInt32("_CultureInfo");
             if (lcid != -1)
                 _CultureInfo = new CultureInfo(lcid);
-#endif            
+#endif
 
             _CodeBase = m_siInfo.GetString("_CodeBase");
             _Version = (Version) m_siInfo.GetValue("_Version", typeof(Version));

--- a/src/mscorlib/src/System/Reflection/ConstructorInfo.cs
+++ b/src/mscorlib/src/System/Reflection/ConstructorInfo.cs
@@ -25,7 +25,9 @@ namespace System.Reflection
     using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
     using System.Runtime.CompilerServices;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ClassInterface(ClassInterfaceType.None)]
     [ComDefaultInterface(typeof(_ConstructorInfo))]
 #pragma warning disable 618
@@ -156,7 +158,9 @@ namespace System.Reflection
 #endif
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class RuntimeConstructorInfo : ConstructorInfo, ISerializable, IRuntimeMethodInfo
     {
         #region Private Data Members

--- a/src/mscorlib/src/System/Reflection/CustomAttributeFormatException.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttributeFormatException.cs
@@ -14,8 +14,10 @@ namespace System.Reflection {
     using System;
     using ApplicationException = System.ApplicationException;
     using System.Runtime.Serialization;
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class CustomAttributeFormatException  : FormatException {
     
         public CustomAttributeFormatException()

--- a/src/mscorlib/src/System/Reflection/EventInfo.cs
+++ b/src/mscorlib/src/System/Reflection/EventInfo.cs
@@ -16,7 +16,9 @@ namespace System.Reflection
     using System.Security.Permissions;
     using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ClassInterface(ClassInterfaceType.None)]
     [ComDefaultInterface(typeof(_EventInfo))]
 #pragma warning disable 618
@@ -223,7 +225,9 @@ namespace System.Reflection
 #endif
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal unsafe sealed class RuntimeEventInfo : EventInfo, ISerializable
     {
         #region Private Data Members

--- a/src/mscorlib/src/System/Reflection/FieldInfo.cs
+++ b/src/mscorlib/src/System/Reflection/FieldInfo.cs
@@ -23,7 +23,9 @@ namespace System.Reflection
     using System.Threading;
     using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ClassInterface(ClassInterfaceType.None)]
     [ComDefaultInterface(typeof(_FieldInfo))]
 #pragma warning disable 618
@@ -219,7 +221,9 @@ namespace System.Reflection
 #endif
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal abstract class RuntimeFieldInfo : FieldInfo, ISerializable
     {
         #region Private Data Members
@@ -820,7 +824,9 @@ namespace System.Reflection
         #endregion
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed unsafe class MdFieldInfo : RuntimeFieldInfo, ISerializable
     {
         #region Private Data Members

--- a/src/mscorlib/src/System/Reflection/InvalidFilterCriteriaException.cs
+++ b/src/mscorlib/src/System/Reflection/InvalidFilterCriteriaException.cs
@@ -17,8 +17,10 @@ namespace System.Reflection {
     using System;
     using System.Runtime.Serialization;
     using ApplicationException = System.ApplicationException;
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
 #if FEATURE_CORECLR
     public class InvalidFilterCriteriaException : Exception {
 #else

--- a/src/mscorlib/src/System/Reflection/MemberFilter.cs
+++ b/src/mscorlib/src/System/Reflection/MemberFilter.cs
@@ -11,9 +11,11 @@
 //
 //
 namespace System.Reflection {
-    
+
     // Define the delegate
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public delegate bool MemberFilter(MemberInfo m, Object filterCriteria);
 }

--- a/src/mscorlib/src/System/Reflection/MemberInfoSerializationHolder.cs
+++ b/src/mscorlib/src/System/Reflection/MemberInfoSerializationHolder.cs
@@ -11,8 +11,10 @@ using System.Globalization;
 using System.Diagnostics.Contracts;
 
 namespace System.Reflection 
-{   
+{
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class MemberInfoSerializationHolder : ISerializable, IObjectReference 
     {
         #region Staitc Public Members

--- a/src/mscorlib/src/System/Reflection/MethodInfo.cs
+++ b/src/mscorlib/src/System/Reflection/MethodInfo.cs
@@ -124,7 +124,9 @@ namespace System.Reflection
 #endif
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class RuntimeMethodInfo : MethodInfo, ISerializable, IRuntimeMethodInfo
     {
         #region Private Data Members

--- a/src/mscorlib/src/System/Reflection/Missing.cs
+++ b/src/mscorlib/src/System/Reflection/Missing.cs
@@ -13,8 +13,10 @@ namespace System.Reflection
     using System.Diagnostics.Contracts;
 
     // This is not serializable because it is a reflection command.
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class Missing: ISerializable
     {
         public static readonly Missing Value = new Missing();

--- a/src/mscorlib/src/System/Reflection/Module.cs
+++ b/src/mscorlib/src/System/Reflection/Module.cs
@@ -55,7 +55,9 @@ namespace System.Reflection
         ARM     = 0x01c4,
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ClassInterface(ClassInterfaceType.None)]
     [ComDefaultInterface(typeof(_Module))]
     [System.Runtime.InteropServices.ComVisible(true)]

--- a/src/mscorlib/src/System/Reflection/ParameterInfo.cs
+++ b/src/mscorlib/src/System/Reflection/ParameterInfo.cs
@@ -259,7 +259,9 @@ namespace System.Reflection
         #endregion
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal unsafe sealed class RuntimeParameterInfo : ParameterInfo, ISerializable
     {
         #region Static Members

--- a/src/mscorlib/src/System/Reflection/Pointer.cs
+++ b/src/mscorlib/src/System/Reflection/Pointer.cs
@@ -18,7 +18,9 @@ namespace System.Reflection {
     using System.Diagnostics.Contracts;
 
     [CLSCompliant(false)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class Pointer: ISerializable {
         [SecurityCritical]

--- a/src/mscorlib/src/System/Reflection/PropertyInfo.cs
+++ b/src/mscorlib/src/System/Reflection/PropertyInfo.cs
@@ -186,7 +186,9 @@ namespace System.Reflection
 #endif
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal unsafe sealed class RuntimePropertyInfo : PropertyInfo, ISerializable
     {
         #region Private Data Members

--- a/src/mscorlib/src/System/Reflection/ReflectionTypeLoadException.cs
+++ b/src/mscorlib/src/System/Reflection/ReflectionTypeLoadException.cs
@@ -21,8 +21,10 @@ namespace System.Reflection {
     using System.Runtime.Serialization;
     using System.Security.Permissions;
     using System.Diagnostics.Contracts;
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class ReflectionTypeLoadException : SystemException, ISerializable {
         private Type[] _classes;
         private Exception[] _exceptions;

--- a/src/mscorlib/src/System/Reflection/StrongNameKeyPair.cs
+++ b/src/mscorlib/src/System/Reflection/StrongNameKeyPair.cs
@@ -40,8 +40,10 @@ namespace System.Reflection
         }
     }
 #else
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class StrongNameKeyPair : IDeserializationCallback, ISerializable 
     {
         private bool    _keyPairExported;

--- a/src/mscorlib/src/System/Reflection/TargetException.cs
+++ b/src/mscorlib/src/System/Reflection/TargetException.cs
@@ -17,8 +17,10 @@ namespace System.Reflection {
     
     using System;
     using System.Runtime.Serialization;
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
 #if FEATURE_CORECLR
     public class TargetException : Exception {
 #else

--- a/src/mscorlib/src/System/Reflection/TargetInvocationException.cs
+++ b/src/mscorlib/src/System/Reflection/TargetInvocationException.cs
@@ -17,8 +17,10 @@ namespace System.Reflection {
     
     using System;
     using System.Runtime.Serialization;
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
 #if FEATURE_CORECLR
     public sealed class TargetInvocationException : Exception {
 #else

--- a/src/mscorlib/src/System/Reflection/TargetParameterCountException.cs
+++ b/src/mscorlib/src/System/Reflection/TargetParameterCountException.cs
@@ -17,8 +17,10 @@ namespace System.Reflection {
     using System;
     using SystemException = System.SystemException;
     using System.Runtime.Serialization;
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
 #if FEATURE_CORECLR
     public sealed class TargetParameterCountException : Exception {
 #else

--- a/src/mscorlib/src/System/Reflection/TypeFilter.cs
+++ b/src/mscorlib/src/System/Reflection/TypeFilter.cs
@@ -11,9 +11,11 @@
 //
 //
 namespace System.Reflection {
-    
+
     // Define the delegate
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public delegate bool TypeFilter(Type m, Object filterCriteria);
 }

--- a/src/mscorlib/src/System/Resources/MissingManifestResourceException.cs
+++ b/src/mscorlib/src/System/Resources/MissingManifestResourceException.cs
@@ -17,8 +17,10 @@ using System;
 using System.Runtime.Serialization;
 
 namespace System.Resources {
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class MissingManifestResourceException : SystemException
     {
         public MissingManifestResourceException() 

--- a/src/mscorlib/src/System/Resources/MissingSatelliteAssemblyException.cs
+++ b/src/mscorlib/src/System/Resources/MissingSatelliteAssemblyException.cs
@@ -19,8 +19,10 @@ using System;
 using System.Runtime.Serialization;
 
 namespace System.Resources {
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class MissingSatelliteAssemblyException : SystemException
     {
         private String _cultureName;

--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -155,7 +155,9 @@ namespace System.Resources {
     // is one such example.
     //
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public class ResourceManager
     {

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -79,7 +79,9 @@ namespace System
         FullName,
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class RuntimeType : 
         System.Reflection.TypeInfo, ISerializable, ICloneable
     {
@@ -5571,7 +5573,9 @@ namespace System
     // method (RuntimeType) and an instance of this type will work around the reason to have this type in the 
     // first place. However given RuntimeType is not public all its methods are protected and require full trust
     // to be accessed
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class ReflectionOnlyType : RuntimeType {
 
         private ReflectionOnlyType() {}

--- a/src/mscorlib/src/System/Runtime/InteropServices/COMException.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/COMException.cs
@@ -22,7 +22,9 @@ namespace System.Runtime.InteropServices {
     // Exception for COM Interop errors where we don't recognize the HResult.
     // 
     [ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class COMException : ExternalException {
         public COMException() 
             : base(Environment.GetResourceString("Arg_COMException"))

--- a/src/mscorlib/src/System/Runtime/InteropServices/ExternalException.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/ExternalException.cs
@@ -20,8 +20,10 @@ namespace System.Runtime.InteropServices {
     // Base exception for COM Interop errors &; Structured Exception Handler
     // exceptions.
     // 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ExternalException : SystemException {
         public ExternalException() 
             : base(Environment.GetResourceString("Arg_ExternalException")) {

--- a/src/mscorlib/src/System/Runtime/InteropServices/InvalidComObjectException.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/InvalidComObjectException.cs
@@ -16,8 +16,10 @@ namespace System.Runtime.InteropServices {
     using System;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class InvalidComObjectException : SystemException {
         public InvalidComObjectException() 
             : base(Environment.GetResourceString("Arg_InvalidComObjectException")) {

--- a/src/mscorlib/src/System/Runtime/InteropServices/InvalidOleVariantTypeException.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/InvalidOleVariantTypeException.cs
@@ -15,8 +15,11 @@ namespace System.Runtime.InteropServices {
     using System;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class InvalidOleVariantTypeException : SystemException {
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class InvalidOleVariantTypeException : SystemException {
         public InvalidOleVariantTypeException() 
             : base(Environment.GetResourceString("Arg_InvalidOleVariantTypeException")) {
             SetErrorCode(__HResults.COR_E_INVALIDOLEVARIANTTYPE);

--- a/src/mscorlib/src/System/Runtime/InteropServices/MarshalDirectiveException.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/MarshalDirectiveException.cs
@@ -16,8 +16,10 @@ namespace System.Runtime.InteropServices {
     using System;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class MarshalDirectiveException : SystemException {
         public MarshalDirectiveException() 
             : base(Environment.GetResourceString("Arg_MarshalDirectiveException")) {

--- a/src/mscorlib/src/System/Runtime/InteropServices/SEHException.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/SEHException.cs
@@ -17,8 +17,10 @@ namespace System.Runtime.InteropServices {
     using System.Runtime.Serialization;
     // Exception for Structured Exception Handler exceptions.
     // 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class SEHException : ExternalException {
         public SEHException() 
             : base() {

--- a/src/mscorlib/src/System/Runtime/InteropServices/SafeArrayRankMismatchException.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/SafeArrayRankMismatchException.cs
@@ -15,8 +15,11 @@ namespace System.Runtime.InteropServices {
     using System;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class SafeArrayRankMismatchException : SystemException {
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class SafeArrayRankMismatchException : SystemException {
         public SafeArrayRankMismatchException() 
             : base(Environment.GetResourceString("Arg_SafeArrayRankMismatchException")) {
             SetErrorCode(__HResults.COR_E_SAFEARRAYRANKMISMATCH);

--- a/src/mscorlib/src/System/Runtime/InteropServices/SafeArrayTypeMismatchException.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/SafeArrayTypeMismatchException.cs
@@ -16,8 +16,11 @@ namespace System.Runtime.InteropServices {
     using System;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class SafeArrayTypeMismatchException : SystemException {
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class SafeArrayTypeMismatchException : SystemException {
         public SafeArrayTypeMismatchException() 
             : base(Environment.GetResourceString("Arg_SafeArrayTypeMismatchException")) {
             SetErrorCode(__HResults.COR_E_SAFEARRAYTYPEMISMATCH);

--- a/src/mscorlib/src/System/Runtime/Serialization/SerializationException.cs
+++ b/src/mscorlib/src/System/Runtime/Serialization/SerializationException.cs
@@ -17,8 +17,11 @@ namespace System.Runtime.Serialization {
     using System;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class SerializationException : SystemException {
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class SerializationException : SystemException {
         
         private static String _nullMessage = Environment.GetResourceString("Arg_SerializationException");
         

--- a/src/mscorlib/src/System/RuntimeHandles.cs
+++ b/src/mscorlib/src/System/RuntimeHandles.cs
@@ -23,8 +23,10 @@ namespace System
     using Microsoft.Win32.SafeHandles;
     using System.Diagnostics.Contracts;
     using StackCrawlMark = System.Threading.StackCrawlMark;
-    
-    [Serializable()]
+
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public unsafe struct RuntimeTypeHandle : ISerializable
     {
@@ -690,9 +692,9 @@ namespace System
         [SuppressUnmanagedCodeSecurity]
         internal extern static bool IsCollectible(RuntimeTypeHandle handle);
         
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecuritySafeCritical] // auto-generated
-        #endif
+#endif
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal extern static bool HasInstantiation(RuntimeType type);
 
@@ -916,9 +918,11 @@ namespace System
         {
             get;
         }
-    }                                       
+    }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public unsafe struct RuntimeMethodHandle : ISerializable
     {
@@ -1163,7 +1167,7 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal extern static object InvokeMethod(object target, object[] arguments, Signature sig, bool constructor);
 
-        #region Private Invocation Helpers
+#region Private Invocation Helpers
         [System.Security.SecurityCritical]  // auto-generated
         internal static INVOCATION_FLAGS GetSecurityFlags(IRuntimeMethodInfo handle)
         {
@@ -1187,7 +1191,7 @@ namespace System
             return;
         }
 #endif //!FEATURE_CORECLR
-        #endregion
+#endregion
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [DebuggerStepThroughAttribute]
@@ -1202,11 +1206,11 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern bool _IsTokenSecurityTransparent(RuntimeModule module, int metaDataToken);
         
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecuritySafeCritical] // auto-generated
-        #else
+#else
         [System.Security.SecurityCritical]
-        #endif
+#endif
         internal static bool IsTokenSecurityTransparent(Module module, int metaDataToken)
         {
             return _IsTokenSecurityTransparent(module.ModuleHandle.GetRuntimeModule(), metaDataToken);
@@ -1466,8 +1470,10 @@ namespace System
         }
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public unsafe struct RuntimeFieldHandle : ISerializable
     {
         // Returns handle for interop with EE. The handle is guaranteed to be non-null.
@@ -1680,27 +1686,27 @@ namespace System
     public unsafe struct ModuleHandle
     {
         // Returns handle for interop with EE. The handle is guaranteed to be non-null.
-        #region Public Static Members
+#region Public Static Members
         public static readonly ModuleHandle EmptyHandle = GetEmptyMH();
-        #endregion
+#endregion
 
         unsafe static private ModuleHandle GetEmptyMH()
         {
             return new ModuleHandle();
         }
 
-        #region Private Data Members
+#region Private Data Members
         private RuntimeModule m_ptr;
-        #endregion
+#endregion
     
-        #region Constructor
+#region Constructor
         internal ModuleHandle(RuntimeModule module) 
         {
             m_ptr = module;
         }
-        #endregion
+#endregion
 
-        #region Internal FCalls
+#region Internal FCalls
 
         internal RuntimeModule GetRuntimeModule()
         {
@@ -1962,12 +1968,12 @@ namespace System
         {
             return new MetadataImport(_GetMetadataImport(module.GetNativeHandle()), module);
         }
-        #endregion
+#endregion
     }
 
     internal unsafe class Signature
     {
-        #region Definitions
+#region Definitions
         internal enum MdSigCallingConvention : byte
         {
             Generics            = 0x10,
@@ -1987,18 +1993,18 @@ namespace System
             GenericInst         = 0x0A,
             Max                 = 0x0B,
         }
-        #endregion
+#endregion
 
-        #region FCalls
+#region FCalls
         [System.Security.SecurityCritical]  // auto-generated
         [MethodImplAttribute(MethodImplOptions.InternalCall)]        
         private extern void GetSignature(
             void* pCorSig, int cCorSig,
             RuntimeFieldHandleInternal fieldHandle, IRuntimeMethodInfo methodHandle, RuntimeType declaringType);
 
-        #endregion
+#endregion
 
-        #region Private Data Members
+#region Private Data Members
         //
         // Keep the layout in sync with SignatureNative in the VM
         //
@@ -2012,9 +2018,9 @@ namespace System
         internal int m_nSizeOfArgStack;
         internal int m_csig;
         internal RuntimeMethodHandleInternal m_pMethod;
-        #endregion
+#endregion
 
-        #region Constructors
+#region Constructors
         [System.Security.SecuritySafeCritical]  // auto-generated
         public Signature (
             IRuntimeMethodInfo method,
@@ -2048,9 +2054,9 @@ namespace System
         {
             GetSignature(pCorSig, cCorSig, new RuntimeFieldHandleInternal(), null, declaringType);
         }
-        #endregion
+#endregion
 
-        #region Internal Members
+#region Internal Members
         internal CallingConventions CallingConvention { get { return (CallingConventions)(byte)m_managedCallingConventionAndArgIteratorFlags; } }
         internal RuntimeType[] Arguments { get { return m_arguments; } }
         internal RuntimeType ReturnType { get { return m_returnTypeORfieldType; } }
@@ -2063,7 +2069,7 @@ namespace System
         [System.Security.SecuritySafeCritical]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal extern Type[] GetCustomModifiers(int position, bool required);
-        #endregion
+#endregion
     }
 
 

--- a/src/mscorlib/src/System/Security/HostProtectionException.cs
+++ b/src/mscorlib/src/System/Security/HostProtectionException.cs
@@ -23,7 +23,10 @@ namespace System.Security
     using System.Diagnostics.Contracts;
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class HostProtectionException : SystemException
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class HostProtectionException : SystemException
     {
         private HostProtectionResource m_protected;
         private HostProtectionResource m_demanded;

--- a/src/mscorlib/src/System/Security/PermissionSet.cs
+++ b/src/mscorlib/src/System/Security/PermissionSet.cs
@@ -33,7 +33,9 @@ namespace System.Security {
         SkipVerification = 3
     }
 
-    [Serializable] 
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
 #if !FEATURE_CORECLR
     [StrongNameIdentityPermissionAttribute(SecurityAction.InheritanceDemand, Name = "mscorlib", PublicKey = "0x" + AssemblyRef.EcmaPublicKeyFull)]
 #endif

--- a/src/mscorlib/src/System/Security/Permissions/SiteIdentityPermission.cs
+++ b/src/mscorlib/src/System/Security/Permissions/SiteIdentityPermission.cs
@@ -15,8 +15,10 @@ namespace System.Security.Permissions
     using System.Globalization;
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     sealed public class SiteIdentityPermission : CodeAccessPermission, IBuiltInPermission
     {
         //------------------------------------------------------

--- a/src/mscorlib/src/System/Security/Permissions/URLIdentityPermission.cs
+++ b/src/mscorlib/src/System/Security/Permissions/URLIdentityPermission.cs
@@ -17,8 +17,11 @@ namespace System.Security.Permissions
     using System.Runtime.Serialization;
     using System.Diagnostics.Contracts;
 
-[System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] sealed public class UrlIdentityPermission : CodeAccessPermission, IBuiltInPermission
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    sealed public class UrlIdentityPermission : CodeAccessPermission, IBuiltInPermission
     {
         //------------------------------------------------------
         //

--- a/src/mscorlib/src/System/Security/Permissions/ZoneIdentityPermission.cs
+++ b/src/mscorlib/src/System/Security/Permissions/ZoneIdentityPermission.cs
@@ -17,8 +17,10 @@ namespace System.Security.Permissions
     using System.Collections.Generic;
     using System.Diagnostics.Contracts;
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     sealed public class ZoneIdentityPermission : CodeAccessPermission, IBuiltInPermission
     {
         //------------------------------------------------------

--- a/src/mscorlib/src/System/Security/Policy/Evidence.cs
+++ b/src/mscorlib/src/System/Security/Policy/Evidence.cs
@@ -43,7 +43,9 @@ namespace System.Security.Policy
     ///     not contain any evidence data or null.  As requests come in for that evidence, we'll populate the
     ///     EvidenceTypeDescriptor appropriately.
     /// </summary>
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ComVisible(true)]
     public sealed class Evidence
 #if FEATURE_CAS_POLICY

--- a/src/mscorlib/src/System/Security/SecurityException.cs
+++ b/src/mscorlib/src/System/Security/SecurityException.cs
@@ -31,7 +31,10 @@ namespace System.Security
     using System.Diagnostics.Contracts;
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class SecurityException : SystemException
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class SecurityException : SystemException
     {
 #if FEATURE_CAS_POLICY        
         private String m_debugString; // NOTE: If you change the name of this field, you'll have to update SOS as well!

--- a/src/mscorlib/src/System/Security/Util/TokenBasedSet.cs
+++ b/src/mscorlib/src/System/Security/Util/TokenBasedSet.cs
@@ -12,7 +12,9 @@ namespace System.Security.Util
     using System.Diagnostics.Contracts;
     using System.Diagnostics.CodeAnalysis;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class TokenBasedSet
     {
 

--- a/src/mscorlib/src/System/Security/Util/URLString.cs
+++ b/src/mscorlib/src/System/Security/Util/URLString.cs
@@ -21,8 +21,10 @@ namespace System.Security.Util {
     using System.Text;
     using System.IO;
     using System.Diagnostics.Contracts;
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class URLString : SiteString
     {
         private String m_protocol;

--- a/src/mscorlib/src/System/Security/VerificationException.cs
+++ b/src/mscorlib/src/System/Security/VerificationException.cs
@@ -10,7 +10,10 @@ namespace System.Security {
     using System.Runtime.Serialization;
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    [Serializable] public class VerificationException : SystemException {
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    public class VerificationException : SystemException {
         public VerificationException() 
             : base(Environment.GetResourceString("Verification_Exception")) {
             SetErrorCode(__HResults.COR_E_VERIFICATION);

--- a/src/mscorlib/src/System/StackOverflowException.cs
+++ b/src/mscorlib/src/System/StackOverflowException.cs
@@ -15,8 +15,10 @@ namespace System {
     
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class StackOverflowException : SystemException {
         public StackOverflowException() 
             : base(Environment.GetResourceString("Arg_StackOverflowException")) {

--- a/src/mscorlib/src/System/SystemException.cs
+++ b/src/mscorlib/src/System/SystemException.cs
@@ -6,8 +6,10 @@ namespace System {
  
     using System;
     using System.Runtime.Serialization;
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class SystemException : Exception
     {
         public SystemException() 

--- a/src/mscorlib/src/System/Text/BaseCodePageEncoding.cs
+++ b/src/mscorlib/src/System/Text/BaseCodePageEncoding.cs
@@ -48,7 +48,9 @@ namespace System.Text
     //       BYTE[]      data;           // data section
     //   }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal abstract class BaseCodePageEncoding : EncodingNLS, ISerializable
     {
         // Static & Const stuff

--- a/src/mscorlib/src/System/Text/CodePageEncoding.cs
+++ b/src/mscorlib/src/System/Text/CodePageEncoding.cs
@@ -20,7 +20,9 @@ namespace System.Text
     ** to Everett compatibility as well.
     ==============================================================================*/
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class CodePageEncoding : ISerializable, IObjectReference
     {
         // Temp stuff
@@ -104,7 +106,9 @@ namespace System.Text
 #endif
 
         // Same problem with the Decoder, this only happens with Everett Decoders
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         internal sealed class Decoder : ISerializable, IObjectReference
         {
             // Might need this when GetRealObjecting

--- a/src/mscorlib/src/System/Text/DBCSCodePageEncoding.cs
+++ b/src/mscorlib/src/System/Text/DBCSCodePageEncoding.cs
@@ -15,7 +15,9 @@ namespace System.Text
 
     // DBCSCodePageEncoding
     //
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class DBCSCodePageEncoding : BaseCodePageEncoding, ISerializable
     {
         // Pointers to our memory section parts

--- a/src/mscorlib/src/System/Text/DecoderExceptionFallback.cs
+++ b/src/mscorlib/src/System/Text/DecoderExceptionFallback.cs
@@ -101,7 +101,9 @@ namespace System.Text
     }
 
     // Exception for decoding unknown byte sequences.
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class DecoderFallbackException : ArgumentException
     {
         byte[]    bytesUnknown = null;

--- a/src/mscorlib/src/System/Text/DecoderNLS.cs
+++ b/src/mscorlib/src/System/Text/DecoderNLS.cs
@@ -21,7 +21,9 @@ namespace System.Text
     // of Encoding objects.
     //
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class DecoderNLS : Decoder, ISerializable
     {
         // Remember our encoding

--- a/src/mscorlib/src/System/Text/EncoderExceptionFallback.cs
+++ b/src/mscorlib/src/System/Text/EncoderExceptionFallback.cs
@@ -103,7 +103,9 @@ namespace System.Text
         }
     }
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class EncoderFallbackException : ArgumentException
     {
         char    charUnknown;

--- a/src/mscorlib/src/System/Text/EncoderNLS.cs
+++ b/src/mscorlib/src/System/Text/EncoderNLS.cs
@@ -21,7 +21,9 @@ namespace System.Text
     // of Encoding objects.
     //
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class EncoderNLS : Encoder, ISerializable
     {
         // Need a place for the last left over character, most of our encodings use this

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -82,8 +82,10 @@ namespace System.Text
     // generally executes faster.
     //
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public abstract class Encoding : ICloneable
     {
         private static volatile Encoding defaultEncoding;
@@ -1610,7 +1612,9 @@ namespace System.Text
             decoder.ClearMustFlush();
         }
 
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         internal class DefaultEncoder : Encoder, ISerializable, IObjectReference
         {
             private Encoding m_encoding;
@@ -1738,7 +1742,9 @@ namespace System.Text
             }
         }
 
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         internal class DefaultDecoder : Decoder, ISerializable, IObjectReference
         {
             private Encoding m_encoding;

--- a/src/mscorlib/src/System/Text/GB18030Encoding.cs
+++ b/src/mscorlib/src/System/Text/GB18030Encoding.cs
@@ -101,7 +101,9 @@ namespace System.Text
     **
     ==============================================================================*/
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class GB18030Encoding : DBCSCodePageEncoding, ISerializable
     {
         // This is the table of 4 byte conversions.
@@ -840,7 +842,9 @@ namespace System.Text
             return new GB18030Decoder(this);
         }
 
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         internal sealed class GB18030Decoder : System.Text.DecoderNLS, ISerializable
         {
             internal short bLeftOver1 = -1;

--- a/src/mscorlib/src/System/Text/ISCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ISCIIEncoding.cs
@@ -28,7 +28,9 @@ namespace System.Text
     //      Form IDNA has the above problems plus case mapping, so false (like most encodings)
     //
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class ISCIIEncoding : EncodingNLS, ISerializable
     {
         // Constants

--- a/src/mscorlib/src/System/Text/Latin1Encoding.cs
+++ b/src/mscorlib/src/System/Text/Latin1Encoding.cs
@@ -19,7 +19,9 @@ namespace System.Text
     // Latin1Encoding is a simple override to optimize the GetString version of Latin1Encoding.
     // because of the best fit cases we can't do this when encoding the string, only when decoding
     //
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class Latin1Encoding : EncodingNLS, ISerializable
     {
         // We only use the best-fit table, of which ASCII is a superset for us.
@@ -490,7 +492,7 @@ namespace System.Text
             }
         }
 
-#if !FEATURE_NORM_IDNA_ONLY        
+#if !FEATURE_NORM_IDNA_ONLY
         public override bool IsAlwaysNormalized(NormalizationForm form)
         {
             // Latin-1 contains precomposed characters, so normal for Form C.

--- a/src/mscorlib/src/System/Text/MLangCodePageEncoding.cs
+++ b/src/mscorlib/src/System/Text/MLangCodePageEncoding.cs
@@ -22,7 +22,9 @@ namespace System.Text
     ** to Everett compatibility as well.
     ==============================================================================*/
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class MLangCodePageEncoding : ISerializable, IObjectReference
     {
         // Temp stuff
@@ -105,8 +107,10 @@ namespace System.Text
         }
 #endif
 
-        // Same problem with the Encoder, this only happens with Everett Encoders
+// Same problem with the Encoder, this only happens with Everett Encoders
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         internal sealed class MLangEncoder : ISerializable, IObjectReference
         {
             // Might need this when GetRealObjecting
@@ -144,7 +148,9 @@ namespace System.Text
 
 
         // Same problem with the Decoder, this only happens with Everett Decoders
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         internal sealed class MLangDecoder : ISerializable, IObjectReference
         {
             // Might need this when GetRealObjecting

--- a/src/mscorlib/src/System/Text/SBCSCodePageEncoding.cs
+++ b/src/mscorlib/src/System/Text/SBCSCodePageEncoding.cs
@@ -15,7 +15,9 @@ namespace System.Text
     using System.Security.Permissions;
 
     // SBCSCodePageEncoding
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal class SBCSCodePageEncoding : BaseCodePageEncoding, ISerializable
     {
         // Pointers to our memory section parts

--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -40,7 +40,9 @@ namespace System.Text {
     // Console.WriteLine(sb2);
     // 
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class StringBuilder : ISerializable {
         // A StringBuilder is internally represented as a linked list of blocks each of which holds
         // a chunk of the string.  It turns out string as a whole can also be represented as just a chunk, 

--- a/src/mscorlib/src/System/Text/SurrogateEncoder.cs
+++ b/src/mscorlib/src/System/Text/SurrogateEncoder.cs
@@ -19,7 +19,9 @@ namespace System.Text
     ** Appropriate Whidbey (V2.0) objects.
     ==============================================================================*/
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     internal sealed class SurrogateEncoder : ISerializable, IObjectReference
     {
         // Might need this when GetRealObjecting

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -14,8 +14,10 @@ namespace System.Text
     using System.Diagnostics.Contracts;
 
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class UTF7Encoding : Encoding
     {
         private const String base64Chars =
@@ -642,7 +644,9 @@ namespace System.Text
             return charCount;
         }
 
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         // Of all the amazing things... This MUST be Decoder so that our com name
         // for System.Text.Decoder doesn't change
         private class Decoder : DecoderNLS, ISerializable
@@ -708,7 +712,9 @@ namespace System.Text
             }
         }
 
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         // Of all the amazing things... This MUST be Encoder so that our com name
         // for System.Text.Encoder doesn't change
         private class Encoder : EncoderNLS, ISerializable

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -2154,7 +2154,9 @@ namespace System.Text
                    UTF8_CODEPAGE + (emitUTF8Identifier?1:0);
         }
 
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         internal class UTF8Encoder : EncoderNLS, ISerializable
         {
             // We must save a high surrogate value until the next call, looking
@@ -2229,7 +2231,9 @@ namespace System.Text
             }
         }
 
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         internal class UTF8Decoder : DecoderNLS, ISerializable
         {
             // We'll need to remember the previous information. See the comments around definition

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -15,7 +15,9 @@ namespace System.Text
     using System.Diagnostics.Contracts;
 
 
-    [Serializable] 
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
     [System.Runtime.InteropServices.ComVisible(true)]
     public class UnicodeEncoding : Encoding
     {
@@ -1761,7 +1763,9 @@ namespace System.Text
                    (byteOrderMark?4:0) + (bigEndian?8:0);
         }
 
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         private class Decoder : System.Text.DecoderNLS, ISerializable
         {
             internal int lastByte = -1;

--- a/src/mscorlib/src/System/Threading/AbandonedMutexException.cs
+++ b/src/mscorlib/src/System/Threading/AbandonedMutexException.cs
@@ -15,8 +15,10 @@ namespace System.Threading {
     using System.Runtime.Serialization;
     using System.Threading;
     using System.Runtime.InteropServices;
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ComVisibleAttribute(false)]
     public class AbandonedMutexException : SystemException {
 

--- a/src/mscorlib/src/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/src/System/Threading/ExecutionContext.cs
@@ -515,7 +515,9 @@ namespace System.Threading
     }
     
 
-    [Serializable] 
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
     public sealed class ExecutionContext : IDisposable, ISerializable
     {
         /*=========================================================================

--- a/src/mscorlib/src/System/Threading/LockRecursionException.cs
+++ b/src/mscorlib/src/System/Threading/LockRecursionException.cs
@@ -18,7 +18,9 @@ namespace System.Threading
     using System.Runtime.Serialization;
     using System.Runtime.CompilerServices;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
     public class LockRecursionException : System.Exception

--- a/src/mscorlib/src/System/Threading/SemaphoreFullException.cs
+++ b/src/mscorlib/src/System/Threading/SemaphoreFullException.cs
@@ -7,7 +7,9 @@ namespace System.Threading {
     using System.Runtime.Serialization;
     using System.Runtime.InteropServices;
 
-    [Serializable()]
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
     [ComVisibleAttribute(false)]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
     public class SemaphoreFullException : SystemException {

--- a/src/mscorlib/src/System/Threading/SynchronizationLockException.cs
+++ b/src/mscorlib/src/System/Threading/SynchronizationLockException.cs
@@ -17,8 +17,10 @@ namespace System.Threading {
 
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class SynchronizationLockException : SystemException {
         public SynchronizationLockException() 
             : base(Environment.GetResourceString("Arg_SynchronizationLockException")) {

--- a/src/mscorlib/src/System/Threading/Tasks/TaskCanceledException.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskCanceledException.cs
@@ -20,7 +20,9 @@ namespace System.Threading.Tasks
     /// <summary>
     /// Represents an exception used to communicate task cancellation.
     /// </summary>
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class TaskCanceledException : OperationCanceledException
     {
 

--- a/src/mscorlib/src/System/Threading/Tasks/TaskSchedulerException.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskSchedulerException.cs
@@ -21,7 +21,9 @@ namespace System.Threading.Tasks
     /// Represents an exception used to communicate an invalid operation by a
     /// <see cref="T:System.Threading.Tasks.TaskScheduler"/>.
     /// </summary>
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class TaskSchedulerException : Exception
     {
         /// <summary>

--- a/src/mscorlib/src/System/Threading/ThreadAbortException.cs
+++ b/src/mscorlib/src/System/Threading/ThreadAbortException.cs
@@ -22,7 +22,9 @@ namespace System.Threading
     using System.Runtime.CompilerServices;
 
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class ThreadAbortException : SystemException 
     {
         private ThreadAbortException() 

--- a/src/mscorlib/src/System/Threading/ThreadInterruptedException.cs
+++ b/src/mscorlib/src/System/Threading/ThreadInterruptedException.cs
@@ -18,7 +18,9 @@ namespace System.Threading {
     using System.Runtime.Serialization;
 
     [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ThreadInterruptedException : SystemException {
         public ThreadInterruptedException() 
             : base(GetMessageFromNativeResources(ExceptionMessageKind.ThreadInterrupted)) {

--- a/src/mscorlib/src/System/Threading/ThreadStartException.cs
+++ b/src/mscorlib/src/System/Threading/ThreadStartException.cs
@@ -10,7 +10,9 @@ namespace System.Threading
     using System.Runtime.Serialization;
     using System.Runtime.InteropServices;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public sealed class ThreadStartException : SystemException 
     {
         private ThreadStartException() 

--- a/src/mscorlib/src/System/Threading/ThreadStateException.cs
+++ b/src/mscorlib/src/System/Threading/ThreadStateException.cs
@@ -16,8 +16,10 @@
 namespace System.Threading {
     using System;
     using System.Runtime.Serialization;
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class ThreadStateException : SystemException {
         public ThreadStateException() 
             : base(Environment.GetResourceString("Arg_ThreadStateException")) {

--- a/src/mscorlib/src/System/Threading/WaitHandleCannotBeOpenedException.cs
+++ b/src/mscorlib/src/System/Threading/WaitHandleCannotBeOpenedException.cs
@@ -9,7 +9,9 @@ namespace System.Threading
     using System.Runtime.Serialization;
     using System.Runtime.InteropServices;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [ComVisibleAttribute(false)]
 
 #if FEATURE_CORECLR

--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -50,7 +50,9 @@ namespace System {
     };
 
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
     sealed public class TimeZoneInfo : IEquatable<TimeZoneInfo>, ISerializable, IDeserializationCallback {
@@ -4452,7 +4454,9 @@ namespace System {
 **
 **
 ============================================================*/
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
         [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
         sealed public class AdjustmentRule : IEquatable<AdjustmentRule>, ISerializable, IDeserializationCallback {
@@ -4761,7 +4765,9 @@ namespace System {
 **
 **
 ============================================================*/
+#if FEATURE_SERIALIZATION
         [Serializable]
+#endif
         [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
         [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
         public struct TransitionTime : IEquatable<TransitionTime>, ISerializable, IDeserializationCallback {

--- a/src/mscorlib/src/System/TimeZoneNotFoundException.cs
+++ b/src/mscorlib/src/System/TimeZoneNotFoundException.cs
@@ -6,7 +6,9 @@ namespace System {
    using  System.Runtime.Serialization;
    using  System.Runtime.CompilerServices;
 
+#if FEATURE_SERIALIZATION
    [Serializable]
+#endif
    [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
    [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
    public class TimeZoneNotFoundException : Exception {

--- a/src/mscorlib/src/System/TimeoutException.cs
+++ b/src/mscorlib/src/System/TimeoutException.cs
@@ -15,8 +15,10 @@ namespace System
 {
     using System.Runtime.Serialization;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class TimeoutException : SystemException {
         
         public TimeoutException() 

--- a/src/mscorlib/src/System/TypeAccessException.cs
+++ b/src/mscorlib/src/System/TypeAccessException.cs
@@ -10,7 +10,9 @@ namespace System
 {
     // TypeAccessException derives from TypeLoadException rather than MemberAccessException because in
     // pre-v4 releases of the runtime TypeLoadException was used in lieu of a TypeAccessException.
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class TypeAccessException : TypeLoadException
     {
         public TypeAccessException()

--- a/src/mscorlib/src/System/TypeInitializationException.cs
+++ b/src/mscorlib/src/System/TypeInitializationException.cs
@@ -19,8 +19,10 @@ using System.Globalization;
 using System.Security.Permissions;
 
 namespace System {
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class TypeInitializationException : SystemException {
         private String _typeName;
 

--- a/src/mscorlib/src/System/TypeLoadException.cs
+++ b/src/mscorlib/src/System/TypeLoadException.cs
@@ -23,8 +23,10 @@ namespace System {
     using System.Security.Permissions;
     using System.Diagnostics.Contracts;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class TypeLoadException : SystemException, ISerializable {
 
         public TypeLoadException() 

--- a/src/mscorlib/src/System/TypeUnloadedException.cs
+++ b/src/mscorlib/src/System/TypeUnloadedException.cs
@@ -15,8 +15,10 @@ namespace System {
     
     using System.Runtime.Serialization;
 
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class TypeUnloadedException : SystemException {
         public TypeUnloadedException() 
             : base(Environment.GetResourceString("Arg_TypeUnloadedException")) {

--- a/src/mscorlib/src/System/UIntPtr.cs
+++ b/src/mscorlib/src/System/UIntPtr.cs
@@ -18,8 +18,10 @@ namespace System {
     using System.Runtime.Serialization;
     using System.Security;
     using System.Diagnostics.Contracts;
-    
+
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     [CLSCompliant(false)] 
     [System.Runtime.InteropServices.ComVisible(true)]
     public struct UIntPtr : ISerializable
@@ -90,12 +92,12 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override int GetHashCode() {
 #if FEATURE_CORECLR
-    #if BIT64
+#if BIT64
             ulong l = (ulong)m_value;
             return (unchecked((int)l) ^ (int)(l >> 32));
-    #else // 32
+#else // 32
             return unchecked((int)m_value);
-    #endif
+#endif
 #else
             return unchecked((int)((long)m_value)) & 0x7fffffff;
 #endif
@@ -197,11 +199,11 @@ namespace System {
 
         [System.Runtime.Versioning.NonVersionable]
         public static UIntPtr operator +(UIntPtr pointer, int offset) {
-            #if BIT64
+#if BIT64
                 return new UIntPtr(pointer.ToUInt64() + (ulong)offset);
-            #else // 32
+#else // 32
                 return new UIntPtr(pointer.ToUInt32() + (uint)offset);
-            #endif
+#endif
         }
 
         [System.Runtime.Versioning.NonVersionable]
@@ -211,11 +213,11 @@ namespace System {
 
         [System.Runtime.Versioning.NonVersionable]
         public static UIntPtr operator -(UIntPtr pointer, int offset) {
-            #if BIT64
+#if BIT64
                 return new UIntPtr(pointer.ToUInt64() - (ulong)offset);
-            #else // 32
+#else // 32
                 return new UIntPtr(pointer.ToUInt32() - (uint)offset);
-            #endif
+#endif
         }
 
         public static int Size

--- a/src/mscorlib/src/System/UnauthorizedAccessException.cs
+++ b/src/mscorlib/src/System/UnauthorizedAccessException.cs
@@ -19,8 +19,10 @@ using System.Runtime.Serialization;
 namespace System {
     // The UnauthorizedAccessException is thrown when access errors 
     // occur from IO or other OS methods.  
+#if FEATURE_SERIALIZATION
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public class UnauthorizedAccessException : SystemException {
         public UnauthorizedAccessException() 
             : base(Environment.GetResourceString("Arg_UnauthorizedAccessException")) {

--- a/src/mscorlib/src/System/UnhandledExceptionEventHandler.cs
+++ b/src/mscorlib/src/System/UnhandledExceptionEventHandler.cs
@@ -5,10 +5,12 @@
 namespace System {
    
     using System;
-     #if FEATURE_CORECLR
+#if FEATURE_CORECLR
      [System.Security.SecurityCritical] // auto-generated
-     #endif
-     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+#endif
+#if FEATURE_SERIALIZATION
+    [Serializable]
+#endif
+    [System.Runtime.InteropServices.ComVisible(true)]
     public delegate void UnhandledExceptionEventHandler(Object sender, UnhandledExceptionEventArgs e);
 }

--- a/src/mscorlib/src/System/UnitySerializationHolder.cs
+++ b/src/mscorlib/src/System/UnitySerializationHolder.cs
@@ -13,7 +13,9 @@ using System.Diagnostics.Contracts;
 
 namespace System {
     
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     // Holds classes (Empty, Null, Missing) for which we guarantee that there is only ever one instance of.
     internal class UnitySerializationHolder : ISerializable, IObjectReference
     {   

--- a/src/mscorlib/src/System/WeakReference.cs
+++ b/src/mscorlib/src/System/WeakReference.cs
@@ -21,7 +21,9 @@ namespace System {
 #if !FEATURE_CORECLR
     [SecurityPermissionAttribute(SecurityAction.InheritanceDemand, Flags=SecurityPermissionFlag.UnmanagedCode)] // Don't call Object::MemberwiseClone.
 #endif
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     public class WeakReference : ISerializable {
         // If you fix bugs here, please fix them in WeakReference<T> at the same time.
 

--- a/src/mscorlib/src/System/WeakReferenceOfT.cs
+++ b/src/mscorlib/src/System/WeakReferenceOfT.cs
@@ -18,7 +18,9 @@ namespace System
     using System.Runtime.Versioning;
     using System.Diagnostics.Contracts;
 
+#if FEATURE_SERIALIZATION
     [Serializable]
+#endif
     // This class is sealed to mitigate security issues caused by Object::MemberwiseClone.
     public sealed class WeakReference<T> : ISerializable where T : class
     {


### PR DESCRIPTION
We're adding BinaryFormatter to corefx.  At present, ISerializable and friends are declared in corefx rather than being exported from System.Private.Corelib.  As a result, there are a fair number of types in mscorlib that try to customize their serialization, but because they're doing so using interfaces that aren't exported (and in some cases, aren't even currently compiled in), a formatter outside of Corelib sees a type as serializable but then tries to serialize it using the default rules and fails.

This commit ifdefs the [Serializable] attribute on types that try to customize their serialization, to reflect that fact that they're really not serializable.  If in the future we decide we want to expose ISerializable and friends from Corelib in order to enable the serialization of these types (which we'll likely want to), e.g Delegate, Exception, etc. we'll need to turn on FEATURE_SERIALIZATION for coreclr, and these will all come back automatically.

cc: @jkotas, @danmosemsft 