### PR TITLE
Add errno.h to resolve (internal) build break

### DIFF
--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -23,6 +23,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #if !defined(PLATFORM_UNIX)
 #include <io.h>    // For _dup, _setmode
 #include <fcntl.h> // For _O_TEXT
+#include <errno.h> // For EINVAL
 #endif
 
 /*****************************************************************************/


### PR DESCRIPTION
Internal build configuration for test broke with the stdout hardening.  This change add the needed header to resolve it.