### PR TITLE
Remove CorUnix::InternalFree from PAL

### DIFF
--- a/src/pal/src/cruntime/malloc.cpp
+++ b/src/pal/src/cruntime/malloc.cpp
@@ -57,7 +57,7 @@ CorUnix::InternalRealloc(
         // If pvMemblock is NULL, there's no reason to call free.
         if (pvMemblock != NULL)
         {
-            InternalFree(pvMemblock);
+            free(pvMemblock);
         }
         pvMem = NULL;
     }
@@ -74,14 +74,6 @@ CorUnix::InternalRealloc(
 void
 __cdecl
 PAL_free(
-    void *pvMem
-    )
-{
-    InternalFree(pvMem);
-}
-
-void
-CorUnix::InternalFree(
     void *pvMem
     )
 {

--- a/src/pal/src/cruntime/printfcpp.cpp
+++ b/src/pal/src/cruntime/printfcpp.cpp
@@ -80,17 +80,17 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
         if (!nsize)
         {
             ASSERT("WideCharToMultiByte failed.  Error is %d\n", GetLastError());
-            InternalFree(newBuff);
+            free(newBuff);
             return -1;
         }
         ret = InternalFwrite(newBuff, 1, count, stream, &iError);
         if (iError != 0)
         {
             ERROR("InternalFwrite did not write the whole buffer. Error is %d\n", iError);
-            InternalFree(newBuff);
+            free(newBuff);
             return -1;
         }
-        InternalFree(newBuff);
+        free(newBuff);
    }
    else
    {
@@ -441,7 +441,7 @@ BOOL Internal_ExtractFormatA(CPalThread *pthrCurrent, LPCSTR *Fmt, LPSTR Out, LP
     }
 
     *Out = 0;  /* end the string */
-    InternalFree(TempStr);
+    free(TempStr);
     return Result;
 }
 
@@ -769,7 +769,7 @@ BOOL Internal_ExtractFormatW(CPalThread *pthrCurrent, LPCWSTR *Fmt, LPSTR Out, L
     }
 
     *Out = 0;  /* end the string */
-    InternalFree(TempStr);
+    free(TempStr);
     return Result;
 }
 
@@ -947,7 +947,7 @@ INT Internal_AddPaddingVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, LPSTR
     }
 
 Done:
-    InternalFree(OutOriginal);
+    free(OutOriginal);
 
     return Written;
 }
@@ -998,7 +998,7 @@ static INT Internal_AddPaddingVfwprintf(CPalThread *pthrCurrent, PAL_FILE *strea
         if (wcscpy_s(Out, iLen, In) != SAFECRT_SUCCESS)
         {
             ERROR("wcscpy_s failed!\n");
-            InternalFree(OutOriginal);
+            free(OutOriginal);
             pthrCurrent->SetLastError(ERROR_INSUFFICIENT_BUFFER);
             return -1;
         }
@@ -1028,7 +1028,7 @@ static INT Internal_AddPaddingVfwprintf(CPalThread *pthrCurrent, PAL_FILE *strea
         if (wcscpy_s(Out, iLen, In) != SAFECRT_SUCCESS)
         {
             ERROR("wcscpy_s failed!\n");
-            InternalFree(OutOriginal);
+            free(OutOriginal);
             pthrCurrent->SetLastError(ERROR_INSUFFICIENT_BUFFER);
             return -1;
         }
@@ -1045,7 +1045,7 @@ static INT Internal_AddPaddingVfwprintf(CPalThread *pthrCurrent, PAL_FILE *strea
         {
             ERROR("fwrite() failed with errno == %d\n", errno);
         }
-        InternalFree(OutOriginal);
+        free(OutOriginal);
     }
 
     return Written;
@@ -1265,7 +1265,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                     pthrCurrent->SetLastError(ERROR_NOT_ENOUGH_MEMORY);
                     if (WStrWasMalloced)
                     {
-                        InternalFree(TempWStr);
+                        free(TempWStr);
                     }
                     va_end(ap);
                     return -1;
@@ -1283,9 +1283,9 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                         ERROR("Internal_AddPaddingVfwprintf failed\n");
                         if (WStrWasMalloced)
                         {
-                            InternalFree(TempWStr);
+                            free(TempWStr);
                         }
-                        InternalFree(WorkingWStr);
+                        free(WorkingWStr);
                         LOGEXIT("wcsncpy_s failed!\n");
                         PERF_EXIT(vfwprintf);
                         va_end(ap);
@@ -1312,9 +1312,9 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                     ERROR("Internal_AddPaddingVfwprintf failed\n");
                     if (WStrWasMalloced)
                     {
-                        InternalFree(TempWStr);
+                        free(TempWStr);
                     }
-                    InternalFree(WorkingWStr);
+                    free(WorkingWStr);
                     LOGEXIT("vfwprintf returns int -1\n");
                     PERF_EXIT(vfwprintf);
                     va_end(ap);
@@ -1322,10 +1322,10 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                 }
                 written += paddingReturnValue;
 
-                InternalFree(WorkingWStr);
+                free(WorkingWStr);
                 if (WStrWasMalloced)
                 {
-                    InternalFree(TempWStr);
+                    free(TempWStr);
                 }
             }
             else if (Prefix == PFF_PREFIX_LONG && Type == PFF_TYPE_CHAR)
