### PR TITLE
Clean up localloc implementation

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1901,8 +1901,8 @@ Lowering::TreeNodeInfoInitLclHeap(GenTree* tree)
     //
     //     Size?                    Init Memory?         # temp regs
     //      0                            -                  0
-    //      const and <=6 ptr words      -                  0
-    //      const and >6 ptr words       Yes                0
+    //      const and <=6 reg words      -                  0
+    //      const and >6 reg words       Yes                0
     //      const and <PageSize          No                 0 (amd64) 1 (x86)
     //      const and >=PageSize         No                 2
     //      Non-const                    Yes                0
@@ -1925,11 +1925,12 @@ Lowering::TreeNodeInfoInitLclHeap(GenTree* tree)
             // Note: The Gentree node is not updated here as it is cheap to recompute stack aligned size.
             // This should also help in debugging as we can examine the original size specified with localloc.
             sizeVal = AlignUp(sizeVal, STACK_ALIGN);
-            size_t cntStackAlignedWidthItems = (sizeVal >> STACK_ALIGN_SHIFT);
 
             // For small allocations up to 6 pointer sized words (i.e. 48 bytes of localloc)
             // we will generate 'push 0'.
-            if (cntStackAlignedWidthItems <= 6)
+            assert((sizeVal % REGSIZE_BYTES) == 0);
+            size_t cntRegSizedWords = sizeVal / REGSIZE_BYTES;
+            if (cntRegSizedWords <= 6)
             {
                 info->internalIntCount = 0;
             }

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -485,6 +485,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define CODE_ALIGN               1       // code alignment requirement
   #define STACK_ALIGN              4       // stack alignment requirement
   #define STACK_ALIGN_SHIFT        2       // Shift-right amount to convert stack size in bytes to size in DWORD_PTRs
+  #define STACK_ALIGN_SHIFT_ALL    2       // Shift-right amount to convert stack size in bytes to size in STACK_ALIGN units
 
   #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_ESI|RBM_EDI)
   #define RBM_INT_CALLEE_TRASH    (RBM_EAX|RBM_ECX|RBM_EDX)
@@ -780,6 +781,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define CODE_ALIGN               1       // code alignment requirement
   #define STACK_ALIGN              16      // stack alignment requirement
   #define STACK_ALIGN_SHIFT        3       // Shift-right amount to convert stack size in bytes to size in pointer sized words
+  #define STACK_ALIGN_SHIFT_ALL    4       // Shift-right amount to convert stack size in bytes to size in STACK_ALIGN units
 
 #if ETW_EBP_FRAMED
   #define RBM_ETW_FRAMED_EBP        RBM_NONE


### PR DESCRIPTION
Reduce the differences between x86 and AMD64 codegen to reduce the number of `#ifdef`s. This changes AMD64 codegen for initialized locallocs by using the x86 style "dec" loop instead of "sub rsp,16". Saves one byte of code size per instance. I ran all standard internal testing on this change.

@sivarv PTAL
cc @dotnet/jit-contrib 
