### PR TITLE
Make PAL_SEHException smaller

### DIFF
--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -558,6 +558,85 @@ BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 #endif // !HAVE_UNW_GET_ACCESSORS
 #endif // _AMD64_
 
+struct ExceptionRecords
+{
+    CONTEXT ContextRecord;
+    EXCEPTION_RECORD ExceptionRecord;
+};
+
+// Max number of fallback contexts that are used when malloc fails to allocate ExceptionRecords structure
+static const int MaxFallbackContexts = sizeof(size_t) * 8;
+// Array of fallback contexts
+static ExceptionRecords s_fallbackContexts[MaxFallbackContexts];
+// Bitmap used for allocating fallback contexts - bits set to 1 represent already allocated context.
+static volatile size_t s_allocatedContextsBitmap = 0;
+
+/*++
+Function:
+    AllocateExceptionRecords
+
+    Allocate EXCEPTION_RECORD and CONTEXT structures for an exception.
+Parameters:
+    exceptionRecord - output pointer to the allocated exception record
+    contextRecord - output pointer to the allocated context record
+--*/
+VOID
+AllocateExceptionRecords(EXCEPTION_RECORD** exceptionRecord, CONTEXT** contextRecord)
+{
+    ExceptionRecords* records;
+    if (posix_memalign((void**)&records, alignof(ExceptionRecords), sizeof(ExceptionRecords)) != 0)
+    {
+        size_t bitmap;
+        size_t newBitmap;
+        int index;
+
+        do
+        {
+            bitmap = s_allocatedContextsBitmap;
+            index = __builtin_ffsl(~bitmap) - 1;
+            if (index < 0)
+            {
+                PROCAbort();
+            }
+
+            newBitmap = bitmap | ((size_t)1 << index);
+        }
+        while (__sync_val_compare_and_swap(&s_allocatedContextsBitmap, bitmap, newBitmap) != bitmap);
+
+        records = &s_fallbackContexts[index];
+    }
+
+    *contextRecord = &records->ContextRecord;
+    *exceptionRecord = &records->ExceptionRecord;
+}
+
+/*++
+Function:
+    PAL_FreeExceptionRecords
+
+    Free EXCEPTION_RECORD and CONTEXT structures of an exception that were allocated by the
+    AllocateExceptionRecords.
+Parameters:
+    exceptionRecord - exception record
+    contextRecord - context record
+--*/
+VOID
+PALAPI
+PAL_FreeExceptionRecords(IN EXCEPTION_RECORD *exceptionRecord, IN CONTEXT *contextRecord)
+{
+    // Both records are allocated at once and the allocated memory starts at the contextRecord
+    ExceptionRecords* records = (ExceptionRecords*)contextRecord;
+    if ((records >= &s_fallbackContexts[0]) && (records < &s_fallbackContexts[MaxFallbackContexts]))
+    {
+        int index = records - &s_fallbackContexts[0];
+        __sync_fetch_and_and(&s_allocatedContextsBitmap, ~((size_t)1 << index));
+    }
+    else
+    {
+        free(contextRecord);
+    }
+}
+
 /*++
 Function:
     RtlpRaiseException
@@ -568,7 +647,7 @@ Parameters:
 Note:
     The name of this function and the name of the ExceptionRecord 
     parameter is used in the sos lldb plugin code to read the exception
-    record. See coreclr\src\ToolBox\SOS\lldbplugin\debugclient.cpp.
+    record. See coreclr\src\ToolBox\SOS\lldbplugin\services.cpp.
 
     This function must not be inlined or optimized so the below PAL_VirtualUnwind
     calls end up with RaiseException caller's context and so the above debugger 
@@ -578,32 +657,9 @@ PAL_NORETURN
 __attribute__((noinline))
 __attribute__((optnone))
 static void 
-RtlpRaiseException(EXCEPTION_RECORD *ExceptionRecord)
+RtlpRaiseException(EXCEPTION_RECORD *ExceptionRecord, CONTEXT *ContextRecord)
 {
-    // Capture the context of RtlpRaiseException.
-    CONTEXT ContextRecord;
-    ZeroMemory(&ContextRecord, sizeof(CONTEXT));
-    ContextRecord.ContextFlags = CONTEXT_FULL;
-    CONTEXT_CaptureContext(&ContextRecord);
-
-    // Find the caller of RtlpRaiseException.  
-    PAL_VirtualUnwind(&ContextRecord, NULL);
-
-    // The frame we're looking at now is RaiseException. We have to unwind one 
-    // level further to get the actual context user code could be resumed at.
-    PAL_VirtualUnwind(&ContextRecord, NULL);
-
-#if defined(_X86_)
-    ExceptionRecord->ExceptionAddress = (void *) ContextRecord.Eip;
-#elif defined(_AMD64_)
-    ExceptionRecord->ExceptionAddress = (void *) ContextRecord.Rip;
-#elif defined(_ARM_) || defined(_ARM64_)
-    ExceptionRecord->ExceptionAddress = (void *) ContextRecord.Pc;
-#else
-#error unsupported architecture
-#endif
-
-    throw PAL_SEHException(ExceptionRecord, &ContextRecord);
+    throw PAL_SEHException(ExceptionRecord, ContextRecord);
 }
 
 /*++
@@ -613,6 +669,7 @@ Function:
 See MSDN doc.
 --*/
 // no PAL_NORETURN, as callers must assume this can return for continuable exceptions.
