### PR TITLE
Fix for VCR 190024210 and Win SDK 10.0.14393.0

### DIFF
--- a/src/inc/debugreturn.h
+++ b/src/inc/debugreturn.h
@@ -27,7 +27,9 @@
 
 #else // !_PREFAST_
 
-#ifdef _DEBUG
+// This is disabled in VS2015 Update 3 and earlier because only C++11 constexpr is supported,
+// which doesn't allow the use of 'if' statements within the body of a constexpr function.
+#if defined(_DEBUG) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024210)
 
 // Code to generate a compile-time error if return statements appear where they
 // shouldn't.
@@ -108,15 +110,17 @@ typedef __SafeToReturn __ReturnOK;
 #define DEBUG_OK_TO_RETURN_BEGIN(arg) { typedef __SafeToReturn __ReturnOK; if (0 && __ReturnOK::used()) { } else {
 #define DEBUG_OK_TO_RETURN_END(arg) } }
 
-#else // !_DEBUG
+#else // defined(_DEBUG) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024210)
 
-#define DEBUG_ASSURE_NO_RETURN_BEGIN(arg)
-#define DEBUG_ASSURE_NO_RETURN_END(arg)
+#define DEBUG_ASSURE_SAFE_TO_RETURN TRUE
 
-#define DEBUG_OK_TO_RETURN_BEGIN(arg)
-#define DEBUG_OK_TO_RETURN_END(arg)
+#define DEBUG_ASSURE_NO_RETURN_BEGIN(arg) {
+#define DEBUG_ASSURE_NO_RETURN_END(arg) }
 
-#endif // !_DEBUG
+#define DEBUG_OK_TO_RETURN_BEGIN(arg) {
+#define DEBUG_OK_TO_RETURN_END(arg) }
+
+#endif // defined(_DEBUG) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024210)
 
 #endif // !_PREFAST_
 


### PR DESCRIPTION
Fix #6642.

Too bad that:

1. we can't use a proper SDK version check `VER_PRODUCTBUILD >= 10011`  from `<ntverp.h>` (https://github.com/dotnet/coreclr/issues/6642#issuecomment-238609867).
2. there is no auto-config (CMAKE or python) in play for Windows build so we can do something like:

```cmake
#cmake Windows SDK detection

if(CMAKE_SYSTEM_NAME STREQUAL Windows)
    check_c_source_compiles("
#include <ntverp.h>

#if VER_PRODUCTBUILD >= 10011 && _MSC_FULL_VER <= 190024210
#error Can't build CoreCLR with VS2015.3 (_MSC_FULL_VER: 190024210) or below and Windows SDK v10.0.14393.0 (VER_PRODUCTBUILD: 10011) and above. Please update VC tool chain. For details, see: https://github.com/dotnet/coreclr/issues/6642.
#endif" VERIFIED_MSVCR_AND_WINDOWS_SDK)

    if(NOT VERIFIED_MSVCR_AND_WINDOWS_SDK)
        message(FATAL_ERROR "Can't build CoreCLR with VS2015.3 (_MSC_FULL_VER: 190024210) or below and Windows SDK v10.0.14393.0 (VER_PRODUCTBUILD: 10011) and above. Please update VC tool chain. For details, see: https://github.com/dotnet/coreclr/issues/6642.")
    endif(NOT VERIFIED_MSVCR_AND_WINDOWS_SDK)
endif(CMAKE_SYSTEM_NAME STREQUAL Windows)
```

Leveraging CMake for Windows builds as well will help this kind of situations IMO.

/cc @jkotas 