### PR TITLE
Do not run local var liveness before rationalize.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4442,13 +4442,6 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, CORJIT_F
 #endif
 
 #ifndef LEGACY_BACKEND
-    // TODO-CQ: Remove "if-block" when lowering doesn't rely on front end liveness.
-    // Remove "if-block" to repro assert('!"We should never hit any assignment operator in lowering"')
-    // using self_host_tests_amd64\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit1_d.exe
-    if (!fgLocalVarLivenessDone)
-    {
-        fgLocalVarLiveness();
-    }
     // rationalize trees
     Rationalizer rat(this); // PHASE_RATIONALIZE
     rat.Run();

--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -26,13 +26,16 @@ public:
     void PrepareForDecomposition();
     void DecomposeBlock(BasicBlock* block);
 
+    static void DecomposeRange(Compiler* compiler, unsigned blockWeight, LIR::Range& range);
+
 private:
-    inline LIR::Range& BlockRange() const
+    inline LIR::Range& Range() const
     {
-        return LIR::AsRange(m_block);
+        return *m_range;
     }
 
     // Driver functions
+    void DecomposeRangeHelper();
     GenTree* DecomposeNode(LIR::Use& use);
 
     // Per-node type decompose cases
@@ -57,7 +60,8 @@ private:
 
     // Data
     Compiler*   m_compiler;
-    BasicBlock* m_block;
+    unsigned    m_blockWeight;
+    LIR::Range* m_range;
 };
 
 #endif // _DECOMPOSELONGS_H_

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1569,10 +1569,12 @@ LIR::Range LIR::EmptyRange()
 }
 
 //------------------------------------------------------------------------
-// LIR::SeqTree: Given a newly created, unsequenced HIR tree, set the evaluation
-// order (call gtSetEvalOrder) and sequence the tree (set gtNext/gtPrev pointers
-// by calling fgSetTreeSeq), and return a Range representing the list of nodes.
-// It is expected this will later be spliced into the LIR graph.
+// LIR::SeqTree:
+//    Given a newly created, unsequenced HIR tree, set the evaluation
+//    order (call gtSetEvalOrder) and sequence the tree (set gtNext/gtPrev
+//    pointers by calling fgSetTreeSeq), and return a Range representing
+//    the list of nodes. It is expected this will later be spliced into
+//    an LIR range.
 //
 // Arguments:
 //    compiler - The Compiler context.
@@ -1589,4 +1591,51 @@ LIR::Range LIR::SeqTree(Compiler* compiler, GenTree* tree)
 
     compiler->gtSetEvalOrder(tree);
     return Range(compiler->fgSetTreeSeq(tree, nullptr, true), tree);
+}
+
+//------------------------------------------------------------------------
+// LIR::InsertBeforeTerminator:
+//    Insert an LIR range before the terminating instruction in the given
+//    basic block. If the basic block has no terminating instruction (i.e.
+//    it has a jump kind that is not `BBJ_RETURN`, `BBJ_COND`, or
+//    `BBJ_SWITCH`), the range is inserted at the end of the block.
+//
+// Arguments:
+//    block - The block in which to insert the range.
+//    range - The range to insert.
+//
+void LIR::InsertBeforeTerminator(BasicBlock* block, LIR::Range&& range)
+{
+    LIR::Range& blockRange = LIR::AsRange(block);
+
+    GenTree* insertionPoint = nullptr;
+    if ((block->bbJumpKind == BBJ_COND) || (block->bbJumpKind == BBJ_SWITCH) || (block->bbJumpKind == BBJ_RETURN))
+    {
+        insertionPoint = blockRange.LastNode();
+        assert(insertionPoint != nullptr);
+
+#if DEBUG
+        switch (block->bbJumpKind)
+        {
+        case BBJ_COND:
+            assert(insertionPoint->OperGet() == GT_JTRUE);
+            break;
+
+        case BBJ_SWITCH:
+            assert((insertionPoint->OperGet() == GT_SWITCH) || (insertionPoint->OperGet() == GT_SWITCH_TABLE));
+            break;
+
+        case BBJ_RETURN:
+            assert((insertionPoint->OperGet() == GT_RETURN) ||
+                (insertionPoint->OperGet() == GT_JMP) ||
+                (insertionPoint->OperGet() == GT_CALL));
+            break;
+
+        default:
+            unreached();
+        }
+#endif
+    }
+
+    blockRange.InsertBefore(insertionPoint, std::move(range));
 }

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -303,6 +303,8 @@ public:
 
     static Range EmptyRange();
     static Range SeqTree(Compiler* compiler, GenTree* tree);
+
+    static void InsertBeforeTerminator(BasicBlock* block, LIR::Range&& range);
 };
 
 #endif // _LIR_H_


### PR DESCRIPTION
Neither rationalize nor lowering depend on liveness being run. The assertion mentioned
in the comment was caused by `fgExtendDbgLifetimes` inserting HIR nodes (GT_ASG nodes,
specifically) into blocks that had already been rationalized.