### PR TITLE
ARM-CI : Disable automatic checks for resolving the unmounting error.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1065,7 +1065,8 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                         Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} Cross ${configuration} Build", "(?i).*test\\W+Linux\\W+arm\\W+cross\\W+${configuration}.*")
                     }
                     else {
-                        Utilities.addGithubPRTriggerForBranch(job, branch, "Linux ARM Emulator Cross ${configuration} Build")
+                        Utilities.addGithubPRTriggerForBranch(job, branch, "Linux ARM Emulator Cross ${configuration} Build", "(?i).*test\\W+Linux\\W+arm\\W+emulator\\W+cross\\W+${configuration}.*")
+
                     }
                     break
                 default:


### PR DESCRIPTION
Now ARM-CI makes building failure frequently with below messages.(#6329)

http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/arm_emulator_cross_debug_ubuntu_prtest/559/console
00:01:27.252 + sudo umount /opt/linux-arm-emulator-root/dev
00:01:27.260 umount: /opt/linux-arm-emulator-root/dev: device is busy.
00:01:27.260 (In some cases useful info about processes that use
00:01:27.260 the device is found by lsof(8) or fuser(1))
00:01:27.265 Build step 'Execute shell' marked build as failure

We are looking into why this failure is occurring basically but we can't get normal results from ARM CI now. So I would disable automatic checks temporarily.

You can check manually with comment for a while likes '@dotnet-bot test Linux ARM Emulator Cross Release Build'