### PR TITLE
Fix Issue 6585: Add offset to struct field arg

### DIFF
--- a/tests/src/JIT/Directed/StructABI/structfieldparam.cs
+++ b/tests/src/JIT/Directed/StructABI/structfieldparam.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This is a repro for Issue6585. The problem was that the source of
+// a GT_OBJ (struct argument) node was a lclFldAddr, and codegen was
+// treating it as a lclVarAddr, i.e. not adding in the offset.
+// The inner struct must either be larger than CPBLK_UNROLL_LIMIT,
+// which is currently 64 bytes, or must contain GC refs.
+
+using System;
+using System.Runtime.CompilerServices;
+namespace structfieldparam
+{
+
+    struct Inner1
+    {
+        public long l1;
+        public long l2;
+        public long l3;
+        public long l4;
+        public long l5;
+        public long l6;
+        public long l7;
+        public long l8;
+        public long[] arr;
+
+        public Inner1(int seed)
+        {
+            l1 = seed;
+            l2 = seed + 1;
+            l3 = seed + 2;
+            l4 = seed + 3;
+            l5 = seed + 4;
+            l6 = seed + 5;
+            l7 = seed + 6;
+            l8 = seed + 7;
+            arr = new long[4];
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public long sum()
+        {
+            return l1 + l2 + l3 + l4 + l5 + l6 + l7 + l8;
+        }
+    }
+
+    struct Outer1
+    {
+        public int i1;
+        public long l1;
+        public Inner1 inner;
+    }
+
+    struct Inner2
+    {
+        public long l1;
+        public long l2;
+        public long l3;
+        public long l4;
+        public long l5;
+        public long l6;
+        public long l7;
+        public long l8;
+        public long l9;
+
+        public Inner2(int seed)
+        {
+            l1 = seed;
+            l2 = seed + 1;
+            l3 = seed + 2;
+            l4 = seed + 3;
+            l5 = seed + 4;
+            l6 = seed + 5;
+            l7 = seed + 6;
+            l8 = seed + 7;
+            l9 = seed + 8;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public long sum()
+        {
+            return l1 + l2 + l3 + l4 + l5 + l6 + l7 + l8 + l9;
+        }
+    }
+
+    struct Outer2
+    {
+        public int i1;
+        public long l1;
+        public Inner2 inner;
+    }
+
+    public class Program
+    {
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        static long test1(Inner1 s)
+        {
+            return s.sum();
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        static long test2(Inner2 s)
+        {
+            return s.sum();
+        }
+
+        public static int Main()
+        {
+            int result = 100;
+
+            Inner1 t1 = new Inner1(10);
+            Outer1 o1;
+            o1.i1 = 1;
+            o1.l1 = 2;
+            o1.inner = t1;
+            long direct = t1.sum();
+            long indirect = test1(o1.inner);
+            if (direct != indirect)
+            {
+                Console.WriteLine("t1.sum() returns " + direct + ", but test(o1.inner) returns " + indirect);
+                result = -1;
+            }
+
+            Inner2 t2 = new Inner2(10);
+            Outer2 o2;
+            o2.i1 = 1;
+            o2.l1 = 2;
+            o2.inner = t2;
+            direct = t2.sum();
+            indirect = test2(o2.inner);
+            if (direct != indirect)
+            {
+                Console.WriteLine("t2.sum() returns " + direct + ", but test(o2.inner) returns " + indirect);
+                result = -1;
+            }
+
+            return result;
+        }
+    }
+}

--- a/tests/src/JIT/Directed/StructABI/structfieldparam_r.csproj
+++ b/tests/src/JIT/Directed/StructABI/structfieldparam_r.csproj
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="structfieldparam.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Directed/StructABI/structfieldparam_ro.csproj
+++ b/tests/src/JIT/Directed/StructABI/structfieldparam_ro.csproj
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="structfieldparam.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
When the child of a `GT_OBJ` is a lclFldAddr, `genConsumePutStructArgStk()`
was not adding the offset of the struct field to the base address of
the local.