### PR TITLE
Fix to ignore codename for arm-softfp

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -52,12 +52,12 @@ for i in "$@"
         __UbuntuCodeName=jessie
         ;;
         vivid)
-        if [ __UbuntuCodeName != "jessie" ]; then
+        if [ "$__UbuntuCodeName" != "jessie" ]; then
             __UbuntuCodeName=vivid
         fi
         ;;
         wily)
-        if [ __UbuntuCodeName != "jessie" ]; then
+        if [ "$__UbuntuCodeName" != "jessie" ]; then
             __UbuntuCodeName=wily
         fi
         ;;


### PR DESCRIPTION
Fix if statement to ignore Ubuntu codename if BuildArch is arm-softfp (#6347)