### PR TITLE
Expose serialization primitives from System.Private.Corelib

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6352,6 +6352,9 @@
       <Member Name="IsStateAvailable" />
       <Member Name="EnsureState" />
    </Type>
+    <Type Name="System.SerializableAttribute">
+      <Member Name="#ctor" />
+    </Type>
     <Type Name="System.Single">
       <Member MemberType="Field" Name="Epsilon" />
       <Member MemberType="Field" Name="MaxValue" />
@@ -9526,10 +9529,97 @@
     <Type Name="System.Runtime.Serialization.FormatterServices">
         <Member Name="GetUninitializedObject(System.Type)" />
     </Type>
+    <Type Name="System.Runtime.Serialization.OptionalFieldAttribute">
+      <Member Name="#ctor" />
+      <Member MemberType="Property" Name="VersionAdded" />
+    </Type>
+    <Type Name="System.Runtime.Serialization.SerializationEntry">
+      <Member MemberType="Property" Name="Value" />
+      <Member MemberType="Property" Name="Name" />
+      <Member MemberType="Property" Name="ObjectType" />
+    </Type>
     <Type Name="System.Runtime.Serialization.SerializationException">
       <Member Name="#ctor" />
       <Member Name="#ctor(System.String)" />
       <Member Name="#ctor(System.String,System.Exception)" />  
+    </Type>
+    <Type Name="System.Runtime.Serialization.SerializationInfo">
+      <Member Name="#ctor(System.Type,System.Runtime.Serialization.IFormatterConverter)" />
+      <Member Name="#ctor(System.Type,System.Runtime.Serialization.IFormatterConverter,System.Boolean)" />
+      <Member Name="SetType(System.Type)" />
+      <Member Name="GetEnumerator" />
+      <Member Name="AddValue(System.String,System.Object,System.Type)" />
+      <Member Name="AddValue(System.String,System.Object)" />
+      <Member Name="AddValue(System.String,System.Boolean)" />
+      <Member Name="AddValue(System.String,System.Char)" />
+      <Member Name="AddValue(System.String,System.SByte)" />
+      <Member Name="AddValue(System.String,System.Byte)" />
+      <Member Name="AddValue(System.String,System.Int16)" />
+      <Member Name="AddValue(System.String,System.UInt16)" />
+      <Member Name="AddValue(System.String,System.Int32)" />
+      <Member Name="AddValue(System.String,System.UInt32)" />
+      <Member Name="AddValue(System.String,System.Int64)" />
+      <Member Name="AddValue(System.String,System.UInt64)" />
+      <Member Name="AddValue(System.String,System.Single)" />
+      <Member Name="AddValue(System.String,System.Double)" />
+      <Member Name="AddValue(System.String,System.Decimal)" />
+      <Member Name="AddValue(System.String,System.DateTime)" />
+      <Member Name="GetValue(System.String,System.Type)" />
+      <Member Name="GetBoolean(System.String)" />
+      <Member Name="GetChar(System.String)" />
+      <Member Name="GetSByte(System.String)" />
+      <Member Name="GetByte(System.String)" />
+      <Member Name="GetInt16(System.String)" />
+      <Member Name="GetUInt16(System.String)" />
+      <Member Name="GetInt32(System.String)" />
+      <Member Name="GetUInt32(System.String)" />
+      <Member Name="GetInt64(System.String)" />
+      <Member Name="GetUInt64(System.String)" />
+      <Member Name="GetSingle(System.String)" />
+      <Member Name="GetDouble(System.String)" />
+      <Member Name="GetDecimal(System.String)" />
+      <Member Name="GetDateTime(System.String)" />
+      <Member Name="GetString(System.String)" />
+      <Member MemberType="Property" Name="FullTypeName" />
+      <Member MemberType="Property" Name="AssemblyName" />
+      <Member MemberType="Property" Name="MemberCount" />
+      <Member MemberType="Property" Name="ObjectType" />
+      <Member MemberType="Property" Name="IsFullTypeNameSetExplicit" />
+      <Member MemberType="Property" Name="IsAssemblyNameSetExplicit" />
+    </Type>
+    <Type Name="System.Runtime.Serialization.SerializationInfoEnumerator">
+      <Member Name="MoveNext" />
+      <Member Name="Reset" />
+      <Member Name="System.Collections.IEnumerator.get_Current" />
+      <Member MemberType="Property" Name="Current" />
+      <Member MemberType="Property" Name="Name" />
+      <Member MemberType="Property" Name="Value" />
+      <Member MemberType="Property" Name="ObjectType" />
+    </Type>
+    <Type Name="System.Runtime.Serialization.ISerializable">
+      <Member Name="GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
+    </Type>
+    <Type Name="System.Runtime.Serialization.IFormatterConverter">
+      <Member Name="Convert(System.Object,System.Type)" />
+      <Member Name="Convert(System.Object,System.TypeCode)" />
+      <Member Name="ToBoolean(System.Object)" />
+      <Member Name="ToChar(System.Object)" />
+      <Member Name="ToSByte(System.Object)" />
+      <Member Name="ToByte(System.Object)" />
+      <Member Name="ToInt16(System.Object)" />
+      <Member Name="ToUInt16(System.Object)" />
+      <Member Name="ToInt32(System.Object)" />
+      <Member Name="ToUInt32(System.Object)" />
+      <Member Name="ToInt64(System.Object)" />
+      <Member Name="ToUInt64(System.Object)" />
+      <Member Name="ToSingle(System.Object)" />
+      <Member Name="ToDouble(System.Object)" />
+      <Member Name="ToDecimal(System.Object)" />
+      <Member Name="ToDateTime(System.Object)" />
+      <Member Name="ToString(System.Object)" />
+    </Type>
+    <Type Name="System.Runtime.Serialization.IDeserializationCallback">
+      <Member Name="OnDeserialization(System.Object)" />
     </Type>
     <Type Status="ApiRoot" Name="System.Runtime.Serialization.OnSerializingAttribute">
       <Member Name="#ctor" />

