### PR TITLE
Expose missing members of System.Reflection in contract to prep for dotnet/corefx#1053

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3765,8 +3765,11 @@
       <Member MemberType="Property" Name="Value" />
     </Type>
     <Type Name="System.Reflection.AssemblyFlagsAttribute">
+      <Member Name="#ctor(System.UInt32)" />
+      <Member Name="#ctor(System.Int32)" />
       <Member Name="#ctor(System.Reflection.AssemblyNameFlags)" />
       <Member Name="get_AssemblyFlags" />
+      <Member Name="get_Flags" />
       <Member MemberType="Property" Name="AssemblyFlags" />
     </Type>
     <Type Name="System.Reflection.AssemblyInformationalVersionAttribute">
@@ -3789,21 +3792,26 @@
       <Member Status="ImplRoot" Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
       <Member Name="get_CultureInfo" />
       <Member Name="get_CultureName" />
+      <Member Name="get_CodeBase" />
       <Member Name="get_ContentType" />
       <Member Name="get_Flags" />
       <Member Name="get_FullName" />
       <Member Name="get_HashAlgorithm" />
+      <Member Name="get_VersionCompatibility" />
       <Member Name="get_Name" />
       <Member Name="get_ProcessorArchitecture" />
       <Member Name="get_Version" />
       <Member Name="GetPublicKey" />
       <Member Name="GetPublicKeyToken" />
       <Member Name="set_CultureInfo(System.Globalization.CultureInfo)" />
+      <Member Name="set_CodeBase(System.String)" />
       <Member Name="set_Flags(System.Reflection.AssemblyNameFlags)" />
       <Member Name="set_HashAlgorithm(System.Configuration.Assemblies.AssemblyHashAlgorithm)" />
+      <Member Name="set_VersionCompatibility(System.Configuration.Assemblies.AssemblyVersionCompatibility)" />
       <Member Name="set_Name(System.String)" />
       <Member Name="set_ProcessorArchitecture(System.Reflection.ProcessorArchitecture)" />
       <Member Name="set_Version(System.Version)" />
+      <Member Name="Clone" />
       <Member Name="SetPublicKey(System.Byte[])" />
       <Member Name="SetPublicKeyToken(System.Byte[])" />
       <Member Name="ToString" />
@@ -3819,6 +3827,8 @@
       <Member MemberType="Property" Name="Version" />
     </Type>
     <Type Name="System.Reflection.AssemblyNameFlags">
+      <Member MemberType="Field" Name="EnableJITcompileOptimizer" />
+      <Member MemberType="Field" Name="EnableJITcompileTracking" />
       <Member MemberType="Field" Name="None" />
       <Member MemberType="Field" Name="PublicKey" />
       <Member MemberType="Field" Name="Retargetable" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3404,6 +3404,24 @@
       <Member Name="#ctor(System.String,System.Exception)" />
       <Member Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
     </Type>
+    <Type Name="System.ModuleHandle">
+      <Member MemberType="Field" Name="EmptyHandle" />
+      <Member Name="get_MDStreamVersion" />
+      <Member Name="GetHashCode" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ModuleHandle)" />
+      <Member Name="op_Equality(System.ModuleHandle,System.ModuleHandle)" />
+      <Member Name="op_Inequality(System.ModuleHandle,System.ModuleHandle)" />
+      <Member Name="GetRuntimeTypeHandleFromMetadataToken(System.Int32)" />
+      <Member Name="GetRuntimeMethodHandleFromMetadataToken(System.Int32)" />
+      <Member Name="GetRuntimeFieldHandleFromMetadataToken(System.Int32)" />
+      <Member Name="ResolveTypeHandle(System.Int32)" />
+      <Member Name="ResolveTypeHandle(System.Int32,System.RuntimeTypeHandle[],System.RuntimeTypeHandle[])" />
+      <Member Name="ResolveMethodHandle(System.Int32)" />
+      <Member Name="ResolveMethodHandle(System.Int32,System.RuntimeTypeHandle[],System.RuntimeTypeHandle[])" />
+      <Member Name="ResolveFieldHandle(System.Int32)" />
+      <Member Name="ResolveFieldHandle(System.Int32,System.RuntimeTypeHandle[],System.RuntimeTypeHandle[])" />
+    </Type>
     <Type Name="System.MTAThreadAttribute">
       <Member Name="#ctor" />
     </Type>
@@ -5467,7 +5485,9 @@
       <Member Name="get_Assembly" />
       <Member Name="get_CustomAttributes" />
       <Member Name="get_FullyQualifiedName" />
+      <Member Name="get_MDStreamVersion" />
       <Member Name="get_MetadataToken" />
+      <Member Name="get_ModuleHandle" />
       <Member Name="get_ModuleVersionId" />
       <Member Name="get_Name" />
       <Member Name="get_ScopeName" />
@@ -5485,6 +5505,7 @@
       <Member Name="GetMethodImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" />
       <Member Name="GetMethods" />
       <Member Name="GetMethods(System.Reflection.BindingFlags)" />
+      <Member Name="GetPEKind(System.Reflection.PortableExecutableKinds@,System.Reflection.ImageFileMachine@)" />
       <Member Name="GetType(System.String)" />
       <Member Name="GetType(System.String,System.Boolean)" />
       <Member Name="GetType(System.String,System.Boolean,System.Boolean)" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3816,6 +3816,8 @@
       <Member Name="SetPublicKey(System.Byte[])" />
       <Member Name="SetPublicKeyToken(System.Byte[])" />
       <Member Name="ToString" />
+      <Member Name="GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
+      <Member Name="OnDeserialization(System.Object)" />
       <Member Name="#ctor(System.String)" />
       <Member MemberType="Property" Name="CodeBase" />
       <Member MemberType="Property" Name="CultureInfo" />
@@ -5458,6 +5460,7 @@
     </Type>
     <Type Name="System.Reflection.Missing">
       <Member MemberType="Field" Name="Value" />
+      <Member Name="System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
     </Type>
     <Type Name="System.Reflection.Module">
       <Member Name="#ctor" />
@@ -5609,6 +5612,7 @@
       <Member Name="#ctor" />
       <Member Name="Box(System.Void*,System.Type)" />
       <Member Name="Unbox(System.Object)" />
+      <Member Name="System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
     </Type>
     <Type Name="System.Reflection.PortableExecutableKinds">
       <Member MemberType="Field" Name="NotAPortableExecutableImage" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3838,6 +3838,7 @@
       <Member MemberType="Field" Name="value__" />
     </Type>
     <Type Name="System.Reflection.AssemblyNameProxy">
+      <Member Name="#ctor" />
     </Type>
     <Type Name="System.Reflection.AssemblyProductAttribute">
       <Member Name="#ctor(System.String)" />
@@ -5311,6 +5312,7 @@
       <Member Name="get_ReflectedType" />
       <Member Name="GetCustomAttributes(System.Boolean)" />
       <Member Name="GetCustomAttributes(System.Type,System.Boolean)" />
+      <Member Name="GetCustomAttributesData" />
       <Member Name="Equals(System.Object)" />
       <Member Name="GetHashCode" />
       <Member Name="IsDefined(System.Type,System.Boolean)" />
@@ -5516,6 +5518,23 @@
       <Member Name="EndInvoke(System.IAsyncResult)" />
       <Member Name="Invoke(System.Object,System.ResolveEventArgs)" />
     </Type>
+    <Type Name="System.Reflection.ObfuscateAssemblyAttribute">
+      <Member Name="#ctor(System.Boolean)" />
+      <Member Name="get_AssemblyIsPrivate" />
+      <Member Name="get_StripAfterObfuscation" />
+      <Member Name="set_StripAfterObfuscation(System.Boolean)" />
+    </Type>
+    <Type Name="System.Reflection.ObfuscationAttribute">
+      <Member Name="#ctor" />
+      <Member Name="get_ApplyToMembers" />
+      <Member Name="get_Exclude" />
+      <Member Name="get_Feature" />
+      <Member Name="get_StripAfterObfuscation" />
+      <Member Name="set_ApplyToMembers(System.Boolean)" />
+      <Member Name="set_Exclude(System.Boolean)" />
+      <Member Name="set_Feature(System.String)" />
+      <Member Name="set_StripAfterObfuscation(System.Boolean)" />
+    </Type>
     <Type Name="System.Reflection.ParameterAttributes">
       <Member MemberType="Field" Name="HasDefault" />
       <Member MemberType="Field" Name="HasFieldMarshal" />
@@ -5556,6 +5575,7 @@
       <Member Name="GetRequiredCustomModifiers" />
       <Member Name="GetCustomAttributes(System.Boolean)" />
       <Member Name="GetCustomAttributes(System.Type,System.Boolean)" />
+      <Member Name="GetCustomAttributesData" />
       <Member Name="IsDefined(System.Type,System.Boolean)" />
       <Member Name="ToString" />
       <Member MemberType="Property" Name="Attributes" />
@@ -5580,6 +5600,7 @@
       <Member MemberType="Property" Name="Item(System.Int32)" />
     </Type>
     <Type Name="System.Reflection.Pointer" >
+      <Member Name="#ctor" />
       <Member Name="Box(System.Void*,System.Type)" />
       <Member Name="Unbox(System.Object)" />
     </Type>

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3905,6 +3905,8 @@
     </Type>
     <Type Name="System.Reflection.ConstructorInfo">
       <Member Name="#ctor" />
+      <Member Name="op_Equality(System.Reflection.ConstructorInfo,System.Reflection.ConstructorInfo)" />
+      <Member Name="op_Inequality(System.Reflection.ConstructorInfo,System.Reflection.ConstructorInfo)" />
       <Member MemberType="Field" Name="ConstructorName" />
       <Member MemberType="Field" Name="TypeConstructorName" />
       <Member Name="get_MemberType" />
@@ -3915,18 +3917,22 @@
       <Member MemberType="Property" Name="MemberType" />
     </Type>
     <Type Name="System.Reflection.CustomAttributeData">
-        <Member Name="get_AttributeType" />
-        <Member Name="get_ConstructorArguments" />
-        <Member Name="get_NamedArguments" />
-        <Member Name="get_Constructor" />
-        <Member Name="GetCustomAttributes(System.Reflection.Assembly)" />
-        <Member Name="GetCustomAttributes(System.Reflection.MemberInfo)" />
-        <Member Name="GetCustomAttributes(System.Reflection.Module)" />
-        <Member Name="GetCustomAttributes(System.Reflection.ParameterInfo)" />
-        <Member MemberType="Property" Name="AttributeType" />
-		<Member MemberType="Property" Name="Constructor" />
-        <Member MemberType="Property" Name="ConstructorArguments" />
-        <Member MemberType="Property" Name="NamedArguments" />
+      <Member Name="#ctor" />
+      <Member Name="get_AttributeType" />
+      <Member Name="get_ConstructorArguments" />
+      <Member Name="get_NamedArguments" />
+      <Member Name="get_Constructor" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="GetCustomAttributes(System.Reflection.Assembly)" />
+      <Member Name="GetCustomAttributes(System.Reflection.MemberInfo)" />
+      <Member Name="GetCustomAttributes(System.Reflection.Module)" />
+      <Member Name="GetCustomAttributes(System.Reflection.ParameterInfo)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member MemberType="Property" Name="AttributeType" />
+      <Member MemberType="Property" Name="Constructor" />
+      <Member MemberType="Property" Name="ConstructorArguments" />
+      <Member MemberType="Property" Name="NamedArguments" />
     </Type>
    <Type Name="System.Reflection.CustomAttributeExtensions">
       <Member Name="GetCustomAttribute(System.Reflection.Assembly,System.Type)" />
@@ -3980,22 +3986,27 @@
       <Member Name="GetRuntimeProperty(System.Type,System.String)" />
     </Type>
     <Type Name="System.Reflection.CustomAttributeNamedArgument">
