### PR TITLE
Add a table of contents to the book of the runtime

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -56,23 +56,16 @@ Testing and Debugging CoreCLR
 Book of the Runtime
 ===================
 
-- [Book of the Runtime FAQ](botr/botr-faq.md)
+The book of the runtime is a set of chapters that go in depth into various 
+interesting aspects of the design of hte .NET Framework.  
+
+- [Book of the Runtime](botr/_tableOfContents.md)
+
+For you convenience, here are a a few quick links to popular chapters.  
+
 - [Introduction to the Common Language Runtime](botr/intro-to-clr.md)
 - [Garbage Collection Design](botr/garbage-collection.md)
-- [Threading](botr/threading.md)
-- [RyuJIT Overview](botr/ryujit-overview.md)
 - [Type System](botr/type-system.md)
-- [Type Loader](botr/type-loader.md)
-- [Method Descriptor](botr/method-descriptor.md)
-- [Virtual Stub Dispatch](botr/virtual-stub-dispatch.md)
-- [Stack Walking](botr/stackwalking.md)
-- [Mscorlib and Calling Into the Runtime](botr/mscorlib.md)
-- [Data Access Component (DAC) Notes](botr/dac-notes.md)
-- [Profiling](botr/profiling.md)
-- [Implementing Profilability](botr/profilability.md)
-- [What Every Dev needs to Know About Exceptions in the Runtime](botr/exceptions.md)
-- [ReadyToRun Overview](botr/readytorun-overview.md)
-- [CLR ABI](botr/clr-abi.md)
 
 Decoder Rings
 =============

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -56,12 +56,12 @@ Testing and Debugging CoreCLR
 Book of the Runtime
 ===================
 
-The book of the runtime is a set of chapters that go in depth into various 
-interesting aspects of the design of hte .NET Framework.  
+The Book of the Runtime is a set of chapters that go in depth into various 
+interesting aspects of the design of the .NET Framework.  
 
 - [Book of the Runtime](botr/_tableOfContents.md)
 
-For you convenience, here are a a few quick links to popular chapters.  
+For your convenience, here are a a few quick links to popular chapters.  
 
 - [Introduction to the Common Language Runtime](botr/intro-to-clr.md)
 - [Garbage Collection Design](botr/garbage-collection.md)

--- a/Documentation/botr/_tableOfContents.md
+++ b/Documentation/botr/_tableOfContents.md
@@ -1,0 +1,30 @@
+
+Welcome to the Book of the (.NET) Runtime (BOTR).  
+
+Below is a table of contents.   
+
+- [Book of the Runtime FAQ](botr-faq.md)
+- [Introduction to the Common Language Runtime](intro-to-clr.md)
+- [Garbage Collection Design](garbage-collection.md)
+- [Threading](threading.md)
+- [RyuJIT Overview](ryujit-overview.md)  
+  - [Porting RyuJIT to other platforms](porting-ryujit.md)
+- [Type System](type-system.md)
+- [Type Loader](type-loader.md)
+- [Method Descriptor](method-descriptor.md)
+- [Virtual Stub Dispatch](virtual-stub-dispatch.md)
+- [Stack Walking](stackwalking.md)
+- [Mscorlib and Calling Into the Runtime](mscorlib.md)
+- [Data Access Component (DAC) Notes](dac-notes.md)
+- [Profiling](profiling.md)
+- [Implementing Profilability](profilability.md)
+- [What Every Dev needs to Know About Exceptions in the Runtime](exceptions.md)
+- [ReadyToRun Overview](readytorun-overview.md)
+- [CLR ABI](clr-abi.md)
+
+
+It may be possible that this table is not complete.  You can get a complete list 
+by looking at the directory where all the chapters are stored on 
+github.  
+
+* [All book of the runtime (BOTR) chapters on GitHub](https://github.com/vancem/coreclr/tree/master/Documentation/botr)


### PR DESCRIPTION
 So you have one link to go to that represents the entire book.