### PR TITLE
Improve performance of string.IndexOf for large strings on 64-bit

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2528,6 +2528,7 @@ namespace System {
                     // We misfired if we got here; so, continue searching at the next word.
                     // Note that we're incrementing count/pCh by 4 rather than Chunk,
                     // since we don't want to skip over the next word in the loop.
+                    // (This will still leave pCh 8-byte aligned.)
                     // Also note that we have to repeat the count >= Chunk check,
                     // since the main loop is a do... while loop and assumes there's
                     // at least Chunk chars left at the beginning.

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2549,13 +2549,13 @@ namespace System {
 
                 FallbackLoop:
 #endif // BIT64
+                char* pEnd = pCh + count;
 
-                while (count > 0)
+                while (pCh != pEnd)
                 {
                     if (*pCh == value)
                         goto ReturnIndex;
 
-                    count--;
                     pCh++;
                 }
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2344,7 +2344,7 @@ namespace System {
                     // Chunk: the number of chars we'll search
                     // per iteration of the loop
                     // Note: Not related to IntPtr.Size, the
-                    // fact that chunk == IntPtr.Size on x64
+                    // fact that Chunk == IntPtr.Size on x64
                     // is a coincidence
                     const int Chunk = 8;
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2439,7 +2439,11 @@ namespace System {
                     //   0x7fff 0xffff 0xffff 0xffff
                     //   ^
                     //   Bit unset here!
-                    
+
+                    // Note: This is based on the trick from
+                    // https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord,
+                    // using 0x7fff instead of 0x7f7f because chars are 2 in size.
+
                     const ulong ZeroMask = 0x7fff7fff7fff7fff;
                     const ulong AllBitsSet = ulong.MaxValue;
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -26,6 +26,12 @@ namespace System {
     using Microsoft.Win32;
     using System.Diagnostics.Contracts;
 
+#if BIT64
+    using nuint = System.UInt64;
+#else // BIT64
+    using nuint = System.UInt32;
+#endif // BIT64
+
     //
     // For Information on these methods, please see COMString.cpp
     //
@@ -2320,17 +2326,120 @@ namespace System {
             {
                 char* pCh = pChars + startIndex;
 
-                while (count >= 4)
-                {
-                    if (*pCh == value) goto ReturnIndex;
-                    if (*(pCh + 1) == value) goto ReturnIndex1;
-                    if (*(pCh + 2) == value) goto ReturnIndex2;
-                    if (*(pCh + 3) == value) goto ReturnIndex3;
+                // Number of chars we'll search per iteration
+                // of the loop
+                // Note: Although it may be techincally equivalent,
+                // the IntPtr.Size check is just a shorthand way
+                // for checking if we're running on 32 or 64-bit,
+                // and is not directly related to the number of chars
+                // we'll write. So you should not change this to:
+                // int chunk = IntPtr.Size;
+                int chunk = IntPtr.Size == 4 ? 4 : 8;
 
-                    count -= 4;
-                    pCh += 4;
+                // First we need to align on a word boundary
+                
+                // We want to calculate the number of chars
+                // until the next aligned address and combine
+                // that with the chars required for at least
+                // one iteration of the optimized loop. If it's
+                // not enough, jump straight to the fallback loop.
+
+#if BIT64
+                // number of bytes until next aligned address (take note: bytes, not chars)
+                int alignment = -(int)pCh % 8; // 0 -> 0, 2 -> 6, 4 -> 4, 6 -> 2, 8 -> 0
+#else // BIT64
+                // On x86 we can get away without inverting pCh,
+                // since [0, -0] and [2, -2] are the same % 4
+                // and pCh will always be at an even address
+                int alignment = (int)pCh % 4;
+#endif // BIT64
+                Contract.Assert(alignment % 2 == 0); // char* from strings should always have an even address
+
+                alignment /= 2; // we're counting in chars, not bytes
+                Contract.Assert(((int)pCh + alignment) % IntPtr.Size == 0);
+
+                if (alignment + chunk > count)
+                {
+                    goto FallbackLoop;
                 }
 
+                // We don't have to check if count > 0 in
+                // this loop, since we verified above that
+                // there's enough space for alignment
+                while ((int)pCh % IntPtr.Size != 0)
+                {
+                    if (*pCh == value)
+                        goto ReturnIndex;
+                    
+                    count--;
+                    pCh++;
+                }
+
+                Contract.Assert(pChars + startIndex + alignment == pCh);
+                Contract.Assert(count >= chunk);
+                
+                nuint zeroMask = 0x7fff7fff;
+                nuint valueMask = ((uint)value << 16) | value; // note: cast to uint instead of nuint is not a typo
+                const nuint AllBitsSet = nuint.MaxValue;
+
+#if BIT64
+                zeroMask = (zeroMask << 32) | zeroMask;
+                valueMask = (valueMask << 32) | valueMask;
+#endif // BIT64
+
+                nuint zeroed;
+
+                Loop:
+                do // we don't have to check the first time, due to the earlier assert
+                {
+#if BIT64
+                    zeroed = *(ulong*)pCh ^ valueMask;
+                    if (((zeroed + zeroMask) | zeroMask) != AllBitsSet) goto MaybeReturn;
+                    zeroed = *(ulong*)(pCh + 4) ^ valueMask;
+                    if (((zeroed + zeroMask) | zeroMask) != AllBitsSet) goto MaybeReturn4;
+#else // BIT64
+                    zeroed = *(uint*)pCh ^ valueMask;
+                    if (((zeroed + zeroMask) | zeroMask) != AllBitsSet) goto MaybeReturn;
+                    zeroed = *(uint*)(pCh + 2) ^ valueMask;
+                    if (((zeroed + zeroMask) | zeroMask) != AllBitsSet) goto MaybeReturn2;
+#endif // BIT64
+
+                    count -= chunk; pCh += chunk;
+                }
+                while (count >= chunk);
+
+                // Didn't find it within the optimized loop, goto
+                // the fallback one and check each char individually
+                goto FallbackLoop;
+
+#if BIT64
+                MaybeReturn4: pCh += 4;
+#else // BIT64
+                MaybeReturn2: pCh += 2;
+#endif // BIT64
+
+                MaybeReturn:
+
+                if (pCh[0] == value)
+                    goto ReturnIndex;
+                if (pCh[1] == value)
+                    goto ReturnIndex1;
+                
+#if BIT64
+                if (pCh[2] == value)
+                    goto ReturnIndex2;
+                if (pCh[3] == value)
+                    goto ReturnIndex3;
+#endif // BIT64
+
+                // We misfired, so continue the search at the next word
+                int processed = IntPtr.Size / 2; // we processed one word, divide by 2 to get number of chars
+                count -= processed;
+                pCh += processed;
+                if (count >= chunk)
+                    goto Loop;
+
+                FallbackLoop:
                 while (count > 0)
                 {
                     if (*pCh == value)
@@ -2342,8 +2451,10 @@ namespace System {
 
                 return -1;
 
+#if BIT64
                 ReturnIndex3: pCh++;
                 ReturnIndex2: pCh++;
+#endif // BIT64
                 ReturnIndex1: pCh++;
                 ReturnIndex:
                 return (int)(pCh - pChars);

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2365,15 +2365,16 @@ namespace System {
                         goto FallbackLoop;
                     }
 
-                    // We don't have to check if count > 0 in
-                    // this loop, since we verified above that
-                    // there's enough space for alignment
+                    // Since we know that there's enough space
+                    // for alignment, subtract it directly
+                    // from count outside the alignment loop
+                    count -= alignment;
+
                     while (alignment > 0)
                     {
                         if (*pCh == value)
                             goto ReturnIndex;
                         
-                        count--;
                         alignment--;
                         pCh++;
                     }

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2355,13 +2355,15 @@ namespace System {
                     // not enough, jump straight to the fallback loop.
 
                     // This calculates the number of bytes until the next aligned address
-                    int alignment = -(int)pCh % 8; // 0 -> 0, 2 -> 6, 4 -> 4, 6 -> 2, 8 -> 0
+                    // We have to use uint and 0u - to stop the jit from generating
+                    // some redundant code
+                    uint alignment = (0u - (uint)pCh) % 8; // 0 -> 0, 2 -> 6, 4 -> 4, 6 -> 2, 8 -> 0
                     Contract.Assert(alignment % 2 == 0); // char* from strings should always have an even address
 
                     alignment /= 2; // we're counting in chars, not bytes, so divide by sizeof(char) which is 2
-                    Contract.Assert(((int)pCh + alignment) % IntPtr.Size == 0);
+                    Contract.Assert(((int)pCh + (int)alignment) % IntPtr.Size == 0);
 
-                    if (alignment + Chunk > count)
+                    if ((int)alignment + Chunk > count)
                     {
                         goto FallbackLoop;
                     }
@@ -2378,7 +2380,7 @@ namespace System {
                         pCh++;
                     }
 
-                    Contract.Assert(pChars + startIndex + alignment == pCh);
+                    Contract.Assert(pChars + startIndex + (int)alignment == pCh);
                     Contract.Assert(count >= Chunk);
 
                     // STEP 2: The main loop

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2354,14 +2354,17 @@ namespace System {
 
                     // This calculates the number of bytes until the next aligned address
                     // We have to use uint and 0u - to stop the jit from generating
-                    // some redundant code
-                    int alignment = (int)((0u - (uint)pCh) % 8); // 0 -> 0, 2 -> 6, 4 -> 4, 6 -> 2, 8 -> 0
-                    Contract.Assert(alignment % 2 == 0); // char* from strings should always have an even address
+                    // some redundant code while doing math
+                    uint ualign = (0u - (uint)pCh) % 8; // 0 -> 0, 2 -> 6, 4 -> 4, 6 -> 2, 8 -> 0
+                    Contract.Assert(ualign % 2 == 0); // char* from strings should always have an even address
 
-                    // We also cast to uint here since otherwise the jit generates inefficient
-                    // code to treat the sign bit specially, when we know it'll never be set
-                    alignment =  (int)((uint)alignment / 2u); // we're counting in chars, not bytes, so divide by sizeof(char) which is 2
-                    Contract.Assert(((int)pCh + alignment) % 8 == 0);
+                    ualign /= 2; // we're counting in chars, not bytes, so divide by sizeof(char) which is 2
+                    Contract.Assert(((uint)pCh + ualign) % 8 == 0);
+
+                    // Now we have to cast to int to prevent Roslyn
+                    // from converting everything to long when mixing
+                    // ints and uints
+                    int alignment = (int)ualign;
 
                     if (alignment + Chunk > count)
                     {

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2361,7 +2361,7 @@ namespace System {
                     Contract.Assert(alignment % 2 == 0); // char* from strings should always have an even address
 
                     alignment /= 2; // we're counting in chars, not bytes, so divide by sizeof(char) which is 2
-                    Contract.Assert(((int)pCh + (int)alignment) % IntPtr.Size == 0);
+                    Contract.Assert(((int)pCh + (int)alignment) % 8 == 0);
 
                     if ((int)alignment + Chunk > count)
                     {
@@ -2371,16 +2371,17 @@ namespace System {
                     // We don't have to check if count > 0 in
                     // this loop, since we verified above that
                     // there's enough space for alignment
-                    while ((int)pCh % IntPtr.Size != 0)
+                    while (alignment > 0)
                     {
                         if (*pCh == value)
                             goto ReturnIndex;
                         
                         count--;
+                        alignment--;
                         pCh++;
                     }
 
-                    Contract.Assert(pChars + startIndex + (int)alignment == pCh);
+                    Contract.Assert((int)pCh % 8 == 0);
                     Contract.Assert(count >= Chunk);
 
                     // STEP 2: The main loop

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2359,7 +2359,7 @@ namespace System {
                     Contract.Assert(ualign % 2 == 0); // char* from strings should always have an even address
 
                     ualign /= 2; // we're counting in chars, not bytes, so divide by sizeof(char) which is 2
-                    Contract.Assert(((uint)pCh + ualign) % 8 == 0);
+                    Contract.Assert((uint)(pCh + ualign) % 8 == 0);
 
                     // Now we have to cast to int to prevent Roslyn
                     // from converting everything to long when mixing

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2368,7 +2368,7 @@ namespace System {
                     // Since we know that there's enough space
                     // for alignment, subtract it directly
                     // from count outside the alignment loop
-                    count -= alignment;
+                    count -= (int)alignment;
 
                     while (alignment > 0)
                     {

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2355,13 +2355,15 @@ namespace System {
                     // This calculates the number of bytes until the next aligned address
                     // We have to use uint and 0u - to stop the jit from generating
                     // some redundant code
-                    uint alignment = (0u - (uint)pCh) % 8; // 0 -> 0, 2 -> 6, 4 -> 4, 6 -> 2, 8 -> 0
+                    int alignment = (int)((0u - (uint)pCh) % 8); // 0 -> 0, 2 -> 6, 4 -> 4, 6 -> 2, 8 -> 0
                     Contract.Assert(alignment % 2 == 0); // char* from strings should always have an even address
 
-                    alignment /= 2; // we're counting in chars, not bytes, so divide by sizeof(char) which is 2
-                    Contract.Assert(((int)pCh + (int)alignment) % 8 == 0);
+                    // We also cast to uint here since otherwise the jit generates inefficient
+                    // code to treat the sign bit specially, when we know it'll never be set
+                    alignment =  (int)((uint)alignment / 2u); // we're counting in chars, not bytes, so divide by sizeof(char) which is 2
+                    Contract.Assert(((int)pCh + alignment) % 8 == 0);
 
-                    if ((int)alignment + Chunk > count)
+                    if (alignment + Chunk > count)
                     {
                         goto FallbackLoop;
                     }

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2343,10 +2343,7 @@ namespace System {
 
                     // Chunk: the number of chars we'll search
                     // per iteration of the loop
-                    // Note: Not related to IntPtr.Size, the
-                    // fact that Chunk == IntPtr.Size on x64
-                    // is a coincidence
-                    const int Chunk = 8;
+                    const int Chunk = 12;
 
                     // We want to calculate the number of chars
                     // until the next aligned address and combine
@@ -2460,6 +2457,8 @@ namespace System {
                         if (((zeroed + ZeroMask) | ZeroMask) != AllBitsSet) goto MaybeReturn;
                         zeroed = *(ulong*)(pCh + 4) ^ valueMask;
                         if (((zeroed + ZeroMask) | ZeroMask) != AllBitsSet) goto MaybeReturn4;
+                        zeroed = *(ulong*)(pCh + 8) ^ valueMask;
+                        if (((zeroed + ZeroMask) | ZeroMask) != AllBitsSet) goto MaybeReturn8;
 
                         count -= Chunk; pCh += Chunk;
                     }
@@ -2494,6 +2493,7 @@ namespace System {
                     // since we don't know which position in the
                     // word the value would be at.
 
+                    MaybeReturn8: pCh += 4;
                     MaybeReturn4: pCh += 4;
 
                     MaybeReturn:


### PR DESCRIPTION
## Summary

This pull request improves the performance of the char-based `string.IndexOf` by about 30% for large strings.

## Description

Right now, the current implementation of `IndexOf` checks each char in the string individually for `value`. While its performance isn't too bad since it's loop unrolled and (I'm asumming) the branch predictor helps out for larger strings, it could be improved.

On 64-bit, I've changed the function to use an approach where instead it reads in one word at a time from the string, and uses a trick to determine if any of the individual 4 chars in it are likely to contain value. If it does, it checks each individual char for value; otherwise, it continues the loop.

### How it works

1. We first align the pointer on an 8-byte boundary by calculating the number of bytes left until the next aligned address, aka `alignment`. We then divide this by 2, since we're counting by chars and not bytes (and `char*` obtained from strings will always have an even address, so the number of bytes to the next aligned address should be even, too).

  - Before aligning, we calculate whether `count` is enough for aligning the pointer + at least one iteration of the loop. If not, we jump straight to the fallback loop where we check one char at a time.

  - We then align the pointer, checking each char at a time for value until we do; since we know that `pAlign` is less than `pEnd` due to the earlier calculation, we don't need to check `pCh < pEnd`.

2. We then go into the main loop, where we process 12 chars at a time. What we do here is create a mask out of value repeated 4x into a word; for example if someone passes in `\u1234` then we want to create `0x1234123412341234`.

  - We then read a word at a time from the target string and xor it with this mask, which is basically equivalent to xoring every individual char in the word with `0x1234`. If there is a `0x1234` in the string, it will be zeroed out.

  - Then, the same trick as #6125 is used to check if a zero is present in the xored string, by adding 0x7fff to each of the chars and checking if any of the high bits are unset. If one of them is, we check each individual char in the word for value. If we find it, we return the index.

    - It's possible for this algorithm to misfire if there's a char >= 0x8000 in the string (besides value | 0x8000, which will yield 0x8000 when xored); in that case, we simply skip the word we just processed and continue the loop if there's enough space left.

3. When the number of chars left goes below the number of chars we can process in the loop (12 in this case), we leave the loop and fallback to processing individual chars.

It's also helpful to read the comments, as I've explained everything there as well.

### Notes

  - If the char we need to find is >= 0x8000, this new algorithm won't work very nicely; assuming a string of ASCII chars, xoring with value would yield something with its high bit set, and adding 0x7fff (unless it's value & ~0x8000) would yield something with its high bit *not* set, and then we would be jumping to `MaybeReturn` for basically *every iteration* of the loop. This is more of a concern than if the string itself contains chars >= 0x8000, since that would only cause a hiccup for one iteration of the loop. (Also, people might use it to check if a string contains invalid chars, e.g. `IndexOf('\uffff') != -1`.) So I fell back to the old algorithm if the char has its high bit set.

  - I had to keep the old implementation for x86 as well; using `uint` instead of `ulong` and even unrolling turned out to have much slower results than the old implementation on 32-bit.

  - I initially loop-unrolled by 8 chars (`Chunk = 8`) due to code size concerns (each check does a xor/add/or/cmp/jne and some other stuff), but unrolling more aggressively to 12 chars at-a-time seemed to yield better performance results (by about 1/16 for larger strings), so I went with that.

    - There appears to be two unnecessary `mov r11, 0x7FFF7FFF7FFF7FFF` in the generated assembly (see below) which are taking up quite a bit of code space inside the loop (probably hurting performance). I don't know if there's a way to tell the JIT to remove them, or I should just wait for the JIT to become better and eliminate these.

  - I also saved on writes to `count` by pre-adding it to `pCh` and comparing `pCh` to that per-iteration of the loop, rather than checking how large `count` was. This saves 1 write per iteration of the loop, which adds an additional 1/15 speedup for larger strings. (I also applied this for the fallback loop.)

### Performance results

Performance results are in [this Gist](https://gist.github.com/jamesqo/df6ab15c3e23d6c3e2bbd68c8f9ce278), including the asm/test source code and results.

  - There is a negligible slowdown for strings of lengths 3/7.

  - There are significant slowdowns for lengths 8-16, especially with length 14 (where the old loop runs thrice and then falls back, and the new loop runs once). However, I'm assuming this is OK since larger strings are more likely to be the bottleneck in an app (otherwise we should just replace all of the code in `String` with naive loops that check one char at a time, since that performs better for smaller strings, right?)

  - The slowdown gets smaller by length 32- it's around 8%.

  - By the 64th position, the new loop is starting to beat the old one by about 7%.

  - **At the 128th and above positions, the new loop is running in about 65-75% the time of the old one.**

  - When 0x8000 is passed in, where we fall back to the old implementation, the new results are still slightly faster; this is presumably due to cfd49d7 so we only make one write per iteration of the loop.

  - When the string itself has lots of 0x8000s, the new loop is of course much slower than the old one (since we have to do constant jumping around and end up with a lot of misfires).

Everything passes the CoreFX test suite; more tests are coming soon to cover the codepaths introduced in this PR. (will post here once that's merged)

Please let me know if there's anyway the performance could be improved. I did some fine tuning for the assembly in some of the commits, but there may still be more opportunities for optimization.

cc: @jkotas @bbowyersmyth @GSPP @stephentoub @omariom