-        <Member Name="get_IsField" />
-        <Member Name="get_MemberName" />
-        <Member Name="get_TypedValue" />
-        <Member Name="op_Equality(System.Reflection.CustomAttributeNamedArgument,System.Reflection.CustomAttributeNamedArgument)" />
-        <Member Name="op_Inequality(System.Reflection.CustomAttributeNamedArgument,System.Reflection.CustomAttributeNamedArgument)" />
-        <Member MemberType="Property" Name="IsField" />
-        <Member MemberType="Property" Name="MemberName" />
-        <Member MemberType="Property" Name="TypedValue" />
+      <Member Name="#ctor(System.Reflection.MemberInfo,System.Object)" />
+      <Member Name="#ctor(System.Reflection.MemberInfo,System.Reflection.CustomAttributeTypedArgument)" />
+      <Member Name="get_IsField" />
+      <Member Name="get_MemberInfo" />
+      <Member Name="get_MemberName" />
+      <Member Name="get_TypedValue" />
+      <Member Name="op_Equality(System.Reflection.CustomAttributeNamedArgument,System.Reflection.CustomAttributeNamedArgument)" />
+      <Member Name="op_Inequality(System.Reflection.CustomAttributeNamedArgument,System.Reflection.CustomAttributeNamedArgument)" />
+      <Member MemberType="Property" Name="IsField" />
+      <Member MemberType="Property" Name="MemberName" />
+      <Member MemberType="Property" Name="TypedValue" />
     </Type>
     <Type Name="System.Reflection.CustomAttributeTypedArgument">
-        <Member Name="get_ArgumentType" />
-        <Member Name="get_Value" />
-        <Member Name="op_Equality(System.Reflection.CustomAttributeTypedArgument,System.Reflection.CustomAttributeTypedArgument)" />
-        <Member Name="op_Inequality(System.Reflection.CustomAttributeTypedArgument,System.Reflection.CustomAttributeTypedArgument)" />
-        <Member MemberType="Property" Name="ArgumentType" />
-        <Member MemberType="Property" Name="Value" />
+      <Member Name="#ctor(System.Object)" />
+      <Member Name="#ctor(System.Type,System.Object)" />
+      <Member Name="get_ArgumentType" />
+      <Member Name="get_Value" />
+      <Member Name="op_Equality(System.Reflection.CustomAttributeTypedArgument,System.Reflection.CustomAttributeTypedArgument)" />
+      <Member Name="op_Inequality(System.Reflection.CustomAttributeTypedArgument,System.Reflection.CustomAttributeTypedArgument)" />
+      <Member MemberType="Property" Name="ArgumentType" />
+      <Member MemberType="Property" Name="Value" />
     </Type>
     <Type Name="System.Reflection.CustomAttributeFormatException">
       <Member Name="#ctor" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -5522,6 +5522,12 @@
       <Member MemberType="Field" Name="value__" />
     </Type>
     <Type Name="System.Reflection.ParameterInfo">
+      <Member MemberType="Field" Name="AttrsImpl" />
+      <Member MemberType="Field" Name="ClassImpl" />
+      <Member MemberType="Field" Name="DefaultValueImpl" />
+      <Member MemberType="Field" Name="MemberImpl" />
+      <Member MemberType="Field" Name="NameImpl" />
+      <Member MemberType="Field" Name="PositionImpl" />
       <Member Name="#ctor" />
       <Member Name="get_Attributes" />
       <Member Name="get_CustomAttributes" />
@@ -5530,6 +5536,7 @@
       <Member Name="get_IsOptional" />
       <Member Name="get_IsOut" />
       <Member Name="get_IsIn" />
+      <Member Name="get_IsLcid" />
       <Member Name="get_IsRetval" />
       <Member Name="get_Member" />
       <Member Name="get_MetadataToken" />
@@ -5542,6 +5549,7 @@
       <Member Name="GetCustomAttributes(System.Boolean)" />
       <Member Name="GetCustomAttributes(System.Type,System.Boolean)" />
       <Member Name="IsDefined(System.Type,System.Boolean)" />
+      <Member Name="ToString" />
       <Member MemberType="Property" Name="Attributes" />
       <Member MemberType="Property" Name="CustomAttributes" />
       <Member MemberType="Property" Name="DefaultValue" />
@@ -5563,6 +5571,19 @@
       <Member Name="set_Item(System.Int32,System.Boolean)" />
       <Member MemberType="Property" Name="Item(System.Int32)" />
     </Type>
+    <Type Name="System.Reflection.Pointer" >
+      <Member Name="Box(System.Void*,System.Type)" />
+      <Member Name="Unbox(System.Object)" />
+    </Type>
+    <Type Name="System.Reflection.PortableExecutableKinds">
+      <Member MemberType="Field" Name="NotAPortableExecutableImage" />
+      <Member MemberType="Field" Name="ILOnly" />
+      <Member MemberType="Field" Name="Required32Bit" />
+      <Member MemberType="Field" Name="PE32Plus" />
+      <Member MemberType="Field" Name="Unmanaged32Bit" />
+      <Member MemberType="Field" Name="Preferred32Bit" />
+      <Member MemberType="Field" Name="value__" />
+    </Type>
     <Type Name="System.Reflection.PropertyAttributes">
       <Member MemberType="Field" Name="HasDefault" />
       <Member MemberType="Field" Name="None" />
@@ -5576,6 +5597,8 @@
     </Type>
     <Type Name="System.Reflection.PropertyInfo">
       <Member Name="#ctor" />
+      <Member Name="op_Equality(System.Reflection.PropertyInfo,System.Reflection.PropertyInfo)" />
+      <Member Name="op_Inequality(System.Reflection.PropertyInfo,System.Reflection.PropertyInfo)" />
       <Member Name="get_Attributes" />
       <Member Name="get_CanRead" />
       <Member Name="get_CanWrite" />
@@ -9291,6 +9314,7 @@
     <Type Name="System.Reflection.ResourceAttributes">
       <Member MemberType="Field" Name="Private" />
       <Member MemberType="Field" Name="Public" />
+      <Member MemberType="Field" Name="value__" />
     </Type>
     <Type Status="ImplRoot" Name="System.Reflection.RtFieldInfo">
       <Member Status="ImplRoot" Name="GetFieldHandle" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -7983,6 +7983,8 @@
       <Member Name="op_Inequality(System.Type,System.Type)" />
       <Member MemberType="Field" Name="Delimiter" />
       <Member MemberType="Field" Name="EmptyTypes" />
+      <Member MemberType="Field" Name="FilterAttribute" />
+      <Member MemberType="Field" Name="FilterName" />
       <Member MemberType="Field" Name="FilterNameIgnoreCase" />
       <Member MemberType="Field" Name="Missing" />
       <Member Name="Equals(System.Object)" />
@@ -8092,20 +8094,29 @@
       <Member Name="GetProperty(System.String,System.Type,System.Type[])" />
       <Member Name="GetProperty(System.String,System.Type,System.Type[],System.Reflection.ParameterModifier[])" />
       <Member Name="GetPropertyImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type,System.Type[],System.Reflection.ParameterModifier[])" />
+      <Member Name="GetType" />
       <Member Name="GetType(System.String)" />
       <Member Name="GetType(System.String,System.Boolean)" />
       <Member Name="GetType(System.String,System.Boolean,System.Boolean)" />
+      <Member Name="GetTypeArray(System.Object[])" />
       <Member Name="GetTypeCode(System.Type)" />
+      <Member Name="GetTypeCodeImpl" />
+      <Member Name="GetTypeFromCLSID(System.Guid)" />
+      <Member Name="GetTypeFromCLSID(System.Guid,System.Boolean)" />
+      <Member Name="GetTypeFromCLSID(System.Guid,System.String)" />
+      <Member Name="GetTypeFromCLSID(System.Guid,System.String,System.Boolean)" />
       <Member Name="GetTypeFromHandle(System.RuntimeTypeHandle)" />
       <Member Name="GetTypeHandle(System.Object)" />
       <Member Name="HasElementTypeImpl" />
       <Member Name="InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[])" />
+      <Member Name="InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Globalization.CultureInfo)" />
       <Member Name="InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])" />
       <Member Name="IsArrayImpl" />
       <Member Name="IsAssignableFrom(System.Type)" />
       <Member Name="IsByRefImpl" />
       <Member Name="IsCOMObjectImpl" />
       <Member Name="IsInstanceOfType(System.Object)" />
+      <Member Name="IsMarshalByRefImpl" />
       <Member Name="IsPointerImpl" />
       <Member Name="IsPrimitiveImpl" />
       <Member Name="IsSubclassOf(System.Type)" />
@@ -8116,6 +8127,7 @@
       <Member Name="MakeByRefType" />
       <Member Name="MakeGenericType(System.Type[])" />
       <Member Name="MakePointerType" />
+      <Member Name="ReflectionOnlyGetType(System.String,System.Boolean,System.Boolean)" />
       <Member Name="ToString" />
       <Member MemberType="Property" Name="Assembly" />
       <Member MemberType="Property" Name="AssemblyQualifiedName" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -5385,7 +5385,10 @@
       <Member Name="GetMethodImplementationFlags" />
       <Member Name="GetParameters" />
       <Member Name="Equals(System.Object)" />
+      <Member Name="op_Equality(System.Reflection.MethodBase,System.Reflection.MethodBase)" />
+      <Member Name="op_Inequality(System.Reflection.MethodBase,System.Reflection.MethodBase)" />
       <Member Name="GetHashCode" />
+      <Member Name="GetMethodBody" />
       <Member Name="Invoke(System.Object,System.Object[])" />
       <Member Name="Invoke(System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)" />
       <Member MemberType="Property" Name="Attributes" />
@@ -5430,6 +5433,8 @@
     </Type>
     <Type Name="System.Reflection.MethodInfo">
       <Member Name="#ctor" />
+      <Member Name="op_Equality(System.Reflection.MethodInfo,System.Reflection.MethodInfo)" />
+      <Member Name="op_Inequality(System.Reflection.MethodInfo,System.Reflection.MethodInfo)" />
       <Member Name="get_MemberType" />
       <Member Name="get_ReturnParameter" />
       <Member Name="get_ReturnType" />
@@ -9290,13 +9295,20 @@
     <Type Status="ImplRoot" Name="System.Reflection.MetadataImport">
       <Member Name="ThrowError(System.Int32)" /> <!-- EE -->
     </Type>
-    <Type Status="ImplRoot" Name="System.Reflection.MethodBody">
-      <Member MemberType="Field" Name="m_exceptionHandlingClauses" />
-      <Member MemberType="Field" Name="m_IL" />
-      <Member MemberType="Field" Name="m_initLocals" />
-      <Member MemberType="Field" Name="m_localSignatureMetadataToken" />
-      <Member MemberType="Field" Name="m_localVariables" />
-      <Member MemberType="Field" Name="m_maxStackSize" />
+    <Type Name="System.Reflection.MethodBody">
+      <Member Name="#ctor" />
+      <Member Name="get_ExceptionHandlingClauses" />
+      <Member Name="get_InitLocals" />
+      <Member Name="get_LocalSignatureMetadataToken" />
+      <Member Name="get_LocalVariables" />
+      <Member Name="get_MaxStackSize" />
+      <Member Name="GetILAsByteArray" />
+      <Member Status="ImplRoot" MemberType="Field" Name="m_exceptionHandlingClauses" />
+      <Member Status="ImplRoot" MemberType="Field" Name="m_IL" />
+      <Member Status="ImplRoot" MemberType="Field" Name="m_initLocals" />
+      <Member Status="ImplRoot" MemberType="Field" Name="m_localSignatureMetadataToken" />
+      <Member Status="ImplRoot" MemberType="Field" Name="m_localVariables" />
+      <Member Status="ImplRoot" MemberType="Field" Name="m_maxStackSize" />
     </Type>
     <Type Status="ImplRoot" Name="System.Reflection.Emit.ExceptionHandler">
       <Member Name="op_Equality(System.Reflection.Emit.ExceptionHandler,System.Reflection.Emit.ExceptionHandler)" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -5482,6 +5482,8 @@
     </Type>
     <Type Name="System.Reflection.Module">
       <Member Name="#ctor" />
+      <Member Name="op_Equality(System.Reflection.Module,System.Reflection.Module)" />
+      <Member Name="op_Inequality(System.Reflection.Module,System.Reflection.Module)" />
       <Member Name="get_Assembly" />
       <Member Name="get_CustomAttributes" />
       <Member Name="get_FullyQualifiedName" />
@@ -5553,6 +5555,8 @@
       <Member Name="get_AssemblyIsPrivate" />
       <Member Name="get_StripAfterObfuscation" />
       <Member Name="set_StripAfterObfuscation(System.Boolean)" />
+      <Member MemberType="Property" Name="AssemblyIsPrivate" />
+      <Member MemberType="Property" Name="StripAfterObfuscation" />
     </Type>
     <Type Name="System.Reflection.ObfuscationAttribute">
       <Member Name="#ctor" />
