### PR TITLE
Stop chmoding nonexistant corerun file in Tools dir

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -116,7 +116,6 @@ if [ ! -e $__PROJECT_JSON_FILE ]; then
     # On ubuntu 14.04, /bin/sh (symbolic link) calls /bin/dash by default.
     $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR
 
-    chmod a+x $__TOOLRUNTIME_DIR/corerun
 else
     echo "$__PROJECT_JSON_FILE found. Skipping .NET CLI installation."   
 fi


### PR DESCRIPTION
After the recent update to buildtools, CoreRun.exe no longer exists in the 'Tools' directory, meaning the line chmod'ing it in init-tools.sh was causing that script to fail. This was also causing our orchestrated builds to fail on this step.

CC @MattGal @sergiy-k @JohnChen0 