### PR TITLE
Issue: If two threads try to load the same type it can cause clr to h…

### DIFF
--- a/src/vm/pendingload.h
+++ b/src/vm/pendingload.h
@@ -135,10 +135,6 @@ public:
             m_pException=NULL;
         }
         EX_END_CATCH(SwallowAllExceptions);
-
-        _ASSERTE(m_fLockAcquired);
-        m_Crst.Leave();
-        m_fLockAcquired = FALSE;
     }
     
     void SetResult(TypeHandle typeHnd)
@@ -153,6 +149,17 @@ public:
         CONTRACTL_END;
 
         m_typeHandle = typeHnd;
+    }
+    
+    void UnblockWaiters()
+    {
+        CONTRACTL
+        {
+              NOTHROW;
+              PRECONDITION(HasLock());
+              PRECONDITION(m_dwWaitCount > 0);
+        }
+        CONTRACTL_END;
 
         _ASSERTE(m_fLockAcquired);
         m_Crst.Leave();


### PR DESCRIPTION
Issue: If two threads try to load the same type it can cause clr to hang if the first thread to start the load happens to be a background thread. Background thread would create PendingTypeLoadEntry  and insert it into unresolvedClassHash. Second thread (having normal priority) would block on PendingTypeLoadEntry->m_crst waiting for the background thread to unblock it. After doing partial load of type background thread periodically checks if there are other threads waiting for type to get loaded. In this case it does find a thread waiting so it unblocks thread. However, background thread has not removed PendingTypeLoadEntry  from unresolvedClassHash. This causes the second thread to continue spinning and so not allowing background thread to get any processor cycles to remove PendingTypeLoadEntry  from unresolvedClassHash. This cause app to be seem like it has hung. It is possible that this may not repro on multi-proc machine where the background thread can get scheduled on another processor when second thread continues to spin on another processor.

Fix: First remove the PendingTypeLoadEntry  from unresolvedClassHash and then unblock the waiting threads.