### PR TITLE
Null check folding.

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -299,6 +299,7 @@ struct BasicBlock
 
 #define BBF_TRY_BEG         0x00000100  // BB starts a 'try' block
 #define BBF_FUNCLET_BEG     0x00000200  // BB is the beginning of a funclet
+#define BBF_HAS_NULLCHECK   0x00000400  // BB contains a null check
 #define BBF_NEEDS_GCPOLL    0x00000800  // This BB is the source of a back edge and needs a GC Poll
 
 #define BBF_RUN_RARELY      0x00001000  // BB is rarely run (catch clauses, blocks with throws etc)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5534,6 +5534,7 @@ public:
 #define OMF_HAS_NEWOBJ      0x00000002  // Method contains 'new' of an object type.
 #define OMF_HAS_ARRAYREF    0x00000004  // Method contains array element loads or stores.
 #define OMF_HAS_VTABLEREF   0x00000008  // Method contains method table reference.
+#define OMF_HAS_NULLCHECK   0x00000010  // Method contains null check.
 
     unsigned   optMethodFlags;
 
@@ -5545,7 +5546,8 @@ public:
     {
         OPK_INVALID,
         OPK_ARRAYLEN,
-        OPK_OBJ_GETTYPE
+        OPK_OBJ_GETTYPE,
+        OPK_NULLCHECK
     };
 
     bool       gtIsVtableRef(GenTreePtr tree);
@@ -5557,6 +5559,8 @@ public:
     bool       optDoEarlyPropForBlock(BasicBlock* block);
     bool       optDoEarlyPropForFunc();
     void       optEarlyProp();
+    void       optFoldNullCheck(GenTreePtr tree);
+    bool       optCanMoveNullCheckPastTree(GenTreePtr tree, bool isInsideTry);
 
 #if ASSERTION_PROP
     /**************************************************************************
@@ -5584,6 +5588,7 @@ public:
                             O1K_CONSTANT_LOOP_BND,
                             O1K_EXACT_TYPE,
                             O1K_SUBTYPE,
+                            O1K_VALUE_NUMBER,
                             O1K_COUNT };
 
     enum optOp2Kind       { O2K_INVALID,

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6129,6 +6129,9 @@ GenTreePtr          Compiler::fgMorphField(GenTreePtr tree, MorphAddrContext* ma
             // An indirection will cause a GPF if the address is null.
             nullchk->gtFlags |= GTF_EXCEPT;
 
+            compCurBB->bbFlags |= BBF_HAS_NULLCHECK;
+            optMethodFlags |= OMF_HAS_NULLCHECK;
+
             if (asg)
             {
                 // Create the "comma" node.
@@ -12115,6 +12118,9 @@ CM_ADD_OP:
             // Originally, I gave all the comma nodes type "byref".  But the ADDR(IND(x)) == x transform
             // might give op1 a type different from byref (like, say, native int).  So now go back and give
             // all the comma nodes the type of op1.
+            // TODO: the comma flag update below is conservative and can be improved.
+            // For example, if we made the ADDR(IND(x)) == x transformation, we may be able to
+            // get rid of some of the the IND flags on the COMMA nodes (e.g., GTF_GLOB_REF).
             commaNode = tree;
             while (commaNode->gtOper == GT_COMMA)
             {
@@ -12974,7 +12980,6 @@ ASG_OP:
     }
     return tree;
 }
-
 
 // code to generate a magic number and shift amount for the magic number division 
 // optimization.  This code is previously from UTC where it notes it was taken from


### PR DESCRIPTION
1. Added a null check folding optimization to early prop. The optimization tries to fold
GT_NULLCHECK(y) nodes  into GT_IND(x) nodes where x=y+const
in the same block (where const is sufficiently small). The algorithm uses SSA use-def info
to go from x to its def and then tries to match the pattern x = COMMA(NULLCHECK(y), ADD(y, const))).
If such a pattern is found, the algorithm checks the trees and statements that are between the use
and the def in execution order to see if they have unsafe side effects: calls, exception sources, and
assignments (all assignment if we are in a try and assignments to global memory if we are not).
If there are no nodes with unsafe side effects, the null check is removed.

2. Made several improvements to null check elimination in assertion propagation.
  * Added a new kind for op1: O1K_VALUE_NUMBER
  * Non-null assertions can now be made about arbitrary value numbers, not just locals
..* Fixed code that was trying to find a ref given a byref: the code now handles an arbitrary number of
    offsets and checks whether the total offsetof is small enough.
 * Added similar code that tries to find a ref VN given a byref VN

This addresses part of the suboptimal code generated for #1226: null check is no longer emitted.

Correctness: ran full desktop and CoreCLR testing.

Throughput: no measurable throughput impact (verified by running internal CQNgenTP several times).

Code size in CoreCLR:

Framework assemblies:

Total bytes of diff: -805 (-0.01 % of base)
    diff is an improvement.
Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes
Top file improvements by size (bytes):
        -352 : System.Private.CoreLib.dasm (-0.01 % of base)
        -306 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01 % of base)
         -58 : Microsoft.CodeAnalysis.dasm (-0.01 % of base)
         -48 : System.Numerics.Vectors.dasm (-0.08 % of base)
         -14 : System.Xml.XmlDocument.dasm (-0.01 % of base)
7 total files with size differences.
Top method improvements by size (bytes):
         -30 : System.Numerics.Vectors.dasm - System.Numerics.Matrix4x4:ToString():ref:this
         -30 : System.Private.CoreLib.dasm - System.DateTimeParse:ParseByFormat(byref,byref,byref,ref,byref):bool
         -24 : Microsoft.CodeAnalysis.CSharp.dasm - <GetMethodsToEmit>d__68:MoveNext():bool:this
         -18 : System.Private.CoreLib.dasm - System.DateTimeParse:Lex(int,byref,byref,byref,byref,byref,int):bool
         -18 : System.Private.CoreLib.dasm - System.DateTimeParse:ProcessDateTimeSuffix(byref,byref,byref):bool
243 total methods with size differences.

JIT Code quality benchmarks in CoreCLR:

Total bytes of diff: -29 (-0.01 % of base)
    diff is an improvement.
Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes
Top file improvements by size (bytes):
         -25 : Bytemark\Bytemark\Bytemark.dasm (-0.03 % of base)
          -4 : BenchmarksGame\pidigits\pi-digits\pi-digits.dasm (-0.21 % of base)
2 total files with size differences.
Top method improvements by size (bytes):
          -9 : Bytemark\Bytemark\Bytemark.dasm - AssignJagged:second_assignments(ref,ref)
          -6 : Bytemark\Bytemark\Bytemark.dasm - EMFloat:MultiplyInternalFPF(byref,byref,byref)
          -4 : Bytemark\Bytemark\Bytemark.dasm - EMFloat:AddSubInternalFPF(ubyte,byref,byref,byref)
          -2 : Bytemark\Bytemark\Bytemark.dasm - EMFloat:denormalize(byref,int)
          -2 : Bytemark\Bytemark\Bytemark.dasm - EMFloat:DivideInternalFPF(byref,byref,byref)
8 total methods with size differences.

In internal SPMI:

3915 methods with diffs, almost everything -- code size improvements
13,715 bytes code size reduction overall 0.51% on affected methods

CQ_Perf: 85 methods with diffs, 84 code size improvements, no regressions
Benchmarks with code size diffs:
Roslyn 59
TrueTypeBench 19
mono-pi-digits 2
mono-chameneos-redux 2
ByteMark\assign_jagged 1
Json_Serialize 1
SharpChess 1
BenchI\mulmtx 1

Internal CQPerf didn't report any runtime wins for these benchmarks.