### PR TITLE
Remove include of <utility> from seh.cpp

### DIFF
--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -26,8 +26,7 @@ Abstract:
 #include "pal/context.h"
 #include "pal.h"
 #include <dlfcn.h>
-#include <exception>
-    
+ 
 #if HAVE_LIBUNWIND_H
 #ifndef __linux__
 #define UNW_LOCAL_ONLY

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -39,7 +39,37 @@ Abstract:
 #include <unistd.h>
 #include <pthread.h>
 #include <stdlib.h>
-#include <utility>
+
+// Define the std::move so that we don't have to include the <utility> header
+// which on some platforms pulls in STL stuff that collides with PAL stuff.
+// The std::move is needed to enable using move constructor and assignment operator
+// for PAL_SEHException.
+namespace std
+{
+    template<typename T>
+    struct remove_reference
+    {
+        typedef T type;
+    };
+
+    template<typename T>
+    struct remove_reference<T&>
+    {
+        typedef T type;
+    };
+
+    template<typename T>
+    struct remove_reference<T&&>
+    {
+        typedef T type;
+    };
+
+    template<class T> inline
+    typename remove_reference<T>::type&& move(T&& arg)
+    {   // forward arg as movable
+        return ((typename remove_reference<T>::type&&)arg);
+    }
+}
 
 using namespace CorUnix;
 


### PR DESCRIPTION
In my previous change that made exceptions smaller, I had `#include <utility>`
and I haven't realized that it pulls in some stl headers. That breaks build
on ARM.
The fix is to replace that include by defining just the std::move that's
all that was needed from the header.