@@ -1499,7 +1499,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                     ERROR("MultiByteToWideChar failed\n");
                     if(TempSprintfStrPtr)
                     {
-                        InternalFree(TempSprintfStrPtr);
+                        free(TempSprintfStrPtr);
                     }
                     LOGEXIT("vfwprintf returns int -1\n");
                     PERF_EXIT(vfwprintf);
@@ -1516,7 +1516,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                     pthrCurrent->SetLastError(ERROR_NOT_ENOUGH_MEMORY);
                     if(TempSprintfStrPtr)
                     {
-                        InternalFree(TempSprintfStrPtr);
+                        free(TempSprintfStrPtr);
                     }
                     va_end(ap);
                     return -1;
@@ -1538,19 +1538,19 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                     ERROR("fwrite() failed with errno == %d (%s)\n", errno, strerror(errno));
                     LOGEXIT("vfwprintf returns int -1\n");
                     PERF_EXIT(vfwprintf);
-                    InternalFree(TempWideBuffer);
+                    free(TempWideBuffer);
                     if(TempSprintfStrPtr)
                     {
-                        InternalFree(TempSprintfStrPtr);
+                        free(TempSprintfStrPtr);
                     }
                     va_end(ap);
                     return -1;
                 }
                 if(TempSprintfStrPtr)
                 {
-                    InternalFree(TempSprintfStrPtr);
+                    free(TempSprintfStrPtr);
                 }
-                InternalFree(TempWideBuffer);
+                free(TempWideBuffer);
             }
         }
         else
@@ -1669,7 +1669,7 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
                     {
                         ASSERT("WideCharToMultiByte failed.  Error is %d\n",
                               GetLastError());
-                        InternalFree(TempStr);
+                        free(TempStr);
                         va_end(ap);
                         return -1;
                     }
@@ -1685,7 +1685,7 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
                     {               
                         ASSERT("WideCharToMultiByte failed.  Error is %d\n",
                               GetLastError());
-                        InternalFree(TempStr);
+                        free(TempStr);
                         va_end(ap);
                         return -1;
                     }
@@ -1699,7 +1699,7 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
                                                    Width - Length,
                                                    Flags);
 
-                InternalFree(TempStr);
+                free(TempStr);
             }
             else if (Prefix == PFF_PREFIX_LONG && Type == PFF_TYPE_CHAR)
             {
@@ -1986,7 +1986,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                     pthrCurrent->SetLastError(ERROR_NOT_ENOUGH_MEMORY);
                     if (needToFree)
                     {
-                        InternalFree(TempWStr);
+                        free(TempWStr);
                     }
                     va_end(ap);
                     return -1;
@@ -2004,9 +2004,9 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                         ERROR("CoreWvsnprintf failed\n");
                         if (needToFree)
                         {
-                            InternalFree(TempWStr);
+                            free(TempWStr);
                         }
-                        InternalFree(WorkingWStr);
+                        free(WorkingWStr);
                         LOGEXIT("wcsncpy_s failed!\n");
                         PERF_EXIT(wvsnprintf);
                         va_end(ap);
@@ -2030,9 +2030,9 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
 
                 if (needToFree)
                 {
-                    InternalFree(TempWStr);
+                    free(TempWStr);
                 }
-                InternalFree(WorkingWStr);
+                free(WorkingWStr);
             }
             else if (Prefix == PFF_PREFIX_LONG && Type == PFF_TYPE_CHAR)
             {
@@ -2159,7 +2159,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                     if (strncpy_s(TempNumberBuffer, TempCount+1, (LPSTR) BufferPtr, TempCount) != SAFECRT_SUCCESS)
                     {
                         ASSERT("strncpy_s failed!\n");
-                        InternalFree(TempNumberBuffer);
+                        free(TempNumberBuffer);
                         va_end(ap);
                         return -1;
                     }
@@ -2172,7 +2172,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                     {                 
                         ASSERT("MultiByteToWideChar failed.  Error is %d\n",
                               GetLastError());
-                        InternalFree(TempNumberBuffer);
+                        free(TempNumberBuffer);
                         va_end(ap);
                         return -1;
                     }
@@ -2193,7 +2193,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                     if (strncpy_s(TempNumberBuffer, TempInt+1, (LPSTR) BufferPtr, TempInt) != SAFECRT_SUCCESS)
                     {
                         ASSERT("strncpy_s failed!\n");
-                        InternalFree(TempNumberBuffer); 
+                        free(TempNumberBuffer); 
                         va_end(ap);
                         return -1;
                     }
@@ -2206,13 +2206,13 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                     {          
                         ASSERT("MultiByteToWideChar failed.  Error is %d\n",
                               GetLastError());
-                        InternalFree(TempNumberBuffer); 
+                        free(TempNumberBuffer); 
                         va_end(ap);
                         return -1;
                     }
                     BufferPtr += TempInt;
                 }
