### PR TITLE
GetGcInfo(): Add a missing contract declaration

### DIFF
--- a/src/vm/codeman.h
+++ b/src/vm/codeman.h
@@ -1771,6 +1771,7 @@ public:
 
     PTR_VOID GetGCInfo()
     {
+        WRAPPER_NO_CONTRACT;
         return GetGCInfoToken().Info;
     }
 


### PR DESCRIPTION
Fixes an x86 build failure in a configuration not tested by the CI.