### PR TITLE
Enable RefEmitted assemblies to have Fallback LoadContext notion

### DIFF
--- a/src/dlls/mscorrc/resource.h
+++ b/src/dlls/mscorrc/resource.h
@@ -946,3 +946,5 @@
 #endif // FEATURE_HOST_ASSEMBLY_RESOLVER
 
 #define IDS_NATIVE_IMAGE_CANNOT_BE_LOADED_MULTIPLE_TIMES                               0x263a
+
+

--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -401,19 +401,26 @@ namespace System.Runtime.Loader
             }
             
             AssemblyLoadContext loadContextForAssembly = null;
-            IntPtr ptrAssemblyLoadContext = GetLoadContextForAssembly((RuntimeAssembly)assembly);
-            if (ptrAssemblyLoadContext == IntPtr.Zero)
-            {
-                // If the load context is returned null, then the assembly was bound using the TPA binder
-                // and we shall return reference to the active "Default" binder - which could be the TPA binder
-                // or an overridden CLRPrivBinderAssemblyLoadContext instance.
-                loadContextForAssembly = AssemblyLoadContext.Default;
-            }
-            else
-            {
-                loadContextForAssembly = (AssemblyLoadContext)(GCHandle.FromIntPtr(ptrAssemblyLoadContext).Target);
-            }
+
+            RuntimeAssembly rtAsm = assembly as RuntimeAssembly;
             
+            // We only support looking up load context for runtime assemblies.
+            if (rtAsm != null)
+            {
+                IntPtr ptrAssemblyLoadContext = GetLoadContextForAssembly(rtAsm);
+                if (ptrAssemblyLoadContext == IntPtr.Zero)
+                {
+                    // If the load context is returned null, then the assembly was bound using the TPA binder
+                    // and we shall return reference to the active "Default" binder - which could be the TPA binder
+                    // or an overridden CLRPrivBinderAssemblyLoadContext instance.
+                    loadContextForAssembly = AssemblyLoadContext.Default;
+                }
+                else
+                {
+                    loadContextForAssembly = (AssemblyLoadContext)(GCHandle.FromIntPtr(ptrAssemblyLoadContext).Target);
+                }
+            }
+
             return loadContextForAssembly;
         }
         

--- a/src/vm/assemblyspec.hpp
+++ b/src/vm/assemblyspec.hpp
@@ -42,6 +42,11 @@ class AssemblySpec  : public BaseAssemblySpec
     DWORD            m_dwHashAlg;
     DomainAssembly  *m_pParentAssembly;
 
+#if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+    // Contains the reference to the fallback load context associated with RefEmitted assembly requesting the load of another assembly (static or dynamic)
+    ICLRPrivBinder *m_pFallbackLoadContextBinder;
+#endif // defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+
     BOOL IsValidAssemblyName();
     
     HRESULT InitializeSpecInternal(mdToken kAssemblyRefOrDef, 
@@ -67,6 +72,11 @@ class AssemblySpec  : public BaseAssemblySpec
     {
         LIMITED_METHOD_CONTRACT;
         m_pParentAssembly = NULL;
+
+#if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+        m_pFallbackLoadContextBinder = NULL;        
+#endif // defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+
     }
 #endif //!DACCESS_COMPILE
 
@@ -74,6 +84,11 @@ class AssemblySpec  : public BaseAssemblySpec
     { 
         LIMITED_METHOD_CONTRACT
         m_pParentAssembly = NULL;
+
+#if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+        m_pFallbackLoadContextBinder = NULL;        
+#endif // defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+
     }
 
 #ifdef FEATURE_FUSION
@@ -158,6 +173,22 @@ class AssemblySpec  : public BaseAssemblySpec
 #endif
     }
 
+#if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+    void SetFallbackLoadContextBinderForRequestingAssembly(ICLRPrivBinder *pFallbackLoadContextBinder)
+    {
+       LIMITED_METHOD_CONTRACT;
+
+        m_pFallbackLoadContextBinder = pFallbackLoadContextBinder;
+    }
+
+    ICLRPrivBinder* GetFallbackLoadContextBinderForRequestingAssembly()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_pFallbackLoadContextBinder;
+    }
+#endif // defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+
     // Note that this method does not clone the fields!
     void CopyFrom(AssemblySpec* pSource)
     {
@@ -173,6 +204,12 @@ class AssemblySpec  : public BaseAssemblySpec
 
         SetIntrospectionOnly(pSource->IsIntrospectionOnly());
         SetParentAssembly(pSource->GetParentAssembly());
+
+#if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+        // Copy the details of the fallback load context binder
+        SetFallbackLoadContextBinderForRequestingAssembly(pSource->GetFallbackLoadContextBinderForRequestingAssembly());
+#endif // defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+
         m_HashForControl = pSource->m_HashForControl;
         m_dwHashAlg = pSource->m_dwHashAlg;
     }

