### PR TITLE
Remove assert validating intrinsic expansion on mustExpand

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3381,13 +3381,6 @@ InterlockedBinOpCommon:
         {
             NO_WAY("JIT must expand the intrinsic!");
         }
-        else if ((retNode->gtFlags & GTF_CALL) != 0)
-        {
-            // If we must expand the intrinsic,
-            // retNode (the tree that corresponds to the intrinsic expansion) must be non-null,
-            // and the returned tree must not contain a call.
-            NO_WAY("JIT must not implement the intrinsic by a user call!");
-        }
     }
 
     return retNode;


### PR DESCRIPTION
The assert is incorrect. Consider expansion of
CORINFO_INTRINSIC_RTH_GetValueInternal, where the RuntimeTypeHandle was
created through a generic lookup helper call. The intrinsic expansion of
this sequence becomes the generic lookup helper call on it's own.