### PR TITLE
disable pass/return struct(float, float) using register in 32bit arch

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -946,6 +946,7 @@ var_types  Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
 
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
     
+#ifdef _TARGET_64BIT_
     // Note this handles an odd case when FEATURE_MULTIREG_RET is disabled and HFAs are enabled
     //
     // getPrimitiveTypeForStruct will return TYP_UNKNOWN for a struct that is an HFA of two floats
@@ -962,6 +963,7 @@ var_types  Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
     {
         useType = TYP_I_IMPL;
     }
+#endif
 
     // Did we change this struct type into a simple "primitive" type?
     //


### PR DESCRIPTION
Disable pass/return struct(float, float) using register in 32bit architecture

When FEATURE_MULTIREG_RET is disabled, pass value of 8byte struct including two float (4byte + 4byte) using integer register. 
But this feature can be usable only 64bit architecture, so we need to disable this feature for 32bit architecture such as ARM32.

releated issue: #6567 
Vector2 struct have two float elements (float x, float y), and CoreFX unittest failed because of this feature.
