### PR TITLE
Fix is_blittable partial specializations

### DIFF
--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -2339,7 +2339,7 @@ namespace serialization { namespace bin {
     };
 
     template <typename _Ty>
-    class is_blittable<_Ty, typename std::enable_if<std::is_arithmetic<_Ty>::value>::type>
+    struct is_blittable<_Ty, typename std::enable_if<std::is_arithmetic<_Ty>::value>::type>
         : std::true_type
     { // determines whether _Ty is blittable
     };
@@ -2347,7 +2347,7 @@ namespace serialization { namespace bin {
     // allow types to declare themselves blittable by including a static bool 
     // member "is_blittable".
     template <typename _Ty>
-    class is_blittable<_Ty, typename std::enable_if<_Ty::is_blittable>::type>
+    struct is_blittable<_Ty, typename std::enable_if<_Ty::is_blittable>::type>
         : std::true_type
     { // determines whether _Ty is blittable
     };


### PR DESCRIPTION
The is_blittable partial specializations were defined using "class", privately
inheriting from std::true_type. This means the ::value member variable will
be inaccessible to most users of these types. Thus the type
``std::enable_if<is_blittable<T>::value>::type'' will always result in a
substitution failure with a compiler that respects accessibility in SFINAE.

This commit changes "class" to "struct" for these partial specializations
so they inherit publicly from std::true_type.