### PR TITLE
WorkerThreadStart volatile read+cmpxchg loop

### DIFF
--- a/src/vm/comthreadpool.cpp
+++ b/src/vm/comthreadpool.cpp
@@ -251,7 +251,6 @@ FCIMPL0(FC_BOOL_RET, ThreadPoolNative::NotifyRequestComplete)
         pThread->HasCriticalRegion() ||
         pThread->HasThreadAffinity();
 
-    // Read fenced call
     bool shouldAdjustWorkers = ThreadpoolMgr::ShouldAdjustMaxWorkersActive();
 
     // 
@@ -267,14 +266,14 @@ FCIMPL0(FC_BOOL_RET, ThreadPoolNative::NotifyRequestComplete)
     {
         HELPER_METHOD_FRAME_BEGIN_RET_0();
 
-        if (needReset)
-            pThread->InternalReset(FALSE, TRUE, TRUE, FALSE);
-
         if (shouldAdjustWorkers)
         {
             ThreadpoolMgr::AdjustMaxWorkersActive();
             tal.Release();
         }
+
+        if (needReset)
+            pThread->InternalReset(FALSE, TRUE, TRUE, FALSE);
 
         HELPER_METHOD_FRAME_END();    
     }

--- a/src/vm/comthreadpool.cpp
+++ b/src/vm/comthreadpool.cpp
@@ -251,6 +251,7 @@ FCIMPL0(FC_BOOL_RET, ThreadPoolNative::NotifyRequestComplete)
         pThread->HasCriticalRegion() ||
         pThread->HasThreadAffinity();
 
+    // Read fenced call
     bool shouldAdjustWorkers = ThreadpoolMgr::ShouldAdjustMaxWorkersActive();
 
     // 
@@ -266,14 +267,14 @@ FCIMPL0(FC_BOOL_RET, ThreadPoolNative::NotifyRequestComplete)
     {
         HELPER_METHOD_FRAME_BEGIN_RET_0();
 
+        if (needReset)
+            pThread->InternalReset(FALSE, TRUE, TRUE, FALSE);
+
         if (shouldAdjustWorkers)
         {
             ThreadpoolMgr::AdjustMaxWorkersActive();
             tal.Release();
         }
-
-        if (needReset)
-            pThread->InternalReset (FALSE, TRUE, TRUE, FALSE);
 
         HELPER_METHOD_FRAME_END();    
     }

--- a/src/vm/threadpoolrequest.cpp
+++ b/src/vm/threadpoolrequest.cpp
@@ -30,11 +30,14 @@
 #endif
 #include "appdomain.inl"
 
+BYTE PerAppDomainTPCountList::padding1[64];
 UnManagedPerAppDomainTPCount PerAppDomainTPCountList::s_unmanagedTPCount;
 
+BYTE PerAppDomainTPCountList::padding2[64];
 //The list of all per-appdomain work-request counts.
 ArrayListStatic PerAppDomainTPCountList::s_appDomainIndexList;    
 
+BYTE PerAppDomainTPCountList::padding3[64];
 //Make this point to unmanaged TP in case, no appdomains have initialized yet.
 LONG PerAppDomainTPCountList::s_ADHint=-1;
 

--- a/src/vm/threadpoolrequest.h
+++ b/src/vm/threadpoolrequest.h
@@ -174,17 +174,13 @@ public:
     void DispatchWorkItem(bool* foundWork, bool* wasNotRecalled);
 
 private:
-    struct {
-        ADID m_id;
-        TPIndex m_index;
-    };
-    struct {
-        DECLSPEC_ALIGN(64) struct {
-            BYTE padding1[64 - sizeof(LONG)];
-            // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
-            LONG m_numRequestsPending;
-            BYTE padding2[64];
-        };
+    ADID m_id;
+    TPIndex m_index;
+    DECLSPEC_ALIGN(64) struct {
+        BYTE m_padding1[64 - sizeof(LONG)];
+        // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
+        LONG m_numRequestsPending;
+        BYTE m_padding2[64];
     };
 };
 
@@ -283,17 +279,13 @@ public:
     }
 
 private:
