### PR TITLE
Optimize the generic string.Join for length 1 collections

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -107,17 +107,36 @@ namespace System {
         }
 
         [ComVisible(false)]
-        public static String Join<T>(String separator, IEnumerable<T> values) {
+        public static String Join<T>(String separator, IEnumerable<T> values)
+        {
             if (values == null)
                 throw new ArgumentNullException("values");
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
-            using(IEnumerator<T> en = values.GetEnumerator()) {
+            using (IEnumerator<T> en = values.GetEnumerator())
+            {
                 if (!en.MoveNext())
-                    return String.Empty;
+                    return string.Empty;
+                
+                // We called MoveNext once, so this will be the first item
+                T firstValue = en.Current;
+
+                // If there's only 1 item, simply call ToString on that
+                if (!en.MoveNext())
+                {
+                    return firstValue?.ToString() ?? string.Empty;
+                }
 
                 StringBuilder result = StringBuilderCache.Acquire();
+
+                if (firstValue != null)
+                {
+                    result.Append(firstValue.ToString());
+                }
+                result.Append(separator);
+
+                // Since we called MoveNext again, this will be the second item
                 T currentValue = en.Current;
 
                 if (currentValue != null) {
@@ -167,15 +186,6 @@ namespace System {
                 return StringBuilderCache.GetStringAndRelease(result);
             }
         }
-
-
-#if BIT64
-        private const int charPtrAlignConst = 3;
-        private const int alignConst        = 7;
-#else
-        private const int charPtrAlignConst = 1;
-        private const int alignConst        = 3;
-#endif
 
         internal char FirstChar { get { return m_firstChar; } }
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -120,35 +120,30 @@ namespace System {
                     return string.Empty;
                 
                 // We called MoveNext once, so this will be the first item
-                T firstValue = en.Current;
+                T currentValue = en.Current;
 
                 // Call ToString before calling MoveNext again, since
                 // we want to stay consistent with the below loop
                 // Everything should be called in the order
                 // MoveNext-Current-ToString, unless further optimizations
                 // can be made, to avoid breaking changes
-                string firstString = firstValue?.ToString();
+                string firstString = currentValue?.ToString();
 
                 // If there's only 1 item, simply call ToString on that
                 if (!en.MoveNext())
                 {
-                    // We have to handle the case of either firstValue
+                    // We have to handle the case of either currentValue
                     // or its ToString being null
                     return firstString ?? string.Empty;
                 }
 
                 StringBuilder result = StringBuilderCache.Acquire();
-
-                // Don't call Append if either firstValue
-                // or its ToString is null (it's a noop)
-                if (firstString != null)
-                {
-                    result.Append(firstString);
-                }
+                
+                result.Append(firstString);
 
                 do
                 {
-                    T currentValue = en.Current;
+                    currentValue = en.Current;
 
                     result.Append(separator);
                     if (currentValue != null)

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -121,7 +121,7 @@ namespace System {
                 
                 // We called MoveNext once, so this will be the first item
                 T firstValue = en.Current;
-                
+
                 // Call ToString before calling MoveNext again, since
                 // we want to stay consistent with the below loop
                 // Everything should be called in the order
@@ -141,23 +141,19 @@ namespace System {
                 {
                     result.Append(firstString);
                 }
-                result.Append(separator);
 
-                // Since we called MoveNext again, this will be the second item
-                T currentValue = en.Current;
-
-                if (currentValue != null) {
-                    result.Append(currentValue.ToString());
-                }
-
-                while (en.MoveNext()) {
-                    currentValue = en.Current;
+                do
+                {
+                    T currentValue = en.Current;
 
                     result.Append(separator);
-                    if (currentValue != null) {
+                    if (currentValue != null)
+                    {
                         result.Append(currentValue.ToString());
                     }
-                }            
+                }
+                while (en.MoveNext());
+
                 return StringBuilderCache.GetStringAndRelease(result);
             }
         }

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -132,11 +132,15 @@ namespace System {
                 // If there's only 1 item, simply call ToString on that
                 if (!en.MoveNext())
                 {
+                    // We have to handle the case of either firstValue
+                    // or its ToString being null
                     return firstString ?? string.Empty;
                 }
 
                 StringBuilder result = StringBuilderCache.Acquire();
 
+                // Don't call Append if either firstValue
+                // or its ToString is null (it's a noop)
                 if (firstString != null)
                 {
                     result.Append(firstString);

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -121,18 +121,25 @@ namespace System {
                 
                 // We called MoveNext once, so this will be the first item
                 T firstValue = en.Current;
+                
+                // Call ToString before calling MoveNext again, since
+                // we want to stay consistent with the below loop
+                // Everything should be called in the order
+                // MoveNext-Current-ToString, unless further optimizations
+                // can be made, to avoid breaking changes
+                string firstString = firstValue?.ToString();
 
                 // If there's only 1 item, simply call ToString on that
                 if (!en.MoveNext())
                 {
-                    return firstValue?.ToString() ?? string.Empty;
+                    return firstString ?? string.Empty;
                 }
 
                 StringBuilder result = StringBuilderCache.Acquire();
 
-                if (firstValue != null)
+                if (firstString != null)
                 {
-                    result.Append(firstValue.ToString());
+                    result.Append(firstString);
                 }
                 result.Append(separator);
 


### PR DESCRIPTION
I noticed an optimization made by @bbowyersmyth for `Join` some time ago for single-item lists-- (#1460) but it looks like it wasn't done for the generic version. The one that accepts an `IEnumerable<T>` is a little trickier to optimize since you need to handle the fact that either `currentValue` or its `ToString` could be null, but here it is.

Notes:

- I took extra care to keep the virtual method call order consistent-- everything is called in the order `MoveNext` / `Current` / `ToString`, in case for some bizarre reason one of the latter 2 modify state.

- I also saw what appeared to be some dead code somewhere else in String (`private consts` that are not used anywhere), so I removed that.

CoreFX tests [already exist](https://github.com/dotnet/corefx/blob/master/src/System.Runtime/tests/System/StringTests.cs#L1463) for this overload, including for objects with `ToString` returning null.

cc @jkotas @bbowyersmyth @AlexGhiondea 