### PR TITLE
Improve Enum.ToString performance

### DIFF
--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -720,26 +720,44 @@ namespace System
                 switch (InternalGetCorElementType())
                 {
                     case CorElementType.I1:
+                        return (ulong)*(sbyte*)pValue;
                     case CorElementType.U1:
-                        return (ulong)*(byte*)pValue;
+                        return *(byte*)pValue;
                     case CorElementType.Boolean:
                         return Convert.ToUInt64(*(bool*)pValue, CultureInfo.InvariantCulture);
                     case CorElementType.I2:
+                        return (ulong)*(short*)pValue;
                     case CorElementType.U2:
                     case CorElementType.Char:
-                        return (ulong)*(ushort*)pValue;
+                        return *(ushort*)pValue;
                     case CorElementType.I4:
+                        return (ulong)*(int*)pValue;
                     case CorElementType.U4:
                     case CorElementType.R4:
-                        return (ulong)*(uint*)pValue;
+                        return *(uint*)pValue;
                     case CorElementType.I8:
+                        return (ulong)*(long*)pValue;
                     case CorElementType.U8:
                     case CorElementType.R8:
-                        return (ulong)*(ulong*)pValue;
+                        return *(ulong*)pValue;
                     case CorElementType.I:
-                        return (ulong)*(IntPtr*)pValue;
+                        if (IntPtr.Size == 8)
+                        {
+                            return *(ulong*)pValue;
+                        }
+                        else
+                        {
+                            return (ulong)*(int*)pValue;
+                        }
                     case CorElementType.U:
-                        return (ulong)*(UIntPtr*)pValue;
+                        if (IntPtr.Size == 8)
+                        {
+                            return *(ulong*)pValue;
+                        }
+                        else
+                        {
+                            return *(uint*)pValue;
+                        }
                     default:
                         Contract.Assert(false, "Invalid primitive type");
                         return 0;
@@ -755,14 +773,14 @@ namespace System
             switch (typeCode)
             {
                 case TypeCode.SByte:
-                    return (byte)(sbyte)value;
+                    return (ulong)(sbyte)value;
                 case TypeCode.Byte:
                     return (byte)value;
                 case TypeCode.Boolean:
                     // direct cast from bool to byte is not allowed
                     return Convert.ToByte((bool)value);
                 case TypeCode.Int16:
-                    return (UInt16)(Int16)value;
+                    return (ulong)(Int16)value;
                 case TypeCode.UInt16:
                     return (UInt16)value;
                 case TypeCode.Char:
@@ -770,11 +788,11 @@ namespace System
                 case TypeCode.UInt32:
                     return (UInt32)value;
                 case TypeCode.Int32:
-                    return (UInt32)(int)value;
+                    return (ulong)(int)value;
                 case TypeCode.UInt64:
-                    return (UInt64)value;
+                    return (ulong)value;
                 case TypeCode.Int64:
-                    return (UInt64)(Int64)value;
+                    return (ulong)(Int64)value;
                 // All unsigned types will be directly cast
                 default:
                     Contract.Assert(false, "Invalid Object type in Format");

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -903,6 +903,8 @@ namespace System
             char formatCh;
             if (format == null || format.Length == 0)
                 formatCh = 'G';
+            else if (format.Length != 1)
+                throw new FormatException(Environment.GetResourceString("Format_InvalidEnumFormatSpecification"));
             else
                 formatCh = format[0];
 

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -620,16 +620,23 @@ namespace System
                     throw new ArgumentException(Environment.GetResourceString("Arg_EnumAndObjectMustBeSameType", valueType.ToString(), enumType.ToString()));
 
                 valueType = valueUnderlyingType;
-                return ((Enum)value).ToString(format);
+                var result = ((Enum)value).ToString(format);
+                if (format.Length != 1)
+                {
+                    // all acceptable format string are of length 1
+                    throw new FormatException(Environment.GetResourceString("Format_InvalidEnumFormatSpecification"));
+                }
+                return result;
             }
             // The value must be of the same type as the Underlying type of the Enum
             else if (valueType != underlyingType) {
                 throw new ArgumentException(Environment.GetResourceString("Arg_EnumFormatUnderlyingTypeAndObjectMustBeSameType", valueType.ToString(), underlyingType.ToString()));
             }
-
-            if (format == null || format.Length == 0)
-                format = "G";
-
+            if (format.Length != 1)
+            {
+                // all acceptable format string are of length 1
+                throw new FormatException(Environment.GetResourceString("Format_InvalidEnumFormatSpecification"));
+            }
             if (String.Compare(format, "G", StringComparison.OrdinalIgnoreCase) == 0)
                 return GetEnumName(rtType, GetValueAsULong(value));
 

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -95,9 +95,9 @@ namespace System
                 case TypeCode.Char:
                     return ((UInt16)(Char)value).ToString("X4", null);
                 case TypeCode.UInt32:
-                    return ((UInt32)value).ToString("X8", null); ;
+                    return ((UInt32)value).ToString("X8", null);
                 case TypeCode.Int32:
-                    return ((UInt32)(Int32)value).ToString("X8", null); ;
+                    return ((UInt32)(Int32)value).ToString("X8", null);
                 case TypeCode.UInt64:
                     return ((UInt64)value).ToString("X16", null);
                 case TypeCode.Int64:

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -50,35 +50,27 @@ namespace System
         {
             fixed (void* pValue = &JitHelpers.GetPinningHelper(this).m_data)
             {
-                unchecked
+                switch (InternalGetCorElementType())
                 {
-                    switch (InternalGetCorElementType())
-                    {
-                        case CorElementType.I1:
-                            return ((byte)*(sbyte*)pValue).ToString("X2", null);
-                        case CorElementType.U1:
-                            return (*(byte*)pValue).ToString("X2", null);
-                        case CorElementType.Boolean:
-                            // direct cast from bool to byte is not allowed
-                            return Convert.ToByte(*(bool*)pValue).ToString("X2", null);
-                        case CorElementType.I2:
-                            return ((ushort)*(short*)pValue).ToString("X4", null);
-                        case CorElementType.U2:
-                            return (*(ushort*)pValue).ToString("X4", null);
-                        case CorElementType.Char:
-                            return ((ushort)*(char*)pValue).ToString("X4", null);
-                        case CorElementType.I4:
-                            return ((uint)*(int*)pValue).ToString("X8", null);
-                        case CorElementType.U4:
-                            return (*(uint*)pValue).ToString("X8", null);
-                        case CorElementType.I8:
-                            return ((ulong)*(long*)pValue).ToString("X16", null);
-                        case CorElementType.U8:
-                            return (*(ulong*)pValue).ToString("X16", null);
-                        default:
-                            Contract.Assert(false, "Invalid Object type in Format");
-                            throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_UnknownEnumType"));
-                    }
+                    case CorElementType.I1:
+                    case CorElementType.U1:
+                        return (*(byte*)pValue).ToString("X2", null);
+                    case CorElementType.Boolean:
+                        // direct cast from bool to byte is not allowed
+                        return Convert.ToByte(*(bool*)pValue).ToString("X2", null);
+                    case CorElementType.I2:
+                    case CorElementType.U2:
+                    case CorElementType.Char:
+                        return (*(ushort*)pValue).ToString("X4", null);
+                    case CorElementType.I4:
+                    case CorElementType.U4:
+                        return (*(uint*)pValue).ToString("X8", null);
+                    case CorElementType.I8:
+                    case CorElementType.U8:
+                        return (*(ulong*)pValue).ToString("X16", null);
+                    default:
+                        Contract.Assert(false, "Invalid Object type in Format");
+                        throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_UnknownEnumType"));
                 }
             }
         }
@@ -668,42 +660,32 @@ namespace System
         {
             fixed (void* pValue = &JitHelpers.GetPinningHelper(this).m_data)
             {
-                unchecked
+                switch (InternalGetCorElementType())
                 {
-                    switch (InternalGetCorElementType())
-                    {
-                        case CorElementType.I1:
-                            return (ulong)*(sbyte*)pValue;
-                        case CorElementType.U1:
-                            return (ulong)*(byte*)pValue;
-                        case CorElementType.Boolean:
-                            return Convert.ToUInt64(*(bool*)pValue, CultureInfo.InvariantCulture);
-                        case CorElementType.I2:
-                            return (ulong)*(short*)pValue;
-                        case CorElementType.U2:
-                            return (ulong)*(ushort*)pValue;
-                        case CorElementType.Char:
-                            return (ulong)*(char*)pValue;
-                        case CorElementType.I4:
-                            return (ulong)*(int*)pValue;
-                        case CorElementType.U4:
-                            return (ulong)*(uint*)pValue;
-                        case CorElementType.R4:
-                            return (ulong)*(float*)pValue;
-                        case CorElementType.I8:
-                            return (ulong)*(long*)pValue;
-                        case CorElementType.U8:
-                            return (ulong)*(ulong*)pValue;
-                        case CorElementType.R8:
-                            return (ulong)*(double*)pValue;
-                        case CorElementType.I:
-                            return (ulong)*(IntPtr*)pValue;
-                        case CorElementType.U:
-                            return (ulong)*(UIntPtr*)pValue;
-                        default:
-                            Contract.Assert(false, "Invalid primitive type");
-                            return 0;
-                    }
+                    case CorElementType.I1:
+                    case CorElementType.U1:
+                        return (ulong)*(byte*)pValue;
+                    case CorElementType.Boolean:
+                        return Convert.ToUInt64(*(bool*)pValue, CultureInfo.InvariantCulture);
+                    case CorElementType.I2:
+                    case CorElementType.U2:
+                    case CorElementType.Char:
+                        return (ulong)*(ushort*)pValue;
+                    case CorElementType.I4:
+                    case CorElementType.U4:
+                    case CorElementType.R4:
+                        return (ulong)*(uint*)pValue;
+                    case CorElementType.I8:
+                    case CorElementType.U8:
+                    case CorElementType.R8:
+                        return (ulong)*(ulong*)pValue;
+                    case CorElementType.I:
+                        return (ulong)*(IntPtr*)pValue;
+                    case CorElementType.U:
+                        return (ulong)*(UIntPtr*)pValue;
+                    default:
+                        Contract.Assert(false, "Invalid primitive type");
+                        return 0;
                 }
             }
         }

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -614,19 +614,16 @@ namespace System
 
             // If the value is an Enum then we need to extract the underlying value from it
             if (valueType.IsEnum) {
-                Type valueUnderlyingType = GetUnderlyingType(valueType);
 
                 if (!valueType.IsEquivalentTo(enumType))
                     throw new ArgumentException(Environment.GetResourceString("Arg_EnumAndObjectMustBeSameType", valueType.ToString(), enumType.ToString()));
 
-                valueType = valueUnderlyingType;
-                var result = ((Enum)value).ToString(format);
                 if (format.Length != 1)
                 {
                     // all acceptable format string are of length 1
                     throw new FormatException(Environment.GetResourceString("Format_InvalidEnumFormatSpecification"));
                 }
-                return result;
+                return ((Enum)value).ToString(format);
             }
             // The value must be of the same type as the Underlying type of the Enum
             else if (valueType != underlyingType) {

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -324,6 +324,11 @@ namespace System.Reflection
             MetadataEnumResult tkCustomAttributeTokens;
             scope.EnumCustomAttributes(targetToken, out tkCustomAttributeTokens);
 
+            if (tkCustomAttributeTokens.Length == 0)
+            {
+                return Array.Empty<CustomAttributeRecord>();
+            }
+
             CustomAttributeRecord[] records = new CustomAttributeRecord[tkCustomAttributeTokens.Length];
 
             for (int i = 0; i < records.Length; i++)

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -3919,17 +3919,9 @@ namespace System
             if (!(valueType.IsEnum || IsIntegerType(valueType)))
                 throw new ArgumentException(Environment.GetResourceString("Arg_MustBeEnumBaseTypeOrEnum"), "value");
 
-            ulong[] ulValues = Enum.InternalGetValues(this);
             ulong ulValue = Enum.ToUInt64(value);
-            int index = Array.BinarySearch(ulValues, ulValue);
 
-            if (index >= 0)
-            {
-                string[] names = Enum.InternalGetNames(this);
-                return names[index];
-            }
-
-            return null;
+            return Enum.GetEnumName(this, ulValue);
         }
         #endregion
 


### PR DESCRIPTION
Reduces allocations by 66%; increases performance by 600% (x7)

With these changes ToString no longer boxes the value and doesn't create an empty array for `CustomAttributeRecords` when the enum is not flagged; also caches whether the enum is flagged.

It still boxes the enum to Enum to make the ToString virtual call however.

Using the @jkotas enummark :wink: 

```csharp
enum MyEnum { One, Two, Three, Four, Five, Six, Seven, Eight, Nine, Ten };
public static void Main(string[] args)
{
    (MyEnum.Seven).ToString();
    int start = Environment.TickCount;
    for (int i = 0; i < 10000000; i++)
    {
        (MyEnum.Seven).ToString();
    }
    int end = Environment.TickCount;
    Console.WriteLine((end - start).ToString());
}
```
Pre: 5828ms, 5828ms, 5829ms (1.7M/s)
Post: 828ms, 828ms, 828ms (12.1M/s)

Allocations pre
![](https://aoa.blob.core.windows.net/aspnet/enum-pre-2.png)

Allocations post
![](https://aoa.blob.core.windows.net/aspnet/enum-post-2.png)

Counts in run are the same, just differ in images from profiling start, stop points

Resolves https://github.com/dotnet/coreclr/issues/3565