-    struct {
-        SpinLock m_lock;
-        ULONG m_NumRequests;
-    };
-    struct {
-        DECLSPEC_ALIGN(64) struct {
-            BYTE padding1[64 - sizeof(LONG)];
-            // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
-            LONG m_outstandingThreadRequestCount;
-            BYTE padding2[64];
-        };
+    SpinLock m_lock;
+    ULONG m_NumRequests;
+    DECLSPEC_ALIGN(64) struct {
+        BYTE m_padding1[64 - sizeof(LONG)];
+        // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
+        LONG m_outstandingThreadRequestCount;
+        BYTE m_padding2[64];
     };
 };
 

--- a/src/vm/threadpoolrequest.h
+++ b/src/vm/threadpoolrequest.h
@@ -172,9 +172,14 @@ public:
     void DispatchWorkItem(bool* foundWork, bool* wasNotRecalled);
 
 private:
-    Volatile<LONG> m_numRequestsPending;
-    ADID m_id;
-    TPIndex m_index;
+    struct {
+        BYTE padding1[64]; // padding to ensure own cache line
+        Volatile<LONG> m_numRequestsPending;
+        BYTE padding2[64]; // padding to ensure own cache line
+        ADID m_id;
+        BYTE padding3[64]; // padding to ensure own cache line
+        TPIndex m_index;
+    };
 };
 
 //--------------------------------------------------------------------------
@@ -272,9 +277,14 @@ public:
     }
 
 private:
-    ULONG m_NumRequests;
-    Volatile<LONG> m_outstandingThreadRequestCount;
-    SpinLock m_lock;
+    struct {
+        BYTE padding1[64]; // padding to ensure own cache line
+        ULONG m_NumRequests;
+        BYTE padding2[64]; // padding to ensure own cache line
+        Volatile<LONG> m_outstandingThreadRequestCount;
+        BYTE padding3[64]; // padding to ensure own cache line
+        SpinLock m_lock;
+    };
 };
 
 //--------------------------------------------------------------------------
@@ -330,11 +340,14 @@ public:
 private:
     static DWORD FindFirstFreeTpEntry();
 
+    static BYTE padding1[64]; // padding to ensure own cache line
     static UnManagedPerAppDomainTPCount s_unmanagedTPCount;
 
-    //The list of all per-appdomain work-request counts.
-    static ArrayListStatic s_appDomainIndexList;    
+    static BYTE padding2[64]; // padding to ensure own cache line
+        //The list of all per-appdomain work-request counts.
+    static ArrayListStatic s_appDomainIndexList;
 
+    static BYTE padding3[64]; // padding to ensure own cache line
     static LONG s_ADHint;
 };
 

--- a/src/vm/threadpoolrequest.h
+++ b/src/vm/threadpoolrequest.h
@@ -175,13 +175,16 @@ public:
 
 private:
     struct {
-        BYTE padding1[64]; // padding to ensure own cache line
-        // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
-        LONG m_numRequestsPending;
-        BYTE padding2[64]; // padding to ensure own cache line
         ADID m_id;
-        BYTE padding3[64]; // padding to ensure own cache line
         TPIndex m_index;
+    };
+    struct {
+        DECLSPEC_ALIGN(64) struct {
+            BYTE padding1[64 - sizeof(LONG)];
+            // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
+            LONG m_numRequestsPending;
+            BYTE padding2[64];
+        };
     };
 };
 
@@ -281,13 +284,16 @@ public:
 
 private:
     struct {
-        BYTE padding1[64]; // padding to ensure own cache line
-        ULONG m_NumRequests;
-        BYTE padding2[64]; // padding to ensure own cache line
-        // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
-        LONG m_outstandingThreadRequestCount;
-        BYTE padding3[64]; // padding to ensure own cache line
         SpinLock m_lock;
+        ULONG m_NumRequests;
+    };
+    struct {
+        DECLSPEC_ALIGN(64) struct {
+            BYTE padding1[64 - sizeof(LONG)];
+            // Only use with VolatileLoad+VolatileStore+FastInterlockCompareExchange
+            LONG m_outstandingThreadRequestCount;
+            BYTE padding2[64];
+        };
     };
 };
 
@@ -344,32 +350,12 @@ public:
 private:
     static DWORD FindFirstFreeTpEntry();
 
