### PR TITLE
Fix the building failure occurred while unmounting device in ARM CI

### DIFF
--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -103,7 +103,7 @@ function unmount_rootfs {
     local rootfsFolder="$1"
 
     if grep -qs "$rootfsFolder" /proc/mounts; then
-        sudo umount "$rootfsFolder"
+        sudo umount -l "$rootfsFolder"
     fi
 }
 


### PR DESCRIPTION
Now, while running arm32_ci_script.sh run from netci.groovy, the building failure is occurred frequently with below messages.


sudo umount /opt/linux-arm-emulator-root/dev
	umount: /opt/linux-arm-emulator-root/dev: device is busy.
	(In some cases useful info about processes that use
	the device is found by lsof(8) or fuser(1))
	step 'Execute shell' marked build as failure
[http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/arm_emulator_cross_debug_ubuntu/151/console]

We are looking into why this failure is occurring basically but we can't get normal results from ARM CI now. So I would fix temporarily.