### PR TITLE
Add in-memory circular buffer for logging virtual memory operations.

### DIFF
--- a/src/pal/src/include/pal/virtual.h
+++ b/src/pal/src/include/pal/virtual.h
@@ -28,10 +28,10 @@ extern "C"
 typedef struct _CMI {
 
     struct _CMI * pNext;        /* Link to the next entry. */
-    struct _CMI * pLast;        /* Link to the previous entry. */
+    struct _CMI * pPrevious;    /* Link to the previous entry. */
 
-    UINT_PTR   startBoundary;   /* Starting location of the region. */
-    SIZE_T   memSize;         /* Size of the entire region.. */
+    UINT_PTR startBoundary;     /* Starting location of the region. */
+    SIZE_T   memSize;           /* Size of the entire region.. */
 
     DWORD  accessProtection;    /* Initial allocation access protection. */
     DWORD  allocationType;      /* Initial allocation type. */


### PR DESCRIPTION
This change adds in-memory logging for virtual memory operations to make it easier to diagnose failures caused by mismanaging memory.

I also did further cleanup in the virtual memory code (in a separate commit) including renaming `pLast` to `pPrevious` in the `CMI` struct. The former name was confusing since the pointer points to the previous entry in the doubly-linked list, not the last element.

@sergiy-k 