### PR TITLE
Fix lexicographical compares of numeric values in a couple of scripts.

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -25,7 +25,7 @@ if [ $# == 0 ]; then
     clean_packages=true
 fi
 
-while [[ $# > 0 ]]
+while [[ $# -gt 0 ]]
 do
     opt="$1"
     case $opt in

--- a/sync.sh
+++ b/sync.sh
@@ -26,7 +26,7 @@ if [ $# == 0 ]; then
     sync_src=true
 fi
 
-while [[ $# > 0 ]]
+while [[ $# -gt 0 ]]
 do
     opt="$1"
     case $opt in


### PR DESCRIPTION
Found this problem in a couple of scripts. The `>` operator in bash is for string comparison; it does a lexicographical compare, so 5 > 10. This change replaces it with `-gt` to do a numeric comparison.

We're comparing the argument count against 0 so it's not likely to cause a problem right now, but the code is incorrect.