@@ -5564,6 +5568,10 @@
       <Member Name="set_Exclude(System.Boolean)" />
       <Member Name="set_Feature(System.String)" />
       <Member Name="set_StripAfterObfuscation(System.Boolean)" />
+      <Member MemberType="Property" Name="ApplyToMembers" />
+      <Member MemberType="Property" Name="Exclude" />
+      <Member MemberType="Property" Name="Feature" />
+      <Member MemberType="Property" Name="StripAfterObfuscation" />
     </Type>
     <Type Name="System.Reflection.ParameterAttributes">
       <Member MemberType="Field" Name="HasDefault" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3600,6 +3600,7 @@
       <Member Name="#ctor" />
       <Member Name="CreateInstance(System.String)" />
       <Member Name="CreateInstance(System.String,System.Boolean)" />
+      <Member Name="CreateInstance(System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[])" />
       <Member Name="CreateQualifiedName(System.String,System.String)" />
       <Member Name="GetReferencedAssemblies" />
       <Member Name="get_EntryPoint" />
@@ -3611,20 +3612,31 @@
       <Member Name="get_ManifestModule" />
       <Member Name="get_CustomAttributes" />
       <Member Name="get_Modules" />
+      <Member Name="get_ReflectionOnly" />
+      <Member Name="GetAssembly(System.Type)" />
+      <Member Name="op_Equality(System.Reflection.Assembly,System.Reflection.Assembly)" />
+      <Member Name="op_Inequality(System.Reflection.Assembly,System.Reflection.Assembly)" />
       <Member Name="GetCallingAssembly" />
       <Member Name="GetCustomAttributes(System.Boolean)" />
       <Member Name="GetCustomAttributes(System.Type,System.Boolean)" />
+      <Member Name="GetCustomAttributesData" />
       <Member Name="GetExecutingAssembly" />
       <Member Name="GetEntryAssembly" />
       <Member Name="GetExportedTypes" />
+      <Member Name="GetLoadedModules" />
+      <Member Name="GetLoadedModules(System.Boolean)" />
       <Member Name="GetManifestResourceNames" />
       <Member Name="GetManifestResourceStream(System.String)" />
       <Member Name="GetManifestResourceInfo(System.String)" />
       <Member Name="GetManifestResourceStream(System.Type,System.String)" />
+      <Member Name="GetModule(System.String)" />
       <Member Name="GetModules" />
+      <Member Name="GetModules(System.Boolean)" />
       <Member Name="Equals(System.Object)" />
       <Member Name="GetHashCode" />
       <Member Name="GetName" />
+      <Member Name="GetSatelliteAssembly(System.Globalization.CultureInfo)" />
+      <Member Name="GetSatelliteAssembly(System.Globalization.CultureInfo,System.Version)" />
       <Member Name="GetType(System.String)" />
       <Member Name="GetType(System.String,System.Boolean)" />
       <Member Name="GetType(System.String,System.Boolean,System.Boolean)" />
@@ -3635,6 +3647,9 @@
       <Member Name="Load(System.String)" />
       <Member Name="Load(System.Byte[])" />
       <Member Name="Load(System.Byte[],System.Byte[])" />
+      <Member Name="ReflectionOnlyLoad(System.String)" />
+      <Member Name="ReflectionOnlyLoad(System.Byte[])" />
+      <Member Name="ReflectionOnlyLoadFrom(System.String)" />
       <Member Name="ToString" />
       <Member MemberType="Property" Name="DefinedTypes" />
       <Member MemberType="Property" Name="CustomAttributes" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -8048,6 +8048,7 @@
       <Member Name="GetArrayRank" />
       <Member Name="GetAttributeFlagsImpl" />
       <Member Name="GetConstructor(System.Reflection.BindingFlags,System.Reflection.Binder,System.Type[],System.Reflection.ParameterModifier[])" />
+      <Member Name="GetConstructor(System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" />
       <Member Name="GetConstructor(System.Type[])" />
       <Member Name="GetConstructorImpl(System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" />
       <Member Name="GetConstructors" />
@@ -8106,6 +8107,10 @@
       <Member Name="GetTypeFromCLSID(System.Guid,System.String)" />
       <Member Name="GetTypeFromCLSID(System.Guid,System.String,System.Boolean)" />
       <Member Name="GetTypeFromHandle(System.RuntimeTypeHandle)" />
+      <Member Name="GetTypeFromProgID(System.String)" />
+      <Member Name="GetTypeFromProgID(System.String,System.Boolean)" />
+      <Member Name="GetTypeFromProgID(System.String,System.String)" />
+      <Member Name="GetTypeFromProgID(System.String,System.String,System.Boolean)" />
       <Member Name="GetTypeHandle(System.Object)" />
       <Member Name="HasElementTypeImpl" />
       <Member Name="InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[])" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3282,6 +3282,8 @@
       <Member Name="get_Value"/>
       <Member Status="ImplRoot" Name="OnSerializing(System.Runtime.Serialization.StreamingContext)" />
     </Type>
+    <Type Name="System.MarshalByRefObject">
+    </Type>
     <Type Status="ImplRoot" Name="System.System_LazyDebugView&lt;T&gt;">
       <Member Status="ImplRoot" Name="#ctor(System.Lazy&lt;T&gt;)"/>
       <Member Status="ImplRoot" MemberType="Property" Name="IsValueCreated"/>
@@ -3806,6 +3808,8 @@
       <Member MemberType="Field" Name="PublicKey" />
       <Member MemberType="Field" Name="Retargetable" />
       <Member MemberType="Field" Name="value__" />
+    </Type>
+    <Type Name="System.Reflection.AssemblyNameProxy">
     </Type>
     <Type Name="System.Reflection.AssemblyProductAttribute">
       <Member Name="#ctor(System.String)" />
@@ -5433,6 +5437,12 @@
       <Member Status="ImplRoot" MemberType="Field" Name="m_pGlobals" /> <!-- EE -->
       <Member Status="ImplRoot" MemberType="Field" Name="m_pRefClass" /> <!-- EE -->
       <Member Status="ImplRoot" MemberType="Field" Name="m_runtimeType" /> <!-- EE -->
+    </Type>
+    <Type Name="System.Reflection.ModuleResolveEventHandler">
+      <Member Name="#ctor(System.Object,System.IntPtr)" />
+      <Member Name="BeginInvoke(System.Object,System.ResolveEventArgs,System.AsyncCallback,System.Object)" />
+      <Member Name="EndInvoke(System.IAsyncResult)" />
+      <Member Name="Invoke(System.Object,System.ResolveEventArgs)" />
     </Type>
     <Type Name="System.Reflection.ParameterAttributes">
       <Member MemberType="Field" Name="HasDefault" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -5325,6 +5325,8 @@
     </Type>
     <Type Name="System.Reflection.MemberInfo">
       <Member Name="#ctor" />
+      <Member Name="op_Equality(System.Reflection.MemberInfo,System.Reflection.MemberInfo)" />
+      <Member Name="op_Inequality(System.Reflection.MemberInfo,System.Reflection.MemberInfo)" />
       <Member Name="get_CustomAttributes" />
       <Member Name="get_DeclaringType" />
       <Member Name="get_MemberType" />
@@ -7977,6 +7979,8 @@
     </Type>
     <Type Name="System.Type">
       <Member Name="#ctor" />
+      <Member Name="op_Equality(System.Type,System.Type)" />
+      <Member Name="op_Inequality(System.Type,System.Type)" />
       <Member MemberType="Field" Name="Delimiter" />
       <Member MemberType="Field" Name="EmptyTypes" />
       <Member MemberType="Field" Name="FilterNameIgnoreCase" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -5255,6 +5255,12 @@
       <Member Name="GetCustomAttributes(System.Type,System.Boolean)" />
       <Member Name="IsDefined(System.Type,System.Boolean)" />
     </Type>
+    <Type Name="System.Reflection.ImageFileMachine">
+      <Member MemberType="Field" Name="I386" />
+      <Member MemberType="Field" Name="IA64" />
+      <Member MemberType="Field" Name="AMD64" />
+      <Member MemberType="Field" Name="ARM" />
+    </Type>
 	<Type Name="System.Reflection.InvalidFilterCriteriaException">
       <Member Name="#ctor" />
       <Member Name="#ctor(System.String)" />
@@ -5267,7 +5273,20 @@
       <Member MemberType="Field" Name="TargetMethods" />
       <Member MemberType="Field" Name="TargetType" />
     </Type>
-    <Type Name="System.Reflection.IReflect" />
+    <Type Name="System.Reflection.IReflect" >
+      <Member Name="get_UnderlyingSystemType" />
+      <Member Name="GetField(System.String,System.Reflection.BindingFlags)" />
+      <Member Name="GetFields(System.Reflection.BindingFlags)" />
+      <Member Name="GetMember(System.String,System.Reflection.BindingFlags)" />
+      <Member Name="GetMembers(System.Reflection.BindingFlags)" />
+      <Member Name="GetMethod(System.String,System.Reflection.BindingFlags)" />
+      <Member Name="GetMethod(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type[],System.Reflection.ParameterModifier[])" />
+      <Member Name="GetMethods(System.Reflection.BindingFlags)" />
+      <Member Name="GetProperty(System.String,System.Reflection.BindingFlags)" />
+      <Member Name="GetProperty(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type,System.Type[],System.Reflection.ParameterModifier[])" />
+      <Member Name="GetProperties(System.Reflection.BindingFlags)" />
+      <Member Name="InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])" />
+    </Type>
     <Type Status="ImplRoot" Name="System.Reflection.LoaderAllocator">
       <Member Status="ImplRoot" Name="#ctor" />
       <Member Status="ImplRoot" MemberType="Field" Name="m_slots" />
@@ -9218,8 +9237,24 @@
     <Type Status="ImplRoot" Name="System.Reflection.Emit.DynamicResolver" />
     <Type Status="ImplRoot" Name="System.Reflection.Emit.DynamicResolver+SecurityControlFlags" />
     <Type Status="ImplRoot" Name="System.Reflection.Emit.DynamicScope" />
-    <Type Status="ImplRoot" Name="System.Reflection.ExceptionHandlingClause" />
 
+    <Type Name="System.Reflection.ExceptionHandlingClause" >
+      <Member Name="#ctor" />
+      <Member Name="get_CatchType" />
+      <Member Name="get_FilterOffset" />
+      <Member Name="get_Flags" />
+      <Member Name="get_HandlerLength" />
+      <Member Name="get_HandlerOffset" />
+      <Member Name="get_TryLength" />
+      <Member Name="get_TryOffset" />
+      <Member Name="ToString" />
+    </Type>
+    <Type Name="System.Reflection.ExceptionHandlingClauseOptions" >
+      <Member MemberType="Field" Name="Clause" />
+      <Member MemberType="Field" Name="Fault" />
+      <Member MemberType="Field" Name="Filter" />
+      <Member MemberType="Field" Name="Finally" />
+    </Type>
     <Type Status="ApiRoot" Name="System.Reflection.LocalVariableInfo">
       <Member Name="#ctor" />
       <Member Name="get_IsPinned" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -5147,6 +5147,8 @@
     </Type>
     <Type Name="System.Reflection.EventInfo">
       <Member Name="#ctor" />
+      <Member Name="op_Equality(System.Reflection.EventInfo,System.Reflection.EventInfo)" />
+      <Member Name="op_Inequality(System.Reflection.EventInfo,System.Reflection.EventInfo)" />
       <Member Name="AddEventHandler(System.Object,System.Delegate)" />
       <Member Name="get_Attributes" />
       <Member Name="get_AddMethod" />
@@ -5158,6 +5160,8 @@
       <Member Name="get_MemberType" />
       <Member Name="GetAddMethod" />
       <Member Name="GetAddMethod(System.Boolean)" />
+      <Member Name="GetOtherMethods" />
+      <Member Name="GetOtherMethods(System.Boolean)" />
       <Member Name="GetRaiseMethod" />
       <Member Name="GetRaiseMethod(System.Boolean)" />
       <Member Name="GetRemoveMethod" />
@@ -5198,6 +5202,8 @@
     </Type>
     <Type Name="System.Reflection.FieldInfo">
       <Member Name="#ctor" />
