### PR TITLE
[SOS][Linux] Change int return values to BOOL for coreclr delegates

### DIFF
--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -2356,10 +2356,10 @@ private:
 #endif // !FEATURE_PAL
 
 #ifdef FEATURE_PAL
-typedef  int (*ResolveSequencePointDelegate)(const char*, const char*, unsigned int, unsigned int*, unsigned int*);
-typedef  int (*LoadSymbolsForModuleDelegate)(const char*);
-typedef  int (*GetLocalVariableName)(const char*, int, int, BSTR*);
-typedef  int (*GetLineByILOffsetDelegate)(const char*, mdMethodDef, ULONG64, ULONG *, BSTR*);
+typedef  BOOL (*ResolveSequencePointDelegate)(const char*, const char*, unsigned int, unsigned int*, unsigned int*);
+typedef  BOOL (*LoadSymbolsForModuleDelegate)(const char*);
+typedef  BOOL (*GetLocalVariableName)(const char*, int, int, BSTR*);
+typedef  BOOL (*GetLineByILOffsetDelegate)(const char*, mdMethodDef, ULONG64, ULONG *, BSTR*);
 static const char *SymbolReaderDllName = "System.Diagnostics.Debug.SymbolReader";
 static const char *SymbolReaderClassName = "System.Diagnostics.Debug.SymbolReader.SymbolReader";
 #endif //FEATURE_PAL

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -110,7 +110,7 @@ GetDebugInfoFromPDB(MethodDesc* MethodDescPtr, SymbolsInfo** symInfo, unsigned i
         return E_OUTOFMEMORY;
     methodDebugInfo->size = numMap;
 
-    if (!getInfoForMethodDelegate(szModName, MethodDescPtr->GetMemberDef(), *methodDebugInfo))
+    if (getInfoForMethodDelegate(szModName, MethodDescPtr->GetMemberDef(), *methodDebugInfo) == FALSE)
         return E_FAIL;
 
     symInfoLen = methodDebugInfo->size;

--- a/src/vm/gdbjithelpers.h
+++ b/src/vm/gdbjithelpers.h
@@ -25,7 +25,7 @@ struct MethodDebugInfo
     int size;
 };
 
-typedef int (*GetInfoForMethodDelegate)(const char*, unsigned int, MethodDebugInfo& methodDebugInfo);
+typedef BOOL (*GetInfoForMethodDelegate)(const char*, unsigned int, MethodDebugInfo& methodDebugInfo);
 extern GetInfoForMethodDelegate getInfoForMethodDelegate;
 
 #endif // !__GDBJITHELPERS_H__


### PR DESCRIPTION
This pull request changes return value of coreclr delegates from `int` to `BOOL` for correct marshaling to managed code. This changes were proposed by @jkotas in PR: https://github.com/dotnet/corefx/pull/10145
@jkotas @mikem8361 PTAL
CC @Dmitri-Botcharnikov @chunseoklee 