### PR TITLE
Not Initialized AssertionDsc

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -794,7 +794,6 @@ Compiler::AssertionIndex Compiler::optCreateAssertion(GenTreePtr op1, GenTreePtr
                                       optAssertionKind assertionKind, 
                                       AssertionDsc* assertion)
 {
-    memset(assertion, 0, sizeof(AssertionDsc));
     //
     // If we cannot create an assertion using op1 and op2 then the assertionKind
     // must be OAK_INVALID, so we initialize it to OAK_INVALID and only change it

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5606,6 +5606,10 @@ public:
                             O2K_SUBRANGE };
     struct AssertionDsc
     {
+        AssertionDsc()
+        {
+          memset(this, 0, sizeof(AssertionDsc));
+        }
         optAssertionKind        assertionKind;
         struct SsaVar
         {


### PR DESCRIPTION
This is the fix for #6271

There's no user-defined constructor for AssertionDsc and Compiler::optCreateAssertion doesn't get called for every created object. So the memset to zeroes doesn't happen for some items which might lead to crashes because of uninitialized data access.