### PR TITLE
Inliner: add a few more observations

### DIFF
--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -80,6 +80,7 @@ INLINE_OBSERVATION(END_OPCODE_SCAN,           bool,   "done looking at opcodes",
 INLINE_OBSERVATION(HAS_SIMD,                  bool,   "has SIMD arg, local, or ret",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                    INFORMATION, CALLEE)
 INLINE_OBSERVATION(IL_CODE_SIZE,              int,    "number of bytes of IL",         INFORMATION, CALLEE)
+INLINE_OBSERVATION(IS_CLASS_CTOR,             bool,   "class constructor",             INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_DISCRETIONARY_INLINE,   bool,   "can inline, check heuristics",  INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_FORCE_INLINE,           bool,   "aggressive inline attribute",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_INSTANCE_CTOR,          bool,   "instance constructor",          INFORMATION, CALLEE)
@@ -96,11 +97,16 @@ INLINE_OBSERVATION(NUMBER_OF_LOCALS,          int,    "number of locals",       
 INLINE_OBSERVATION(RANDOM_ACCEPT,             bool,   "random accept",                 INFORMATION, CALLEE)
 INLINE_OBSERVATION(UNSUPPORTED_OPCODE,        bool,   "unsupported opcode",            INFORMATION, CALLEE)
 
-// ------ Caller Corectness ------- 
+// ------ Caller Correctness -------
 
 INLINE_OBSERVATION(DEBUG_CODEGEN,             bool,   "debug codegen",                 FATAL,       CALLER)
 INLINE_OBSERVATION(IS_JIT_NOINLINE,           bool,   "noinline per JitNoInlineRange", FATAL,       CALLER)
 INLINE_OBSERVATION(NEEDS_SECURITY_CHECK,      bool,   "needs security check",          FATAL,       CALLER)
+
+// ------ Caller Information -------
+
+INLINE_OBSERVATION(HAS_NEWARRAY,              bool,   "has newarray",                  INFORMATION, CALLER)
+INLINE_OBSERVATION(HAS_NEWOBJ,                bool,   "has newobj",                    INFORMATION, CALLER)
 
 // ------ Call Site Correctness ------- 
 
@@ -157,6 +163,7 @@ INLINE_OBSERVATION(CONSTANT_ARG_FEEDS_TEST,   bool,   "constant argument feeds t
 INLINE_OBSERVATION(DEPTH,                     int,    "depth",                         INFORMATION, CALLSITE)
 INLINE_OBSERVATION(FREQUENCY,                 int,    "rough call site frequency",     INFORMATION, CALLSITE)
 INLINE_OBSERVATION(IS_PROFITABLE_INLINE,      bool,   "profitable inline",             INFORMATION, CALLSITE)
+INLINE_OBSERVATION(IS_SAME_THIS,              bool,   "same this as root caller",      INFORMATION, CALLSITE)
 INLINE_OBSERVATION(IS_SIZE_DECREASING_INLINE, bool,   "size decreasing inline",        INFORMATION, CALLSITE)
 INLINE_OBSERVATION(LOG_REPLAY_ACCEPT,         bool,   "accepted by log replay",        INFORMATION, CALLSITE)
 INLINE_OBSERVATION(RANDOM_ACCEPT,             bool,   "random accept",                 INFORMATION, CALLSITE)

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -1232,10 +1232,15 @@ DiscretionaryPolicy::DiscretionaryPolicy(Compiler* compiler, bool isPrejitRoot)
     , m_StaticFieldStoreCount(0)
     , m_LoadAddressCount(0)
     , m_ThrowCount(0)
+    , m_ReturnCount(0)
     , m_CallCount(0)
     , m_CallSiteWeight(0)
     , m_ModelCodeSizeEstimate(0)
     , m_PerCallInstructionEstimate(0)
+    , m_IsClassCtor(false)
+    , m_IsSameThis(false)
+    , m_CallerHasNewArray(false)
+    , m_CallerHasNewObj(false)
 {
     // Empty
 }
@@ -1269,6 +1274,22 @@ void DiscretionaryPolicy::NoteBool(InlineObservation obs, bool value)
     case InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST:
         assert(value);
         m_ConstantArgFeedsConstantTest++;
+        break;
+
+    case InlineObservation::CALLEE_IS_CLASS_CTOR:
+        m_IsClassCtor = value;
+        break;
+
+    case InlineObservation::CALLSITE_IS_SAME_THIS:
+        m_IsSameThis = value;
+        break;
+
+    case InlineObservation::CALLER_HAS_NEWARRAY:
+        m_CallerHasNewArray = value;
+        break;
+
+    case InlineObservation::CALLER_HAS_NEWOBJ:
+        m_CallerHasNewObj = value;
         break;
 
     default:
@@ -1596,6 +1617,9 @@ void DiscretionaryPolicy::ComputeOpcodeBin(OPCODE opcode)
             m_ThrowCount++;
             break;
 
+        case CEE_RET:
+            m_ReturnCount++;
+
         default:
             break;
     }
@@ -1910,6 +1934,7 @@ void DiscretionaryPolicy::DumpSchema(FILE* file) const
     fprintf(file, ",StaticFieldStoreCount");
     fprintf(file, ",LoadAddressCount");
     fprintf(file, ",ThrowCount");
+    fprintf(file, ",ReturnCount");
     fprintf(file, ",CallCount");
     fprintf(file, ",CallSiteWeight");
     fprintf(file, ",IsForceInline");
@@ -1925,6 +1950,10 @@ void DiscretionaryPolicy::DumpSchema(FILE* file) const
     fprintf(file, ",CallsiteNativeSizeEstimate");
     fprintf(file, ",ModelCodeSizeEstimate");
     fprintf(file, ",ModelPerCallInstructionEstimate");
+    fprintf(file, ",IsClassCtor");
+    fprintf(file, ",IsSameThis");
+    fprintf(file, ",CallerHasNewArray");
+    fprintf(file, ",CallerHasNewObj");
 }
 
 //------------------------------------------------------------------------
@@ -1984,6 +2013,7 @@ void DiscretionaryPolicy::DumpData(FILE* file) const
     fprintf(file, ",%u", m_StaticFieldLoadCount);
     fprintf(file, ",%u", m_StaticFieldStoreCount);
     fprintf(file, ",%u", m_LoadAddressCount);
+    fprintf(file, ",%u", m_ReturnCount);
     fprintf(file, ",%u", m_ThrowCount);
     fprintf(file, ",%u", m_CallCount);
     fprintf(file, ",%u", m_CallSiteWeight);
@@ -2000,6 +2030,10 @@ void DiscretionaryPolicy::DumpData(FILE* file) const
     fprintf(file, ",%d", m_CallsiteNativeSizeEstimate);
     fprintf(file, ",%d", m_ModelCodeSizeEstimate);
     fprintf(file, ",%d", m_PerCallInstructionEstimate);
+    fprintf(file, ",%u", m_IsClassCtor ? 1 : 0);
+    fprintf(file, ",%u", m_IsSameThis ? 1 : 0);
+    fprintf(file, ",%u", m_CallerHasNewArray ? 1 : 0);
+    fprintf(file, ",%u", m_CallerHasNewObj ? 1 : 0);
 }
 
 #endif // defined(DEBUG) || defined(INLINE_DATA)

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -9,17 +9,20 @@
 //
 // -- CLASSES --
 //
