### PR TITLE
Optimize bounds checks with correct assertion set

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -844,6 +844,8 @@ public:
 
     #define GTF_NO_OP_NO        0x80000000  // GT_NO_OP   --Have the codegenerator generate a special nop
 
+    #define GTF_ARR_BOUND_INBND 0x80000000  // GT_ARR_BOUNDS_CHECK -- have proved this check is always in-bounds
+
     //----------------------------------------------------------------
 
     #define GTF_STMT_CMPADD     0x80000000  // GT_STMT    -- added by compiler

--- a/tests/src/JIT/Regression/JitBlue/GitHub_6318/GitHub_6318.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_6318/GitHub_6318.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Runtime.CompilerServices;
+using System.Numerics;
+
+namespace N
+{
+    public static class C
+    {
+        public static int Main(string[] args)
+        {
+            // Regression test for an issue with assertion prop leading
+            // to the wrong exception being thrown from Vector<T>.CopyTo
+            try
+            {
+                Foo(Vector<int>.Zero);
+            }
+            catch (System.ArgumentOutOfRangeException)
+            {
+                // Caught the right exception
+                return 100;
+            }
+            catch
+            {
+                // Caught the wrong exception
+                return -1;
+            }
+            // Caught no exception
+            return -2;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int Foo(Vector<int> vec)
+        {
+            int[] a = new int[5];
+            // The index [5] is outside the bounds of array 'a',
+            // so this should throw ArgumentOutOfRangeException.
+            // There's a subsequent check for whether the destination
+            // has enough space to receive the vector, which would
+            // raise an ArgumentException; the bug was that assertion
+            // prop was using the later exception check to prove the
+            // prior one "redundant" because the commas confused the
+            // ordering.
+            vec.CopyTo(a, 5);
+            return a[0];
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_6318/GitHub_6318.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_6318/GitHub_6318.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{80B4796D-0D4C-46A3-9185-6EEA11DD4090}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)threading+thread\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)threading+thread\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)threading+thread\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_6318/app.config
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_6318/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Assertion prop defers removing redundant bounds checks until processing
the parent comma, because the rewrite involves the comma as well.  The
code currently has a bug in that its checks for whether the bounds check
is redundant also occurs when processing reaches the comma, which is wrong
because the assertion set may then include assertions generated by the RHS
of the comma (there is code to compensate for the assertion generated by
the bounds check itself, which is the LHS of the comma, but no compensation
for the RHS).

This change moves the analysis of whether bounds checks are redundant to
the proper spot in the processing order, and delays only the rewrite to
the processing of the comma; the redundancy of the bounds check is
communicated by updating its throw kind flag to None.

The 'throw kind == None' range checks can sometimes persist to lowering,
because upstream optimization may have moved/removed the check's parent
comma (e.g. this happens in one of the JIT Methodical IL tests, where the
RHS of the comma is a NOP that gets removed).  This change updates the
lowering to handle such checks, inserting a failfast on the failure path,
though of course it will be preferable in the future to
revisit/codify/enforce our canonical form for range checks (as LHS of
commas), and/or to update our optimizations to either handle removing
range checks that aren't children of commas or maintain the parent node
context when optimizing them.

Fixes #6318.

@dotnet/jit-contrib PTAL.  Diffs are minimal; nothing in frameworks assemblies, and SuperPMI just turns up three tests where a couple bounds-checks are left in due to the bugfix (i.e. removing them was unsound) and a couple bounds-checks are proven in-bounds but not in the canonical comma form and so an extra (unreachable) call to failfast gets emitted.