### PR TITLE
[WIP] Move the GC behind an interface and use that interface in the VM

### DIFF
--- a/src/classlibnative/bcltype/arraynative.cpp
+++ b/src/classlibnative/bcltype/arraynative.cpp
@@ -961,7 +961,7 @@ void memmoveGCRefs(void *dest, const void *src, size_t len)
         }
     }
 
-    GCHeap::GetGCHeap()->SetCardsAfterBulkCopy((Object**)dest, len);
+    IGCHeap::GetGCHeap()->SetCardsAfterBulkCopy((Object**)dest, len);
 }
 
 void ArrayNative::ArrayCopyNoTypeCheck(BASEARRAYREF pSrc, unsigned int srcIndex, BASEARRAYREF pDest, unsigned int destIndex, unsigned int length)

--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -673,7 +673,7 @@ FCIMPL0(FC_BOOL_RET, SystemNative::IsServerGC)
 {
     FCALL_CONTRACT;
 
-    FC_RETURN_BOOL(GCHeap::IsServerHeap());
+    FC_RETURN_BOOL(IGCHeap::IsServerHeap());
 }
 FCIMPLEND
 

--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -7974,7 +7974,7 @@ HRESULT DacHandleWalker::Init(ClrDataAccess *dac, UINT types[], UINT typeCount, 
 {
     SUPPORTS_DAC;
     
-    if (gen < 0 || gen > (int)GCHeap::GetMaxGeneration())
+    if (gen < 0 || gen > (int)IGCHeap::GetGCHeap()->GetMaxGeneration())
         return E_INVALIDARG;
         
     mGenerationFilter = gen;
@@ -8033,7 +8033,7 @@ bool DacHandleWalker::FetchMoreHandles(HANDLESCANPROC callback)
     int max_slots = 1;
     
 #ifdef FEATURE_SVR_GC
-    if (GCHeap::IsServerHeap())
+    if (IGCHeap::IsServerHeap())
         max_slots = GCHeapCount();
 #endif // FEATURE_SVR_GC
 
@@ -8089,7 +8089,7 @@ bool DacHandleWalker::FetchMoreHandles(HANDLESCANPROC callback)
                                 HndScanHandlesForGC(hTable, callback, 
                                                     (LPARAM)&param, 0, 
                                                      &handleType, 1, 
-                                                     mGenerationFilter, GCHeap::GetMaxGeneration(), 0);
+                                                     mGenerationFilter, IGCHeap::GetGCHeap()->GetMaxGeneration(), 0);
                             else
                                 HndEnumHandles(hTable, &handleType, 1, callback, (LPARAM)&param, 0, FALSE);
                         }

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -6517,7 +6517,7 @@ HRESULT DacHeapWalker::Init(CORDB_ADDRESS start, CORDB_ADDRESS end)
             if (thread == NULL)
                 continue;
 
-            alloc_context *ctx = thread->GetAllocContext();
+            gc_alloc_context *ctx = thread->GetAllocContext();
             if (ctx == NULL)
                 continue;
 
@@ -6533,7 +6533,7 @@ HRESULT DacHeapWalker::Init(CORDB_ADDRESS start, CORDB_ADDRESS end)
     }
 
 #ifdef FEATURE_SVR_GC
-    HRESULT hr = GCHeap::IsServerHeap() ? InitHeapDataSvr(mHeaps, mHeapCount) : InitHeapDataWks(mHeaps, mHeapCount);
+    HRESULT hr = IGCHeap::IsServerHeap() ? InitHeapDataSvr(mHeaps, mHeapCount) : InitHeapDataWks(mHeaps, mHeapCount);
 #else
     HRESULT hr = InitHeapDataWks(mHeaps, mHeapCount);
 #endif

--- a/src/debug/daccess/enummem.cpp
+++ b/src/debug/daccess/enummem.cpp
@@ -316,7 +316,7 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
 #ifdef FEATURE_SVR_GC
     CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED
     (
-        GCHeap::gcHeapType.EnumMem();
+        IGCHeap::gcHeapType.EnumMem();
     );
 #endif // FEATURE_SVR_GC
 

--- a/src/debug/daccess/request.cpp
+++ b/src/debug/daccess/request.cpp
@@ -2982,10 +2982,10 @@ ClrDataAccess::GetGCHeapData(struct DacpGcHeapData *gcheapData)
     if (SUCCEEDED(hr))
     {
         // Now we can get other important information about the heap
-        gcheapData->g_max_generation = GCHeap::GetMaxGeneration();
-        gcheapData->bServerMode = GCHeap::IsServerHeap();
+        gcheapData->g_max_generation = IGCHeap::GetGCHeap()->GetMaxGeneration();
+        gcheapData->bServerMode = IGCHeap::IsServerHeap();
         gcheapData->bGcStructuresValid = GCScan::GetGcRuntimeStructuresValid();
-        if (GCHeap::IsServerHeap())
+        if (IGCHeap::IsServerHeap())
         {
 #if !defined (FEATURE_SVR_GC)
             _ASSERTE(0);
@@ -3856,7 +3856,7 @@ ClrDataAccess::EnumWksGlobalMemoryRegions(CLRDataEnumMemoryFlags flags)
             // enumerating the generations from max (which is normally gen2) to max+1 gives you
             // the segment list for all the normal segements plus the large heap segment (max+1)
             // this is the convention in the GC so it is repeated here
-            for (ULONG i = GCHeap::GetMaxGeneration(); i <= GCHeap::GetMaxGeneration()+1; i++)
+            for (ULONG i = IGCHeap::GetGCHeap()->GetMaxGeneration(); i <= IGCHeap::GetGCHeap()->GetMaxGeneration()+1; i++)
             {
                 __DPtr<WKS::heap_segment> seg = dac_cast<TADDR>(WKS::generation_table[i].start_segment);
                 while (seg)

--- a/src/debug/daccess/request_svr.cpp
+++ b/src/debug/daccess/request_svr.cpp
@@ -256,7 +256,7 @@ ClrDataAccess::EnumSvrGlobalMemoryRegions(CLRDataEnumMemoryFlags flags)
         // enumerating the generations from max (which is normally gen2) to max+1 gives you
         // the segment list for all the normal segements plus the large heap segment (max+1)
         // this is the convention in the GC so it is repeated here
-        for (ULONG i = GCHeap::GetMaxGeneration(); i <= GCHeap::GetMaxGeneration()+1; i++)
+        for (ULONG i = IGCHeap::GetGCHeap()->GetMaxGeneration(); i <= IGCHeap::GetGCHeap()->GetMaxGeneration()+1; i++)
         {
             __DPtr<SVR::heap_segment> seg = dac_cast<TADDR>(pHeap->generation_table[i].start_segment);
             while (seg)

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -9,10 +9,11 @@
 
 struct ScanContext;
 class CrawlFrame;
+struct gc_alloc_context;
 
 typedef void promote_func(PTR_PTR_Object, ScanContext*, uint32_t);
 
-typedef void enum_alloc_context_func(alloc_context*, void*);
+typedef void enum_alloc_context_func(gc_alloc_context*, void*);
 
 typedef struct
 {
@@ -74,7 +75,7 @@ public:
     static void EnablePreemptiveGC(Thread * pThread);
     static void DisablePreemptiveGC(Thread * pThread);
 
-    static alloc_context * GetAllocContext(Thread * pThread);
+    static gc_alloc_context * GetAllocContext(Thread * pThread);
     static bool CatchAtSafePoint(Thread * pThread);
 
     static void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -444,8 +444,6 @@ public:
 #endif //VERIFY_HEAP    
 };
 
-extern VOLATILE(int32_t) m_GCLock;
-
 // Go through and touch (read) each page straddled by a memory block.
 void TouchPages(void * pStart, size_t cb);
 

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -15,10 +15,11 @@
 #include "gc.h"
 
 #ifdef FEATURE_SVR_GC
-SVAL_IMPL_INIT(uint32_t,GCHeap,gcHeapType,GCHeap::GC_HEAP_INVALID);
+SVAL_IMPL_INIT(uint32_t, IGCHeap, gcHeapType, IGCHeap::GC_HEAP_INVALID);
 #endif // FEATURE_SVR_GC
 
-GPTR_IMPL(GCHeap,g_pGCHeap);
+
+GPTR_IMPL(IGCHeap, g_pGCHeap);
 
 /* global versions of the card table and brick table */ 
 GPTR_IMPL(uint32_t,g_card_table);
@@ -110,6 +111,24 @@ void record_changed_seg (uint8_t* start, uint8_t* end,
     {
         saved_changed_segs_count = 0;
     }
+}
+
+// Initializes the garbage collector by invoking the appropriate
+// CreateGCHeap function, depending on whether or not Server GC
+// is enabled.
+IGCHeap* InitializeGarbageCollector(ICLRToGC* clrToGC)
+{
+    WRAPPER_NO_CONTRACT;
+    UNREFERENCED_PARAMETER(clrToGC);
+
+    GCHeap* pGCHeap;
+#if defined(FEATURE_SVR_GC)
+    pGCHeap = (IGCHeap::IsServerHeap() ? SVR::CreateGCHeap() : WKS::CreateGCHeap());
+#else
+    pGCHeap = WKS::CreateGCHeap();
+#endif // defined(FEATURE_SVR_GC)
+
+    return pGCHeap;
 }
 
 #endif // !DACCESS_COMPILE

--- a/src/gc/gcimpl.h
+++ b/src/gc/gcimpl.h
@@ -119,9 +119,9 @@ private:
 public:
 #endif // FEATURE_64BIT_ALIGNMENT
     Object*  AllocLHeap (size_t size, uint32_t flags);
-    Object* Alloc (alloc_context* acontext, size_t size, uint32_t flags);
+    Object* Alloc (gc_alloc_context* acontext, size_t size, uint32_t flags);
 
-    void FixAllocContext (alloc_context* acontext,
+    void FixAllocContext (gc_alloc_context* acontext,
                                             BOOL lockp, void* arg, void *heap);
 
     Object* GetContainingObject(void *pInteriorPtr);
@@ -132,7 +132,7 @@ public:
 #endif //MULTIPLE_HEAPS
 
     int GetHomeHeapNumber ();
-    bool IsThreadUsingAllocationContextHeap(alloc_context* acontext, int thread_number);
+    bool IsThreadUsingAllocationContextHeap(gc_alloc_context* acontext, int thread_number);
     int GetNumberOfHeaps ();
     void HideAllocContext(alloc_context*);
     void RevealAllocContext(alloc_context*);
@@ -200,7 +200,11 @@ public:
     int StartNoGCRegion(uint64_t totalSize, BOOL lohSizeKnown, uint64_t lohSize, BOOL disallowFullBlockingGC);
     int EndNoGCRegion();
 
-    PER_HEAP_ISOLATED     unsigned GetMaxGeneration();
+    unsigned GetMaxGeneration() 
+    {
+        LIMITED_METHOD_DAC_CONTRACT;  
+        return max_generation;
+    }
  
     unsigned GetGcCount();
 
@@ -285,7 +289,7 @@ private:
 #ifdef STRESS_HEAP 
 public:
     //return TRUE if GC actually happens, otherwise FALSE
-    BOOL    StressHeap(alloc_context * acontext = 0);
+    BOOL    StressHeap(gc_alloc_context * acontext = 0);
 protected:
 
     // only used in BACKGROUND_GC, but the symbol is not defined yet...

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -1,0 +1,394 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef _GC_INTERFACE_H_
+#define _GC_INTERFACE_H_
+
+// The allocation context must be known to the VM for use in the allocation
+// fast path and known to the GC for performing the allocation. Every Thread
+// has its own allocation context that it hands to the GC when allocating.
+struct gc_alloc_context
+{
+    uint8_t*       alloc_ptr;
+    uint8_t*       alloc_limit;
+    int64_t        alloc_bytes; //Number of bytes allocated on SOH by this context
+    int64_t        alloc_bytes_loh; //Number of bytes allocated on LOH by this context
+    // These two fields are deliberately not exposed past the EE-GC interface.
+    void*          gc_reserved_1;
+    void*          gc_reserved_2;
+    int            alloc_count;
+public:
+
+    void init()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        alloc_ptr = 0;
+        alloc_limit = 0;
+        alloc_bytes = 0;
+        alloc_bytes_loh = 0;
+        gc_reserved_1 = 0;
+        gc_reserved_1 = 0;
+        alloc_count = 0;
+    }
+};
+
+#ifdef PROFILING_SUPPORTED
+#define GC_PROFILING       //Turn on profiling
+#endif // PROFILING_SUPPORTED
+
+#define LARGE_OBJECT_SIZE ((size_t)(85000))
+
+class Object;
+class IGCHeap;
+class ICLRToGC;
+
+GPTR_DECL(IGCHeap, g_pGCHeap);
+
+// Initializes the garbage collector. Should only be called
+// once, during EE startup.
+IGCHeap* InitializeGarbageCollector(ICLRToGC* clrToGC);
+
+#ifndef DACCESS_COMPILE
+extern "C" {
+#endif // !DACCESS_COMPILE
+GPTR_DECL(uint8_t,g_lowest_address);
+GPTR_DECL(uint8_t,g_highest_address);
+GPTR_DECL(uint32_t,g_card_table);
+#ifndef DACCESS_COMPILE
+} 
+#endif // !DACCESS_COMPILE
+
+extern "C" uint8_t* g_ephemeral_low;
+extern "C" uint8_t* g_ephemeral_high;
+
+#ifdef WRITE_BARRIER_CHECK
+//always defined, but should be 0 in Server GC
+extern uint8_t* g_GCShadow;
+extern uint8_t* g_GCShadowEnd;
+// saves the g_lowest_address in between GCs to verify the consistency of the shadow segment
+extern uint8_t* g_shadow_lowest_address;
+#endif
+
+// For low memory notification from host
+extern int32_t g_bLowMemoryFromHost;
+
+// !!!!!!!!!!!!!!!!!!!!!!!
+// make sure you change the def in bcl\system\gc.cs 
+// if you change this!
+enum collection_mode
+{
+    collection_non_blocking = 0x00000001,
+    collection_blocking = 0x00000002,
+    collection_optimized = 0x00000004,
+    collection_compacting = 0x00000008
+#ifdef STRESS_HEAP
+    , collection_gcstress = 0x80000000
+#endif // STRESS_HEAP
+};
+
+// !!!!!!!!!!!!!!!!!!!!!!!
+// make sure you change the def in bcl\system\gc.cs 
+// if you change this!
+enum wait_full_gc_status
+{
+    wait_full_gc_success = 0,
+    wait_full_gc_failed = 1,
+    wait_full_gc_cancelled = 2,
+    wait_full_gc_timeout = 3,
+    wait_full_gc_na = 4
+};
+
+// !!!!!!!!!!!!!!!!!!!!!!!
+// make sure you change the def in bcl\system\gc.cs 
+// if you change this!
+enum start_no_gc_region_status
+{
+    start_no_gc_success = 0,
+    start_no_gc_no_memory = 1,
+    start_no_gc_too_large = 2,
+    start_no_gc_in_progress = 3
+};
+
+enum end_no_gc_region_status
+{
+    end_no_gc_success = 0,
+    end_no_gc_not_in_progress = 1,
+    end_no_gc_induced = 2,
+    end_no_gc_alloc_exceeded = 3
+};
+
+typedef BOOL (* walk_fn)(Object*, void*);
+typedef void (* gen_walk_fn)(void *context, int generation, uint8_t *range_start, uint8_t * range_end, uint8_t *range_reserved);
+
+// IGCHeap is the interface that the VM will use when interacting with the GC.
+class IGCHeap {
+public:
+    virtual HRESULT Initialize() = 0;
+    virtual BOOL IsPromoted(Object *object) = 0;
+    virtual BOOL IsHeapPointer(void* object, BOOL small_heap_only = FALSE) = 0;
+    virtual Object* GetNextFinalizable() = 0;
+    virtual unsigned WhichGeneration(Object* obj) = 0;
+    virtual size_t GetTotalBytesInUse() = 0;
+    virtual unsigned GetCondemnedGeneration() = 0;
+    virtual int GetGcLatencyMode() = 0;
+    virtual int SetGcLatencyMode(int newLatencyMode) = 0;
+    virtual int GetLOHCompactionMode() = 0;
+    virtual void SetLOHCompactionMode(int newLOHCompactionMode) = 0;
+    virtual BOOL RegisterForFullGCNotification(uint32_t gen2Percentage, uint32_t lohPercentage) = 0;
+    virtual BOOL CancelFullGCNotification() = 0;
+    virtual int WaitForFullGCApproach(int millisecondsTimeout) = 0;
+    virtual int WaitForFullGCComplete(int millisecondsTimeout) = 0;
+    virtual int CollectionCount(int generation, int get_bgc_fgc_coutn = 0) = 0;
+    virtual size_t GetLastGCStartTime(int generation) = 0;
+    virtual size_t GetLastGCDuration(int generation) = 0;
+    virtual size_t GetNow() = 0;
+
+    // TODO(segilles) these are all referenced by the VM. Are all of them
+    // essential?
+    virtual BOOL    IsGCInProgressHelper (BOOL bConsiderGCStart = FALSE) = 0;
+    virtual unsigned GetMaxGeneration() = 0;
+    virtual void SetCardsAfterBulkCopy(Object** obj, size_t length) = 0;
+    virtual BOOL IsValidSegmentSize(size_t size) = 0;
+    virtual BOOL IsValidGen0MaxSize(size_t size) = 0;
+    virtual HRESULT GarbageCollect(int generation = -1, BOOL low_memory_p = FALSE, int mode = collection_blocking) = 0;
+    virtual void WaitUntilConcurrentGCComplete() = 0;
+    virtual BOOL IsConcurrentGCInProgress() = 0;
+    virtual size_t GetValidSegmentSize(BOOL large_seg = FALSE) = 0;
+    virtual BOOL FinalizeAppDomain(AppDomain *pDomain, BOOL fRunFinalizers) = 0;
+    virtual void SetFinalizeQueueForShutdown(BOOL fHasLock) = 0;
+    virtual size_t GetNumberOfFinalizable() = 0;
+    virtual BOOL ShouldRestartFinalizerWatchDog() = 0;
+    virtual unsigned GetGcCount() = 0;
+    virtual bool IsThreadUsingAllocationContextHeap(gc_alloc_context* acontext, int thread_number) = 0;
+    virtual BOOL IsObjectInFixedHeap(Object *pObj) = 0;
+    virtual BOOL IsEphemeral (Object* object) = 0;
+    virtual uint32_t WaitUntilGCComplete (BOOL bConsiderGCStart = FALSE) = 0;
+    virtual void FixAllocContext (gc_alloc_context* acontext, BOOL lockp, void* arg, void *heap) = 0;
+    virtual int StartNoGCRegion(uint64_t totalSize, BOOL lohSizeKnown, uint64_t lohSize, BOOL disallowFullBlockingGC) = 0;
+    virtual int EndNoGCRegion() = 0;
+    virtual void SetFinalizationRun (Object* obj) = 0;
+    virtual bool RegisterForFinalization (int gen, Object* obj) = 0;
+    virtual size_t GetCurrentObjSize() = 0;
+    virtual void TemporaryEnableConcurrentGC() = 0;
+    virtual void TemporaryDisableConcurrentGC() = 0;
+    virtual BOOL IsConcurrentGCEnabled() = 0;
+    virtual Object* Alloc (gc_alloc_context* acontext, size_t size, uint32_t flags) = 0;
+    virtual Object* Alloc (size_t size, uint32_t flags) = 0;
+    virtual Object* AllocLHeap (size_t size, uint32_t flags) = 0;
+    virtual void PublishObject(uint8_t* obj) = 0;
+    virtual Object* GetContainingObject(void *pInteriorPtr) = 0;
+    virtual void SetGCInProgress(BOOL fInProgress) = 0;
+    virtual CLREventStatic * GetWaitForGCEvent() = 0;
+    virtual void TraceGCSegments() = 0;
+
+#ifdef VERIFY_HEAP
+    virtual void    ValidateObjectMember (Object *obj) = 0;
+    virtual Object * NextObj (Object * object) = 0;
+#endif // VERIFY_HEAP
+
+#ifndef DACCESS_COMPILE    
+    virtual HRESULT WaitUntilConcurrentGCCompleteAsync(int millisecondsTimeout) = 0;    // Use in native threads. TRUE if succeed. FALSE if failed or timeout
+#endif
+
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+    virtual void WalkObject (Object* obj, walk_fn fn, void* context) = 0;
+    virtual void DescrGenerationsToProfiler (gen_walk_fn fn, void *context) = 0;
+#endif //defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)    
+
+    IGCHeap() {}
+    virtual ~IGCHeap() {}
+
+#ifdef STRESS_HEAP
+    //return TRUE if GC actually happens, otherwise FALSE
+    virtual BOOL    StressHeap(gc_alloc_context * acontext = 0) = 0;
+#endif // STRESS_HEAP
+
+    inline static IGCHeap* GetGCHeap()
+    {
+        assert(g_pGCHeap != nullptr);
+        return g_pGCHeap;
+    }
+
+#ifndef DACCESS_COMPILE
+    inline static IGCHeap* CreateGCHeap(ICLRToGC* clrToGC)
+    {
+        IGCHeap* heap = InitializeGarbageCollector(clrToGC);
+        assert(heap != nullptr);
+        g_pGCHeap = heap;
+        return g_pGCHeap;
+    }
+#endif
+
+    inline static bool IsGCHeapInitialized()
+    {
+        return g_pGCHeap != nullptr;
+    }
+
+    inline static BOOL IsGCInProgress(BOOL bConsiderGCStart = FALSE) 
+    {
+        WRAPPER_NO_CONTRACT;
+
+        return (IsGCHeapInitialized() ? GetGCHeap()->IsGCInProgressHelper(bConsiderGCStart) : false);
+    }
+
+    inline static BOOL MarkShouldCompeteForStatics()
+    {
+        WRAPPER_NO_CONTRACT;
+
+        return IsServerHeap() && g_SystemInfo.dwNumberOfProcessors >= 2;
+    }
+
+    inline static void WaitForGCCompletion(BOOL bConsiderGCStart = FALSE)
+    {
+        WRAPPER_NO_CONTRACT;
+
+        if (IsGCHeapInitialized())
+            GetGCHeap()->WaitUntilGCComplete(bConsiderGCStart);
+    }
+
+    // The runtime needs to know whether we're using workstation or server GC 
+    // long before the GCHeap is created.  So IsServerHeap cannot be a virtual 
+    // method on GCHeap.  Instead we make it a static method and initialize 
+    // gcHeapType before any of the calls to IsServerHeap.  Note that this also 
+    // has the advantage of getting the answer without an indirection
+    // (virtual call), which is important for perf critical codepaths.
+#ifndef DACCESS_COMPILE
+    inline static void InitializeHeapType(bool bServerHeap)
+    {
+        LIMITED_METHOD_CONTRACT;
+#ifdef FEATURE_SVR_GC
+        gcHeapType = bServerHeap ? GC_HEAP_SVR : GC_HEAP_WKS;
+#ifdef WRITE_BARRIER_CHECK
+        if (gcHeapType == GC_HEAP_SVR)
+        {
+            g_GCShadow = 0;
+            g_GCShadowEnd = 0;
+        }
+#endif // WRITE_BARRIER_CHECK
+#else // FEATURE_SVR_GC
+        UNREFERENCED_PARAMETER(bServerHeap);
+        CONSISTENCY_CHECK(bServerHeap == false);
+#endif // FEATURE_SVR_GC
+    }
+#endif // DACCESS_COMPILE
+
+    inline static bool IsServerHeap() 
+    {
+        LIMITED_METHOD_CONTRACT;
+#ifdef FEATURE_SVR_GC
+        _ASSERTE(gcHeapType != GC_HEAP_INVALID);
+        return (gcHeapType == GC_HEAP_SVR);
+#else // FEATURE_SVR_GC
+        return false;
+#endif // FEATURE_SVR_GC
+    }
+   
+
+    inline static bool UseAllocationContexts()
+    {
+        WRAPPER_NO_CONTRACT;
+#ifdef FEATURE_REDHAWK
+        // SIMPLIFY:  only use allocation contexts
+        return true;
+#else
+#if defined(_TARGET_ARM_) || defined(FEATURE_PAL)
+        return true;
+#else
+        return ((IsServerHeap() ? true : (g_SystemInfo.dwNumberOfProcessors >= 2)));
+#endif 
+#endif 
+    }
+
+    typedef enum
+    {
+        GC_HEAP_INVALID = 0,
+        GC_HEAP_WKS     = 1,
+        GC_HEAP_SVR     = 2
+    } GC_HEAP_TYPE;
+
+#ifdef FEATURE_SVR_GC
+    SVAL_DECL(uint32_t, gcHeapType); 
+#endif
+};
+
+#ifdef WRITE_BARRIER_CHECK
+void updateGCShadow(Object** ptr, Object* val);
+#endif
+
+//constants for the flags parameter to the gc call back
+
+#define GC_CALL_INTERIOR            0x1
+#define GC_CALL_PINNED              0x2
+#define GC_CALL_CHECK_APP_DOMAIN    0x4
+
+//flags for IGCHeapAlloc(...)
+#define GC_ALLOC_FINALIZE 0x1
+#define GC_ALLOC_CONTAINS_REF 0x2
+#define GC_ALLOC_ALIGN8_BIAS 0x4
+#define GC_ALLOC_ALIGN8 0x8
+
+// TODO(segilles) Does this belong here?
+struct ScanContext
+{
+    Thread* thread_under_crawl;
+    int thread_number;
+    uintptr_t stack_limit; // Lowest point on the thread stack that the scanning logic is permitted to read
+    BOOL promotion; //TRUE: Promotion, FALSE: Relocation.
+    BOOL concurrent; //TRUE: concurrent scanning 
+#if CHECK_APP_DOMAIN_LEAKS || defined (FEATURE_APPDOMAIN_RESOURCE_MONITORING) || defined (DACCESS_COMPILE)
+    AppDomain *pCurrentDomain;
+#endif //CHECK_APP_DOMAIN_LEAKS || FEATURE_APPDOMAIN_RESOURCE_MONITORING || DACCESS_COMPILE
+
+#ifndef FEATURE_REDHAWK
+#if defined(GC_PROFILING) || defined (DACCESS_COMPILE)
+    MethodDesc *pMD;
+#endif //GC_PROFILING || DACCESS_COMPILE
+#endif // FEATURE_REDHAWK
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+    EtwGCRootKind dwEtwRootKind;
+#endif // GC_PROFILING || FEATURE_EVENT_TRACE
+    
+    ScanContext()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        thread_under_crawl = 0;
+        thread_number = -1;
+        stack_limit = 0;
+        promotion = FALSE;
+        concurrent = FALSE;
+#ifdef GC_PROFILING
+        pMD = NULL;
+#endif //GC_PROFILING
+#ifdef FEATURE_EVENT_TRACE
+        dwEtwRootKind = kEtwGCRootKindOther;
+#endif // FEATURE_EVENT_TRACE
+    }
+};
+
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+struct ProfilingScanContext : ScanContext
+{
+    BOOL fProfilerPinned;
+    void * pvEtwContext;
+    void *pHeapId;
+    
+    ProfilingScanContext(BOOL fProfilerPinnedParam) : ScanContext()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        pHeapId = NULL;
+        fProfilerPinned = fProfilerPinnedParam;
+        pvEtwContext = NULL;
+#ifdef FEATURE_CONSERVATIVE_GC
+        // To not confuse GCScan::GcScanRoots
+        promotion = g_pConfig->GetGCConservative();
+#endif
+    }
+};
+#endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+
+#endif // _GC_INTERFACE_H_

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -75,6 +75,8 @@ extern uint8_t* g_shadow_lowest_address;
 // For low memory notification from host
 extern int32_t g_bLowMemoryFromHost;
 
+extern VOLATILE(int32_t) m_GCLock;
+
 // !!!!!!!!!!!!!!!!!!!!!!!
 // make sure you change the def in bcl\system\gc.cs 
 // if you change this!

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -1111,13 +1111,13 @@ SLOW_PATH:
         // we have the lock held but the part we care about (the async table scan) takes the table lock during
         // a preparation step so we'll be able to complete our segment moves before the async scan has a
         // chance to interfere with us (or vice versa).
-        if (GCHeap::GetGCHeap()->IsConcurrentGCInProgress())
+        if (IGCHeap::GetGCHeap()->IsConcurrentGCInProgress())
         {
             // A concurrent GC is in progress so someone might be scanning our segments asynchronously.
             // Release the lock, wait for the GC to complete and try again. The order is important; if we wait
             // before releasing the table lock we can deadlock with an async table scan.
             ch.Release();
-            GCHeap::GetGCHeap()->WaitUntilConcurrentGCComplete();
+            IGCHeap::GetGCHeap()->WaitUntilConcurrentGCComplete();
             continue;
         }
 

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -184,7 +184,7 @@ void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
     pThread->DisablePreemptiveGC();
 }
 
-alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
+gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
 {
     return pThread->GetAllocContext();
 }

--- a/src/inc/dacvars.h
+++ b/src/inc/dacvars.h
@@ -125,7 +125,7 @@ DEFINE_DACVAR(ULONG, PTR_Thread, dac__g_pFinalizerThread, ::g_pFinalizerThread)
 DEFINE_DACVAR(ULONG, PTR_Thread, dac__g_pSuspensionThread, ::g_pSuspensionThread)
 
 #ifdef FEATURE_SVR_GC
-DEFINE_DACVAR(ULONG, DWORD, GCHeap__gcHeapType, GCHeap::gcHeapType)
+DEFINE_DACVAR(ULONG, DWORD, IGCHeap__gcHeapType, IGCHeap::gcHeapType)
 #endif // FEATURE_SVR_GC
 
 DEFINE_DACVAR(ULONG, PTR_BYTE, WKS__gc_heap__alloc_allocated, WKS::gc_heap::alloc_allocated)
@@ -198,7 +198,7 @@ DEFINE_DACVAR(ULONG, PTR_DWORD, dac__g_card_table, ::g_card_table)
 DEFINE_DACVAR(ULONG, PTR_BYTE, dac__g_lowest_address, ::g_lowest_address)
 DEFINE_DACVAR(ULONG, PTR_BYTE, dac__g_highest_address, ::g_highest_address)
 
-DEFINE_DACVAR(ULONG, GCHeap, dac__g_pGCHeap, ::g_pGCHeap)
+DEFINE_DACVAR(ULONG, IGCHeap, dac__g_pGCHeap, ::g_pGCHeap)
 
 #ifdef GC_CONFIG_DRIVEN
 DEFINE_DACVAR_NO_DUMP(ULONG, SIZE_T, dac__interesting_data_per_heap, WKS::interesting_data_per_heap)

--- a/src/strongname/api/common.h
+++ b/src/strongname/api/common.h
@@ -156,7 +156,7 @@ typedef DPTR(class TypeHandle)          PTR_TypeHandle;
 typedef VPTR(class VirtualCallStubManager) PTR_VirtualCallStubManager;
 typedef VPTR(class VirtualCallStubManagerManager) PTR_VirtualCallStubManagerManager;
 #endif
-typedef VPTR(class GCHeap)              PTR_GCHeap;
+typedef VPTR(class IGCHeap)              PTR_IGCHeap;
 
 //
 // _UNCHECKED_OBJECTREF is for code that can't deal with DEBUG OBJECTREFs

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -3,8 +3,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Needed due to the cmunged files being in the binary folders, the set(CMAKE_INCLUDE_CURRENT_DIR ON) is not enough
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}) 
 
