### PR TITLE
Set DOES_NOT_RETURN gtCallMoreFlags in fgFindJumpTargets 

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4355,7 +4355,7 @@ protected:
 
     void fgLinkBasicBlocks();
 
-    void fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, BYTE* jumpTarget);
+    unsigned fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, BYTE* jumpTarget);
 
     void fgCheckBasicBlockControlFlow();
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4269,6 +4269,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, BYTE*
     const bool  isForceInline          = (info.compFlags & CORINFO_FLG_FORCEINLINE) != 0;
     const bool  makeInlineObservations = (compInlineResult != nullptr);
     const bool  isInlining             = compIsForInlining();
+    unsigned retBlocks = 0;
 
     if (makeInlineObservations)
     {
@@ -4638,6 +4639,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, BYTE*
             break;
 
             case CEE_JMP:
+                retBlocks++;
 
 #if !defined(_TARGET_X86_) && !defined(_TARGET_ARM_)
                 if (!isInlining)
@@ -4730,6 +4732,8 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, BYTE*
                     fgObserveInlineConstants(opcode, pushedStack, isInlining);
                 }
                 break;
+            case CEE_RET:
+                retBlocks++;
 
             default:
                 break;
@@ -4772,6 +4776,19 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, BYTE*
 
             if (isInlining)
             {
+                if (retBlocks == 0)
+                {
+                    // If there are no return blocks we know it does not return, however if there
+                    // return blocks we don't know it returns as it may be counting unreachable code.
+                    // So only make the CALLEE_DOES_NOT_RETURN observations if no returns.
+
+                    if (!compInlineResult->UsesLegacyPolicy())
+                    {
+                        // Mark the call node as "no return" as it can impact caller's code quality.
+                        impInlineInfo->iciCall->gtCallMoreFlags |= GTF_CALL_M_DOES_NOT_RETURN;
+                    }
+                }
+
                 // Assess profitability...
                 CORINFO_METHOD_INFO* methodInfo = &impInlineInfo->inlineCandidateInfo->methInfo;
                 compInlineResult->DetermineProfitability(methodInfo);


### PR DESCRIPTION
Adds `gtCallMoreFlags |= GTF_CALL_M_DOES_NOT_RETURN` to `fgFindJumpTargets` which happens in early in pipeline (which may mark the method as uninlinable, so prevent the later setting in `fgFindBasicBlocks`). 

Count the BBJ_RETURNs in `fgMakeBasicBlocks` rather than recounting afterwards (perf)

With current branch -0.88 % diff improvement
```
Summary:
(Note: Lower is better)

Total bytes of diff: -27333 (-0.88 % of base)
    diff is an improvement.

Total byte diff includes -30363 bytes from reconciling methods
        Base had  434 unique methods,    30363 unique bytes
        Diff had    0 unique methods,        0 unique bytes

Top file improvements by size (bytes):
      -27333 : System.Private.CoreLib.dasm (-0.88 % of base)

1 total files with size differences.

Top method regessions by size (bytes):
         679 : System.Private.CoreLib.dasm - Dictionary`2:System.Collections.ICollection.CopyTo(ref,int):this
         661 : System.Private.CoreLib.dasm - KeyCollection:System.Collections.ICollection.CopyTo(ref,int):this
         660 : System.Private.CoreLib.dasm - ValueCollection:System.Collections.ICollection.CopyTo(ref,int):this
         642 : System.Private.CoreLib.dasm - Enumerator:System.Collections.IEnumerator.get_Current():ref:this
         624 : System.Private.CoreLib.dasm - ReadOnlyCollection`1:System.Collections.ICollection.CopyTo(ref,int):this

Top method improvements by size (bytes):
       -1311 : System.Private.CoreLib.dasm - __Error:WinIOError(int,ref)
        -955 : System.Private.CoreLib.dasm - EventProvider:WriteEvent(byref,long,long,ref):bool:this
        -712 : System.Private.CoreLib.dasm - ManifestBasedResourceGroveler:HandleSatelliteMissing():this
        -644 : System.Private.CoreLib.dasm - List`1:CopyTo(int,ref,int,int):this
        -580 : System.Private.CoreLib.dasm - EncoderExceptionFallbackBuffer:Fallback(char,char,int):bool:this

1000 total methods with size differences.
```

With https://github.com/dotnet/coreclr/pull/6634 from -1.44% to -2.49%

```
Total bytes of diff: -77277 (-2.49 % of base)
    diff is an improvement.

Total byte diff includes -29108 bytes from reconciling methods
        Base had  414 unique methods,    29108 unique bytes
        Diff had    0 unique methods,        0 unique bytes

Top file improvements by size (bytes):
      -77277 : System.Private.CoreLib.dasm (-2.49 % of base)

1 total files with size differences.

Top method regessions by size (bytes):
         642 : System.Private.CoreLib.dasm - Enumerator:System.Collections.IEnumerator.get_Current():ref:this
         624 : System.Private.CoreLib.dasm - ReadOnlyCollection`1:System.Collections.ICollection.CopyTo(ref,int):this
         418 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref,struct):this
         389 : System.Private.CoreLib.dasm - Dictionary`2:System.Collections.ICollection.CopyTo(ref,int):this
         371 : System.Private.CoreLib.dasm - KeyCollection:System.Collections.ICollection.CopyTo(ref,int):this

Top method improvements by size (bytes):
       -3288 : System.Private.CoreLib.dasm - Array:Sort(ref,int,int,ref)
       -2214 : System.Private.CoreLib.dasm - Array:LastIndexOf(ref,struct,int,int):int
       -1540 : System.Private.CoreLib.dasm - Array:IndexOf(ref,struct,int,int):int
       -1311 : System.Private.CoreLib.dasm - __Error:WinIOError(int,ref)
       -1255 : System.Private.CoreLib.dasm - EventProvider:WriteEvent(byref,long,long,ref):bool:this

1339 total methods with size differences.
```

Resolves https://github.com/dotnet/coreclr/issues/6744

@mikedn @AndyAyersMS @kyulee1