### PR TITLE
Fix build break when FEATURE_SERIALIZATION defined

### DIFF
--- a/src/mscorlib/src/System/IO/DriveInfo.cs
+++ b/src/mscorlib/src/System/IO/DriveInfo.cs
@@ -46,7 +46,7 @@ namespace System.IO
     [ComVisible(true)]
     public sealed class DriveInfo
 #if FEATURE_SERIALIZATION
-        , ISerializable
+        : ISerializable
 #endif
     {
         private String _name;

--- a/src/mscorlib/src/System/Reflection/Pointer.cs
+++ b/src/mscorlib/src/System/Reflection/Pointer.cs
@@ -24,7 +24,7 @@ namespace System.Reflection {
     [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class Pointer
 #if FEATURE_SERIALIZATION
-        , ISerializable
+        : ISerializable
 #endif
     {
     [SecurityCritical]


### PR DESCRIPTION
Copy-and-paste error I didn't notice as CI doesn't build with this compilation constant defined.
cc: @jkotas, @swaroop-sridhar 