### PR TITLE
Fix bug: inlinee did not copy inlinee bbFlags to caller bbFlags.

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -372,10 +372,10 @@ struct BasicBlock
 
 // TODO: Should BBF_RUN_RARELY be added to BBF_SPLIT_GAINED ?
 
-#define BBF_SPLIT_GAINED   (BBF_DONT_REMOVE | BBF_HAS_LABEL |                    \
+#define BBF_SPLIT_GAINED   (BBF_DONT_REMOVE | BBF_HAS_LABEL     |                \
                             BBF_HAS_JMP     | BBF_BACKWARD_JUMP |                \
-                            BBF_HAS_INDX    | BBF_HAS_NEWARRAY |                 \
-                            BBF_PROF_WEIGHT |                                    \
+                            BBF_HAS_INDX    | BBF_HAS_NEWARRAY  |                \
+                            BBF_PROF_WEIGHT | BBF_HAS_NEWOBJ    |                \
                             BBF_KEEP_BBJ_ALWAYS)
 
 #ifndef __GNUC__ // GCC doesn't like C_ASSERT at global scope

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -22012,6 +22012,12 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
                 stmtAfter = fgInsertStmtListAfter(iciBlock,
                                                   stmtAfter,
                                                   InlineeCompiler->fgFirstBB->bbTreeList);
+
+                // Copy inlinee bbFlags to caller bbFlags.
+                const unsigned int inlineeBlockFlags = InlineeCompiler->fgFirstBB->bbFlags;
+                noway_assert((inlineeBlockFlags & BBF_HAS_JMP) == 0);
+                noway_assert((inlineeBlockFlags & BBF_KEEP_BBJ_ALWAYS) == 0);
+                iciBlock->bbFlags |= inlineeBlockFlags;
             }
 #ifdef DEBUG
             if (verbose)


### PR DESCRIPTION
The bug manifests itself in two cases:

1. When inlinee has one basic block - the inliner simply inserts stmt tree instead of the method call and forgets to copy flags over to the caller basic block.
2. When inlinee has more than one basic block - the inliner splits the target basic block in two parts and copies only flags of callee's basic block which are defined in `BBF_SPLIT_GAINED`.

Fixed by explicit copying flags in case 1 and extending `BBF_SPLIT_GAINED` in case 2. 

I did normal internal testing and verified no diffs.

@erozenfeld @AndyAyersMS @dotnet/jit-contrib PTAL