+__attribute__((noinline))
 VOID
 PALAPI
 RaiseException(IN DWORD dwExceptionCode,
@@ -642,20 +699,34 @@ RaiseException(IN DWORD dwExceptionCode,
         nNumberOfArguments = EXCEPTION_MAXIMUM_PARAMETERS;
     }
 
-    EXCEPTION_RECORD exceptionRecord;
-    ZeroMemory(&exceptionRecord, sizeof(EXCEPTION_RECORD));
+    CONTEXT *contextRecord;
+    EXCEPTION_RECORD *exceptionRecord;
+    AllocateExceptionRecords(&exceptionRecord, &contextRecord);
 
-    exceptionRecord.ExceptionCode = dwExceptionCode;
-    exceptionRecord.ExceptionFlags = dwExceptionFlags;
-    exceptionRecord.ExceptionRecord = NULL;
-    exceptionRecord.ExceptionAddress = NULL; // will be set by RtlpRaiseException
-    exceptionRecord.NumberParameters = nNumberOfArguments;
+    ZeroMemory(exceptionRecord, sizeof(EXCEPTION_RECORD));
+
+    exceptionRecord->ExceptionCode = dwExceptionCode;
+    exceptionRecord->ExceptionFlags = dwExceptionFlags;
+    exceptionRecord->ExceptionRecord = NULL;
+    exceptionRecord->ExceptionAddress = NULL; // will be set by RtlpRaiseException
+    exceptionRecord->NumberParameters = nNumberOfArguments;
     if (nNumberOfArguments)
     {
-        CopyMemory(exceptionRecord.ExceptionInformation, lpArguments,
+        CopyMemory(exceptionRecord->ExceptionInformation, lpArguments,
                    nNumberOfArguments * sizeof(ULONG_PTR));
     }
-    RtlpRaiseException(&exceptionRecord);
+
+    // Capture the context of RaiseException.
+    ZeroMemory(contextRecord, sizeof(CONTEXT));
+    contextRecord->ContextFlags = CONTEXT_FULL;
+    CONTEXT_CaptureContext(contextRecord);
+
+    // We have to unwind one level to get the actual context user code could be resumed at.
+    PAL_VirtualUnwind(contextRecord, NULL);
+
+    exceptionRecord->ExceptionAddress = (void *)CONTEXTGetPC(contextRecord);
+
+    RtlpRaiseException(exceptionRecord, contextRecord);
 
     LOGEXIT("RaiseException returns\n");
 }

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -74,7 +74,7 @@ static void sigint_handler(int code, siginfo_t *siginfo, void *context);
 static void sigquit_handler(int code, siginfo_t *siginfo, void *context);
 static void sigterm_handler(int code, siginfo_t *siginfo, void *context);
 
-static void common_signal_handler(int code, siginfo_t *siginfo, void *sigcontext, int numParams, ...);
+static bool common_signal_handler(int code, siginfo_t *siginfo, void *sigcontext, int numParams, ...);
 
 #ifdef INJECT_ACTIVATION_SIGNAL
 static void inject_activation_handler(int code, siginfo_t *siginfo, void *context);
@@ -217,7 +217,10 @@ static void sigill_handler(int code, siginfo_t *siginfo, void *context)
 {
     if (PALIsInitialized())
     {
-        common_signal_handler(code, siginfo, context, 0);
+        if (common_signal_handler(code, siginfo, context, 0))
+        {
+            return;
+        }
     }
 
     if (g_previous_sigill.sa_sigaction != NULL)
@@ -248,7 +251,10 @@ static void sigfpe_handler(int code, siginfo_t *siginfo, void *context)
 {
     if (PALIsInitialized())
     {
-        common_signal_handler(code, siginfo, context, 0);
+        if (common_signal_handler(code, siginfo, context, 0))
+        {
+            return;
+        }
     }
 
     if (g_previous_sigfpe.sa_sigaction != NULL)
@@ -282,7 +288,10 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
         // TODO: First variable parameter says whether a read (0) or write (non-0) caused the
         // fault. We must disassemble the instruction at record.ExceptionAddress
         // to correctly fill in this value.
-        common_signal_handler(code, siginfo, context, 2, (size_t)0, (size_t)siginfo->si_addr);
+        if (common_signal_handler(code, siginfo, context, 2, (size_t)0, (size_t)siginfo->si_addr))
+        {
+            return;
+        }
     }
 
     if (g_previous_sigsegv.sa_sigaction != NULL)
@@ -313,7 +322,10 @@ static void sigtrap_handler(int code, siginfo_t *siginfo, void *context)
 {
     if (PALIsInitialized())
     {
-        common_signal_handler(code, siginfo, context, 0);
+        if (common_signal_handler(code, siginfo, context, 0))
+        {
+            return;
+        }
     }
 
     if (g_previous_sigtrap.sa_sigaction != NULL)
@@ -348,7 +360,10 @@ static void sigbus_handler(int code, siginfo_t *siginfo, void *context)
         // TODO: First variable parameter says whether a read (0) or write (non-0) caused the
         // fault. We must disassemble the instruction at record.ExceptionAddress
         // to correctly fill in this value.
-        common_signal_handler(code, siginfo, context, 2, (size_t)0, (size_t)siginfo->si_addr);
+        if (common_signal_handler(code, siginfo, context, 2, (size_t)0, (size_t)siginfo->si_addr))
+        {
+            return;
+        }
     }
 
     if (g_previous_sigbus.sa_sigaction != NULL)
@@ -563,47 +578,44 @@ Parameters :
     int numParams : number of variable parameters of the exception
     ... : variable parameters of the exception (each of size_t type)
 
-    (no return value)
+    Returns true if the execution should continue or false if the exception was unhandled
 Note:
     the "pointers" parameter should contain a valid exception record pointer,
     but the ContextRecord pointer will be overwritten.
 --*/
-static void common_signal_handler(int code, siginfo_t *siginfo, void *sigcontext, int numParams, ...)
+static bool common_signal_handler(int code, siginfo_t *siginfo, void *sigcontext, int numParams, ...)
 {
     sigset_t signal_set;
-    CONTEXT context;
-    EXCEPTION_RECORD record;
-    EXCEPTION_POINTERS pointers;
+    CONTEXT *contextRecord;
+    EXCEPTION_RECORD *exceptionRecord;
     native_context_t *ucontext;
 
     ucontext = (native_context_t *)sigcontext;
 
-    record.ExceptionCode = CONTEXTGetExceptionCodeForSignal(siginfo, ucontext);
-    record.ExceptionFlags = EXCEPTION_IS_SIGNAL;
-    record.ExceptionRecord = NULL;
-    record.ExceptionAddress = GetNativeContextPC(ucontext);
-    record.NumberParameters = numParams;
+    AllocateExceptionRecords(&exceptionRecord, &contextRecord);
+
+    exceptionRecord->ExceptionCode = CONTEXTGetExceptionCodeForSignal(siginfo, ucontext);
+    exceptionRecord->ExceptionFlags = EXCEPTION_IS_SIGNAL;
+    exceptionRecord->ExceptionRecord = NULL;
+    exceptionRecord->ExceptionAddress = GetNativeContextPC(ucontext);
+    exceptionRecord->NumberParameters = numParams;
 
     va_list params;
     va_start(params, numParams);
 
     for (int i = 0; i < numParams; i++)
     {
-        record.ExceptionInformation[i] = va_arg(params, size_t);
+        exceptionRecord->ExceptionInformation[i] = va_arg(params, size_t);
     }
-
-    pointers.ExceptionRecord = &record;
 
     // Pre-populate context with data from current frame, because ucontext doesn't have some data (e.g. SS register)
     // which is required for restoring context
-    RtlCaptureContext(&context);
+    RtlCaptureContext(contextRecord);
 
     // Fill context record with required information. from pal.h:
     // On non-Win32 platforms, the CONTEXT pointer in the
     // PEXCEPTION_POINTERS will contain at least the CONTEXT_CONTROL registers.
-    CONTEXTFromNativeContext(ucontext, &context, CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT);
-
-    pointers.ContextRecord = &context;
+    CONTEXTFromNativeContext(ucontext, contextRecord, CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT);
 
     /* Unmask signal so we can receive it again */
     sigemptyset(&signal_set);
@@ -614,7 +626,18 @@ static void common_signal_handler(int code, siginfo_t *siginfo, void *sigcontext
         ASSERT("pthread_sigmask failed; error number is %d\n", sigmaskRet);
     }
 
-    SEHProcessException(&pointers);
+    contextRecord->ContextFlags |= CONTEXT_EXCEPTION_ACTIVE;
+    // The exception object takes ownership of the exceptionRecord and contextRecord
+    PAL_SEHException exception(exceptionRecord, contextRecord);
+
+    if (SEHProcessException(&exception))
+    {
+        // Exception handling may have modified the context, so update it.
+        CONTEXTToNativeContext(contextRecord, ucontext);
+        return true;
+    }
+
+    return false;
 }
 
 /*++

--- a/src/pal/src/include/pal/seh.hpp
+++ b/src/pal/src/include/pal/seh.hpp
@@ -63,16 +63,30 @@ SEHCleanup();
 Function:
     SEHProcessException
 
-    Build the PAL exception and sent it to any handler registered.
+    Send the PAL exception to any handler registered.
 
 Parameters:
-    None
+    PAL_SEHException* exception
 
 Return value:
-    Does not return
+    Returns TRUE if the exception happened in managed code and the execution should 
+    continue (with possibly modified context).
+    Returns FALSE if the exception happened in managed code and it was not handled.
+    In case the exception was handled by calling a catch handler, it doesn't return at all.
 --*/
-VOID 
-SEHProcessException(PEXCEPTION_POINTERS pointers);
+BOOL 
+SEHProcessException(PAL_SEHException* exception);
+
+/*++
+Function:
+    AllocateExceptionRecords
+
+Parameters:
+    exceptionRecord - output pointer to the allocated Windows exception record
+    contextRecord - output pointer to the allocated Windows context record
+--*/
+VOID
+AllocateExceptionRecords(EXCEPTION_RECORD** exceptionRecord, CONTEXT** contextRecord);
 
 #if !HAVE_MACH_EXCEPTIONS
 // TODO: Implement for Mach exceptions.  Not in CoreCLR surface area.

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
@@ -45,7 +45,7 @@ int DllTest1()
         }
 
         // Validate that the faulting address is correct; the contents of "p" (0x11).
-        if (ex.ExceptionRecord.ExceptionInformation[1] != 0x11)
+        if (ex.GetExceptionRecord()->ExceptionInformation[1] != 0x11)
         {
             Fail("ERROR: PAL_EXCEPT ExceptionInformation[1] != 0x11\n");
         }

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
@@ -45,7 +45,7 @@ int DllTest2()
         }
 
         // Validate that the faulting address is correct; the contents of "p" (0x22).
