### PR TITLE
Makes FCallMemcpy unwindable

### DIFF
--- a/src/pal/inc/unixasmmacrosarm.inc
+++ b/src/pal/inc/unixasmmacrosarm.inc
@@ -21,6 +21,10 @@ C_FUNC(\Name):
         LEAF_END \Name, \Section
 .endm
 
+.macro NESTED_END_MARKED Name, Section
+        LEAF_END_MARKED \Name, \Section
+.endm
+
 .macro PATCH_LABEL Name
         .thumb_func
         .global C_FUNC(\Name)

--- a/src/vm/arm/memcpy.S
+++ b/src/vm/arm/memcpy.S
@@ -14,7 +14,7 @@
 // Copy a block of memory in a forward direction.
 //
 
-    LEAF_ENTRY FCallMemcpy, _TEXT
+    NESTED_ENTRY FCallMemcpy, _TEXT, NoHandler
         cmp r2, #0
         
         beq LOCAL_LABEL(GC_POLL)
@@ -36,4 +36,4 @@ LOCAL_LABEL(GC_POLL):
         it ne
         bne C_FUNC(FCallMemCpy_GCPoll)
         bx lr
-    LEAF_END_MARKED FCallMemcpy, _TEXT
+    NESTED_END_MARKED FCallMemcpy, _TEXT

--- a/src/vm/arm/memcpy.S
+++ b/src/vm/arm/memcpy.S
@@ -18,13 +18,16 @@
         cmp r2, #0
         
         beq LOCAL_LABEL(GC_POLL)
+
+        PROLOG_PUSH  "{r7, lr}"
+        PROLOG_STACK_SAVE r7
         
         ldr r3, [r0]
         ldr r3, [r1]
         
-        push {r7, lr} // r7 as a dummy to make SP aligned
         blx C_FUNC(memcpy)
-        pop {r7, lr}
+
+        EPILOG_POP   "{r7, pc}"
 
 LOCAL_LABEL(GC_POLL):
         ldr r0, =g_TrapReturningThreads


### PR DESCRIPTION
FCallMemcpy function in vm/arm/memcpy.S creates an stack frame that
libunwind cannot recognize, which leads to the issue in #6752.

This commit makes the stack frame of FCallMemcpy unwindable to fix
issue #6752.