### PR TITLE
[ARM/Linux] Fix build break in arm cross build with clang-3.8

### DIFF
--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -7318,7 +7318,7 @@ VOID * GetHijackAddr(Thread *pThread, EECodeInfo *codeInfo)
     }
 #endif // _TARGET_X86_
 
-    return OnHijackTripThread;
+    return (VOID *) OnHijackTripThread;
 }
 
 #ifndef PLATFORM_UNIX


### PR DESCRIPTION
* error: cannot initialize return object of type 'void *' with an lvalue of type 'void ()'