### PR TITLE
Fix invalid checks for CONTEXT_XSTATE

### DIFF
--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -468,7 +468,7 @@ void CONTEXTToNativeContext(CONST CONTEXT *lpContext, native_context_t *native)
 
     // TODO: Enable for all Unix systems
 #if defined(_AMD64_) && defined(__linux__)
-    if ((lpContext->ContextFlags & CONTEXT_XSTATE) != 0)
+    if ((lpContext->ContextFlags & CONTEXT_XSTATE) == CONTEXT_XSTATE)
     {
         _ASSERTE(FPREG_HasExtendedState(native));
         memcpy_s(FPREG_Xstate_Ymmh(native), sizeof(M128A) * 16, lpContext->VectorRegister, sizeof(M128A) * 16);
@@ -566,7 +566,7 @@ void CONTEXTFromNativeContext(const native_context_t *native, LPCONTEXT lpContex
 
     // TODO: Enable for all Unix systems
 #if defined(_AMD64_) && defined(__linux__)
-    if ((contextFlags & CONTEXT_XSTATE) != 0)
+    if ((contextFlags & CONTEXT_XSTATE) == CONTEXT_XSTATE)
     {
         if (FPREG_HasExtendedState(native))
         {


### PR DESCRIPTION
Checks for context flags containing CONTEXT_XSTATE were incorrect at two places.
The issue was that CONTEXT_XSTATE is not a single bit flag, but contains two
bits set - it is CONTEXT_AMD64 | 0x40. So testing the flag using
(contextFlags & CONTEXT_XSTATE) != 0 was always true, since context flags
on AMD64 always contain CONTEXT_AMD64 and so the `&` result is always non-zero.