### PR TITLE
Fix up for grabs issues link in contributing workflow doc

### DIFF
--- a/Documentation/project-docs/contributing-workflow.md
+++ b/Documentation/project-docs/contributing-workflow.md
@@ -6,7 +6,7 @@ You can contribute to .NET Core with issues and PRs. Simply filing issues for pr
 Getting Started
 ===============
 
-If you are looking at getting your feet wet with some simple (but still beneficial) changes, check out _up for grabs_ issues on the [CoreCLR](https://github.com/dotnet/coreclr/labels/up for grabs) and [CoreFX](https://github.com/dotnet/corefx/labels/up for grabs) repos. 
+If you are looking at getting your feet wet with some simple (but still beneficial) changes, check out _up for grabs_ issues on the [CoreCLR](https://github.com/dotnet/coreclr/labels/up-for-grabs) and [CoreFX](https://github.com/dotnet/corefx/labels/up%20for%20grabs) repos. 
 
 For new ideas, please always start with an issue before starting development of an implementation. See [project priorities](project-priorities.md) to understand the Microsoft team's approach to engagement on general improvements to the product. Use [CODE_OWNERS.TXT](https://github.com/dotnet/coreclr/blob/master/CODE_OWNERS.TXT) to find relevant maintainers and @ mention them to ask for feedback on your issue.
 


### PR DESCRIPTION
Current link to up for grabs issues for CoreCLR repository leads to the empty list because there's not such label as "up for grabs" (existing label name is "up-for-grabs").

Ideally, both CoreCLR and CoreFX repos should use exactly the same label for public issues to avoid possible mistakes.