### PR TITLE
Decrease writes to local variables in Buffer.MemoryCopy

### DIFF
--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -404,34 +404,28 @@ namespace System {
             // P/Invoke into the native version for large lengths
             if (len >= 512) goto PInvoke;
 
+            nuint i = 0; // byte offset at which we're copying
+
             if (((int)dest & 3) != 0)
             {
                 if (((int)dest & 1) != 0)
                 {
                     *dest = *src;
-                    src++;
-                    dest++;
-                    len--;
-                    if (((int)dest & 2) == 0)
-                    {
-                        goto Int32Aligned;
-                    }
+                    i++;
+                    if (((int)dest & 2) != 0)
+                        goto IntAligned;
                 }
                 *(short*)dest = *(short*)src;
-                src += 2;
-                dest += 2;
-                len -= 2;
+                i += 2;
             }
 
-            Int32Aligned:
+            IntAligned:
 
 #if BIT64
-            if (((int)dest & 4) != 0)
+            if ((((int)dest - 1) & 3) == 0)
             {
                 *(int*)dest = *(int*)src;
-                src += 4;
-                dest += 4;
-                len -= 4;
+                i += 4;
             }
 #endif
 
@@ -504,7 +498,6 @@ namespace System {
         [SecurityCritical]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         extern private unsafe static void __Memmove(byte* dest, byte* src, nuint len);
-
 
         // The attributes on this method are chosen for best JIT performance. 
         // Please do not edit unless intentional.

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -546,7 +546,7 @@ namespace System {
             }
             if ((len & 2) != 0) 
             {
-                *(short*)(dest + i) = *(int*)(src + i);
+                *(short*)(dest + i) = *(short*)(src + i);
                 i += 2;
             }
             if ((len & 1) != 0)
@@ -559,7 +559,6 @@ namespace System {
             return;
 
             PInvoke:
-            Contract.Assert(i == 0, "This variable should only be used if we do a managed copy.");
             _Memmove(dest, src, len);
 
         }

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -521,13 +521,11 @@ namespace System {
 
             do
             {
-                // This loop looks very costly since there
-                // appear to be a bunch of temporary values
-                // being created with the adds, but the jit
-                // (for x86 anyways) will convert each of
+                // This loop looks very costly since there appear to be a bunch of temporary values
+                // being created with the adds, but the jit (for x86 anyways) will convert each of
                 // these to use memory addressing operands.
-                // So the only cost is a bit of code size,
-                // which is made up for by the fact that
+                
+                // So the only cost is a bit of code size, which is made up for by the fact that
                 // we save on writes to dest/src.
 
 #if BIT64

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -422,7 +422,7 @@ namespace System {
             IntAligned:
 
 #if BIT64
-            if ((((int)dest - 1) & 3) == 0)
+            if ((((int)dest - 1) & 4) == 0)
             {
                 *(int*)dest = *(int*)src;
                 i += 4;

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -285,6 +285,9 @@ namespace System {
             // Note: It's important that this switch handles lengths at least up to 22.
             // See notes below near the main loop for why.
 
+            // The switch will be very fast since it can be implemented using a jump
+            // table in assembly. See http://stackoverflow.com/a/449297/4077294 for more info.
+
             switch (len)
             {
             case 0:

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -544,7 +544,7 @@ namespace System {
             }
             while (i <= end);
 
-            len -= i;
+            len -= i; // len now represents how many bytes are left after the unrolled loop
 
             if ((len & 8) != 0)
             {

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -417,7 +417,7 @@ namespace System {
                         goto Int32Aligned;
                     }
                 }
-                *(short *)dest = *(short *)src;
+                *(short*)dest = *(short*)src;
                 src += 2;
                 dest += 2;
                 len -= 2;
@@ -428,7 +428,7 @@ namespace System {
 #if BIT64
             if (((int)dest & 4) != 0)
             {
-                *(int *)dest = *(int *)src;
+                *(int*)dest = *(int*)src;
                 src += 4;
                 dest += 4;
                 len -= 4;

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -491,12 +491,12 @@ namespace System {
             {
                 if (((int)dest & 1) != 0)
                 {
-                    *dest = *src;
-                    i++;
+                    *(dest + i) = *(src + i);
+                    i += 1;
                     if (((int)dest & 2) != 0)
                         goto IntAligned;
                 }
-                *(short*)dest = *(short*)src;
+                *(short*)(dest + i) = *(short*)(src + i);
                 i += 2;
             }
 
@@ -505,7 +505,7 @@ namespace System {
 #if BIT64
             if ((((int)dest - 1) & 4) == 0)
             {
-                *(int*)dest = *(int*)src;
+                *(int*)(dest + i) = *(int*)(src + i);
                 i += 4;
             }
 #endif

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -435,7 +435,9 @@ namespace System {
             }
 #endif
 
-            nuint count = len & ~15;
+            // Since we know due to the above switch that
+            // len is >= 16, this will never be 0
+            nuint count = len & ~15u;
             nuint i = 0;
 
             do
@@ -492,11 +494,7 @@ namespace System {
         [SecurityCritical]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-#if BIT64
-        private unsafe static void _Memmove(byte* dest, byte* src, ulong len)
-#else
-        private unsafe static void _Memmove(byte* dest, byte* src, uint len)
-#endif
+        private unsafe static void _Memmove(byte* dest, byte* src, nuint len)
         {
             __Memmove(dest, src, len);
         }
@@ -505,11 +503,7 @@ namespace System {
         [SuppressUnmanagedCodeSecurity]
         [SecurityCritical]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#if BIT64
-        extern private unsafe static void __Memmove(byte* dest, byte* src, ulong len);
-#else
-        extern private unsafe static void __Memmove(byte* dest, byte* src, uint len);
-#endif
+        extern private unsafe static void __Memmove(byte* dest, byte* src, nuint len);
 
 
         // The attributes on this method are chosen for best JIT performance. 
@@ -523,11 +517,7 @@ namespace System {
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.sourceBytesToCopy);
             }
-#if BIT64
-            Memmove((byte*)destination, (byte*)source, checked((ulong) sourceBytesToCopy));
-#else
-            Memmove((byte*)destination, (byte*)source, checked((uint)sourceBytesToCopy));
-#endif // BIT64
+            Memmove((byte*)destination, (byte*)source, checked((nuint)sourceBytesToCopy));
         }
 
 
@@ -544,7 +534,7 @@ namespace System {
             }
 #if BIT64
             Memmove((byte*)destination, (byte*)source, sourceBytesToCopy);
-#else
+#else // BIT64
             Memmove((byte*)destination, (byte*)source, checked((uint)sourceBytesToCopy));
 #endif // BIT64
         }

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -282,6 +282,9 @@ namespace System {
             // Ideally, we would just use the cpblk IL instruction here. Unfortunately, cpblk IL instruction is not as efficient as
             // possible yet and so we have this implementation here for now.
 
+            // Note: It's important that this switch handles lengths at least up to 22.
+            // See notes below near the main loop for why.
+
             switch (len)
             {
             case 0:
@@ -515,6 +518,15 @@ namespace System {
 
             do
             {
+                // This loop looks very costly since there
+                // appear to be a bunch of temporary values
+                // being created with the adds, but the jit
+                // (for x86 anyways) will convert each of
+                // these to use memory addressing operands.
+                // So the only cost is a bit of code size,
+                // which is made up for by the fact that
+                // we save on writes to dest/src.
+
 #if BIT64
                 *(long*)(dest + i) = *(long*)(src + i);
                 *(long*)(dest + i + 8) = *(long*)(src + i + 8);

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -544,6 +544,8 @@ namespace System {
             }
             while (i <= end);
 
+            len -= i;
+
             if ((len & 8) != 0)
             {
 #if BIT64

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -435,9 +435,10 @@ namespace System {
             }
 #endif
 
-            nuint count = len / 16;
+            nuint count = len & ~15;
+            byte* end = (nuint)dest + count;
 
-            while (count > 0)
+            while (dest != end)
             {
 #if BIT64
                 ((long*)dest)[0] = ((long*)src)[0];
@@ -450,7 +451,6 @@ namespace System {
 #endif
                 dest += 16;
                 src += 16;
-                count--;
             }
 
             if ((len & 8) != 0)

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -436,22 +436,23 @@ namespace System {
 #endif
 
             nuint count = len & ~15;
-            byte* end = (nuint)dest + count;
+            nuint i = 0;
 
-            while (dest != end)
+            do
             {
 #if BIT64
-                ((long*)dest)[0] = ((long*)src)[0];
-                ((long*)dest)[1] = ((long*)src)[1];
+                *(long*)(dest + i) = *(long*)(src + i);
+                *(long*)(dest + i + 8) = *(long*)(src + i + 8);
 #else
-                ((int*)dest)[0] = ((int*)src)[0];
-                ((int*)dest)[1] = ((int*)src)[1];
-                ((int*)dest)[2] = ((int*)src)[2];
-                ((int*)dest)[3] = ((int*)src)[3];
+                *(int*)(dest + i) = *(int*)(src + i);
+                *(int*)(dest + i + 4) = *(int*)(src + i + 4);
+                *(int*)(dest + i + 8) = *(int*)(src + i + 8);
+                *(int*)(dest + i + 12) = *(int*)(src + i + 12);
 #endif
-                dest += 16;
-                src += 16;
+
+                i += 16;
             }
+            while (i != count);
 
             if ((len & 8) != 0)
             {

--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -399,6 +399,81 @@ namespace System {
                 *(int*)(dest + 12) = *(int*)(src + 12);
 #endif
                 return;
+            case 17:
+#if BIT64
+                *(long*)dest = *(long*)src;
+                *(long*)(dest + 8) = *(long*)(src + 8);
+#else
+                *(int*)dest = *(int*)src;
+                *(int*)(dest + 4) = *(int*)(src + 4);
+                *(int*)(dest + 8) = *(int*)(src + 8);
+                *(int*)(dest + 12) = *(int*)(src + 12);
+#endif
+                *(dest + 16) = *(src + 16);
+                return;
+            case 18:
+#if BIT64
+                *(long*)dest = *(long*)src;
+                *(long*)(dest + 8) = *(long*)(src + 8);
+#else
+                *(int*)dest = *(int*)src;
+                *(int*)(dest + 4) = *(int*)(src + 4);
+                *(int*)(dest + 8) = *(int*)(src + 8);
+                *(int*)(dest + 12) = *(int*)(src + 12);
+#endif
+                *(short*)(dest + 16) = *(short*)(src + 16);
+                return;
+            case 19:
+#if BIT64
+                *(long*)dest = *(long*)src;
+                *(long*)(dest + 8) = *(long*)(src + 8);
+#else
+                *(int*)dest = *(int*)src;
+                *(int*)(dest + 4) = *(int*)(src + 4);
+                *(int*)(dest + 8) = *(int*)(src + 8);
+                *(int*)(dest + 12) = *(int*)(src + 12);
+#endif
+                *(short*)(dest + 16) = *(short*)(src + 16);
+                *(dest + 18) = *(src + 18);
+                return;
+            case 20:
+#if BIT64
+                *(long*)dest = *(long*)src;
+                *(long*)(dest + 8) = *(long*)(src + 8);
+#else
+                *(int*)dest = *(int*)src;
+                *(int*)(dest + 4) = *(int*)(src + 4);
+                *(int*)(dest + 8) = *(int*)(src + 8);
+                *(int*)(dest + 12) = *(int*)(src + 12);
+#endif
+                *(int*)(dest + 16) = *(int*)(src + 16);
+                return;
+            case 21:
+#if BIT64
+                *(long*)dest = *(long*)src;
+                *(long*)(dest + 8) = *(long*)(src + 8);
+#else
+                *(int*)dest = *(int*)src;
+                *(int*)(dest + 4) = *(int*)(src + 4);
+                *(int*)(dest + 8) = *(int*)(src + 8);
+                *(int*)(dest + 12) = *(int*)(src + 12);
+#endif
+                *(int*)(dest + 16) = *(int*)(src + 16);
+                *(dest + 20) = *(src + 20);
+                return;
+            case 22:
+#if BIT64
+                *(long*)dest = *(long*)src;
+                *(long*)(dest + 8) = *(long*)(src + 8);
+#else
+                *(int*)dest = *(int*)src;
+                *(int*)(dest + 4) = *(int*)(src + 4);
+                *(int*)(dest + 8) = *(int*)(src + 8);
+                *(int*)(dest + 12) = *(int*)(src + 12);
+#endif
+                *(int*)(dest + 16) = *(int*)(src + 16);
+                *(short*)(dest + 20) = *(short*)(src + 20);
+                return;
             }
 
             // P/Invoke into the native version for large lengths


### PR DESCRIPTION
In `Buffer.MemoryCopy` currently we are making 4 writes every time we copy some data; 1 to update `*dest`, 1 to update `dest`, 1 to update `src` and 1 to update `len`. I've decreased it to 2; one to update a new local variable `i`, which keeps track of how many bytes we are into the buffer. All writes are now made using

```cs
*(dest + i + x) = *(src + i + x)
```

which has no additional overhead since they're converted to using memory addressing operands by the jit.

Another change I made was to add a few extra cases for the switch-case at the beginning that does copying for small sizes without any branches. It now covers sizes 0-22. This is beneficial to the main codepath, since we can convert the unrolled loop to a `do..while` loop and save an extra branch at the beginning. (max 7 bytes for alignment, 16 for 1 iteration of the loop, so the min bytes we can copy without checking whether we should stop is 23.) This adds 

This PR increases the performance of `MemoryCopy` by 10-20% for most buffer sizes on x86; you can see the performance test/results (and the generated assembly for each version) [here](https://gist.github.com/jamesqo/337852c8ce09205a8289ce1f1b9b5382). (Note that this codepath is also used by `wstrcpy` at the moment, so this directly affects many common String operations.)

Note that I haven't tested this on ARM or anything (only i386 and x86_64), so I'm not sure how these changes will affect other platforms.

I have yet to write up tests for this in CoreFX, but I will later when I get the time.

cc @jkotas @nietras @mikedn @GSPP @omariom @bbowyersmyth 