-        if (ex.ExceptionRecord.ExceptionInformation[1] != 0x22)
+        if (ex.GetExceptionRecord()->ExceptionInformation[1] != 0x22)
         {
             Fail("ERROR: PAL_EXCEPT ExceptionInformation[1] != 0x22\n");
         }

--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -108,6 +108,10 @@ public:
         m_pInitialExplicitFrame = NULL;
         m_pLimitFrame = NULL;
         m_csfEHClauseOfCollapsedTracker.Clear();
+
+#ifdef FEATURE_PAL
+        m_fOwnsExceptionPointers = FALSE;
+#endif
     }
 
     ExceptionTracker(DWORD_PTR             dwExceptionPc,
@@ -167,6 +171,10 @@ public:
         m_sfLastUnwoundEstablisherFrame.Clear();
         m_pInitialExplicitFrame = NULL;
         m_csfEHClauseOfCollapsedTracker.Clear();
+
+#ifdef FEATURE_PAL
+        m_fOwnsExceptionPointers = FALSE;
+#endif
     }
 
     ~ExceptionTracker()
@@ -384,6 +392,16 @@ public:
     static void DebugLogTrackerRanges(__in_z const char *pszTag);
 
     bool IsStackOverflowException();
+
+#ifdef FEATURE_PAL
+    void TakeExceptionPointersOwnership(PAL_SEHException* ex)
+    {
+        _ASSERTE(ex->GetExceptionRecord() == m_ptrs.ExceptionRecord);
+        _ASSERTE(ex->GetContextRecord() == m_ptrs.ContextRecord);
+        ex->Clear();
+        m_fOwnsExceptionPointers = TRUE;
+    }
+#endif // FEATURE_PAL
 
 private:
     DWORD_PTR