-include_directories(${CLR_DIR}/src/gc)
-
 include_directories(${ARCH_SOURCES_DIR})
 
 add_definitions(-DFEATURE_LEAVE_RUNTIME_HOLDER=1)

--- a/src/vm/amd64/asmconstants.h
+++ b/src/vm/amd64/asmconstants.h
@@ -164,10 +164,10 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__Thread__m_ThreadId
                     == offsetof(Thread, m_ThreadId));
 
 #define               OFFSET__Thread__m_alloc_context__alloc_ptr 0x60
-ASMCONSTANTS_C_ASSERT(OFFSET__Thread__m_alloc_context__alloc_ptr == offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_ptr));
+ASMCONSTANTS_C_ASSERT(OFFSET__Thread__m_alloc_context__alloc_ptr == offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_ptr));
 
 #define               OFFSET__Thread__m_alloc_context__alloc_limit 0x68
-ASMCONSTANTS_C_ASSERT(OFFSET__Thread__m_alloc_context__alloc_limit == offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_limit));
+ASMCONSTANTS_C_ASSERT(OFFSET__Thread__m_alloc_context__alloc_limit == offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_limit));
 
 #define               OFFSETOF__ThreadExceptionState__m_pCurrentTracker 0x000
 ASMCONSTANTS_C_ASSERT(OFFSETOF__ThreadExceptionState__m_pCurrentTracker

--- a/src/vm/amd64/excepamd64.cpp
+++ b/src/vm/amd64/excepamd64.cpp
@@ -21,7 +21,7 @@
 #include "comutilnative.h"
 #include "sigformat.h"
 #include "siginfo.hpp"
-#include "gc.h"
+#include "gcinterface.h"
 #include "eedbginterfaceimpl.h" //so we can clearexception in COMPlusThrow
 #include "perfcounters.h"
 #include "asmconstants.h"

--- a/src/vm/amd64/jitinterfaceamd64.cpp
+++ b/src/vm/amd64/jitinterfaceamd64.cpp
@@ -390,7 +390,7 @@ bool WriteBarrierManager::NeedDifferentWriteBarrier(bool bReqUpperBoundsCheck, W
             }
 #endif
 
-            writeBarrierType = GCHeap::IsServerHeap() ? WRITE_BARRIER_SVR64 : WRITE_BARRIER_PREGROW64;
+            writeBarrierType = IGCHeap::IsServerHeap() ? WRITE_BARRIER_SVR64 : WRITE_BARRIER_PREGROW64;
             continue;
 
         case WRITE_BARRIER_PREGROW64:

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1295,7 +1295,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
         OBJECTHANDLE h = ::CreateSizedRefHandle(
-            m_hHandleTableBucket->pTable[GCHeap::IsServerHeap() ? (m_dwSizedRefHandles % m_iNumberOfProcessors) : GetCurrentThreadHomeHeapNumber()], 
+            m_hHandleTableBucket->pTable[IGCHeap::GetGCHeap()->IsServerHeap() ? (m_dwSizedRefHandles % m_iNumberOfProcessors) : GetCurrentThreadHomeHeapNumber()], 
             object);
         InterlockedIncrement((LONG*)&m_dwSizedRefHandles);
         return h;
@@ -4533,8 +4533,8 @@ public:
         if (m_UnloadIsAsync)
         {
             pDomain->AddRef();
-            int iGCRefPoint=GCHeap::GetGCHeap()->CollectionCount(GCHeap::GetGCHeap()->GetMaxGeneration());
-            if (GCHeap::GetGCHeap()->IsGCInProgress())
+            int iGCRefPoint=IGCHeap::GetGCHeap()->CollectionCount(IGCHeap::GetGCHeap()->GetMaxGeneration());
+            if (IGCHeap::GetGCHeap()->IsGCInProgress())
                 iGCRefPoint++;
             pDomain->SetGCRefPoint(iGCRefPoint);
         }
@@ -4554,8 +4554,8 @@ public:
         pAllocator->m_pLoaderAllocatorDestroyNext=m_pDelayedUnloadListOfLoaderAllocators;
         m_pDelayedUnloadListOfLoaderAllocators=pAllocator;
 
-        int iGCRefPoint=GCHeap::GetGCHeap()->CollectionCount(GCHeap::GetGCHeap()->GetMaxGeneration());
-        if (GCHeap::GetGCHeap()->IsGCInProgress())
+        int iGCRefPoint=IGCHeap::GetGCHeap()->CollectionCount(IGCHeap::GetGCHeap()->GetMaxGeneration());
+        if (IGCHeap::GetGCHeap()->IsGCInProgress())
             iGCRefPoint++;
         pAllocator->SetGCRefPoint(iGCRefPoint);
     }

--- a/src/vm/arm/asmconstants.h
+++ b/src/vm/arm/asmconstants.h
@@ -225,10 +225,10 @@ ASMCONSTANTS_C_ASSERT(UnmanagedToManagedFrame__m_pvDatum == offsetof(UnmanagedTo
 
 #ifndef CROSSGEN_COMPILE
 #define               Thread__m_alloc_context__alloc_limit   0x44
-ASMCONSTANTS_C_ASSERT(Thread__m_alloc_context__alloc_limit == offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_limit));
+ASMCONSTANTS_C_ASSERT(Thread__m_alloc_context__alloc_limit == offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_limit));
 
 #define               Thread__m_alloc_context__alloc_ptr   0x40