-                InternalFree(TempNumberBuffer);
+                free(TempNumberBuffer);
             }
         }
         else
@@ -2326,7 +2326,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                     {
                         ASSERT("WideCharToMultiByte failed.  Error is %d\n",
                               GetLastError());
-                        InternalFree(TempStr);
+                        free(TempStr);
                         PERF_EXIT(vfprintf);
                         va_end(ap);
                         return -1;
@@ -2343,7 +2343,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                     {
                         ASSERT("WideCharToMultiByte failed.  Error is %d\n",
                               GetLastError());
-                        InternalFree(TempStr);
+                        free(TempStr);
                         PERF_EXIT(vfprintf);
                         va_end(ap);
                         return -1;
@@ -2358,14 +2358,14 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                 if (-1 == paddingReturnValue)
                 {
                     ERROR("Internal_AddPaddingVfprintf failed\n");
-                    InternalFree(TempStr);
+                    free(TempStr);
                     PERF_EXIT(vfprintf);  
                     va_end(ap);
                     return -1;
                 }
                 written += paddingReturnValue;
 
-                InternalFree(TempStr);
+                free(TempStr);
             }
             else if (Prefix == PFF_PREFIX_LONG && Type == PFF_TYPE_CHAR)
             {

--- a/src/pal/src/debug/debug.cpp
+++ b/src/pal/src/debug/debug.cpp
@@ -236,12 +236,12 @@ OutputDebugStringW(
     {
         ASSERT("failed to convert wide chars to multibytes\n");
         SetLastError(ERROR_INTERNAL_ERROR);
-        InternalFree(lpOutputStringA);
+        free(lpOutputStringA);
         goto EXIT;
     }
     
     OutputDebugStringA(lpOutputStringA);
-    InternalFree(lpOutputStringA);
+    free(lpOutputStringA);
 
 EXIT:
     LOGEXIT("OutputDebugStringW returns\n");
@@ -388,7 +388,7 @@ DebugBreakCommand()
             goto FAILED;
         }
 
-        InternalFree(command_string);
+        free(command_string);
         return 1;
     }
 
@@ -397,7 +397,7 @@ DebugBreakCommand()
 FAILED:
     if (command_string)
     {
-        InternalFree(command_string);
+        free(command_string);
     }
 
     fprintf (stderr, "Failed to execute command: '%s'\n", command_string);
@@ -1519,7 +1519,7 @@ PROCFSCLEANUP:
 CLEANUP2:
     if (lpTmpBuffer) 
     {
-        InternalFree(lpTmpBuffer);
+        free(lpTmpBuffer);
     }
 #endif  // !HAVE_TTRACE
 
@@ -1816,7 +1816,7 @@ PROCFSCLEANUP:
 CLEANUP2:
     if (lpTmpBuffer) 
     {
-        InternalFree(lpTmpBuffer);
+        free(lpTmpBuffer);
     }
 #endif  // !HAVE_TTRACE
 

--- a/src/pal/src/exception/machexception.cpp
+++ b/src/pal/src/exception/machexception.cpp
@@ -177,7 +177,7 @@ GetExceptionMask()
         if (exceptionSettings)
         {
             exMode = (MachExceptionMode)atoi(exceptionSettings);
-            InternalFree(exceptionSettings);
+            free(exceptionSettings);
         }
         else
         {

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -203,7 +203,7 @@ void FILEGetProperNotFoundError( LPCSTR lpPath, LPDWORD lpErrorCode )
         *lpErrorCode = ERROR_FILE_NOT_FOUND;
     }
     
-    InternalFree(lpDupedPath);
+    free(lpDupedPath);
     lpDupedPath = NULL;
     TRACE( "FILEGetProperNotFoundError returning TRUE\n" );
     return;
@@ -3598,7 +3598,7 @@ GetTempFileNameW(
         path_size = MultiByteToWideChar( CP_ACP, 0, tempfile_name, -1, 
                                            lpTempFileName, MAX_LONGPATH );
 
-        InternalFree(tempfile_name);
+        free(tempfile_name);
         tempfile_name = NULL;
         if (!path_size)
         {
@@ -3814,7 +3814,7 @@ CopyFileA(
         goto done;
     }
 
-    InternalFree(lpUnixPath);
+    free(lpUnixPath);
     lpUnixPath = strdup(lpNewFileName);
     if ( lpUnixPath == NULL )
     {
@@ -3877,7 +3877,7 @@ done:
     }
     if (lpUnixPath) 
     {
-        InternalFree(lpUnixPath);
+        free(lpUnixPath);
     }
 
     LOGEXIT("CopyFileA returns BOOL %d\n", bGood);
@@ -4004,7 +4004,7 @@ done:
         pThread->SetLastError(dwLastError);
     }
     
-    InternalFree(unixFileName);
+    free(unixFileName);
 
     LOGEXIT("SetFileAttributesA returns BOOL %d\n", bRet);
     PERF_EXIT(SetFileAttributesA);

--- a/src/pal/src/file/find.cpp
+++ b/src/pal/src/file/find.cpp
@@ -201,7 +201,7 @@ FindFirstFileA(
                     }
                 }
             }
