### PR TITLE
update GC shadow heap as part of writebarrier jit helper

### DIFF
--- a/src/vm/arm64/asmmacros.h
+++ b/src/vm/arm64/asmmacros.h
@@ -9,6 +9,15 @@
 ;; ==--==
 
 ;-----------------------------------------------------------------------------
+; Macro used to assign an alternate name to a symbol containing characters normally disallowed in a symbol
+; name (e.g. C++ decorated names).
+    MACRO
+      SETALIAS   $name, $symbol
+        GBLS    $name
+$name   SETS    "|$symbol|"
+    MEND
+
+;-----------------------------------------------------------------------------
 ; Basic extension of Assembler Macros- For Consistency
 
     MACRO


### PR DESCRIPTION
This enables Complus_heapVerify=2 (check to ensure that all updates to managed object pointers in managed heap happen via writebarrier)