### PR TITLE
Remove GTF_REDINDEX_CHECK

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -8774,14 +8774,6 @@ int cTreeFlagsIR(Compiler *comp, GenTree *tree)
             chars += printf("[SPILLED_OP2]");
         }
 #endif
-        if (tree->gtFlags & GTF_REDINDEX_CHECK)
-        {
-            chars += printf("[REDINDEX_CHECK]");
-        }
-        if (tree->gtFlags & GTF_REDINDEX_CHECK)
-        {
-            chars += printf("[REDINDEX_CHECK]");
-        }
         if (tree->gtFlags & GTF_ZSF_SET)
         {
             chars += printf("[ZSF_SET]");

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -677,8 +677,6 @@ public:
     #define GTF_NOREG_AT_USE    0x00000100  // tree node is in memory at the point of use
 #endif // LEGACY_BACKEND
 
-    #define GTF_REDINDEX_CHECK  0x00000100  // Used for redundant range checks. Disjoint from GTF_SPILLED_OPER
-
     #define GTF_ZSF_SET         0x00000400  // the zero(ZF) and sign(SF) flags set to the operand
 #if FEATURE_SET_FLAGS
     #define GTF_SET_FLAGS       0x00000800  // Requires that codegen for this node set the flags


### PR DESCRIPTION
This flag is unused.  Its description also sounds like it's redundant with
the GTF_ARR_BOUND_INBND flag, so the latter flag could be used if a new
need to convey this information arises in the future.

Preserving GTF_ARR_BOUND_INBND and removing GTF_REDINDEX_CHECK makes more
sense than the other way around since GTF_ARR_BOUND_INBND is specific to
the relevant opcode.

@dotnet/jit-contrib PTAL.