-            InternalFree(lpTemp);
+            free(lpTemp);
             lpTemp = NULL;
             goto done;
         }
@@ -226,7 +226,7 @@ done:
             {
                 globfree( &(find_data->gGlob) );
             }
-            InternalFree(find_data);
+            free(find_data);
         }
         if (dwLastError)
         {
@@ -571,7 +571,7 @@ FindClose(
     {
         globfree( &(find_data->gGlob) );
     }
-    InternalFree(find_data);
+    free(find_data);
 
 done:
     if (dwLastError)

--- a/src/pal/src/include/pal/handlemgr.hpp
+++ b/src/pal/src/include/pal/handlemgr.hpp
@@ -105,7 +105,7 @@ namespace CorUnix
 
             if (NULL != m_rghteHandleTable)
             {
-                InternalFree(m_rghteHandleTable);
+                free(m_rghteHandleTable);
             }
         }
 

--- a/src/pal/src/include/pal/malloc.hpp
+++ b/src/pal/src/include/pal/malloc.hpp
@@ -70,11 +70,6 @@ namespace CorUnix{
         size_t szSize
         );
 
-    void
-    InternalFree(
-        void *pvMem
-        );
-
     // Define common code for "new" style allocators below.
 #define INTERNAL_NEW_COMMON()                    \
         T *pMem = (T*)InternalMalloc(sizeof(T)); \
@@ -137,7 +132,7 @@ namespace CorUnix{
         if (p)
         {
             p->~T();
-            InternalFree(p);
+            free(p);
         }
     }
 
@@ -149,7 +144,7 @@ namespace CorUnix{
             size_t cElements = *pRealMem;
             for (size_t i = 0; i < cElements; i++)
                 p[i].~T();
-            InternalFree(pRealMem);
+            free(pRealMem);
         }
     }
 }

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -571,9 +571,9 @@ CLEANUP6:
 CLEANUP5:
     PROCCleanupInitialProcess();
 CLEANUP2:
-    InternalFree(exe_path);
+    free(exe_path);
 CLEANUP1e:
-    InternalFree(command_line);
+    free(command_line);
 CLEANUP1d:
     // Cleanup synchronization manager
 CLEANUP1c:
@@ -1111,7 +1111,7 @@ static LPWSTR INIT_FormatCommandLine (int argc, const char * const *argv)
     if (i == 0)
     {
         ASSERT("MultiByteToWideChar failure\n");
-        InternalFree(command_line);
+        free(command_line);
         return NULL;
     }
 
@@ -1119,20 +1119,20 @@ static LPWSTR INIT_FormatCommandLine (int argc, const char * const *argv)
     if(retval == NULL)
     {
         ERROR("can't allocate memory for Unicode command line!\n");
-        InternalFree(command_line);
+        free(command_line);
         return NULL;
     }
 
     if(!MultiByteToWideChar(CP_ACP, 0,command_line, i, retval, i))
     {
         ASSERT("MultiByteToWideChar failure\n");
-        InternalFree(retval);
+        free(retval);
         retval = NULL;
     }
     else
         TRACE("Command line is %s\n", command_line);
 
-    InternalFree(command_line);
+    free(command_line);
     return retval;
 }
 
@@ -1206,7 +1206,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
                                         return_value, return_size))
                 {
                     ASSERT("MultiByteToWideChar failure\n");
-                    InternalFree(return_value);
+                    free(return_value);
                     return_value = NULL;
                 }
                 else
@@ -1226,7 +1226,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
         WARN("$PATH isn't set.\n");
         if (env_path != NULL)
         {
-            InternalFree(env_path);
+            free(env_path);
         }
 
         goto last_resort;
@@ -1281,8 +1281,8 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
         if (strcpy_s(full_path, iLength, cur_dir) != SAFECRT_SUCCESS)
         {
             ERROR("strcpy_s failed!\n");
-            InternalFree(full_path);
-            InternalFree(env_path);
+            free(full_path);
+            free(env_path);
             return NULL;
         }
 
@@ -1291,8 +1291,8 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
             if (strcat_s(full_path, iLength, "/") != SAFECRT_SUCCESS)
             {
                 ERROR("strcat_s failed!\n");
-                InternalFree(full_path);
-                InternalFree(env_path);
+                free(full_path);
+                free(env_path);
                 return NULL;
             }
         }
