### PR TITLE
Expose SerializationInfo.UpdateValue for corefx

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -9583,6 +9583,7 @@
       <Member Name="GetDecimal(System.String)" />
       <Member Name="GetDateTime(System.String)" />
       <Member Name="GetString(System.String)" />
+      <Member Name="UpdateValue(System.String,System.Object,System.Type)" />
       <Member MemberType="Property" Name="FullTypeName" />
       <Member MemberType="Property" Name="AssemblyName" />
       <Member MemberType="Property" Name="MemberCount" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -11418,6 +11418,7 @@ namespace System.Runtime.Serialization
         public ulong GetUInt64(string name) { throw null; }
         public object GetValue(string name, Type type) { throw null; }
         public void SetType(Type type) { }
+        public void UpdateValue(string name, object value, Type type) { }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed class SerializationInfoEnumerator : System.Collections.IEnumerator

--- a/src/mscorlib/src/System/Runtime/Serialization/SerializationInfo.cs
+++ b/src/mscorlib/src/System/Runtime/Serialization/SerializationInfo.cs
@@ -408,16 +408,23 @@ namespace System.Runtime.Serialization
         /*=================================UpdateValue==================================
         **Action: Finds the value if it exists in the current data.  If it does, we replace
         **        the values, if not, we append it to the end.  This is useful to the 
-        **        ObjectManager when it's performing fixups, but shouldn't be used by 
-        **        clients.  Exposing out this functionality would allow children to overwrite
-        **        their parent's values.
+        **        ObjectManager when it's performing fixups.
         **Returns: void
         **Arguments: name  -- the name of the data to be updated.
         **           value -- the new value.
         **           type  -- the type of the data being added.
-        **Exceptions: None.  All error checking is done with asserts.
+        **Exceptions: None.  All error checking is done with asserts. Although public in coreclr,
+        **            it's not exposed in a contract and is only meant to be used by corefx.
         ==============================================================================*/
-        internal void UpdateValue(String name, Object value, Type type)
+#if FEATURE_CORECLR
+        // This should not be used by clients: exposing out this functionality would allow children
+        // to overwrite their parent's values. It is public in order to give corefx access to it for
+        // its ObjectManager implementation, but it should not be exposed out of a contract.
+        public
+#else
+        internal
+#endif
+        void UpdateValue(String name, Object value, Type type)
         {
             Contract.Assert(null != name, "[SerializationInfo.UpdateValue]name!=null");
             Contract.Assert(null != value, "[SerializationInfo.UpdateValue]value!=null");


### PR DESCRIPTION
ObjectManager in corefx needs to access to SerializationInfo.UpdateValue, which is currently internal.  We don't need to expose UpdateValue in a public contract (which would necessitate adding it to desktop), but by making it public we can give corefx the functionality it needs without needing to move a whole bunch more down from corefx into the runtime.

cc: @jkotas 