### PR TITLE
Change warning to error for future test asset framework issues

### DIFF
--- a/tests/publishdependency.targets
+++ b/tests/publishdependency.targets
@@ -29,7 +29,7 @@
 
     <!-- This will use the overridden PrereleaseResolveNuGetPackageAssets, which outputs copy local items
          for the xunit wrapper projects -->
-    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
+    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="false"
                                          IncludeFrameworkReferences="false"
                                          NuGetPackagesDirectory="$(PackagesDir)"
                                          RuntimeIdentifier="$(TestNugetRuntimeId)"


### PR DESCRIPTION
Changes the type of warning seen in https://github.com/dotnet/coreclr/issues/6022 into an error so it won't get reintroduced. The warnings were fixed in https://github.com/dotnet/coreclr/pull/6479 by upgrading to `netcoreapp1.0`.

I wouldn't say this is a fix for https://github.com/dotnet/coreclr/issues/5784, because there are still other warnings. (But it's a step.)

/cc @RussKeldorph @ericstj