@@ -1300,8 +1300,8 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
         if (strcat_s(full_path, iLength, exe_name) != SAFECRT_SUCCESS)
         {
             ERROR("strcat_s failed!\n");
-            InternalFree(full_path);
-            InternalFree(env_path);
+            free(full_path);
+            free(env_path);
             return NULL;
         }
 
@@ -1314,17 +1314,17 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
                 if (!CorUnix::RealPathHelper(full_path, real_path))
                 {
                     ERROR("realpath() failed!\n");
-                    InternalFree(full_path);
-                    InternalFree(env_path);
+                    free(full_path);
+                    free(env_path);
                     return NULL;
                 }
-                InternalFree(full_path);
+                free(full_path);
 
                 return_size = MultiByteToWideChar(CP_ACP,0,real_path,-1,NULL,0);
                 if ( 0 == return_size )
                 {
                     ASSERT("MultiByteToWideChar failure\n");
-                    InternalFree(env_path);
+                    free(env_path);
                     return NULL;
                 }
 
@@ -1332,7 +1332,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
                 if ( NULL == return_value )
                 {
                     ERROR("Not enough memory to create full path\n");
-                    InternalFree(env_path);
+                    free(env_path);
                     return NULL;
                 }
 
@@ -1340,7 +1340,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
                                     return_size))
                 {
                     ASSERT("MultiByteToWideChar failure\n");
-                    InternalFree(return_value);
+                    free(return_value);
                     return_value = NULL;
                 }
                 else
@@ -1349,19 +1349,19 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
                           cur_dir,real_path.GetString());
                 }
 
-                InternalFree(env_path);
+                free(env_path);
                 return return_value;
             }
         }
 
         /* file doesn't exist : keep searching */
-        InternalFree(full_path);
+        free(full_path);
 
         /* path_ptr is NULL if there's no ':' after this directory */
         cur_dir=path_ptr;
     }
 
-    InternalFree(env_path);
+    free(env_path);
     TRACE("No %s found in $PATH (%s)\n", exe_name, EnvironGetenv("PATH", FALSE));
 
 last_resort:
@@ -1396,7 +1396,7 @@ last_resort:
                                         return_value, return_size))
                 {
                     ASSERT("MultiByteToWideChar failure\n");
-                    InternalFree(return_value);
+                    free(return_value);
                     return_value = NULL;
                 }
                 else
@@ -1464,7 +1464,7 @@ last_resort:
                                 return_value, return_size))
         {
             ASSERT("MultiByteToWideChar failure\n");
-            InternalFree(return_value);
+            free(return_value);
             return_value = NULL;
         }
         else

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -189,7 +189,7 @@ LoadLibraryExA(
  Done:
     if (lpstr != nullptr)
     {
-        InternalFree(lpstr);
+        free(lpstr);
     }
 
     LOGEXIT("LoadLibraryExA returns HMODULE %p\n", hModule);
@@ -754,7 +754,7 @@ PAL_LOADLoadPEFile(HANDLE hFile)
                 loadedBase = MAPMapPEFile(hFile); // load it again
             }
 
-            InternalFree(envVar);
+            free(envVar);
         }
     }
 #endif // _DEBUG
@@ -908,7 +908,7 @@ BOOL LOADSetExeName(LPWSTR name)
     LockModuleList();
 
     // Save the exe path in the exe module struct
-    InternalFree(exe_module.lib_name);
+    free(exe_module.lib_name);
     exe_module.lib_name = name;
 
     // For platforms where we can't trust the handle to be constant, we need to 
@@ -939,7 +939,7 @@ BOOL LOADSetExeName(LPWSTR name)
 exit:
     if (pszExeName)
     {
-        InternalFree(pszExeName);
+        free(pszExeName);
     }
 #endif
     UnlockModuleList();
@@ -1111,8 +1111,8 @@ static BOOL LOADFreeLibrary(MODSTRUCT *module, BOOL fCallDllMain)
     }
 
     /* release all memory */
-    InternalFree(module->lib_name);
-    InternalFree(module);
+    free(module->lib_name);
+    free(module);
 
     retval = TRUE;
 
@@ -1423,7 +1423,7 @@ static MODSTRUCT *LOADAllocModule(void *dl_handle, LPCSTR name)
     if (nullptr == wide_name)
     {
         ERROR("couldn't convert name to a wide-character string\n");
-        InternalFree(module);
+        free(module);
         return nullptr;
     }
 

