### PR TITLE
More verbose logging for arm32 umount

### DIFF
--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -102,7 +102,15 @@ function check_git_head {
 function unmount_rootfs {
     local rootfsFolder="$1"
 
-    if grep -qs "$rootfsFolder" /proc/mounts; then
+    #Check if there are any open files in this directory.
+    if [ -d $rootfsFolder ]; then
+        #If we find information about the file
+        if sudo lsof +D $rootfsFolder; then
+            (set +x; echo 'See above for lsof information. Continuing with the build.')
+        fi
+    fi
+
+    if mountpoint -q -- "$rootfsFolder"; then
         sudo umount "$rootfsFolder"
     fi
 }


### PR DESCRIPTION
Umount fails occasionally in the arm32 ci script. Add some logging
information using lsof before calling umount to diagnose which files are
open.

In addition, instead of determining if the folder is mounted due to /proc/mounts, use the mountpoint command.