### PR TITLE
[WIP] Fix build break from alignments

### DIFF
--- a/src/vm/threadpoolrequest.h
+++ b/src/vm/threadpoolrequest.h
@@ -67,6 +67,11 @@ typedef DPTR(IPerAppDomainTPCount) PTR_IPerAppDomainTPCount;
 
 static const LONG ADUnloading = -1;
 
+#ifdef _MSC_VER
+// Disable this warning - we intentionally want __declspec(align()) to insert padding for us
+#pragma warning(disable: 4324) // structure was padded due to __declspec(align())
+#endif
+
 //--------------------------------------------------------------------------
 //ManagedPerAppDomainTPCount maintains per-appdomain thread pool state. 
 //This class maintains the count of per-appdomain work-items queued by
@@ -289,6 +294,10 @@ private:
     };
 };
 
+#ifdef _MSC_VER
+#pragma warning(default: 4324)  // structure was padded due to __declspec(align())
+#endif
+
 //--------------------------------------------------------------------------
 //PerAppDomainTPCountList maintains the collection of per-appdomain thread 
 //pool states. Per appdomain counts are added to the list during appdomain
@@ -343,8 +352,8 @@ private:
     static DWORD FindFirstFreeTpEntry();
 
     static BYTE s_padding[64 - sizeof(LONG)];
-    static LONG s_ADHint;
-    static UnManagedPerAppDomainTPCount s_unmanagedTPCount;
+    DECLSPEC_ALIGN(64) static LONG s_ADHint;
+    DECLSPEC_ALIGN(64) static UnManagedPerAppDomainTPCount s_unmanagedTPCount;
 
     //The list of all per-appdomain work-request counts.
     static ArrayListStatic s_appDomainIndexList;

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -1305,11 +1305,11 @@ private:
     SVAL_DECL(LONG,MinLimitTotalWorkerThreads);         // same as MinLimitTotalCPThreads
     SVAL_DECL(LONG,MaxLimitTotalWorkerThreads);         // same as MaxLimitTotalCPThreads
         
-    static unsigned int LastDequeueTime;      // used to determine if work items are getting thread starved 
+    DECLSPEC_ALIGN(64) static unsigned int LastDequeueTime;      // used to determine if work items are getting thread starved 
     
     static HillClimbing HillClimbingInstance;
 
-    static LONG PriorCompletedWorkRequests;
+    DECLSPEC_ALIGN(64) static LONG PriorCompletedWorkRequests;
     static DWORD PriorCompletedWorkRequestsTime;
     static DWORD NextCompletedWorkRequestsTime;
 
@@ -1335,7 +1335,7 @@ private:
     static const DWORD WorkerTimeout = 20 * 1000;
     static const DWORD WorkerTimeoutAppX = 5 * 1000;    // shorter timeout to allow threads to exit prior to app suspension
 
-    SVAL_DECL(ThreadCounter,WorkerCounter);
+    DECLSPEC_ALIGN(64) SVAL_DECL(ThreadCounter,WorkerCounter);
 
     // 
     // WorkerSemaphore is an UnfairSemaphore because:
@@ -1364,7 +1364,7 @@ private:
     SVAL_DECL(LIST_ENTRY,TimerQueue);                   // queue of timers
     static HANDLE TimerThread;                          // Currently we only have one timer thread
     static Thread*  pTimerThread;
-    static DWORD LastTickCount;                         // the count just before timer thread goes to sleep
+    DECLSPEC_ALIGN(64) static DWORD LastTickCount;      // the count just before timer thread goes to sleep
 
     static BOOL InitCompletionPortThreadpool;           // flag indicating whether completion port threadpool has been initialized
     static HANDLE GlobalCompletionPort;                 // used for binding io completions on file handles
@@ -1377,20 +1377,20 @@ private:
     SVAL_DECL(LONG,MinLimitTotalCPThreads);             
     SVAL_DECL(LONG,MaxFreeCPThreads);                   // = MaxFreeCPThreadsPerCPU * Number of CPUS
 
-    static LONG   GateThreadStatus;                    // See GateThreadStatus enumeration
+    DECLSPEC_ALIGN(64) static LONG GateThreadStatus;    // See GateThreadStatus enumeration
 
     static Volatile<LONG> NumCPInfrastructureThreads;   // number of threads currently busy handling draining cycle
 
     SVAL_DECL(LONG,cpuUtilization);
     static LONG cpuUtilizationAverage;
 
-    static RecycledListsWrapper RecycledLists;
+    DECLSPEC_ALIGN(64) static RecycledListsWrapper RecycledLists;
 
 #ifdef _DEBUG
     static DWORD   TickCountAdjustment;                 // add this value to value returned by GetTickCount
 #endif
 
-    static int offset_counter;
+    DECLSPEC_ALIGN(64) static int offset_counter;
     static const int offset_multiplier = 128;
 };
 


### PR DESCRIPTION
MSVC seems to require alignment specification to be on the declaration as well as the definition