### PR TITLE
RC2 release used version 4.6.*. However RTM release started to use th…

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -8,6 +8,12 @@
     <OsEnvironment Condition="'$(OsEnvironment)'==''">$(OS)</OsEnvironment>
   </PropertyGroup>
 
+  <!-- Version numbers for both managed & native binaries -->
+  <PropertyGroup>
+    <MajorVersion>4</MajorVersion>
+    <MinorVersion>6</MinorVersion>
+  </PropertyGroup>
+
   <!-- Build Tools Versions -->
   <PropertyGroup>
     <RoslynVersion>1.0.0-rc3-20150510-01</RoslynVersion>


### PR DESCRIPTION
…e default values of 1.0.* by mistake. Revert back to using 4.6 as major & minor version number for binaries