--- a/src/pal/src/loader/modulename.cpp
+++ b/src/pal/src/loader/modulename.cpp
@@ -82,7 +82,7 @@ int GetLibRotorNameViaLoadQuery(LPSTR pszBuf)
         iLQRetVal = loadquery(L_GETINFO, pLoadQueryBuf, cbBuf);
         if (iLQRetVal < 0)
         {
-            InternalFree(pThread, pLoadQueryBuf);
+            free(pThread, pLoadQueryBuf);
             pLoadQueryBuf = NULL;
             DWORD dwLastError = GetLastError();
             if (dwLastError == ERROR_NOT_ENOUGH_MEMORY)
@@ -137,7 +137,7 @@ int GetLibRotorNameViaLoadQuery(LPSTR pszBuf)
     }
 Done:
     if (pLoadQueryBuf)
-        InternalFree(pThread, pLoadQueryBuf);
+        free(pThread, pLoadQueryBuf);
     return iRetVal;
 }
 #endif // defined(_AIX)

--- a/src/pal/src/map/map.cpp
+++ b/src/pal/src/map/map.cpp
@@ -1345,7 +1345,7 @@ CorUnix::InternalMapViewOfFile(
                         ERROR( "Failed setting protections on reused mapping\n");
 
                         NativeMapHolderRelease(pThread, pReusedMapping->pNMHolder);
-                        InternalFree(pReusedMapping);
+                        free(pReusedMapping);
                         pReusedMapping = NULL;
                     }
                 }
@@ -1422,7 +1422,7 @@ CorUnix::InternalMapViewOfFile(
             {
                 pNewView->pFileMapping->ReleaseReference(pThread);
                 RemoveEntryList(&pNewView->Link);
-                InternalFree(pNewView);
+                free(pNewView);
                 palError = ERROR_INTERNAL_ERROR;
             }
 #endif // ONE_SHARED_MAPPING_PER_FILEREGION_PER_PROCESS
@@ -1507,7 +1507,7 @@ CorUnix::InternalUnmapViewOfFile(
 
     RemoveEntryList(&pView->Link);
     pMappingObject = pView->pFileMapping;
-    InternalFree(pView);
+    free(pView);
     
 InternalUnmapViewOfFileExit:
 
@@ -2168,7 +2168,7 @@ static LONG NativeMapHolderRelease(CPalThread *pThread, NativeMapHolder * thisNM
             TRACE( "Successfully unmapped %p (size=%lu)\n", 
                    thisNMH->address, (unsigned long)thisNMH->size);
         }
-        InternalFree (thisNMH);
+        free (thisNMH);
     }
     else if (ret < 0)
     {
@@ -2407,7 +2407,7 @@ void * MAPMapPEFile(HANDLE hFile)
             TRACE_(LOADER)("Forcing rebase of image\n");
         }
 
-        InternalFree(envVar);
+        free(envVar);
     }
 
     void * pForceRelocBase;
@@ -2741,7 +2741,7 @@ BOOL MAPUnmapPEFile(LPCVOID lpAddress)
         {
             pFileObject->ReleaseReference(pThread);
         }
-        InternalFree(pView); // this leaves pLink dangling
+        free(pView); // this leaves pLink dangling
     }
 
     TRACE_(LOADER)("MAPUnmapPEFile returning %d\n", retval);

--- a/src/pal/src/map/virtual.cpp
+++ b/src/pal/src/map/virtual.cpp
@@ -194,11 +194,11 @@ void VIRTUALCleanup()
     {
         WARN( "The memory at %d was not freed through a call to VirtualFree.\n",
               pEntry->startBoundary );
-        InternalFree(pEntry->pAllocState);
-        InternalFree(pEntry->pProtectionState );
+        free(pEntry->pAllocState);
+        free(pEntry->pProtectionState );
         pTempEntry = pEntry;
         pEntry = pEntry->pNext;
-        InternalFree(pTempEntry );
+        free(pTempEntry );
     }
     pVirtualMemory = NULL;
 
@@ -533,13 +533,13 @@ static BOOL VIRTUALReleaseMemory( PCMI pMemoryToBeReleased )
         }
     }
 
-    InternalFree( pMemoryToBeReleased->pAllocState );
+    free( pMemoryToBeReleased->pAllocState );
     pMemoryToBeReleased->pAllocState = NULL;
 
-    InternalFree( pMemoryToBeReleased->pProtectionState );
+    free( pMemoryToBeReleased->pProtectionState );
     pMemoryToBeReleased->pProtectionState = NULL;
 
-    InternalFree( pMemoryToBeReleased );
+    free( pMemoryToBeReleased );
     pMemoryToBeReleased = NULL;
 
     return bRetVal;