--- a/src/mscorlib/src/System/DateTime.cs
+++ b/src/mscorlib/src/System/DateTime.cs
@@ -55,7 +55,11 @@ namespace System {
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    public struct DateTime : IComparable, IFormattable, IConvertible, ISerializable, IComparable<DateTime>,IEquatable<DateTime> {
+    public struct DateTime : IComparable, IFormattable, IConvertible, IComparable<DateTime>, IEquatable<DateTime>
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
+    {
     
         // Number of 100ns ticks per time unit
         private const long TicksPerMillisecond = 10000;

--- a/src/mscorlib/src/System/DateTimeOffset.cs
+++ b/src/mscorlib/src/System/DateTimeOffset.cs
@@ -36,9 +36,12 @@ namespace System {
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    public struct DateTimeOffset : IComparable, IFormattable, ISerializable, IDeserializationCallback,
-                                   IComparable<DateTimeOffset>, IEquatable<DateTimeOffset> {
-    
+    public struct DateTimeOffset : IComparable, IFormattable,
+                                   IComparable<DateTimeOffset>, IEquatable<DateTimeOffset>
+#if FEATURE_SERIALIZATION
+        , ISerializable, IDeserializationCallback
+#endif
+    {
         // Constants
         internal const Int64 MaxOffset = TimeSpan.TicksPerHour * 14;
         internal const Int64 MinOffset = -MaxOffset;

--- a/src/mscorlib/src/System/Decimal.cs
+++ b/src/mscorlib/src/System/Decimal.cs
@@ -61,8 +61,11 @@ namespace System {
 #endif
     [System.Runtime.InteropServices.ComVisible(true)]
     [System.Runtime.Versioning.NonVersionable] // This only applies to field layout
-    public struct Decimal : IFormattable, IComparable, IConvertible, IDeserializationCallback
-            , IComparable<Decimal>, IEquatable<Decimal> {
+    public struct Decimal : IFormattable, IComparable, IConvertible, IComparable<Decimal>, IEquatable<Decimal>
+#if FEATURE_SERIALIZATION
+        , IDeserializationCallback
+#endif
+    {
 
         // Sign mask for the flags field. A value of zero in this bit indicates a
         // positive Decimal value, and a value of one in this bit indicates a

--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -31,7 +31,10 @@ namespace System.Globalization {
     [Serializable]
 #endif
     [System.Runtime.InteropServices.ComVisible(true)]
-    public class TextInfo : ICloneable, IDeserializationCallback
+    public class TextInfo : ICloneable
+#if FEATURE_SERIALIZATION
+        , IDeserializationCallback
+#endif
     {
         //--------------------------------------------------------------------//
         //                        Internal Information                        //

--- a/src/mscorlib/src/System/IO/DriveInfo.cs
+++ b/src/mscorlib/src/System/IO/DriveInfo.cs
@@ -44,7 +44,10 @@ namespace System.IO
     [Serializable]
 #endif
     [ComVisible(true)]
-    public sealed class DriveInfo : ISerializable
+    public sealed class DriveInfo
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
     {
         private String _name;
 

--- a/src/mscorlib/src/System/IntPtr.cs
+++ b/src/mscorlib/src/System/IntPtr.cs
@@ -26,7 +26,10 @@ namespace System {
     [Serializable]
 #endif
     [System.Runtime.InteropServices.ComVisible(true)]
-    public struct IntPtr : ISerializable
+    public struct IntPtr
+#if FEATURE_SERIALIZATION
+        : ISerializable
+#endif
     {
         [SecurityCritical]
         unsafe private void* m_value; // The compiler treats void* closest to uint hence explicit casts are required to preserve int behavior

--- a/src/mscorlib/src/System/Reflection/AssemblyName.cs
+++ b/src/mscorlib/src/System/Reflection/AssemblyName.cs
@@ -31,7 +31,10 @@ namespace System.Reflection {
     [ClassInterface(ClassInterfaceType.None)]
     [ComDefaultInterface(typeof(_AssemblyName))]
     [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class AssemblyName : _AssemblyName, ICloneable, ISerializable, IDeserializationCallback
+    public sealed class AssemblyName : _AssemblyName, ICloneable
+#if FEATURE_SERIALIZATION
+        , ISerializable, IDeserializationCallback
+#endif
     {
         //
         // READ ME

--- a/src/mscorlib/src/System/Reflection/Missing.cs
+++ b/src/mscorlib/src/System/Reflection/Missing.cs
@@ -17,7 +17,10 @@ namespace System.Reflection
     [Serializable]
 #endif
     [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class Missing: ISerializable
+    public sealed class Missing
+#if FEATURE_SERIALIZATION
+        : ISerializable
+#endif
     {
         public static readonly Missing Value = new Missing();
 

--- a/src/mscorlib/src/System/Reflection/Pointer.cs
+++ b/src/mscorlib/src/System/Reflection/Pointer.cs
@@ -22,8 +22,12 @@ namespace System.Reflection {
     [Serializable]
 #endif
     [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class Pointer: ISerializable {
-        [SecurityCritical]
+    public sealed class Pointer
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
+    {
+    [SecurityCritical]
         unsafe private void* _ptr;
         private RuntimeType _ptrType;
 

--- a/src/mscorlib/src/System/Runtime/Serialization/IDeserializationCallback.cs
+++ b/src/mscorlib/src/System/Runtime/Serialization/IDeserializationCallback.cs
@@ -18,9 +18,6 @@ namespace System.Runtime.Serialization {
     // Interface does not need to be marked with the serializable attribute    
     [System.Runtime.InteropServices.ComVisible(true)]
     public interface IDeserializationCallback {
-#if FEATURE_SERIALIZATION
         void OnDeserialization(Object sender);
-#endif
-    
     }
 }

--- a/src/mscorlib/src/System/Runtime/Serialization/ISerializable.cs
+++ b/src/mscorlib/src/System/Runtime/Serialization/ISerializable.cs
@@ -22,10 +22,8 @@ namespace System.Runtime.Serialization {
 
     [System.Runtime.InteropServices.ComVisible(true)]
     public interface ISerializable {
-#if FEATURE_SERIALIZATION
         [System.Security.SecurityCritical]  // auto-generated_required
         void GetObjectData(SerializationInfo info, StreamingContext context);
-#endif
     }
 
 }

--- a/src/mscorlib/src/System/Runtime/Serialization/SerializationInfo.cs
+++ b/src/mscorlib/src/System/Runtime/Serialization/SerializationInfo.cs
@@ -173,10 +173,12 @@ namespace System.Runtime.Serialization
         [SecuritySafeCritical]
         internal static void DemandForUnsafeAssemblyNameAssignments(string originalAssemblyName, string newAssemblyName)
         {
+#if !FEATURE_CORECLR
             if (!IsAssemblyNameAssignmentSafe(originalAssemblyName, newAssemblyName))
             {
                 CodeAccessPermission.Demand(PermissionType.SecuritySerialization);
             }
+#endif
         }
 
         internal static bool IsAssemblyNameAssignmentSafe(string originalAssemblyName, string newAssemblyName)

--- a/src/mscorlib/src/System/Security/PermissionSet.cs
+++ b/src/mscorlib/src/System/Security/PermissionSet.cs
@@ -40,12 +40,15 @@ namespace System.Security {
     [StrongNameIdentityPermissionAttribute(SecurityAction.InheritanceDemand, Name = "mscorlib", PublicKey = "0x" + AssemblyRef.EcmaPublicKeyFull)]
 #endif
     [System.Runtime.InteropServices.ComVisible(true)]
-    public class PermissionSet : ISecurityEncodable, ICollection, IStackWalk, IDeserializationCallback
+    public class PermissionSet : ISecurityEncodable, ICollection, IStackWalk
+#if FEATURE_SERIALIZATION
+        , IDeserializationCallback
+#endif
     {
-    #if _DEBUG
+#if _DEBUG
         internal static readonly bool debug;
-    #endif
-    
+#endif
+
         [System.Diagnostics.Conditional( "_DEBUG" )]
         private static void DEBUG_WRITE(String str) {
         #if _DEBUG

--- a/src/mscorlib/src/System/Text/CodePageEncoding.cs
+++ b/src/mscorlib/src/System/Text/CodePageEncoding.cs
@@ -23,7 +23,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    internal sealed class CodePageEncoding : ISerializable, IObjectReference
+    internal sealed class CodePageEncoding : IObjectReference
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
     {
         // Temp stuff
         [NonSerialized]
@@ -109,7 +112,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
         [Serializable]
 #endif
-        internal sealed class Decoder : ISerializable, IObjectReference
+        internal sealed class Decoder : IObjectReference
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
             // Might need this when GetRealObjecting
             [NonSerialized]

--- a/src/mscorlib/src/System/Text/DecoderNLS.cs
+++ b/src/mscorlib/src/System/Text/DecoderNLS.cs
@@ -24,7 +24,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    internal class DecoderNLS : Decoder, ISerializable
+    internal class DecoderNLS : Decoder
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
     {
         // Remember our encoding
                         protected   Encoding m_encoding;

--- a/src/mscorlib/src/System/Text/EncoderNLS.cs
+++ b/src/mscorlib/src/System/Text/EncoderNLS.cs
@@ -24,7 +24,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    internal class EncoderNLS : Encoder, ISerializable
+    internal class EncoderNLS : Encoder
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
     {
         // Need a place for the last left over character, most of our encodings use this
         internal char   charLeftOver;

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -1615,7 +1615,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
         [Serializable]
 #endif
-        internal class DefaultEncoder : Encoder, ISerializable, IObjectReference
+        internal class DefaultEncoder : Encoder, IObjectReference
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
             private Encoding m_encoding;
             [NonSerialized] private bool m_hasInitializedEncoding;
@@ -1745,7 +1748,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
         [Serializable]
 #endif
-        internal class DefaultDecoder : Decoder, ISerializable, IObjectReference
+        internal class DefaultDecoder : Decoder, IObjectReference
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
             private Encoding m_encoding;
             [NonSerialized]

--- a/src/mscorlib/src/System/Text/ISCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ISCIIEncoding.cs
@@ -31,7 +31,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    internal class ISCIIEncoding : EncodingNLS, ISerializable
+    internal class ISCIIEncoding : EncodingNLS
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
     {
         // Constants
         private const int CodeDefault       = 0;    // 0x40       Default

--- a/src/mscorlib/src/System/Text/Latin1Encoding.cs
+++ b/src/mscorlib/src/System/Text/Latin1Encoding.cs
@@ -22,7 +22,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    internal class Latin1Encoding : EncodingNLS, ISerializable
+    internal class Latin1Encoding : EncodingNLS
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
     {
         // We only use the best-fit table, of which ASCII is a superset for us.
         public Latin1Encoding() : base(Encoding.ISO_8859_1)

--- a/src/mscorlib/src/System/Text/MLangCodePageEncoding.cs
+++ b/src/mscorlib/src/System/Text/MLangCodePageEncoding.cs
@@ -25,7 +25,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    internal sealed class MLangCodePageEncoding : ISerializable, IObjectReference
+    internal sealed class MLangCodePageEncoding : IObjectReference
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
     {
         // Temp stuff
         [NonSerialized]
@@ -111,7 +114,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
         [Serializable]
 #endif
-        internal sealed class MLangEncoder : ISerializable, IObjectReference
+        internal sealed class MLangEncoder : IObjectReference
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
             // Might need this when GetRealObjecting
             [NonSerialized]
@@ -151,7 +157,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
         [Serializable]
 #endif
-        internal sealed class MLangDecoder : ISerializable, IObjectReference
+        internal sealed class MLangDecoder : IObjectReference
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
             // Might need this when GetRealObjecting
             [NonSerialized]

--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -43,7 +43,11 @@ namespace System.Text {
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    public sealed class StringBuilder : ISerializable {
+    public sealed class StringBuilder
+#if FEATURE_SERIALIZATION
+        : ISerializable
+#endif
+    {
         // A StringBuilder is internally represented as a linked list of blocks each of which holds
         // a chunk of the string.  It turns out string as a whole can also be represented as just a chunk, 
         // so that is what we do.  

--- a/src/mscorlib/src/System/Text/SurrogateEncoder.cs
+++ b/src/mscorlib/src/System/Text/SurrogateEncoder.cs
@@ -22,7 +22,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    internal sealed class SurrogateEncoder : ISerializable, IObjectReference
+    internal sealed class SurrogateEncoder : IObjectReference
+#if FEATURE_SERIALIZATION
+        , ISerializable
+#endif
     {
         // Might need this when GetRealObjecting
         [NonSerialized]

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -649,9 +649,13 @@ namespace System.Text
 #endif
         // Of all the amazing things... This MUST be Decoder so that our com name
         // for System.Text.Decoder doesn't change
-        private class Decoder : DecoderNLS, ISerializable
+        private class Decoder : DecoderNLS
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
-            /*private*/ internal int bits;
+            /*private*/
+            internal int bits;
             /*private*/ internal int bitCount;
             /*private*/ internal bool firstByte;
 
@@ -717,9 +721,13 @@ namespace System.Text
 #endif
         // Of all the amazing things... This MUST be Encoder so that our com name
         // for System.Text.Encoder doesn't change
-        private class Encoder : EncoderNLS, ISerializable
+        private class Encoder : EncoderNLS
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
-            /*private*/ internal int bits;
+            /*private*/
+            internal int bits;
             /*private*/ internal int bitCount;
 
             public Encoder(UTF7Encoding encoding) : base(encoding)

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -2157,7 +2157,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
         [Serializable]
 #endif
-        internal class UTF8Encoder : EncoderNLS, ISerializable
+        internal class UTF8Encoder : EncoderNLS
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
             // We must save a high surrogate value until the next call, looking
             // for a low surrogate value.
@@ -2234,7 +2237,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
         [Serializable]
 #endif
-        internal class UTF8Decoder : DecoderNLS, ISerializable
+        internal class UTF8Decoder : DecoderNLS
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
             // We'll need to remember the previous information. See the comments around definition
             // of FinalByte for details.

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -1766,7 +1766,10 @@ namespace System.Text
 #if FEATURE_SERIALIZATION
         [Serializable]
 #endif
-        private class Decoder : System.Text.DecoderNLS, ISerializable
+        private class Decoder : System.Text.DecoderNLS
+#if FEATURE_SERIALIZATION
+            , ISerializable
+#endif
         {
             internal int lastByte = -1;
             internal char lastChar = '\0';

--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -55,8 +55,11 @@ namespace System {
 #endif
     [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
-    sealed public class TimeZoneInfo : IEquatable<TimeZoneInfo>, ISerializable, IDeserializationCallback {
-
+    sealed public class TimeZoneInfo : IEquatable<TimeZoneInfo>
+#if FEATURE_SERIALIZATION
+        , ISerializable, IDeserializationCallback
+#endif
+    {
         // ---- SECTION:  members supporting exposed properties -------------*
         private String m_id;
         private String m_displayName;
@@ -1129,7 +1132,7 @@ namespace System {
         //
         // private ctor
         //
-#if FEATURE_WIN32_REGISTRY 
+#if FEATURE_WIN32_REGISTRY
         [System.Security.SecurityCritical]  // auto-generated
         private TimeZoneInfo(Win32Native.TimeZoneInformation zone, Boolean dstDisabled) {
             
@@ -4459,7 +4462,11 @@ namespace System {
 #endif
         [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
         [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
-        sealed public class AdjustmentRule : IEquatable<AdjustmentRule>, ISerializable, IDeserializationCallback {
+        sealed public class AdjustmentRule : IEquatable<AdjustmentRule>
+#if FEATURE_SERIALIZATION
+            , ISerializable, IDeserializationCallback
+#endif
+            {
 
             // ---- SECTION:  members supporting exposed properties -------------*
             private DateTime m_dateStart;
@@ -4770,8 +4777,11 @@ namespace System {
 #endif
         [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
         [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
-        public struct TransitionTime : IEquatable<TransitionTime>, ISerializable, IDeserializationCallback {
-
+        public struct TransitionTime : IEquatable<TransitionTime>
+#if FEATURE_SERIALIZATION
+            , ISerializable, IDeserializationCallback
+#endif
+        {
             // ---- SECTION:  members supporting exposed properties -------------*
             private DateTime m_timeOfDay;
             private byte m_month;

--- a/src/mscorlib/src/System/UIntPtr.cs
+++ b/src/mscorlib/src/System/UIntPtr.cs
@@ -24,7 +24,10 @@ namespace System {
 #endif
     [CLSCompliant(false)] 
     [System.Runtime.InteropServices.ComVisible(true)]
-    public struct UIntPtr : ISerializable
+    public struct UIntPtr
+#if FEATURE_SERIALIZATION
+        : ISerializable
+#endif
     {
         [SecurityCritical]
         unsafe private void* m_value;

--- a/src/mscorlib/src/System/WeakReference.cs
+++ b/src/mscorlib/src/System/WeakReference.cs
@@ -24,7 +24,11 @@ namespace System {
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    public class WeakReference : ISerializable {
+    public class WeakReference
+#if FEATURE_SERIALIZATION
+        : ISerializable 
+#endif
+    {
         // If you fix bugs here, please fix them in WeakReference<T> at the same time.
 
         // This field is not a regular GC handle. It can have a special values that are used to prevent a race condition between setting the target and finalization.

--- a/src/mscorlib/src/System/WeakReferenceOfT.cs
+++ b/src/mscorlib/src/System/WeakReferenceOfT.cs
@@ -22,7 +22,11 @@ namespace System
     [Serializable]
 #endif
     // This class is sealed to mitigate security issues caused by Object::MemberwiseClone.
-    public sealed class WeakReference<T> : ISerializable where T : class
+    public sealed class WeakReference<T>
+#if FEATURE_SERIALIZATION
+        : ISerializable 
+#endif
+        where T : class
     {
         // If you fix bugs here, please fix them in WeakReference at the same time.
 


### PR DESCRIPTION
- Update the model.xml file to expose the serialization primitives from the runtime, e.g. [Serializable], [NonSerialized], ISerializable, etc.
- Tweak how FEATURE_SERIALIZATION is used on some types.  ISerializable and IDeserializationCallback are not ifdef'd based on FEATURE_SERIALIZATION, but their members are, which means there are some types which are implementing the interface but have the implementation of the interface's method ifdef'd.  This commit removes the ifdef'ing of the methods on the interface, and then ifdef's the implementation of the interface on the offending types.

cc: @jkotas, @danmosemsft 

After this, we can:
- Update the implementation in corefx to type-forward for these interfaces/attributes/etc. to the runtime (at least for coreclr), and expose them from mscorlib
- Start using these to implement the various types in corefx that should be serializable
- Audit the serializable types in mscorlib and start bringing in their serialization implementations... since these serialization primitives are included even when FEATURE_SERIALIZATION isn't set, we should be able to just remove the ifdef'ing from types as they're reviewed, and add the relevant members for each to the model.xml.