-    static BYTE padding1[64]; // padding to ensure own cache line
+    static BYTE s_padding[64 - sizeof(LONG)];
+    static LONG s_ADHint;
     static UnManagedPerAppDomainTPCount s_unmanagedTPCount;
 
-    static BYTE padding2[64]; // padding to ensure own cache line
-        //The list of all per-appdomain work-request counts.
+    //The list of all per-appdomain work-request counts.
     static ArrayListStatic s_appDomainIndexList;
-
-    static BYTE padding3[64]; // padding to ensure own cache line
-    static LONG s_ADHint;
 };
 
 #endif //_THREADPOOL_REQUEST_H
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -1263,10 +1263,10 @@ void ThreadpoolMgr::AdjustMaxWorkersActive()
         }
 
         PriorCompletedWorkRequests = totalNumCompletions;
-        PriorCompletedWorkRequestsTime = currentTicks;
         NextCompletedWorkRequestsTime = currentTicks + ThreadAdjustmentInterval;
-        CurrentSampleStartTime = endTime;
-        MemoryBarrier();
+        MemoryBarrier(); // flush previous writes (especially NextCompletedWorkRequestsTime)
+        PriorCompletedWorkRequestsTime = currentTicks;
+        CurrentSampleStartTime = endTime;;
     }
 }
 

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -4987,10 +4987,8 @@ DWORD __stdcall ThreadpoolMgr::TimerThreadStart(LPVOID p)
     if (pThread == NULL)
         return 0;
 
-    if (pTimerThread != pThread) {
-        pTimerThread = pThread;
-        // Timer threads never die
-    }
+    pTimerThread = pThread;
+    // Timer threads never die
 
     LastTickCount = GetTickCount();
 

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -1262,11 +1262,11 @@ void ThreadpoolMgr::AdjustMaxWorkersActive()
             }
         }
 
-        // Memory fences below writes
-        VolatileStore(&PriorCompletedWorkRequests, totalNumCompletions);
+        PriorCompletedWorkRequests = totalNumCompletions;
         PriorCompletedWorkRequestsTime = currentTicks;
         NextCompletedWorkRequestsTime = currentTicks + ThreadAdjustmentInterval;
         CurrentSampleStartTime = endTime;
+        MemoryBarrier();
     }
 }
 

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -1142,8 +1142,9 @@ public:
         if (CLRThreadpoolHosted())
             return false;
 
+        MemoryBarrier();
         DWORD priorTime = PriorCompletedWorkRequestsTime; 