--- a/src/vm/pefile.cpp
+++ b/src/vm/pefile.cpp
@@ -99,6 +99,9 @@ PEFile::PEFile(PEImage *identity, BOOL fCheckAuthenticodeSignature/*=TRUE*/) :
     ,m_securityManagerLock(CrstPEFileSecurityManager)
 #endif // FEATURE_CAS_POLICY
     ,m_pHostAssembly(nullptr)
+#if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+    ,m_pFallbackLoadContextBinder(nullptr)
+#endif // defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
 {
     CONTRACTL
     {

--- a/src/vm/pefile.h
+++ b/src/vm/pefile.h
@@ -659,6 +659,17 @@ public:
 protected:
     PTR_ICLRPrivAssembly m_pHostAssembly;
 
+#if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+    // For certain assemblies, we do not have m_pHostAssembly since they are not bound using an actual binder.
+    // An example is Ref-Emitted assemblies. Thus, when such assemblies trigger load of their dependencies, 
+    // we need to ensure they are loaded in appropriate load context.
+    //
+    // To enable this, we maintain a concept of "Fallback LoadContext", which will be set to the Binder of the
+    // assembly that created the dynamic assembly. If the creator assembly is dynamic itself, then its fallback
+    // load context would be propagated to the assembly being dynamically generated.
+    ICLRPrivBinder *m_pFallbackLoadContextBinder;
+#endif // defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+
 protected:
 
     friend class CLRPrivBinderFusion;
@@ -684,6 +695,21 @@ public:
 
     bool CanUseWithBindingCache()
     { LIMITED_METHOD_CONTRACT; return !HasHostAssembly(); }
+
+#if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+    void SetFallbackLoadContextBinder(ICLRPrivBinder *pFallbackLoadContextBinder)
+    { 
+        LIMITED_METHOD_CONTRACT; 
+        m_pFallbackLoadContextBinder = pFallbackLoadContextBinder; 
+    }
+
+    ICLRPrivBinder *GetFallbackLoadContextBinder()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_pFallbackLoadContextBinder;
+    }
+#endif //defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
 };  // class PEFile
 
 

--- a/src/vm/typeparse.cpp
+++ b/src/vm/typeparse.cpp
@@ -1902,6 +1902,16 @@ DomainAssembly * LoadDomainAssembly(
         spec.SetParentAssembly(pRequestingAssembly->GetDomainAssembly());
     }
     
+#if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)    
+    // If the requesting assembly has Fallback LoadContext binder available,
+    // then set it up in the AssemblySpec.
+    if (pRequestingAssembly != NULL)
+    {
+        PEFile *pRequestingAssemblyManifestFile = pRequestingAssembly->GetManifestFile();
+        spec.SetFallbackLoadContextBinderForRequestingAssembly(pRequestingAssemblyManifestFile->GetFallbackLoadContextBinder());
+    }
+#endif // defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
+
     if (bThrowIfNotFound)
     {
         pDomainAssembly = spec.LoadDomainAssembly(FILE_LOADED);


### PR DESCRIPTION
Refemitted assemblies do not have any host assembly (and thus, a real binder) associated with them. As a result, when they trigger assembly load, GetBindingContextFromParentAssembly defaults to returning TPA binder to bind the load, resulting in failure to consume the loaded assembly from the dynamic assembly.

Fix:
	1) Setup the notion of fallback load context, during creation of dynamic assembly, which refers to the binder of the assembly emitting the dynamic assembly. If the creator assembly is dynamic, then we use its fallback load context.
	2) During assembly loading, pass the requesting assembly in the AssemblySpec that will be referred to by GetBindingContextFromParentAssembly.
		a. Update AssemblySpec::CopyFrom
	3) When fetching loadcontext of a dynamic assembly (using ALC.GetLoadContext API), we will return null since they do not have any load context associated with them.
	4) Since Collectible assemblies can get collected, we should save the binder reference in AssemblySpec instead of DomainAssembly reference.

@jkotas PTAL