### PR TITLE
Propagate known array lengths to more places

### DIFF
--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -251,7 +251,7 @@ void BasicBlock::dspFlags()
     if (bbFlags & BBF_HAS_JMP)              printf("jmp ");
     if (bbFlags & BBF_GC_SAFE_POINT)        printf("gcsafe ");
     if (bbFlags & BBF_FUNCLET_BEG)          printf("flet ");
-    if (bbFlags & BBF_HAS_INDX)             printf("idx ");
+    if (bbFlags & BBF_HAS_IDX_LEN)          printf("idxlen ");
     if (bbFlags & BBF_HAS_NEWARRAY)         printf("new[] ");
     if (bbFlags & BBF_HAS_NEWOBJ)           printf("newobj ");
 #if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -316,7 +316,7 @@ struct BasicBlock
                                         // we've determined that all paths in the loop body leading to BB
                                         // include a call.
 #define BBF_HAS_VTABREF     0x00100000  // BB contains reference of vtable
-#define BBF_HAS_INDX        0x00200000  // BB contains simple index expressions on a array local var.
+#define BBF_HAS_IDX_LEN     0x00200000  // BB contains simple index or length expressions on an array local var.
 #define BBF_HAS_NEWARRAY    0x00400000  // BB contains 'new' of an array
 #define BBF_HAS_NEWOBJ      0x00800000  // BB contains 'new' of an object type. 
 
@@ -349,7 +349,7 @@ struct BasicBlock
 #define BBF_COMPACT_UPD (BBF_CHANGED     |                                    \
                          BBF_GC_SAFE_POINT | BBF_HAS_JMP |                    \
                          BBF_NEEDS_GCPOLL |                                   \
-                         BBF_HAS_INDX      | BBF_BACKWARD_JUMP |              \
+                         BBF_HAS_IDX_LEN  | BBF_BACKWARD_JUMP |              \
                          BBF_HAS_NEWARRAY  | BBF_HAS_NEWOBJ)
 
 // Flags a block should not have had before it is split.
@@ -379,7 +379,7 @@ struct BasicBlock
 
 #define BBF_SPLIT_GAINED   (BBF_DONT_REMOVE | BBF_HAS_LABEL     |                \
                             BBF_HAS_JMP     | BBF_BACKWARD_JUMP |                \
-                            BBF_HAS_INDX    | BBF_HAS_NEWARRAY  |                \
+                            BBF_HAS_IDX_LEN | BBF_HAS_NEWARRAY  |                \
                             BBF_PROF_WEIGHT | BBF_HAS_NEWOBJ    |                \
                             BBF_KEEP_BBJ_ALWAYS)
 

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -27,7 +27,7 @@ bool Compiler::optDoEarlyPropForFunc()
 
 bool Compiler::optDoEarlyPropForBlock(BasicBlock* block)
 {
-    bool bbHasArrayRef = (block->bbFlags & BBF_HAS_INDX) != 0;
+    bool bbHasArrayRef = (block->bbFlags & BBF_HAS_IDX_LEN) != 0;
     bool bbHasVtableRef = (block->bbFlags & BBF_HAS_VTABREF) != 0;
     bool bbHasNullCheck = (block->bbFlags & BBF_HAS_NULLCHECK) != 0;
     return bbHasArrayRef || bbHasVtableRef || bbHasNullCheck;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -10108,7 +10108,7 @@ ARR_LD_POST_VERIFY:
                     op2->gtOper == GT_CNS_INT ||
                     op2->gtOper == GT_ADD)
                 {
-                    block->bbFlags |= BBF_HAS_INDX;
+                    block->bbFlags |= BBF_HAS_IDX_LEN;
                     optMethodFlags |= OMF_HAS_ARRAYREF;
                 }
             }
@@ -10337,7 +10337,7 @@ ARR_LD_POST_VERIFY:
                     op1->gtOper == GT_CNS_INT ||
                     op1->gtOper == GT_ADD)
                 {
-                    block->bbFlags |= BBF_HAS_INDX;
+                    block->bbFlags |= BBF_HAS_IDX_LEN;
                     optMethodFlags |= OMF_HAS_ARRAYREF;
                 }
             }
@@ -13845,6 +13845,14 @@ OBJ:
                 /* Use GT_ARR_LENGTH operator so rng check opts see this */
                 GenTreeArrLen* arrLen = new (this, GT_ARR_LENGTH) GenTreeArrLen(TYP_INT, op1, offsetof(CORINFO_Array, length)
                                                                                );
+
+                /* Mark the block as containing a length expression */
+
+                if (op1->gtOper == GT_LCL_VAR)
+                {
+                  block->bbFlags |= BBF_HAS_IDX_LEN;
+                }
+
                 op1 = arrLen;
             }
             else

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -3455,6 +3455,13 @@ void                Compiler::fgOptWhileLoop(BasicBlock * block)
         copyOfCondStmt->gtStmt.gtStmtILoffsx = condStmt->gtStmt.gtStmtILoffsx;
 #endif
 
+    // Flag the block that received the copy as potentially having an array/vtable
+    // reference if the block copied from did; this is a conservative guess.
+    if (auto copyFlags = bTest->bbFlags & (BBF_HAS_VTABREF | BBF_HAS_IDX_LEN))
+    {
+        block->bbFlags |= copyFlags;
+    }
+
     // If we have profile data for all blocks and we know that we are cloning the 
     //  bTest block into block and thus changing the control flow from block so
     //  that it no longer goes directly to bTest anymore, we have to adjust the 


### PR DESCRIPTION
Earlyprop limits its propagation of array lengths to blocks marked
BBF_HAS_INDX, for throughput reasons.  The importer sets that flag on
blocks that store/load array elements, but not blocks that simply extract
an array's length.  This change renames the flag to BBF_HAS_IDX_LEN, and
updates the importer to set it also on blocks with ldlen operations.  This
change also updates fgOptWhileLoop to propagate the flag when it
copies such an expression as part of a zero-trip test.

Fixes #2325.

This change has ~20 diffs in corelib, none in the other core framework dlls, and ~120 more in SuperPMI.  All diffs (checked exhaustively in corelib and spot-checked elsewhere) are length loads replaced with constants or length loads feeding compares where the whole load, compare, and conditional chunk of code have been removed.
This change has no diffs in benchstones or benchmarks game; we may want to start tracking "forceinline" variants where we make sure the inner routines are inlined into the context where the array creations are in scope.
Runs of cqNgenTP indicate throughput impact within noise range.

@dotnet/jit-contrib PTAL.