### PR TITLE
Record expr location for opqaue value numbers

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -897,17 +897,18 @@ struct BasicBlock
 
     /* The following fields used for loop detection */
 
+    typedef unsigned char loopNumber;
     static const unsigned NOT_IN_LOOP = UCHAR_MAX;
 
 #ifdef DEBUG
     // This is the label a loop gets as part of the second, reachability-based
     // loop discovery mechanism.  This is apparently only used for debugging.
     // We hope we'll eventually just have one loop-discovery mechanism, and this will go away.
-    unsigned char bbLoopNum; // set to 'n' for a loop #n header
-#endif                       // DEBUG
+    loopNumber bbLoopNum; // set to 'n' for a loop #n header
+#endif                    // DEBUG
 
-    unsigned char bbNatLoopNum; // Index, in optLoopTable, of most-nested loop that contains this block,
-                                // or else NOT_IN_LOOP if this block is not in a loop.
+    loopNumber bbNatLoopNum; // Index, in optLoopTable, of most-nested loop that contains this block,
+                             // or else NOT_IN_LOOP if this block is not in a loop.
 
 #define MAX_LOOP_NUM 16       // we're using a 'short' for the mask
 #define LOOP_MASK_TP unsigned // must be big enough for a mask

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15518,7 +15518,7 @@ void GenTree::ParseArrayAddress(
     if (!FitsIn<ssize_t>(fieldOffsets + arrayInfo->m_elemOffset) || !FitsIn<ssize_t>(arrayInfo->m_elemSize))
     {
         // This seems unlikely, but no harm in being safe...
-        *pInxVN = comp->GetValueNumStore()->VNForExpr(TYP_INT);
+        *pInxVN = comp->GetValueNumStore()->VNForExpr(nullptr, TYP_INT);
         return;
     }
     // Otherwise...

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5403,7 +5403,7 @@ void Compiler::fgMoveOpsLeft(GenTreePtr tree)
                 (ad2->gtVNPair.GetLiberal() == ValueNumStore::NoVN) ||
                 (ad2->gtVNPair.GetLiberal() != op1->gtVNPair.GetLiberal()))
             {
-                new_op1->gtVNPair.SetBoth(vnStore->VNForExpr(new_op1->TypeGet()));
+                new_op1->gtVNPair.SetBoth(vnStore->VNForExpr(nullptr, new_op1->TypeGet()));
             }
         }
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6409,8 +6409,18 @@ bool Compiler::optVNIsLoopInvariant(ValueNum vn, unsigned lnum, VNToBoolMap* loo
     }
     else
     {
-        // Otherwise, assume non-function "new, unique" VN's are not loop invariant.
-        res = false;
+        // Non-function "new, unique" VN's may be annotated with the loop nest where
+        // their definition occurs.
+        BasicBlock::loopNumber vnLoopNum = vnStore->LoopOfVN(vn);
+
+        if (vnLoopNum == MAX_LOOP_NUM)
+        {
+            res = false;
+        }
+        else
+        {
+            res = !optLoopContains(lnum, vnLoopNum);
+        }
     }
 
     loopVnInvariantCache->Set(vn, res);


### PR DESCRIPTION
When value numbering sees an expression that is too complex, runs out of
compile-time budget for deep field/phi sequences, etc., it assigns
`VNForExpr()` for the expression whose value number is being computed.
This produces a new, unique, opaque value number that will compare as
equal to itself but not to any other value number.

This change updates value numbering to record the location of the
expression whose value such a value numbers is created to stand in for.
While attaching location information to value numbers in general must be
done with care regarding subtleties of correlating value numbers for
expressions in different locations that compute the same value, those
subtleties are not relevant in the case of these unique/opaque value
numbers, whose point is to stand in for the value of one particular
expression and whose value may be propagated by copies but will never be
computed by other redundant expressions.

Loop-invariant code hoisting is updated to take these locations into
account when determining loop-invariance; the opaque value number is
loop-invariant if the expression whose value it represents is outside the
loop.

The `VNForExpr()` method is updated to take a `BasicBlock*` to identify
the location, but the backing store only records the block's loop number,
since the loop-invariance check is the only consumer of this information
and doing so allows a more compact representation (in particular, we avoid
allocating `m_defs` backing storage for these value numbers, since they are
used for the "give up and be conservative" cases).

The `BasicBlock*` passed to `VNForExpr()` can be `nullptr` to still have
the prior semantics of a fully opaque value number that can't be proved
loop-invariant; this is used for a handful of cases where the budgeting
results are memoized and so expressions at different locations could end
up sharing opaque value numbers, as well as a few cases where the
`VNForExpr()` call is covering a rare corner case in a utility for which
the corresponding `BasicBlock` may not be handy.

Fixes #6303.