### PR TITLE
ARM-CI : Check a device is already mounted while mounting a device.

### DIFF
--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -121,26 +121,10 @@ function clean_emulator {
     sudo rm -rf "$__ARMRootfsCoreclrPath" "$__ARMRootfsCorefxPath"
 }
 
-#Unmount the emulator file systems
-function unmount_emulator {
-    (set +x; echo 'Unmounting emulator...')
-
-    #Unmount all the mounted emulator file systems
-    unmount_rootfs "$__ARMRootfsMountPath/proc"
-    unmount_rootfs "$__ARMRootfsMountPath/dev/pts"
-    unmount_rootfs "$__ARMRootfsMountPath/dev"
-    unmount_rootfs "$__ARMRootfsMountPath/run/shm"
-    unmount_rootfs "$__ARMRootfsMountPath/sys"
-    unmount_rootfs "$__ARMRootfsMountPath"
-}
-
 #Clean the changes made to the environment by the script
 function clean_env {
     #Clean the emulator
     clean_emulator
-
-    #Unmount the emulator
-    unmount_emulator
 
     #Check for revert of git changes
     check_git_head
@@ -152,11 +136,35 @@ function handle_ctrl_c {
 
     echo 'ERROR: Ctrl-C handled. Script aborted before complete execution.'
 
-    clean_env
-
     exit 1
 }
 trap handle_ctrl_c INT
+
+#Trap Exit and handle it
+function handle_exit {
+    set +x
+
+    echo 'The script is exited. Cleaning environment..'
+
+    clean_env
+}
+trap handle_exit EXIT
+
+
+#Mount with checking to be already existed
+function mount_with_checking {
+    set +x
+    local options="$1"
+    local from="$2"
+    local rootfsFolder="$3"
+
+    if mountpoint -q -- "$rootfsFolder"; then
+        (set +x; echo "$rootfsFolder is already mounted.")
+    else {
+        (set -x; sudo mount $options "$from" "$rootfsFolder")
+    }
+    fi
+}
 
 #Mount emulator to the target mount path
 function mount_emulator {
@@ -165,15 +173,13 @@ function mount_emulator {
         sudo mkdir "$__ARMRootfsMountPath"
     fi
 
-    #Unmount the emulator if already mounted at the mount path and mount again
-    unmount_emulator
-
-    sudo mount "$__ARMEmulPath"/platform/rootfs-t30.ext4 "$__ARMRootfsMountPath"
-    sudo mount -t proc /proc    "$__ARMRootfsMountPath"/proc
-    sudo mount -o bind /dev/    "$__ARMRootfsMountPath"/dev
-    sudo mount -o bind /dev/pts "$__ARMRootfsMountPath"/dev/pts
-    sudo mount -t tmpfs shm     "$__ARMRootfsMountPath"/run/shm
-    sudo mount -o bind /sys     "$__ARMRootfsMountPath"/sys
+    set +x
+    mount_with_checking "" "$__ARMEmulPath/platform/rootfs-t30.ext4" "$__ARMRootfsMountPath"
+    mount_with_checking "-t proc" "/proc"    "$__ARMRootfsMountPath/proc"
+    mount_with_checking "-o bind" "/dev/"    "$__ARMRootfsMountPath/dev"
+    mount_with_checking "-o bind" "/dev/pts" "$__ARMRootfsMountPath/dev/pts"
+    mount_with_checking "-t tmpfs" "shm"     "$__ARMRootfsMountPath/run/shm"
+    mount_with_checking "-o bind" "/sys"     "$__ARMRootfsMountPath/sys"
 }
 
 #Cross builds coreclr


### PR DESCRIPTION
Now ARM-CI makes building failure frequently with below messages.(#6329)

http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/arm_emulator_cross_debug_ubuntu_prtest/559/console
00:01:27.252 + sudo umount /opt/linux-arm-emulator-root/dev
00:01:27.260 umount: /opt/linux-arm-emulator-root/dev: device is busy.
00:01:27.260 (In some cases useful info about processes that use
00:01:27.260 the device is found by lsof(8) or fuser(1))
00:01:27.265 Build step 'Execute shell' marked build as failure

I think ARM CI jobs have tried to unmount the same rootfs by an 'arm32_ci_script.sh' at the same time. (At this time, other jobs still are on running...)
So I suggest though the script is exited by any cases, the script would not run un-mounting.
But whenever CI is running and mounting a device, It will check the device is already mounted.