### PR TITLE
Change SOS to use wrapper class that is now in System.Diagnostics.StackTrace.

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -92,6 +92,7 @@ if(WIN32)
     kernel32.lib
     user32.lib
     ole32.lib
+    oleaut32.lib
     dbghelp.lib
     uuid.lib
     version.lib

--- a/src/ToolBox/SOS/Strike/disasmARM.cpp
+++ b/src/ToolBox/SOS/Strike/disasmARM.cpp
@@ -365,7 +365,7 @@ void ARMMachine::Unassembly (
     bool fLastWasMovW = false;
     INT_PTR lowbits = 0;
     ULONG curLine = -1;
-    char  filename[MAX_PATH_FNAME+1];
+    WCHAR filename[MAX_LONGPATH];
     ULONG linenum;
 
     while (PC < PCEnd)
@@ -375,13 +375,12 @@ void ARMMachine::Unassembly (
 
         // Print out line numbers if needed
         if (!bSuppressLines
-            && SUCCEEDED(GetLineByOffset(TO_CDADDR(PC), 
-                           &linenum, filename, MAX_PATH_FNAME+1)))
+            && SUCCEEDED(GetLineByOffset(TO_CDADDR(PC), &linenum, filename, MAX_LONGPATH)))
         {
             if (linenum != curLine)
             {
                 curLine = linenum;
-                ExtOut("\n%s @ %d:\n", filename, linenum);
+                ExtOut("\n%S @ %d:\n", filename, linenum);
             }
         }
 

--- a/src/ToolBox/SOS/Strike/disasmARM64.cpp
+++ b/src/ToolBox/SOS/Strike/disasmARM64.cpp
@@ -163,7 +163,7 @@ void ARM64Machine::Unassembly (
     char line[1024];
     ULONG lineNum;
     ULONG curLine = -1;
-    char fileName[MAX_PATH_FNAME+1];
+    WCHAR fileName[MAX_LONGPATH];
     char *ptr;
     INT_PTR accumulatedConstant = 0;
     BOOL loBitsSet = FALSE;
@@ -203,18 +203,18 @@ void ARM64Machine::Unassembly (
         
         // This is the new instruction
 
-
         if (IsInterrupt())
             return;
         //
         // Print out line numbers if needed
         //
-        if (!bSuppressLines && SUCCEEDED(GetLineByOffset(TO_CDADDR(PC), &lineNum, fileName, MAX_PATH_FNAME+1)))
+        if (!bSuppressLines && 
+            SUCCEEDED(GetLineByOffset(TO_CDADDR(PC), &lineNum, fileName, MAX_LONGPATH)))
         {
             if (lineNum != curLine)
             {
                 curLine = lineNum;
-                ExtOut("\n%s @ %d:\n", fileName, lineNum);
+                ExtOut("\n%S @ %d:\n", fileName, lineNum);
             }
         }
 

--- a/src/ToolBox/SOS/Strike/disasmX86.cpp
+++ b/src/ToolBox/SOS/Strike/disasmX86.cpp
@@ -522,7 +522,7 @@ void
     char *ptr;
 
     ULONG curLine = -1;
-    char  filename[MAX_PATH_FNAME+1];
+    WCHAR filename[MAX_LONGPATH];
     ULONG linenum;
 
     while (IP < IPEnd)
@@ -532,13 +532,12 @@ void
 
         // Print out line numbers if needed
         if (!bSuppressLines
-            && SUCCEEDED(GetLineByOffset(TO_CDADDR(IP), 
-                           &linenum, filename, MAX_PATH_FNAME+1)))
+            && SUCCEEDED(GetLineByOffset(TO_CDADDR(IP), &linenum, filename, MAX_LONGPATH)))
         {
             if (linenum != curLine)
             {
                 curLine = linenum;
-                ExtOut("\n%s @ %d:\n", filename, linenum);
+                ExtOut("\n%S @ %d:\n", filename, linenum);
             }
         }
 

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -164,14 +164,16 @@ HMODULE g_hInstance = NULL;
 #pragma warning(disable:4189)   // local variable is initialized but not referenced
 #endif
 
-
+#ifdef FEATURE_PAL
+#define SOSPrefix ""
+#else
+#define SOSPrefix "!"
+#endif
 
 #if defined _X86_ && !defined FEATURE_PAL
 // disable FPO for X86 builds
 #pragma optimize("y", off)
 #endif
-
-
 
 #undef assert
 
@@ -297,7 +299,7 @@ DECLARE_API(IP2MD)
     DMLOut("MethodDesc:   %s\n", DMLMethodDesc(pMD));
     DumpMDInfo(TO_TADDR(pMD), cdaStart, FALSE /* fStackTraceFormat */);
 
-    char  filename[MAX_PATH_FNAME+1];
+    WCHAR filename[MAX_LONGPATH];
     ULONG linenum;
     // symlines will be non-zero only if SYMOPT_LOAD_LINES was set in the symbol options
     ULONG symlines = 0;
@@ -306,13 +308,10 @@ DECLARE_API(IP2MD)
         symlines &= SYMOPT_LOAD_LINES;
     }
 
-    if (symlines != 0
-        && SUCCEEDED(GetLineByOffset(TO_CDADDR(IP), 
-                         &linenum,
-                         filename,
-                         MAX_PATH_FNAME+1)))
+    if (symlines != 0 && 
+        SUCCEEDED(GetLineByOffset(TO_CDADDR(IP), &linenum, filename, _countof(filename))))
     {
-        ExtOut("Source file:  %s @ %d\n", filename, linenum);
+        ExtOut("Source file:  %S @ %d\n", filename, linenum);
     }
 
     return Status;
@@ -2305,11 +2304,12 @@ size_t FormatGeneratedException (DWORD_PTR dataPtr,
         // or did not update so (when ste is an explicit frames), do not update wszBuffer
         if (Status == S_OK)
         {
-            char filename[MAX_LONGPATH+1] = "";
+            WCHAR filename[MAX_LONGPATH] = W("");
             ULONG linenum = 0;
-            if (bLineNumbers && SUCCEEDED(GetLineByOffset(TO_CDADDR(ste.ip), &linenum, filename, _countof(filename))))
+            if (bLineNumbers && 
+                SUCCEEDED(GetLineByOffset(TO_CDADDR(ste.ip), &linenum, filename, _countof(filename))))
             {
-                swprintf_s(wszLineBuffer, _countof(wszLineBuffer), W("    %s [%S @ %d]\n"), so.String(), filename, linenum);
+                swprintf_s(wszLineBuffer, _countof(wszLineBuffer), W("    %s [%s @ %d]\n"), so.String(), filename, linenum);
             }
             else
             {
@@ -6278,7 +6278,7 @@ public:
     {
         PendingBreakpoint *pCur = m_breakpoints;
         size_t iBreakpointIndex = 1;
-        ExtOut("!bpmd pending breakpoint list\n Breakpoint index - Location, ModuleID, Method Token\n");
+        ExtOut(SOSPrefix "bpmd pending breakpoint list\n Breakpoint index - Location, ModuleID, Method Token\n");
         while(pCur)
         {
             //windbg likes to format %p as always being 64 bits
@@ -6360,49 +6360,14 @@ public:
     HRESULT LoadSymbolsForModule(TADDR mod, SymbolReader* pSymbolReader)
     {
         HRESULT Status = S_OK;
-        ToRelease<IXCLRDataModule> module;
-        IfFailRet(g_sos->GetModule(mod, &module));
+        ToRelease<IXCLRDataModule> pModule;
+        IfFailRet(g_sos->GetModule(mod, &pModule));
 
         ToRelease<IMetaDataImport> pMDImport = NULL;
-        IfFailRet(module->QueryInterface(IID_IMetaDataImport, (LPVOID *) &pMDImport));
+        IfFailRet(pModule->QueryInterface(IID_IMetaDataImport, (LPVOID *) &pMDImport));
 
-        WCHAR wszNameBuffer[MAX_LONGPATH];
-        ULONG32 nameLen = 0;
-        if(FAILED(Status = module->GetFileName(MAX_LONGPATH, &nameLen, wszNameBuffer)))
-        {
-            ExtOut("SOS error: IXCLRDataModule->GetFileName failed hr=0x%x\n", wszNameBuffer);
-            return Status;
-        }
+        IfFailRet(pSymbolReader->LoadSymbols(pMDImport, pModule));
 
-        //get a pointer to just the filename (the portion after the last backslash)
-        WCHAR* pModuleFilename = wszNameBuffer;
-        WCHAR* pSlash = _wcschr(pModuleFilename, DIRECTORY_SEPARATOR_CHAR_W);
-        while(pSlash != NULL)
-        {
-            pModuleFilename = pSlash+1;
-            pSlash = _wcschr(pModuleFilename, DIRECTORY_SEPARATOR_CHAR_W);
-        }
-#ifndef FEATURE_PAL
-
-        ImageInfo ii;
-        if(FAILED(Status = GetClrModuleImages(module, CLRDATA_MODULE_PE_FILE, &ii)))
-        {
-            ExtOut("SOS error: GetClrModuleImages failed hr=0x%x\n", Status);
-            return Status;
-        }
-
-        if(FAILED(Status = pSymbolReader->LoadSymbols(pMDImport, ii.modBase, pModuleFilename, FALSE)) &&
-           FAILED(pSymbolReader->LoadSymbols(pMDImport, ii.modBase, pModuleFilename, TRUE)))
-        {
-            ExtOut("SOS warning: No symbols for module %S, source line breakpoints in this module will not bind hr=0x%x\n", wszNameBuffer, Status);
-            return S_FALSE; // not finding symbols is a typical case
-        }
-#else
-        if(FAILED(Status = pSymbolReader->LoadSymbols(pMDImport, 0, pModuleFilename, FALSE)))
-        {
-            return S_FALSE;
-        }
-#endif // FEATURE_PAL
         return S_OK;
     }
 
@@ -6425,15 +6390,14 @@ public:
 
     HRESULT ResolvePendingNonModuleBoundBreakpoint(__in_z WCHAR* pModuleName, __in_z WCHAR* pMethodName, TADDR mod, DWORD ilOffset)
     {
-        int numModule;
+        HRESULT Status = S_OK;
         char szName[mdNameLen];
+        int numModule;
         
         ToRelease<IXCLRDataModule> module;
-        HRESULT Status = S_OK;
         IfFailRet(g_sos->GetModule(mod, &module));
 
-        WideCharToMultiByte(CP_ACP, 0, pModuleName, (int) (_wcslen(pModuleName) + 1),
-            szName, mdNameLen, NULL, NULL);            
+        WideCharToMultiByte(CP_ACP, 0, pModuleName, (int)(_wcslen(pModuleName) + 1), szName, mdNameLen, NULL, NULL);
 
         ArrayHolder<DWORD_PTR> moduleList = ModuleFromName(szName, &numModule);
         if (moduleList == NULL)
@@ -6442,7 +6406,7 @@ public:
             return E_FAIL;
         }
 
-        for(int i=0;i<numModule;i++)
+        for (int i = 0; i < numModule; i++)
         {
             // If any one entry in moduleList matches, then the current PendingBreakpoint
             // is the right one.
@@ -7026,7 +6990,7 @@ DECLARE_API(bpmd)
     
     if (IsDumpFile())
     {
-        ExtOut("!bpmd is not supported on a dump file.\n");
+        ExtOut(SOSPrefix "bpmd is not supported on a dump file.\n");
         return Status;
     }
 
@@ -7132,26 +7096,22 @@ DECLARE_API(bpmd)
                 fBadParam = true;
             }
             if(nArg != 1) fBadParam = 1;
-#ifdef FEATURE_PAL
-            if (!SymbolReader::SymbolReaderDllExists())
-            {
-                ExtOut("Can't find dll for symbol reader.");
-                ExtOut("File name:Line number not supported\n");
-                fBadParam = true;
-            }
-#endif // FEATURE_PAL
         }
     }
 
     if (fBadParam || (commandsParsed != 1))
     {
-        ExtOut("Usage: !bpmd -md <MethodDesc pointer>\n");
-        ExtOut("Usage: !bpmd [-nofuturemodule] <module name> <managed function name> [<il offset>]\n");
-        ExtOut("Usage: !bpmd <filename>:<line number>\n");
-        ExtOut("Usage: !bpmd -list\n");
-        ExtOut("Usage: !bpmd -clear <pending breakpoint number>\n");
-        ExtOut("Usage: !bpmd -clearall\n");
+        ExtOut("Usage: " SOSPrefix "bpmd -md <MethodDesc pointer>\n");
+        ExtOut("Usage: " SOSPrefix "bpmd [-nofuturemodule] <module name> <managed function name> [<il offset>]\n");
+        ExtOut("Usage: " SOSPrefix "bpmd <filename>:<line number>\n");
+        ExtOut("Usage: " SOSPrefix "bpmd -list\n");
+        ExtOut("Usage: " SOSPrefix "bpmd -clear <pending breakpoint number>\n");
+        ExtOut("Usage: " SOSPrefix "bpmd -clearall\n");
+#ifdef FEATURE_PAL
+        ExtOut("See \"soshelp bpmd\" for more details.\n");
+#else
         ExtOut("See \"!help bpmd\" for more details.\n");
+#endif
         return Status;
     }
 
@@ -7288,8 +7248,6 @@ DECLARE_API(bpmd)
             // for filename+line number only print extra info if symbols for this module are loaded (it can get quite noisy otherwise).
             if ((!fIsFilename) || (fIsFilename && symbolsLoaded == S_OK))
             {
-                ExtOut("Found %d methods in module %p...\n", numMethods, moduleList[iModule]);
-
                 for (int i = 0; i < numMethods; i++)
                 {
                     if (pMDs[i] == MD_NOT_YET_LOADED)
@@ -7319,6 +7277,11 @@ DECLARE_API(bpmd)
                 g_bpoints.Add(Filename, lineNumber, NULL);
             }
             bNeedNotificationExceptions = TRUE;
+
+            ULONG32 flags = 0;
+            g_clrData->GetOtherNotificationFlags(&flags);
+            flags |= (CLRDATA_NOTIFY_ON_MODULE_LOAD | CLRDATA_NOTIFY_ON_MODULE_UNLOAD);
+            g_clrData->SetOtherNotificationFlags(flags);
         }
     }
     else /* We were given a MethodDesc already */
@@ -9444,11 +9407,11 @@ DECLARE_API(Name2EE)
     
     if (nArg != 2)
     {
-        ExtOut("Usage: !Name2EE module_name item_name\n");
-        ExtOut("  or    !Name2EE module_name!item_name\n");        
+        ExtOut("Usage: " SOSPrefix "name2ee module_name item_name\n");
+        ExtOut("  or   " SOSPrefix "name2ee module_name!item_name\n");        
         ExtOut("       use * for module_name to search all loaded modules\n");
-        ExtOut("Examples: !Name2EE  mscorlib.dll System.String.ToString\n");
-        ExtOut("          !Name2EE *!System.String\n");
+        ExtOut("Examples: " SOSPrefix "name2ee  mscorlib.dll System.String.ToString\n");
+        ExtOut("          " SOSPrefix "name2ee *!System.String\n");
         return Status;
     }
     
@@ -10846,7 +10809,6 @@ DECLARE_API(GCHandleLeaks)
 class ClrStackImplWithICorDebug
 {
 private:
-
     static HRESULT DereferenceAndUnboxValue(ICorDebugValue * pValue, ICorDebugValue** ppOutputValue, BOOL * pIsNull = NULL)
     {
         HRESULT Status = S_OK;
@@ -10886,6 +10848,7 @@ private:
         (*ppOutputValue)->AddRef();
         return S_OK;
     }
+
     static BOOL ShouldExpandVariable(__in_z WCHAR* varToExpand, __in_z WCHAR* currentExpansion)
     {
         if(currentExpansion == NULL || varToExpand == NULL) return FALSE;
@@ -10898,6 +10861,7 @@ private:
 
         return TRUE;
     }
+
     static BOOL IsEnum(ICorDebugValue * pInputValue)
     {
         ToRelease<ICorDebugValue> pValue;
@@ -10915,6 +10879,7 @@ private:
 
         return (_wcsncmp(baseTypeName, W("System.Enum"), 11) == 0);
     }
+
     static HRESULT AddGenericArgs(ICorDebugType * pType, __inout_ecount(typeNameLen) WCHAR* typeName, ULONG typeNameLen)
     {
         bool isFirst = true;
@@ -10946,6 +10911,7 @@ private:
 
         return S_OK;
     }
+
     static HRESULT GetTypeOfValue(ICorDebugType * pType, __inout_ecount(typeNameLen) WCHAR* typeName, ULONG typeNameLen)
     {
         HRESULT Status = S_OK;
@@ -11101,6 +11067,7 @@ private:
         }
         return S_OK;
     }
+
     static HRESULT GetTypeOfValue(ICorDebugValue * pValue, __inout_ecount(typeNameLen) WCHAR* typeName, ULONG typeNameLen)
     {
         HRESULT Status = S_OK;
@@ -11117,6 +11084,7 @@ private:
 
         return S_OK;
     }
+
     static HRESULT PrintEnumValue(ICorDebugValue* pInputValue, BYTE* enumValue)
     {
         HRESULT Status = S_OK;
@@ -11238,6 +11206,7 @@ private:
 
         return S_OK;
     }
+
     static HRESULT PrintStringValue(ICorDebugValue * pValue)
     {
         HRESULT Status;
@@ -11262,6 +11231,7 @@ private:
         
         return S_OK;
     }
+
     static HRESULT PrintSzArrayValue(ICorDebugValue * pValue, ICorDebugILFrame * pILFrame, IMetaDataImport * pMD, int indent, __in_z WCHAR* varToExpand, __inout_ecount(currentExpansionSize) WCHAR* currentExpansion, DWORD currentExpansionSize, int currentFrame)
     {
         HRESULT Status = S_OK;
@@ -11328,6 +11298,7 @@ private:
 
         return S_OK;
     }
+
     static HRESULT PrintValue(ICorDebugValue * pInputValue, ICorDebugILFrame * pILFrame, IMetaDataImport * pMD, int indent, __in_z WCHAR* varToExpand, __inout_ecount(currentExpansionSize) WCHAR* currentExpansion, DWORD currentExpansionSize, int currentFrame)
     {
         HRESULT Status = S_OK;
@@ -11479,6 +11450,7 @@ private:
 
         return S_OK;
     }
+
     static HRESULT PrintParameters(BOOL bParams, BOOL bLocals, IMetaDataImport * pMD, mdTypeDef typeDef, mdMethodDef methodDef, ICorDebugILFrame * pILFrame, ICorDebugModule * pModule, __in_z WCHAR* varToExpand, int currentFrame)
     {
         HRESULT Status = S_OK;
@@ -11725,11 +11697,6 @@ private:
         pMD->CloseEnum(fEnum);
         return S_OK;
     }
-
-    
-
-   
-
 
 public:
 
@@ -12204,7 +12171,7 @@ public:
     
     static void PrintNativeStackFrame(TableOutput out, PDEBUG_STACK_FRAME frame, BOOL bSuppressLines)
     {
-        char filename[MAX_PATH_FNAME + 1];
+        char filename[MAX_LONGPATH + 1];
         char symbol[1024];
         ULONG64 displacement;
 
@@ -14394,7 +14361,7 @@ void PrintHelp (__in_z LPCSTR pszCmdName)
     }
 
     // Find our line in the text file
-    char searchString[MAX_PATH_FNAME];
+    char searchString[MAX_LONGPATH];
     sprintf_s(searchString, _countof(searchString), "COMMAND: %s.", pszCmdName);
     
     LPSTR pStart = strstr(pText, searchString);

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -43,19 +43,19 @@
 char symBuffer[SYM_BUFFER_SIZE];
 PIMAGEHLP_SYMBOL sym = (PIMAGEHLP_SYMBOL) symBuffer;
 #else
-
 #include <sys/stat.h>
 #include <coreruncommon.h>
 #include <dlfcn.h>
-#include <coreclrhost.h>
+#endif // !FEATURE_PAL
 
-void *SymbolReader::coreclrLib;
-ResolveSequencePointDelegate SymbolReader::resolveSequencePointDelegate;
+#include <coreclrhost.h>
+#include <set>
+
 LoadSymbolsForModuleDelegate SymbolReader::loadSymbolsForModuleDelegate;
+DisposeDelegate SymbolReader::disposeDelegate;
+ResolveSequencePointDelegate SymbolReader::resolveSequencePointDelegate;
 GetLocalVariableName SymbolReader::getLocalVariableNameDelegate;
 GetLineByILOffsetDelegate SymbolReader::getLineByILOffsetDelegate;
-
-#endif // !FEATURE_PAL
 
 const char * const CorElementTypeName[ELEMENT_TYPE_MAX]=
 {
@@ -816,9 +816,6 @@ EEFLAVOR GetEEFlavor ()
 
 BOOL IsDumpFile ()
 {
-#ifdef FEATURE_PAL
-    return FALSE;
-#else
     static int g_fDumpFile = -1;
     if (g_fDumpFile == -1) {
         ULONG Class;
@@ -830,7 +827,6 @@ BOOL IsDumpFile ()
             g_fDumpFile = 0;
     }
     return g_fDumpFile != 0;
-#endif //FEATURE_PAL
 }
 
 BOOL g_InMinidumpSafeMode = FALSE;
@@ -2730,7 +2726,7 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
         return NULL;
     }
 
-    WCHAR StringData[MAX_PATH_FNAME];
+    WCHAR StringData[MAX_LONGPATH];
     char fileName[sizeof(StringData)/2];
     
     // Search all domains to find a module
@@ -2772,8 +2768,8 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
                 ExtOut("Unable to get array of Assemblies for the given AppDomain..\n");
                 goto Failure;
             }
-                
-            for (int nAssem = 0;nAssem < appDomain.AssemblyCount;nAssem ++)
+
+            for (int nAssem = 0; nAssem < appDomain.AssemblyCount; nAssem ++)
             {
                 if (IsInterrupt())
                 {
@@ -2794,8 +2790,8 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
                     ExtOut("Failed to get the modules for the given assembly.\n");
                     goto Failure;
                 }
-                
-                for (UINT nModule=0;nModule<assemblyData.ModuleCount;nModule++)
+
+                for (UINT nModule = 0; nModule < assemblyData.ModuleCount; nModule++)
                 {
                     if (IsInterrupt())
                     {
@@ -2813,8 +2809,10 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
 
                     FileNameForModule ((DWORD_PTR)ModuleAddr, StringData);
                     int m;
-                    for (m = 0; StringData[m] != L'\0'; m ++)
+                    for (m = 0; StringData[m] != L'\0'; m++)
+                    {
                         fileName[m] = (char)StringData[m];
+                    }
                     fileName[m] = '\0';
                     
                     if ((mName == NULL) || 
@@ -2822,8 +2820,7 @@ DWORD_PTR *ModuleFromName(__in_opt LPSTR mName, int *numModule)
                         DebuggerModuleNamesMatch(ModuleData.File, mName) ||
                         IsFusionLoadedModule(fileName, mName))
                     {
-                        AddToModuleList(moduleList, *numModule, maxList,
-                                         (DWORD_PTR)ModuleAddr);
+                        AddToModuleList(moduleList, *numModule, maxList, (DWORD_PTR)ModuleAddr);
                     }    
                 }                        
 
@@ -3188,7 +3185,7 @@ void GetInfoFromModule (DWORD_PTR ModuleAddr, ULONG token, DWORD_PTR *ret)
                         else
                             ExtOut("Not JITTED yet. Use !bpmd -md %p to break on run.\n", SOS_PTR(md));
 #else
-                        ExtOut("Not JITTED yet. Use 'sos bpmd -md %p' to break on run.\n", SOS_PTR(md));
+                        ExtOut("Not JITTED yet. Use 'bpmd -md %p' to break on run.\n", SOS_PTR(md));
 #endif
                     }
                 }
@@ -4162,7 +4159,6 @@ void ResetGlobals(void)
 // Return Value:
 //      HRESULT indicating success or failure
 //
-
 HRESULT LoadClrDebugDll(void)
 {
     HRESULT hr = S_OK;
@@ -4184,14 +4180,14 @@ HRESULT LoadClrDebugDll(void)
         {
             return CORDBG_E_MISSING_DEBUGGER_EXPORTS;
         }
-        PFN_CLRDataCreateInstance pCLRDataCreateInstance = (PFN_CLRDataCreateInstance)GetProcAddress(hdac, "CLRDataCreateInstance");
-        if (pCLRDataCreateInstance == NULL)
+        PFN_CLRDataCreateInstance pfnCLRDataCreateInstance = (PFN_CLRDataCreateInstance)GetProcAddress(hdac, "CLRDataCreateInstance");
+        if (pfnCLRDataCreateInstance == NULL)
         {
             FreeLibrary(hdac);
             return CORDBG_E_MISSING_DEBUGGER_EXPORTS;
         }
         ICLRDataTarget *target = new DataTarget();
-        hr = pCLRDataCreateInstance(__uuidof(IXCLRDataProcess), target, (void**)&s_clrDataProcess);
+        hr = pfnCLRDataCreateInstance(__uuidof(IXCLRDataProcess), target, (void**)&s_clrDataProcess);
         if (FAILED(hr))
         {
             s_clrDataProcess = NULL;
@@ -5582,101 +5578,6 @@ NoOutputHolder::~NoOutputHolder()
 //
 
 // 
-// This function retrieves ImageInfo related to the module
-// containing the addressed passed in "Base".
-//
-// NOTE: This doesn't work on xplat/PAL because the managed
-// assembly PE isn't in the native debugger's module list.
-//
-HRESULT
-GetImageFromBase(
-    ___in ULONG64 Base,
-    ___out ImageInfo* Image)
-{
-    ULONG modIdx = 0;
-    ULONG64 modBase = 0;
-    if (FAILED(g_ExtSymbols->GetModuleByOffset(Base, 0, &modIdx, &modBase)))
-    {
-        return E_FAIL;
-    }
-
-    Image->modBase = modBase;
-    return S_OK;
-}
-
-// 
-// Retrieve ImageInfo associated with the IXCLRDataModule instance
-// passed in, and the extent type requested.
-HRESULT
-GetClrModuleImages(
-    ___in IXCLRDataModule* Module,
-    ___in CLRDataModuleExtentType DesiredType,
-    ___out ImageInfo* FirstAdd)
-{
-    HRESULT Status;
-    CLRDATA_ENUM EnumExtents;
-
-    if (FirstAdd)
-    {
-        FirstAdd->modBase = 0;
-    }
-
-    if ((Status = Module->StartEnumExtents(&EnumExtents)) != S_OK)
-    {
-        return FAILED(Status) ? Status : S_OK;
-    }
-
-    CLRDATA_MODULE_EXTENT Extent;
-
-    while (Module->EnumExtent(&EnumExtents, &Extent) == S_OK)
-    {
-        if ((DesiredType == CLRDATA_MODULE_OTHER) || (DesiredType == Extent.type))
-        {
-            ImageInfo Image;
-
-            if (FAILED(Status = GetImageFromBase(Extent.base, &Image)))
-            {
-                break;
-            }
-
-            Status = S_OK;
-            if (FirstAdd)
-            {
-                *FirstAdd = Image;
-                break;
-            }
-        }
-    }
-
-    Module->EndEnumExtents(EnumExtents);
-    return Status;
-}
-
-// 
-// Retrieve ImageInfo associated with the IXCLRDataModule instance
-// passed in. First look for NGENed module, second for IL modules.
-HRESULT
-FindClrModuleImage(
-    ___in IXCLRDataModule* Module,
-    ___out ImageInfo* Image)
-{
-    HRESULT Status;
-    
-    // Prefer the ngen image, but look for the base image if necessary.
-    if ((Status = GetClrModuleImages(Module, CLRDATA_MODULE_PREJIT_FILE, Image)) == S_OK &&
-        Image->modBase != 0)
-    {
-        return S_OK;
-    }
-    if ((Status = GetClrModuleImages(Module, CLRDATA_MODULE_PE_FILE, Image)) == S_OK &&
-        Image->modBase == 0)
-    {
-        Status = E_NOINTERFACE;
-    }
-    return Status;
-}
-
-// 
 // Retrieves the IXCLRDataMethodInstance* instance associated with the
 // passed in native offset.
 HRESULT
@@ -5697,31 +5598,6 @@ GetClrMethodInstance(
 
     // Any alternate success is a true failure here.
     return (Status == S_OK || FAILED(Status)) ? Status : E_NOINTERFACE;
-}
-
-// 
-// Retrieves the Token and ImageInfo associated with a managed method
-// identified by the passed in IXCLRDataMethodInstance* instance.
-HRESULT
-GetMethodInstanceTokenAndScope(
-    ___in IXCLRDataMethodInstance* Method,
-    ___out mdMethodDef* MethodToken,
-    ___out ImageInfo* Image)
-{
-    HRESULT Status;
-    IXCLRDataModule* Module;
-
-    if ((Status = Method->GetTokenAndScope(MethodToken, &Module)) != S_OK)
-    {
-        return Status;
-    }
-#ifndef FEATURE_PAL
-
-    Status = FindClrModuleImage(Module, Image);
-#endif //FEATURE_PAL
-
-    Module->Release();
-    return Status;
 }
 
 // 
@@ -5797,161 +5673,75 @@ GetLastMethodIlOffset(
 // represent an "IL offset".
 HRESULT
 ConvertNativeToIlOffset(
-    ___in ULONG64 Native,
-    __in_opt IXCLRDataMethodInstance* MethodInst,
-    ___out ImageInfo* Image,
-    ___out mdMethodDef* MethodToken,
-    ___out PULONG32 MethodOffs)
+    ___in ULONG64 native,
+    ___out IXCLRDataModule** ppModule,
+    ___out mdMethodDef* methodToken,
+    ___out PULONG32 methodOffs)
 {
+    ToRelease<IXCLRDataMethodInstance> pMethodInst(NULL);
     HRESULT Status;
 
-    if (!MethodInst)
+    if ((Status = GetClrMethodInstance(native, &pMethodInst)) != S_OK)
     {
-        if ((Status = GetClrMethodInstance(Native, &MethodInst)) != S_OK)
-        {
-            return Status;
-        }
-    }
-    else
-    {
-        MethodInst->AddRef();
+        return Status;
     }
 
-    if ((Status = MethodInst->GetILOffsetsByAddress(Native, 1, NULL, MethodOffs)) != S_OK)
+    if ((Status = pMethodInst->GetILOffsetsByAddress(native, 1, NULL, methodOffs)) != S_OK)
     {
-        *MethodOffs = 0;
+        *methodOffs = 0;
     }
     else
     {
-        switch((LONG)*MethodOffs)
+        switch((LONG)*methodOffs)
         {
         case CLRDATA_IL_OFFSET_NO_MAPPING:
-            MethodInst->Release();
             return E_NOINTERFACE;
             
         case CLRDATA_IL_OFFSET_PROLOG:
             // Treat all of the prologue as part of
             // the first source line.
-            *MethodOffs = 0;
+            *methodOffs = 0;
             break;
             
         case CLRDATA_IL_OFFSET_EPILOG:
             // Back up until we find the last real
             // IL offset.
-            if ((Status = GetLastMethodIlOffset(MethodInst, MethodOffs)) != S_OK)
+            if ((Status = GetLastMethodIlOffset(pMethodInst, methodOffs)) != S_OK)
             {
-                MethodInst->Release();
                 return Status;
             }
             break;
         }
     }
 
-    Status = GetMethodInstanceTokenAndScope(MethodInst, MethodToken, Image);
-
-    MethodInst->Release();
-
-    return Status;
+    return pMethodInst->GetTokenAndScope(methodToken, ppModule);
 }
 
 // Based on a native offset, passed in the first argument this function
 // identifies the corresponding source file name and line number.
 HRESULT
 GetLineByOffset(
-    ___in ULONG64 Offset,
+    ___in ULONG64 offset,
     ___out ULONG *pLinenum,
-    __out_ecount(cbFileName) LPSTR lpszFileName,
-    ___in ULONG cbFileName)
+    __out_ecount(cchFileName) WCHAR* pwszFileName,
+    ___in ULONG cchFileName)
 {
-    HRESULT hr = S_OK;
-    ULONG64 displacement = 0;
+    HRESULT Status = S_OK;
+    ULONG32 methodToken;
+    ULONG32 methodOffs;
 
-    // first let's try it the hard way, this will work with the public debuggers
-    {
-        ImageInfo Image = {0};
-        ULONG64 modBase = 0;
-        ULONG32 MethodToken;
-        ULONG32 MethodOffs;
-        ULONG64 IlOffset;
+    // Find the image, method token and IL offset that correspond to "offset"
+    ToRelease<IXCLRDataModule> pModule(NULL);
+    IfFailRet(ConvertNativeToIlOffset(offset, &pModule, &methodToken, &methodOffs));
 
-#ifndef FEATURE_PAL
-        ToRelease<IDebugSymbols3> spSym3(NULL);
-        if (FAILED(g_ExtSymbols->QueryInterface(__uuidof(IDebugSymbols3), (void**)&spSym3)))
-        {
-            hr = E_FAIL;
-            goto fallback;
-        }
-#endif //!FEATURE_PAL
+    ToRelease<IMetaDataImport> pMDImport(NULL);
+    IfFailRet(pModule->QueryInterface(IID_IMetaDataImport, (LPVOID *) &pMDImport));
 
-        // find the image, method token and IL offset that correspond
-        // to "Offset"
-        if ((hr = ConvertNativeToIlOffset(Offset, NULL, &Image,
-                                    &MethodToken, &MethodOffs)) != S_OK)
-        {
-            goto fallback;
-        }
+    SymbolReader symbolReader;
+    IfFailRet(symbolReader.LoadSymbols(pMDImport, pModule));
 
-#ifndef FEATURE_PAL
-        modBase = Image.modBase;
-        DEBUG_MODULE_AND_ID id;
-        DEBUG_SYMBOL_ENTRY symInfo;
-        if (FAILED(spSym3->GetSymbolEntryByToken(modBase, MethodToken, &id))
-            || FAILED(spSym3->GetSymbolEntryInformation(&id, &symInfo)))
-        {
-            hr = E_FAIL;
-            goto fallback;
-        }
-
-        IlOffset = symInfo.Offset + MethodOffs;
-#else
-        // Source lines with 0xFEEFEE markers are filtered out on the managed side.
-        const String &moduleName = ModuleNameFromIP(TO_CDADDR(Offset));
-        return SymbolReader::GetLineByILOffset(moduleName.c_str(), MethodToken, MethodOffs, pLinenum, lpszFileName, cbFileName);
-#endif //!FEATURE_PAL
-        //
-        // Source maps for managed code can end
-        // up with special 0xFEEFEE markers that
-        // indicate don't-stop points.  Try and
-        // filter those out.
-        //
-        for (ULONG SkipCount = 64; SkipCount > 0; SkipCount--)
-        {
-            if (FAILED(g_ExtSymbols->GetLineByOffset(
-                        IlOffset, 
-                        pLinenum,
-                        lpszFileName,
-                        cbFileName,
-                        NULL,
-                        &displacement)))
-            {
-                hr = E_FAIL;
-                goto fallback;
-            }
-
-            if (*pLinenum == 0xfeefee)
-            {
-                ++IlOffset;
-            }
-            else
-            {
-                return S_OK;
-            }
-        }
-
-        // Fall into the regular translation as a last-ditch effort.
-        Offset = IlOffset;
-    }
-
-fallback:
-    return g_ExtSymbols->GetLineByOffset(
-                    Offset, 
-                    pLinenum,
-                    lpszFileName,
-                    cbFileName,
-                    NULL,
-                    &displacement);
+    return symbolReader.GetLineByILOffset(methodToken, methodOffs, pLinenum, pwszFileName, cchFileName);
 }
-
 
 void TableOutput::ReInit(int numColumns, int defaultColumnWidth, Alignment alignmentDefault, int indent, int padding)
 {
@@ -6185,183 +5975,92 @@ HRESULT __stdcall PERvaMemoryReader::ReadExecutableAtRVA(DWORD relativeVirtualAd
 
 #endif // FEATURE_PAL
 
-HRESULT SymbolReader::LoadSymbols(IMetaDataImport * pMD, ICorDebugModule * pModule)
+HRESULT SymbolReader::LoadSymbols(IMetaDataImport* pMD, ICorDebugModule* pModule)
 {
     HRESULT Status = S_OK;
-    if(m_pSymReader != NULL) return S_OK;
-    
     BOOL isDynamic = FALSE;
     BOOL isInMemory = FALSE;
     IfFailRet(pModule->IsDynamic(&isDynamic));
     IfFailRet(pModule->IsInMemory(&isInMemory));
 
-    if(isDynamic)
+    if (isDynamic)
     {
-        // Dynamic and in memory assemblies are a special case 
-        // which we will ignore for now
-        // now
-        ExtOut("SOS Warning: Loading symbols for dynamic assemblies is not yet supported\n");
+        // Dynamic and in memory assemblies are a special case which we will ignore for now now
+        ExtWarn("SOS Warning: Loading symbols for dynamic assemblies is not yet supported\n");
         return E_FAIL;
     }
 
-    ULONG64 baseAddress = 0;
-    IfFailRet(pModule->GetBaseAddress(&baseAddress));
+    ULONG64 peAddress = 0;
+    ULONG32 peSize = 0;
+    IfFailRet(pModule->GetBaseAddress(&peAddress));
+    IfFailRet(pModule->GetSize(&peSize));
 
     ULONG32 len = 0; 
     WCHAR moduleName[MAX_LONGPATH];
     IfFailRet(pModule->GetName(_countof(moduleName), &len, moduleName));
 
-    return LoadSymbols(pMD, baseAddress, moduleName, isInMemory);
-}
-
-#ifdef FEATURE_PAL
-bool SymbolReader::SymbolReaderDllExists()
-{
-    struct stat sb;
-    std::string SymbolReaderDll(SymbolReaderDllName);
-    SymbolReaderDll += ".dll";
-
-    return stat(SymbolReaderDll.c_str(), &sb) == 0;
-}
-
-HRESULT SymbolReader::PrepareSymbolReader()
-{
-    static bool attemptedSymbolReaderPreparation = false;
-    if (attemptedSymbolReaderPreparation)
+#ifndef FEATURE_PAL
+    if (SUCCEEDED(LoadSymbolsForWindows(pMD, peAddress, moduleName, isInMemory)))
     {
-        // If we already tried to set up the symbol reader, we won't try again.
+        return S_OK;
+    }
+#endif // FEATURE_PAL
+    return LoadSymbolsForPortablePDB(isInMemory, moduleName, peAddress, peSize, 0, 0);
+}
+
+HRESULT SymbolReader::LoadSymbols(IMetaDataImport* pMD, IXCLRDataModule* pModule)
+{
+    DacpGetModuleData moduleData;
+    HRESULT hr = moduleData.Request(pModule);
+    if (FAILED(hr))
+    {
+        ExtOut("LoadSymbols moduleData.Request FAILED 0x%08x\n", hr);
+        return hr;
+    }
+
+    if (moduleData.bIsDynamic)
+    {
+        ExtWarn("SOS Warning: Loading symbols for dynamic assemblies is not yet supported\n");
         return E_FAIL;
     }
 
-    attemptedSymbolReaderPreparation = true;
-
-    std::string absolutePath;
-    std::string coreClrPath = g_ExtServices->GetCoreClrDirectory();
-    if (!GetAbsolutePath(coreClrPath.c_str(), absolutePath))
+    ArrayHolder<WCHAR> pModuleName = new WCHAR[MAX_LONGPATH + 1];
+    ULONG32 nameLen = 0;
+    hr = pModule->GetFileName(MAX_LONGPATH, &nameLen, pModuleName);
+    if (FAILED(hr))
     {
-        ExtErr("Error: fail to convert CLR files path to absolute path \n");
-        return E_FAIL;
+        ExtOut("LoadSymbols: IXCLRDataModule->GetFileName FAILED 0x%08x\n", hr);
+        return hr;
     }
 
-    coreClrPath.append("/");
-    coreClrPath.append(coreClrDll);
-    coreclrLib = dlopen(coreClrPath.c_str(), RTLD_NOW | RTLD_LOCAL);
-    if (coreclrLib == nullptr)
+#ifndef FEATURE_PAL
+    // TODO: in-memory windows PDB not supported
+    hr = LoadSymbolsForWindows(pMD, moduleData.LoadedPEAddress, pModuleName, moduleData.bIsInMemory);
+    if (SUCCEEDED(hr))
     {
-        ExtErr("Error: Fail to load %s\n", coreClrPath.c_str());
-        return E_FAIL;
+        return hr;
     }
+#endif // FEATURE_PAL
 
-    void *hostHandle;
-    unsigned int domainId;
-    coreclr_initialize_ptr initializeCoreCLR =
-        (coreclr_initialize_ptr)dlsym(coreclrLib, "coreclr_initialize");
-
-    // FIXME: We should shutdown coreclr when it is not needed
-    coreclr_shutdown_ptr shutdownCoreCLR =
-        (coreclr_shutdown_ptr)dlsym(coreclrLib, "coreclr_shutdown");
-
-    std::string tpaList;
-    AddFilesFromDirectoryToTpaList(absolutePath.c_str(), tpaList);
-
-    const char *propertyKeys[] = {
-        "TRUSTED_PLATFORM_ASSEMBLIES", "APP_PATHS", "APP_NI_PATHS",
-        "NATIVE_DLL_SEARCH_DIRECTORIES", "AppDomainCompatSwitch"};
-
-    const char *propertyValues[] = {// TRUSTED_PLATFORM_ASSEMBLIES
-                                    tpaList.c_str(),
-                                    // APP_PATHS
-                                    absolutePath.c_str(),
-                                    // APP_NI_PATHS
-                                    absolutePath.c_str(),
-                                    // NATIVE_DLL_SEARCH_DIRECTORIES
-                                    absolutePath.c_str(),
-                                    // AppDomainCompatSwitch
-                                    "UseLatestBehaviorWhenTFMNotSpecified"};
-
-    std::string entryPointExecutablePath;
-    if (!GetEntrypointExecutableAbsolutePath(entryPointExecutablePath))
-    {
-        ExtErr("Could not get full path to current executable");
-        return E_FAIL;
-    }
-
-    HRESULT Status = initializeCoreCLR(entryPointExecutablePath.c_str(), "soscorerun",
-                         sizeof(propertyKeys) / sizeof(propertyKeys[0]),
-                         propertyKeys, propertyValues, &hostHandle, &domainId);
-    if (Status != S_OK)
-    {
-        ExtErr("Error: Fail to initialize CoreCLR\n");
-        return Status;
-    }
-
-    coreclr_create_delegate_ptr CreateDelegate =
-        (coreclr_create_delegate_ptr)dlsym(coreclrLib, "coreclr_create_delegate");
-
-    IfFailRet(CreateDelegate(hostHandle, domainId, SymbolReaderDllName,
-                        SymbolReaderClassName, "ResolveSequencePoint",
-                        (void **)&resolveSequencePointDelegate));
-    IfFailRet(CreateDelegate(hostHandle, domainId, SymbolReaderDllName,
-                        SymbolReaderClassName, "LoadSymbolsForModule",
-                        (void **)&loadSymbolsForModuleDelegate));
-    IfFailRet(CreateDelegate(hostHandle, domainId, SymbolReaderDllName,
-                        SymbolReaderClassName, "GetLocalVariableName",
-                             (void **)&getLocalVariableNameDelegate));
-    IfFailRet(CreateDelegate(hostHandle, domainId, SymbolReaderDllName,
-                        SymbolReaderClassName, "GetLineByILOffset",
-                             (void **)&getLineByILOffsetDelegate));
-    return Status;
+    return LoadSymbolsForPortablePDB(
+        moduleData.bIsInMemory,
+        pModuleName, 
+        moduleData.LoadedPEAddress,
+        moduleData.LoadedPESize, 
+        moduleData.InMemoryPdbAddress,
+        moduleData.InMemoryPdbSize);
 }
-
-HRESULT SymbolReader::GetLineByILOffset(__in_z const char* szModuleName, mdMethodDef MethodToken,
-                                         ULONG64 IlOffset, ___out ULONG *pLinenum,
-                                         __out_ecount(cbFileName) LPSTR lpszFileName,
-                                         ___in ULONG cbFileName)
-{
-    HRESULT Status = S_OK;
-
-    if (getLineByILOffsetDelegate == nullptr)
-    {
-        IfFailRet(SymbolReader::PrepareSymbolReader());
-    }
-
-    BSTR wszFileName = SysAllocStringLen(0, cbFileName);
-    if (wszFileName == nullptr)
-    {
-        return E_OUTOFMEMORY;
-    }
-
-    if (getLineByILOffsetDelegate(szModuleName, MethodToken, IlOffset, pLinenum, &wszFileName) == TRUE)
-    {
-        WideCharToMultiByte(CP_ACP, 0, wszFileName, (int) (_wcslen(wszFileName) + 1),
-                            lpszFileName, cbFileName, NULL, NULL);
-        if (*pLinenum == 0)
-        {
-            *pLinenum = -1;
-            Status = E_FAIL;
-        }
-    }
-    else
-    {
-        Status = E_FAIL;
-    }
-
-    SysFreeString(wszFileName);
-
-    return Status;
-}
-#endif //FEATURE_PAL
-
-HRESULT SymbolReader::LoadSymbols(IMetaDataImport * pMD, ULONG64 baseAddress, __in_z WCHAR* pModuleName, BOOL isInMemory)
-{
-   HRESULT Status = S_OK;
 
 #ifndef FEATURE_PAL
 
-    if (m_pSymReader != NULL) return S_OK;
+HRESULT SymbolReader::LoadSymbolsForWindows(IMetaDataImport* pMD, ULONG64 peAddress, __in_z WCHAR* pModuleName, BOOL isInMemory)
+{
+    HRESULT Status = S_OK;
+
+    if (m_pSymReader != NULL) 
+        return S_OK;
 
     IfFailRet(CoInitialize(NULL));
-
 
     // We now need a binder object that will take the module and return a 
     // reader object
@@ -6406,74 +6105,368 @@ HRESULT SymbolReader::LoadSymbols(IMetaDataImport * pMD, ULONG64 baseAddress, __
     ToRelease<IUnknown> pCallback = NULL;
     if (isInMemory)
     {
-        pCallback = (IUnknown*) new PEOffsetMemoryReader(TO_TADDR(baseAddress));
+        pCallback = (IUnknown*) new PEOffsetMemoryReader(TO_TADDR(peAddress));
     }
     else
     {
-        pCallback = (IUnknown*) new PERvaMemoryReader(TO_TADDR(baseAddress));
+        pCallback = (IUnknown*) new PERvaMemoryReader(TO_TADDR(peAddress));
     }
 
     // TODO: this should be better integrated with windbg's symbol lookup
-    Status = pSymBinder->GetReaderFromCallback(pMD, pModuleName, symbolPath, AllowRegistryAccess | AllowSymbolServerAccess | AllowOriginalPathAccess | AllowReferencePathAccess, pCallback, &m_pSymReader);
+    Status = pSymBinder->GetReaderFromCallback(pMD, pModuleName, symbolPath, 
+        AllowRegistryAccess | AllowSymbolServerAccess | AllowOriginalPathAccess | AllowReferencePathAccess, pCallback, &m_pSymReader);
+
     if (FAILED(Status) && m_pSymReader != NULL)
     {
         m_pSymReader->Release();
         m_pSymReader = NULL;
     }
     return Status;
-#else
+}
+
+#endif // FEATURE_PAL
+
+int ReadMemoryForSymbols(ULONG64 address, char *buffer, int cb)
+{
+    ULONG read;
+    if (SafeReadMemory(address, (PVOID)buffer, cb, &read))
+    {
+        return read;
+    }
+    return 0;
+}
+
+HRESULT SymbolReader::LoadSymbolsForPortablePDB(BOOL isInMemory, __in_z WCHAR* pModuleName, ULONG64 peAddress, 
+    ULONG64 peSize, ULONG64 inMemoryPdbAddress, ULONG64 inMemoryPdbSize)
+{
+    HRESULT Status = S_OK;
+
     if (loadSymbolsForModuleDelegate == nullptr)
     {
         IfFailRet(PrepareSymbolReader());
     }
 
-    WideCharToMultiByte(CP_ACP, 0, pModuleName, (int) (_wcslen(pModuleName) + 1), m_szModuleName, mdNameLen, NULL, NULL);
-    if (loadSymbolsForModuleDelegate(m_szModuleName) == FALSE)
+    // The module name needs to be null for in-memory PE's.
+    ArrayHolder<char> szModuleName = nullptr;
+    if (!isInMemory && pModuleName != nullptr)
+    {
+        szModuleName = new char[MAX_LONGPATH];
+        if (WideCharToMultiByte(CP_ACP, 0, pModuleName, (int)(_wcslen(pModuleName) + 1), szModuleName, MAX_LONGPATH, NULL, NULL) == 0)
+        {
+            return E_FAIL;
+        }
+    }
+
+    m_symbolReaderHandle = loadSymbolsForModuleDelegate(szModuleName, peAddress, (int)peSize, inMemoryPdbAddress, (int)inMemoryPdbSize, ReadMemoryForSymbols);
+    if (m_symbolReaderHandle == 0)
     {
         return E_FAIL;
     }
 
     return Status;
-#endif // FEATURE_PAL
 }
 
-HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDebugILFrame * pILFrame, mdMethodDef methodToken, ULONG localIndex, __inout_ecount(paramNameLen) WCHAR* paramName, ULONG paramNameLen, ICorDebugValue** ppValue)
+#ifndef FEATURE_PAL
+
+void AddFilesFromDirectoryToTpaList(const char* directory, std::string& tpaList)
+{
+    const char * const tpaExtensions[] = {
+        "*.ni.dll",      // Probe for .ni.dll first so that it's preferred if ni and il coexist in the same dir
+        "*.dll",
+        "*.ni.exe",
+        "*.exe",
+    };
+
+    std::set<std::string> addedAssemblies;
+
+    // Walk the directory for each extension separately so that we first get files with .ni.dll extension,
+    // then files with .dll extension, etc.
+    for (int extIndex = 0; extIndex < sizeof(tpaExtensions) / sizeof(tpaExtensions[0]); extIndex++)
+    {
+        const char* ext = tpaExtensions[extIndex];
+        size_t extLength = strlen(ext);
+
+        std::string assemblyPath(directory);
+        assemblyPath.append(DIRECTORY_SEPARATOR_STR_A);
+        assemblyPath.append(tpaExtensions[extIndex]);
+
+        WIN32_FIND_DATAA data;
+        HANDLE findHandle = FindFirstFileA(assemblyPath.c_str(), &data);
+
+        if (findHandle != INVALID_HANDLE_VALUE) 
+        {
+            do
+            {
+                if (!(data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+                {
+
+                    std::string filename(data.cFileName);
+                    size_t extPos = filename.length() - extLength;
+                    std::string filenameWithoutExt(filename.substr(0, extPos));
+
+                    // Make sure if we have an assembly with multiple extensions present,
+                    // we insert only one version of it.
+                    if (addedAssemblies.find(filenameWithoutExt) == addedAssemblies.end())
+                    {
+                        addedAssemblies.insert(filenameWithoutExt);
+
+                        tpaList.append(directory);
+                        tpaList.append(DIRECTORY_SEPARATOR_STR_A);
+                        tpaList.append(filename);
+                        tpaList.append(";");
+                    }
+                }
+            } 
+            while (0 != FindNextFileA(findHandle, &data));
+
+            FindClose(findHandle);
+        }
+    }
+}
+
+bool GetEntrypointExecutableAbsolutePath(std::string& entrypointExecutable)
+{
+    ArrayHolder<char> hostPath = new char[MAX_LONGPATH+1];
+    if (::GetModuleFileName(NULL, hostPath, MAX_LONGPATH) == 0)
+    {
+        return false;
+    }
+
+    entrypointExecutable.clear();
+    entrypointExecutable.append(hostPath);
+
+    return true;
+}
+
+#endif // FEATURE_PAL
+
+HRESULT SymbolReader::PrepareSymbolReader()
+{
+    static bool attemptedSymbolReaderPreparation = false;
+    if (attemptedSymbolReaderPreparation)
+    {
+        // If we already tried to set up the symbol reader, we won't try again.
+        return E_FAIL;
+    }
+
+    attemptedSymbolReaderPreparation = true;
+
+    std::string absolutePath;
+    std::string coreClrPath;
+    HRESULT Status;
+
+#ifdef FEATURE_PAL
+    coreClrPath = g_ExtServices->GetCoreClrDirectory();
+    if (!GetAbsolutePath(coreClrPath.c_str(), absolutePath))
+    {
+        ExtErr("Error: Failed to get coreclr absolute path\n");
+        return E_FAIL;
+    }
+    coreClrPath.append(DIRECTORY_SEPARATOR_STR_A);
+    coreClrPath.append(MAIN_CLR_DLL_NAME_A);
+#else
+    ULONG index;
+    Status = g_ExtSymbols->GetModuleByModuleName(MAIN_CLR_MODULE_NAME_A, 0, &index, NULL);
+    if (FAILED(Status))
+    {
+        ExtErr("Error: Can't find coreclr module\n");
+        return Status;
+    }
+    ArrayHolder<char> szModuleName = new char[MAX_LONGPATH + 1];
+    Status = g_ExtSymbols->GetModuleNames(index, 0, szModuleName, MAX_LONGPATH, NULL, NULL, 0, NULL, NULL, 0, NULL);
+    if (FAILED(Status))
+    {
+        ExtErr("Error: Failed to get coreclr module name\n");
+        return Status;
+    }
+    coreClrPath = szModuleName;
+
+    // Parse off the module name to get just the path
+    size_t pos = coreClrPath.rfind(DIRECTORY_SEPARATOR_CHAR_A);
+    if (pos == std::string::npos)
+    {
+        ExtErr("Error: Failed to parse coreclr module name\n");
+        return E_FAIL;
+    }
+    absolutePath.assign(coreClrPath, 0, pos);
+#endif // FEATURE_PAL
+
+    HMODULE coreclrLib = LoadLibraryA(coreClrPath.c_str());
+    if (coreclrLib == nullptr)
+    {
+        ExtErr("Error: Failed to load %s\n", coreClrPath.c_str());
+        return E_FAIL;
+    }
+
+    void *hostHandle;
+    unsigned int domainId;
+    coreclr_initialize_ptr initializeCoreCLR = (coreclr_initialize_ptr)GetProcAddress(coreclrLib, "coreclr_initialize");
+    if (initializeCoreCLR == nullptr)
+    {
+        ExtErr("Error: coreclr_initialize not found\n");
+        return E_FAIL;
+    }
+
+    std::string tpaList;
+    AddFilesFromDirectoryToTpaList(absolutePath.c_str(), tpaList);
+
+    const char *propertyKeys[] = {
+        "TRUSTED_PLATFORM_ASSEMBLIES", "APP_PATHS", "APP_NI_PATHS",
+        "NATIVE_DLL_SEARCH_DIRECTORIES", "AppDomainCompatSwitch"};
+
+    const char *propertyValues[] = {// TRUSTED_PLATFORM_ASSEMBLIES
+                                    tpaList.c_str(),
+                                    // APP_PATHS
+                                    absolutePath.c_str(),
+                                    // APP_NI_PATHS
+                                    absolutePath.c_str(),
+                                    // NATIVE_DLL_SEARCH_DIRECTORIES
+                                    absolutePath.c_str(),
+                                    // AppDomainCompatSwitch
+                                    "UseLatestBehaviorWhenTFMNotSpecified"};
+
+    std::string entryPointExecutablePath;
+    if (!GetEntrypointExecutableAbsolutePath(entryPointExecutablePath))
+    {
+        ExtErr("Could not get full path to current executable");
+        return E_FAIL;
+    }
+
+    Status = initializeCoreCLR(entryPointExecutablePath.c_str(), "sos", 
+        sizeof(propertyKeys) / sizeof(propertyKeys[0]), propertyKeys, propertyValues, &hostHandle, &domainId);
+
+    if (FAILED(Status))
+    {
+        ExtErr("Error: Fail to initialize CoreCLR %08x\n", Status);
+        return Status;
+    }
+
+    coreclr_create_delegate_ptr createDelegate = (coreclr_create_delegate_ptr)GetProcAddress(coreclrLib, "coreclr_create_delegate");
+    if (createDelegate == nullptr)
+    {
+        ExtErr("Error: coreclr_create_delegate not found\n");
+        return E_FAIL;
+    }
+
+    IfFailRet(createDelegate(hostHandle, domainId, SymbolReaderDllName, SymbolReaderClassName, "LoadSymbolsForModule", (void **)&loadSymbolsForModuleDelegate));
+    IfFailRet(createDelegate(hostHandle, domainId, SymbolReaderDllName, SymbolReaderClassName, "Dispose", (void **)&disposeDelegate));
+    IfFailRet(createDelegate(hostHandle, domainId, SymbolReaderDllName, SymbolReaderClassName, "ResolveSequencePoint", (void **)&resolveSequencePointDelegate));
+    IfFailRet(createDelegate(hostHandle, domainId, SymbolReaderDllName, SymbolReaderClassName, "GetLocalVariableName", (void **)&getLocalVariableNameDelegate));
+    IfFailRet(createDelegate(hostHandle, domainId, SymbolReaderDllName, SymbolReaderClassName, "GetLineByILOffset", (void **)&getLineByILOffsetDelegate));
+
+    return Status;
+}
+
+HRESULT SymbolReader::GetLineByILOffset(mdMethodDef methodToken, ULONG64 ilOffset,
+    ___out ULONG *pLinenum, __out_ecount(cbFileName) WCHAR* pwszFileName, ___in ULONG cchFileName)
 {
     HRESULT Status = S_OK;
-#ifdef FEATURE_PAL
-    if (getLocalVariableNameDelegate == nullptr)
+
+    if (m_symbolReaderHandle != 0)
     {
-        IfFailRet(PrepareSymbolReader());
-    }
+        _ASSERTE(getLineByILOffsetDelegate != nullptr);
 
-    BSTR wszParamName = SysAllocStringLen(0, mdNameLen);
-    if (wszParamName == NULL)
-    {
-        return E_OUTOFMEMORY;
-    }
-
-    if (getLocalVariableNameDelegate(m_szModuleName, methodToken, localIndex, &wszParamName) == FALSE)
-    {
-        SysFreeString(wszParamName);
-        return E_FAIL;
-    }
-
-    wcscpy_s(paramName, _wcslen(wszParamName) + 1, wszParamName);
-    paramNameLen = _wcslen(paramName);
-
-    SysFreeString(wszParamName);
-
-    if (SUCCEEDED(pILFrame->GetLocalVariable(localIndex, ppValue)) && (*ppValue != NULL))
-    {
+        BSTR bstrFileName = SysAllocStringLen(0, MAX_LONGPATH);
+        if (bstrFileName == nullptr)
+        {
+            return E_OUTOFMEMORY;
+        }
+        // Source lines with 0xFEEFEE markers are filtered out on the managed side.
+        if ((getLineByILOffsetDelegate(m_symbolReaderHandle, methodToken, ilOffset, pLinenum, &bstrFileName) == FALSE) || (*pLinenum == 0))
+        {
+            SysFreeString(bstrFileName);
+            return E_FAIL;
+        }
+        wcscpy_s(pwszFileName, cchFileName, bstrFileName);
+        SysFreeString(bstrFileName);
         return S_OK;
     }
-    else
-    {
-        *ppValue = NULL;
+
+#ifndef FEATURE_PAL
+    if (m_pSymReader == NULL)
         return E_FAIL;
+
+    ToRelease<ISymUnmanagedMethod> pSymMethod(NULL);
+    IfFailRet(m_pSymReader->GetMethod(methodToken, &pSymMethod));
+
+    ULONG32 seqPointCount = 0;
+    IfFailRet(pSymMethod->GetSequencePointCount(&seqPointCount));
+
+    if (seqPointCount == 0)
+        return E_FAIL;
+
+    // allocate memory for the objects to be fetched
+    ArrayHolder<ULONG32> offsets(new ULONG32[seqPointCount]);
+    ArrayHolder<ULONG32> lines(new ULONG32[seqPointCount]);
+    ArrayHolder<ULONG32> columns(new ULONG32[seqPointCount]);
+    ArrayHolder<ULONG32> endlines(new ULONG32[seqPointCount]);
+    ArrayHolder<ULONG32> endcolumns(new ULONG32[seqPointCount]);
+    ArrayHolder<ToRelease<ISymUnmanagedDocument>> documents(new ToRelease<ISymUnmanagedDocument>[seqPointCount]);
+
+    ULONG32 realSeqPointCount = 0;
+    IfFailRet(pSymMethod->GetSequencePoints(seqPointCount, &realSeqPointCount, offsets, &(documents[0]), lines, columns, endlines, endcolumns));
+
+    const ULONG32 HiddenLine = 0x00feefee;
+    int bestSoFar = -1;
+
+    for (int i = 0; i < (int)realSeqPointCount; i++)
+    {
+        if (offsets[i] > ilOffset)
+            break;
+
+        if (lines[i] != HiddenLine)
+            bestSoFar = i;
     }
 
-#else
+    if (bestSoFar != -1)
+    {
+        ULONG32 cchNeeded = 0;
+        IfFailRet(documents[bestSoFar]->GetURL(cchFileName, &cchNeeded, pwszFileName));
+
+        *pLinenum = lines[bestSoFar];
+        return S_OK;
+    }
+#endif // FEATURE_PAL
+
+    return E_FAIL;
+}
+
+HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDebugILFrame * pILFrame, mdMethodDef methodToken, 
+    ULONG localIndex, __inout_ecount(paramNameLen) WCHAR* paramName, ULONG paramNameLen, ICorDebugValue** ppValue)
+{
+    HRESULT Status = S_OK;
+
+    if (m_symbolReaderHandle != 0)
+    {
+        _ASSERTE(getLocalVariableNameDelegate != nullptr);
+
+        BSTR wszParamName = SysAllocStringLen(0, mdNameLen);
+        if (wszParamName == NULL)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        if (getLocalVariableNameDelegate(m_symbolReaderHandle, methodToken, localIndex, &wszParamName) == FALSE)
+        {
+            SysFreeString(wszParamName);
+            return E_FAIL;
+        }
+
+        wcscpy_s(paramName, paramNameLen, wszParamName);
+        SysFreeString(wszParamName);
+
+        if (FAILED(pILFrame->GetLocalVariable(localIndex, ppValue)) || (*ppValue == NULL))
+        {
+            *ppValue = NULL;
+            return E_FAIL;
+        }
+        return S_OK;
+    }
+
+#ifndef FEATURE_PAL
+    if (m_pSymReader == NULL)
+        return E_FAIL;
+
     if (pScope == NULL)
     {
         ToRelease<ISymUnmanagedMethod> pSymMethod;
@@ -6534,14 +6527,14 @@ HRESULT SymbolReader::GetNamedLocalVariable(ISymUnmanagedScope * pScope, ICorDeb
         }
 
         for (ULONG j = 0; j < numChildren; j++) pChildren[j]->Release();
-
     }
+#endif // FEATURE_PAL
 
     return E_FAIL;
-#endif // FEATURE_PAL
 }
 
-HRESULT SymbolReader::GetNamedLocalVariable(ICorDebugFrame * pFrame, ULONG localIndex, __inout_ecount(paramNameLen) WCHAR* paramName, ULONG paramNameLen, ICorDebugValue** ppValue)
+HRESULT SymbolReader::GetNamedLocalVariable(ICorDebugFrame * pFrame, ULONG localIndex, 
+    __inout_ecount(paramNameLen) WCHAR* paramName, ULONG paramNameLen, ICorDebugValue** ppValue)
 {
     HRESULT Status = S_OK;
 
@@ -6568,7 +6561,26 @@ HRESULT SymbolReader::ResolveSequencePoint(__in_z WCHAR* pFilename, ULONG32 line
 {
     HRESULT Status = S_OK;
 
+    if (m_symbolReaderHandle != 0)
+    {
+        _ASSERTE(resolveSequencePointDelegate != nullptr);
+
+        char szName[mdNameLen];
+        if (WideCharToMultiByte(CP_ACP, 0, pFilename, (int)(_wcslen(pFilename) + 1), szName, mdNameLen, NULL, NULL) == 0)
+        { 
+            return E_FAIL;
+        }
+        if (resolveSequencePointDelegate(m_symbolReaderHandle, szName, lineNumber, pToken, pIlOffset) == FALSE)
+        {
+            return E_FAIL;
+        }
+        return S_OK;
+    }
+
 #ifndef FEATURE_PAL
+    if (m_pSymReader == NULL)
+        return E_FAIL;
+
     ULONG32 cDocs = 0;
     ULONG32 cDocsNeeded = 0;
     ArrayHolder<ToRelease<ISymUnmanagedDocument>> pDocs = NULL;
@@ -6580,7 +6592,7 @@ HRESULT SymbolReader::ResolveSequencePoint(__in_z WCHAR* pFilename, ULONG32 line
 
     ULONG32 filenameLen = (ULONG32) _wcslen(pFilename);
 
-    for(ULONG32 i = 0; i < cDocs; i++)
+    for (ULONG32 i = 0; i < cDocs; i++)
     {
         ULONG32 cchUrl = 0;
         ULONG32 cchUrlNeeded = 0;
@@ -6591,18 +6603,18 @@ HRESULT SymbolReader::ResolveSequencePoint(__in_z WCHAR* pFilename, ULONG32 line
         IfFailRet(pDocs[i]->GetURL(cchUrl, &cchUrlNeeded, pUrl));
 
         // If the URL is exactly as long as the filename then compare the two names directly
-        if(cchUrl-1 == filenameLen)
+        if (cchUrl-1 == filenameLen)
         {
-            if(0!=_wcsicmp(pUrl, pFilename))
+            if (0!=_wcsicmp(pUrl, pFilename))
                 continue;
         }
         // does the URL suffix match [back]slash + filename?
-        else if(cchUrl-1 > filenameLen)
+        else if (cchUrl-1 > filenameLen)
         {
             WCHAR* slashLocation = pUrl + (cchUrl - filenameLen - 2);
-            if(*slashLocation != L'\\' && *slashLocation != L'/')
+            if (*slashLocation != L'\\' && *slashLocation != L'/')
                 continue;
-            if(0 != _wcsicmp(slashLocation+1, pFilename))
+            if (0 != _wcsicmp(slashLocation+1, pFilename))
                 continue;
         }
         // URL is too short to match
@@ -6610,7 +6622,7 @@ HRESULT SymbolReader::ResolveSequencePoint(__in_z WCHAR* pFilename, ULONG32 line
             continue;
 
         ULONG32 closestLine = 0;
-        if(FAILED(pDocs[i]->FindClosestLine(lineNumber, &closestLine)))
+        if (FAILED(pDocs[i]->FindClosestLine(lineNumber, &closestLine)))
             continue;
 
         ToRelease<ISymUnmanagedMethod> pSymUnmanagedMethod;
@@ -6625,29 +6637,9 @@ HRESULT SymbolReader::ResolveSequencePoint(__in_z WCHAR* pFilename, ULONG32 line
         }
         return S_OK;
     }
-    return E_FAIL;
-
-#else
-    if (loadSymbolsForModuleDelegate == nullptr)
-    {
-        IfFailRet(PrepareSymbolReader());
-    }
-
-    char szName[mdNameLen];
-    WideCharToMultiByte(CP_ACP, 0, pFilename, (int) (_wcslen(pFilename) + 1), szName, mdNameLen, NULL, NULL);
-
-    WCHAR FileNameW[MAX_LONGPATH];
-    char FileName[MAX_LONGPATH];
-    FileNameForModule(mod, FileNameW);
-
-    WideCharToMultiByte(CP_ACP, 0, FileNameW, (int) (_wcslen(FileNameW) + 1), FileName, MAX_LONGPATH, NULL, NULL);
-    if (resolveSequencePointDelegate(FileName, szName, lineNumber, pToken, pIlOffset) == FALSE)
-    {
-        return E_FAIL;
-    }
-
-    return S_OK;
 #endif // FEATURE_PAL
+
+    return E_FAIL;
 }
 
 static void AddAssemblyName(WString& methodOutput, CLRDATA_ADDRESS mdesc)
@@ -6658,17 +6650,21 @@ static void AddAssemblyName(WString& methodOutput, CLRDATA_ADDRESS mdesc)
         DacpModuleData dmd;
         if (SUCCEEDED(dmd.Request(g_sos, mdescData.ModulePtr)))
         {
-            ArrayHolder<WCHAR> wszFileName = new WCHAR[MAX_LONGPATH+1];
-            if (SUCCEEDED(g_sos->GetPEFileName(dmd.File, MAX_LONGPATH, wszFileName, NULL)))
+            ToRelease<IXCLRDataModule> pModule;
+            if (SUCCEEDED(g_sos->GetModule(mdescData.ModulePtr, &pModule)))
             {
-                if (wszFileName[0] != W('\0'))
+                ArrayHolder<WCHAR> wszFileName = new WCHAR[MAX_LONGPATH + 1];
+                ULONG32 nameLen = 0;
+                if (SUCCEEDED(pModule->GetFileName(MAX_LONGPATH, &nameLen, wszFileName)))
                 {
-                    WCHAR *pJustName = _wcsrchr(wszFileName, DIRECTORY_SEPARATOR_CHAR_W);
-                    if (pJustName == NULL)
-                        pJustName = wszFileName - 1;
-
-                    methodOutput += (pJustName + 1);
-                    methodOutput += W("!");
+                    if (wszFileName[0] != W('\0'))
+                    {
+                        WCHAR *pJustName = _wcsrchr(wszFileName, DIRECTORY_SEPARATOR_CHAR_W);
+                        if (pJustName == NULL)
+                            pJustName = wszFileName - 1;
+                        methodOutput += (pJustName + 1);
+                        methodOutput += W("!");
+                    }
                 }
             }
         }
@@ -6728,30 +6724,6 @@ WString GetFrameFromAddress(TADDR frameAddr, IXCLRDataStackWalk *pStackWalk, BOO
     }
     
     return frameOutput;
-}
-
-String ModuleNameFromIP(CLRDATA_ADDRESS ip)
-{
-    CLRDATA_ADDRESS mdesc = 0;
-    if (SUCCEEDED(g_sos->GetMethodDescPtrFromIP(ip, &mdesc)))
-    {
-        DacpMethodDescData mdescData;
-        DacpModuleData moduleData;
-        if (SUCCEEDED(mdescData.Request(g_sos, mdesc)))
-        {
-            if (SUCCEEDED(moduleData.Request(g_sos, mdescData.ModulePtr)))
-            {
-                ArrayHolder<WCHAR> wszModuleName = new WCHAR[MAX_LONGPATH+1];
-                if (SUCCEEDED(g_sos->GetPEFileName(moduleData.File, MAX_LONGPATH, wszModuleName, NULL)))
-                {
-                    ArrayHolder<char> szModuleName = new char[MAX_LONGPATH+1];
-                    WideCharToMultiByte(CP_ACP, 0, wszModuleName, (int) (_wcslen(wszModuleName) + 1), szModuleName, mdNameLen, NULL, NULL);
-                    return szModuleName.GetPtr();
-                }
-            }
-        }
-    }
-    return "";
 }
 
 WString MethodNameFromIP(CLRDATA_ADDRESS ip, BOOL bSuppressLines, BOOL bAssemblyName, BOOL bDisplacement)
@@ -6825,15 +6797,10 @@ WString MethodNameFromIP(CLRDATA_ADDRESS ip, BOOL bSuppressLines, BOOL bAssembly
             methodOutput = W("<unknown>");
         }
 
-        ArrayHolder<char> szFileName = new char[MAX_LONGPATH+1];
-
+        ArrayHolder<WCHAR> wszFileName = new WCHAR[MAX_LONGPATH];
         if (!bSuppressLines &&
-            SUCCEEDED(GetLineByOffset(TO_CDADDR(ip), &linenum, szFileName, MAX_LONGPATH)))
+            SUCCEEDED(GetLineByOffset(TO_CDADDR(ip), &linenum, wszFileName, MAX_LONGPATH)))
         {
-            int len = MultiByteToWideChar(CP_ACP, 0, szFileName, MAX_LONGPATH, NULL, 0);
-            ArrayHolder<WCHAR> wszFileName = new WCHAR[len];
-            MultiByteToWideChar(CP_ACP, 0, szFileName, MAX_LONGPATH, wszFileName, len);
-            
             methodOutput += WString(W(" [")) + wszFileName + W(" @ ") + Decimal(linenum) + W("]");
         }
     }

--- a/src/ToolBox/SOS/lldbplugin/inc/lldbservices.h
+++ b/src/ToolBox/SOS/lldbplugin/inc/lldbservices.h
@@ -67,6 +67,17 @@ extern "C" {
 #define DEBUG_CLASS_USER_WINDOWS  2
 #define DEBUG_CLASS_IMAGE_FILE    3
 
+// Generic dump types.  These can be used
+// with either user or kernel sessions.
+// Session-type-specific aliases are also
+// provided.
+#define DEBUG_DUMP_SMALL      1024
+#define DEBUG_DUMP_DEFAULT    1025
+#define DEBUG_DUMP_FULL       1026
+#define DEBUG_DUMP_IMAGE_FILE 1027
+#define DEBUG_DUMP_TRACE_LOG  1028
+#define DEBUG_DUMP_WINDOWS_CE 1029
+
 #define IMAGE_FILE_MACHINE_I386              0x014c  // Intel 386.
 #define IMAGE_FILE_MACHINE_ARMNT             0x01c4  // ARM Thumb-2 Little-Endian
 #define IMAGE_FILE_MACHINE_AMD64             0x8664  // AMD64 (K8)

--- a/src/debug/daccess/dacimpl.h
+++ b/src/debug/daccess/dacimpl.h
@@ -2570,9 +2570,14 @@ public:
         /* [size_is][out] */ BYTE *outBuffer);
 
     HRESULT RequestGetModulePtr(IN ULONG32 inBufferSize,
-                              IN BYTE* inBuffer,
-                              IN ULONG32 outBufferSize,
-                              OUT BYTE* outBuffer);
+                                IN BYTE* inBuffer,
+                                IN ULONG32 outBufferSize,
+                                OUT BYTE* outBuffer);
+
+    HRESULT RequestGetModuleData(IN ULONG32 inBufferSize,
+                                 IN BYTE* inBuffer,
+                                 IN ULONG32 outBufferSize,
+                                 OUT BYTE* outBuffer);
 
     Module* GetModule(void)
     {

--- a/src/debug/daccess/task.cpp
+++ b/src/debug/daccess/task.cpp
@@ -2710,6 +2710,55 @@ ClrDataModule::RequestGetModulePtr(
     outGMA->ModulePtr = TO_CDADDR(PTR_HOST_TO_TADDR(m_module));
     return S_OK;    
 }
+
+HRESULT 
+ClrDataModule::RequestGetModuleData(
+    /* [in] */ ULONG32 inBufferSize,
+    /* [size_is][in] */ BYTE *inBuffer,
+    /* [in] */ ULONG32 outBufferSize,
+    /* [size_is][out] */ BYTE *outBuffer)
+{
+    // Validate params.
+    // Input: Nothing.
+    // Output: a DacpGetModuleData structure.
+    if ((inBufferSize != 0) ||
+        (inBuffer != NULL) ||
+        (outBufferSize != sizeof(DacpGetModuleData)) ||
+        (outBuffer == NULL))
+    {
+        return E_INVALIDARG;
+    }
+
+    DacpGetModuleData * outGMD = reinterpret_cast<DacpGetModuleData *>(outBuffer);
+    ZeroMemory(outGMD, sizeof(DacpGetModuleData));
+
+    Module* pModule = GetModule();
+    PEFile *pPEFile = pModule->GetFile();
+
+    outGMD->PEFile = TO_CDADDR(PTR_HOST_TO_TADDR(pPEFile));
+    outGMD->bIsDynamic = pModule->IsReflection();
+
+    if (pPEFile != NULL)
+    {
+        outGMD->bIsInMemory = pPEFile->GetPath().IsEmpty();
+
+        COUNT_T peSize;
+        outGMD->LoadedPEAddress = TO_CDADDR(PTR_TO_TADDR(pPEFile->GetLoadedImageContents(&peSize)));
+        outGMD->LoadedPESize = (ULONG64)peSize;
+    }
+
+    // If there is a in memory symbol stream
+    CGrowableStream* stream = pModule->GetInMemorySymbolStream();
+    if (stream != NULL)
+    {
+        // Save the in-memory PDB address and size
+        MemoryRange range = stream->GetRawBuffer();
+        outGMD->InMemoryPdbAddress = TO_CDADDR(PTR_TO_TADDR(range.StartAddress()));
+        outGMD->InMemoryPdbSize = range.Size();
+    }
+
+    return S_OK;    
+}
         
 HRESULT STDMETHODCALLTYPE
 ClrDataModule::Request( 
@@ -2742,9 +2791,11 @@ ClrDataModule::Request(
             break;
 
         case DACDATAMODULEPRIV_REQUEST_GET_MODULEPTR:
-            status = RequestGetModulePtr(inBufferSize, inBuffer,
-                                         outBufferSize, outBuffer);
+            status = RequestGetModulePtr(inBufferSize, inBuffer, outBufferSize, outBuffer);
+            break;
 
+        case DACDATAMODULEPRIV_REQUEST_GET_MODULEDATA:
+            status = RequestGetModuleData(inBufferSize, inBuffer, outBufferSize, outBuffer);
             break;
                 
         default:

--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -250,8 +250,8 @@ int coreclr_initialize(
 
         hr = coreclr_create_delegate(*hostHandle,
                                      *domainId,
-                                     "System.Diagnostics.Debug.SymbolReader",
-                                     "System.Diagnostics.Debug.SymbolReader.SymbolReader",
+                                     "System.Diagnostics.StackTrace",
+                                     "System.Diagnostics.SymbolReader",
                                      "GetInfoForMethod",
                                      (void**)&getInfoForMethodDelegate);
 

--- a/src/inc/dacprivate.h
+++ b/src/inc/dacprivate.h
@@ -46,7 +46,8 @@ struct ZeroInit
 // Private requests for DataModules
 enum
 {
-    DACDATAMODULEPRIV_REQUEST_GET_MODULEPTR = 0xf0000000
+    DACDATAMODULEPRIV_REQUEST_GET_MODULEPTR = 0xf0000000,
+    DACDATAMODULEPRIV_REQUEST_GET_MODULEDATA = 0xf0000001
 };
 
 
@@ -902,9 +903,23 @@ struct DacpGetModuleAddress : ZeroInit<DacpGetModuleAddress>
     CLRDATA_ADDRESS ModulePtr;
     HRESULT Request(IXCLRDataModule* pDataModule)
     {
-        return pDataModule->Request(DACDATAMODULEPRIV_REQUEST_GET_MODULEPTR,
-                                0, NULL,
-                                sizeof(*this), (PBYTE) this);
+        return pDataModule->Request(DACDATAMODULEPRIV_REQUEST_GET_MODULEPTR, 0, NULL, sizeof(*this), (PBYTE) this);
+    }
+};
+
+struct DacpGetModuleData : ZeroInit<DacpGetModuleData>
+{
+    CLRDATA_ADDRESS PEFile;
+    BOOL bIsDynamic;
+    BOOL bIsInMemory;
+    CLRDATA_ADDRESS LoadedPEAddress;
+    ULONG64 LoadedPESize;
+    CLRDATA_ADDRESS InMemoryPdbAddress;
+    ULONG64 InMemoryPdbSize;
+
+    HRESULT Request(IXCLRDataModule* pDataModule)
+    {
+        return pDataModule->Request(DACDATAMODULEPRIV_REQUEST_GET_MODULEDATA, 0, NULL, sizeof(*this), (PBYTE) this);
     }
 };
 

--- a/src/inc/palclr.h
+++ b/src/inc/palclr.h
@@ -86,6 +86,7 @@
 #endif
 
 #define DIRECTORY_SEPARATOR_CHAR_A '\\'
+#define DIRECTORY_SEPARATOR_STR_A "\\"
 #define DIRECTORY_SEPARATOR_CHAR_W W('\\')
 #define DIRECTORY_SEPARATOR_STR_W W("\\")
 

--- a/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
+++ b/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
@@ -125,13 +125,13 @@ namespace System.Diagnostics {
                 if (s_symbolsMethodInfo == null)
                 {
                     s_symbolsType = Type.GetType(
-                        "System.Diagnostics.StackTraceSymbols, System.Diagnostics.StackTrace, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                        "System.Diagnostics.StackTraceSymbols, System.Diagnostics.StackTrace, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
                         throwOnError: false);
 
                     if (s_symbolsType == null)
                         return;
 
-                    s_symbolsMethodInfo = s_symbolsType.GetMethod("GetSourceLineInfo");
+                    s_symbolsMethodInfo = s_symbolsType.GetMethod("GetSourceLineInfo", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
                     if (s_symbolsMethodInfo == null)
                         return;
                 }
@@ -147,7 +147,7 @@ namespace System.Diagnostics {
 
                 for (int index = 0; index < iFrameCount; index++)
                 {
-                    // If there was some reason not to try get get the symbols from the portable PDB reader like the module was
+                    // If there was some reason not to try get the symbols from the portable PDB reader like the module was
                     // ENC or the source/line info was already retrieved, the method token is 0.
                     if (rgiMethodToken[index] != 0)
                     {

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -99,18 +99,24 @@ GetDebugInfoFromPDB(MethodDesc* MethodDescPtr, SymbolsInfo** symInfo, unsigned i
 
     const Module* mod = MethodDescPtr->GetMethodTable()->GetModule();
     SString modName = mod->GetFile()->GetPath();
+
+    COUNT_T peSize;
+    PTR_CVOID peAddress = mod->GetFile()->GetLoadedImageContents(&peSize);
+
     StackScratchBuffer scratch;
     const char* szModName = modName.GetUTF8(scratch);
 
     MethodDebugInfo* methodDebugInfo = new (nothrow) MethodDebugInfo();
     if (methodDebugInfo == nullptr)
         return E_OUTOFMEMORY;
+
     methodDebugInfo->points = (SequencePointInfo*) CoTaskMemAlloc(sizeof(SequencePointInfo) * numMap);
     if (methodDebugInfo->points == nullptr)
         return E_OUTOFMEMORY;
+
     methodDebugInfo->size = numMap;
 
-    if (getInfoForMethodDelegate(szModName, MethodDescPtr->GetMemberDef(), *methodDebugInfo) == FALSE)
+    if (getInfoForMethodDelegate(szModName, PTR_TO_TADDR(peAddress), (int)peSize, MethodDescPtr->GetMemberDef(), *methodDebugInfo) == FALSE)
         return E_FAIL;
 
     symInfoLen = methodDebugInfo->size;

--- a/src/vm/gdbjithelpers.h
+++ b/src/vm/gdbjithelpers.h
@@ -25,7 +25,7 @@ struct MethodDebugInfo
     int size;
 };
 
-typedef BOOL (*GetInfoForMethodDelegate)(const char*, unsigned int, MethodDebugInfo& methodDebugInfo);
+typedef BOOL (*GetInfoForMethodDelegate)(const char*, ULONG64, int, unsigned int, MethodDebugInfo& methodDebugInfo);
 extern GetInfoForMethodDelegate getInfoForMethodDelegate;
 
 #endif // !__GDBJITHELPERS_H__


### PR DESCRIPTION
The portable PDB helper code for SOS source/line support has been moved from
System.Diagnostics.Debug.SymbolReader to System.Diagnostics.StackTrace.

The public APIs have now been made internal.

Plumb through the loaded PE address to the managed SymbolReader functions so it can be used as a key.

Fixed a stack trashing/overflow when a unresolved managed breakpoint is resolved because one of the
module name buffers was too small (MAX_PATH_FNAME). Changed it (and others) to MAXLONGPATH.

SOS now works with Portable PDBs on Windows.

New dac private get module data request. Used to get the necessary info for portable PDBs.

SOS now supports in-memory PDB's on xplat and Windows.

Better Windows GetLineByILOffset support. Uses the SymbolReader and now works with in-memory PEs.

Misc code formatting and general cleanup.