### PR TITLE
Re-enable two tests testing GC.GetGeneration(System.WeakReference)

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -543,13 +543,5 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd">
              <Issue>needs triage</Issue>
         </ExcludeList>
-        
-        <!-- GC.GetGeneration on weak references -->
-        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGenerationWR\GetGenerationWR.cmd">
-            <Issue>5514</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGenerationWR2\GetGenerationWR2.cmd">
-            <Issue>5514</Issue>
-        </ExcludeList>
     </ItemGroup>
 </Project>

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -71,5 +71,3 @@ GC/Features/LOHFragmentation/lohfragmentation/lohfragmentation.sh
 GC/Features/SustainedLowLatency/scenario/scenario.sh
 GC/Regressions/dev10bugs/536168/536168/536168.sh
 GC/Stress/Framework/ReliabilityFramework/ReliabilityFramework.sh
-GC/API/GC/GetGenerationWR/GetGenerationWR.sh
-GC/API/GC/GetGenerationWR2/GetGenerationWR2.sh

--- a/tests/x86_jit32_issues.targets
+++ b/tests/x86_jit32_issues.targets
@@ -276,16 +276,6 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- GC.GetGeneration on weak references -->
-    <ItemGroup>
-        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGenerationWR\GetGenerationWR.cmd">
-            <Issue>5514</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGenerationWR2\GetGenerationWR2.cmd">
-            <Issue>5514</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\arglist\arglist.cmd">

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -370,14 +370,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\baseservices\threading\waithandle\waitall\waitallex8a\*">
       <Issue>3832</Issue>
     </ExcludeList>
-    
-    <!-- GC.GetGeneration on weak references -->
-    <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGenerationWR\GetGenerationWR.cmd">
-        <Issue>5514</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGenerationWR2\GetGenerationWR2.cmd">
-        <Issue>5514</Issue>
-    </ExcludeList>
   </ItemGroup>
   
   <!-- Tests that need to be triaged for vararg usage as that is not supported -->


### PR DESCRIPTION
Since https://github.com/dotnet/coreclr/pull/6310 has been merged, we can now re-enable these two tests. 