### PR TITLE
Revises isSingleFloat32Struct

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -475,7 +475,7 @@ bool Compiler::isSingleFloat32Struct(CORINFO_CLASS_HANDLE clsHnd)
     for (;;)
     {
         // all of class chain must be of value type and must have only one field
-        if (!info.compCompHnd->isValueClass(clsHnd) && info.compCompHnd->getClassNumInstanceFields(clsHnd) != 1)
+        if (!info.compCompHnd->isValueClass(clsHnd) || info.compCompHnd->getClassNumInstanceFields(clsHnd) != 1)
         {
             return false;
         }


### PR DESCRIPTION
``isSingleFloat32Struct`` currently checkes whether the current handle is not a
value class handle, or it has more than one field.

If not, it proceeds to the next step that checks the type of each fields.

Unfortunately, if the current handle is not a value class, but has one
field (somehow), ``getFieldInClass`` failed with the assertion discussed in #6569.

This commit tries to fix this invalid terminating condition.