### PR TITLE
Exposing ISerializable implementation in System.DateTime

### DIFF
--- a/src/mscorlib/src/System/DateTime.cs
+++ b/src/mscorlib/src/System/DateTime.cs
@@ -52,13 +52,8 @@ namespace System {
     // 
     // 
     [StructLayout(LayoutKind.Auto)]
-#if FEATURE_SERIALIZATION
     [Serializable]
-#endif
-    public struct DateTime : IComparable, IFormattable, IConvertible, IComparable<DateTime>, IEquatable<DateTime>
-#if FEATURE_SERIALIZATION
-        , ISerializable
-#endif
+    public struct DateTime : IComparable, IFormattable, IConvertible, IComparable<DateTime>, IEquatable<DateTime>, ISerializable
     {
     
         // Number of 100ns ticks per time unit
@@ -676,8 +671,7 @@ namespace System {
         public static DateTime FromOADate(double d) {
             return new DateTime(DoubleDateToTicks(d), DateTimeKind.Unspecified);
         }        
-        
-#if FEATURE_SERIALIZATION
+
         [System.Security.SecurityCritical /*auto-generated_required*/]
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) {
             if (info==null) {
@@ -688,8 +682,7 @@ namespace System {
             // Serialize both the old and the new format
             info.AddValue(TicksField, InternalTicks);
             info.AddValue(DateDataField, dateData);
-        }        
-#endif
+        }
 
         public Boolean IsDaylightSavingTime() {
             if (Kind == DateTimeKind.Utc) {


### PR DESCRIPTION
cc: @weshaggard @stephentoub @jkotas @danmosemsft 

We need this in order to finish exposing all DateTime members in System.Runtime

related: dotnet/corefx#10241 