### PR TITLE
Apply correct symbolic name _ARM_ instead of _TARGET_ARM_

### DIFF
--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -285,7 +285,7 @@ int ExecuteManagedAssembly(
     // Indicates failure
     int exitCode = -1;
 
-#ifdef _TARGET_ARM_
+#ifdef _ARM_
     // libunwind library is used to unwind stack frame, but libunwind for ARM
     // does not support ARM vfpv3/NEON registers in DWARF format correctly.
     // Therefore let's disable stack unwinding using DWARF information
@@ -297,7 +297,7 @@ int ExecuteManagedAssembly(
     // UNW_ARM_METHOD_FRAME        0x02
     // UNW_ARM_METHOD_EXIDX        0x04
     putenv(const_cast<char *>("UNW_ARM_UNWIND_METHOD=6"));
-#endif // _TARGET_ARM_
+#endif // _ARM_
 
     std::string coreClrDllPath(clrFilesAbsolutePath);
     coreClrDllPath.append("/");


### PR DESCRIPTION
Fix #6755.  PR #6700 does not work as intended, due to wrong symoblic name.

It also fix #6178 .
Signed-off-by: Hyung-Kyu Choi <hk0110.choi@samsung.com>