-// LegalPolicy         - partial class providing common legality checks
-// LegacyPolicy        - policy that provides legacy inline behavior
-// DiscretionaryPolicy - legacy variant with uniform size policy
-// ModelPolicy         - policy based on statistical modelling
+// LegalPolicy          - partial class providing common legality checks
+// LegacyPolicy         - policy that provides legacy inline behavior
+// EnhancedLegacyPolicy - legacy variant with some enhancements
+// DiscretionaryPolicy  - legacy variant with uniform size policy
+// ModelPolicy          - policy based on statistical modelling
 //
 // These experimental policies are available only in
 // DEBUG or release+INLINE_DATA builds of the jit.
 //
-// RandomPolicy        - randomized inlining
-// FullPolicy          - inlines everything up to size and depth limits
-// SizePolicy          - tries not to increase method sizes
+// RandomPolicy         - randomized inlining
+// FullPolicy           - inlines everything up to size and depth limits
+// SizePolicy           - tries not to increase method sizes
+//
+// The default policy in use is the EnhancedLegacyPolicy.
 
 #ifndef _INLINE_POLICY_H_
 #define _INLINE_POLICY_H_
@@ -313,10 +316,15 @@ protected:
     unsigned    m_StaticFieldStoreCount;
     unsigned    m_LoadAddressCount;
     unsigned    m_ThrowCount;
+    unsigned    m_ReturnCount;
     unsigned    m_CallCount;
     unsigned    m_CallSiteWeight;
     int         m_ModelCodeSizeEstimate;
     int         m_PerCallInstructionEstimate;
+    bool        m_IsClassCtor;
+    bool        m_IsSameThis;
+    bool        m_CallerHasNewArray;
+    bool        m_CallerHasNewObj;
 };
 
 // ModelPolicy is an experimental policy that uses the results


### PR DESCRIPTION
Now that we can trust `optMethodFlags`, note if the root caller has
newarr or newobj. We can't yet tell if these operations might feed
a particular call's arguments but their presence in the root method
alone might be enough to build correlations with performance changes.

Count number of returns in the callee. Note if callee has same this
as the (root) caller. Note when callee is a class constructor.

Add code to dump out the new observations. No policies act on these yet.