### PR TITLE
Revert: Pull crash dump links

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1,6 +1,7 @@
 // Import the utility functionality.
 
-import jobs.generation.*
+import jobs.generation.Utilities;
+import jobs.generation.JobReport;
 
 // The input project name (e.g. dotnet/coreclr)
 def project = GithubProject
@@ -2250,13 +2251,6 @@ combinedScenarios.each { scenario ->
                         // Publish coverage reports
                         Utilities.addHtmlPublisher(newJob, '${WORKSPACE}/coverage/Coverage/reports', 'Code Coverage Report', 'coreclr.html')
                         addEmailPublisher(newJob, 'clrcoverage@microsoft.com')
-                    }
-
-                    // Experimental: If on Ubuntu 14.04, then attempt to pull in crash dump links
-                    if (os in ['Ubuntu']) {
-                        SummaryBuilder summaries = new SummaryBuilder()
-                        summaries.addLinksSummaryFromFile('Crash dumps from this run:', 'dumplings.txt')
-                        summaries.emit(newJob)
                     }
 
                     setMachineAffinity(newJob, os, architecture)


### PR DESCRIPTION
Ubuntu testing is failing with a groovy scripting error.
Matt asked me to revert this change for now.

This reverts commit 7fc5cb7e52c5db53a5696d398e281c0f6f6a1588.