### PR TITLE
[Proposal] Enum.IsDefined()

### DIFF
--- a/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
@@ -1413,7 +1413,7 @@ namespace Microsoft.Win32 {
                 throw new ArgumentException(Environment.GetResourceString("Arg_RegValStrLenBug"));
             }
 
-            if (!Enum.IsDefined(typeof(RegistryValueKind), valueKind))
+            if (!valueKind.IsDefined())
                 throw new ArgumentException(Environment.GetResourceString("Arg_RegBadKeyKind"), "valueKind");
 
             EnsureWriteable();

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -6392,7 +6392,7 @@ namespace System.Diagnostics.Tracing
                     if (channelInfo.Attribs != null)
                     {
                         var attribs = channelInfo.Attribs;
-                        if (Enum.IsDefined(typeof(EventChannelType), attribs.EventChannelType))
+                        if (attribs.EventChannelType.IsDefined())
                             channelType = attribs.EventChannelType.ToString();
                         enabled = attribs.Enabled;
 #if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -612,7 +612,15 @@ namespace System
 
             return enumType.IsEnumDefined(value);
         }
-        
+
+        [System.Security.SecuritySafeCritical]
+        public bool IsDefined()
+        {
+            ulong[] ulValues = Enum.InternalGetValues((RuntimeType)GetType());
+
+            return (Array.BinarySearch(ulValues, ToUInt64()) >= 0);
+        }
+
         [System.Runtime.InteropServices.ComVisible(true)]
         public static String Format(Type enumType, Object value, String format)
         {

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -1410,7 +1410,7 @@ namespace System {
         
         [System.Security.SecuritySafeCritical]  // auto-generated
         public static string GetFolderPath(SpecialFolder folder) {
-            if (!Enum.IsDefined(typeof(SpecialFolder), folder))
+            if (!folder.IsDefined())
                 throw new ArgumentException(Environment.GetResourceString("Arg_EnumIllegalVal", (int)folder));
             Contract.EndContractBlock();
 
@@ -1419,9 +1419,9 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public static string GetFolderPath(SpecialFolder folder, SpecialFolderOption option) {
-            if (!Enum.IsDefined(typeof(SpecialFolder),folder))
+            if (!folder.IsDefined())
                 throw new ArgumentException(Environment.GetResourceString("Arg_EnumIllegalVal", (int)folder));
-            if (!Enum.IsDefined(typeof(SpecialFolderOption),option))
+            if (!option.IsDefined())
                 throw new ArgumentException(Environment.GetResourceString("Arg_EnumIllegalVal", (int)option));
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/Resources/NeutralResourcesLanguageAttribute.cs
+++ b/src/mscorlib/src/System/Resources/NeutralResourcesLanguageAttribute.cs
@@ -46,7 +46,7 @@ namespace System.Resources {
         {
             if (cultureName == null)
                 throw new ArgumentNullException("cultureName");
-            if (!Enum.IsDefined(typeof(UltimateResourceFallbackLocation), location))
+            if (!location.IsDefined())
                 throw new ArgumentException(Environment.GetResourceString("Arg_InvalidNeutralResourcesLanguage_FallbackLoc", location));
             Contract.EndContractBlock();
 


### PR DESCRIPTION
Code for https://github.com/dotnet/corefx/issues/10692

So rather than doing this:
```csharp
string DoTheThing(MyEnum argument)
{
    if (!Enum.IsDefined(typeof(MyEnum), argument))
    {
         Log.Warn(...);
         return String.Empty;
    }
    return argument.ToString();
}
```
You can do this:
```csharp
string DoTheThing(MyEnum argument)
{
    if (!argument.IsDefined())
    {
         Log.Warn(...);
         return String.Empty;
    }
    return argument.ToString();
}
```

`Enum.IsDefined(typeof(MyEnum), argument)` is also quite slow as it needs to do lots of conversion checks etc; whereas if you already have the enum these don't need to be done.

e.g.
https://github.com/dotnet/corefx/blob/master/src/System.Private.Uri/src/System/UriExt.cs#L19-L24