### PR TITLE
ARM64: Cross-Target Jit

### DIFF
--- a/clrdefinitions.cmake
+++ b/clrdefinitions.cmake
@@ -132,13 +132,6 @@ add_definitions(-DFEATURE_MANAGED_ETW_CHANNELS)
 add_definitions(-DFEATURE_MAIN_CLR_MODULE_USES_CORE_NAME)
 add_definitions(-DFEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE)
 
-if(CLR_CMAKE_TARGET_ARCH_ARM64)
-  # TODO_DJIT: Remove this as part of enabling cross-compiling standalone JIT binary.
-  if (NOT CLR_CMAKE_PLATFORM_UNIX)
-    set(FEATURE_MERGE_JIT_AND_ENGINE 1)
-  endif(NOT CLR_CMAKE_PLATFORM_UNIX)
-endif(CLR_CMAKE_TARGET_ARCH_ARM64)
-
 if(FEATURE_MERGE_JIT_AND_ENGINE)
   # Disable the following for UNIX altjit on Windows
   add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)

--- a/crosscomponents.cmake
+++ b/crosscomponents.cmake
@@ -5,4 +5,5 @@ set (CLR_CROSS_COMPONENTS_LIST
   mscordaccore   
   mscordbi   
   sos
+  clrjit
 )  

--- a/src/.nuget/Microsoft.NETCore.Jit/win/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/win/Microsoft.NETCore.Jit.pkgproj
@@ -9,8 +9,12 @@
   </PropertyGroup>
   <ItemGroup>
     <ArchitectureSpecificNativeFile Include="$(BinDir)clrjit.dll" />
+    <CrossArchitectureSpecificNativeFile Include="$(BinDir)$(CrossTargetComponentFolder)\clrjit.dll" />
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(CrossTargetComponentFolder)_$(PackagePlatform)/native</TargetPath>
     </File>
   </ItemGroup>
   <ItemGroup>
@@ -22,8 +26,13 @@
     <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
+    <CrossArchitectureSpecificNativeSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(CrossTargetComponentFolder)_$(PackagePlatform)/native</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>
     </File>
   </ItemGroup>


### PR DESCRIPTION
Fixes #6279
Fixes #6280

- This builds x64_arm64 clrjit.dll
- crossgen is not statically linked to jit anymore. It needs clrjit.dll
  dynamically
- Adding this cross-component binary into Jit pacakge.

So, clrjit.dll (native-target) is consumed by coreclr or crossgen
(native-target)
clrjit.dll (cross-target) is consumed by crossgen (cross-target).
Likewise, later this cross-target clrjit.dll can be used for corert targeting arm64
so that we can generate arm64 code on host machine (x64).