### PR TITLE
Inliner: gather summary stats and dump to Jit CSV log

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3984,6 +3984,12 @@ void                 Compiler::compCompile(void * * methodCodePtr,
                                            ULONG  * methodCodeSize,
                                            CORJIT_FLAGS * compileFlags)
 {
+    if (compIsForInlining())
+    {
+        // Notify root instance that an inline attempt is about to import IL
+        impInlineRoot()->m_inlineStrategy->NoteImport();
+    }
+
     hashBv::Init(this);
 
     VarSetOps::AssignAllowUninitRhs(this, compCurLife, VarSetOps::UninitVal());
@@ -7092,6 +7098,9 @@ void JitTimer::PrintCsvHeader()
         {
             fprintf(fp, "\"%s\",", PhaseNames[i]);
         }
+
+        InlineStrategy::DumpCsvHeader(fp);
+
         fprintf(fp, "\"Total Cycles\",");
         fprintf(fp, "\"CPS\"\n");
         fclose(fp);
@@ -7136,6 +7145,9 @@ void JitTimer::PrintCsvMethodStats(Compiler* comp)
             totCycles += m_info.m_cyclesByPhase[i];
         fprintf(fp, "%I64u,", m_info.m_cyclesByPhase[i]);
     }
+
+    comp->m_inlineStrategy->DumpCsvData(fp);
+
     fprintf(fp, "%I64u,", m_info.m_totalCycles);
     fprintf(fp, "%f\n", CycleTimer::CyclesPerSecond());
     fclose(fp);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4872,6 +4872,7 @@ TOO_FAR:
                 
                 if (compInlineResult->IsFailure())
                 {
+                    impInlineRoot()->m_inlineStrategy->NoteUnprofitable();
                     JITDUMP("\n\nInline expansion aborted, inline not profitable\n");
                     return;
                 }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -16970,7 +16970,10 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode,
                                                CORINFO_CONTEXT_HANDLE exactContextHnd, 
                                                CORINFO_CALL_INFO* callInfo)
 {
-    if  (!opts.OptEnabled(CLFLG_INLINING))
+    // Let the strategy know there's another call
+    impInlineRoot()->m_inlineStrategy->NoteCall();
+
+    if (!opts.OptEnabled(CLFLG_INLINING))
     {                 
         /* XXX Mon 8/18/2008
          * This assert is misleading.  The caller does not ensure that we have CLFLG_INLINING set before

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -400,7 +400,7 @@ public:
     // Determine if this inline is profitable
     void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo)
     {
-        return m_Policy->DetermineProfitability(methodInfo);
+        m_Policy->DetermineProfitability(methodInfo);
     }
 
     // Ensure details of this inlining process are appropriately
@@ -751,8 +751,40 @@ public:
         return m_InitialSizeEstimate;
     }
 
+    // Inform strategy that there's another call
+    void NoteCall()
+    {
+        m_CallCount++;
+    }
+
     // Inform strategy that there's a new inline candidate.
-    void NoteCandidate();
+    void NoteCandidate()
+    {
+        m_CandidateCount++;
+    }
+
+    // Inform strategy that a candidate was assessed and determined to
+    // be unprofitable.
+    void NoteUnprofitable()
+    {
+        m_UnprofitableCandidateCount++;
+    }
+
+    // Inform strategy that a candidate has passed screening
+    // and that the jit will attempt to inline.
+    void NoteAttempt(InlineResult* result);
+
+    // Inform strategy that jit is about to import the inlinee IL.
+    void NoteImport()
+    {
+        m_ImportCount++;
+    }
+
+    // Dump csv header for inline stats to indicated file.
+    static void DumpCsvHeader(FILE* f);
+
+    // Dump csv data for inline stats to indicated file.
+    void DumpCsvData(FILE* f);
 
     // See if an inline of this size would fit within the current jit
     // time budget.
@@ -834,8 +866,13 @@ private:
     InlineContext* m_RootContext;
     InlinePolicy*  m_LastSuccessfulPolicy;
     InlineContext* m_LastContext;
+    unsigned       m_CallCount;
     unsigned       m_CandidateCount;
-    unsigned       m_InlineAttemptCount;
+    unsigned       m_AlwaysCandidateCount;
+    unsigned       m_ForceCandidateCount;
+    unsigned       m_DiscretionaryCandidateCount;
+    unsigned       m_UnprofitableCandidateCount;
+    unsigned       m_ImportCount;
     unsigned       m_InlineCount;
     unsigned       m_MaxInlineSize;
     unsigned       m_MaxInlineDepth;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6516,6 +6516,8 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
     }
 #endif
 
+    impInlineRoot()->m_inlineStrategy->NoteAttempt(result);
+
     //
     // Invoke the compiler to inline the call.
     //


### PR DESCRIPTION
Collect per-method summary stats about inlining: number of calls,
number of candidates, etc.