### PR TITLE
Fix exception filter getter for native frames

### DIFF
--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -417,7 +417,7 @@ NativeExceptionHolderBase::FindNextHolder(NativeExceptionHolderBase *currentHold
 
     while (holder != nullptr)
     {
-        if (((void *)holder > stackLowAddress) && ((void *)holder < stackHighAddress))
+        if (((void *)holder >= stackLowAddress) && ((void *)holder < stackHighAddress))
         { 
             return holder;
         }


### PR DESCRIPTION
@dotnet/dotnet-diag please, look at this PR and add anyone you think should take a look to.

For the OSX x64 Release build it appears that holder address is exactly matching stackLowAddress. So it's never called. For Debug build or Windows build this is not true.

Example of my debug output for Release build:
NativeExceptionHolderBase::FindNextHolder: init holder=0x7fff501ea888 stackLowAddress=**0x7fff501ea8c0** stackHighAddress=0x7fff501ea930 
NativeExceptionHolderBase::FindNextHolder: next: holder=0x7fff501ea888 name=NativeExceptionHolderNoCatch 
NativeExceptionHolderBase::FindNextHolder: next: holder=**0x7fff501ea8c0** name=NativeExceptionHolder<?> 

Example of my debug output for Debug build:
NativeExceptionHolderBase::FindNextHolder: init holder=0x7fff540cb0a0 **stackLowAddress**=0x7fff540cb110 stackHighAddress=**0x7fff540cb1d0** 
NativeExceptionHolderBase::FindNextHolder: next: holder=0x7fff540cb0a0 name=NativeExceptionHolderNoCatch 
NativeExceptionHolderBase::FindNextHolder: next: holder=**0x7fff540cb150** name=NativeExceptionHolder<?> 

This is during excecution of method call via reflection. Full code could be found in debuggertests repo at Debuggees/ReflectionTest/ReflectionTest.cs

Brief code:
...


// invoke ExceptionNoHandler() 
retval = (string)mi2.Invoke(invoked, null);

...

public string ExceptionNoHandler()
 {
    Console.WriteLine("Beginning of ExceptionNoHandler()");
    int i = 1;
    if (i == 1)
        throw new Exception("Exception from InvokedCode.Invoked.ExceptionNoHandler()");
    return "ERROR: Returned from ExceptionNoHandler()";
}


