### PR TITLE
Update FieldSeq annotations in EarlyProp

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -14706,6 +14706,10 @@ void GenTree::LabelIndex(Compiler* comp, bool isConst)
         gtOp.gtOp1->LabelIndex(comp, isConst);
         break;
 
+    case GT_ARR_LENGTH:
+        gtFlags |= GTF_ARRLEN_ARR_IDX;
+        return;
+
     default:
         // For all other operators, peel off one constant; and then label the other if it's also a constant.
         if (OperIsArithmetic() || OperIsCompare())

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -844,6 +844,8 @@ public:
 
     #define GTF_ARR_BOUND_INBND 0x80000000  // GT_ARR_BOUNDS_CHECK -- have proved this check is always in-bounds
 
+    #define GTF_ARRLEN_ARR_IDX  0x80000000  // GT_ARR_LENGTH -- Length which feeds into an array index expression
+
     //----------------------------------------------------------------
 
     #define GTF_STMT_CMPADD     0x80000000  // GT_STMT    -- added by compiler

--- a/tests/src/JIT/Regression/JitBlue/GitHub_6649/GitHub_6649.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_6649/GitHub_6649.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Regression test for failure to maintain FieldSeq annotations in EarlyProp
+using System.Runtime.CompilerServices;
+
+namespace N
+{
+    public static class C
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int Exn()
+        {
+            int[] arr = { 1, 2, 3 };
+            // When the "arr.Length" below gets replaced with "3", EarlyProp needs
+            // to mark it with a ConstantIndex FieldSeq to avoid a downstream assertion
+            // about lost FieldSeq annotations.
+            return arr[0] + arr[arr.Length];
+        }
+
+        public static int Main(string[] args)
+        {
+            try
+            {
+                Exn();
+                return -1;
+            }
+            catch (System.IndexOutOfRangeException) { }
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_6649/GitHub_6649.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_6649/GitHub_6649.csproj
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{5C94DE9A-B2C4-4A0C-96CC-FEAE2E8EEBE9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_6649/app.config
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_6649/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
When morph expands `ldelem`s, it annotates local vars and int constants
that contribute linearly to the index.  When value-numbering runs,
ParseArrayAddress must still be able to discover annotations.  EarlyProp
runs between morph and value-numbering, and might replace a `ldlen` that
happens to be in an array index expression with a constant.  This change
updates EarlyProp to call LabelIndex in such cases to annotate the
constants appropriately for their new context.

In order to ensure that EarlyProp can determine whether a replacement is
in an array index context or not, this change also adds a new flag
`GTF_ARRLEN_ARR_IDX`, which LabelIndex sets on GT_ARR_LENGTH nodes and
EarlyProp can subsequently check.

Fixes #6649.

@dotnet/jit-contrib PTAL.  No Selfhost/SPMI asm diffs.