@@ -753,13 +753,13 @@ static BOOL VIRTUALStoreAllocationInfo(
     {
         ERROR( "Unable to allocate memory for the structure.\n");
 
-        if (pNewEntry->pProtectionState) InternalFree(pNewEntry->pProtectionState);
+        if (pNewEntry->pProtectionState) free(pNewEntry->pProtectionState);
         pNewEntry->pProtectionState = nullptr;
 
-        if (pNewEntry->pAllocState) InternalFree(pNewEntry->pAllocState);
+        if (pNewEntry->pAllocState) free(pNewEntry->pAllocState);
         pNewEntry->pAllocState = nullptr;
 
-        InternalFree(pNewEntry);
+        free(pNewEntry);
         pNewEntry = nullptr;
 
         return FALSE;

--- a/src/pal/src/memory/heap.cpp
+++ b/src/pal/src/memory/heap.cpp
@@ -285,7 +285,6 @@ HeapFree(
 
     bRetVal = TRUE;
 #ifdef __APPLE__
-    // This is patterned off of InternalFree in malloc.cpp.
     {
         malloc_zone_free((malloc_zone_t *)hHeap, lpMem);
     }

--- a/src/pal/src/misc/dbgmsg.cpp
+++ b/src/pal/src/misc/dbgmsg.cpp
@@ -837,7 +837,7 @@ bool DBG_ShouldCheckStackAlignment()
 
         if (checkAlignmentSettings && shouldFreeCheckAlignmentSettings)
         {
-            InternalFree(checkAlignmentSettings);
+            free(checkAlignmentSettings);
         }
     }
     
@@ -880,7 +880,7 @@ void PAL_DisplayDialog(const char *szTitle, const char *szText)
         if (displayDialog)
         {
             int i = atoi(displayDialog);
-            InternalFree(displayDialog);
+            free(displayDialog);
 
             switch (i)
             {

--- a/src/pal/src/misc/environ.cpp
+++ b/src/pal/src/misc/environ.cpp
@@ -749,7 +749,7 @@ void EnvironUnsetenv(const char *name)
             if (memcmp(name, palEnvironment[i], nameLength) == 0)
             {
                 // Free the string we're removing.
-                InternalFree(palEnvironment[i]);
+                free(palEnvironment[i]);
 
                 // Move the last environment variable pointer here.
                 palEnvironment[i] = palEnvironment[palEnvironmentCount - 1];
@@ -818,7 +818,7 @@ BOOL EnvironPutenv(const char* entry, BOOL deleteIfEmpty)
         copy[nameLength] = '\0';
 
         EnvironUnsetenv(copy);
-        InternalFree(copy);
+        free(copy);
 
         result = TRUE;
     }
@@ -845,7 +845,7 @@ BOOL EnvironPutenv(const char* entry, BOOL deleteIfEmpty)
             {
                 if (memcmp(entry, palEnvironment[i], nameLength) == 0)
                 {
-                    InternalFree(palEnvironment[i]);
+                    free(palEnvironment[i]);
                     palEnvironment[i] = copy;
 
                     result = TRUE;
@@ -864,7 +864,7 @@ BOOL EnvironPutenv(const char* entry, BOOL deleteIfEmpty)
                 int resizeRet = ResizeEnvironment(palEnvironmentCapacity * 2);
                 if (resizeRet != TRUE)
                 {
-                    InternalFree(copy);
+                    free(copy);
                     goto done;
                 }
             }

--- a/src/pal/src/misc/strutil.cpp
+++ b/src/pal/src/misc/strutil.cpp
@@ -92,5 +92,5 @@ void
 CPalString::FreeBuffer()
 {
     _ASSERTE(NULL != m_pwsz);
-    InternalFree(const_cast<WCHAR*>(m_pwsz));
+    free(const_cast<WCHAR*>(m_pwsz));
 }

--- a/src/pal/src/objmgr/palobjbase.cpp
+++ b/src/pal/src/objmgr/palobjbase.cpp
@@ -341,12 +341,12 @@ CPalObjectBase::~CPalObjectBase()
 
     if (NULL != m_pvImmutableData)
     {
-        InternalFree(m_pvImmutableData);
+        free(m_pvImmutableData);
     }
 
     if (NULL != m_pvLocalData)
     {
-        InternalFree(m_pvLocalData);
+        free(m_pvLocalData);
     }
 
     if (NULL != m_oa.sObjectName.GetString())

--- a/src/pal/src/objmgr/shmobject.cpp
+++ b/src/pal/src/objmgr/shmobject.cpp
@@ -508,7 +508,7 @@ CSharedMemoryObject::PromoteSharedData(
             m_pot->GetSharedDataSize()
             );
         
-        InternalFree(m_pvSharedData);
+        free(m_pvSharedData);
         m_pvSharedData = pvSharedData;
     }
 
@@ -869,7 +869,7 @@ CSharedMemoryObject::~CSharedMemoryObject()
 
     if (NULL != m_pvSharedData && ProcessLocalObject == m_ObjectDomain)
     {
-        InternalFree(m_pvSharedData);
+        free(m_pvSharedData);
     }
     else if (SHMNULL != m_shmod && m_fDeleteSharedData)
     {

--- a/src/pal/src/sharedmemory/sharedmemory.cpp
+++ b/src/pal/src/sharedmemory/sharedmemory.cpp
@@ -38,7 +38,7 @@ AutoFreeBuffer::~AutoFreeBuffer()
 {
     if (!m_cancel && m_buffer != nullptr)
     {
-        InternalFree(m_buffer);
+        free(m_buffer);
     }
 }
 

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -394,9 +394,9 @@ CreateProcessA(
         lpProcessInformation
         );
 done:
-    InternalFree(ApplicationNameW);
-    InternalFree(CommandLineW);
-    InternalFree(CurrentDirectoryW);
+    free(ApplicationNameW);
+    free(CommandLineW);
+    free(CurrentDirectoryW);
 
     if (NO_ERROR != palError)
     {
@@ -1091,7 +1091,7 @@ InternalCreateProcessExit:
 
     if (EnvironmentArray)
     {
-        InternalFree(EnvironmentArray);
+        free(EnvironmentArray);
     }
 
     /* if we still have the file structures at this point, it means we 
@@ -1131,8 +1131,8 @@ InternalCreateProcessExit:
     /* free allocated memory */
     if (lppArgv)
     {
-        InternalFree(*lppArgv);
-        InternalFree(lppArgv);
+        free(*lppArgv);
+        free(lppArgv);
     }
 
     return palError;
@@ -2832,7 +2832,7 @@ DestroyProcessModules(IN ProcessModules *listHead)
     for (ProcessModules *entry = listHead; entry != NULL; )
     {
         ProcessModules *next = entry->Next;
-        InternalFree(entry);
+        free(entry);
         entry = next;
     }
 }
@@ -3086,18 +3086,18 @@ CorUnix::InitializeProcessCommandLine(
         if (wcscpy_s(initial_dir, iLen, lpwstrFullPath) != SAFECRT_SUCCESS)
         {
             ERROR("wcscpy_s failed!\n");
-            InternalFree(initial_dir);
+            free(initial_dir);
             palError = ERROR_INTERNAL_ERROR;
             goto exit;
         }
 
         lpwstr[0] = '/';
 
-        InternalFree(g_lpwstrAppDir);
+        free(g_lpwstrAppDir);
         g_lpwstrAppDir = initial_dir;
     }
 
-    InternalFree(g_lpwstrCmdLine);
+    free(g_lpwstrCmdLine);
     g_lpwstrCmdLine = lpwstrCmdLine;
 
 exit:
@@ -3243,12 +3243,12 @@ PROCCleanupInitialProcess(VOID)
     CPalThread *pThread = InternalGetCurrentThread();
 
     InternalEnterCriticalSection(pThread, &g_csProcess);
-    
+
     /* Free the application directory */
-    InternalFree(g_lpwstrAppDir);
-    
+    free(g_lpwstrAppDir);
+
     /* Free the stored command line */
-    InternalFree(g_lpwstrCmdLine);
+    free(g_lpwstrCmdLine);
 
     InternalLeaveCriticalSection(pThread, &g_csProcess);
 
@@ -4290,7 +4290,7 @@ buildArgv(
                                  pChar, iWlen+1, NULL, NULL))
         {
             ASSERT("Unable to convert to a multibyte string\n");
-            InternalFree(lpAsciiCmdLine);
+            free(lpAsciiCmdLine);
             return NULL;
         }
     }
@@ -4378,7 +4378,7 @@ buildArgv(
 
     if (lppArgv == NULL)
     {
-        InternalFree(lpAsciiCmdLine);
+        free(lpAsciiCmdLine);
         return NULL;
     }
 
@@ -4569,7 +4569,7 @@ getPath(
 
         if (!lpPathFileName.Reserve(nextLen + lpFileNameString.GetCount() + 1))
         {
-            InternalFree(lpPath);
+            free(lpPath);
             ERROR("StackString ran out of memory for full path\n");
             return FALSE;
         }
@@ -4587,14 +4587,14 @@ getPath(
         if ( access (lpPathFileName, F_OK) == 0)
         {
             TRACE("Found %s in $PATH element %s\n", lpFileName, lpNext);
-            InternalFree(lpPath);
+            free(lpPath);
             return TRUE;
         }
 
         lpNext = lpCurrent;  /* search in the next directory */
     }
 
-    InternalFree(lpPath);
+    free(lpPath);
     TRACE("File %s not found in $PATH\n", lpFileName);
     return FALSE;
 }

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -1780,7 +1780,7 @@ CorUnix::InitializeGlobalThreadData(
             CPalThread::s_dwDefaultThreadStackSize = dw;
         }
 
-        InternalFree(pszStackSize);
+        free(pszStackSize);
     }
 
     return palError;


### PR DESCRIPTION
I noticed while working in the virtual memory code that `InternalFree` still exists, but is just a wrapper around `free`. This change removes it and updates the PAL code that was using it to just use `free`.

I left `InternalMalloc` alone since it has a bit of extra logic to handle the case where the size requested is 0 (it changes the size to 1 since `malloc(0)` might return null).

@sergiy-k PTAL