### PR TITLE
[SOS][ARM/Linux] Enable clru SOS command

### DIFF
--- a/src/ToolBox/SOS/Strike/disasmARM.cpp
+++ b/src/ToolBox/SOS/Strike/disasmARM.cpp
@@ -271,8 +271,14 @@ static TADDR MDForCall (TADDR callee)
 // Determine if a value is MT/MD/Obj
 static void HandleValue(TADDR value)
 {
+#ifndef FEATURE_PAL
     // remove the thumb bit (if set)
     value = value & ~1;
+#else
+    // set the thumb bit (if not set)
+    value = value | 1;
+#endif //!FEATURE_PAL
+
     // A MethodTable?
     if (IsMethodTable(value))
     {

--- a/src/ToolBox/SOS/Strike/disasmARM.cpp
+++ b/src/ToolBox/SOS/Strike/disasmARM.cpp
@@ -250,7 +250,6 @@ void ARMMachine::IsReturnAddress(TADDR retAddr, TADDR* whereCalled) const
     }
 }
 
-#ifndef FEATURE_PAL
 
 // Return 0 for non-managed call.  Otherwise return MD address.
 static TADDR MDForCall (TADDR callee)
@@ -336,8 +335,6 @@ static void HandleValue(TADDR value)
     }
 }
 
-#endif // !FEATURE_PAL
-
 /**********************************************************************\
 * Routine Description:                                                 *
 *                                                                      *
@@ -355,7 +352,6 @@ void ARMMachine::Unassembly (
     BOOL bSuppressLines,
     BOOL bDisplayOffsets) const
 {
-#ifndef FEATURE_PAL
     ULONG_PTR PC = PCBegin;
     char line[1024];
     char *ptr;
@@ -383,6 +379,7 @@ void ARMMachine::Unassembly (
             }
         }
 
+#ifndef FEATURE_PAL
         //
         // Print out any GC information corresponding to the current instruction offset.
         //
@@ -397,7 +394,7 @@ void ARMMachine::Unassembly (
                 SwitchToFiber(pGCEncodingInfo->pvGCTableFiber);
             }
         }
-
+#endif //!FEATURE_PAL
         //
         // Print out any EH info corresponding to the current offset
         //
@@ -529,7 +526,6 @@ void ARMMachine::Unassembly (
 
         ExtOut ("\n");
     }
-#endif // !FEATURE_PAL
 }
 
 #if 0 // @ARMTODO: Figure out how to extract this information under CoreARM


### PR DESCRIPTION
This PR removes `#ifndef FEATURE_PAL ` to enable `clru` command on ARM/Linux. From CoreCLR side we just need to remove #ifdefs, on `lldb` side we have to slightly change the code to enable armv7l architechture.
Related issue: https://github.com/dotnet/coreclr/issues/6458
CC: @Dmitri-Botcharnikov @chunseoklee @mikem8361