### PR TITLE
Support for reg optional tree temps.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1398,6 +1398,29 @@ regNumber           CodeGenInterface::genGetThisArgReg(GenTreePtr  call)
     return REG_ARG_0;
 }
 
+//----------------------------------------------------------------------
+// getSpillTempDsc: get the TempDsc corresponding to a spilled tree.
+//
+// Arguments:
+//   tree  -  spilled GenTree node
+//
+// Return Value:
+//   TempDsc corresponding to tree
+TempDsc*  CodeGenInterface::getSpillTempDsc(GenTree* tree)
+{
+    // tree must be in spilled state.
+    assert((tree->gtFlags & GTF_SPILLED) != 0);
+
+    // Get the tree's SpillDsc.
+    RegSet::SpillDsc* prevDsc;
+    RegSet::SpillDsc* spillDsc = regSet.rsGetSpillInfo(tree, tree->gtRegNum, &prevDsc);
+    assert(spillDsc != nullptr);
+
+    // Get the temp desc.
+    TempDsc* temp = regSet.rsGetSpillTempWord(tree->gtRegNum, spillDsc, prevDsc);
+    return temp;
+}
+
 #ifdef _TARGET_XARCH_
 
 #ifdef _TARGET_AMD64_

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -313,6 +313,9 @@ public:
     void                SpillFloat              (regNumber reg, bool bIsCall = false);
 #endif // LEGACY_BACKEND
 
+    // The following method is used by xarch emitter for handling contained tree temps.
+    TempDsc*            getSpillTempDsc(GenTree* tree);
+
 public:
     emitter*            getEmitter()                { return m_cgEmitter; }
 protected:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -13317,13 +13317,22 @@ GenTree::IsLclVarUpdateTree(GenTree** pOtherTree, genTreeOps *pOper)
 // until after the LSRA phase has allocated physical registers to the treenodes.
 bool GenTree::isContained() const
 {
+    if (isContainedSpillTemp())
+    {
+        return true;
+    }
+
     if (gtHasReg())
+    {
         return false;
+    }
 
     // these actually produce a register (the flags reg, we just don't model it)
     // and are a separate instruction from the branch that consumes the result
     if (OperKind() & GTK_RELOP)
+    {
         return false;
+    }
 
     // TODO-Cleanup : this is not clean, would be nice to have some way of marking this.
     switch (OperGet())

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1372,22 +1372,29 @@ public:
                ) && !AllocateIfProfitable();
     }
 
-    // Returns true whether this ref position is to be allocated
-    // a reg only if it is profitable.  Currently these are the
+    // Indicates whether this ref position is to be allocated
+    // a reg only if profitable. Currently these are the
     // ref positions that lower/codegen has indicated as reg
     // optional and is considered a contained memory operand if
     // no reg is allocated.
+    unsigned        allocRegIfProfitable : 1;
+
+    void            setAllocateIfProfitable(unsigned val)
+    {
+        allocRegIfProfitable = val;
+    }
+
+    // Returns true whether this ref position is to be allocated
+    // a reg only if it is profitable.
     bool           AllocateIfProfitable()
     {
         // TODO-CQ: Right now if a ref position is marked as
         // copyreg or movereg, then it is not treated as
         // 'allocate if profitable'. This is an implementation
         // limitation that needs to be addressed.
-        return (refType == RefTypeUse) &&
-                !copyReg &&
-                !moveReg &&
-                (treeNode != nullptr) &&
-                treeNode->IsRegOptional();
+        return allocRegIfProfitable &&
+               !copyReg &&
+               !moveReg;
     }
 
     // Used by RefTypeDef/Use positions of a multi-reg call node.


### PR DESCRIPTION
This is the phase 2 implementation of reg optional operands aimed to support spilled tree temps as reg optional at their use positions.

Example: 
op1= GT_CALL
op2 = GT_CALL
parent node = GT_ADD(op1,op2)

Since op2 will kill and redefine return registers,  under register pressure result of op1 will be spilled and reloaded to a different register at its use in GT_ADD.    To allocate a register for op1's use, LSRA might have to spill another register.  Instead, we can treat spilled op1 as contained spill tmp at its point of use in  GT_ADD so that a reload and requiring to allocate a reg is avoided.

Similar cases occur under register pressure when op1 and op2 are arbitrary tree nodes.   When one of op1 or op2 is marked as reg optional and LSRA will not allocate a reg to its use position, if it is beneficial.

Here is the summary of code changes:

lsra.h/lsra.cpp:
In case of untracked locals and non-local tree nodes, only the def ref position carries tree node but not the use position.  For this reason, AllocateIfProfitable() cannot depend a non-tree node presence to know whether lower has marked a tree node as reg optional.  Now ref positions carry a bit to indicate whether allocate if profitable.

AllocateBusyReg() - in case of tie in weight and farthest next distance to next reference, it will prefer to spill those ref positions that are marked as reload and Allocate if profitable.

resolveRegisters() - while resolving def positions of an untracked/non-local tree nodes don't carry tree node, a check is made to see whether its next ref position wasn't allocated a register.  If so then the tree node is marked as GTF_NOREG_AT_USE to indicate to codegen that no register was allocated at its use.  

updateMaxSpill: since use position of a spill temp if marked reg-optional will not be allocated a reg with reload=false, to properly account max spill this routine was updated to decrement spill count for reg-optional spill temps.

gentree.h/gentree.cpp: if a tree node is marked as GTF_SPILLED and GTF_NOREG_AT_USE, then it is considered a contained spill temp.

codegeninterface.h/codegencommon.cpp/codegenxarch.cpp/emixarch.cpp:
At the point of use of an operand, codegen needs to check whether it is marked as contained before using its gtRegNum field, because gtRegNum field of a tree temp still be a valid regNum as was allocated to its def position.

emitInsBinary() needs spill temp number to generate code in case of contained spill temps.  Emitter can query that info from codegen through getSpillTempDsc().  

lower.h/Lowerxarch.cpp
Renamed TryToSetRegOptional() as SetRegOptional().
In a couple of cases, there is no need to call SetRegOptionalForBinOp() since it is already known that only op2 can be reg-optional (e.g. op2 of a floating point operation, div operation).
LowerCmp() - there are quite a few cases where one of its operand could be marked as reg optional.
SetMulOpCounts() - added logic to mark reg optional operands.
IsProfitableToMarkOp2AsRegOptional() - since only one of op1 or op2 can be marked as reg optional, this routine encapsulates heuristics to determine marking which operand is likely to be beneficial.

Asm Diffs:
Indicate minor code size win.
cq perf suite: code size win of 893 bytes, 229 methods impacted with 0.29% improvement over the methods that got impacted.
Desktop Fx assemblies: code size win of 1034 bytes, 4264 methods impacted with 0.31% improvement over the methods that got impacted.

CQ Perf benchmark numbers are within the noise levels.  That is execution perf did not move.

Throughput: there is no throughput impact and within noise levels.
Mscorlib: Before 11420 and after 11352
System.Windows.Forms: Before 8299 and after 8220

Testing:
Ran LSRA stress testing on windows and linux
Ran jitstress=2 on windows and linux
Ran corefx-baseline on windows and linux.
Standard internal testing.

Fixes #6126 
