### PR TITLE
ARM64: Fix Build Break

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -6,7 +6,10 @@ if not defined VisualStudioVersion (
 	 if not exist "%VS140COMNTOOLS%\..\IDE\devenv.exe"      goto NoVS
 	 if not exist "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" goto NoVS
 	 if not exist "%VS140COMNTOOLS%\VsDevCmd.bat" 			  goto NoVS
-    call "%VS140COMNTOOLS%\VsDevCmd.bat"
+    :: arm64 build already sets environment for either cross or native components respectively.
+    if /i not "%__BuildArch%"=="arm64" (
+        call "%VS140COMNTOOLS%\VsDevCmd.bat"
+    )
     goto :Run
   )
 


### PR DESCRIPTION
Do not set vs environment under run.cmd since arm64 build already sets it
for cross/native components respectively.