### PR TITLE
Stop building targetingPack package on non-windows

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -156,15 +156,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-    # Build the TargetingPack package
-    $__ProjectRoot/Tools/dotnetcli/dotnet "$__MSBuildPath" /nologo "$__ProjectRoot/src\.nuget\Microsoft.TargetingPack.Private.CoreCLR\Microsoft.TargetingPack.Private.CoreCLR.pkgproj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$binclashlog" /t:Build /p:__BuildOS=$__BuildOS /p:__BuildArch=$__BuildArch /p:__BuildType=$__BuildType /p:__IntermediatesDir=$__IntermediatesDir /p:BuildNugetPackage=false /p:UseSharedCompilation=false
-
-if [ $? -ne 0 ]; then
-    echo -e "\nAn error occurred. Aborting build-packages.sh ." >> $build_packages_log
-    echo "ERROR: An error occurred while building packages, see $build_packages_log for more details."
-    exit 1
-fi
-
 echo "Done building packages."
 echo -e "\nDone building packages." >> $build_packages_log
 exit 0


### PR DESCRIPTION
CC @gkhanna79 @weshaggard 

Previously we weren't building this package at all on non-Windows. Since the package publishing scripts just grab everything in the .nuget folder and publish them, the easiest way to stop publishing this package is to stop building it. If we want to build it again later, it's very easy to turn that back on.