+      <Member Name="op_Equality(System.Reflection.FieldInfo,System.Reflection.FieldInfo)" />
+      <Member Name="op_Inequality(System.Reflection.FieldInfo,System.Reflection.FieldInfo)" />
       <Member Name="get_Attributes" />
       <Member Name="get_FieldHandle" />
       <Member Name="get_FieldType" />
@@ -5211,6 +5217,9 @@
       <Member Name="get_IsPinvokeImpl" />
       <Member Name="get_IsPrivate" />
       <Member Name="get_IsPublic" />
+      <Member Name="get_IsSecurityCritical" />
+      <Member Name="get_IsSecuritySafeCritical" />
+      <Member Name="get_IsSecurityTransparent" />
       <Member Name="get_IsSpecialName" />
       <Member Name="get_IsStatic" />
       <Member Name="get_MemberType" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3634,6 +3634,7 @@
       <Member Name="GetModules(System.Boolean)" />
       <Member Name="Equals(System.Object)" />
       <Member Name="GetHashCode" />
+      <Member Name="GetName(System.Boolean)" />
       <Member Name="GetName" />
       <Member Name="GetSatelliteAssembly(System.Globalization.CultureInfo)" />
       <Member Name="GetSatelliteAssembly(System.Globalization.CultureInfo,System.Version)" />
@@ -3816,6 +3817,7 @@
       <Member Name="SetPublicKeyToken(System.Byte[])" />
       <Member Name="ToString" />
       <Member Name="#ctor(System.String)" />
+      <Member MemberType="Property" Name="CodeBase" />
       <Member MemberType="Property" Name="CultureInfo" />
       <Member MemberType="Property" Name="CultureName" />
       <Member MemberType="Property" Name="ContentType" />
@@ -3825,6 +3827,7 @@
       <Member MemberType="Property" Name="Name" />
       <Member MemberType="Property" Name="ProcessorArchitecture" />
       <Member MemberType="Property" Name="Version" />
+      <Member MemberType="Property" Name="VersionCompatibility" />
     </Type>
     <Type Name="System.Reflection.AssemblyNameFlags">
       <Member MemberType="Field" Name="EnableJITcompileOptimizer" />
@@ -5690,11 +5693,66 @@
       <Member MemberType="Field" Name="value__" />
       <Member MemberType="Field" Name="VisibilityMask" />
     </Type>
-    <Type Status="ImplRoot" Name="System.Reflection.TypeDelegator">
-        <Member Name="#ctor" />
-        <Member Name="#ctor(System.Type)" />
-        <Member Name="get_MetadataToken" />
-        <Member MemberType="Property" Name="MetadataToken" />
+    <Type Name="System.Reflection.TypeDelegator">
+      <Member Name="#ctor" />
+      <Member Name="#ctor(System.Type)" />
+      <Member Name="get_GUID" />
+      <Member Name="get_MetadataToken" />
+      <Member Name="InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])" />
+      <Member Name="get_Module" />
+      <Member Name="get_Assembly" />
+      <Member Name="get_TypeHandle" />
+      <Member Name="get_Name" />
+      <Member Name="get_FullName" />
+      <Member Name="get_Namespace" />
+      <Member Name="get_AssemblyQualifiedName" />
+      <Member Name="get_BaseType" />
+      <Member Name="GetConstructorImpl(System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" />
+      <Member Name="GetConstructors(System.Reflection.BindingFlags)" />
+      <Member Name="GetMethodImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" />
+      <Member Name="GetMethods(System.Reflection.BindingFlags)" />
+      <Member Name="GetField(System.String,System.Reflection.BindingFlags)" />
+      <Member Name="GetFields(System.Reflection.BindingFlags)" />
+      <Member Name="GetInterface(System.String,System.Boolean)" />
+      <Member Name="GetInterfaces" />
+      <Member Name="GetEvent(System.String,System.Reflection.BindingFlags)" />
+      <Member Name="GetEvents" />
+      <Member Name="GetPropertyImpl(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type,System.Type[],System.Reflection.ParameterModifier[])" />
+      <Member Name="GetProperties(System.Reflection.BindingFlags)" />
+      <Member Name="GetEvents(System.Reflection.BindingFlags)" />
+      <Member Name="GetNestedTypes(System.Reflection.BindingFlags)" />
+      <Member Name="GetNestedType(System.String,System.Reflection.BindingFlags)" />
+      <Member Name="GetMember(System.String,System.Reflection.MemberTypes,System.Reflection.BindingFlags)" />
+      <Member Name="GetMembers(System.Reflection.BindingFlags)" />
+      <Member Name="GetAttributeFlagsImpl" />
+      <Member Name="IsArrayImpl" />
+      <Member Name="IsPrimitiveImpl" />
+      <Member Name="IsByRefImpl" />
+      <Member Name="IsPointerImpl" />
+      <Member Name="IsValueTypeImpl" />
+      <Member Name="IsCOMObjectImpl" />
+      <Member Name="get_IsConstructedGenericType" />
+      <Member Name="GetElementType" />
+      <Member Name="HasElementTypeImpl" />
+      <Member Name="get_UnderlyingSystemType" />
+      <Member Name="GetCustomAttributes(System.Boolean)" />
+      <Member Name="GetCustomAttributes(System.Type,System.Boolean)" />
+      <Member Name="IsDefined(System.Type,System.Boolean)" />
+      <Member Name="IsAssignableFrom(System.Reflection.TypeInfo)" />
+      <Member Name="GetInterfaceMap(System.Type)" />
+      <Member MemberType="Field" Name="typeImpl" />
+      <Member MemberType="Property" Name="GUID" />
+      <Member MemberType="Property" Name="MetadataToken" />
+      <Member MemberType="Property" Name="Module" />
+      <Member MemberType="Property" Name="Assembly" />
+      <Member MemberType="Property" Name="TypeHandle" />
+      <Member MemberType="Property" Name="Name" />
+      <Member MemberType="Property" Name="FullName" />
+      <Member MemberType="Property" Name="Namespace" />
+      <Member MemberType="Property" Name="AssemblyQualifiedName" />
+      <Member MemberType="Property" Name="BaseType" />
+      <Member MemberType="Property" Name="IsConstructedGenericType" />
+      <Member MemberType="Property" Name="UnderlyingSystemType" />
     </Type>
     <Type Name="System.ResolveEventArgs">
       <Member Name="#ctor(System.String)" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3875,6 +3875,7 @@
       <Member Name="ReorderArgumentArray(System.Object[]@,System.Object)" />
       <Member Name="SelectMethod(System.Reflection.BindingFlags,System.Reflection.MethodBase[],System.Type[],System.Reflection.ParameterModifier[])" />
       <Member Name="SelectProperty(System.Reflection.BindingFlags,System.Reflection.PropertyInfo[],System.Type,System.Type[],System.Reflection.ParameterModifier[])" />
+      <Member Name="CanChangeType(System.Object,System.Type,System.Globalization.CultureInfo)" />
     </Type>
     <Type Name="System.Reflection.BindingFlags">
       <Member MemberType="Field" Name="CreateInstance" />
@@ -5470,6 +5471,7 @@
       <Member Name="FindTypes(System.Reflection.TypeFilter,System.Object)" />
 	  <Member Name="GetCustomAttributes(System.Boolean)" />
       <Member Name="GetCustomAttributes(System.Type,System.Boolean)" />
+      <Member Name="GetCustomAttributesData" />
       <Member Name="GetField(System.String)" />
       <Member Name="GetField(System.String,System.Reflection.BindingFlags)" />
       <Member Name="GetFields" />
@@ -5487,10 +5489,14 @@
       <Member Name="Equals(System.Object)" />
       <Member Name="GetHashCode" />
       <Member Name="IsDefined(System.Type,System.Boolean)" />
+      <Member Name="IsResource" />
+      <Member Name="ResolveMember(System.Int32)" />
+      <Member Name="ResolveMember(System.Int32,System.Type[],System.Type[])" />
       <Member Name="ResolveMethod(System.Int32)" />
       <Member Name="ResolveMethod(System.Int32,System.Type[],System.Type[])" />
       <Member Name="ResolveField(System.Int32)" />
       <Member Name="ResolveField(System.Int32,System.Type[],System.Type[])" />
+      <Member Name="ResolveSignature(System.Int32)" />
       <Member Name="ResolveString(System.Int32)" />
       <Member Name="ResolveType(System.Int32)" />
       <Member Name="ResolveType(System.Int32,System.Type[],System.Type[])" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -7174,6 +7174,8 @@ namespace System.Reflection
     public abstract partial class EventInfo : System.Reflection.MemberInfo
     {
         protected EventInfo() { }
+        public static bool operator ==(System.Reflection.EventInfo left, System.Reflection.EventInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.EventInfo left, System.Reflection.EventInfo right) { throw null; }
         public virtual System.Reflection.MethodInfo AddMethod { get { throw null; } }
         public abstract System.Reflection.EventAttributes Attributes { get; }
         public virtual System.Type EventHandlerType { get { throw null; } }
@@ -7189,6 +7191,8 @@ namespace System.Reflection
         public System.Reflection.MethodInfo GetAddMethod() { throw null; }
         public abstract System.Reflection.MethodInfo GetAddMethod(bool nonPublic);
         public override int GetHashCode() { throw null; }
+        public System.Reflection.MethodInfo[] GetOtherMethods() { throw null; }
+        public virtual System.Reflection.MethodInfo[] GetOtherMethods(bool nonPublic) { throw null; }
         public System.Reflection.MethodInfo GetRaiseMethod() { throw null; }
         public abstract System.Reflection.MethodInfo GetRaiseMethod(bool nonPublic);
         public System.Reflection.MethodInfo GetRemoveMethod() { throw null; }
@@ -7226,6 +7230,8 @@ namespace System.Reflection
     public abstract partial class FieldInfo : System.Reflection.MemberInfo
     {
         protected FieldInfo() { }
+        public static bool operator ==(System.Reflection.FieldInfo left, System.Reflection.FieldInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.FieldInfo left, System.Reflection.FieldInfo right) { throw null; }
         public abstract System.Reflection.FieldAttributes Attributes { get; }
         public abstract System.RuntimeFieldHandle FieldHandle { get; }
         public abstract System.Type FieldType { get; }
@@ -7239,6 +7245,9 @@ namespace System.Reflection
         public bool IsPinvokeImpl { get { throw null; } }
         public bool IsPrivate { get { throw null; } }
         public bool IsPublic { get { throw null; } }
+        public virtual bool IsSecurityCritical { get { throw null; } }
+        public virtual bool IsSecuritySafeCritical { get { throw null; } }
+        public virtual bool IsSecurityTransparent { get { throw null; } }
         public bool IsSpecialName { get { throw null; } }
         public bool IsStatic { get { throw null; } }
         public override System.Reflection.MemberTypes MemberType { get { throw null; } }

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -6735,30 +6735,45 @@ namespace System.Reflection
         public virtual System.Reflection.Module ManifestModule { get { throw null; } }
         public virtual event ModuleResolveEventHandler ModuleResolve { [System.Security.SecurityCriticalAttribute]add { } [System.Security.SecurityCriticalAttribute]remove { } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.Module> Modules { get { throw null; } }
+        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+        public virtual bool ReflectionOnly { get { throw null; } }
         public object CreateInstance(string typeName) { throw null; }
         public object CreateInstance(string typeName, bool ignoreCase) { throw null; }
+        public virtual object CreateInstance(String typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, System.Globalization.CultureInfo culture, Object[] activationAttributes) { throw null; }
         public static string CreateQualifiedName(string assemblyName, string typeName) { throw null; }
         public override bool Equals(object o) { throw null; }
+        public static Assembly GetAssembly(Type type) { throw null; }
+        public static bool operator ==(System.Reflection.Assembly left, System.Reflection.Assembly right) { throw null; }
+        public static bool operator !=(System.Reflection.Assembly left, System.Reflection.Assembly right) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)][System.Security.SecuritySafeCriticalAttribute]
         public static System.Reflection.Assembly GetCallingAssembly() { throw null; }
         public virtual object[] GetCustomAttributes(bool inherit) { throw null; }
         public virtual object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public virtual System.Collections.Generic.IList<CustomAttributeData> GetCustomAttributesData() { throw null; }
         [System.Security.SecuritySafeCriticalAttribute]
         public static System.Reflection.Assembly GetEntryAssembly() { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)][System.Security.SecuritySafeCriticalAttribute]
         public static System.Reflection.Assembly GetExecutingAssembly() { throw null; }
         public virtual System.Type[] GetExportedTypes() { throw null; }
         public override int GetHashCode() { throw null; }
