### PR TITLE
Swallow exception in gc_heap::fire_etw_allocation_event

### DIFF
--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -665,14 +665,21 @@ void gc_heap::fire_etw_allocation_event (size_t allocation_amount, int gen_numbe
 #ifdef FEATURE_REDHAWK
     typeId = RedhawkGCInterface::GetLastAllocEEType();
 #else
-    TypeHandle th = GetThread()->GetTHAllocContextObj();
-    if (th != 0)
+    InlineSString<MAX_CLASSNAME_LENGTH> strTypeName;
+
+    EX_TRY
     {
-        InlineSString<MAX_CLASSNAME_LENGTH> strTypeName;
-        th.GetName(strTypeName);
-        typeId = th.GetMethodTable();
-        name = strTypeName.GetUnicode();
+        TypeHandle th = GetThread()->GetTHAllocContextObj();
+
+        if (th != 0)
+        {
+            th.GetName(strTypeName);
+            name = strTypeName.GetUnicode();
+            typeId = th.GetMethodTable();
+        }
     }
+    EX_CATCH {}
+    EX_END_CATCH(SwallowAllExceptions)
 #endif
 
     if (typeId != nullptr)


### PR DESCRIPTION
The gc_heap::fire_etw_allocation_event calls TypeHandle::GetName that can throw
due to OOM. But we don't want failures to fire event cause a failure during the GC,
so such exception should be swallowed and no event fired in such case.
This was discovered as a contract failure during test runs with ETW logging enabled
when this function was transitively called from Thread::PerformPreemptiveGC which
was recently modified to have NOTHROW contract.
Interestingly, this was not detected by the static contract checker.