@@ -700,6 +718,9 @@ private: ;
 
     StackRange              m_ScannedStackRange;
     DAC_EXCEPTION_POINTERS  m_ptrs;
+#ifdef FEATURE_PAL
+    BOOL                    m_fOwnsExceptionPointers;
+#endif
     OBJECTHANDLE            m_hThrowable;
     StackTraceInfo          m_StackTraceInfo;
     UINT_PTR                m_uCatchToCallPC;

--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -330,7 +330,7 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
         }                                           \
         catch (PAL_SEHException& ex)                \
         {                                           \
-            exCopy = ex;                            \
+            exCopy = std::move(ex);                 \
             hasCaughtException = true;              \
         }                                           \
         if (hasCaughtException)                     \


### PR DESCRIPTION
The PAL_SEHException is quite large due to the fact that it contains context
and exception records. This causes a problem when we try to throw it and
system gets out of memory. The C++ runtime can throw exceptions even in that
case, but only if they are smaller than certain threshold. So in our case,
it just aborts the process.

This change separates the context and exception records from the exception,
which ensures that the above mentioned mechanism in the C++ runtime can
kick in and the exception can be thrown even when malloc fails to allocate
it.

I have also modified HandleHardwareException to return BOOL indicating whether
the execution should continue at the possibly modified exception context
instead of using RtlRestoreContext. In that case, we return all the way back
to the signal handler, update the ucontext in there and return from it.