### PR TITLE
Fix compile error

### DIFF
--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -7314,11 +7314,11 @@ VOID * GetHijackAddr(Thread *pThread, EECodeInfo *codeInfo)
 #ifdef _TARGET_X86_
     if (returnKind == RT_Float)
     {
-        return OnHijackFPTripThread;
+        return reinterpret_cast<VOID *>(OnHijackTripThread);
     }
 #endif // _TARGET_X86_
 
-    return OnHijackTripThread;
+    return reinterpret_cast<VOID *>(OnHijackTripThread);
 }
 
 #ifndef PLATFORM_UNIX


### PR DESCRIPTION
error: cannot initialize return object of type 'void *' with an lvalue
of type 'void ()'