### PR TITLE
Add VS Code local settings folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ FakesAssemblies/
 # C/C++ extension for Visual Studio Code
 browse.VC.db
 
+# Local settings folder for Visual Studio Code
+.vscode/
+
 ### MonoDevelop ###
 
 *.pidb


### PR DESCRIPTION
Visual Studio Code occasionally creates a directory with this name where it puts local settings, including the `browse.VC.db` file used for C/C++ symbols.