### PR TITLE
Add ICloneable back to several globalization types on Unix

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/Calendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/Calendar.cs
@@ -31,7 +31,7 @@ namespace System.Globalization
 
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    public abstract class Calendar
+    public abstract class Calendar : ICloneable
     {
         // Number of 100ns (10E-7 second) ticks per time unit
         internal const long TicksPerMillisecond = 10000;
@@ -143,11 +143,11 @@ namespace System.Globalization
         //
         //  Clone
         //
-        //  Is the implementation of IColnable.
+        //  Is the implementation of ICloneable.
         //
         ////////////////////////////////////////////////////////////////////////
         [System.Runtime.InteropServices.ComVisible(false)]
-        internal virtual Object Clone()
+        public virtual object Clone()
         {
             object o = MemberwiseClone();
             ((Calendar)o).SetReadOnlyState(false);

--- a/src/mscorlib/corefx/System/Globalization/CultureInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureInfo.cs
@@ -47,7 +47,7 @@ namespace System.Globalization
     using StringCultureInfoDictionary = LowLevelDictionary<string, CultureInfo>;
 #endif
 
-    public partial class CultureInfo : IFormatProvider
+    public partial class CultureInfo : IFormatProvider, ICloneable
     {
         //--------------------------------------------------------------------//
         //                        Internal Information                        //

--- a/src/mscorlib/corefx/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/DateTimeFormatInfo.cs
@@ -55,7 +55,7 @@ namespace System.Globalization
 
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class DateTimeFormatInfo : IFormatProvider
+    public sealed class DateTimeFormatInfo : IFormatProvider, ICloneable
     {
         // cache for the invariant culture.
         // invariantInfo is constant irrespective of your current culture.

--- a/src/mscorlib/corefx/System/Globalization/NumberFormatInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/NumberFormatInfo.cs
@@ -41,7 +41,7 @@ namespace System.Globalization
     //
 
     [System.Runtime.InteropServices.ComVisible(true)]
-    sealed public class NumberFormatInfo : IFormatProvider
+    sealed public class NumberFormatInfo : IFormatProvider, ICloneable
     {
         // invariantInfo is constant irrespective of your current culture.
         private static volatile NumberFormatInfo invariantInfo;

--- a/src/mscorlib/corefx/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.cs
@@ -25,7 +25,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Globalization
 {
-    public partial class TextInfo
+    public partial class TextInfo : ICloneable
     {
         ////--------------------------------------------------------------------//
         ////                        Internal Information                        //
@@ -145,7 +145,7 @@ namespace System.Globalization
         ////  Is the implementation of IColnable.
         ////
         //////////////////////////////////////////////////////////////////////////
-        internal virtual Object Clone()
+        public virtual Object Clone()
         {
             object o = MemberwiseClone();
             ((TextInfo)o).SetReadOnlyState(false);

--- a/src/mscorlib/src/System/Globalization/Calendar.cs
+++ b/src/mscorlib/src/System/Globalization/Calendar.cs
@@ -170,7 +170,7 @@ namespace System.Globalization {
         //
         //  Clone
         //
-        //  Is the implementation of IColnable.
+        //  Is the implementation of ICloneable.
         //
         ////////////////////////////////////////////////////////////////////////
         [System.Runtime.InteropServices.ComVisible(false)]

--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -433,7 +433,7 @@ namespace System.Globalization {
         //
         //  Clone
         //
-        //  Is the implementation of IColnable.
+        //  Is the implementation of ICloneable.
         //
         ////////////////////////////////////////////////////////////////////////
         [System.Runtime.InteropServices.ComVisible(false)]


### PR DESCRIPTION
The globalization implementation used for corefx on Unix came from corert, which didn't have ICloneable, and thus the globalization types that implement ICloneable in desktop and coreclr on Windows don't on Unix.  Now that ICloneable is coming back, we need these types to implement ICloneable appropriately.

cc: @jkotas, @tarekgh 