### PR TITLE
[SOS][Linux] Fix incorrect processing 'setclrpath' command with portable PDB reader

### DIFF
--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -6229,9 +6229,13 @@ HRESULT SymbolReader::LoadCoreCLR()
 {
     HRESULT Status = S_OK;
 
-    std::string absolutePath, coreClrPath;
-    absolutePath = g_ExtServices->GetCoreClrDirectory();
-    GetDirectory(absolutePath.c_str(), coreClrPath);
+    std::string absolutePath;
+    std::string coreClrPath = g_ExtServices->GetCoreClrDirectory();
+    if (!GetAbsolutePath(coreClrPath.c_str(), absolutePath))
+    {
+        fprintf(stderr, "Error: fail to convert CLR files path to absolute path \n");
+        return E_FAIL;
+    }
     coreClrPath.append("/");
     coreClrPath.append(coreClrDll);
 

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -6233,7 +6233,7 @@ HRESULT SymbolReader::LoadCoreCLR()
     std::string coreClrPath = g_ExtServices->GetCoreClrDirectory();
     if (!GetAbsolutePath(coreClrPath.c_str(), absolutePath))
     {
-        fprintf(stderr, "Error: fail to convert CLR files path to absolute path \n");
+        ExtErr("Error: fail to convert CLR files path to absolute path \n");
         return E_FAIL;
     }
     coreClrPath.append("/");
@@ -6242,7 +6242,7 @@ HRESULT SymbolReader::LoadCoreCLR()
     coreclrLib = dlopen(coreClrPath.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (coreclrLib == nullptr)
     {
-        fprintf(stderr, "Error: Fail to load %s\n", coreClrPath.c_str());
+        ExtErr("Error: Fail to load %s\n", coreClrPath.c_str());
         return E_FAIL;
     }
     void *hostHandle;
@@ -6274,7 +6274,7 @@ HRESULT SymbolReader::LoadCoreCLR()
 
     if (!GetEntrypointExecutableAbsolutePath(entryPointExecutablePath))
     {
-        perror("Could not get full path to current executable");
+        ExtErr("Could not get full path to current executable");
         return E_FAIL;
     }
 
@@ -6284,7 +6284,7 @@ HRESULT SymbolReader::LoadCoreCLR()
                           propertyKeys, propertyValues, &hostHandle, &domainId);
     if (Status != S_OK)
     {
-        fprintf(stderr, "Error: Fail to initialize CoreCLR\n");
+        ExtErr("Error: Fail to initialize CoreCLR\n");
         return Status;
     }
 


### PR DESCRIPTION
This pull request fixes issue with incorrect absolute path if `setclrpath ./` command was added. 
As a result of this issue, coreclr instance can't initialize for creation delegates to portable pdb reader.
```
 lldb -o "plugin load libsosplugin.so" -o "process launch -s" -o "setclrpath ./" -o "breakpoint set -n LoadLibraryExW" -o "c" -o "br del" -- corerun hello.exe
(lldb) target create "corerun"
Current executable set to 'corerun' (arm).
(lldb) settings set -- target.run-args  "hello.exe"
(lldb) plugin load libsosplugin.so
(lldb) process launch -s
(lldb) setclrpath ./
(lldb) breakpoint set -n LoadLibraryExW
(lldb) br del
(lldb) bpmd hello.cs:7
Error: Fail to initialize CoreCLR

```
CC: @Dmitri-Botcharnikov, @chunseoklee, @mikem8361