+        public System.Reflection.Module[] GetLoadedModules() { throw null; }
+        public virtual System.Reflection.Module[] GetLoadedModules(bool getResourceModules) { throw null; }
         public virtual System.Reflection.ManifestResourceInfo GetManifestResourceInfo(string resourceName) { throw null; }
         public virtual string[] GetManifestResourceNames() { throw null; }
         public virtual System.IO.Stream GetManifestResourceStream(string name) { throw null; }
         public virtual System.IO.Stream GetManifestResourceStream(System.Type type, string name) { throw null; }
+        public virtual System.Reflection.Module GetModule(String name) { throw null; }
         public System.Reflection.Module[] GetModules() { throw null; }
+        public virtual System.Reflection.Module[] GetModules(bool getResourceModules) { throw null; }
         [System.Security.SecurityCriticalAttribute]
         public virtual System.Reflection.AssemblyName GetName() { throw null; }
         [System.Security.SecurityCriticalAttribute]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual System.Reflection.AssemblyName[] GetReferencedAssemblies() { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public virtual Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public virtual Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture, System.Version version) { throw null; }
         public virtual System.Type GetType(string name) { throw null; }
         public virtual System.Type GetType(string name, bool throwOnError) { throw null; }
         public virtual System.Type GetType(string name, bool throwOnError, bool ignoreCase) { throw null; }
@@ -6772,6 +6787,12 @@ namespace System.Reflection
         public static System.Reflection.Assembly Load(System.Reflection.AssemblyName assemblyRef) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)][System.Security.SecuritySafeCriticalAttribute]
         public static System.Reflection.Assembly Load(string assemblyString) { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute][System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public static Assembly ReflectionOnlyLoad(byte[] rawAssembly) { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute][System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public static Assembly ReflectionOnlyLoad(String assemblyString) { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute][System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public static Assembly ReflectionOnlyLoadFrom(string assemblyFile) { throw null; }
         public override string ToString() { throw null; }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -6916,7 +6916,7 @@ namespace System.Reflection
     }
     [System.Runtime.InteropServices.ClassInterfaceAttribute((System.Runtime.InteropServices.ClassInterfaceType)(0))]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class AssemblyName : System.ICloneable
+    public sealed partial class AssemblyName : System.ICloneable, System.Runtime.Serialization.ISerializable, System.Runtime.Serialization.IDeserializationCallback
     {
         public AssemblyName() { }
         [System.Security.SecuritySafeCriticalAttribute]
@@ -6940,6 +6940,9 @@ namespace System.Reflection
         public void SetPublicKey(byte[] publicKey) { }
         public void SetPublicKeyToken(byte[] publicKeyToken) { }
         public override string ToString() { throw null; }
+        [System.Security.SecurityCriticalAttribute]
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { throw null; }
+        public void OnDeserialization(Object sender) { throw null; }
     }
     [System.FlagsAttribute]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -7543,10 +7546,12 @@ namespace System.Reflection
         public virtual System.Reflection.MethodInfo MakeGenericMethod(params System.Type[] typeArguments) { throw null; }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class Missing
+    public sealed partial class Missing : System.Runtime.Serialization.ISerializable
     {
         internal Missing() { }
         public static readonly System.Reflection.Missing Value;
+        [System.Security.SecurityCriticalAttribute]
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     [System.Runtime.InteropServices.ClassInterfaceAttribute((System.Runtime.InteropServices.ClassInterfaceType)(0))]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -7683,12 +7688,14 @@ namespace System.Reflection
     }
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed class Pointer
+    public sealed class Pointer : System.Runtime.Serialization.ISerializable
     {
         [System.Security.SecurityCriticalAttribute]
         public static unsafe Object Box(void *ptr, System.Type type) { throw null; }
         [System.Security.SecurityCriticalAttribute]
         public static unsafe void* Unbox(object ptr) { throw null; }
+        [System.Security.SecurityCriticalAttribute]
+        unsafe void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     [System.FlagsAttribute]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -2496,6 +2496,26 @@ namespace System
         protected MissingMethodException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public override string Message { [System.Security.SecuritySafeCriticalAttribute]get { throw null; } }
     }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public unsafe struct ModuleHandle
+    {
+        public static readonly System.ModuleHandle EmptyHandle;
+        public int MDStreamVersion { get { throw null; } }
+        public override int GetHashCode() { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public unsafe bool Equals(System.ModuleHandle handle) { throw null; }
+        public static bool operator ==(System.ModuleHandle left, System.ModuleHandle right) { throw null; }
+        public static bool operator !=(System.ModuleHandle left, System.ModuleHandle right) { throw null; }
+        public System.RuntimeTypeHandle GetRuntimeTypeHandleFromMetadataToken(int typeToken) { throw null; }
+        public System.RuntimeTypeHandle ResolveTypeHandle(int typeToken) { throw null; }
+        public System.RuntimeTypeHandle ResolveTypeHandle(int typeToken, System.RuntimeTypeHandle[] typeInstantiationContext, System.RuntimeTypeHandle[] methodInstantiationContext) { throw null; }
+        public System.RuntimeMethodHandle GetRuntimeMethodHandleFromMetadataToken(int methodToken) { throw null; }
+        public System.RuntimeMethodHandle ResolveMethodHandle(int methodToken) { throw null; }
+        public System.RuntimeMethodHandle ResolveMethodHandle(int methodToken, System.RuntimeTypeHandle[] typeInstantiationContext, System.RuntimeTypeHandle[] methodInstantiationContext) { throw null; }
+        public System.RuntimeFieldHandle GetRuntimeFieldHandleFromMetadataToken(int fieldToken) { throw null; }
+        public System.RuntimeFieldHandle ResolveFieldHandle(int fieldToken) { throw null; }
+        public System.RuntimeFieldHandle ResolveFieldHandle(int fieldToken, System.RuntimeTypeHandle[] typeInstantiationContext, System.RuntimeTypeHandle[] methodInstantiationContext) { throw null; }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(64))]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class MTAThreadAttribute : System.Attribute
@@ -7561,8 +7581,10 @@ namespace System.Reflection
         public static readonly System.Reflection.TypeFilter FilterTypeNameIgnoreCase;
         protected Module() { }
         public virtual System.Reflection.Assembly Assembly { get { throw null; } }
+        public System.ModuleHandle ModuleHandle { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }
         public virtual string FullyQualifiedName { [System.Security.SecurityCriticalAttribute]get { throw null; } }
+        public virtual int MDStreamVersion { get { throw null; } }
         public virtual int MetadataToken { get { throw null; } }
         public virtual System.Guid ModuleVersionId { get { throw null; } }
         public virtual string Name { get { throw null; } }
@@ -7584,6 +7606,7 @@ namespace System.Reflection
         public virtual System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingFlags) { throw null; }
         [System.Security.SecurityCriticalAttribute]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public virtual void GetPEKind(out System.Reflection.PortableExecutableKinds peKind, out System.Reflection.ImageFileMachine machine) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(true)]
         public virtual System.Type GetType(string className) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(true)]

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -7201,6 +7201,28 @@ namespace System.Reflection
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public virtual void RemoveEventHandler(object target, System.Delegate handler) { }
     }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public class ExceptionHandlingClause
+    {
+        protected ExceptionHandlingClause() { }
+        public virtual System.Reflection.ExceptionHandlingClauseOptions Flags { get { throw null; } }
+        public virtual int TryOffset { get { throw null; } }
+        public virtual int TryLength { get { throw null; } }
+        public virtual int HandlerOffset { get { throw null; } }
+        public virtual int HandlerLength { get { throw null; } }
+        public virtual int FilterOffset { get { throw null; } }
+        public virtual System.Type CatchType { get { throw null; } }
+        public override string ToString() { throw null; }
+    }
+    [System.FlagsAttribute]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public enum ExceptionHandlingClauseOptions: int
+    {
+        Clause = 0,
+        Filter = 1,
+        Finally = 2,
+        Fault = 4,
+    }
     [System.FlagsAttribute]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public enum FieldAttributes
@@ -7283,6 +7305,14 @@ namespace System.Reflection
         object[] GetCustomAttributes(bool inherit);
         object[] GetCustomAttributes(System.Type attributeType, bool inherit);
         bool IsDefined(System.Type attributeType, bool inherit);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public enum ImageFileMachine
