### PR TITLE
Check PAL_VirtualUnwind failure during GC

### DIFF
--- a/src/vm/amd64/gmsamd64.cpp
+++ b/src/vm/amd64/gmsamd64.cpp
@@ -62,7 +62,12 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
             DacError(hr);
         }
 #else
-        PAL_VirtualUnwind(&ctx, &nonVolRegPtrs);
+        BOOL success = PAL_VirtualUnwind(&ctx, &nonVolRegPtrs);
+        if (!success)
+        {
+            _ASSERTE(!"unwindLazyState: Unwinding failed");
+            EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+        }
 #endif  // DACCESS_COMPILE    
 
         pvControlPc = GetIP(&ctx);

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -544,7 +544,12 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
             DacError(hr);
         }
 #else // DACCESS_COMPILE
-        PAL_VirtualUnwind(&ctx, &nonVolRegPtrs);
+        BOOL success = PAL_VirtualUnwind(&ctx, &nonVolRegPtrs);
+        if ( !success )
+        {
+          _ASSERTE(!"unwindLazyState: Unwinding failed");
+          EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+        }
 #endif // DACCESS_COMPILE
         pvControlPc = GetIP(&ctx);
 #endif // !FEATURE_PAL

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -545,10 +545,10 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
         }
 #else // DACCESS_COMPILE
         BOOL success = PAL_VirtualUnwind(&ctx, &nonVolRegPtrs);
-        if ( !success )
+        if (!success)
         {
-          _ASSERTE(!"unwindLazyState: Unwinding failed");
-          EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+            _ASSERTE(!"unwindLazyState: Unwinding failed");
+            EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
         }
 #endif // DACCESS_COMPILE
         pvControlPc = GetIP(&ctx);

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -330,7 +330,7 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
             DacError(hr);
         }
 #else // DACCESS_COMPILE
-        BOOL success = PAL_VirtualUnwind(&ctx, &nonVolRegPtrs);
+        BOOL success = PAL_VirtualUnwind(&ctx, &nonVolContextPtrs);
         if (!success)
         {
             _ASSERTE(!"unwindLazyState: Unwinding failed");

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -330,7 +330,12 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
             DacError(hr);
         }
 #else // DACCESS_COMPILE
-        PAL_VirtualUnwind(&context, &nonVolContextPtrs);  
+        BOOL success = PAL_VirtualUnwind(&ctx, &nonVolRegPtrs);
+        if (!success)
+        {
+            _ASSERTE(!"unwindLazyState: Unwinding failed");
+            EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+        }
 #endif // DACCESS_COMPILE
         pvControlPc = GetIP(&context);
 #endif // !FEATURE_PAL


### PR DESCRIPTION
As discussed in #6525, ``PAL_VirtualUnwind`` sometimes fails during GC.

This failure leads to very unpredictable behavior (which is very hard to
analyze).

This commit tries to stop the execution at the point where error
happens.