-ASMCONSTANTS_C_ASSERT(Thread__m_alloc_context__alloc_ptr == offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_ptr));
+ASMCONSTANTS_C_ASSERT(Thread__m_alloc_context__alloc_ptr == offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_ptr));
 #endif // CROSSGEN_COMPILE
 
 #define               Thread__m_fPreemptiveGCDisabled   0x08

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -2650,7 +2650,7 @@ void InitJITHelpers1()
         ))
     {
 
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(IGCHeap::UseAllocationContexts());
         // If the TLS for Thread is low enough use the super-fast helpers
         if (gThreadTLSIndex < TLS_MINIMUM_AVAILABLE)
         {

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -3427,8 +3427,8 @@ void Module::EnumRegularStaticGCRefs(AppDomain* pAppDomain, promote_func* fn, Sc
     }
     CONTRACT_END;
 
-    _ASSERTE(GCHeap::IsGCInProgress() && 
-         GCHeap::IsServerHeap() && 
+    _ASSERTE(IGCHeap::IsGCInProgress() && 
+         IGCHeap::IsServerHeap() && 
          IsGCSpecialThread());
 
 
@@ -6264,7 +6264,7 @@ Module *Module::GetModuleIfLoaded(mdFile kFile, BOOL onlyLoadedInAppDomain, BOOL
 #ifndef DACCESS_COMPILE
 #if defined(FEATURE_MULTIMODULE_ASSEMBLIES)
     // check if actually loaded, unless happens during GC (GC works only with loaded assemblies)
-    if (!GCHeap::IsGCInProgress() && onlyLoadedInAppDomain && pModule && !pModule->IsManifest())
+    if (!IGCHeap::IsGCInProgress() && onlyLoadedInAppDomain && pModule && !pModule->IsManifest())
     {
         DomainModule *pDomainModule = pModule->FindDomainModule(GetAppDomain());
         if (pDomainModule == NULL || !pDomainModule->IsLoaded())

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -150,7 +150,7 @@
 #include "frames.h"
 #include "threads.h"
 #include "stackwalk.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "interoputil.h"
 #include "security.h"
 #include "fieldmarshaler.h"
@@ -640,7 +640,7 @@ void InitializeStartupFlags()
         g_fEnableARM = TRUE;
 #endif // !FEATURE_CORECLR
 
-    GCHeap::InitializeHeapType((flags & STARTUP_SERVER_GC) != 0);
+    IGCHeap::InitializeHeapType((flags & STARTUP_SERVER_GC) != 0);
 
 #ifdef FEATURE_LOADER_OPTIMIZATION            
     g_dwGlobalSharePolicy = (flags&STARTUP_LOADER_OPTIMIZATION_MASK)>>1;
@@ -3719,7 +3719,8 @@ void InitializeGarbageCollector()
     g_pFreeObjectMethodTable->SetBaseSize(ObjSizeOf (ArrayBase));
     g_pFreeObjectMethodTable->SetComponentSize(1);
 
-    GCHeap *pGCHeap = GCHeap::CreateGCHeap();
+    // TODO(segilles) - ICLRToGC isn't used yet.
+    IGCHeap *pGCHeap = IGCHeap::CreateGCHeap(nullptr);
     if (!pGCHeap)
         ThrowOutOfMemory();
 
@@ -3833,7 +3834,7 @@ BOOL STDMETHODCALLTYPE EEDllMain( // TRUE on success, FALSE on error.
                 {
                     // GetThread() may be set to NULL for Win9x during shutdown.
                     Thread *pThread = GetThread();
-                    if (GCHeap::IsGCInProgress() &&
+                    if (IGCHeap::IsGCInProgress() &&
                         ( (pThread && (pThread != ThreadSuspend::GetSuspensionThread() ))
                             || !g_fSuspendOnShutdown))
                     {

--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -31,7 +31,7 @@
 #include "log.h"
 #include "fieldmarshaler.h"
 #include "cgensys.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "security.h"
 #include "dbginterface.h"
 #include "comdelegate.h"

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -3397,7 +3397,7 @@ void ExecutionManager::CleanupCodeHeaps()
     }
     CONTRACTL_END;
 
-    _ASSERTE (g_fProcessDetach || (GCHeap::IsGCInProgress()  && ::IsGCThread()));
+    _ASSERTE (g_fProcessDetach || (IGCHeap::IsGCInProgress()  && ::IsGCThread()));
 
     GetEEJitManager()->CleanupCodeHeaps();
 }
@@ -3411,7 +3411,7 @@ void EEJitManager::CleanupCodeHeaps()
     }
     CONTRACTL_END;
 
-    _ASSERTE (g_fProcessDetach || (GCHeap::IsGCInProgress() && ::IsGCThread()));
+    _ASSERTE (g_fProcessDetach || (IGCHeap::IsGCInProgress() && ::IsGCThread()));
 
     CrstHolder ch(&m_CodeHeapCritSec);
 
@@ -4451,7 +4451,7 @@ RangeSection* ExecutionManager::GetRangeSection(TADDR addr)
     // Unless we are on an MP system with many cpus
     // where this sort of caching actually diminishes scaling during server GC
     // due to many processors writing to a common location
-    if (g_SystemInfo.dwNumberOfProcessors < 4 || !GCHeap::IsServerHeap() || !GCHeap::IsGCInProgress())
+    if (g_SystemInfo.dwNumberOfProcessors < 4 || !IGCHeap::IsServerHeap() || !IGCHeap::IsGCInProgress())
         pHead->pLastUsed = pLast;
 #endif
 

--- a/src/vm/commemoryfailpoint.cpp
+++ b/src/vm/commemoryfailpoint.cpp
@@ -26,7 +26,7 @@ FCIMPL2(void, COMMemoryFailPoint::GetMemorySettings, UINT64* pMaxGCSegmentSize, 
 {
     FCALL_CONTRACT;
 
-    GCHeap * pGC = GCHeap::GetGCHeap();
+    IGCHeap * pGC = IGCHeap::GetGCHeap();
     size_t segment_size = pGC->GetValidSegmentSize(FALSE);
     size_t large_segment_size = pGC->GetValidSegmentSize(TRUE);
     _ASSERTE(segment_size < SIZE_T_MAX && large_segment_size < SIZE_T_MAX);

--- a/src/vm/common.h
+++ b/src/vm/common.h
@@ -177,7 +177,7 @@ typedef DPTR(class StringBufferObject)  PTR_StringBufferObject;
 typedef DPTR(class TypeHandle)          PTR_TypeHandle;
 typedef VPTR(class VirtualCallStubManager) PTR_VirtualCallStubManager;
 typedef VPTR(class VirtualCallStubManagerManager) PTR_VirtualCallStubManagerManager;
-typedef VPTR(class GCHeap)              PTR_GCHeap;
+typedef VPTR(class IGCHeap)              PTR_IGCHeap;
 
 //
 // _UNCHECKED_OBJECTREF is for code that can't deal with DEBUG OBJECTREFs

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -27,7 +27,7 @@
 #include "frames.h"
 #include "field.h"
 #include "winwrap.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "fcall.h"
 #include "invokeutil.h"
 #include "eeconfig.h"
@@ -1638,7 +1638,7 @@ FCIMPL0(int, GCInterface::GetGcLatencyMode)
 
     FC_GC_POLL_NOT_NEEDED();
 
-    int result = (INT32)GCHeap::GetGCHeap()->GetGcLatencyMode();
+    int result = (INT32)IGCHeap::GetGCHeap()->GetGcLatencyMode();
     return result;
 }
 FCIMPLEND
@@ -1649,7 +1649,7 @@ FCIMPL1(int, GCInterface::SetGcLatencyMode, int newLatencyMode)
 
     FC_GC_POLL_NOT_NEEDED();
     
-    return GCHeap::GetGCHeap()->SetGcLatencyMode(newLatencyMode);
+    return IGCHeap::GetGCHeap()->SetGcLatencyMode(newLatencyMode);
 }
 FCIMPLEND
 
@@ -1659,7 +1659,7 @@ FCIMPL0(int, GCInterface::GetLOHCompactionMode)
 
     FC_GC_POLL_NOT_NEEDED();
 
-    int result = (INT32)GCHeap::GetGCHeap()->GetLOHCompactionMode();
+    int result = (INT32)IGCHeap::GetGCHeap()->GetLOHCompactionMode();
     return result;
 }
 FCIMPLEND
@@ -1670,7 +1670,7 @@ FCIMPL1(void, GCInterface::SetLOHCompactionMode, int newLOHCompactionyMode)
 
     FC_GC_POLL_NOT_NEEDED();
     
-    GCHeap::GetGCHeap()->SetLOHCompactionMode(newLOHCompactionyMode);
+    IGCHeap::GetGCHeap()->SetLOHCompactionMode(newLOHCompactionyMode);
 }
 FCIMPLEND
 
@@ -1681,7 +1681,7 @@ FCIMPL2(FC_BOOL_RET, GCInterface::RegisterForFullGCNotification, UINT32 gen2Perc
 
     FC_GC_POLL_NOT_NEEDED();
 
-    FC_RETURN_BOOL(GCHeap::GetGCHeap()->RegisterForFullGCNotification(gen2Percentage, lohPercentage));
+    FC_RETURN_BOOL(IGCHeap::GetGCHeap()->RegisterForFullGCNotification(gen2Percentage, lohPercentage));
 }
 FCIMPLEND
 
@@ -1690,7 +1690,7 @@ FCIMPL0(FC_BOOL_RET, GCInterface::CancelFullGCNotification)
     FCALL_CONTRACT;
 
     FC_GC_POLL_NOT_NEEDED();
-    FC_RETURN_BOOL(GCHeap::GetGCHeap()->CancelFullGCNotification());
+    FC_RETURN_BOOL(IGCHeap::GetGCHeap()->CancelFullGCNotification());
 }
 FCIMPLEND
 
@@ -1711,7 +1711,7 @@ FCIMPL1(int, GCInterface::WaitForFullGCApproach, int millisecondsTimeout)
     HELPER_METHOD_FRAME_BEGIN_RET_0();
 
     DWORD dwMilliseconds = ((millisecondsTimeout == -1) ? INFINITE : millisecondsTimeout);
-    result = GCHeap::GetGCHeap()->WaitForFullGCApproach(dwMilliseconds);
+    result = IGCHeap::GetGCHeap()->WaitForFullGCApproach(dwMilliseconds);
 
     HELPER_METHOD_FRAME_END();
 
@@ -1736,7 +1736,7 @@ FCIMPL1(int, GCInterface::WaitForFullGCComplete, int millisecondsTimeout)
     HELPER_METHOD_FRAME_BEGIN_RET_0();
 
     DWORD dwMilliseconds = ((millisecondsTimeout == -1) ? INFINITE : millisecondsTimeout);
-    result = GCHeap::GetGCHeap()->WaitForFullGCComplete(dwMilliseconds);
+    result = IGCHeap::GetGCHeap()->WaitForFullGCComplete(dwMilliseconds);
 
     HELPER_METHOD_FRAME_END();
 
@@ -1757,7 +1757,7 @@ FCIMPL1(int, GCInterface::GetGeneration, Object* objUNSAFE)
     if (objUNSAFE == NULL)
         FCThrowArgumentNull(W("obj"));
 
-    int result = (INT32)GCHeap::GetGCHeap()->WhichGeneration(objUNSAFE);
+    int result = (INT32)IGCHeap::GetGCHeap()->WhichGeneration(objUNSAFE);
     FC_GC_POLL_RET();
     return result;
 }
@@ -1777,7 +1777,7 @@ FCIMPL2(int, GCInterface::CollectionCount, INT32 generation, INT32 getSpecialGCC
     _ASSERTE(generation >= 0);
 
     //We don't need to check the top end because the GC will take care of that.
-    int result = (INT32)GCHeap::GetGCHeap()->CollectionCount(generation, getSpecialGCCount);
+    int result = (INT32)IGCHeap::GetGCHeap()->CollectionCount(generation, getSpecialGCCount);
     FC_GC_POLL_RET();
     return result;
 }
@@ -1793,7 +1793,7 @@ int QCALLTYPE GCInterface::StartNoGCRegion(INT64 totalSize, BOOL lohSizeKnown, I
 
     GCX_COOP();
 
-    retVal = GCHeap::GetGCHeap()->StartNoGCRegion((ULONGLONG)totalSize, 
+    retVal = IGCHeap::GetGCHeap()->StartNoGCRegion((ULONGLONG)totalSize, 
                                                   lohSizeKnown,
                                                   (ULONGLONG)lohSize,
                                                   disallowFullBlockingGC);
@@ -1811,7 +1811,7 @@ int QCALLTYPE GCInterface::EndNoGCRegion()
 
     BEGIN_QCALL;
 
-    retVal = GCHeap::GetGCHeap()->EndNoGCRegion();
+    retVal = IGCHeap::GetGCHeap()->EndNoGCRegion();
 
     END_QCALL;
 
@@ -1837,7 +1837,7 @@ FCIMPL1(int, GCInterface::GetGenerationWR, LPVOID handle)
     if (temp == NULL)
         COMPlusThrowArgumentNull(W("weak handle"));
 
-    iRetVal = (INT32)GCHeap::GetGCHeap()->WhichGeneration(OBJECTREFToObject(temp));
+    iRetVal = (INT32)IGCHeap::GetGCHeap()->WhichGeneration(OBJECTREFToObject(temp));
 
     HELPER_METHOD_FRAME_END();
 
@@ -1860,7 +1860,7 @@ INT64 QCALLTYPE GCInterface::GetTotalMemory()
     BEGIN_QCALL;
 
     GCX_COOP();
-    iRetVal = (INT64) GCHeap::GetGCHeap()->GetTotalBytesInUse();
+    iRetVal = (INT64) IGCHeap::GetGCHeap()->GetTotalBytesInUse();
 
     END_QCALL;
 
@@ -1885,7 +1885,7 @@ void QCALLTYPE GCInterface::Collect(INT32 generation, INT32 mode)
     //We don't need to check the top end because the GC will take care of that.
 
     GCX_COOP();
-    GCHeap::GetGCHeap()->GarbageCollect(generation, FALSE, mode);
+    IGCHeap::GetGCHeap()->GarbageCollect(generation, FALSE, mode);
 
     END_QCALL;
 }
@@ -1918,7 +1918,7 @@ FCIMPL0(int, GCInterface::GetMaxGeneration)
 {
     FCALL_CONTRACT;
 
-    return(INT32)GCHeap::GetGCHeap()->GetMaxGeneration();
+    return(INT32)IGCHeap::GetGCHeap()->GetMaxGeneration();
 }
 FCIMPLEND
 
@@ -1938,7 +1938,7 @@ FCIMPL1(void, GCInterface::SuppressFinalize, Object *obj)
     if (!obj->GetMethodTable ()->HasFinalizer())
         return;
 
-    GCHeap::GetGCHeap()->SetFinalizationRun(obj);
+    IGCHeap::GetGCHeap()->SetFinalizationRun(obj);
     FC_GC_POLL();
 }
 FCIMPLEND
@@ -1959,7 +1959,7 @@ FCIMPL1(void, GCInterface::ReRegisterForFinalize, Object *obj)
     if (obj->GetMethodTable()->HasFinalizer())
     {
         HELPER_METHOD_FRAME_BEGIN_1(obj);
-        GCHeap::GetGCHeap()->RegisterForFinalization(-1, obj);
+        IGCHeap::GetGCHeap()->RegisterForFinalization(-1, obj);
         HELPER_METHOD_FRAME_END();
     }
 }
@@ -2061,7 +2061,7 @@ void GCInterface::AddMemoryPressure(UINT64 bytesAllocated)
             m_ulThreshold = (addMethod > multMethod) ? addMethod : multMethod;
             for (int i = 0; i <= 1; i++)
             {
-                if ((GCHeap::GetGCHeap()->CollectionCount(i) / RELATIVE_GC_RATIO) > GCHeap::GetGCHeap()->CollectionCount(i + 1))
+                if ((IGCHeap::GetGCHeap()->CollectionCount(i) / RELATIVE_GC_RATIO) > IGCHeap::GetGCHeap()->CollectionCount(i + 1))
                 {
                     gen_collect = i + 1;
                     break;
@@ -2071,14 +2071,14 @@ void GCInterface::AddMemoryPressure(UINT64 bytesAllocated)
 
         PREFIX_ASSUME(gen_collect <= 2);
 
-        if ((gen_collect == 0) || (m_gc_counts[gen_collect] == GCHeap::GetGCHeap()->CollectionCount(gen_collect)))
+        if ((gen_collect == 0) || (m_gc_counts[gen_collect] == IGCHeap::GetGCHeap()->CollectionCount(gen_collect)))
         {
             GarbageCollectModeAny(gen_collect);
         }
 
         for (int i = 0; i < 3; i++) 
         {
-            m_gc_counts [i] = GCHeap::GetGCHeap()->CollectionCount(i);
+            m_gc_counts [i] = IGCHeap::GetGCHeap()->CollectionCount(i);
         }
     }
 }
@@ -2097,7 +2097,7 @@ void GCInterface::CheckCollectionCount()
 {
     LIMITED_METHOD_CONTRACT;
 
-    GCHeap * pHeap = GCHeap::GetGCHeap();
+    IGCHeap * pHeap = IGCHeap::GetGCHeap();
     
     if (m_gc_counts[2] != pHeap->CollectionCount(2))
     {
@@ -2182,7 +2182,7 @@ void GCInterface::NewAddMemoryPressure(UINT64 bytesAllocated)
         // If still over budget, check current managed heap size
         if (newMemValue >= budget)
         {
-            GCHeap *pGCHeap = GCHeap::GetGCHeap();
+            IGCHeap *pGCHeap = IGCHeap::GetGCHeap();
             UINT64 heapOver3 = pGCHeap->GetCurrentObjSize() / 3;
 
             if (budget < heapOver3) // Max
@@ -2256,7 +2256,7 @@ void GCInterface::RemoveMemoryPressure(UINT64 bytesAllocated)
 
         for (int i = 0; i < 3; i++) 
         {
-            m_gc_counts [i] = GCHeap::GetGCHeap()->CollectionCount(i);
+            m_gc_counts [i] = IGCHeap::GetGCHeap()->CollectionCount(i);
         }
     }
 }
@@ -2330,7 +2330,7 @@ NOINLINE void GCInterface::GarbageCollectModeAny(int generation)
     CONTRACTL_END;
 
     GCX_COOP();
-    GCHeap::GetGCHeap()->GarbageCollect(generation, FALSE, collection_non_blocking);
+    IGCHeap::GetGCHeap()->GarbageCollect(generation, FALSE, collection_non_blocking);
 }
 
 //

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -5170,7 +5170,7 @@ public:
 
         HRESULT     hr = S_OK;
 
-        if (Generation > (int) GCHeap::GetGCHeap()->GetMaxGeneration())
+        if (Generation > (int) IGCHeap::GetGCHeap()->GetMaxGeneration())
             hr = E_INVALIDARG;
 
         if (SUCCEEDED(hr))
@@ -5188,7 +5188,7 @@ public:
                 EX_TRY
                 {
                     STRESS_LOG0(LF_GC, LL_INFO100, "Host triggers GC\n");
-                    hr = GCHeap::GetGCHeap()->GarbageCollect(Generation);
+                    hr = IGCHeap::GetGCHeap()->GarbageCollect(Generation);
                 }
                 EX_CATCH
                 {
@@ -5354,7 +5354,7 @@ HRESULT CCLRGCManager::_SetGCSegmentSize(SIZE_T SegmentSize)
     HRESULT hr = S_OK;
 
     // Sanity check the value, it must be a power of two and big enough.
-    if (!GCHeap::IsValidSegmentSize(SegmentSize))
+    if (!IGCHeap::GetGCHeap()->IsValidSegmentSize(SegmentSize))
     {
         hr = E_INVALIDARG;
     }
@@ -5380,7 +5380,7 @@ HRESULT CCLRGCManager::_SetGCMaxGen0Size(SIZE_T MaxGen0Size)
     HRESULT hr = S_OK;
 
     // Sanity check the value is at least large enough.
-    if (!GCHeap::IsValidGen0MaxSize(MaxGen0Size))
+    if (!IGCHeap::GetGCHeap()->IsValidGen0MaxSize(MaxGen0Size))
     {
         hr = E_INVALIDARG;
     }
@@ -6408,7 +6408,7 @@ HRESULT CCLRDebugManager::SetConnectionTasks(
             }
 
             // Check for Finalizer thread
-            if (GCHeap::IsGCHeapInitialized() && (pThread == FinalizerThread::GetFinalizerThread()))
+            if (IGCHeap::IsGCHeapInitialized() && (pThread == FinalizerThread::GetFinalizerThread()))
             {
                 // _ASSERTE(!"Host should not try to schedule user code on our Finalizer Thread");
                 IfFailGo(E_INVALIDARG);

--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -130,7 +130,7 @@ BOOL __SwitchToThread(DWORD, DWORD)
 // Globals and misc other
 //
 
-GPTR_IMPL(GCHeap,g_pGCHeap);
+GPTR_IMPL(IGCHeap, g_pGCHeap);
 
 BOOL g_fEEOtherStartup=FALSE;
 BOOL g_fEEComActivatedStartup=FALSE;
@@ -138,7 +138,7 @@ BOOL g_fEEComActivatedStartup=FALSE;
 GVAL_IMPL_INIT(DWORD, g_fHostConfig, 0);
 
 #ifdef FEATURE_SVR_GC
-SVAL_IMPL_INIT(uint32_t,GCHeap,gcHeapType,GCHeap::GC_HEAP_WKS);
+SVAL_IMPL_INIT(uint32_t, IGCHeap, gcHeapType, IGCHeap::GC_HEAP_WKS);
 #endif
 
 void UpdateGCSettingFromHost()

--- a/src/vm/crst.cpp
+++ b/src/vm/crst.cpp
@@ -627,7 +627,7 @@ void CrstBase::PreEnter()
                           || (pThread != NULL && pThread->PreemptiveGCDisabled())
                            // If GC heap has not been initialized yet, there is no need to synchronize with GC.
                            // This check is mainly for code called from EEStartup.
-                          || (pThread == NULL && !GCHeap::IsGCHeapInitialized()) );
+                          || (pThread == NULL && !IGCHeap::IsGCHeapInitialized()) );
     }
     
     if ((pThread != NULL) && 
@@ -910,7 +910,7 @@ BOOL CrstBase::IsSafeToTake()
     _ASSERTE(pThread == NULL ||
              (pThread->PreemptiveGCDisabled() == ((m_dwFlags & CRST_UNSAFE_COOPGC) != 0)) ||
              ((m_dwFlags & (CRST_UNSAFE_ANYMODE | CRST_GC_NOTRIGGER_WHEN_TAKEN)) != 0) ||
-             (GCHeap::IsGCInProgress() && pThread == ThreadSuspend::GetSuspensionThread()));
+             (IGCHeap::IsGCInProgress() && pThread == ThreadSuspend::GetSuspensionThread()));
     END_GETTHREAD_ALLOWED;
 
     if (m_holderthreadid.IsCurrentThread())

