### PR TITLE
Enable crossgen to use SSE2 instructions for x86

### DIFF
--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -3225,7 +3225,7 @@ void GetNGenCpuInfo(CORINFO_CPU * cpuInfo)
         0                           // dwExtendedFeatures
     };
 
-#if !defined(FEATURE_CORECLR) && !defined(CROSSGEN_COMPILE)
+#if !defined(CROSSGEN_COMPILE)
     GetSpecificCpuInfo(cpuInfo);
     if (!IsCompatibleCpuInfo(cpuInfo, &ngenCpuInfo))
     {
@@ -3233,7 +3233,7 @@ void GetNGenCpuInfo(CORINFO_CPU * cpuInfo)
         // with the "recommended" processor. We expect most platforms to be compatible
         return;
     }
-#endif // !defined(FEATURE_CORECLR) && !defined(CROSSGEN_COMPILE)
+#endif // !defined(CROSSGEN_COMPILE)
 
     *cpuInfo = ngenCpuInfo;
 

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -3203,8 +3203,8 @@ void GetTimeStampsForNativeImage(CORCOMPILE_VERSION_INFO * pNativeVersionInfo)
 #endif // FEATURE_CORECLR
 }
 
-static constexpr uint32_t CmovFlags = 0x00008001;
-static constexpr uint32_t Sse2Flags = 0x04000000;
+static constexpr uint32_t CMOVFlags = 0x00008001;
+static constexpr uint32_t SSE2Flags = 0x04000000;
 
 //
 // Which processor should ngen target?
@@ -3221,7 +3221,7 @@ void GetNGenCpuInfo(CORINFO_CPU * cpuInfo)
     static CORINFO_CPU ngenCpuInfo =
     {
         (CPU_X86_PENTIUM_4 << 8),   // dwCPUType
-        CmovFlags | Sse2Flags,      // dwFeatures
+        CMOVFlags | SSE2Flags,      // dwFeatures
         0                           // dwExtendedFeatures
     };
 
@@ -3239,7 +3239,7 @@ void GetNGenCpuInfo(CORINFO_CPU * cpuInfo)
 
 #else // _TARGET_X86_
     cpuInfo->dwCPUType = 0;
-    cpuInfo->dwFeatures = 0; // CMOV and SSE2 are enabled by default for x86_64
+    cpuInfo->dwFeatures = 0; // CMOV and SSE2 are enabled by default for AMD64
     cpuInfo->dwExtendedFeatures = 0;
 #endif // _TARGET_X86_
 }

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -3203,8 +3203,8 @@ void GetTimeStampsForNativeImage(CORCOMPILE_VERSION_INFO * pNativeVersionInfo)
 #endif // FEATURE_CORECLR
 }
 
-static constexpr uint32_t CMOVFlags = 0x00008001;
-static constexpr uint32_t SSE2Flags = 0x04000000;
+static const uint32_t CMOVFlags = 0x00008001;
+static const uint32_t SSE2Flags = 0x04000000;
 
 //
 // Which processor should ngen target?


### PR DESCRIPTION
crossgen currently doesn't generate SSE instructions of any kind for x86, which was causing issues in #6638 when I was attempting to use it with 16-and-larger byte types. This change enables it to use SSE2 instructions, dropping support for processors that don't support that.

[Here](https://gist.githubusercontent.com/jamesqo/2311301df084e20ab6265fdbff382fbe/raw/0c585a9bc4278c0a011e423b2a95b18687653802/MovqXmm.output) is the gist that results when I dump the disassembly of every method in the `System.Private.CoreLib` native image, and grep for `xmm`.

Notes:

- According [to Wikipedia](https://en.wikipedia.org/wiki/SSE2) Pentium 4 (which is targeted for the framework) already supports SSE2, so there's no reason not to enable this for the framework.
- The region ifdef'd under `FEATURE_CORECLR` seems to target Pentium Pro ([released in 1995](https://en.wikipedia.org/wiki/Pentium_Pro)), an *older* processor than Pentium 4. Since this has no support for SSE, I just deleted this and retargeted it to Pentium 4.
- Removed `ifndef` for CoreCLR that contained a call to `GetSpecificCpuInfo`, which is presumably querying the actual processor's features at runtime. Is there any reason this wasn't enabled before?

cc @jkotas @benaadams @tannergooding @mikedn