-        DWORD requiredInterval = VolatileLoad(&NextCompletedWorkRequestsTime) - priorTime; // fences above read
+        DWORD requiredInterval = NextCompletedWorkRequestsTime - priorTime; // fences above read
         DWORD elapsedInterval = GetTickCount() - priorTime;
         if (elapsedInterval >= requiredInterval)
         {

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -1142,9 +1142,9 @@ public:
         if (CLRThreadpoolHosted())
             return false;
 
-        MemoryBarrier();
-        DWORD priorTime = PriorCompletedWorkRequestsTime; 
-        DWORD requiredInterval = NextCompletedWorkRequestsTime - priorTime; // fences above read
+        DWORD priorTime = PriorCompletedWorkRequestsTime;
+        MemoryBarrier(); // read fresh value for NextCompletedWorkRequestsTime below
+        DWORD requiredInterval = NextCompletedWorkRequestsTime - priorTime;
         DWORD elapsedInterval = GetTickCount() - priorTime;
         if (elapsedInterval >= requiredInterval)
         {

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -378,12 +378,12 @@ public:
 
         Counts GetCleanCounts()
         {
+            LIMITED_METHOD_CONTRACT;
 #ifdef _WIN64
             // VolatileLoad x64 bit read is atomic
             return DangerousGetDirtyCounts();
 #else // !_WIN64
             // VolatileLoad may result in torn read
-            LIMITED_METHOD_CONTRACT;
             Counts result;
 #ifndef DACCESS_COMPILE
             result.AsLongLong = FastInterlockCompareExchangeLong(&counts.AsLongLong, 0, 0);

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -373,6 +373,9 @@ public:
 
         } counts;
 
+        // padding to ensure we get our own cache line
+        BYTE padding[64];
+
         Counts GetCleanCounts()
         {
 #ifdef _WIN64
@@ -529,7 +532,7 @@ public:
     static inline void UpdateLastDequeueTime()
     {
         LIMITED_METHOD_CONTRACT;
-        LastDequeueTime = GetTickCount();
+        VolatileStore(&LastDequeueTime, (unsigned int)GetTickCount());
     }
 
     static BOOL CreateTimerQueueTimer(PHANDLE phNewTimer,
@@ -1301,17 +1304,13 @@ private:
     SVAL_DECL(LONG,MinLimitTotalWorkerThreads);         // same as MinLimitTotalCPThreads
     SVAL_DECL(LONG,MaxLimitTotalWorkerThreads);         // same as MaxLimitTotalCPThreads
         
-    static Volatile<unsigned int> LastDequeueTime;      // used to determine if work items are getting thread starved 
+    static unsigned int LastDequeueTime;      // used to determine if work items are getting thread starved 
     
     static HillClimbing HillClimbingInstance;
-
-    static BYTE padding1[64]; // padding to ensure own cache line
 
     static LONG PriorCompletedWorkRequests;
     static DWORD PriorCompletedWorkRequestsTime;
     static DWORD NextCompletedWorkRequestsTime;
-
-    static BYTE padding2[64]; // padding to ensure own cache line
 
     static LARGE_INTEGER CurrentSampleStartTime;
 

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -375,6 +375,11 @@ public:
 
         Counts GetCleanCounts()
         {
+#ifdef _WIN64
+            // VolatileLoad x64 bit read is atomic
+            return DangerousGetDirtyCounts();
+#else // !_WIN64
+            // VolatileLoad may result in torn read
             LIMITED_METHOD_CONTRACT;
             Counts result;
 #ifndef DACCESS_COMPILE
@@ -384,6 +389,7 @@ public:
             result.AsLongLong = 0; //prevents prefast warning for DAC builds
 #endif
             return result;
+#endif // !_WIN64
         }
 
         //


### PR DESCRIPTION
#Currently ThreadPoolMgr::WorkerThreadStart and ThreadPoolMgr::MaybeAddWorkingWorker use `FastInterlockCompareExchangeLong` to do read and couple with a `FastInterlockCompareExchangeLong` loop to do set.

Current Code:
```cpp
counts = WorkerCounter.GetCleanCounts(); 
// return FastInterlockCompareExchangeLong(&counts.AsLongLong,0,0);
while (true)
{
    newCounts = counts;
    // adjust newCounts to wanted values

    Counts oldCounts = WorkerCounter.CompareExchangeCounts(newCounts, counts);

    if (oldCounts == counts)
        break;

    counts = oldCounts;
}
```
It looks like the `lock cmpxchg` "write read" causes a pipeline stall. As its then followed by a `lock cmpxchg` loop to set the value it should be able to use a volatile read to get the initial value as that will then be validated by the set.

Changed code:
```cpp
counts = WorkerCounter.DangerousGetDirtyCounts(); 
// return VolatileLoad(&counts.AsLongLong);
while (true)
{
    newCounts = counts;
    // adjust newCounts to wanted values

    Counts oldCounts = WorkerCounter.CompareExchangeCounts(newCounts, counts);

    if (oldCounts == counts)
        break;

    counts = oldCounts;
}
```

Also changed GetCleanCounts to use the VolatileLoad on x64.

Before WorkerThreadStart is 2nd most expensive function and MaybeAddWorkingWorker is 10th for multicore contested QUWI
![WorkerThreadStart-1](https://aoa.blob.core.windows.net/aspnet/WorkerThreadStart-1.png)

After (3 commits) WorkerThreadStart drops to 17th and the rest of the native functions are also pushed out of the top hot spots:
![WorkerThreadStart-5](https://aoa.blob.core.windows.net/aspnet/WorkerThreadStart-5.png)

Resolves #6132
Resolves #6476

Questions:
* Is `_WIN64` the correct ifdef to used for x64? (Or `_TARGET_64BIT_` or `AMD64` etc)

/cc  @kouvel @jkotas @stephentoub 