### PR TITLE
Fix for CoreCLR 6269

### DIFF
--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -1850,29 +1850,6 @@ AssemblySpecBindingCache::AssemblyBinding* AssemblySpecBindingCache::GetAssembly
     }
     
     pEntry = (AssemblyBinding *) m_map.LookupValue(lookupKey, pSpec);
-    if (pEntry == (AssemblyBinding *) INVALIDENTRY)
-    {
-        // We didnt find the AssemblyBinding entry against the binder of the parent assembly.
-        // It is possible that the AssemblySpec corresponds to a TPA assembly, so try the lookup
-        // against the TPABinder context.
-        ICLRPrivBinder* pTPABinderContext = pSpecDomain->GetTPABinderContext();
-        if ((pTPABinderContext != NULL) && !AreSameBinderInstance(pTPABinderContext, pBinderContextForLookup))
-        {
-            UINT_PTR tpaBinderID = 0;
-            HRESULT hr = pTPABinderContext->GetBinderID(&tpaBinderID);
-            _ASSERTE(SUCCEEDED(hr));
-            lookupKey = key^tpaBinderID;
-            
-            // Set the binding context in AssemblySpec to be TPABinder
-            // as that will be used in the Lookup operation below.
-            if (fGetBindingContextFromParent)
-            {
-                pSpec->SetBindingContext(pTPABinderContext);
-            }
-            
-            pEntry = (AssemblyBinding *) m_map.LookupValue(lookupKey, pSpec);
-        }
-    }
     
     // Reset the binding context if one was originally never present in the AssemblySpec and we didnt find any entry
     // in the cache.

--- a/src/vm/coreassemblyspec.cpp
+++ b/src/vm/coreassemblyspec.cpp
@@ -183,9 +183,16 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
                           &pPrivAsm);
     }
 
+    bool fBoundUsingTPABinder = false;
     if(SUCCEEDED(hr))
     {
         _ASSERTE(pPrivAsm != nullptr);
+
+        if (AreSameBinderInstance(pTPABinder, reinterpret_cast<ICLRPrivBinder *>(pPrivAsm.Extract())))
+        {
+            fBoundUsingTPABinder = true;
+        }
+
         result = BINDER_SPACE::GetAssemblyFromPrivAssemblyFast(pPrivAsm.Extract());
         _ASSERTE(result != nullptr);
     }
@@ -193,13 +200,20 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
     pResult->SetHRBindResult(hr);
     if (SUCCEEDED(hr))
     {
-        BOOL fIsInGAC = pAppDomain->IsImageFromTrustedPath(result->GetNativeOrILPEImage());
+        BOOL fIsInGAC = FALSE;
         BOOL fIsOnTpaList = FALSE;
-        const SString &sImagePath = result->GetNativeOrILPEImage()->GetPath();
-        if (pTPABinder->IsInTpaList(sImagePath))
+
+        // Only initialize TPA/GAC status if we bound using DefaultContext
+        if (fBoundUsingTPABinder == true)
         {
-            fIsOnTpaList = TRUE;
+            fIsInGAC = pAppDomain->IsImageFromTrustedPath(result->GetNativeOrILPEImage());
+            const SString &sImagePath = result->GetNativeOrILPEImage()->GetPath();
+            if (pTPABinder->IsInTpaList(sImagePath))
+            {
+                fIsOnTpaList = TRUE;
+            }
         }
+
         pResult->Init(result,fIsInGAC, fIsOnTpaList);
     }
     else if (FAILED(hr) && (fThrowOnFileNotFound || (!Assembly::FileNotFound(hr))))


### PR DESCRIPTION
Trigger formal binding if domain-wide cache does not have entry for an assembly in custom load context. This will enable Load method override, of the custom load context, to kick in and specify assembly to be loaded even if the exact version is loaded in default context.

Fixes https://github.com/dotnet/coreclr/issues/6269

@jkotas PTAL