### PR TITLE
Adding support for more generic dictionary entry slots for R2R

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -732,6 +732,7 @@ enum CORCOMPILE_FIXUP_BLOB_KIND
 
     ENCODE_DELEGATE_CTOR,
 
+    ENCODE_DECLARINGTYPE_HANDLE,
 
     ENCODE_MODULE_HANDLE                = 0x50,     /* Module token */
     ENCODE_STATIC_FIELD_ADDRESS,                    /* For accessing a static field */

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -1311,9 +1311,10 @@ struct CORINFO_LOOKUP_KIND
     bool                        needsRuntimeLookup;
     CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind;
 
-    // The 'runtimeLookupFlags' field is just for internal VM / ZAP communication, 
-    // not to be used by the JIT.
+    // The 'runtimeLookupFlags' and 'runtimeLookupArgs' fields
+    // are just for internal VM / ZAP communication, not to be used by the JIT.
     WORD                        runtimeLookupFlags;
+    void *                      runtimeLookupArgs;
 } ;
 
 #else

--- a/src/inc/readytorun.h
+++ b/src/inc/readytorun.h
@@ -166,6 +166,7 @@ enum ReadyToRunFixupKind
     READYTORUN_FIXUP_Check_FieldOffset          = 0x2B,
 
     READYTORUN_FIXUP_DelegateCtor               = 0x2C, /* optimized delegate ctor */
+    READYTORUN_FIXUP_DeclaringTypeHandle        = 0x2D,
 };
 
 //

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -3134,27 +3134,36 @@ void CEEInfo::ComputeRuntimeLookupForSharedGenericToken(DictionaryEntryKind entr
 #if defined(_TARGET_ARM_)
         ThrowHR(E_NOTIMPL); /* TODO - NYI */
 #endif
+        pResultLookup->lookupKind.runtimeLookupArgs = NULL;
+
         switch (entryKind)
         {
+        case DeclaringTypeHandleSlot:
+            _ASSERTE(pTemplateMD != NULL);
+            pResultLookup->lookupKind.runtimeLookupArgs = pTemplateMD->GetMethodTable();
+            pResultLookup->lookupKind.runtimeLookupFlags = READYTORUN_FIXUP_DeclaringTypeHandle;
+            break;
+
         case TypeHandleSlot:
             pResultLookup->lookupKind.runtimeLookupFlags = READYTORUN_FIXUP_TypeHandle;
             break;
 
         case MethodDescSlot:
         case MethodEntrySlot:
+        case ConstrainedMethodEntrySlot:
         case DispatchStubAddrSlot:
         {
             if (pTemplateMD != (MethodDesc*)pResolvedToken->hMethod)
                 ThrowHR(E_NOTIMPL);
-            if (((MethodDesc*)pResolvedToken->hMethod)->GetMethodTable_NoLogging() != (MethodTable*)pResolvedToken->hClass)
-                ThrowHR(E_NOTIMPL);
 
             if (entryKind == MethodDescSlot)
                 pResultLookup->lookupKind.runtimeLookupFlags = READYTORUN_FIXUP_MethodHandle;
-            else if (entryKind == MethodEntrySlot)
+            else if (entryKind == MethodEntrySlot || entryKind == ConstrainedMethodEntrySlot)
                 pResultLookup->lookupKind.runtimeLookupFlags = READYTORUN_FIXUP_MethodEntry;
             else
                 pResultLookup->lookupKind.runtimeLookupFlags = READYTORUN_FIXUP_VirtualEntry;
+
+            pResultLookup->lookupKind.runtimeLookupArgs = pConstrainedResolvedToken;
 
             break;
         }
@@ -3162,10 +3171,6 @@ void CEEInfo::ComputeRuntimeLookupForSharedGenericToken(DictionaryEntryKind entr
         case FieldDescSlot:
             pResultLookup->lookupKind.runtimeLookupFlags = READYTORUN_FIXUP_FieldHandle;
             break;
-
-        case DeclaringTypeHandleSlot:
-        case ConstrainedMethodEntrySlot:
-            ThrowHR(E_NOTIMPL);
 
         default:
             _ASSERTE(!"Unknown dictionary entry kind!");
@@ -5282,12 +5287,6 @@ void CEEInfo::getCallInfo(
 
             // For reference types, the constrained type does not affect method resolution
             DictionaryEntryKind entryKind = (!constrainedType.IsNull() && constrainedType.IsValueType()) ? ConstrainedMethodEntrySlot : MethodEntrySlot;
-
-            if (IsReadyToRunCompilation() && pConstrainedResolvedToken != NULL)
-            {
-                // READYTORUN: FUTURE: Constrained generic calls
-                ThrowHR(E_NOTIMPL);
-            }
 
             ComputeRuntimeLookupForSharedGenericToken(entryKind,
                                                       pResolvedToken,

--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -1368,8 +1368,16 @@ BOOL ZapSig::EncodeMethod(
 #ifdef FEATURE_READYTORUN_COMPILER
     if ((methodFlags & ENCODE_METHOD_SIG_Constrained) != 0)
     {
-        if (!zapSig.GetSignatureForTypeHandle(TypeHandle(pConstrainedResolvedToken->hClass), pSigBuilder))
-            return FALSE;
+        if (fEncodeUsingResolvedTokenSpecStreams && pConstrainedResolvedToken->pTypeSpec != NULL)
+        {
+            _ASSERTE(pConstrainedResolvedToken->cbTypeSpec > 0);
+            pSigBuilder->AppendBlob((PVOID)pConstrainedResolvedToken->pTypeSpec, pConstrainedResolvedToken->cbTypeSpec);
+        }
+        else
+        {
+            if (!zapSig.GetSignatureForTypeHandle(TypeHandle(pConstrainedResolvedToken->hClass), pSigBuilder))
+                return FALSE;
+        }
     }
 #endif
 

--- a/src/zap/zapreadytorun.cpp
+++ b/src/zap/zapreadytorun.cpp
@@ -515,6 +515,8 @@ static_assert_no_msg((int)READYTORUN_FIXUP_Check_FieldOffset         == (int)ENC
 
 static_assert_no_msg((int)READYTORUN_FIXUP_DelegateCtor              == (int)ENCODE_DELEGATE_CTOR);
 
+static_assert_no_msg((int)READYTORUN_FIXUP_DeclaringTypeHandle       == (int)ENCODE_DECLARINGTYPE_HANDLE);
+
 //
 // READYTORUN_EXCEPTION
 //


### PR DESCRIPTION
Adding support to the following generic dictionary entry slots for R2R:
	DeclaringTypeHandleSlot
	ConstrainedMethodEntrySlot