+    {
+        I386    = 332,
+        IA64    = 512,
+        AMD64   = 34404,
+        ARM     = 452,
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -7467,10 +7467,15 @@ namespace System.Reflection
         public abstract System.RuntimeMethodHandle MethodHandle { get; }
         public virtual System.Reflection.MethodImplAttributes MethodImplementationFlags { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]public static System.Reflection.MethodBase GetCurrentMethod() { throw null; }
+        public static bool operator ==(System.Reflection.MethodBase left, System.Reflection.MethodBase right) { throw null; }
+        public static bool operator !=(System.Reflection.MethodBase left, System.Reflection.MethodBase right) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public static System.Reflection.MethodBase GetCurrentMethod() { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(true)]
         public virtual System.Type[] GetGenericArguments() { throw null; }
         public override int GetHashCode() { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute]
+        public virtual System.Reflection.MethodBody GetMethodBody() { throw null; }
         public static System.Reflection.MethodBase GetMethodFromHandle(System.RuntimeMethodHandle handle) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public static System.Reflection.MethodBase GetMethodFromHandle(System.RuntimeMethodHandle handle, System.RuntimeTypeHandle declaringType) { throw null; }
@@ -7480,6 +7485,17 @@ namespace System.Reflection
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public object Invoke(object obj, object[] parameters) { throw null; }
         public abstract object Invoke(object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public class MethodBody
+    {
+        protected MethodBody() { }
+        public virtual int LocalSignatureMetadataToken { get { throw null; } }
+        public virtual System.Collections.Generic.IList<LocalVariableInfo> LocalVariables { get { throw null; } }
+        public virtual int MaxStackSize { get { throw null; } }
+        public virtual bool InitLocals { get { throw null; } }
+        public virtual byte[] GetILAsByteArray() { throw null; }
+        public virtual System.Collections.Generic.IList<ExceptionHandlingClause> ExceptionHandlingClauses { get { throw null; } }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public enum MethodImplAttributes
@@ -7507,6 +7523,8 @@ namespace System.Reflection
     public abstract partial class MethodInfo : System.Reflection.MethodBase
     {
         protected MethodInfo() { }
+        public static bool operator ==(System.Reflection.MethodInfo left, System.Reflection.MethodInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.MethodInfo left, System.Reflection.MethodInfo right) { throw null; }
         public override System.Reflection.MemberTypes MemberType { get { throw null; } }
         public virtual System.Reflection.ParameterInfo ReturnParameter { get { throw null; } }
         public virtual System.Type ReturnType { get { throw null; } }

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -3484,6 +3484,8 @@ namespace System
     {
         public static readonly char Delimiter;
         public static readonly System.Type[] EmptyTypes;
+        public static readonly System.Reflection.MemberFilter FilterAttribute;
+        public static readonly System.Reflection.MemberFilter FilterName;
         public static readonly System.Reflection.MemberFilter FilterNameIgnoreCase;
         public static readonly object Missing;
         protected Type() { }
@@ -3514,6 +3516,7 @@ namespace System
         public bool IsClass { get { throw null; } }
         public bool IsCOMObject { get { throw null; } }
         public virtual bool IsConstructedGenericType { get { throw null; } }
+        public bool IsContextful { [System.Diagnostics.Contracts.PureAttribute]get { throw null;} }
         public bool IsEnum { get { throw null; } }
         public bool IsExplicitLayout { get { throw null; } }
         public virtual bool IsGenericParameter { get { throw null; } }
@@ -3564,6 +3567,8 @@ namespace System
         public System.Reflection.ConstructorInfo[] GetConstructors() { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(true)]
         public abstract System.Reflection.ConstructorInfo[] GetConstructors(System.Reflection.BindingFlags bindingAttr);
+        [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+        public System.Reflection.ConstructorInfo GetConstructor(System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public virtual System.Reflection.MemberInfo[] GetDefaultMembers() { throw null; }
         public abstract System.Type GetElementType();
         public virtual string GetEnumName(object value) { throw null; }
@@ -3615,25 +3620,46 @@ namespace System
         public System.Reflection.PropertyInfo GetProperty(string name, System.Type returnType, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
         public System.Reflection.PropertyInfo GetProperty(string name, System.Type[] types) { throw null; }
         protected abstract System.Reflection.PropertyInfo GetPropertyImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type returnType, System.Type[] types, System.Reflection.ParameterModifier[] modifiers);
+        public new System.Type GetType() { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]public static System.Type GetType(string typeName) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]public static System.Type GetType(string typeName, bool throwOnError) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]public static System.Type GetType(string typeName, bool throwOnError, bool ignoreCase) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public static System.Type GetType(string typeName, System.Func<System.Reflection.AssemblyName, System.Reflection.Assembly> assemblyResolver, System.Func<System.Reflection.Assembly, string, bool, System.Type> typeResolver) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public static System.Type GetType(string typeName, System.Func<System.Reflection.AssemblyName, System.Reflection.Assembly> assemblyResolver, System.Func<System.Reflection.Assembly, string, bool, System.Type> typeResolver, bool throwOnError) { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public static System.Type GetType(string typeName, System.Func<System.Reflection.AssemblyName, System.Reflection.Assembly> assemblyResolver, System.Func<System.Reflection.Assembly, string, bool, System.Type> typeResolver, bool throwOnError, bool ignoreCase) { throw null; }
+        public static System.Type[] GetTypeArray(System.Object[] args) { throw null; }
         public static System.TypeCode GetTypeCode(System.Type type) { throw null; }
+        protected virtual System.TypeCode GetTypeCodeImpl() { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute]public static System.Type GetTypeFromCLSID(System.Guid clsid) { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute]public static System.Type GetTypeFromCLSID(System.Guid clsid, bool throwOnError) { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute]public static System.Type GetTypeFromCLSID(System.Guid clsid, string server) { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute]public static System.Type GetTypeFromCLSID(System.Guid clsid, string server, bool throwOnError) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
         public static System.Type GetTypeFromHandle(System.RuntimeTypeHandle handle) { throw null; }
+        [System.Security.SecurityCriticalAttribute]public static System.Type GetTypeFromProgID(string progID) { throw null; }
+        [System.Security.SecurityCriticalAttribute]public static System.Type GetTypeFromProgID(string progID, bool throwOnError) { throw null; }
+        [System.Security.SecurityCriticalAttribute]public static System.Type GetTypeFromProgID(string progID, string server) { throw null; }
+        [System.Security.SecurityCriticalAttribute]public static System.Type GetTypeFromProgID(string progID, string server, bool throwOnError) { throw null; }
         public static System.RuntimeTypeHandle GetTypeHandle(object o) { throw null; }
         protected abstract bool HasElementTypeImpl();
         [System.Diagnostics.DebuggerHiddenAttribute]
         [System.Diagnostics.DebuggerStepThroughAttribute]
         public object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute][System.Diagnostics.DebuggerHiddenAttribute]
+        public System.Object InvokeMember(System.String name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object target, System.Object[] args, System.Globalization.CultureInfo culture) { throw null; }
         public abstract object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters);
         protected abstract bool IsArrayImpl();
         public virtual bool IsAssignableFrom(System.Type c) { throw null; }
         protected abstract bool IsByRefImpl();
         protected abstract bool IsCOMObjectImpl();
+        protected virtual bool IsContextfulImpl() { throw null; }
         public virtual bool IsEnumDefined(object value) { throw null; }
         public virtual bool IsEquivalentTo(System.Type other) { throw null; }
         public virtual bool IsInstanceOfType(object o) { throw null; }
+        protected virtual bool IsMarshalByRefImpl() { throw null; }
         protected abstract bool IsPointerImpl();
         protected abstract bool IsPrimitiveImpl();
         [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -3644,6 +3670,8 @@ namespace System
         public virtual System.Type MakeByRefType() { throw null; }
         public virtual System.Type MakeGenericType(params System.Type[] typeArguments) { throw null; }
         public virtual System.Type MakePointerType() { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        public static System.Type ReflectionOnlyGetType(System.String typeName, bool throwIfNotFound, bool ignoreCase) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial class TypeAccessException : System.TypeLoadException
@@ -3702,6 +3730,17 @@ namespace System
         public string TypeName { get { throw null; } }
         [System.Security.SecurityCriticalAttribute]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    internal sealed class TypeNameParser : System.IDisposable
+    {
+        [System.Security.SecuritySafeCriticalAttribute]public void Dispose() { throw null; }
+    }
+    [System.Security.SecurityCriticalAttribute]
+    internal class SafeTypeNameParserHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SafeTypeNameParserHandle(): base() { }
+        [System.Security.SecurityCriticalAttribute]
+        protected override bool ReleaseHandle() { throw null; }
     }
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -7042,6 +7042,8 @@ namespace System.Reflection
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public abstract partial class ConstructorInfo : System.Reflection.MethodBase
     {
+        public static bool operator ==(System.Reflection.ConstructorInfo left, System.Reflection.ConstructorInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.ConstructorInfo left, System.Reflection.ConstructorInfo right) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(true)]
         public static readonly string ConstructorName;
         [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -7125,7 +7127,10 @@ namespace System.Reflection
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CustomAttributeNamedArgument
     {
+        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, object value) { }
+        public CustomAttributeNamedArgument(System.Reflection.MemberInfo memberInfo, System.Reflection.CustomAttributeTypedArgument typedArgument) { }
         public bool IsField { get { throw null; } }
+        public System.Reflection.MemberInfo MemberInfo { get { throw null; } }
         public string MemberName { get { throw null; } }
         public System.Reflection.CustomAttributeTypedArgument TypedValue { get { throw null; } }
         public override bool Equals(object obj) { throw null; }
@@ -7138,6 +7143,8 @@ namespace System.Reflection
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct CustomAttributeTypedArgument
     {
+        public CustomAttributeTypedArgument(System.Type argumentType, object value) { }
+        public CustomAttributeTypedArgument(object value) { }
         public System.Type ArgumentType { get { throw null; } }
         public object Value { get { throw null; } }
         public override bool Equals(object obj) { throw null; }

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -7580,6 +7580,8 @@ namespace System.Reflection
         public static readonly System.Reflection.TypeFilter FilterTypeName;
         public static readonly System.Reflection.TypeFilter FilterTypeNameIgnoreCase;
         protected Module() { }
+        public static bool operator ==(System.Reflection.Module left, System.Reflection.Module right) { throw null; }
+        public static bool operator !=(System.Reflection.Module left, System.Reflection.Module right) { throw null; }
         public virtual System.Reflection.Assembly Assembly { get { throw null; } }
         public System.ModuleHandle ModuleHandle { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -7002,6 +7002,7 @@ namespace System.Reflection
         public abstract void ReorderArgumentArray(ref object[] args, object state);
         public abstract System.Reflection.MethodBase SelectMethod(System.Reflection.BindingFlags bindingAttr, System.Reflection.MethodBase[] match, System.Type[] types, System.Reflection.ParameterModifier[] modifiers);
         public abstract System.Reflection.PropertyInfo SelectProperty(System.Reflection.BindingFlags bindingAttr, System.Reflection.PropertyInfo[] match, System.Type returnType, System.Type[] indexes, System.Reflection.ParameterModifier[] modifiers);
+        public virtual bool CanChangeType(System.Object value,System.Type type,System.Globalization.CultureInfo culture) { throw null; }
     }
     [System.FlagsAttribute]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -7586,10 +7587,15 @@ namespace System.Reflection
         public virtual System.Type GetType(string className, bool throwOnError, bool ignoreCase) { throw null; }
         public virtual System.Type[] GetTypes() { throw null; }
         public virtual bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        public virtual bool IsResource() { throw null; }
+        public virtual System.Collections.Generic.IList<CustomAttributeData> GetCustomAttributesData() { throw null; }
         public System.Reflection.FieldInfo ResolveField(int metadataToken) { throw null; }
         public virtual System.Reflection.FieldInfo ResolveField(int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw null; }
+        public System.Reflection.MemberInfo ResolveMember(int metadataToken) { throw null; }
+        public virtual System.Reflection.MemberInfo ResolveMember(int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw null; }
         public System.Reflection.MethodBase ResolveMethod(int metadataToken) { throw null; }
         public virtual System.Reflection.MethodBase ResolveMethod(int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw null; }
+        public virtual byte[] ResolveSignature(int metadataToken) { throw null; }
         public virtual string ResolveString(int metadataToken) { throw null; }
         public System.Type ResolveType(int metadataToken) { throw null; }
         public virtual System.Type ResolveType(int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw null; }

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -6884,7 +6884,7 @@ namespace System.Reflection
         public AssemblyFlagsAttribute(System.Reflection.AssemblyNameFlags assemblyFlags) { }
         public int AssemblyFlags { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        public int Flags { get { throw null; } }
+        public uint Flags { get { throw null; } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -7061,7 +7061,7 @@ namespace System.Reflection
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public partial class CustomAttributeData
     {
-        internal CustomAttributeData() { }
+        protected CustomAttributeData() { }
         public System.Type AttributeType { get { throw null; } }
         [System.Runtime.InteropServices.ComVisibleAttribute(true)]
         public virtual System.Reflection.ConstructorInfo Constructor { get { throw null; } }
@@ -7394,6 +7394,7 @@ namespace System.Reflection
         public override bool Equals(object obj) { throw null; }
         public abstract object[] GetCustomAttributes(bool inherit);
         public abstract object[] GetCustomAttributes(System.Type attributeType, bool inherit);
+        public virtual System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributesData() { throw null; }
         public override int GetHashCode() { throw null; }
         public abstract bool IsDefined(System.Type attributeType, bool inherit);
     }
@@ -7594,6 +7595,25 @@ namespace System.Reflection
         public virtual System.Type ResolveType(int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw null; }
         public override string ToString() { throw null; }
     }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false, Inherited=false)]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public sealed class ObfuscateAssemblyAttribute : System.Attribute
+    {
+        public ObfuscateAssemblyAttribute(bool assemblyIsPrivate) { throw null; }
+        public bool AssemblyIsPrivate { get { throw null; } }
+        public bool StripAfterObfuscation { get { throw null; } set { } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1) | (System.AttributeTargets)(4) | (System.AttributeTargets)(8) | (System.AttributeTargets)(64) | (System.AttributeTargets)(2048) | (System.AttributeTargets)(256) | (System.AttributeTargets)(128) | (System.AttributeTargets)(512) | (System.AttributeTargets)(1024) | (System.AttributeTargets)(16) | (System.AttributeTargets)(4096),
+    AllowMultiple = true, Inherited = false)]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public sealed class ObfuscationAttribute: System.Attribute
+    {
+        public ObfuscationAttribute() { }
+        public bool StripAfterObfuscation { get { throw null; } set { } }
+        public bool Exclude { get { throw null; } set { } }
+        public bool ApplyToMembers { get { throw null; } set { } }
+        public string Feature { get { throw null; } set { } }
+    }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public delegate System.Reflection.Module ModuleResolveEventHandler(object sender, System.ResolveEventArgs e);
     [System.FlagsAttribute]
@@ -7640,6 +7660,7 @@ namespace System.Reflection
         public virtual object RawDefaultValue { get { throw null; } }
         public virtual object[] GetCustomAttributes(bool inherit) { throw null; }
         public virtual object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public virtual System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetCustomAttributesData() { throw null; }
         public virtual System.Type[] GetOptionalCustomModifiers() { throw null; }
         [System.Security.SecurityCriticalAttribute]
         public object GetRealObject(System.Runtime.Serialization.StreamingContext context) { throw null; }

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -6773,14 +6773,14 @@ namespace System.Reflection
         public System.Reflection.Module[] GetModules() { throw null; }
         public virtual System.Reflection.Module[] GetModules(bool getResourceModules) { throw null; }
         [System.Security.SecurityCriticalAttribute]
+        public virtual System.Reflection.AssemblyName GetName(bool copiedName) { throw null; }
+        [System.Security.SecurityCriticalAttribute]
         public virtual System.Reflection.AssemblyName GetName() { throw null; }
         [System.Security.SecurityCriticalAttribute]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual System.Reflection.AssemblyName[] GetReferencedAssemblies() { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        public virtual Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture) { throw null; }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        public virtual Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture, System.Version version) { throw null; }
+        public virtual System.Reflection.Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture) { throw null; }
+        public virtual System.Reflection.Assembly GetSatelliteAssembly(System.Globalization.CultureInfo culture, System.Version version) { throw null; }
         public virtual System.Type GetType(string name) { throw null; }
         public virtual System.Type GetType(string name, bool throwOnError) { throw null; }
         public virtual System.Type GetType(string name, bool throwOnError, bool ignoreCase) { throw null; }
@@ -7845,6 +7845,60 @@ namespace System.Reflection
         VisibilityMask = 7,
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         WindowsRuntime = 16384,
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public class TypeDelegator : System.Reflection.TypeInfo
+    {
+        protected System.Type typeImpl;
+        public override bool IsAssignableFrom(System.Reflection.TypeInfo typeInfo) { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute]
+        protected TypeDelegator() { }
+        public TypeDelegator(System.Type delegatingType) { }
+        public override System.Guid GUID { get { throw null; } }
+        public override int MetadataToken { get { throw null; } }
+        public override object InvokeMember(System.String name,System.Reflection.BindingFlags invokeAttr,System.Reflection.Binder binder,System.Object target, System.Object[] args,System.Reflection.ParameterModifier[] modifiers,System.Globalization.CultureInfo culture,System.String[] namedParameters) { throw null; }
+        public override System.Reflection.Module Module { get { throw null; } }
+        public override System.Reflection.Assembly Assembly { get { throw null; } }
+        public override System.RuntimeTypeHandle TypeHandle { get { throw null; } }
+        public override System.String Name { get { throw null; } }
+        public override System.String FullName { get { throw null; } }
+        public override System.String Namespace { get { throw null; } }
+        public override System.String AssemblyQualifiedName { get { throw null; } }
+        public override System.Type BaseType { get { throw null; } }
+        protected override System.Reflection.ConstructorInfo GetConstructorImpl(System.Reflection.BindingFlags bindingAttr,System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+        public override System.Reflection.ConstructorInfo[] GetConstructors(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        protected override System.Reflection.MethodInfo GetMethodImpl(System.String name,System.Reflection.BindingFlags bindingAttr,System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types,System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        public override System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.FieldInfo GetField(System.String name, System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.FieldInfo[] GetFields(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Type GetInterface(System.String name, bool ignoreCase) { throw null; }
+        public override System.Type[] GetInterfaces() { throw null; }
+        public override System.Reflection.EventInfo GetEvent(System.String name,System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.EventInfo[] GetEvents() { throw null; }
+        protected override System.Reflection.PropertyInfo GetPropertyImpl(System.String name,System.Reflection.BindingFlags bindingAttr,System.Reflection.Binder binder, System.Type returnType, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw null; }
+        public override System.Reflection.PropertyInfo[] GetProperties(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.EventInfo[] GetEvents(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Type[] GetNestedTypes(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Type GetNestedType(System.String name, System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.MemberInfo[] GetMember(System.String name,  System.Reflection.MemberTypes type, System.Reflection.BindingFlags bindingAttr) { throw null; }
+        public override System.Reflection.MemberInfo[] GetMembers(System.Reflection.BindingFlags bindingAttr) { throw null; }
+        protected override TypeAttributes GetAttributeFlagsImpl() { throw null; }
+        protected override bool IsArrayImpl() { throw null; }
+        protected override bool IsPrimitiveImpl() { throw null; }
+        protected override bool IsByRefImpl() { throw null; }
+        protected override bool IsPointerImpl() { throw null; }
+        protected override bool IsValueTypeImpl() { throw null; }
+        protected override bool IsCOMObjectImpl() { throw null; }
+        public override bool IsConstructedGenericType { get { throw null; } }
+        public override System.Type GetElementType() { throw null; }
+        protected override bool HasElementTypeImpl() { throw null; }
+        public override System.Type UnderlyingSystemType { get { throw null; } }
+        public override System.Object[] GetCustomAttributes(bool inherit) { throw null; }
+        public override System.Object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+        public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+        [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+        public override System.Reflection.InterfaceMapping GetInterfaceMap(System.Type interfaceType) { throw null; }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public delegate bool TypeFilter(System.Type m, object filterCriteria);

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -4572,6 +4572,13 @@ namespace System.Configuration.Assemblies
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         SHA512 = 32782,
     }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public enum AssemblyVersionCompatibility
+    {
+        SameMachine         = 1,
+        SameProcess         = 2,
+        SameDomain          = 3,
+    }
 }
 namespace System.Diagnostics
 {
@@ -6871,8 +6878,13 @@ namespace System.Reflection
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class AssemblyFlagsAttribute : System.Attribute
     {
+        [System.CLSCompliantAttribute(false)]
+        public AssemblyFlagsAttribute(uint flags) { }
+        public AssemblyFlagsAttribute(int assemblyFlags) { }
         public AssemblyFlagsAttribute(System.Reflection.AssemblyNameFlags assemblyFlags) { }
         public int AssemblyFlags { get { throw null; } }
+        [System.CLSCompliantAttribute(false)]
+        public int Flags { get { throw null; } }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -6912,10 +6924,12 @@ namespace System.Reflection
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public System.Reflection.AssemblyContentType ContentType { get { throw null; } set { } }
         public System.Globalization.CultureInfo CultureInfo { get { throw null; } set { } }
-        public string CultureName { get { throw null; } set { } }
+        public string CultureName { [System.Security.SecurityCriticalAttribute]get { throw null; } [System.Security.SecurityCriticalAttribute]set { } }
+        public string CodeBase { get { throw null; } set { } }
         public System.Reflection.AssemblyNameFlags Flags { get { throw null; } set { } }
         public string FullName { [System.Security.SecuritySafeCriticalAttribute]get { throw null; } }
         public System.Configuration.Assemblies.AssemblyHashAlgorithm HashAlgorithm { get { throw null; } set { } }
+        public System.Configuration.Assemblies.AssemblyVersionCompatibility VersionCompatibility { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }
         public System.Reflection.ProcessorArchitecture ProcessorArchitecture { get { throw null; } set { } }
         public System.Version Version { get { throw null; } set { } }

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -2335,6 +2335,11 @@ namespace System
         public T Value { get { throw null; } }
         public override string ToString() { throw null; }
     }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public abstract partial class MarshalByRefObject
+    {
+        internal MarshalByRefObject() { }
+    }
     public static partial class Math
     {
         public const double E = 2.7182818284590451;
@@ -6728,6 +6733,7 @@ namespace System.Reflection
         public virtual string Location { [System.Security.SecurityCriticalAttribute]get { throw null; } }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public virtual System.Reflection.Module ManifestModule { get { throw null; } }
+        public virtual event ModuleResolveEventHandler ModuleResolve { [System.Security.SecurityCriticalAttribute]add { } [System.Security.SecurityCriticalAttribute]remove { } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.Module> Modules { get { throw null; } }
         public object CreateInstance(string typeName) { throw null; }
         public object CreateInstance(string typeName, bool ignoreCase) { throw null; }
@@ -6909,6 +6915,11 @@ namespace System.Reflection
         None = 0,
         PublicKey = 1,
         Retargetable = 256,
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public class AssemblyNameProxy : System.MarshalByRefObject
+    {
+        internal AssemblyNameProxy() { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -7484,6 +7495,8 @@ namespace System.Reflection
         public virtual System.Type ResolveType(int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw null; }
         public override string ToString() { throw null; }
     }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public delegate System.Reflection.Module ModuleResolveEventHandler(object sender, System.ResolveEventArgs e);
     [System.FlagsAttribute]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public enum ParameterAttributes

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -7598,12 +7598,19 @@ namespace System.Reflection
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public partial class ParameterInfo : System.Reflection.ICustomAttributeProvider, System.Runtime.Serialization.IObjectReference
     {
+        protected String NameImpl;
+        protected Type ClassImpl;
+        protected int PositionImpl;
+        protected System.Reflection.ParameterAttributes AttrsImpl;
+        protected Object DefaultValueImpl;
+        protected MemberInfo MemberImpl;
         protected ParameterInfo() { }
         public virtual System.Reflection.ParameterAttributes Attributes { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }
         public virtual object DefaultValue { get { throw null; } }
         public virtual bool HasDefaultValue { get { throw null; } }
         public bool IsIn { get { throw null; } }
+        public bool IsLcid { get { throw null; } }
         public bool IsOptional { get { throw null; } }
         public bool IsOut { get { throw null; } }
         public bool IsRetval { get { throw null; } }
@@ -7628,6 +7635,27 @@ namespace System.Reflection
     {
         public ParameterModifier(int parameterCount) { throw null;}
         public bool this[int index] { get { throw null; } set { } }
+    }
+    [System.CLSCompliantAttribute(false)]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public sealed class Pointer
+    {
+        [System.Security.SecurityCriticalAttribute]
+        public static unsafe Object Box(void *ptr, System.Type type) { throw null; }
+        [System.Security.SecurityCriticalAttribute]
+        public static unsafe void* Unbox(object ptr) { throw null; }
+    }
+    [System.FlagsAttribute]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public enum PortableExecutableKinds
+    {
+        NotAPortableExecutableImage = 0,
+        ILOnly                      = 1,
+        Required32Bit               = 2,
+        PE32Plus                    = 4,
+        Unmanaged32Bit              = 8,
+        [System.Runtime.InteropServices.ComVisible(false)]
+        Preferred32Bit              = 16,
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public enum ProcessorArchitecture
@@ -7657,6 +7685,8 @@ namespace System.Reflection
     public abstract partial class PropertyInfo : System.Reflection.MemberInfo
     {
         protected PropertyInfo() { }
+        public static bool operator ==(System.Reflection.PropertyInfo left, System.Reflection.PropertyInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.PropertyInfo left, System.Reflection.PropertyInfo right) { throw null; }
         public abstract System.Reflection.PropertyAttributes Attributes { get; }
         public abstract bool CanRead { get; }
         public abstract bool CanWrite { get; }

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -3487,6 +3487,10 @@ namespace System
         public static readonly System.Reflection.MemberFilter FilterNameIgnoreCase;
         public static readonly object Missing;
         protected Type() { }
+        [System.Security.SecuritySafeCriticalAttribute][System.Diagnostics.Contracts.PureAttribute][System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)]
+        public static bool operator ==(System.Type left, System.Type right) { throw null; }
+        [System.Security.SecuritySafeCriticalAttribute][System.Diagnostics.Contracts.PureAttribute][System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)]
+        public static bool operator !=(System.Type left, System.Type right) { throw null; }
         public abstract System.Reflection.Assembly Assembly { get; }
         public abstract string AssemblyQualifiedName { get; }
         public System.Reflection.TypeAttributes Attributes { get { throw null; } }
@@ -7408,6 +7412,8 @@ namespace System.Reflection
     public abstract partial class MemberInfo : System.Reflection.ICustomAttributeProvider
     {
         protected MemberInfo() { }
+        public static bool operator ==(System.Reflection.MemberInfo left, System.Reflection.MemberInfo right) { throw null; }
+        public static bool operator !=(System.Reflection.MemberInfo left, System.Reflection.MemberInfo right) { throw null; }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }
         public abstract System.Type DeclaringType { get; }
         public abstract System.Reflection.MemberTypes MemberType { get; }

--- a/src/mscorlib/src/System/Reflection/Assembly.cs
+++ b/src/mscorlib/src/System/Reflection/Assembly.cs
@@ -77,7 +77,6 @@ namespace System.Reflection
                 return m.Assembly;
         }
 
-#if !FEATURE_CORECLR
         public static bool operator ==(Assembly left, Assembly right)
         {
             if (ReferenceEquals(left, right))
@@ -95,7 +94,6 @@ namespace System.Reflection
         {
             return !(left == right);
         }
-#endif // !FEATURE_CORECLR
 
         public override bool Equals(object o)
         {

--- a/src/mscorlib/src/System/Reflection/Binder.cs
+++ b/src/mscorlib/src/System/Reflection/Binder.cs
@@ -48,13 +48,11 @@ namespace System.Reflection {
 
         public abstract void ReorderArgumentArray(ref Object[] args, Object state);
 
-#if !FEATURE_COMINTEROP
         // CanChangeType
         // This method checks whether the value can be converted into the property type.
         public virtual bool CanChangeType(Object value,Type type,CultureInfo culture)
         {
             return false;
         }
-#endif
     }
 }

--- a/src/mscorlib/src/System/Reflection/ConstructorInfo.cs
+++ b/src/mscorlib/src/System/Reflection/ConstructorInfo.cs
@@ -46,7 +46,6 @@ namespace System.Reflection
         protected ConstructorInfo() { }
         #endregion
 
-#if !FEATURE_CORECLR
         public static bool operator ==(ConstructorInfo left, ConstructorInfo right)
         {
             if (ReferenceEquals(left, right))
@@ -64,7 +63,6 @@ namespace System.Reflection
         {
             return !(left == right);
         }
-#endif // !FEATURE_CORECLR
 
         public override bool Equals(object obj)
         {

--- a/src/mscorlib/src/System/Reflection/EventInfo.cs
+++ b/src/mscorlib/src/System/Reflection/EventInfo.cs
@@ -29,7 +29,6 @@ namespace System.Reflection
         protected EventInfo() { }
         #endregion
 
-#if !FEATURE_CORECLR
         public static bool operator ==(EventInfo left, EventInfo right)
         {
             if (ReferenceEquals(left, right))
@@ -47,7 +46,6 @@ namespace System.Reflection
         {
             return !(left == right);
         }
-#endif // !FEATURE_CORECLR
 
         public override bool Equals(object obj)
         {

--- a/src/mscorlib/src/System/Reflection/FieldInfo.cs
+++ b/src/mscorlib/src/System/Reflection/FieldInfo.cs
@@ -63,7 +63,6 @@ namespace System.Reflection
         protected FieldInfo() { }       
         #endregion
 
-#if !FEATURE_CORECLR
         public static bool operator ==(FieldInfo left, FieldInfo right)
         {
             if (ReferenceEquals(left, right))
@@ -81,7 +80,6 @@ namespace System.Reflection
         {
             return !(left == right);
         }
-#endif // !FEATURE_CORECLR
 
         public override bool Equals(object obj)
         {

--- a/src/mscorlib/src/System/Reflection/MemberInfo.cs
+++ b/src/mscorlib/src/System/Reflection/MemberInfo.cs
@@ -74,7 +74,6 @@ namespace System.Reflection
         
         #endregion
 
-#if !FEATURE_CORECLR
         public static bool operator ==(MemberInfo left, MemberInfo right)
         {
             if (ReferenceEquals(left, right))
@@ -107,7 +106,6 @@ namespace System.Reflection
         {
             return !(left == right);
         }
-#endif // !FEATURE_CORECLR
 
         public override bool Equals(object obj)
         {

--- a/src/mscorlib/src/System/Reflection/MethodBase.cs
+++ b/src/mscorlib/src/System/Reflection/MethodBase.cs
@@ -95,7 +95,6 @@ namespace System.Reflection
         protected MethodBase() { }
         #endregion
 
-#if !FEATURE_CORECLR
         public static bool operator ==(MethodBase left, MethodBase right)
         {
             if (ReferenceEquals(left, right))
@@ -119,7 +118,6 @@ namespace System.Reflection
         {
             return !(left == right);
         }
-#endif // !FEATURE_CORECLR
 
         public override bool Equals(object obj)
         {

--- a/src/mscorlib/src/System/Reflection/MethodInfo.cs
+++ b/src/mscorlib/src/System/Reflection/MethodInfo.cs
@@ -39,7 +39,6 @@ namespace System.Reflection
         protected MethodInfo() { }
         #endregion
 
-#if !FEATURE_CORECLR
         public static bool operator ==(MethodInfo left, MethodInfo right)
         {
             if (ReferenceEquals(left, right))
@@ -57,7 +56,6 @@ namespace System.Reflection
         {
             return !(left == right);
         }
-#endif // !FEATURE_CORECLR
 
         public override bool Equals(object obj)
         {

--- a/src/mscorlib/src/System/Reflection/Module.cs
+++ b/src/mscorlib/src/System/Reflection/Module.cs
@@ -84,7 +84,6 @@ namespace System.Reflection
         public static readonly TypeFilter FilterTypeName;
         public static readonly TypeFilter FilterTypeNameIgnoreCase;
 
-#if !FEATURE_CORECLR
         public static bool operator ==(Module left, Module right)
         {
             if (ReferenceEquals(left, right))
@@ -103,7 +102,6 @@ namespace System.Reflection
         {
             return !(left == right);
         }
-#endif // !FEATURE_CORECLR
 
         public override bool Equals(object o)
         {

--- a/src/mscorlib/src/System/Reflection/ParameterInfo.cs
+++ b/src/mscorlib/src/System/Reflection/ParameterInfo.cs
@@ -102,10 +102,8 @@ namespace System.Reflection
         }
 
         public bool IsIn { get { return((Attributes & ParameterAttributes.In) != 0); } }        
-        public bool IsOut { get { return((Attributes & ParameterAttributes.Out) != 0); } }  
-#if FEATURE_USE_LCID        
-        public bool IsLcid { get { return((Attributes & ParameterAttributes.Lcid) != 0); } }        
-#endif
+        public bool IsOut { get { return((Attributes & ParameterAttributes.Out) != 0); } }
+        public bool IsLcid { get { return((Attributes & ParameterAttributes.Lcid) != 0); } }
         public bool IsRetval { get { return((Attributes & ParameterAttributes.Retval) != 0); } }        
         public bool IsOptional { get { return((Attributes & ParameterAttributes.Optional) != 0); } }
 

--- a/src/mscorlib/src/System/Reflection/Pointer.cs
+++ b/src/mscorlib/src/System/Reflection/Pointer.cs
@@ -18,14 +18,9 @@ namespace System.Reflection {
     using System.Diagnostics.Contracts;
 
     [CLSCompliant(false)]
-#if FEATURE_SERIALIZATION
     [Serializable]
-#endif
     [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class Pointer
-#if FEATURE_SERIALIZATION
-        : ISerializable
-#endif
+    public sealed class Pointer : ISerializable
     {
     [SecurityCritical]
         unsafe private void* _ptr;
@@ -78,12 +73,10 @@ namespace System.Reflection {
             return (IntPtr)_ptr;
         }
 
-#if FEATURE_SERIALIZATION
         [System.Security.SecurityCritical]
         unsafe void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) {
             info.AddValue("_ptr", new IntPtr(_ptr));
             info.AddValue("_ptrType", _ptrType);
         }
-#endif
     }
 }

--- a/src/mscorlib/src/System/Reflection/PropertyInfo.cs
+++ b/src/mscorlib/src/System/Reflection/PropertyInfo.cs
@@ -32,7 +32,6 @@ namespace System.Reflection
         protected PropertyInfo() { }
         #endregion
 
-#if !FEATURE_CORECLR
         public static bool operator ==(PropertyInfo left, PropertyInfo right)
         {
             if (ReferenceEquals(left, right))
@@ -50,7 +49,6 @@ namespace System.Reflection
         {
             return !(left == right);
         }
-#endif // !FEATURE_CORECLR
 
         public override bool Equals(object obj)
         {

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -5313,7 +5313,6 @@ namespace System
             return _CreateEnum(enumType, value);
         }
 
-#if FEATURE_COMINTEROP
         [System.Security.SecurityCritical]  // auto-generated
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private extern Object InvokeDispMethod(
@@ -5339,7 +5338,6 @@ namespace System
             throw new NotImplementedException("CoreCLR_REMOVED -- Unmanaged activation removed"); 
         }
 #endif // FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
-#endif
 
         #endregion
 

--- a/src/mscorlib/src/System/Type.cs
+++ b/src/mscorlib/src/System/Type.cs
@@ -1782,7 +1782,6 @@ namespace System {
             return (Object.ReferenceEquals(this.UnderlyingSystemType, o.UnderlyingSystemType));
         }
 
-#if !FEATURE_CORECLR
         [System.Security.SecuritySafeCritical]
         [Pure]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -1792,7 +1791,6 @@ namespace System {
         [Pure]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern bool operator !=(Type left, Type right);
-#endif // !FEATURE_CORECLR
 
         public override int GetHashCode()
         {

--- a/src/mscorlib/src/System/Type.cs
+++ b/src/mscorlib/src/System/Type.cs
@@ -99,7 +99,6 @@ namespace System {
             return RuntimeType.GetType(typeName, false, false, false, ref stackMark);
         }
 
-#if !FEATURE_CORECLR
         [MethodImplAttribute(MethodImplOptions.NoInlining)] // Methods containing StackCrawlMark local var has to be marked non-inlineable
         public static Type GetType(
             string typeName,
@@ -132,7 +131,6 @@ namespace System {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
             return TypeNameParser.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, ref stackMark);
         }
-#endif //!FEATURE_CORECLR
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)] // Methods containing StackCrawlMark local var has to be marked non-inlineable
         public static Type ReflectionOnlyGetType(String typeName, bool throwIfNotFound, bool ignoreCase) 
@@ -147,7 +145,6 @@ namespace System {
         public virtual Type MakeArrayType() { throw new NotSupportedException(); }
         public virtual Type MakeArrayType(int rank) { throw new NotSupportedException(); }
 
-#if FEATURE_COMINTEROP
         ////////////////////////////////////////////////////////////////////////////////
         // This will return a class based upon the progID.  This is provided for 
         // COM classic support.  Program ID's are not used in COM+ because they 
@@ -220,7 +217,6 @@ namespace System {
         {
                 return RuntimeType.GetTypeFromCLSIDImpl(clsid, server, throwOnError);
         }
-#endif // FEATURE_COMINTEROP
 
         // GetTypeCode
         // This method will return a TypeCode for the passed
@@ -1811,7 +1807,6 @@ namespace System {
             throw new NotSupportedException(Environment.GetResourceString("NotSupported_SubclassOverride"));
         }
 
-#if !FEATURE_CORECLR
         // this method is required so Object.GetType is not made virtual by the compiler 
         // _Type.GetType()
         public new Type GetType()
@@ -1819,6 +1814,7 @@ namespace System {
             return base.GetType();
         }
 
+#if !FEATURE_CORECLR
         void _Type.GetTypeInfoCount(out uint pcTInfo)
         {
             throw new NotImplementedException();

--- a/src/mscorlib/src/System/TypeNameParser.cs
+++ b/src/mscorlib/src/System/TypeNameParser.cs
@@ -13,7 +13,6 @@ using System.Threading;
 using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 
-#if !FEATURE_CORECLR
 namespace System
 {
     [SecurityCritical]
@@ -364,4 +363,3 @@ namespace System
         #endregion
     }
 }
-#endif //!FEATURE_CORECLR

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -387,11 +387,9 @@ FCFuncEnd()
 
 FCFuncStart(gSystem_Type)
     FCIntrinsic("GetTypeFromHandle", RuntimeTypeHandle::GetTypeFromHandle, CORINFO_INTRINSIC_GetTypeFromHandle)
-#ifndef FEATURE_CORECLR
     FCFuncElement("GetTypeFromHandleUnsafe", RuntimeTypeHandle::GetRuntimeType)
     FCIntrinsic("op_Equality", RuntimeTypeHandle::TypeEQ, CORINFO_INTRINSIC_TypeEQ)
     FCIntrinsic("op_Inequality", RuntimeTypeHandle::TypeNEQ, CORINFO_INTRINSIC_TypeNEQ)
-#endif // !FEATURE_CORECLR
 FCFuncEnd()
 
 FCFuncStart(gSystem_RuntimeType)

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -399,8 +399,8 @@ FCFuncStart(gSystem_RuntimeType)
     FCFuncElement("AllocateValueType", ReflectionInvocation::AllocateValueType)
 #if defined(FEATURE_COMINTEROP)
     FCFuncElement("GetTypeFromCLSIDImpl", ReflectionInvocation::GetClassFromCLSID)
-#if !defined(FEATURE_CORECLR)
     FCFuncElement("GetTypeFromProgIDImpl", ReflectionInvocation::GetClassFromProgID)
+#if !defined(FEATURE_CORECLR)
     FCFuncElement("InvokeDispMethod", ReflectionInvocation::InvokeDispMethod)
 #endif 
 #ifdef FEATURE_COMINTEROP_WINRT_MANAGED_ACTIVATION


### PR DESCRIPTION
I had to also add few APIs in System namespace

Note: I did not add `StrongNameKeyPair` yet. @weshaggard do we want to switch the implementation of this class in [here](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Reflection/StrongNameKeyPair.cs)? (Apparently, right now we are using the dummy implementation of this type)