### PR TITLE
Add IObjectReference to mscorlib ref assembly

### DIFF
--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -11314,6 +11314,11 @@ namespace System.Runtime.Serialization
         DateTime ToDateTime(object value);
         String ToString(object value);
     }
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public interface IObjectReference
+    {
+        object GetRealObject(StreamingContext context);
+    }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public interface ISerializable
     {


### PR DESCRIPTION
I previously added this to the model.xml which got it added to System.Private.CoreLib.dll, but CoreFx is still referencing the mscorlib.dll façade, so we need it there, too.