--- a/src/vm/debugdebugger.cpp
+++ b/src/vm/debugdebugger.cpp
@@ -22,7 +22,7 @@
 #include "frames.h"
 #include "vars.hpp"
 #include "field.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "jitinterface.h"
 #include "debugdebugger.h"
 #include "dbginterface.h"

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -4140,8 +4140,8 @@ void DomainAssembly::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
     }
     CONTRACT_END;
 
-    _ASSERTE(GCHeap::IsGCInProgress() &&
-         GCHeap::IsServerHeap()   &&
+    _ASSERTE(IGCHeap::IsGCInProgress() &&
+         IGCHeap::IsServerHeap()   &&
          IsGCSpecialThread());
 
     DomainModuleIterator i = IterateModules(kModIterIncludeLoaded);

--- a/src/vm/dwreport.cpp
+++ b/src/vm/dwreport.cpp
@@ -3212,7 +3212,7 @@ FaultReportResult DoFaultReport(            // Was Watson attempted, successful?
             // thread under Coop mode, this will let the new generated DoFaultReportCallBack 
             // thread trigger a deadlock. So in this case, we should directly abort the fault 
             // report to avoid the deadlock.
-            ((IsGCThread() || pThread->PreemptiveGCDisabled()) && GCHeap::IsGCInProgress()) ||
+            ((IsGCThread() || pThread->PreemptiveGCDisabled()) && IGCHeap::IsGCInProgress()) ||
              FAILED(g_pDebugInterface->RequestFavor(DoFaultReportFavorWorker, pData)))
         {
             // If we can't initialize the debugger helper thread or we are running on the debugger helper

--- a/src/vm/eehash.h
+++ b/src/vm/eehash.h
@@ -74,7 +74,7 @@ struct EEHashEntry
 // Struct to hold a client's iteration state
 struct EEHashTableIteration;
 
-class GCHeap;
+class IGCHeap;
 
 // Generic hash table.
 

--- a/src/vm/eetoprofinterfaceimpl.cpp
+++ b/src/vm/eetoprofinterfaceimpl.cpp
@@ -2294,7 +2294,7 @@ HRESULT EEToProfInterfaceImpl::SetEventMask(DWORD dwEventMask, DWORD dwEventMask
             // in this function
             if (g_profControlBlock.curProfStatus.Get() == kProfStatusInitializingForAttachLoad)
             {
-                if (GCHeap::GetGCHeap()->IsConcurrentGCEnabled())
+                if (IGCHeap::GetGCHeap()->IsConcurrentGCEnabled())
                 {
                     // We only allow turning off concurrent GC in the profiler attach thread inside
                     // InitializeForAttach, otherwise we would be vulnerable to weird races such as 
@@ -2316,7 +2316,7 @@ HRESULT EEToProfInterfaceImpl::SetEventMask(DWORD dwEventMask, DWORD dwEventMask
                 // Fail if concurrent GC is enabled
                 // This should only happen for attach profilers if user didn't turn on COR_PRF_MONITOR_GC 
                 // at attach time
-                if (GCHeap::GetGCHeap()->IsConcurrentGCEnabled())
+                if (IGCHeap::GetGCHeap()->IsConcurrentGCEnabled())
                 {
                     return CORPROF_E_CONCURRENT_GC_NOT_PROFILABLE;
                 }        
@@ -2384,7 +2384,7 @@ HRESULT EEToProfInterfaceImpl::SetEventMask(DWORD dwEventMask, DWORD dwEventMask
     if (fNeedToTurnOffConcurrentGC)
     {
         // Turn off concurrent GC if it is on so that user can walk the heap safely in GC callbacks
-        GCHeap * pGCHeap = GCHeap::GetGCHeap();
+        IGCHeap * pGCHeap = IGCHeap::GetGCHeap();
         
         LOG((LF_CORPROF, LL_INFO10, "**PROF: Turning off concurrent GC at attach.\n"));
         
@@ -5609,7 +5609,7 @@ HRESULT EEToProfInterfaceImpl::MovedReferences(GCReferencesData *pData)
         LL_INFO10000, 
         "**PROF: MovedReferences.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!IGCHeap::GetGCHeap()->IsConcurrentGCEnabled());
     
     if (pData->curIdx == 0)
     {
@@ -5805,7 +5805,7 @@ HRESULT EEToProfInterfaceImpl::ObjectReference(ObjectID objId,
         LL_INFO100000, 
         "**PROF: ObjectReferences.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!IGCHeap::GetGCHeap()->IsConcurrentGCEnabled());
     
     {                
         // All callbacks are really NOTHROW, but that's enforced partially by the profiler,
@@ -5844,7 +5844,7 @@ HRESULT EEToProfInterfaceImpl::FinalizeableObjectQueued(BOOL isCritical, ObjectI
                                 LL_INFO100, 
                                 "**PROF: Notifying profiler of finalizeable object.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!IGCHeap::GetGCHeap()->IsConcurrentGCEnabled());
     
     {                
         // All callbacks are really NOTHROW, but that's enforced partially by the profiler,
@@ -5883,7 +5883,7 @@ HRESULT EEToProfInterfaceImpl::RootReferences2(GCReferencesData *pData)
         LL_INFO10000, 
         "**PROF: RootReferences2.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!IGCHeap::GetGCHeap()->IsConcurrentGCEnabled());
     
     HRESULT hr = S_OK;
 
@@ -5948,7 +5948,7 @@ HRESULT EEToProfInterfaceImpl::ConditionalWeakTableElementReferences(GCReference
         LL_INFO10000, 
         "**PROF: ConditionalWeakTableElementReferences.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!IGCHeap::GetGCHeap()->IsConcurrentGCEnabled());
     
     HRESULT hr = S_OK;
 
@@ -6082,7 +6082,7 @@ HRESULT EEToProfInterfaceImpl::GarbageCollectionStarted(int cGenerations, BOOL g
         LL_INFO10000, 
         "**PROF: GarbageCollectionStarted.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!IGCHeap::GetGCHeap()->IsConcurrentGCEnabled());
     
     {            
         // All callbacks are really NOTHROW, but that's enforced partially by the profiler,
@@ -6120,7 +6120,7 @@ HRESULT EEToProfInterfaceImpl::GarbageCollectionFinished()
         LL_INFO10000, 
         "**PROF: GarbageCollectionFinished.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!IGCHeap::GetGCHeap()->IsConcurrentGCEnabled());
     
     {        
         // All callbacks are really NOTHROW, but that's enforced partially by the profiler,

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -431,19 +431,19 @@ ETW::SamplingLog::EtwStackWalkStatus ETW::SamplingLog::SaveCurrentStack(int skip
 
 VOID ETW::GCLog::GCSettingsEvent()
 {
-    if (GCHeap::IsGCHeapInitialized())
+    if (IGCHeap::IsGCHeapInitialized())
     {
         if (ETW_TRACING_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_Context, 
                                                  GCSettings))
         {
             ETW::GCLog::ETW_GC_INFO Info;
 
-            Info.GCSettings.ServerGC = GCHeap::IsServerHeap ();
-            Info.GCSettings.SegmentSize = GCHeap::GetGCHeap()->GetValidSegmentSize (FALSE);
-            Info.GCSettings.LargeObjectSegmentSize = GCHeap::GetGCHeap()->GetValidSegmentSize (TRUE);
+            Info.GCSettings.ServerGC = IGCHeap::IsServerHeap ();
+            Info.GCSettings.SegmentSize = IGCHeap::GetGCHeap()->GetValidSegmentSize (FALSE);
+            Info.GCSettings.LargeObjectSegmentSize = IGCHeap::GetGCHeap()->GetValidSegmentSize (TRUE);
             FireEtwGCSettings_V1(Info.GCSettings.SegmentSize, Info.GCSettings.LargeObjectSegmentSize, Info.GCSettings.ServerGC, GetClrInstanceId());
         }  
-        GCHeap::GetGCHeap()->TraceGCSegments();
+        IGCHeap::GetGCHeap()->TraceGCSegments();
     }
 };
 
@@ -892,7 +892,7 @@ VOID ETW::GCLog::FireGcStartAndGenerationRanges(ETW_GC_INFO * pGcInfo)
         // GCStart, then retrieve it
         LONGLONG l64ClientSequenceNumberToLog = 0;
         if ((s_l64LastClientSequenceNumber != 0) &&
-            (pGcInfo->GCStart.Depth == GCHeap::GetMaxGeneration()) &&
+            (pGcInfo->GCStart.Depth == IGCHeap::GetGCHeap()->GetMaxGeneration()) &&
             (pGcInfo->GCStart.Reason == ETW_GC_INFO::GC_INDUCED))
         {
             l64ClientSequenceNumberToLog = InterlockedExchange64(&s_l64LastClientSequenceNumber, 0);
@@ -901,7 +901,7 @@ VOID ETW::GCLog::FireGcStartAndGenerationRanges(ETW_GC_INFO * pGcInfo)
         FireEtwGCStart_V2(pGcInfo->GCStart.Count, pGcInfo->GCStart.Depth, pGcInfo->GCStart.Reason, pGcInfo->GCStart.Type, GetClrInstanceId(), l64ClientSequenceNumberToLog);
 
         // Fire an event per range per generation
-        GCHeap *hp = GCHeap::GetGCHeap();
+        IGCHeap *hp = IGCHeap::GetGCHeap();
         hp->DescrGenerationsToProfiler(FireSingleGenerationRangeEvent, NULL /* context */);
     }
 }
@@ -928,7 +928,7 @@ VOID ETW::GCLog::FireGcEndAndGenerationRanges(ULONG Count, ULONG Depth)
         CLR_GC_KEYWORD))
     {
         // Fire an event per range per generation
-        GCHeap *hp = GCHeap::GetGCHeap();
+        IGCHeap *hp = IGCHeap::GetGCHeap();
         hp->DescrGenerationsToProfiler(FireSingleGenerationRangeEvent, NULL /* context */);
 
         // GCEnd
@@ -938,7 +938,7 @@ VOID ETW::GCLog::FireGcEndAndGenerationRanges(ULONG Count, ULONG Depth)
  
 //---------------------------------------------------------------------------------------
 //
-// Callback made by GC when we call GCHeap::DescrGenerationsToProfiler().  This is
+// Callback made by GC when we call IGCHeap::DescrGenerationsToProfiler().  This is
 // called once per range per generation, and results in a single ETW event per range per
 // generation.
 //
@@ -1033,7 +1033,7 @@ HRESULT ETW::GCLog::ForceGCForDiagnostics()
         
         ForcedGCHolder forcedGCHolder;
         
-        hr = GCHeap::GetGCHeap()->GarbageCollect(
+        hr = IGCHeap::GetGCHeap()->GarbageCollect(
             -1,     // all generations should be collected
             FALSE,  // low_memory_p
             collection_blocking);

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -20,7 +20,7 @@
 #include "cgensys.h"
 #include "comutilnative.h"
 #include "siginfo.hpp"
-#include "gc.h"
+#include "gcinterface.h"
 #include "eedbginterfaceimpl.h" //so we can clearexception in RealCOMPlusThrow
 #include "perfcounters.h"
 #include "dllimportcallback.h"

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -295,7 +295,7 @@ Object * FinalizerThread::FinalizeAllObjects(Object* fobj, int bitToCheck)
         {
             return NULL;
         }
-        fobj = GCHeap::GetGCHeap()->GetNextFinalizable();
+        fobj = IGCHeap::GetGCHeap()->GetNextFinalizable();
     }
 
     Thread *pThread = GetThread();
@@ -320,7 +320,7 @@ Object * FinalizerThread::FinalizeAllObjects(Object* fobj, int bitToCheck)
             {
                 return NULL;
             }
-            fobj = GCHeap::GetGCHeap()->GetNextFinalizable();
+            fobj = IGCHeap::GetGCHeap()->GetNextFinalizable();
         }
         else
         {
@@ -337,7 +337,7 @@ Object * FinalizerThread::FinalizeAllObjects(Object* fobj, int bitToCheck)
                 {
                     return NULL;
                 }
-                fobj = GCHeap::GetGCHeap()->GetNextFinalizable();
+                fobj = IGCHeap::GetGCHeap()->GetNextFinalizable();
             }
         }
     }
@@ -533,7 +533,7 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
             case (WAIT_OBJECT_0 + kLowMemoryNotification):
                 //short on memory GC immediately
                 GetFinalizerThread()->DisablePreemptiveGC();
-                GCHeap::GetGCHeap()->GarbageCollect(0, TRUE);
+                IGCHeap::GetGCHeap()->GarbageCollect(0, TRUE);
                 GetFinalizerThread()->EnablePreemptiveGC();
                 //wait only on the event for 2s 
                 switch (event->Wait(2000, FALSE))
@@ -584,7 +584,7 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
                 if (WaitForSingleObject(MHandles[kLowMemoryNotification], 0) == WAIT_OBJECT_0) {
                     //short on memory GC immediately
                     GetFinalizerThread()->DisablePreemptiveGC();
-                    GCHeap::GetGCHeap()->GarbageCollect(0, TRUE);
+                    IGCHeap::GetGCHeap()->GarbageCollect(0, TRUE);
                     GetFinalizerThread()->EnablePreemptiveGC();
                 }
                 //wait only on the event for 2s
@@ -604,7 +604,7 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
                         if (sLastLowMemoryFromHost != 0)
                         {
                             GetFinalizerThread()->DisablePreemptiveGC();
-                            GCHeap::GetGCHeap()->GarbageCollect(0, TRUE);
+                            IGCHeap::GetGCHeap()->GarbageCollect(0, TRUE);
                             GetFinalizerThread()->EnablePreemptiveGC();
                         }
                     }
@@ -677,7 +677,7 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
         {
             s_forcedGCInProgress = true;
             GetFinalizerThread()->DisablePreemptiveGC();
-            GCHeap::GetGCHeap()->GarbageCollect(2, FALSE, collection_blocking);
+            IGCHeap::GetGCHeap()->GarbageCollect(2, FALSE, collection_blocking);
             GetFinalizerThread()->EnablePreemptiveGC();
             s_forcedGCInProgress = false;
             
@@ -710,14 +710,14 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
 
             do
             {
-                last_gc_count = GCHeap::GetGCHeap()->CollectionCount(0);
+                last_gc_count = IGCHeap::GetGCHeap()->CollectionCount(0);
                 GetFinalizerThread()->m_GCOnTransitionsOK = FALSE; 
                 GetFinalizerThread()->EnablePreemptiveGC();
                 __SwitchToThread (0, ++dwSwitchCount);
                 GetFinalizerThread()->DisablePreemptiveGC();             
                 // If no GCs happended, then we assume we are quiescent
                 GetFinalizerThread()->m_GCOnTransitionsOK = TRUE; 
-            } while (GCHeap::GetGCHeap()->CollectionCount(0) - last_gc_count > 0);
+            } while (IGCHeap::GetGCHeap()->CollectionCount(0) - last_gc_count > 0);
         }
 #endif //_DEBUG
 
@@ -747,7 +747,7 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
             }
             else if (UnloadingAppDomain == NULL)
                 break;
-            else if (!GCHeap::GetGCHeap()->FinalizeAppDomain(UnloadingAppDomain, fRunFinalizersOnUnload))
+            else if (!IGCHeap::GetGCHeap()->FinalizeAppDomain(UnloadingAppDomain, fRunFinalizersOnUnload))
             {
                 break;
             }
@@ -916,7 +916,7 @@ DWORD __stdcall FinalizerThread::FinalizerThreadStart(void *args)
             if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_FinalizeOnShutdown) != 0)
             {
                 // Finalize all registered objects during shutdown, even they are still reachable.
-                GCHeap::GetGCHeap()->SetFinalizeQueueForShutdown(FALSE);
+                IGCHeap::GetGCHeap()->SetFinalizeQueueForShutdown(FALSE);
 
                 // This will apply any policy for swallowing exceptions during normal
                 // processing, without allowing the finalizer thread to disappear on us.
@@ -1380,7 +1380,7 @@ BOOL FinalizerThread::FinalizerThreadWatchDogHelper()
     }
     else
     {
-        prevCount = GCHeap::GetGCHeap()->GetNumberOfFinalizable();
+        prevCount = IGCHeap::GetGCHeap()->GetNumberOfFinalizable();
     }
 
     DWORD maxTry = (DWORD)(totalWaitTimeout*1.0/FINALIZER_WAIT_TIMEOUT + 0.5);
@@ -1447,11 +1447,11 @@ BOOL FinalizerThread::FinalizerThreadWatchDogHelper()
         }
         else
         {
-            curCount = GCHeap::GetGCHeap()->GetNumberOfFinalizable();
+            curCount = IGCHeap::GetGCHeap()->GetNumberOfFinalizable();
         }
 
         if ((prevCount <= curCount)
-            && !GCHeap::GetGCHeap()->ShouldRestartFinalizerWatchDog()
+            && !IGCHeap::GetGCHeap()->ShouldRestartFinalizerWatchDog()
             && (pThread == NULL || !(pThread->m_State & (Thread::TS_UserSuspendPending | Thread::TS_DebugSuspendPending)))){
             if (nTry == maxTry) {
                 if (!s_fRaiseExitProcessEvent) {

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -18,7 +18,7 @@
 #include "fieldmarshaler.h"
 #include "objecthandle.h"
 #include "siginfo.hpp"
-#include "gc.h"
+#include "gcinterface.h"
 #include "dllimportcallback.h"
 #include "stackwalk.h"
 #include "dbginterface.h"

--- a/src/vm/gc.h
+++ b/src/vm/gc.h
@@ -1,5 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-#include "../gc/gc.h"

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1234,8 +1234,8 @@ void checkAndUpdateReg(DWORD& origVal, DWORD curVal, bool gcHappened) {
     // the validation infrastructure has got a bug.
 
     _ASSERTE(gcHappened);    // If the register values are different, a GC must have happened
-    _ASSERTE(GCHeap::GetGCHeap()->IsHeapPointer((BYTE*) size_t(origVal)));    // And the pointers involved are on the GCHeap
-    _ASSERTE(GCHeap::GetGCHeap()->IsHeapPointer((BYTE*) size_t(curVal)));
+    _ASSERTE(IGCHeap::GetGCHeap()->IsHeapPointer((BYTE*) size_t(origVal)));    // And the pointers involved are on the GCHeap
+    _ASSERTE(IGCHeap::GetGCHeap()->IsHeapPointer((BYTE*) size_t(curVal)));
     origVal = curVal;       // this is now the best estimate of what should be returned. 
 }
 
@@ -1478,7 +1478,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
             if (gcCover->callerThread == 0) {
                 if (FastInterlockCompareExchangePointer(&gcCover->callerThread, pThread, 0) == 0) {
                     gcCover->callerRegs = *regs;
-                    gcCover->gcCount = GCHeap::GetGCHeap()->GetGcCount();
+                    gcCover->gcCount = IGCHeap::GetGCHeap()->GetGcCount();
                     bShouldUpdateProlog = false;
                 }
             }    
@@ -1564,13 +1564,13 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
             // instruction in the epilog  (TODO: fix it for the first instr Case)
             
             _ASSERTE(pThread->PreemptiveGCDisabled());    // Epilogs should be in cooperative mode, no GC can happen right now. 
-            bool gcHappened = gcCover->gcCount != GCHeap::GetGCHeap()->GetGcCount();
+            bool gcHappened = gcCover->gcCount != IGCHeap::GetGCHeap()->GetGcCount();
             checkAndUpdateReg(gcCover->callerRegs.Edi, *regDisp.pEdi, gcHappened);
             checkAndUpdateReg(gcCover->callerRegs.Esi, *regDisp.pEsi, gcHappened);
             checkAndUpdateReg(gcCover->callerRegs.Ebx, *regDisp.pEbx, gcHappened);
             checkAndUpdateReg(gcCover->callerRegs.Ebp, *regDisp.pEbp, gcHappened);
             
-            gcCover->gcCount = GCHeap::GetGCHeap()->GetGcCount();
+            gcCover->gcCount = IGCHeap::GetGCHeap()->GetGcCount();
 
         }        
         return;
@@ -1777,7 +1777,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
     // Do the actual stress work
     //
 
-    if (!GCHeap::GetGCHeap()->StressHeap())
+    if (!IGCHeap::GetGCHeap()->StressHeap())
         UpdateGCStressInstructionWithoutGC ();
 
     // Must flush instruction cache before returning as instruction has been modified.

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -550,7 +550,7 @@ void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, 
     STRESS_LOG1(LF_GCROOTS, LL_INFO10, "GCScan: Promotion Phase = %d\n", sc->promotion);
 
     // In server GC, we should be competing for marking the statics
-    if (GCHeap::MarkShouldCompeteForStatics())
+    if (IGCHeap::MarkShouldCompeteForStatics())
     {
         if (condemned == max_gen && sc->promotion)
         {
@@ -563,7 +563,7 @@ void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, 
     {
         STRESS_LOG2(LF_GC | LF_GCROOTS, LL_INFO100, "{ Starting scan of Thread %p ID = %x\n", pThread, pThread->GetThreadId());
 
-        if (GCHeap::GetGCHeap()->IsThreadUsingAllocationContextHeap(
+        if (IGCHeap::GetGCHeap()->IsThreadUsingAllocationContextHeap(
             GCToEEInterface::GetAllocContext(pThread), sc->thread_number))
         {
             sc->thread_under_crawl = pThread;
@@ -693,7 +693,7 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int max_gen)
     SyncBlockCache::GetSyncBlockCache()->GCDone(FALSE, max_gen);
 }
 
-alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
+gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
 {
     WRAPPER_NO_CONTRACT;
     return pThread->GetAllocContext();

--- a/src/vm/gchost.cpp
+++ b/src/vm/gchost.cpp
@@ -22,7 +22,7 @@
 #include "corhost.h"
 #include "excep.h"
 #include "field.h"
-#include "gc.h"
+#include "gcinterface.h"
 
 #if !defined(FEATURE_CORECLR)
 inline size_t SizeInKBytes(size_t cbSize)
@@ -48,7 +48,7 @@ HRESULT CorGCHost::_SetGCSegmentSize(SIZE_T SegmentSize)
     HRESULT hr = S_OK;
 
     // Sanity check the value, it must be a power of two and big enough.
-    if (!GCHeap::IsValidSegmentSize(SegmentSize))
+    if (!IGCHeap::IsValidSegmentSize(SegmentSize))
     {
         hr = E_INVALIDARG;
     }
@@ -74,7 +74,7 @@ HRESULT CorGCHost::_SetGCMaxGen0Size(SIZE_T MaxGen0Size)
     HRESULT hr = S_OK;
 
     // Sanity check the value is at least large enough.
-    if (!GCHeap::IsValidGen0MaxSize(MaxGen0Size))
+    if (!IGCHeap::IsValidGen0MaxSize(MaxGen0Size))
     {
         hr = E_INVALIDARG;
     }
@@ -151,7 +151,7 @@ HRESULT CorGCHost::Collect(
     
     HRESULT     hr = E_FAIL;
     
-    if (Generation > (int) GCHeap::GetGCHeap()->GetMaxGeneration())
+    if (Generation > (int) IGCHeap::GetGCHeap()->GetMaxGeneration())
         hr = E_INVALIDARG;
     else
     {
@@ -170,7 +170,7 @@ HRESULT CorGCHost::Collect(
 
             EX_TRY
             {			
-                hr = GCHeap::GetGCHeap()->GarbageCollect(Generation);
+                hr = IGCHeap::GetGCHeap()->GarbageCollect(Generation);
             }
             EX_CATCH
             {
@@ -268,7 +268,7 @@ HRESULT CorGCHost::SetVirtualMemLimit(
     }
     CONTRACTL_END;
 
-    GCHeap::GetGCHeap()->SetReservedVMLimit (sztMaxVirtualMemMB);
+    IGCHeap::GetGCHeap()->SetReservedVMLimit (sztMaxVirtualMemMB);
     return (S_OK);
 }
 #endif // !defined(FEATURE_CORECLR)

--- a/src/vm/gcinterface.h
+++ b/src/vm/gcinterface.h
@@ -1,0 +1,1 @@
+#include "../gc/gcinterface.h"

--- a/src/vm/gcstress.h
+++ b/src/vm/gcstress.h
@@ -280,17 +280,17 @@ namespace _GCStress
     // GC Trigger policy classes define how a garbage collection is triggered
 
     // This is the default GC Trigger policy that simply calls 
-    // GCHeap::StressHeap
+    // IGCHeap::StressHeap
     class StressGcTriggerPolicy
     {
     public:
         FORCEINLINE
         static void Trigger()
-        { GCHeap::GetGCHeap()->StressHeap(); }
+        { IGCHeap::GetGCHeap()->StressHeap(); }
 
         FORCEINLINE
-        static void Trigger(::alloc_context* acontext)
-        { GCHeap::GetGCHeap()->StressHeap(acontext); }
+        static void Trigger(::gc_alloc_context* acontext)
+        { IGCHeap::GetGCHeap()->StressHeap(acontext); }
     };
 
     // This is an overriding GC Trigger policy that triggers a GC by calling
@@ -403,7 +403,7 @@ namespace _GCStress
         // Additionally it switches the GC mode as specified by GcModePolicy, and it 
         // uses GcTriggerPolicy::Trigger(alloc_context*) to actually trigger the GC
         FORCEINLINE
-        static void MaybeTrigger(::alloc_context* acontext, DWORD minFastGc = 0)
+        static void MaybeTrigger(::gc_alloc_context* acontext, DWORD minFastGc = 0)
         {
             if (IsEnabled(minFastGc) && GCStressPolicy::IsEnabled())
             {
@@ -455,7 +455,7 @@ namespace _GCStress
     public:
 
         FORCEINLINE
-        static void MaybeTrigger(::alloc_context* acontext)
+        static void MaybeTrigger(::gc_alloc_context* acontext)
         {
             GcStressBase::MaybeTrigger(acontext);
 

--- a/src/vm/hash.cpp
+++ b/src/vm/hash.cpp
@@ -547,8 +547,8 @@ UPTR HashMap::LookupValue(UPTR key, UPTR value)
 
     // BROKEN: This is called for the RCWCache on the GC thread
     // Also called by AppDomain::FindCachedAssembly to resolve AssemblyRef -- this is used by stack walking on the GC thread.
-    // See comments in GCHeap::RestartEE (above the call to SyncClean::CleanUp) for reason to enter COOP mode.
-    // However, if the current thread is the GC thread, we know we're not going to call GCHeap::RestartEE
+    // See comments in IGCHeap::RestartEE (above the call to SyncClean::CleanUp) for reason to enter COOP mode.
+    // However, if the current thread is the GC thread, we know we're not going to call IGCHeap::RestartEE
     // while accessing the HashMap, so it's safe to proceed.
     // (m_fAsyncMode && !IsGCThread() is the condition for entering COOP mode.  I.e., enable COOP GC only if
     // the HashMap is in async mode and this is not a GC thread.)

--- a/src/vm/i386/excepx86.cpp
+++ b/src/vm/i386/excepx86.cpp
@@ -19,7 +19,7 @@
 #include "comutilnative.h"
 #include "sigformat.h"
 #include "siginfo.hpp"
-#include "gc.h"
+#include "gcinterface.h"
 #include "eedbginterfaceimpl.h" //so we can clearexception in COMPlusThrow
 #include "perfcounters.h"
 #include "eventtrace.h"

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -57,10 +57,10 @@ extern "C" void STDCALL WriteBarrierAssert(BYTE* ptr, Object* obj)
     if (fVerifyHeap)
     {
         obj->Validate(FALSE);
-        if(GCHeap::GetGCHeap()->IsHeapPointer(ptr))
+        if(IGCHeap::GetGCHeap()->IsHeapPointer(ptr))
         {
             Object* pObj = *(Object**)ptr;
-            _ASSERTE (pObj == NULL || GCHeap::GetGCHeap()->IsHeapPointer(pObj));
+            _ASSERTE (pObj == NULL || IGCHeap::GetGCHeap()->IsHeapPointer(pObj));
         }
     }
     else
@@ -610,7 +610,7 @@ void JIT_TrialAlloc::EmitCore(CPUSTUBLINKER *psl, CodeLabel *noLock, CodeLabel *
         if (flags & (ALIGN8 | SIZE_IN_EAX | ALIGN8OBJ))
         {
             // MOV EBX, [edx]Thread.m_alloc_context.alloc_ptr
-            psl->X86EmitOffsetModRM(0x8B, kEBX, kEDX, offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_ptr));
+            psl->X86EmitOffsetModRM(0x8B, kEBX, kEDX, offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_ptr));
             // add EAX, EBX
             psl->Emit16(0xC303);
             if (flags & ALIGN8)
@@ -619,11 +619,11 @@ void JIT_TrialAlloc::EmitCore(CPUSTUBLINKER *psl, CodeLabel *noLock, CodeLabel *
         else
         {
             // add             eax, [edx]Thread.m_alloc_context.alloc_ptr
-            psl->X86EmitOffsetModRM(0x03, kEAX, kEDX, offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_ptr));
+            psl->X86EmitOffsetModRM(0x03, kEAX, kEDX, offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_ptr));
         }
 
         // cmp             eax, [edx]Thread.m_alloc_context.alloc_limit
-        psl->X86EmitOffsetModRM(0x3b, kEAX, kEDX, offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_limit));
+        psl->X86EmitOffsetModRM(0x3b, kEAX, kEDX, offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_limit));
 
         // ja              noAlloc
         psl->X86EmitCondJump(noAlloc, X86CondCode::kJA);
@@ -631,7 +631,7 @@ void JIT_TrialAlloc::EmitCore(CPUSTUBLINKER *psl, CodeLabel *noLock, CodeLabel *
         // Fill in the allocation and get out.
 
         // mov             [edx]Thread.m_alloc_context.alloc_ptr, eax
-        psl->X86EmitIndexRegStore(kEDX, offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_ptr), kEAX);
+        psl->X86EmitIndexRegStore(kEDX, offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_ptr), kEAX);
 
         if (flags & (ALIGN8 | SIZE_IN_EAX | ALIGN8OBJ))
         {
@@ -1502,7 +1502,7 @@ void InitJITHelpers1()
 
     _ASSERTE(g_SystemInfo.dwNumberOfProcessors != 0);
 
-    JIT_TrialAlloc::Flags flags = GCHeap::UseAllocationContexts() ?
+    JIT_TrialAlloc::Flags flags = IGCHeap::UseAllocationContexts() ?
         JIT_TrialAlloc::MP_ALLOCATOR : JIT_TrialAlloc::NORMAL;
 
     // Get CPU features and check for SSE2 support.

--- a/src/vm/i386/virtualcallstubcpu.hpp
+++ b/src/vm/i386/virtualcallstubcpu.hpp
@@ -695,7 +695,7 @@ BOOL isDelegateCall(BYTE *interiorPtr)
 {
     LIMITED_METHOD_CONTRACT;
 
-    if (GCHeap::GetGCHeap()->IsHeapPointer((void*)interiorPtr))
+    if (IGCHeap::GetGCHeap()->IsHeapPointer((void*)interiorPtr))
     {
         Object *delegate = (Object*)(interiorPtr - DelegateObject::GetOffsetOfMethodPtrAux());
         VALIDATEOBJECTREF(ObjectToOBJECTREF(delegate));

--- a/src/vm/interoputil.cpp
+++ b/src/vm/interoputil.cpp
@@ -2130,7 +2130,7 @@ void MinorCleanupSyncBlockComData(InteropSyncBlockInfo* pInteropInfo)
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION( GCHeap::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ) );
+        PRECONDITION( IGCHeap::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ) );
     }
     CONTRACTL_END;
 

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -14,7 +14,7 @@
 #include "openum.h"
 #include "fcall.h"
 #include "frames.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include <float.h>
 #include "jitinterface.h"
 #include "safemath.h"

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -23,7 +23,7 @@
 #include "security.h"
 #include "securitymeta.h"
 #include "dllimport.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "comdelegate.h"
 #include "jitperf.h" // to track jit perf
 #include "corprof.h"
@@ -2858,7 +2858,7 @@ HCIMPL1(Object*, JIT_NewS_MP_FastPortable, CORINFO_CLASS_HANDLE typeHnd_)
 
     do
     {
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(IGCHeap::UseAllocationContexts());
 
         // This is typically the only call in the fast path. Making the call early seems to be better, as it allows the compiler
         // to use volatile registers for intermediate values. This reduces the number of push/pop instructions and eliminates
@@ -2872,7 +2872,7 @@ HCIMPL1(Object*, JIT_NewS_MP_FastPortable, CORINFO_CLASS_HANDLE typeHnd_)
         SIZE_T size = methodTable->GetBaseSize();
         _ASSERTE(size % DATA_ALIGNMENT == 0);
 
-        alloc_context *allocContext = thread->GetAllocContext();
+        gc_alloc_context *allocContext = thread->GetAllocContext();
         BYTE *allocPtr = allocContext->alloc_ptr;
         _ASSERTE(allocPtr <= allocContext->alloc_limit);
         if (size > static_cast<SIZE_T>(allocContext->alloc_limit - allocPtr))
@@ -2997,7 +2997,7 @@ HCIMPL1(StringObject*, AllocateString_MP_FastPortable, DWORD stringLength)
 
     do
     {
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(IGCHeap::UseAllocationContexts());
 
         // Instead of doing elaborate overflow checks, we just limit the number of elements. This will avoid all overflow
         // problems, as well as making sure big string objects are correctly allocated in the big object heap.
@@ -3021,7 +3021,7 @@ HCIMPL1(StringObject*, AllocateString_MP_FastPortable, DWORD stringLength)
         _ASSERTE(alignedTotalSize >= totalSize);
         totalSize = alignedTotalSize;
 
-        alloc_context *allocContext = thread->GetAllocContext();
+        gc_alloc_context *allocContext = thread->GetAllocContext();
         BYTE *allocPtr = allocContext->alloc_ptr;
         _ASSERTE(allocPtr <= allocContext->alloc_limit);
         if (totalSize > static_cast<SIZE_T>(allocContext->alloc_limit - allocPtr))
@@ -3161,7 +3161,7 @@ HCIMPL2(Object*, JIT_NewArr1VC_MP_FastPortable, CORINFO_CLASS_HANDLE arrayTypeHn
 
     do
     {
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(IGCHeap::UseAllocationContexts());
 
         // Do a conservative check here.  This is to avoid overflow while doing the calculations.  We don't
         // have to worry about "large" objects, since the allocation quantum is never big enough for
@@ -3198,7 +3198,7 @@ HCIMPL2(Object*, JIT_NewArr1VC_MP_FastPortable, CORINFO_CLASS_HANDLE arrayTypeHn
         _ASSERTE(alignedTotalSize >= totalSize);
         totalSize = alignedTotalSize;
 
-        alloc_context *allocContext = thread->GetAllocContext();
+        gc_alloc_context *allocContext = thread->GetAllocContext();
         BYTE *allocPtr = allocContext->alloc_ptr;
         _ASSERTE(allocPtr <= allocContext->alloc_limit);
         if (totalSize > static_cast<SIZE_T>(allocContext->alloc_limit - allocPtr))
@@ -3238,7 +3238,7 @@ HCIMPL2(Object*, JIT_NewArr1OBJ_MP_FastPortable, CORINFO_CLASS_HANDLE arrayTypeH
 
     do
     {
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(IGCHeap::UseAllocationContexts());
 
         // Make sure that the total size cannot reach LARGE_OBJECT_SIZE, which also allows us to avoid overflow checks. The
         // "256" slack is to cover the array header size and round-up, using a constant value here out of laziness.
@@ -3266,7 +3266,7 @@ HCIMPL2(Object*, JIT_NewArr1OBJ_MP_FastPortable, CORINFO_CLASS_HANDLE arrayTypeH
 
         _ASSERTE(ALIGN_UP(totalSize, DATA_ALIGNMENT) == totalSize);
 
-        alloc_context *allocContext = thread->GetAllocContext();
+        gc_alloc_context *allocContext = thread->GetAllocContext();
         BYTE *allocPtr = allocContext->alloc_ptr;
         _ASSERTE(allocPtr <= allocContext->alloc_limit);
         if (totalSize > static_cast<SIZE_T>(allocContext->alloc_limit - allocPtr))
@@ -6431,7 +6431,7 @@ HCIMPL0(VOID, JIT_StressGC)
     bool fSkipGC = false;
 
     if (!fSkipGC)
-        GCHeap::GetGCHeap()->GarbageCollect();
+        IGCHeap::GetGCHeap()->GarbageCollect();
 
 // <TODO>@TODO: the following ifdef is in error, but if corrected the
 // compiler complains about the *__ms->pRetAddr() saying machine state

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -27,7 +27,7 @@
 #include "security.h"
 #include "securitymeta.h"
 #include "dllimport.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "comdelegate.h"
 #include "jitperf.h" // to track jit perf
 #include "corprof.h"

--- a/src/vm/jitinterfacegen.cpp
+++ b/src/vm/jitinterfacegen.cpp
@@ -221,7 +221,7 @@ void InitJITHelpers1()
         ))
     {
         // if (multi-proc || server GC)
-        if (GCHeap::UseAllocationContexts())
+        if (IGCHeap::UseAllocationContexts())
         {
 #ifdef FEATURE_IMPLICIT_TLS
             SetJitHelperFunction(CORINFO_HELP_NEWSFAST, JIT_NewS_MP_FastPortable);

--- a/src/vm/marshalnative.cpp
+++ b/src/vm/marshalnative.cpp
@@ -27,7 +27,7 @@
 #include "log.h"
 #include "fieldmarshaler.h"
 #include "cgensys.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "security.h"
 #include "dbginterface.h"
 #include "objecthandle.h"
@@ -38,7 +38,8 @@
 #include "remoting.h"
 #endif
 #include "comdelegate.h"
-#include "handletablepriv.h"
+// TODO(segilles) interface violation
+#include "../gc/handletablepriv.h"
 #include "mdaassistants.h"
 #include "typestring.h"
 #include "appdomain.inl"

--- a/src/vm/mdaassistants.cpp
+++ b/src/vm/mdaassistants.cpp
@@ -137,7 +137,7 @@ void TriggerGCForMDAInternal()
 
     EX_TRY
     {
-        GCHeap::GetGCHeap()->GarbageCollect();
+        IGCHeap::GetGCHeap()->GarbageCollect();
 
 #ifdef FEATURE_SYNCHRONIZATIONCONTEXT_WAIT
         //
@@ -868,7 +868,7 @@ LPVOID MdaInvalidOverlappedToPinvoke::CheckOverlappedPointer(UINT index, LPVOID 
 
         {
             GCX_COOP();
-            GCHeap *pHeap = GCHeap::GetGCHeap();
+            GCHeap *pHeap = IGCHeap::GetGCHeap();
             fHeapPointer = pHeap->IsHeapPointer(pOverlapped);
         }
 

--- a/src/vm/memberload.cpp
+++ b/src/vm/memberload.cpp
@@ -30,7 +30,7 @@
 #include "log.h"
 #include "fieldmarshaler.h"
 #include "cgensys.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "security.h"
 #include "dbginterface.h"
 #include "comdelegate.h"

--- a/src/vm/message.cpp
+++ b/src/vm/message.cpp
@@ -249,7 +249,7 @@ void CMessage::GetObjectFromStack(OBJECTREF* ppDest, PVOID val, const CorElement
 
         _ASSERTE(ty.GetMethodTable()->IsValueType() || ty.GetMethodTable()->IsEnum());
 
-        _ASSERTE(!GCHeap::GetGCHeap()->IsHeapPointer((BYTE *) ppDest) ||
+        _ASSERTE(!IGCHeap::GetGCHeap()->IsHeapPointer((BYTE *) ppDest) ||
              !"(pDest) can not point to GC Heap");
         MethodTable* pMT = ty.GetMethodTable();
 

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -33,7 +33,7 @@
 #include "log.h"
 #include "fieldmarshaler.h"
 #include "cgensys.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "security.h"
 #include "dbginterface.h"
 #include "comdelegate.h"
@@ -9804,11 +9804,11 @@ BOOL MethodTable::Validate()
     }
 
     DWORD dwLastVerifiedGCCnt = m_pWriteableData->m_dwLastVerifedGCCnt;
-    // Here we used to assert that (dwLastVerifiedGCCnt <= GCHeap::GetGCHeap()->GetGcCount()) but 
+    // Here we used to assert that (dwLastVerifiedGCCnt <= IGCHeap::GetGCHeap()->GetGcCount()) but 
     // this is no longer true because with background gc. Since the purpose of having 
     // m_dwLastVerifedGCCnt is just to only verify the same method table once for each GC
     // I am getting rid of the assert.
-    if (g_pConfig->FastGCStressLevel () > 1 && dwLastVerifiedGCCnt == GCHeap::GetGCHeap()->GetGcCount())
+    if (g_pConfig->FastGCStressLevel () > 1 && dwLastVerifiedGCCnt == IGCHeap::GetGCHeap()->GetGcCount())
         return TRUE;
 #endif //_DEBUG
 
@@ -9835,7 +9835,7 @@ BOOL MethodTable::Validate()
     // It is not a fatal error to fail the update the counter. We will run slower and retry next time, 
     // but the system will function properly.
     if (EnsureWritablePagesNoThrow(m_pWriteableData, sizeof(MethodTableWriteableData)))
-        m_pWriteableData->m_dwLastVerifedGCCnt = GCHeap::GetGCHeap()->GetGcCount();
+        m_pWriteableData->m_dwLastVerifedGCCnt = IGCHeap::GetGCHeap()->GetGcCount();
 #endif //_DEBUG
 
     return TRUE;

--- a/src/vm/nativeoverlapped.h
+++ b/src/vm/nativeoverlapped.h
@@ -62,7 +62,7 @@ public:
         STATIC_CONTRACT_SO_TOLERANT;
         
         _ASSERTE (nativeOverlapped != NULL);
-        _ASSERTE (GCHeap::GetGCHeap()->IsHeapPointer((BYTE *) nativeOverlapped));
+        _ASSERTE (IGCHeap::GetGCHeap()->IsHeapPointer((BYTE *) nativeOverlapped));
         
         return (OverlappedDataObject*)((BYTE*)nativeOverlapped - offsetof(OverlappedDataObject, Internal));
     }

--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -17,7 +17,7 @@
 #include "threads.h"
 #include "excep.h"
 #include "eeconfig.h"
-#include "gc.h"
+#include "gcinterface.h"
 #ifdef FEATURE_REMOTING
 #include "remoting.h"
 #endif
@@ -243,7 +243,7 @@ TypeHandle Object::GetGCSafeTypeHandleIfPossible() const
     // 
     // where MyRefType2's module was unloaded by the time the GC occurred. In at least
     // one case, the GC was caused by the AD unload itself (AppDomain::Unload ->
-    // AppDomain::Exit -> GCInterface::AddMemoryPressure -> WKS::GCHeap::GarbageCollect).
+    // AppDomain::Exit -> GCInterface::AddMemoryPressure -> WKS::IGCHeap::GarbageCollect).
     // 
     // To protect against all scenarios, verify that
     // 
@@ -1764,9 +1764,9 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
         BOOL bSmallObjectHeapPtr = FALSE, bLargeObjectHeapPtr = FALSE;
         if (!noRangeChecks)
         {
-            bSmallObjectHeapPtr = GCHeap::GetGCHeap()->IsHeapPointer(this, TRUE);
+            bSmallObjectHeapPtr = IGCHeap::GetGCHeap()->IsHeapPointer(this, TRUE);
             if (!bSmallObjectHeapPtr)
-                bLargeObjectHeapPtr = GCHeap::GetGCHeap()->IsHeapPointer(this);
+                bLargeObjectHeapPtr = IGCHeap::GetGCHeap()->IsHeapPointer(this);
                 
             CHECK_AND_TEAR_DOWN(bSmallObjectHeapPtr || bLargeObjectHeapPtr);
         }
@@ -1781,7 +1781,7 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
         lastTest = 4;
 
         if (bDeep && (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)) {
-            GCHeap::GetGCHeap()->ValidateObjectMember(this);
+            IGCHeap::GetGCHeap()->ValidateObjectMember(this);
         }
 
         lastTest = 5;
@@ -1790,7 +1790,7 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
         // we skip checking noRangeChecks since if skipping
         // is enabled bSmallObjectHeapPtr will always be false.
         if (bSmallObjectHeapPtr) {
-            CHECK_AND_TEAR_DOWN(!GCHeap::GetGCHeap()->IsObjectInFixedHeap(this));
+            CHECK_AND_TEAR_DOWN(!IGCHeap::GetGCHeap()->IsObjectInFixedHeap(this));
         }
 
         lastTest = 6;
@@ -1815,9 +1815,9 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
             && bVerifyNextHeader 
             && GCScan::GetGcRuntimeStructuresValid ()
             //NextObj could be very slow if concurrent GC is going on
-            && !(GCHeap::IsGCHeapInitialized() && GCHeap::GetGCHeap ()->IsConcurrentGCInProgress ()))
+            && !(IGCHeap::IsGCHeapInitialized() && IGCHeap::GetGCHeap ()->IsConcurrentGCInProgress ()))
         {
-            Object * nextObj = GCHeap::GetGCHeap ()->NextObj (this);
+            Object * nextObj = IGCHeap::GetGCHeap ()->NextObj (this);
             if ((nextObj != NULL) &&
                 (nextObj->GetGCSafeMethodTable() != g_pFreeObjectMethodTable))
             {
@@ -1949,7 +1949,7 @@ STRINGREF StringObject::NewString(const WCHAR *pwsz)
         // pinning and then later put into a struct and that struct is
         // then marshalled to managed.  
         //
-        _ASSERTE(!GCHeap::GetGCHeap()->IsHeapPointer((BYTE *) pwsz) ||
+        _ASSERTE(!IGCHeap::GetGCHeap()->IsHeapPointer((BYTE *) pwsz) ||
                  !"pwsz can not point to GC Heap");
 #endif // 0
 
@@ -1988,7 +1988,7 @@ STRINGREF StringObject::NewString(const WCHAR *pwsz, int length) {
         // pinning and then later put into a struct and that struct is
         // then marshalled to managed.  
         //
-        _ASSERTE(!GCHeap::GetGCHeap()->IsHeapPointer((BYTE *) pwsz) ||
+        _ASSERTE(!IGCHeap::GetGCHeap()->IsHeapPointer((BYTE *) pwsz) ||
                  !"pwsz can not point to GC Heap");
 #endif // 0
         STRINGREF pString = AllocateString(length);
@@ -2664,7 +2664,7 @@ OBJECTREF::OBJECTREF(const OBJECTREF & objref)
     // !!! Either way you need to fix the code.
     _ASSERTE(Thread::IsObjRefValid(&objref));
     if ((objref.m_asObj != 0) &&
-        ((GCHeap*)GCHeap::GetGCHeap())->IsHeapPointer( (BYTE*)this ))
+        ((GCHeap*)IGCHeap::GetGCHeap())->IsHeapPointer( (BYTE*)this ))
     {
         _ASSERTE(!"Write Barrier violation. Must use SetObjectReference() to assign OBJECTREF's into the GC heap!");
     }
@@ -2718,7 +2718,7 @@ OBJECTREF::OBJECTREF(Object *pObject)
     DEBUG_ONLY_FUNCTION;
     
     if ((pObject != 0) &&
-        ((GCHeap*)GCHeap::GetGCHeap())->IsHeapPointer( (BYTE*)this ))
+        ((GCHeap*)IGCHeap::GetGCHeap())->IsHeapPointer( (BYTE*)this ))
     {
         _ASSERTE(!"Write Barrier violation. Must use SetObjectReference() to assign OBJECTREF's into the GC heap!");
     }
@@ -2901,7 +2901,7 @@ OBJECTREF& OBJECTREF::operator=(const OBJECTREF &objref)
     _ASSERTE(Thread::IsObjRefValid(&objref));
 
     if ((objref.m_asObj != 0) &&
-        ((GCHeap*)GCHeap::GetGCHeap())->IsHeapPointer( (BYTE*)this ))
+        ((GCHeap*)IGCHeap::GetGCHeap())->IsHeapPointer( (BYTE*)this ))
     {
         _ASSERTE(!"Write Barrier violation. Must use SetObjectReference() to assign OBJECTREF's into the GC heap!");
     }
@@ -2948,14 +2948,14 @@ void* __cdecl GCSafeMemCpy(void * dest, const void * src, size_t len)
     {
         Thread* pThread = GetThread();
 
-        // GCHeap::IsHeapPointer has race when called in preemptive mode. It walks the list of segments
+        // IGCHeap::IsHeapPointer has race when called in preemptive mode. It walks the list of segments
         // that can be modified by GC. Do the check below only if it is safe to do so.
         if (pThread != NULL && pThread->PreemptiveGCDisabled())
         {
             // Note there is memcpyNoGCRefs which will allow you to do a memcpy into the GC
             // heap if you really know you don't need to call the write barrier
 
-            _ASSERTE(!GCHeap::GetGCHeap()->IsHeapPointer((BYTE *) dest) ||
+            _ASSERTE(!IGCHeap::GetGCHeap()->IsHeapPointer((BYTE *) dest) ||
                      !"using memcpy to copy into the GC heap, use CopyValueClass");
         }
     }

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1175,7 +1175,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
     if (g_pConfig->ShouldPrestubGC(this))
     {
         GCX_COOP();
-        GCHeap::GetGCHeap()->GarbageCollect(-1);
+        IGCHeap::GetGCHeap()->GarbageCollect(-1);
     }
 #endif // _DEBUG
 

--- a/src/vm/profattach.cpp
+++ b/src/vm/profattach.cpp
@@ -806,7 +806,7 @@ void ProfilingAPIAttachDetach::InitializeAttachThreadingMode()
     // Environment variable trumps all, so check it first
     DWORD dwAlwaysOn = g_pConfig->GetConfigDWORD_DontUse_(
         CLRConfig::EXTERNAL_AttachThreadAlwaysOn,
-        GCHeap::IsServerHeap() ? 1 : 0);      // Default depends on GC server mode
+        IGCHeap::IsServerHeap() ? 1 : 0);      // Default depends on GC server mode
 
     if (dwAlwaysOn == 0)
     {

--- a/src/vm/profilinghelper.cpp
+++ b/src/vm/profilinghelper.cpp
@@ -1413,7 +1413,7 @@ void ProfilingAPIUtility::TerminateProfiling()
         {
             // We know for sure GC has been fully initialized as we've turned off concurrent GC before
             _ASSERTE(IsGarbageCollectorFullyInitialized());
-            GCHeap::GetGCHeap()->TemporaryEnableConcurrentGC();
+            IGCHeap::GetGCHeap()->TemporaryEnableConcurrentGC();
             g_profControlBlock.fConcurrentGCDisabledForAttach = FALSE;
         }
 

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -754,7 +754,7 @@ struct GenerationTable
 
 //---------------------------------------------------------------------------------------
 //
-// This is a callback used by the GC when we call GCHeap::DescrGenerationsToProfiler
+// This is a callback used by the GC when we call IGCHeap::DescrGenerationsToProfiler
 // (from UpdateGenerationBounds() below).  The GC gives us generation information through
 // this callback, which we use to update the GenerationDesc in the corresponding
 // GenerationTable
@@ -874,7 +874,7 @@ void __stdcall UpdateGenerationBounds()
 #endif
         // fill in the values by calling back into the gc, which will report
         // the ranges by calling GenWalkFunc for each one
-        GCHeap *hp = GCHeap::GetGCHeap();
+        IGCHeap *hp = IGCHeap::GetGCHeap();
         hp->DescrGenerationsToProfiler(GenWalkFunc, newGenerationTable);
 
         // remember the old table and plug in the new one
@@ -1018,7 +1018,7 @@ ClassID SafeGetClassIDFromObject(Object * pObj)
 
 //---------------------------------------------------------------------------------------
 //
-// Callback of type walk_fn used by GCHeap::WalkObject.  Keeps a count of each
+// Callback of type walk_fn used by IGCHeap::WalkObject.  Keeps a count of each
 // object reference found.
 //
 // Arguments:
@@ -1040,7 +1040,7 @@ BOOL CountContainedObjectRef(Object * pBO, void * context)
 
 //---------------------------------------------------------------------------------------
 //
-// Callback of type walk_fn used by GCHeap::WalkObject.  Stores each object reference
+// Callback of type walk_fn used by IGCHeap::WalkObject.  Stores each object reference
 // encountered into an array.
 //
 // Arguments:
@@ -1113,7 +1113,7 @@ BOOL HeapWalkHelper(Object * pBO, void * pvContext)
     if (pMT->ContainsPointersOrCollectible())
     {
         // First round through calculates the number of object refs for this class
-        GCHeap::GetGCHeap()->WalkObject(pBO, &CountContainedObjectRef, (void *)&cNumRefs);
+        IGCHeap::GetGCHeap()->WalkObject(pBO, &CountContainedObjectRef, (void *)&cNumRefs);
 
         if (cNumRefs > 0)
         {
@@ -1138,7 +1138,7 @@ BOOL HeapWalkHelper(Object * pBO, void * pvContext)
 
             // Second round saves off all of the ref values
             OBJECTREF * pCurObjRef = arrObjRef;
-            GCHeap::GetGCHeap()->WalkObject(pBO, &SaveContainedObjectRef, (void *)&pCurObjRef);
+            IGCHeap::GetGCHeap()->WalkObject(pBO, &SaveContainedObjectRef, (void *)&pCurObjRef);
         }
     }
 
@@ -9461,7 +9461,7 @@ FCIMPL2(void, ProfilingFCallHelper::FC_RemotingClientSendingMessage, GUID *pId, 
     // it is a value class declared on the stack and so GC doesn't
     // know about it.
 
-    _ASSERTE (!GCHeap::GetGCHeap()->IsHeapPointer(pId));     // should be on the stack, not in the heap
+    _ASSERTE (!IGCHeap::GetGCHeap()->IsHeapPointer(pId));     // should be on the stack, not in the heap
     HELPER_METHOD_FRAME_BEGIN_NOPOLL();
 
     {

--- a/src/vm/rcwwalker.cpp
+++ b/src/vm/rcwwalker.cpp
@@ -129,10 +129,10 @@ STDMETHODIMP CLRServicesImpl::GarbageCollect(DWORD dwFlags)
     {
         GCX_COOP_THREAD_EXISTS(GET_THREAD());
         if (dwFlags & GC_FOR_APPX_SUSPEND) {
-            GCHeap::GetGCHeap()->GarbageCollect(2, TRUE, collection_blocking | collection_optimized);
+            IGCHeap::GetGCHeap()->GarbageCollect(2, TRUE, collection_blocking | collection_optimized);
         }
         else
-            GCHeap::GetGCHeap()->GarbageCollect();
+            IGCHeap::GetGCHeap()->GarbageCollect();
     }
     END_EXTERNAL_ENTRYPOINT;
     return hr;

--- a/src/vm/runtimecallablewrapper.cpp
+++ b/src/vm/runtimecallablewrapper.cpp
@@ -1591,7 +1591,7 @@ public:
 
         if (pRCW->IsValid())
         {
-            if (!GCHeap::GetGCHeap()->IsPromoted(OBJECTREFToObject(pRCW->GetExposedObject())) &&
+            if (!IGCHeap::GetGCHeap()->IsPromoted(OBJECTREFToObject(pRCW->GetExposedObject())) &&
                 !pRCW->IsDetached())
             {
                 // No need to use InterlockedOr here since every other place that modifies the flags
@@ -1612,7 +1612,7 @@ void RCWCache::DetachWrappersWorker()
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION(GCHeap::IsGCInProgress()); // GC is in progress and the runtime is suspended
+        PRECONDITION(IGCHeap::IsGCInProgress()); // GC is in progress and the runtime is suspended
     }
     CONTRACTL_END;
 
@@ -2808,7 +2808,7 @@ void RCW::MinorCleanup()
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION(GCHeap::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ));
+        PRECONDITION(IGCHeap::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ));
     }
     CONTRACTL_END;
     

--- a/src/vm/safehandle.cpp
+++ b/src/vm/safehandle.cpp
@@ -246,7 +246,7 @@ void SafeHandle::Dispose()
     // Suppress finalization on this object (we may be racing here but the
     // operation below is idempotent and a dispose should never race a
     // finalization).
-    GCHeap::GetGCHeap()->SetFinalizationRun(OBJECTREFToObject(sh));
+    IGCHeap::GetGCHeap()->SetFinalizationRun(OBJECTREFToObject(sh));
     GCPROTECT_END();
 }
 
@@ -394,7 +394,7 @@ FCIMPL1(void, SafeHandle::SetHandleAsInvalid, SafeHandle* refThisUNSAFE)
 
     } while (InterlockedCompareExchange((LONG*)&sh->m_state, newState, oldState) != oldState);
 
-    GCHeap::GetGCHeap()->SetFinalizationRun(OBJECTREFToObject(sh));
+    IGCHeap::GetGCHeap()->SetFinalizationRun(OBJECTREFToObject(sh));
 }
 FCIMPLEND
 

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -14,7 +14,7 @@
 #include "clsload.hpp"
 #include "vars.hpp"
 #include "excep.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "field.h"
 #include "eeconfig.h"
 #include "runtimehandles.h" // for SignatureNative

--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -19,7 +19,7 @@
 #include "security.h"
 #include "eventtrace.h"
 #include "comdatetime.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "interoputil.h"
 #include "gcscan.h"
 #ifdef FEATURE_REMOTING
@@ -70,7 +70,7 @@ void StubHelpers::ValidateObjectInternal(Object *pObjUNSAFE, BOOL fValidateNextO
 	// and the next object as required
 	if (fValidateNextObj)
 	{
-		Object *nextObj = GCHeap::GetGCHeap()->NextObj(pObjUNSAFE);
+		Object *nextObj = IGCHeap::GetGCHeap()->NextObj(pObjUNSAFE);
 		if (nextObj != NULL)
 		{
 			// Note that the MethodTable of the object (i.e. the pointer at offset 0) can change from
@@ -162,7 +162,7 @@ void StubHelpers::ProcessByrefValidationList()
         {
             entry = s_ByrefValidationEntries[i];
 
-            Object *pObjUNSAFE = GCHeap::GetGCHeap()->GetGCHeap()->GetContainingObject(entry.pByref);
+            Object *pObjUNSAFE = IGCHeap::GetGCHeap()->GetContainingObject(entry.pByref);
             ValidateObjectInternal(pObjUNSAFE, TRUE);
         }
     }
@@ -2000,7 +2000,7 @@ FCIMPL3(void, StubHelpers::ValidateObject, Object *pObjUNSAFE, MethodDesc *pMD, 
         AVInRuntimeImplOkayHolder AVOkay;
 		// don't validate the next object if a BGC is in progress.  we can race with background
 	    // sweep which could make the next object a Free object underneath us if it's dead.
-        ValidateObjectInternal(pObjUNSAFE, !(GCHeap::GetGCHeap()->IsConcurrentGCInProgress()));
+        ValidateObjectInternal(pObjUNSAFE, !(IGCHeap::GetGCHeap()->IsConcurrentGCInProgress()));
     }
     EX_CATCH
     {
@@ -2027,7 +2027,7 @@ FCIMPL3(void, StubHelpers::ValidateByref, void *pByref, MethodDesc *pMD, Object 
     // perform the validation on next GC (see code:StubHelpers.ProcessByrefValidationList).
 
     // Skip byref if is not pointing inside managed heap
-    if (!GCHeap::GetGCHeap()->IsHeapPointer(pByref))
+    if (!IGCHeap::GetGCHeap()->IsHeapPointer(pByref))
     {
         return;
     }
@@ -2062,7 +2062,7 @@ FCIMPL3(void, StubHelpers::ValidateByref, void *pByref, MethodDesc *pMD, Object 
     if (NumOfEntries > BYREF_VALIDATION_LIST_MAX_SIZE)
     {
         // if the list is too big, trigger GC now
-        GCHeap::GetGCHeap()->GarbageCollect(0);
+        IGCHeap::GetGCHeap()->GarbageCollect(0);
     }
 
     HELPER_METHOD_FRAME_END();

--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -1372,7 +1372,7 @@ void SyncBlockCache::GCWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintp
        STRESS_LOG0 (LF_GC | LF_SYNC, LL_INFO100, "GCWeakPtrScan starting\n");
 #endif
 
-   if (GCHeap::GetGCHeap()->GetCondemnedGeneration() < GCHeap::GetGCHeap()->GetMaxGeneration())
+   if (IGCHeap::GetGCHeap()->GetCondemnedGeneration() < IGCHeap::GetGCHeap()->GetMaxGeneration())
    {
 #ifdef VERIFY_HEAP
         //for VSW 294550: we saw stale obeject reference in SyncBlkCache, so we want to make sure the card 
@@ -1416,7 +1416,7 @@ void SyncBlockCache::GCWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintp
                                 Object* o = SyncTableEntry::GetSyncTableEntry()[nb].m_Object;
                                 if (o && !((size_t)o & 1))
                                 {
-                                    if (GCHeap::GetGCHeap()->IsEphemeral (o))
+                                    if (IGCHeap::GetGCHeap()->IsEphemeral (o))
                                     {
                                         clear_card = FALSE;
 
@@ -1615,8 +1615,8 @@ void SyncBlockCache::GCDone(BOOL demoting, int max_gen)
     CONTRACTL_END;
 
     if (demoting && 
-        (GCHeap::GetGCHeap()->GetCondemnedGeneration() == 
-         GCHeap::GetGCHeap()->GetMaxGeneration()))
+        (IGCHeap::GetGCHeap()->GetCondemnedGeneration() == 
+         IGCHeap::GetGCHeap()->GetMaxGeneration()))
     {
         //scan the bitmap
         size_t dw = 0;
@@ -1643,7 +1643,7 @@ void SyncBlockCache::GCDone(BOOL demoting, int max_gen)
                                 Object* o = SyncTableEntry::GetSyncTableEntry()[nb].m_Object;
                                 if (o && !((size_t)o & 1))
                                 {
-                                    if (GCHeap::GetGCHeap()->WhichGeneration (o) < (unsigned int)max_gen)
+                                    if (IGCHeap::GetGCHeap()->WhichGeneration (o) < (unsigned int)max_gen)
                                     {
                                         SetCard (card);
                                         break;
@@ -1713,7 +1713,7 @@ void SyncBlockCache::VerifySyncTableEntry()
             
             DWORD idx = o->GetHeader()->GetHeaderSyncBlockIndex();
             _ASSERTE(idx == nb || ((0 == idx) && (loop == max_iterations)));
-            _ASSERTE(!GCHeap::GetGCHeap()->IsEphemeral(o) || CardSetP(CardOf(nb)));
+            _ASSERTE(!IGCHeap::GetGCHeap()->IsEphemeral(o) || CardSetP(CardOf(nb)));
         }
     }
 }
@@ -2498,10 +2498,10 @@ BOOL ObjHeader::Validate (BOOL bVerifySyncBlkIndex)
     //BIT_SBLK_GC_RESERVE (0x20000000) is only set during GC. But for frozen object, we don't clean the bit
     if (bits & BIT_SBLK_GC_RESERVE)
     {
-        if (!GCHeap::GetGCHeap()->IsGCInProgress () && !GCHeap::GetGCHeap()->IsConcurrentGCInProgress ())
+        if (!IGCHeap::GetGCHeap()->IsGCInProgress () && !IGCHeap::GetGCHeap()->IsConcurrentGCInProgress ())
         {
 #ifdef FEATURE_BASICFREEZE
-            ASSERT_AND_CHECK (GCHeap::GetGCHeap()->IsInFrozenSegment(obj));
+            ASSERT_AND_CHECK (IGCHeap::GetGCHeap()->IsInFrozenSegment(obj));
 #else //FEATURE_BASICFREEZE
             _ASSERTE(!"Reserve bit not cleared");
             return FALSE;

--- a/src/vm/syncclean.cpp
+++ b/src/vm/syncclean.cpp
@@ -73,7 +73,7 @@ void SyncClean::CleanUp ()
     // Only GC thread can call this.
     _ASSERTE (g_fProcessDetach || 
               IsGCSpecialThread() ||
-              (GCHeap::IsGCInProgress()  && GetThread() == ThreadSuspend::GetSuspensionThread()));
+              (IGCHeap::IsGCInProgress()  && GetThread() == ThreadSuspend::GetSuspensionThread()));
     if (m_HashMap)
     {
         Bucket * pTempBucket = FastInterlockExchangePointer(m_HashMap.GetPointer(), NULL);

--- a/src/vm/testhookmgr.cpp
+++ b/src/vm/testhookmgr.cpp
@@ -655,7 +655,7 @@ HRESULT CLRTestHookManager::GC(int generation)
     CONTRACTL_END;
 
     _ASSERTE(GetThread()==NULL || !GetThread()->PreemptiveGCDisabled());
-    GCHeap::GetGCHeap()->GarbageCollect(generation);
+    IGCHeap::GetGCHeap()->GarbageCollect(generation);
     FinalizerThread::FinalizerThreadWait();
     return S_OK;
 }

--- a/src/vm/threadpoolrequest.cpp
+++ b/src/vm/threadpoolrequest.cpp
@@ -511,11 +511,11 @@ void UnManagedPerAppDomainTPCount::DispatchWorkItem(bool* foundWork, bool* wasNo
         firstIteration = false;
         *foundWork = true;
 
-        if (GCHeap::IsGCInProgress(TRUE))
+        if (IGCHeap::IsGCInProgress(TRUE))
         {
             // GC is imminent, so wait until GC is complete before executing next request.
             // this reduces in-flight objects allocated right before GC, easing the GC's work
-            GCHeap::WaitForGCCompletion(TRUE);
+            IGCHeap::WaitForGCCompletion(TRUE);
         }
 
         PREFIX_ASSUME(pWorkRequest != NULL);

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -18,7 +18,7 @@
 #include "excep.h"
 #include "comsynchronizable.h"
 #include "log.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "mscoree.h"
 #include "dbginterface.h"
 #include "corprof.h"                // profiling
@@ -3892,14 +3892,14 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
 #endif
     }
 
-    if  (GCHeap::IsGCHeapInitialized())
+    if  (IGCHeap::IsGCHeapInitialized())
     {
         // Guaranteed to NOT be a shutdown case, because we tear down the heap before
         // we tear down any threads during shutdown.
         if (ThisThreadID == CurrentThreadID)
         {
             GCX_COOP();
-            GCHeap::GetGCHeap()->FixAllocContext(&m_alloc_context, FALSE, NULL, NULL);
+            IGCHeap::GetGCHeap()->FixAllocContext(&m_alloc_context, FALSE, NULL, NULL);
             m_alloc_context.init();
         }
     }
@@ -3960,11 +3960,11 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
 #endif
         }
 
-        if  (GCHeap::IsGCHeapInitialized() && ThisThreadID != CurrentThreadID)
+        if  (IGCHeap::IsGCHeapInitialized() && ThisThreadID != CurrentThreadID)
         {
             // We must be holding the ThreadStore lock in order to clean up alloc context.
             // We should never call FixAllocContext during GC.
-            GCHeap::GetGCHeap()->FixAllocContext(&m_alloc_context, FALSE, NULL, NULL);
+            IGCHeap::GetGCHeap()->FixAllocContext(&m_alloc_context, FALSE, NULL, NULL);
             m_alloc_context.init();
         }
 
@@ -9849,7 +9849,7 @@ void Thread::DoExtraWorkForFinalizer()
         Thread::CleanupDetachedThreads();
     }
     
-    if(ExecutionManager::IsCacheCleanupRequired() && GCHeap::GetGCHeap()->GetCondemnedGeneration()>=1)
+    if(ExecutionManager::IsCacheCleanupRequired() && IGCHeap::GetGCHeap()->GetCondemnedGeneration()>=1)
     {
         ExecutionManager::ClearCaches();
     }
@@ -11189,7 +11189,7 @@ void Thread::SetHasPromotedBytes ()
 
     m_fPromoted = TRUE;
 
-    _ASSERTE(GCHeap::IsGCInProgress()  && IsGCThread ());
+    _ASSERTE(IGCHeap::IsGCInProgress()  && IsGCThread ());
 
     if (!m_fPreemptiveGCDisabled)
     {
@@ -11619,7 +11619,7 @@ HRESULT Thread::GetMemStats (COR_GC_THREAD_STATS *pStats)
     CONTRACTL_END;
 
     // Get the allocation context which contains this counter in it.
-    alloc_context *p = &m_alloc_context;
+    gc_alloc_context *p = &m_alloc_context;
     pStats->PerThreadAllocation = p->alloc_bytes + p->alloc_bytes_loh;
     if (GetHasPromotedBytes())
         pStats->Flags = COR_GC_THREAD_HAS_PROMOTED_BYTES;

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -142,7 +142,7 @@
 #include "regdisp.h"
 #include "mscoree.h"
 #include "appdomainstack.h"
-#include "gc.h"
+#include "gcinterface.h"
 #include "gcinfotypes.h"
 #include <clrhost.h>
 
@@ -1739,9 +1739,9 @@ public:
 
     // on MP systems, each thread has its own allocation chunk so we can avoid
     // lock prefixes and expensive MP cache snooping stuff
-    alloc_context        m_alloc_context;
+    gc_alloc_context        m_alloc_context;
 
-    inline alloc_context *GetAllocContext() { LIMITED_METHOD_CONTRACT; return &m_alloc_context; }
+    inline gc_alloc_context *GetAllocContext() { LIMITED_METHOD_CONTRACT; return &m_alloc_context; }
 
     // This is the type handle of the first object in the alloc context at the time 
     // we fire the AllocationTick event. It's only for tooling purpose.
@@ -4884,7 +4884,7 @@ private:
 private:
     // When we create an object, or create an OBJECTREF, or create an Interior Pointer, or enter EE from managed
     // code, we will set this flag.
-    // Inside GCHeap::StressHeap, we only do GC if this flag is TRUE.  Then we reset it to zero.
+    // Inside IGCHeap::StressHeap, we only do GC if this flag is TRUE.  Then we reset it to zero.
     BOOL m_fStressHeapCount;
 public:
     void EnableStressHeap()

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -3278,7 +3278,7 @@ void Thread::RareDisablePreemptiveGC()
         __SwitchToThread(0, CALLER_LIMITS_SPINNING);
     }
 
-    if (!GCHeap::IsGCHeapInitialized())
+    if (!IGCHeap::IsGCHeapInitialized())
     {
         goto Exit;
     }
@@ -3286,7 +3286,7 @@ void Thread::RareDisablePreemptiveGC()
     // Note IsGCInProgress is also true for say Pause (anywhere SuspendEE happens) and GCThread is the 
     // thread that did the Pause. While in Pause if another thread attempts Rev/Pinvoke it should get inside the following and 
     // block until resume
-    if (((GCHeap::IsGCInProgress()  && (this != ThreadSuspend::GetSuspensionThread())) ||
+    if (((IGCHeap::IsGCInProgress()  && (this != ThreadSuspend::GetSuspensionThread())) ||
         (m_State & (TS_UserSuspendPending | TS_DebugSuspendPending | TS_StackCrawlNeeded))) &&
         (!g_fSuspendOnShutdown || IsFinalizerThread() || IsShutdownSpecialThread()))
     {
@@ -3352,7 +3352,7 @@ void Thread::RareDisablePreemptiveGC()
 
                     DWORD status = S_OK;
                     SetThreadStateNC(TSNC_WaitUntilGCFinished);
-                    status = GCHeap::GetGCHeap()->WaitUntilGCComplete();
+                    status = IGCHeap::GetGCHeap()->WaitUntilGCComplete();
                     ResetThreadStateNC(TSNC_WaitUntilGCFinished);
 
                     if (status == (DWORD)COR_E_STACKOVERFLOW)
@@ -3361,7 +3361,7 @@ void Thread::RareDisablePreemptiveGC()
                         // 1. GC is suspending the process.  GC needs to wait.
                         // 2. GC is proceeding after suspension.  The current thread needs to spin.
                         SetThreadState(TS_BlockGCForSO);
-                        while (GCHeap::IsGCInProgress() && m_fPreemptiveGCDisabled.Load() == 0)
+                        while (IGCHeap::IsGCInProgress() && m_fPreemptiveGCDisabled.Load() == 0)
                         {
 #undef Sleep
                             // We can not go to a host for blocking operation due ot lack of stack.
@@ -3378,7 +3378,7 @@ void Thread::RareDisablePreemptiveGC()
                             break;
                         }
                     }
-                    if (!GCHeap::IsGCInProgress())
+                    if (!IGCHeap::IsGCInProgress())
                     {
                         if (HasThreadState(TS_StackCrawlNeeded))
                         {
@@ -3413,7 +3413,7 @@ void Thread::RareDisablePreemptiveGC()
                 // thread while in this loop.  This happens if you use the COM+
                 // debugger to suspend this thread and then release it.
 
-            } while ((GCHeap::IsGCInProgress()  && (this != ThreadSuspend::GetSuspensionThread())) ||
+            } while ((IGCHeap::IsGCInProgress()  && (this != ThreadSuspend::GetSuspensionThread())) ||
                      (m_State & (TS_UserSuspendPending | TS_DebugSuspendPending | TS_StackCrawlNeeded)));
         }
         STRESS_LOG0(LF_SYNC, LL_INFO1000, "RareDisablePreemptiveGC: leaving\n");
@@ -3707,7 +3707,7 @@ void Thread::PerformPreemptiveGC()
     if (!GCStressPolicy::IsEnabled() || !GCStress<cfg_transition>::IsEnabled())
         return;
 
-    if (!GCHeap::IsGCHeapInitialized())
+    if (!IGCHeap::IsGCHeapInitialized())
         return;
 
     if (!m_GCOnTransitionsOK
@@ -3715,8 +3715,8 @@ void Thread::PerformPreemptiveGC()
         || RawGCNoTrigger()
 #endif
         || g_fEEShutDown
-        || GCHeap::IsGCInProgress(TRUE)
-        || GCHeap::GetGCHeap()->GetGcCount() == 0    // Need something that works for isolated heap.
+        || IGCHeap::IsGCInProgress(TRUE)
+        || IGCHeap::GetGCHeap()->GetGcCount() == 0    // Need something that works for isolated heap.
         || ThreadStore::HoldingThreadStore())
         return;
 
@@ -3740,7 +3740,7 @@ void Thread::PerformPreemptiveGC()
     {
         GCX_COOP();
         m_bGCStressing = TRUE;
-        GCHeap::GetGCHeap()->StressHeap();
+        IGCHeap::GetGCHeap()->StressHeap();
         m_bGCStressing = FALSE;
     }
     m_GCOnTransitionsOK = TRUE;
@@ -4848,7 +4848,7 @@ HRESULT ThreadSuspend::SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason)
     // Caller is expected to be holding the ThreadStore lock.  Also, caller must
     // have set GcInProgress before coming here, or things will break;
     _ASSERTE(ThreadStore::HoldingThreadStore() || IsAtProcessExit());
-    _ASSERTE(GCHeap::IsGCInProgress() );
+    _ASSERTE(IGCHeap::IsGCInProgress() );
 
     STRESS_LOG1(LF_SYNC, LL_INFO1000, "Thread::SuspendRuntime(reason=0x%x)\n", reason);
 
@@ -5549,7 +5549,7 @@ void ThreadSuspend::ResumeRuntime(BOOL bFinishedGC, BOOL SuspendSucceded)
     // reset GcInProgress, or threads will continue to suspend themselves and won't
     // be resumed until the next GC.
     _ASSERTE(IsGCSpecialThread() || ThreadStore::HoldingThreadStore());
-    _ASSERTE(!GCHeap::IsGCInProgress() );
+    _ASSERTE(!IGCHeap::IsGCInProgress() );
 
     STRESS_LOG2(LF_SYNC, LL_INFO1000, "Thread::ResumeRuntime(finishedGC=%d, SuspendSucceeded=%d) - Start\n", bFinishedGC, SuspendSucceded);
 
@@ -5566,7 +5566,7 @@ void ThreadSuspend::ResumeRuntime(BOOL bFinishedGC, BOOL SuspendSucceded)
     {
         // If we the suspension was for a GC, tell the host what generation GC.
         DWORD   Generation = (bFinishedGC
-                              ? GCHeap::GetGCHeap()->GetCondemnedGeneration()
+                              ? IGCHeap::GetGCHeap()->GetCondemnedGeneration()
                               : ~0U);
 
         pGCThreadControl->SuspensionEnding(Generation);
@@ -5576,7 +5576,7 @@ void ThreadSuspend::ResumeRuntime(BOOL bFinishedGC, BOOL SuspendSucceded)
     {
         // If we the suspension was for a GC, tell the host what generation GC.
         DWORD   Generation = (bFinishedGC
-                              ? GCHeap::GetGCHeap()->GetCondemnedGeneration()
+                              ? IGCHeap::GetGCHeap()->GetCondemnedGeneration()
                               : ~0U);
 
         BEGIN_SO_TOLERANT_CODE_CALLING_HOST(GetThread());
@@ -7900,7 +7900,7 @@ void ThreadSuspend::RestartEE(BOOL bFinishedGC, BOOL SuspendSucceded)
     // Revert to being a normal thread
     // 
     ClrFlsClearThreadType (ThreadType_DynamicSuspendEE);
-    GCHeap::GetGCHeap()->SetGCInProgress(FALSE);
+    IGCHeap::GetGCHeap()->SetGCInProgress(FALSE);
 
     //
     // Allow threads to enter COOP mode (though we still need to wake the ones
@@ -7908,7 +7908,7 @@ void ThreadSuspend::RestartEE(BOOL bFinishedGC, BOOL SuspendSucceded)
     //
     // Note: this is the last barrier that keeps managed threads
     // from entering cooperative mode. If the sequence changes,
-    // you may have to change routine GCHeap::SafeToRestartManagedThreads
+    // you may have to change routine IGCHeap::SafeToRestartManagedThreads
     // as well.
     //
     ThreadStore::TrapReturningThreads(FALSE);
@@ -7917,7 +7917,7 @@ void ThreadSuspend::RestartEE(BOOL bFinishedGC, BOOL SuspendSucceded)
     // 
     // Any threads that are waiting in WaitUntilGCComplete will continue now.
     //
-    GCHeap::GetGCHeap()->GetWaitForGCEvent()->Set();
+    IGCHeap::GetGCHeap()->GetWaitForGCEvent()->Set();
     _ASSERTE(IsGCSpecialThread() || ThreadStore::HoldingThreadStore());
 
     ResumeRuntime(bFinishedGC, SuspendSucceded);
@@ -7966,7 +7966,7 @@ void ThreadSuspend::SuspendEE(SUSPEND_REASON reason)
     ETW::GCLog::ETW_GC_INFO Info;
     Info.SuspendEE.Reason = reason;
     Info.SuspendEE.GcCount = (((reason == SUSPEND_FOR_GC) || (reason == SUSPEND_FOR_GC_PREP)) ? 
-                              (ULONG)GCHeap::GetGCHeap()->GetGcCount() : (ULONG)-1);
+                              (ULONG)IGCHeap::GetGCHeap()->GetGcCount() : (ULONG)-1);
 
     FireEtwGCSuspendEEBegin_V1(Info.SuspendEE.Reason, Info.SuspendEE.GcCount, GetClrInstanceId());
 
@@ -8043,7 +8043,7 @@ retry_for_debugger:
         //
         // First, we reset the event that we're about to tell other threads to wait for.
         //
-        GCHeap::GetGCHeap()->GetWaitForGCEvent()->Reset();
+        IGCHeap::GetGCHeap()->GetWaitForGCEvent()->Reset();
 
         //
         // Remember that we're the one doing the GC.  Actually, maybe we're not doing a GC -
@@ -8068,7 +8068,7 @@ retry_for_debugger:
             // It seems like much of the above is redundant.  We should investigate reducing the number
             // of mechanisms we use to indicate that a suspension is in progress.
             //
-            GCHeap::GetGCHeap()->SetGCInProgress(TRUE);
+            IGCHeap::GetGCHeap()->SetGCInProgress(TRUE);
 
             //
             // Gratuitous memory barrier.  (may be needed - but I'm not sure why.)
@@ -8359,7 +8359,7 @@ void ThreadSuspend::Initialize()
 BOOL Debug_IsLockedViaThreadSuspension()
 {
     LIMITED_METHOD_CONTRACT;
-    return GCHeap::IsGCInProgress() && 
+    return IGCHeap::IsGCInProgress() && 
                     (dbgOnly_IsSpecialEEThread() || 
                     IsGCSpecialThread() || 
                     GetThread() == ThreadSuspend::GetSuspensionThread());
@@ -8487,7 +8487,7 @@ void SuspendStatistics::EndSuspend(BOOL bForGC)
     // details on suspends...
     if (!bForGC)
         cntNonGCSuspends++;
-    if (GCHeap::GetGCHeap()->IsConcurrentGCInProgress())
+    if (IGCHeap::GetGCHeap()->IsConcurrentGCInProgress())
     {
         cntSuspendsInBGC++;
         if (!bForGC)

--- a/src/vm/vars.hpp
+++ b/src/vm/vars.hpp
@@ -81,7 +81,7 @@ typedef unsigned short wchar_t;
 
 class ClassLoader;
 class LoaderHeap;
-class GCHeap;
+class IGCHeap;
 class Object;
 class StringObject;
 class TransparentProxyObject;

--- a/src/vm/weakreferencenative.cpp
+++ b/src/vm/weakreferencenative.cpp
@@ -12,7 +12,8 @@
 #include "common.h"
 
 #include "weakreferencenative.h"
-#include "handletablepriv.h"
+// TODO(segilles) GC interface violation
+#include "../gc/handletablepriv.h"
 
 //************************************************************************
 

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -2350,11 +2350,11 @@ Work:
         counts = oldCounts;
     }
 
-    if (GCHeap::IsGCInProgress(TRUE))
+    if (IGCHeap::IsGCInProgress(TRUE))
     {
         // GC is imminent, so wait until GC is complete before executing next request.
         // this reduces in-flight objects allocated right before GC, easing the GC's work
-        GCHeap::WaitForGCCompletion(TRUE);
+        IGCHeap::WaitForGCCompletion(TRUE);
     }
 
     {
@@ -3964,7 +3964,7 @@ Top:
 
             if (key != 0)
             {
-                if (GCHeap::IsGCInProgress(TRUE))
+                if (IGCHeap::IsGCInProgress(TRUE))
                 {
                     //Indicate that this thread is free, and waiting on GC, not doing any user work.
                     //This helps in threads not getting injected when some threads have woken up from the
@@ -3980,7 +3980,7 @@ Top:
 
                     // GC is imminent, so wait until GC is complete before executing next request.
                     // this reduces in-flight objects allocated right before GC, easing the GC's work
-                    GCHeap::WaitForGCCompletion(TRUE);
+                    IGCHeap::WaitForGCCompletion(TRUE);
 
                     while (true)
                     {
@@ -4193,7 +4193,7 @@ BOOL ThreadpoolMgr::ShouldGrowCompletionPortThreadpool(ThreadCounter::Counts cou
 
     if (counts.NumWorking >= counts.NumActive 
         && NumCPInfrastructureThreads == 0
-        && (counts.NumActive == 0 ||  !GCHeap::IsGCInProgress(TRUE))
+        && (counts.NumActive == 0 ||  !IGCHeap::IsGCInProgress(TRUE))
         )
     {
         // adjust limit if neeeded
@@ -4593,7 +4593,7 @@ DWORD __stdcall ThreadpoolMgr::GateThreadStart(LPVOID lpArgs)
             EX_END_CATCH(SwallowAllExceptions);
         }
 
-        if (!GCHeap::IsGCInProgress(FALSE) )
+        if (!IGCHeap::IsGCInProgress(FALSE) )
         {
             if (IgnoreNextSample)
             {
@@ -4635,7 +4635,7 @@ DWORD __stdcall ThreadpoolMgr::GateThreadStart(LPVOID lpArgs)
                 oldCounts.NumActive < MaxLimitTotalCPThreads &&
                 !g_fCompletionPortDrainNeeded &&
                 NumCPInfrastructureThreads == 0 &&       // infrastructure threads count as "to be free as needed"
-                !GCHeap::IsGCInProgress(TRUE))
+                !IGCHeap::IsGCInProgress(TRUE))
 
             {
                 BOOL status;


### PR DESCRIPTION
This is quite a large change that introduces a new interface `IGCHeap` that abstracts away the details of the GC away from the VM. The changes in this PR fall into three categories:

1. The definition of `IGCHeap` itself (`gcinterface.h`) and code motion from `gc.h` to `gcinterface.h`. The public interface of the GC was moved from `gc.h` to `gcinterface.h`. This includes a number of enums and macro definitions that were used throughout the VM.
2. The abstraction of `alloc_context` (`gcinterface.h`). `alloc_context` is embedded by-value into the `Thread` class and so its layout must be known to the VM at compile-time. However, `alloc_context` also contains implementation details of the GC that can't be exposed by the interface. To solve this problem, `gc_alloc_context` is defined in `gcinterface.h` that provides the VM-facing interface of `alloc_context` (including two void pointers, containing GC implementation details). `alloc_context` is defined in `gc.h`, which contains two inline methods that reinterpret the opaque fields in `gc_alloc_context` as the values that the GC expects to be there today. This change required renaming VM uses of `alloc_context` to `gc_alloc_context`, as well as requiring a few downcasts within the GC itself whenever the GC-specific fields on `gc_alloc_context` are used. This accounts for the majority of the changes within `gc.cpp`.
3. Changing uses of `GCHeap` to `IGCHeap`. The VM today refers to the GC using the `GCHeap` class, so the act of introducing an interface naturally required uses of `GCHeap` to be renamed to `IGCHeap`.

While doing this work, I encountered six GC interface violations that I have left in place:

* [weakreference.cpp](https://github.com/swgillespie/coreclr/blob/gc-interface/src/vm/weakreferencenative.cpp#L16)
* [marshalnative.cpp](https://github.com/swgillespie/coreclr/blob/gc-interface/src/vm/marshalnative.cpp#L42)
* [appdomain.cpp 1](https://github.com/swgillespie/coreclr/blob/gc-interface/src/vm/appdomain.cpp#L5041)
* [appdomain.cpp 2](https://github.com/swgillespie/coreclr/blob/gc-interface/src/vm/appdomain.cpp#L5141)
* [appdomain.cpp 3](https://github.com/swgillespie/coreclr/blob/gc-interface/src/vm/appdomain.cpp#L5467)
* [appdomain.cpp 4](https://github.com/swgillespie/coreclr/blob/gc-interface/src/vm/appdomain.cpp#L11568)

All of these files directly reference private details of the handle table. We will need to address these at some point. All of the uses within `appdomain.cpp` are for debug asserts, but the uses within `weakreference.cpp` and `marshaknative.cpp` are not.

Once this has been merged, the next steps will be to ensure that the GC always interacts with the EE and OS through `GCToEEInterface` and `GCToOSInterface`, respectively. From there, we can decouple the GC from VM internals. Another step that will need to be done (not necessarily before or after the previous step) will be to trim down `IGCHeap` until it presents the interface that we'd like to exist, rather than how it is today.

I welcome any and all comments on this change. This is the start of a large change to the GC and VM as a whole, so I welcome all feedback to ensure that we are doing this in the most efficient and clean way. I do not plan on merging this until we are all happy with the direction and implications of this change.
