### PR TITLE
Fix copy check condition for native interop test library.

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -1045,7 +1045,7 @@ fi
 if [ -z "$mscorlibDir" ]; then
     mscorlibDir=$coreClrBinDir
 fi
-if [ -d $mscorlibDir/bin ]; then
+if [ -d "$mscorlibDir" ] && [ -d "$mscorlibDir/bin" ]; then
     cp $mscorlibDir/bin/* $mscorlibDir
 fi
 


### PR DESCRIPTION
When executing `runtest.sh` without both `--mscorlibDir=` and `--coreClrBinDir=` command line options, in other words executing `runtest.sh` with ` --coreOverlayDir=` command line options, it erroneously try to copy all files from `/bin/*` to there, produces following log.
```
sjlee@pi2:~/unit_test$ ./runtest.sh \
--testRootDir=/home/sjlee/Windows_NT.x86.Release \
--coreOverlayDir=/home/sjlee/unit_test/overlay.Linux.arm.Release \
--show-time

cp: target ‘/bin/znew’ is not a directory <--------- 'result of copy /bin/*'
Skipping crossgen of FX assemblies.
...
```