### PR TITLE
Fix for Issue 5954

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -971,6 +971,19 @@ public:
     }
 
     static
+    bool            OperIsLocalField(genTreeOps gtOper)
+    {
+        return (gtOper == GT_LCL_FLD       ||
+                gtOper == GT_LCL_FLD_ADDR  ||
+                gtOper == GT_STORE_LCL_FLD   );
+    }
+
+    inline bool     OperIsLocalField() const
+    {
+        return OperIsLocalField(gtOper);
+    }
+
+    static
     bool           OperIsScalarLocal(genTreeOps gtOper)
     {
         return (gtOper == GT_LCL_VAR ||

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -42,7 +42,7 @@ void                 Compiler::fgMarkUseDef(GenTreeLclVarCommon *tree, GenTree *
     }
     else
     {
-        noway_assert(tree->gtOper == GT_LCL_FLD || tree->gtOper == GT_LCL_FLD_ADDR || tree->gtOper == GT_STORE_LCL_FLD);
+        noway_assert(tree->OperIsLocalField());
         lclNum = tree->gtLclFld.gtLclNum;
     }
 


### PR DESCRIPTION
Fix for issue 5954 - Assert 'fieldSeq != FieldSeqStore::NotAField()'

Added new method GenTree:OperIsLocalField()
Fixes DefinesLocalAddress to properly update pIsEntire when we have a LocalField node type
Fixed fgValueNumberBlockAssignment to handle a GT_COPYBLK or GT_COPYOBJ operation
   where we have an incomplete field sequence for the Dst/LHS node.
   We already were handling an incomplete field sequence for the Src/RHS node.
   Update the dump to properly print "new uniq" whenever we issue a conservative value number.
