### PR TITLE
Move the GC behind an interface and use that interface in the VM

### DIFF
--- a/src/classlibnative/bcltype/arraynative.cpp
+++ b/src/classlibnative/bcltype/arraynative.cpp
@@ -961,7 +961,7 @@ void memmoveGCRefs(void *dest, const void *src, size_t len)
         }
     }
 
-    GCHeap::GetGCHeap()->SetCardsAfterBulkCopy((Object**)dest, len);
+    GCHeapUtilities::GetGCHeap()->SetCardsAfterBulkCopy((Object**)dest, len);
 }
 
 void ArrayNative::ArrayCopyNoTypeCheck(BASEARRAYREF pSrc, unsigned int srcIndex, BASEARRAYREF pDest, unsigned int destIndex, unsigned int length)

--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -673,7 +673,7 @@ FCIMPL0(FC_BOOL_RET, SystemNative::IsServerGC)
 {
     FCALL_CONTRACT;
 
-    FC_RETURN_BOOL(GCHeap::IsServerHeap());
+    FC_RETURN_BOOL(GCHeapUtilities::IsServerHeap());
 }
 FCIMPLEND
 

--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -7974,7 +7974,7 @@ HRESULT DacHandleWalker::Init(ClrDataAccess *dac, UINT types[], UINT typeCount, 
 {
     SUPPORTS_DAC;
     
-    if (gen < 0 || gen > (int)GCHeap::GetMaxGeneration())
+    if (gen < 0 || gen > (int)GCHeapUtilities::GetMaxGeneration())
         return E_INVALIDARG;
         
     mGenerationFilter = gen;
@@ -8033,7 +8033,7 @@ bool DacHandleWalker::FetchMoreHandles(HANDLESCANPROC callback)
     int max_slots = 1;
     
 #ifdef FEATURE_SVR_GC
-    if (GCHeap::IsServerHeap())
+    if (GCHeapUtilities::IsServerHeap())
         max_slots = GCHeapCount();
 #endif // FEATURE_SVR_GC
 
@@ -8089,7 +8089,7 @@ bool DacHandleWalker::FetchMoreHandles(HANDLESCANPROC callback)
                                 HndScanHandlesForGC(hTable, callback, 
                                                     (LPARAM)&param, 0, 
                                                      &handleType, 1, 
-                                                     mGenerationFilter, GCHeap::GetMaxGeneration(), 0);
+                                                     mGenerationFilter, GCHeapUtilities::GetMaxGeneration(), 0);
                             else
                                 HndEnumHandles(hTable, &handleType, 1, callback, (LPARAM)&param, 0, FALSE);
                         }

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -6517,7 +6517,7 @@ HRESULT DacHeapWalker::Init(CORDB_ADDRESS start, CORDB_ADDRESS end)
             if (thread == NULL)
                 continue;
 
-            alloc_context *ctx = thread->GetAllocContext();
+            gc_alloc_context *ctx = thread->GetAllocContext();
             if (ctx == NULL)
                 continue;
 
@@ -6533,7 +6533,7 @@ HRESULT DacHeapWalker::Init(CORDB_ADDRESS start, CORDB_ADDRESS end)
     }
 
 #ifdef FEATURE_SVR_GC
-    HRESULT hr = GCHeap::IsServerHeap() ? InitHeapDataSvr(mHeaps, mHeapCount) : InitHeapDataWks(mHeaps, mHeapCount);
+    HRESULT hr = GCHeapUtilities::IsServerHeap() ? InitHeapDataSvr(mHeaps, mHeapCount) : InitHeapDataWks(mHeaps, mHeapCount);
 #else
     HRESULT hr = InitHeapDataWks(mHeaps, mHeapCount);
 #endif
@@ -6777,7 +6777,7 @@ HRESULT DacDbiInterfaceImpl::GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> *p
     HeapData *heaps = 0;
     
 #ifdef FEATURE_SVR_GC
-    HRESULT hr = GCHeap::IsServerHeap() ? DacHeapWalker::InitHeapDataSvr(heaps, heapCount) : DacHeapWalker::InitHeapDataWks(heaps, heapCount);
+    HRESULT hr = GCHeapUtilities::IsServerHeap() ? DacHeapWalker::InitHeapDataSvr(heaps, heapCount) : DacHeapWalker::InitHeapDataWks(heaps, heapCount);
 #else
     HRESULT hr = DacHeapWalker::InitHeapDataWks(heaps, heapCount);
 #endif
@@ -7171,7 +7171,7 @@ void DacDbiInterfaceImpl::GetGCHeapInformation(COR_HEAPINFO * pHeapInfo)
     pHeapInfo->areGCStructuresValid = GCScan::GetGcRuntimeStructuresValid();
     
 #ifdef FEATURE_SVR_GC
-    if (GCHeap::IsServerHeap())
+    if (GCHeapUtilities::IsServerHeap())
     {
         pHeapInfo->gcType = CorDebugServerGC;
         pHeapInfo->numHeaps = DacGetNumHeaps();

--- a/src/debug/daccess/enummem.cpp
+++ b/src/debug/daccess/enummem.cpp
@@ -250,9 +250,9 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
         ReportMem(m_globalBase + g_dacGlobals.SharedDomain__m_pSharedDomain,
                   sizeof(SharedDomain));
 
-        // We need GCHeap pointer to make EEVersion work
+        // We need IGCHeap pointer to make EEVersion work
         ReportMem(m_globalBase + g_dacGlobals.dac__g_pGCHeap,
-              sizeof(GCHeap *));
+              sizeof(IGCHeap *));
 
         // see synblk.cpp, the pointer is pointed to a static byte[]
         SyncBlockCache::s_pSyncBlockCache.EnumMem();
@@ -316,7 +316,7 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
 #ifdef FEATURE_SVR_GC
     CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED
     (
-        GCHeap::gcHeapType.EnumMem();
+        IGCHeap::gcHeapType.EnumMem();
     );
 #endif // FEATURE_SVR_GC
 

--- a/src/debug/daccess/request_svr.cpp
+++ b/src/debug/daccess/request_svr.cpp
@@ -256,7 +256,7 @@ ClrDataAccess::EnumSvrGlobalMemoryRegions(CLRDataEnumMemoryFlags flags)
         // enumerating the generations from max (which is normally gen2) to max+1 gives you
         // the segment list for all the normal segements plus the large heap segment (max+1)
         // this is the convention in the GC so it is repeated here
-        for (ULONG i = GCHeap::GetMaxGeneration(); i <= GCHeap::GetMaxGeneration()+1; i++)
+        for (ULONG i = GCHeapUtilities::GetMaxGeneration(); i <= GCHeapUtilities::GetMaxGeneration()+1; i++)
         {
             __DPtr<SVR::heap_segment> seg = dac_cast<TADDR>(pHeap->generation_table[i].start_segment);
             while (seg)
@@ -271,7 +271,7 @@ ClrDataAccess::EnumSvrGlobalMemoryRegions(CLRDataEnumMemoryFlags flags)
 
 DWORD DacGetNumHeaps()
 {
-    if (GCHeap::IsServerHeap())
+    if (GCHeapUtilities::IsServerHeap())
         return (DWORD)SVR::gc_heap::n_heaps;
         
     // workstation gc

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -9,10 +9,11 @@
 
 struct ScanContext;
 class CrawlFrame;
+struct gc_alloc_context;
 
 typedef void promote_func(PTR_PTR_Object, ScanContext*, uint32_t);
 
-typedef void enum_alloc_context_func(alloc_context*, void*);
+typedef void enum_alloc_context_func(gc_alloc_context*, void*);
 
 typedef struct
 {
@@ -74,7 +75,7 @@ public:
     static void EnablePreemptiveGC(Thread * pThread);
     static void DisablePreemptiveGC(Thread * pThread);
 
-    static alloc_context * GetAllocContext(Thread * pThread);
+    static gc_alloc_context * GetAllocContext(Thread * pThread);
     static bool CatchAtSafePoint(Thread * pThread);
 
     static void GcEnumAllocContexts(enum_alloc_context_func* fn, void* param);

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -14,9 +14,8 @@ Module Name:
 #ifndef __GC_H
 #define __GC_H
 
-#ifdef PROFILING_SUPPORTED
-#define GC_PROFILING       //Turn on profiling
-#endif // PROFILING_SUPPORTED
+#include "gcinterface.h"
+
 
 /*
  * Promotion Function Prototypes
@@ -80,6 +79,24 @@ enum oom_reason
     oom_unproductive_full_gc = 6
 };
 
+// TODO : it would be easier to make this an ORed value
+enum gc_reason
+{
+    reason_alloc_soh = 0,
+    reason_induced = 1,
+    reason_lowmemory = 2,
+    reason_empty = 3,
+    reason_alloc_loh = 4,
+    reason_oos_soh = 5,
+    reason_oos_loh = 6,
+    reason_induced_noforce = 7, // it's an induced GC and doesn't have to be blocking.
+    reason_gcstress = 8,        // this turns into reason_induced & gc_mechanisms.stress_induced = true
+    reason_lowmemory_blocking = 9,
+    reason_induced_compacting = 10,
+    reason_lowmemory_host = 11,
+    reason_max
+};
+
 struct oom_history
 {
     oom_reason reason;
@@ -97,27 +114,15 @@ struct oom_history
 class CObjectHeader;
 class Object;
 
-class GCHeap;
+class IGCHeapInternal;
 
 /* misc defines */
 #define LARGE_OBJECT_SIZE ((size_t)(85000))
-
-GPTR_DECL(GCHeap, g_pGCHeap);
 
 #ifdef GC_CONFIG_DRIVEN
 #define MAX_GLOBAL_GC_MECHANISMS_COUNT 6
 GARY_DECL(size_t, gc_global_mechanisms, MAX_GLOBAL_GC_MECHANISMS_COUNT);
 #endif //GC_CONFIG_DRIVEN
-
-#ifndef DACCESS_COMPILE
-extern "C" {
-#endif
-GPTR_DECL(uint8_t,g_lowest_address);
-GPTR_DECL(uint8_t,g_highest_address);
-GPTR_DECL(uint32_t,g_card_table);
-#ifndef DACCESS_COMPILE
-}
-#endif
 
 #ifdef DACCESS_COMPILE
 class DacHeapWalker;
@@ -127,136 +132,21 @@ class DacHeapWalker;
 #define  _LOGALLOC
 #endif
 
-#ifdef WRITE_BARRIER_CHECK
-//always defined, but should be 0 in Server GC
-extern uint8_t* g_GCShadow;
-extern uint8_t* g_GCShadowEnd;
-// saves the g_lowest_address in between GCs to verify the consistency of the shadow segment
-extern uint8_t* g_shadow_lowest_address;
-#endif
-
 #define MP_LOCKS
 
-extern "C" uint8_t* g_ephemeral_low;
-extern "C" uint8_t* g_ephemeral_high;
-
 namespace WKS {
-    ::GCHeap* CreateGCHeap();
+    ::IGCHeapInternal* CreateGCHeap();
     class GCHeap;
     class gc_heap;
     }
 
 #if defined(FEATURE_SVR_GC)
 namespace SVR {
-    ::GCHeap* CreateGCHeap();
+    ::IGCHeapInternal* CreateGCHeap();
     class GCHeap;
     class gc_heap;
 }
 #endif // defined(FEATURE_SVR_GC)
-
-/*
- * Ephemeral Garbage Collected Heap Interface
- */
-
-
-struct alloc_context 
-{
-    friend class WKS::gc_heap;
-#if defined(FEATURE_SVR_GC)
-    friend class SVR::gc_heap;
-    friend class SVR::GCHeap;
-#endif // defined(FEATURE_SVR_GC)
-    friend struct ClassDumpInfo;
-
-    uint8_t*       alloc_ptr;
-    uint8_t*       alloc_limit;
-    int64_t        alloc_bytes; //Number of bytes allocated on SOH by this context
-    int64_t        alloc_bytes_loh; //Number of bytes allocated on LOH by this context
-#if defined(FEATURE_SVR_GC)
-    SVR::GCHeap*   alloc_heap;
-    SVR::GCHeap*   home_heap;
-#endif // defined(FEATURE_SVR_GC)
-    int            alloc_count;
-public:
-
-    void init()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        alloc_ptr = 0;
-        alloc_limit = 0;
-        alloc_bytes = 0;
-        alloc_bytes_loh = 0;
-#if defined(FEATURE_SVR_GC)
-        alloc_heap = 0;
-        home_heap = 0;
-#endif // defined(FEATURE_SVR_GC)
-        alloc_count = 0;
-    }
-};
-
-struct ScanContext
-{
-    Thread* thread_under_crawl;
-    int thread_number;
-    uintptr_t stack_limit; // Lowest point on the thread stack that the scanning logic is permitted to read
-    BOOL promotion; //TRUE: Promotion, FALSE: Relocation.
-    BOOL concurrent; //TRUE: concurrent scanning 
-#if CHECK_APP_DOMAIN_LEAKS || defined (FEATURE_APPDOMAIN_RESOURCE_MONITORING) || defined (DACCESS_COMPILE)
-    AppDomain *pCurrentDomain;
-#endif //CHECK_APP_DOMAIN_LEAKS || FEATURE_APPDOMAIN_RESOURCE_MONITORING || DACCESS_COMPILE
-
-#ifndef FEATURE_REDHAWK
-#if defined(GC_PROFILING) || defined (DACCESS_COMPILE)
-    MethodDesc *pMD;
-#endif //GC_PROFILING || DACCESS_COMPILE
-#endif // FEATURE_REDHAWK
-#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
-    EtwGCRootKind dwEtwRootKind;
-#endif // GC_PROFILING || FEATURE_EVENT_TRACE
-    
-    ScanContext()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        thread_under_crawl = 0;
-        thread_number = -1;
-        stack_limit = 0;
-        promotion = FALSE;
-        concurrent = FALSE;
-#ifdef GC_PROFILING
-        pMD = NULL;
-#endif //GC_PROFILING
-#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
-        dwEtwRootKind = kEtwGCRootKindOther;
-#endif // GC_PROFILING || FEATURE_EVENT_TRACE
-    }
-};
-
-typedef BOOL (* walk_fn)(Object*, void*);
-typedef void (* gen_walk_fn)(void *context, int generation, uint8_t *range_start, uint8_t * range_end, uint8_t *range_reserved);
-
-#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
-struct ProfilingScanContext : ScanContext
-{
-    BOOL fProfilerPinned;
-    void * pvEtwContext;
-    void *pHeapId;
-    
-    ProfilingScanContext(BOOL fProfilerPinnedParam) : ScanContext()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        pHeapId = NULL;
-        fProfilerPinned = fProfilerPinnedParam;
-        pvEtwContext = NULL;
-#ifdef FEATURE_CONSERVATIVE_GC
-        // To not confuse GCScan::GcScanRoots
-        promotion = g_pConfig->GetGCConservative();
-#endif
-    }
-};
-#endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
 #ifdef STRESS_HEAP
 #define IN_STRESS_HEAP(x) x
@@ -266,58 +156,12 @@ struct ProfilingScanContext : ScanContext
 #define STRESS_HEAP_ARG(x)
 #endif // STRESS_HEAP
 
-
 //dynamic data interface
 struct gc_counters
 {
     size_t current_size;
     size_t promoted_size;
     size_t collection_count;
-};
-
-// !!!!!!!!!!!!!!!!!!!!!!!
-// make sure you change the def in bcl\system\gc.cs 
-// if you change this!
-enum collection_mode
-{
-    collection_non_blocking = 0x00000001,
-    collection_blocking = 0x00000002,
-    collection_optimized = 0x00000004,
-    collection_compacting = 0x00000008
-#ifdef STRESS_HEAP
-    , collection_gcstress = 0x80000000
-#endif // STRESS_HEAP
-};
-
-// !!!!!!!!!!!!!!!!!!!!!!!
-// make sure you change the def in bcl\system\gc.cs 
-// if you change this!
-enum wait_full_gc_status
-{
-    wait_full_gc_success = 0,
-    wait_full_gc_failed = 1,
-    wait_full_gc_cancelled = 2,
-    wait_full_gc_timeout = 3,
-    wait_full_gc_na = 4
-};
-
-// !!!!!!!!!!!!!!!!!!!!!!!
-// make sure you change the def in bcl\system\gc.cs 
-// if you change this!
-enum start_no_gc_region_status
-{
-    start_no_gc_success = 0,
-    start_no_gc_no_memory = 1,
-    start_no_gc_too_large = 2,
-    start_no_gc_in_progress = 3
-};
-
-enum end_no_gc_region_status
-{
-    end_no_gc_success = 0,
-    end_no_gc_not_in_progress = 1,
-    end_no_gc_induced = 2,
-    end_no_gc_alloc_exceeded = 3
 };
 
 enum bgc_state
@@ -352,19 +196,32 @@ void record_changed_seg (uint8_t* start, uint8_t* end,
 void record_global_mechanism (int mech_index);
 #endif //GC_CONFIG_DRIVEN
 
-//constants for the flags parameter to the gc call back
+struct alloc_context : gc_alloc_context 
+{
+#ifdef FEATURE_SVR_GC
+    inline SVR::GCHeap* get_alloc_heap()
+    {
+        return static_cast<SVR::GCHeap*>(gc_reserved_1);
+    }
 
-#define GC_CALL_INTERIOR            0x1
-#define GC_CALL_PINNED              0x2
-#define GC_CALL_CHECK_APP_DOMAIN    0x4
+    inline void set_alloc_heap(SVR::GCHeap* heap)
+    {
+        gc_reserved_1 = heap;
+    }
 
-//flags for GCHeap::Alloc(...)
-#define GC_ALLOC_FINALIZE 0x1
-#define GC_ALLOC_CONTAINS_REF 0x2
-#define GC_ALLOC_ALIGN8_BIAS 0x4
-#define GC_ALLOC_ALIGN8 0x8
+    inline SVR::GCHeap* get_home_heap()
+    {
+        return static_cast<SVR::GCHeap*>(gc_reserved_2);
+    }
 
-class GCHeap {
+    inline void set_home_heap(SVR::GCHeap* heap)
+    {
+        gc_reserved_2 = heap;
+    }
+#endif // FEATURE_SVR_GC
+};
+
+class IGCHeapInternal : public IGCHeap {
     friend struct ::_DacGlobals;
 #ifdef DACCESS_COMPILE
     friend class ClrDataAccess;
@@ -372,256 +229,39 @@ class GCHeap {
     
 public:
 
-    virtual ~GCHeap() {}
+    virtual ~IGCHeapInternal() {}
 
-    static GCHeap *GetGCHeap()
+private:
+    virtual Object* AllocAlign8Common (void* hp, alloc_context* acontext, size_t size, uint32_t flags) = 0;
+public:
+    virtual void SetReservedVMLimit (size_t vmlimit) = 0;
+    virtual int GetNumberOfHeaps () = 0; 
+    virtual int GetHomeHeapNumber () = 0;
+    virtual size_t GetPromotedBytes(int heap_index) = 0;
+
+    unsigned GetMaxGeneration()
     {
-        LIMITED_METHOD_CONTRACT;
-
-        _ASSERTE(g_pGCHeap != NULL);
-        return g_pGCHeap;
+        return IGCHeap::maxGeneration;
     }
 
-#ifndef DACCESS_COMPILE
-    static BOOL IsGCInProgress(BOOL bConsiderGCStart = FALSE)
-    {
-        WRAPPER_NO_CONTRACT;
-
-        return (IsGCHeapInitialized() ? GetGCHeap()->IsGCInProgressHelper(bConsiderGCStart) : false);
-    }   
-#endif
-    
-    static BOOL IsGCHeapInitialized()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        return (g_pGCHeap != NULL);
-    }
-
-    static void WaitForGCCompletion(BOOL bConsiderGCStart = FALSE)
-    {
-        WRAPPER_NO_CONTRACT;
-
-        if (IsGCHeapInitialized())
-            GetGCHeap()->WaitUntilGCComplete(bConsiderGCStart);
-    }   
-
-    // The runtime needs to know whether we're using workstation or server GC 
-    // long before the GCHeap is created.  So IsServerHeap cannot be a virtual 
-    // method on GCHeap.  Instead we make it a static method and initialize 
-    // gcHeapType before any of the calls to IsServerHeap.  Note that this also 
-    // has the advantage of getting the answer without an indirection
-    // (virtual call), which is important for perf critical codepaths.
-
-    #ifndef DACCESS_COMPILE
-    static void InitializeHeapType(bool bServerHeap)
-    {
-        LIMITED_METHOD_CONTRACT;
-#ifdef FEATURE_SVR_GC
-        gcHeapType = bServerHeap ? GC_HEAP_SVR : GC_HEAP_WKS;
-#ifdef WRITE_BARRIER_CHECK
-        if (gcHeapType == GC_HEAP_SVR)
-        {
-            g_GCShadow = 0;
-            g_GCShadowEnd = 0;
-        }
-#endif
-#else // FEATURE_SVR_GC
-        UNREFERENCED_PARAMETER(bServerHeap);
-        CONSISTENCY_CHECK(bServerHeap == false);
-#endif // FEATURE_SVR_GC
-    }
-    #endif
-    
-    static BOOL IsValidSegmentSize(size_t cbSize)
+    BOOL IsValidSegmentSize(size_t cbSize)
     {
         //Must be aligned on a Mb and greater than 4Mb
         return (((cbSize & (1024*1024-1)) ==0) && (cbSize >> 22));
     }
 
-    static BOOL IsValidGen0MaxSize(size_t cbSize)
+    BOOL IsValidGen0MaxSize(size_t cbSize)
     {
         return (cbSize >= 64*1024);
     }
 
-    inline static bool IsServerHeap()
+    BOOL IsLargeObject(MethodTable *mt)
     {
-        LIMITED_METHOD_CONTRACT;
-#ifdef FEATURE_SVR_GC
-        _ASSERTE(gcHeapType != GC_HEAP_INVALID);
-        return (gcHeapType == GC_HEAP_SVR);
-#else // FEATURE_SVR_GC
-        return false;
-#endif // FEATURE_SVR_GC
-    }
-
-    inline static bool UseAllocationContexts()
-    {
-        WRAPPER_NO_CONTRACT;
-#ifdef FEATURE_REDHAWK
-        // SIMPLIFY:  only use allocation contexts
-        return true;
-#else
-#if defined(_TARGET_ARM_) || defined(FEATURE_PAL)
-        return true;
-#else
-        return ((IsServerHeap() ? true : (g_SystemInfo.dwNumberOfProcessors >= 2)));
-#endif
-#endif 
-    }
-
-   inline static bool MarkShouldCompeteForStatics()
-    {
-        WRAPPER_NO_CONTRACT;
-
-        return IsServerHeap() && g_SystemInfo.dwNumberOfProcessors >= 2;
-    }
-    
-#ifndef DACCESS_COMPILE
-    static GCHeap * CreateGCHeap()
-    {
-        WRAPPER_NO_CONTRACT;
-
-        GCHeap * pGCHeap;
-
-#if defined(FEATURE_SVR_GC)
-        pGCHeap = (IsServerHeap() ? SVR::CreateGCHeap() : WKS::CreateGCHeap());
-#else
-        pGCHeap = WKS::CreateGCHeap();
-#endif // defined(FEATURE_SVR_GC)
-
-        g_pGCHeap = pGCHeap;
-        return pGCHeap;
-    }
-#endif // DACCESS_COMPILE
-
-private:
-    typedef enum
-    {
-        GC_HEAP_INVALID = 0,
-        GC_HEAP_WKS     = 1,
-        GC_HEAP_SVR     = 2
-    } GC_HEAP_TYPE;
-    
-#ifdef FEATURE_SVR_GC
-    SVAL_DECL(uint32_t,gcHeapType);
-#endif // FEATURE_SVR_GC
-
-public:
-        // TODO Synchronization, should be moved out
-    virtual BOOL    IsGCInProgressHelper (BOOL bConsiderGCStart = FALSE) = 0;
-    virtual uint32_t    WaitUntilGCComplete (BOOL bConsiderGCStart = FALSE) = 0;
-    virtual void SetGCInProgress(BOOL fInProgress) = 0;
-    virtual CLREventStatic * GetWaitForGCEvent() = 0;
-
-    virtual void    SetFinalizationRun (Object* obj) = 0;
-    virtual Object* GetNextFinalizable() = 0;
-    virtual size_t GetNumberOfFinalizable() = 0;
-
-    virtual void SetFinalizeQueueForShutdown(BOOL fHasLock) = 0;
-    virtual BOOL FinalizeAppDomain(AppDomain *pDomain, BOOL fRunFinalizers) = 0;
-    virtual BOOL ShouldRestartFinalizerWatchDog() = 0;
-
-    //wait for concurrent GC to finish
-    virtual void WaitUntilConcurrentGCComplete () = 0;                                  // Use in managed threads
-#ifndef DACCESS_COMPILE    
-    virtual HRESULT WaitUntilConcurrentGCCompleteAsync(int millisecondsTimeout) = 0;    // Use in native threads. TRUE if succeed. FALSE if failed or timeout
-#endif    
-    virtual BOOL IsConcurrentGCInProgress() = 0;
-
-    // Enable/disable concurrent GC    
-    virtual void TemporaryEnableConcurrentGC() = 0;
-    virtual void TemporaryDisableConcurrentGC() = 0;
-    virtual BOOL IsConcurrentGCEnabled() = 0;
-
-    virtual void FixAllocContext (alloc_context* acontext, BOOL lockp, void* arg, void *heap) = 0;
-    virtual Object* Alloc (alloc_context* acontext, size_t size, uint32_t flags) = 0;
-
-    // This is safe to call only when EE is suspended.
-    virtual Object* GetContainingObject(void *pInteriorPtr) = 0;
-
-        // TODO Should be folded into constructor
-    virtual HRESULT Initialize () = 0;
-
-    virtual HRESULT GarbageCollect (int generation = -1, BOOL low_memory_p=FALSE, int mode = collection_blocking) = 0;
-    virtual Object*  Alloc (size_t size, uint32_t flags) = 0;
-#ifdef FEATURE_64BIT_ALIGNMENT
-    virtual Object*  AllocAlign8 (size_t size, uint32_t flags) = 0;
-    virtual Object*  AllocAlign8 (alloc_context* acontext, size_t size, uint32_t flags) = 0;
-private:
-    virtual Object*  AllocAlign8Common (void* hp, alloc_context* acontext, size_t size, uint32_t flags) = 0;
-public:
-#endif // FEATURE_64BIT_ALIGNMENT
-    virtual Object*  AllocLHeap (size_t size, uint32_t flags) = 0;
-    virtual void     SetReservedVMLimit (size_t vmlimit) = 0;
-    virtual void SetCardsAfterBulkCopy( Object**, size_t ) = 0;
-#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
-    virtual void WalkObject (Object* obj, walk_fn fn, void* context) = 0;
-#endif //defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
-
-    virtual bool IsThreadUsingAllocationContextHeap(alloc_context* acontext, int thread_number) = 0;
-    virtual int GetNumberOfHeaps () = 0; 
-    virtual int GetHomeHeapNumber () = 0;
-    
-    virtual int CollectionCount (int generation, int get_bgc_fgc_count = 0) = 0;
-
-        // Finalizer queue stuff (should stay)
-    virtual bool    RegisterForFinalization (int gen, Object* obj) = 0;
-
-        // General queries to the GC
-    virtual BOOL    IsPromoted (Object *object) = 0;
-    virtual unsigned WhichGeneration (Object* object) = 0;
-    virtual BOOL    IsEphemeral (Object* object) = 0;
-    virtual BOOL    IsHeapPointer (void* object, BOOL small_heap_only = FALSE) = 0;
-
-    virtual unsigned GetCondemnedGeneration() = 0;
-    virtual int GetGcLatencyMode() = 0;
-    virtual int SetGcLatencyMode(int newLatencyMode) = 0;
-
-    virtual int GetLOHCompactionMode() = 0;
-    virtual void SetLOHCompactionMode(int newLOHCompactionyMode) = 0;
-
-    virtual BOOL RegisterForFullGCNotification(uint32_t gen2Percentage,
-                                               uint32_t lohPercentage) = 0;
-    virtual BOOL CancelFullGCNotification() = 0;
-    virtual int WaitForFullGCApproach(int millisecondsTimeout) = 0;
-    virtual int WaitForFullGCComplete(int millisecondsTimeout) = 0;
-
-    virtual int StartNoGCRegion(uint64_t totalSize, BOOL lohSizeKnown, uint64_t lohSize, BOOL disallowFullBlockingGC) = 0;
-    virtual int EndNoGCRegion() = 0;
-
-    virtual BOOL IsObjectInFixedHeap(Object *pObj) = 0;
-    virtual size_t  GetTotalBytesInUse () = 0;
-    virtual size_t  GetCurrentObjSize() = 0;
-    virtual size_t  GetLastGCStartTime(int generation) = 0;
-    virtual size_t  GetLastGCDuration(int generation) = 0;
-    virtual size_t  GetNow() = 0;
-    virtual unsigned GetGcCount() = 0;
-    virtual void TraceGCSegments() = 0;
-
-    virtual void PublishObject(uint8_t* obj) = 0;
-
-    // static if since restricting for all heaps is fine
-    virtual size_t GetValidSegmentSize(BOOL large_seg = FALSE) = 0;
-
-    static BOOL IsLargeObject(MethodTable *mt) {
         WRAPPER_NO_CONTRACT;
 
         return mt->GetBaseSize() >= LARGE_OBJECT_SIZE;
     }
 
-    static unsigned GetMaxGeneration() {
-        LIMITED_METHOD_DAC_CONTRACT;  
-        return max_generation;
-    }
-
-    virtual size_t GetPromotedBytes(int heap_index) = 0;
-
-private:
-    enum {
-        max_generation  = 2,
-    };
-    
 public:
 
 #ifdef FEATURE_BASICFREEZE
@@ -630,42 +270,16 @@ public:
     virtual void UnregisterFrozenSegment(segment_handle seg) = 0;
 #endif //FEATURE_BASICFREEZE
 
-        // debug support 
-#ifndef FEATURE_REDHAWK // Redhawk forces relocation a different way
-#ifdef STRESS_HEAP
-    //return TRUE if GC actually happens, otherwise FALSE
-    virtual BOOL    StressHeap(alloc_context * acontext = 0) = 0;
-#endif
-#endif // FEATURE_REDHAWK
-#ifdef VERIFY_HEAP
-    virtual void    ValidateObjectMember (Object *obj) = 0;
-#endif
-
-#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
-    virtual void DescrGenerationsToProfiler (gen_walk_fn fn, void *context) = 0;
-#endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
-
 protected: 
-#ifdef VERIFY_HEAP
 public:
-    // Return NULL if can't find next object. When EE is not suspended,
-    // the result is not accurate: if the input arg is in gen0, the function could 
-    // return zeroed out memory as next object
-    virtual Object * NextObj (Object * object) = 0;
-#ifdef FEATURE_BASICFREEZE
+#if defined(FEATURE_BASICFREEZE) && defined(VERIFY_HEAP)
     // Return TRUE if object lives in frozen segment
     virtual BOOL IsInFrozenSegment (Object * object) = 0;
-#endif //FEATURE_BASICFREEZE
-#endif //VERIFY_HEAP    
+#endif // defined(FEATURE_BASICFREEZE) && defined(VERIFY_HEAP)
 };
-
-extern VOLATILE(int32_t) m_GCLock;
 
 // Go through and touch (read) each page straddled by a memory block.
 void TouchPages(void * pStart, size_t cb);
-
-// For low memory notification from host
-extern int32_t g_bLowMemoryFromHost;
 
 #ifdef WRITE_BARRIER_CHECK
 void updateGCShadow(Object** ptr, Object* val);
@@ -676,5 +290,28 @@ extern MethodTable  *pWeakReferenceMT;
 // The canonical method table for WeakReference<T>
 extern MethodTable  *pWeakReferenceOfTCanonMT;
 extern void FinalizeWeakReference(Object * obj);
+
+// The single GC heap instance, shared with the VM.
+extern IGCHeapInternal* g_theGcHeap;
+
+#ifndef DACCESS_COMPILE
+inline BOOL IsGCInProgress(bool bConsiderGCStart = FALSE)
+{
+    WRAPPER_NO_CONTRACT;
+
+    return g_theGcHeap != nullptr ? g_theGcHeap->IsGCInProgressHelper(bConsiderGCStart) : false;
+}
+#endif // DACCESS_COMPILE
+
+inline BOOL IsServerHeap()
+{
+    LIMITED_METHOD_CONTRACT;
+#ifdef FEATURE_SVR_GC
+    _ASSERTE(IGCHeap::gcHeapType != IGCHeap::GC_HEAP_INVALID);
+    return (IGCHeap::gcHeapType == IGCHeap::GC_HEAP_SVR);
+#else // FEATURE_SVR_GC
+    return false;
+#endif // FEATURE_SVR_GC
+}
 
 #endif // __GC_H

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -148,7 +148,7 @@ void GCHeap::UpdatePostGCCounters()
     // if a max gen garbage collection was performed, resync the GC Handle counter; 
     // if threads are currently suspended, we do not need to obtain a lock on each handle table
     if (condemned_gen == max_generation)
-        total_num_gc_handles = HndCountAllHandles(!GCHeap::IsGCInProgress());
+        total_num_gc_handles = HndCountAllHandles(!IsGCInProgress());
 #endif //FEATURE_REDHAWK
 
     // per generation calculation.
@@ -782,7 +782,7 @@ void gc_heap::background_gc_wait_lh (alloc_wait_reason awr)
 
 
 /******************************************************************************/
-::GCHeap* CreateGCHeap() {
+IGCHeapInternal* CreateGCHeap() {
     return new(nothrow) GCHeap();   // we return wks or svr 
 }
 
@@ -823,12 +823,12 @@ void GCHeap::TraceGCSegments()
 #endif // FEATURE_EVENT_TRACE
 }
 
-#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 void GCHeap::DescrGenerationsToProfiler (gen_walk_fn fn, void *context)
 {
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
     pGenGCHeap->descr_generations_to_profiler(fn, context);
-}
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+}
 
 #ifdef FEATURE_BASICFREEZE
 segment_handle GCHeap::RegisterFrozenSegment(segment_info *pseginfo)

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -1,0 +1,509 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef _GC_INTERFACE_H_
+#define _GC_INTERFACE_H_
+
+// The allocation context must be known to the VM for use in the allocation
+// fast path and known to the GC for performing the allocation. Every Thread
+// has its own allocation context that it hands to the GC when allocating.
+struct gc_alloc_context
+{
+    uint8_t*       alloc_ptr;
+    uint8_t*       alloc_limit;
+    int64_t        alloc_bytes; //Number of bytes allocated on SOH by this context
+    int64_t        alloc_bytes_loh; //Number of bytes allocated on LOH by this context
+    // These two fields are deliberately not exposed past the EE-GC interface.
+    void*          gc_reserved_1;
+    void*          gc_reserved_2;
+    int            alloc_count;
+public:
+
+    void init()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        alloc_ptr = 0;
+        alloc_limit = 0;
+        alloc_bytes = 0;
+        alloc_bytes_loh = 0;
+        gc_reserved_1 = 0;
+        gc_reserved_2 = 0;
+        alloc_count = 0;
+    }
+};
+
+#ifdef PROFILING_SUPPORTED
+#define GC_PROFILING       //Turn on profiling
+#endif // PROFILING_SUPPORTED
+
+#define LARGE_OBJECT_SIZE ((size_t)(85000))
+
+class Object;
+class IGCHeap;
+class IGCToCLR;
+
+// Initializes the garbage collector. Should only be called
+// once, during EE startup.
+IGCHeap* InitializeGarbageCollector(IGCToCLR* clrToGC);
+
+// The runtime needs to know whether we're using workstation or server GC 
+// long before the GCHeap is created. This function sets the type of
+// heap that will be created, before InitializeGarbageCollector is called
+// and the heap is actually recated.
+void InitializeHeapType(bool bServerHeap);
+
+#ifndef DACCESS_COMPILE
+extern "C" {
+#endif // !DACCESS_COMPILE
+GPTR_DECL(uint8_t,g_lowest_address);
+GPTR_DECL(uint8_t,g_highest_address);
+GPTR_DECL(uint32_t,g_card_table);
+#ifndef DACCESS_COMPILE
+} 
+#endif // !DACCESS_COMPILE
+
+extern "C" uint8_t* g_ephemeral_low;
+extern "C" uint8_t* g_ephemeral_high;
+
+#ifdef WRITE_BARRIER_CHECK
+//always defined, but should be 0 in Server GC
+extern uint8_t* g_GCShadow;
+extern uint8_t* g_GCShadowEnd;
+// saves the g_lowest_address in between GCs to verify the consistency of the shadow segment
+extern uint8_t* g_shadow_lowest_address;
+#endif
+
+// For low memory notification from host
+extern int32_t g_bLowMemoryFromHost;
+
+extern VOLATILE(int32_t) m_GCLock;
+
+// !!!!!!!!!!!!!!!!!!!!!!!
+// make sure you change the def in bcl\system\gc.cs 
+// if you change this!
+enum collection_mode
+{
+    collection_non_blocking = 0x00000001,
+    collection_blocking = 0x00000002,
+    collection_optimized = 0x00000004,
+    collection_compacting = 0x00000008
+#ifdef STRESS_HEAP
+    , collection_gcstress = 0x80000000
+#endif // STRESS_HEAP
+};
+
+// !!!!!!!!!!!!!!!!!!!!!!!
+// make sure you change the def in bcl\system\gc.cs 
+// if you change this!
+enum wait_full_gc_status
+{
+    wait_full_gc_success = 0,
+    wait_full_gc_failed = 1,
+    wait_full_gc_cancelled = 2,
+    wait_full_gc_timeout = 3,
+    wait_full_gc_na = 4
+};
+
+// !!!!!!!!!!!!!!!!!!!!!!!
+// make sure you change the def in bcl\system\gc.cs 
+// if you change this!
+enum start_no_gc_region_status
+{
+    start_no_gc_success = 0,
+    start_no_gc_no_memory = 1,
+    start_no_gc_too_large = 2,
+    start_no_gc_in_progress = 3
+};
+
+enum end_no_gc_region_status
+{
+    end_no_gc_success = 0,
+    end_no_gc_not_in_progress = 1,
+    end_no_gc_induced = 2,
+    end_no_gc_alloc_exceeded = 3
+};
+
+typedef BOOL (* walk_fn)(Object*, void*);
+typedef void (* gen_walk_fn)(void* context, int generation, uint8_t* range_start, uint8_t* range_end, uint8_t* range_reserved);
+
+// IGCHeap is the interface that the VM will use when interacting with the GC.
+class IGCHeap {
+public:
+    /*
+    ===========================================================================
+    Hosting APIs. These are used by GC hosting. The code that
+    calls these methods may possibly be moved behind the interface -
+    today, the VM handles the setting of segment size and max gen 0 size.
+    (See src/vm/corehost.cpp)
+    ===========================================================================
+    */
+
+    // Returns whether or not the given size is a valid segment size.
+    virtual BOOL IsValidSegmentSize(size_t size) = 0;
+
+    // Returns whether or not the given size is a valid gen 0 max size.
+    virtual BOOL IsValidGen0MaxSize(size_t size) = 0;
+
+    // Gets a valid segment size.
+    virtual size_t GetValidSegmentSize(BOOL large_seg = FALSE) = 0;
+
+    /*
+    ===========================================================================
+    Concurrent GC routines. These are used in various places in the VM
+    to synchronize with the GC, when the VM wants to update something that
+    the GC is potentially using, if it's doing a background GC.
+
+    Concrete examples of this are moving async pinned handles across appdomains
+    and profiling/ETW scenarios.
+    ===========================================================================
+    */
+
+    // Blocks until any running concurrent GCs complete.
+    virtual void WaitUntilConcurrentGCComplete() = 0;
+
+    // Returns true if a concurrent GC is in progress, false otherwise.
+    virtual BOOL IsConcurrentGCInProgress() = 0;
+
+    // Temporarily enables concurrent GC, used during profiling.
+    virtual void TemporaryEnableConcurrentGC() = 0;
+
+    // Temporarily disables concurrent GC, used during profiling.
+    virtual void TemporaryDisableConcurrentGC() = 0;
+
+    // Returns whether or not Concurrent GC is enabled.
+    virtual BOOL IsConcurrentGCEnabled() = 0;
+
+    // Wait for a concurrent GC to complete if one is in progress, with the given timeout.
+    virtual HRESULT WaitUntilConcurrentGCCompleteAsync(int millisecondsTimeout) = 0;    // Use in native threads. TRUE if succeed. FALSE if failed or timeout
+
+
+    /*
+    ===========================================================================
+    Finalization routines. These are used by the finalizer thread to communicate
+    with the GC.
+    ===========================================================================
+    */
+
+    // Finalizes an app domain by finalizing objects within that app domain.
+    virtual BOOL FinalizeAppDomain(AppDomain* pDomain, BOOL fRunFinalizers) = 0;
+
+    // Finalizes all registered objects for shutdown, even if they are still reachable.
+    virtual void SetFinalizeQueueForShutdown(BOOL fHasLock) = 0;
+
+    // Gets the number of finalizable objects.
+    virtual size_t GetNumberOfFinalizable() = 0;
+
+    // Traditionally used by the finalizer thread on shutdown to determine
+    // whether or not to time out. Returns true if the GC lock has not been taken.
+    virtual BOOL ShouldRestartFinalizerWatchDog() = 0;
+
+    // Gets the next finalizable object.
+    virtual Object* GetNextFinalizable() = 0;
+
+    /*
+    ===========================================================================
+    BCL routines. These are routines that are directly exposed by mscorlib
+    as a part of the `System.GC` class. These routines behave in the same
+    manner as the functions on `System.GC`.
+    ===========================================================================
+    */
+
+    // Gets the current GC latency mode.
+    virtual int GetGcLatencyMode() = 0;
+
+    // Sets the current GC latency mode. newLatencyMode has already been
+    // verified by mscorlib to be valid.
+    virtual int SetGcLatencyMode(int newLatencyMode) = 0;
+
+    // Gets the current LOH compaction mode.
+    virtual int GetLOHCompactionMode() = 0;
+
+    // Sets the current LOH compaction mode. newLOHCompactionMode has
+    // already been verified by mscorlib to be valid.
+    virtual void SetLOHCompactionMode(int newLOHCompactionMode) = 0;
+
+    // Registers for a full GC notification, raising a notification if the gen 2 or
+    // LOH object heap thresholds are exceeded.
+    virtual BOOL RegisterForFullGCNotification(uint32_t gen2Percentage, uint32_t lohPercentage) = 0;
+
+    // Cancels a full GC notification that was requested by `RegisterForFullGCNotification`.
+    virtual BOOL CancelFullGCNotification() = 0;
+
+    // Returns the status of a registered notification for determining whether a blocking
+    // Gen 2 collection is about to be initiated, with the given timeout.
+    virtual int WaitForFullGCApproach(int millisecondsTimeout) = 0;
+
+    // Returns the status of a registered notification for determining whether a blocking
+    // Gen 2 collection has completed, with the given timeout.
+    virtual int WaitForFullGCComplete(int millisecondsTimeout) = 0;
+
+    // Returns the generation in which obj is found. Also used by the VM
+    // in some places, in particular syncblk code.
+    virtual unsigned WhichGeneration(Object* obj) = 0;
+
+    // Returns the number of GCs that have transpired in the given generation
+    // since the beginning of the life of the process. Also used by the VM
+    // for debug code and app domains.
+    virtual int CollectionCount(int generation, int get_bgc_fgc_coutn = 0) = 0;
+
+    // Begins a no-GC region, returning a code indicating whether entering the no-GC
+    // region was successful.
+    virtual int StartNoGCRegion(uint64_t totalSize, BOOL lohSizeKnown, uint64_t lohSize, BOOL disallowFullBlockingGC) = 0;
+
+    // Exits a no-GC region.
+    virtual int EndNoGCRegion() = 0;
+
+    // Gets the total number of bytes in use.
+    virtual size_t GetTotalBytesInUse() = 0;
+
+    // Forces a garbage collection of the given generation. Also used extensively
+    // throughout the VM.
+    virtual HRESULT GarbageCollect(int generation = -1, BOOL low_memory_p = FALSE, int mode = collection_blocking) = 0;
+
+    // Gets the largest GC generation. Also used extensively throughout the VM.
+    virtual unsigned GetMaxGeneration() = 0;
+
+    // Indicates that an object's finalizer should not be run upon the object's collection.
+    virtual void SetFinalizationRun(Object* obj) = 0;
+
+    // Indicates that an object's finalizer should be run upon the object's collection.
+    virtual bool RegisterForFinalization(int gen, Object* obj) = 0;
+
+    /*
+    ===========================================================================
+    Miscellaneous routines used by the VM.
+    ===========================================================================
+    */
+
+    // Initializes the GC heap, returning whether or not the initialization
+    // was successful.
+    virtual HRESULT Initialize() = 0;
+
+    // Returns whether nor this GC was promoted by the last GC.
+    virtual BOOL IsPromoted(Object* object) = 0;
+
+    // Returns true if this pointer points into a GC heap, false otherwise.
+    virtual BOOL IsHeapPointer(void* object, BOOL small_heap_only = FALSE) = 0;
+
+    // Return the generation that has been condemned by the current GC.
+    virtual unsigned GetCondemnedGeneration() = 0;
+
+    // Returns whether or not a GC is in progress.
+    virtual BOOL IsGCInProgressHelper(BOOL bConsiderGCStart = FALSE) = 0;
+
+    // Returns the number of GCs that have occured. Mainly used for
+    // sanity checks asserting that a GC has not occured.
+    virtual unsigned GetGcCount() = 0;
+
+    // Sets cards after an object has been memmoved. 
+    virtual void SetCardsAfterBulkCopy(Object** obj, size_t length) = 0;
+
+    // Gets whether or not the home heap of this alloc context matches the heap
+    // associated with this thread.
+    virtual bool IsThreadUsingAllocationContextHeap(gc_alloc_context* acontext, int thread_number) = 0;
+    
+    // Returns whether or not this object resides in an ephemeral generation.
+    virtual BOOL IsEphemeral(Object* object) = 0;
+
+    // Blocks until a GC is complete, returning a code indicating the wait was successful.
+    virtual uint32_t WaitUntilGCComplete(BOOL bConsiderGCStart = FALSE) = 0;
+
+    // "Fixes" an allocation context by binding its allocation pointer to a
+    // location on the heap.
+    virtual void FixAllocContext(gc_alloc_context* acontext, BOOL lockp, void* arg, void* heap) = 0;
+
+    // Gets the total survived size plus the total allocated bytes on the heap.
+    virtual size_t GetCurrentObjSize() = 0;
+
+    // Sets whether or not a GC is in progress.
+    virtual void SetGCInProgress(BOOL fInProgress) = 0;
+
+    /*
+    Add/RemoveMemoryPressure support routines. These are on the interface
+    for now, but we should move Add/RemoveMemoryPressure from the VM to the GC.
+    When that occurs, these three routines can be removed from the interface.
+    */
+
+    // Get the timestamp corresponding to the last GC that occured for the
+    // given generation.
+    virtual size_t GetLastGCStartTime(int generation) = 0;
+
+    // Gets the duration of the last GC that occured for the given generation.
+    virtual size_t GetLastGCDuration(int generation) = 0;
+
+    // Gets a timestamp for the current moment in time.
+    virtual size_t GetNow() = 0;
+
+    /*
+    ===========================================================================
+    Allocation routines. These all call into the GC's allocator and may trigger a garbage
+    collection.
+    ===========================================================================
+    */
+
+    // Allocates an object on the given allocation context with the given size and flags.
+    virtual Object* Alloc(gc_alloc_context* acontext, size_t size, uint32_t flags) = 0;
+
+    // Allocates an object on the default allocation context with the given size and flags.
+    virtual Object* Alloc(size_t size, uint32_t flags) = 0;
+
+    // Allocates an object on the large object heap with the given size and flags.
+    virtual Object* AllocLHeap(size_t size, uint32_t flags) = 0;
+
+    // Allocates an object on the default allocation context, aligned to 64 bits,
+    // with the given size and flags.
+    virtual Object* AllocAlign8 (size_t size, uint32_t flags) = 0;
+
+    // Allocates an object on the given allocation context, aligned to 64 bits,
+    // with the given size and flags.
+    virtual Object* AllocAlign8 (gc_alloc_context* acontext, size_t size, uint32_t flags) = 0;
+
+    // If allocating on the LOH, blocks if a BGC is in a position (concurrent mark)
+    // where the LOH allocator can't allocate.
+    virtual void PublishObject(uint8_t* obj) = 0;
+
+    // Gets the event that suspended threads will use to wait for the
+    // end of a GC.
+    virtual CLREventStatic* GetWaitForGCEvent() = 0;
+
+    /*
+    ===========================================================================
+    Heap verification routines. These are used during heap verification only.
+    ===========================================================================
+    */
+    // Returns whether or not this object is in the fixed heap.
+    virtual BOOL IsObjectInFixedHeap(Object* pObj) = 0;
+
+    // Walks an object and validates its members.
+    virtual void ValidateObjectMember(Object* obj) = 0;
+
+    // Retrieves the next object after the given object. When the EE
+    // is not suspended, the result is not accurate - if the input argument
+    // is in Gen0, the function could return zeroed out memory as the next object.
+    virtual Object* NextObj(Object* object) = 0;
+
+    // Given an interior pointer, return a pointer to the object
+    // containing that pointer. This is safe to call only when the EE is suspended.
+    virtual Object* GetContainingObject(void* pInteriorPtr) = 0;
+
+    /*
+    ===========================================================================
+    Profiling routines. Used for event tracing and profiling to broadcast
+    information regarding the heap.
+    ===========================================================================
+    */
+
+    // Walks an object, invoking a callback on each member.
+    virtual void WalkObject(Object* obj, walk_fn fn, void* context) = 0;
+
+    // Describes all generations to the profiler, invoking a callback on each generation.
+    virtual void DescrGenerationsToProfiler(gen_walk_fn fn, void* context) = 0;
+
+    // Traces all GC segments and fires ETW events with information on them.
+    virtual void TraceGCSegments() = 0;
+
+    /*
+    ===========================================================================
+    GC Stress routines. Used only when running under GC Stress.
+    ===========================================================================
+    */
+
+    // Returns TRUE if GC actually happens, otherwise FALSE
+    virtual BOOL StressHeap(gc_alloc_context* acontext = 0) = 0;
+
+    IGCHeap() {}
+    virtual ~IGCHeap() {}
+
+    typedef enum
+    {
+        GC_HEAP_INVALID = 0,
+        GC_HEAP_WKS     = 1,
+        GC_HEAP_SVR     = 2
+    } GC_HEAP_TYPE;
+
+#ifdef FEATURE_SVR_GC
+    SVAL_DECL(uint32_t, gcHeapType);
+#endif
+
+    SVAL_DECL(uint32_t, maxGeneration);
+};
+
+#ifdef WRITE_BARRIER_CHECK
+void updateGCShadow(Object** ptr, Object* val);
+#endif
+
+//constants for the flags parameter to the gc call back
+
+#define GC_CALL_INTERIOR            0x1
+#define GC_CALL_PINNED              0x2
+#define GC_CALL_CHECK_APP_DOMAIN    0x4
+
+//flags for IGCHeapAlloc(...)
+#define GC_ALLOC_FINALIZE 0x1
+#define GC_ALLOC_CONTAINS_REF 0x2
+#define GC_ALLOC_ALIGN8_BIAS 0x4
+#define GC_ALLOC_ALIGN8 0x8
+
+struct ScanContext
+{
+    Thread* thread_under_crawl;
+    int thread_number;
+    uintptr_t stack_limit; // Lowest point on the thread stack that the scanning logic is permitted to read
+    BOOL promotion; //TRUE: Promotion, FALSE: Relocation.
+    BOOL concurrent; //TRUE: concurrent scanning 
+#if CHECK_APP_DOMAIN_LEAKS || defined (FEATURE_APPDOMAIN_RESOURCE_MONITORING) || defined (DACCESS_COMPILE)
+    AppDomain *pCurrentDomain;
+#endif //CHECK_APP_DOMAIN_LEAKS || FEATURE_APPDOMAIN_RESOURCE_MONITORING || DACCESS_COMPILE
+
+#ifndef FEATURE_REDHAWK
+#if defined(GC_PROFILING) || defined (DACCESS_COMPILE)
+    MethodDesc *pMD;
+#endif //GC_PROFILING || DACCESS_COMPILE
+#endif // FEATURE_REDHAWK
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+    EtwGCRootKind dwEtwRootKind;
+#endif // GC_PROFILING || FEATURE_EVENT_TRACE
+    
+    ScanContext()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        thread_under_crawl = 0;
+        thread_number = -1;
+        stack_limit = 0;
+        promotion = FALSE;
+        concurrent = FALSE;
+#ifdef GC_PROFILING
+        pMD = NULL;
+#endif //GC_PROFILING
+#ifdef FEATURE_EVENT_TRACE
+        dwEtwRootKind = kEtwGCRootKindOther;
+#endif // FEATURE_EVENT_TRACE
+    }
+};
+
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+struct ProfilingScanContext : ScanContext
+{
+    BOOL fProfilerPinned;
+    void * pvEtwContext;
+    void *pHeapId;
+    
+    ProfilingScanContext(BOOL fProfilerPinnedParam) : ScanContext()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        pHeapId = NULL;
+        fProfilerPinned = fProfilerPinnedParam;
+        pvEtwContext = NULL;
+#ifdef FEATURE_CONSERVATIVE_GC
+        // To not confuse GCScan::GcScanRoots
+        promotion = g_pConfig->GetGCConservative();
+#endif
+    }
+};
+#endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+
+#endif // _GC_INTERFACE_H_

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -2547,9 +2547,9 @@ protected:
     PER_HEAP
     void descr_generations (BOOL begin_gc_p);
 
-#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
     PER_HEAP_ISOLATED
     void descr_generations_to_profiler (gen_walk_fn fn, void *context);
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
     PER_HEAP
     void record_survived_for_profiler(int condemned_gen_number, uint8_t * first_condemned_address);
     PER_HEAP
@@ -2978,7 +2978,7 @@ protected:
     PER_HEAP
     VOLATILE(int) alloc_context_count;
 #else //MULTIPLE_HEAPS
-#define vm_heap ((GCHeap*) g_pGCHeap)
+#define vm_heap ((GCHeap*) g_theGcHeap)
 #define heap_number (0)
 #endif //MULTIPLE_HEAPS
 

--- a/src/gc/gcscan.cpp
+++ b/src/gc/gcscan.cpp
@@ -129,7 +129,7 @@ static void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t * /*
     LOG((LF_GC, LL_INFO100000, LOG_HANDLE_OBJECT_CLASS("Checking referent of Weak-", pObjRef, "to ", *pObjRef)));
 
     Object **pRef = (Object **)pObjRef;
-    if (!GCHeap::GetGCHeap()->IsPromoted(*pRef))
+    if (!g_theGcHeap->IsPromoted(*pRef))
     {
         LOG((LF_GC, LL_INFO100, LOG_HANDLE_OBJECT_CLASS("Severing Weak-", pObjRef, "to unreachable ", *pObjRef)));
 
@@ -240,14 +240,14 @@ void GCScan::GcRuntimeStructuresValid (BOOL bValid)
 void GCScan::GcDemote (int condemned, int max_gen, ScanContext* sc)
 {
     Ref_RejuvenateHandles (condemned, max_gen, (uintptr_t)sc);
-    if (!GCHeap::IsServerHeap() || sc->thread_number == 0)
+    if (!IsServerHeap() || sc->thread_number == 0)
         GCToEEInterface::SyncBlockCacheDemote(max_gen);
 }
 
 void GCScan::GcPromotionsGranted (int condemned, int max_gen, ScanContext* sc)
 {
     Ref_AgeHandles(condemned, max_gen, (uintptr_t)sc);
-    if (!GCHeap::IsServerHeap() || sc->thread_number == 0)
+    if (!IsServerHeap() || sc->thread_number == 0)
         GCToEEInterface::SyncBlockCachePromotionsGranted(max_gen);
 }
 

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -755,7 +755,7 @@ void HndLogSetEvent(OBJECTHANDLE handle, _UNCHECKED_OBJECTREF value)
         uint32_t hndType = HandleFetchType(handle);
         ADIndex appDomainIndex = HndGetHandleADIndex(handle);   
         AppDomain* pAppDomain = SystemDomain::GetAppDomainAtIndex(appDomainIndex);
-        uint32_t generation = value != 0 ? GCHeap::GetGCHeap()->WhichGeneration(value) : 0;
+        uint32_t generation = value != 0 ? g_theGcHeap->WhichGeneration(value) : 0;
         FireEtwSetGCHandle((void*) handle, value, hndType, generation, (int64_t) pAppDomain, GetClrInstanceId());
         FireEtwPrvSetGCHandle((void*) handle, value, hndType, generation, (int64_t) pAppDomain, GetClrInstanceId());
 
@@ -774,14 +774,14 @@ void HndLogSetEvent(OBJECTHANDLE handle, _UNCHECKED_OBJECTREF value)
                     for (size_t i = 0; i < num; i ++)
                     {
                         value = ppObj[i];
-                        uint32_t generation = value != 0 ? GCHeap::GetGCHeap()->WhichGeneration(value) : 0;
+                        uint32_t generation = value != 0 ? g_theGcHeap->WhichGeneration(value) : 0;
                         FireEtwSetGCHandle(overlapped, value, HNDTYPE_PINNED, generation, (int64_t) pAppDomain, GetClrInstanceId());
                     }
                 }
                 else
                 {
                     value = OBJECTREF_TO_UNCHECKED_OBJECTREF(overlapped->m_userObject);
-                    uint32_t generation = value != 0 ? GCHeap::GetGCHeap()->WhichGeneration(value) : 0;
+                    uint32_t generation = value != 0 ? g_theGcHeap->WhichGeneration(value) : 0;
                     FireEtwSetGCHandle(overlapped, value, HNDTYPE_PINNED, generation, (int64_t) pAppDomain, GetClrInstanceId());
                 }
             }
@@ -838,7 +838,7 @@ void HndWriteBarrier(OBJECTHANDLE handle, OBJECTREF objref)
     if (*pClumpAge != 0) // Perf optimization: if clumpAge is 0, nothing more to do
     {
         // find out generation
-        int generation = GCHeap::GetGCHeap()->WhichGeneration(value);
+        int generation = g_theGcHeap->WhichGeneration(value);
         uint32_t uType = HandleFetchType(handle);
 
 #ifndef FEATURE_REDHAWK

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -14,6 +14,7 @@
 #include "common.h"
 
 #include "gcenv.h"
+#include "gc.h"
 
 #ifndef FEATURE_REDHAWK
 #include "nativeoverlapped.h"
@@ -1111,13 +1112,13 @@ SLOW_PATH:
         // we have the lock held but the part we care about (the async table scan) takes the table lock during
         // a preparation step so we'll be able to complete our segment moves before the async scan has a
         // chance to interfere with us (or vice versa).
-        if (GCHeap::GetGCHeap()->IsConcurrentGCInProgress())
+        if (g_theGcHeap->IsConcurrentGCInProgress())
         {
             // A concurrent GC is in progress so someone might be scanning our segments asynchronously.
             // Release the lock, wait for the GC to complete and try again. The order is important; if we wait
             // before releasing the table lock we can deadlock with an async table scan.
             ch.Release();
-            GCHeap::GetGCHeap()->WaitUntilConcurrentGCComplete();
+            g_theGcHeap->WaitUntilConcurrentGCComplete();
             continue;
         }
 

--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -818,7 +818,7 @@ void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sca
             {
                 if (!HndIsNullOrDestroyedHandle(*pValue))
                 {
-                    int thisAge = GCHeap::GetGCHeap()->WhichGeneration(*pValue);
+                    int thisAge = g_theGcHeap->WhichGeneration(*pValue);
                     if (minAge > thisAge)
                         minAge = thisAge;
 
@@ -830,7 +830,7 @@ void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sca
                         if (pOverlapped->m_userObject != NULL)
                         {
                             Object * pUserObject = OBJECTREFToObject(pOverlapped->m_userObject);
-                            thisAge = GCHeap::GetGCHeap()->WhichGeneration(pUserObject);
+                            thisAge = g_theGcHeap->WhichGeneration(pUserObject);
                             if (minAge > thisAge)
                                 minAge = thisAge;
                             if (pOverlapped->m_isArray)
@@ -840,7 +840,7 @@ void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sca
                                 size_t num = pUserArrayObject->GetNumComponents();
                                 for (size_t i = 0; i < num; i ++)
                                 {
-                                     thisAge = GCHeap::GetGCHeap()->WhichGeneration(pObj[i]);
+                                     thisAge = g_theGcHeap->WhichGeneration(pObj[i]);
                                      if (minAge > thisAge)
                                          minAge = thisAge;
                                  }                                    
@@ -925,10 +925,10 @@ static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTRE
     UNREFERENCED_PARAMETER(pValue);
     VerifyObject(from, obj);
 
-    int thisAge = GCHeap::GetGCHeap()->WhichGeneration(obj);
+    int thisAge = g_theGcHeap->WhichGeneration(obj);
 
     //debugging code
-    //if (minAge > thisAge && thisAge < GCHeap::GetGCHeap()->GetMaxGeneration())
+    //if (minAge > thisAge && thisAge < g_theGcHeap->GetMaxGeneration())
     //{
     //    if ((*pValue) == obj)
     //        printf("Handle (age %u) %p -> %p (age %u)", minAge, pValue, obj, thisAge);
@@ -946,7 +946,7 @@ static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTRE
     //    }
     //}
 
-    if (minAge >= GEN_MAX_AGE || (minAge > thisAge && thisAge < static_cast<int>(GCHeap::GetGCHeap()->GetMaxGeneration())))
+    if (minAge >= GEN_MAX_AGE || (minAge > thisAge && thisAge < static_cast<int>(g_theGcHeap->GetMaxGeneration())))
     {
         _ASSERTE(!"Fatal Error in HandleTable.");
         EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);

--- a/src/gc/sample/GCSample.cpp
+++ b/src/gc/sample/GCSample.cpp
@@ -68,7 +68,7 @@ Object * AllocateObject(MethodTable * pMT)
     }
     else
     {
-        pObject = GCHeap::GetGCHeap()->Alloc(acontext, size, 0);
+        pObject = g_theGcHeap->Alloc(acontext, size, 0);
         if (pObject == NULL)
             return NULL;
     }
@@ -137,7 +137,7 @@ int __cdecl main(int argc, char* argv[])
     //
     // Initialize GC heap
     //
-    GCHeap *pGCHeap = GCHeap::CreateGCHeap();
+    IGCHeap *pGCHeap = InitializeGarbageCollector(nullptr);
     if (!pGCHeap)
         return -1;
 

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -131,7 +131,7 @@ void ThreadStore::AttachCurrentThread()
 
 void GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_REASON reason)
 {
-    GCHeap::GetGCHeap()->SetGCInProgress(TRUE);
+    g_theGcHeap->SetGCInProgress(TRUE);
 
     // TODO: Implement
 }
@@ -140,7 +140,7 @@ void GCToEEInterface::RestartEE(bool bFinishedGC)
 {
     // TODO: Implement
 
-    GCHeap::GetGCHeap()->SetGCInProgress(FALSE);
+    g_theGcHeap->SetGCInProgress(FALSE);
 }
 
 void GCToEEInterface::GcScanRoots(promote_func* fn,  int condemned, int max_gen, ScanContext* sc)
@@ -184,7 +184,7 @@ void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
     pThread->DisablePreemptiveGC();
 }
 
-alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
+gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
 {
     return pThread->GetAllocContext();
 }

--- a/src/gc/sample/gcenv.h
+++ b/src/gc/sample/gcenv.h
@@ -64,6 +64,9 @@
 
 #define LOG(x)
 
+#define SVAL_IMPL_INIT(type, cls, var, init) \
+    type cls::var = init
+
 //
 // Thread
 //

--- a/src/inc/dacvars.h
+++ b/src/inc/dacvars.h
@@ -125,9 +125,10 @@ DEFINE_DACVAR(ULONG, PTR_Thread, dac__g_pFinalizerThread, ::g_pFinalizerThread)
 DEFINE_DACVAR(ULONG, PTR_Thread, dac__g_pSuspensionThread, ::g_pSuspensionThread)
 
 #ifdef FEATURE_SVR_GC
-DEFINE_DACVAR(ULONG, DWORD, GCHeap__gcHeapType, GCHeap::gcHeapType)
+DEFINE_DACVAR(ULONG, DWORD, IGCHeap__gcHeapType, IGCHeap::gcHeapType)
 #endif // FEATURE_SVR_GC
 
+DEFINE_DACVAR(ULONG, DWORD, IGCHeap__maxGeneration, IGCHeap::maxGeneration)
 DEFINE_DACVAR(ULONG, PTR_BYTE, WKS__gc_heap__alloc_allocated, WKS::gc_heap::alloc_allocated)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE /*PTR_heap_segment*/, WKS__gc_heap__ephemeral_heap_segment, WKS::gc_heap::ephemeral_heap_segment)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE /*PTR_CFinalize*/, WKS__gc_heap__finalize_queue, WKS::gc_heap::finalize_queue)
@@ -198,7 +199,7 @@ DEFINE_DACVAR(ULONG, PTR_DWORD, dac__g_card_table, ::g_card_table)
 DEFINE_DACVAR(ULONG, PTR_BYTE, dac__g_lowest_address, ::g_lowest_address)
 DEFINE_DACVAR(ULONG, PTR_BYTE, dac__g_highest_address, ::g_highest_address)
 
-DEFINE_DACVAR(ULONG, GCHeap, dac__g_pGCHeap, ::g_pGCHeap)
+DEFINE_DACVAR(ULONG, IGCHeap, dac__g_pGCHeap, ::g_pGCHeap)
 
 #ifdef GC_CONFIG_DRIVEN
 DEFINE_DACVAR_NO_DUMP(ULONG, SIZE_T, dac__interesting_data_per_heap, WKS::interesting_data_per_heap)

--- a/src/inc/stresslog.h
+++ b/src/inc/stresslog.h
@@ -683,7 +683,7 @@ public:
     static const char* gcRootPromoteMsg()
     {
         STATIC_CONTRACT_LEAF;
-        return "    GCHeap::Promote: Promote GC Root *%p = %p MT = %pT\n";
+        return "    IGCHeap::Promote: Promote GC Root *%p = %p MT = %pT\n";
     }
 
     static const char* gcPlugMoveMsg()

--- a/src/strongname/api/common.h
+++ b/src/strongname/api/common.h
@@ -156,7 +156,7 @@ typedef DPTR(class TypeHandle)          PTR_TypeHandle;
 typedef VPTR(class VirtualCallStubManager) PTR_VirtualCallStubManager;
 typedef VPTR(class VirtualCallStubManagerManager) PTR_VirtualCallStubManagerManager;
 #endif
-typedef VPTR(class GCHeap)              PTR_GCHeap;
+typedef VPTR(class IGCHeap)              PTR_IGCHeap;
 
 //
 // _UNCHECKED_OBJECTREF is for code that can't deal with DEBUG OBJECTREFs

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -70,6 +70,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     formattype.cpp
     fptrstubs.cpp
     frames.cpp
+    gcheaputilities.cpp
     genericdict.cpp
     generics.cpp
     hash.cpp

--- a/src/vm/amd64/asmconstants.h
+++ b/src/vm/amd64/asmconstants.h
@@ -164,10 +164,10 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__Thread__m_ThreadId
                     == offsetof(Thread, m_ThreadId));
 
 #define               OFFSET__Thread__m_alloc_context__alloc_ptr 0x60
-ASMCONSTANTS_C_ASSERT(OFFSET__Thread__m_alloc_context__alloc_ptr == offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_ptr));
+ASMCONSTANTS_C_ASSERT(OFFSET__Thread__m_alloc_context__alloc_ptr == offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_ptr));
 
 #define               OFFSET__Thread__m_alloc_context__alloc_limit 0x68
-ASMCONSTANTS_C_ASSERT(OFFSET__Thread__m_alloc_context__alloc_limit == offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_limit));
+ASMCONSTANTS_C_ASSERT(OFFSET__Thread__m_alloc_context__alloc_limit == offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_limit));
 
 #define               OFFSETOF__ThreadExceptionState__m_pCurrentTracker 0x000
 ASMCONSTANTS_C_ASSERT(OFFSETOF__ThreadExceptionState__m_pCurrentTracker

--- a/src/vm/amd64/excepamd64.cpp
+++ b/src/vm/amd64/excepamd64.cpp
@@ -21,7 +21,7 @@
 #include "comutilnative.h"
 #include "sigformat.h"
 #include "siginfo.hpp"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "eedbginterfaceimpl.h" //so we can clearexception in COMPlusThrow
 #include "perfcounters.h"
 #include "asmconstants.h"

--- a/src/vm/amd64/jitinterfaceamd64.cpp
+++ b/src/vm/amd64/jitinterfaceamd64.cpp
@@ -390,7 +390,7 @@ bool WriteBarrierManager::NeedDifferentWriteBarrier(bool bReqUpperBoundsCheck, W
             }
 #endif
 
-            writeBarrierType = GCHeap::IsServerHeap() ? WRITE_BARRIER_SVR64 : WRITE_BARRIER_PREGROW64;
+            writeBarrierType = GCHeapUtilities::IsServerHeap() ? WRITE_BARRIER_SVR64 : WRITE_BARRIER_PREGROW64;
             continue;
 
         case WRITE_BARRIER_PREGROW64:

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -30,6 +30,7 @@
 #include "fptrstubs.h"
 #include "ilstubcache.h"
 #include "testhookmgr.h"
+#include "gcheaputilities.h"
 #ifdef FEATURE_VERSIONING
 #include "../binder/inc/applicationcontext.hpp"
 #endif // FEATURE_VERSIONING
@@ -1295,7 +1296,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
         OBJECTHANDLE h = ::CreateSizedRefHandle(
-            m_hHandleTableBucket->pTable[GCHeap::IsServerHeap() ? (m_dwSizedRefHandles % m_iNumberOfProcessors) : GetCurrentThreadHomeHeapNumber()], 
+            m_hHandleTableBucket->pTable[GCHeapUtilities::IsServerHeap() ? (m_dwSizedRefHandles % m_iNumberOfProcessors) : GetCurrentThreadHomeHeapNumber()], 
             object);
         InterlockedIncrement((LONG*)&m_dwSizedRefHandles);
         return h;
@@ -4533,8 +4534,8 @@ public:
         if (m_UnloadIsAsync)
         {
             pDomain->AddRef();
-            int iGCRefPoint=GCHeap::GetGCHeap()->CollectionCount(GCHeap::GetGCHeap()->GetMaxGeneration());
-            if (GCHeap::GetGCHeap()->IsGCInProgress())
+            int iGCRefPoint=GCHeapUtilities::GetGCHeap()->CollectionCount(GCHeapUtilities::GetGCHeap()->GetMaxGeneration());
+            if (GCHeapUtilities::IsGCInProgress())
                 iGCRefPoint++;
             pDomain->SetGCRefPoint(iGCRefPoint);
         }
@@ -4554,8 +4555,8 @@ public:
         pAllocator->m_pLoaderAllocatorDestroyNext=m_pDelayedUnloadListOfLoaderAllocators;
         m_pDelayedUnloadListOfLoaderAllocators=pAllocator;
 
-        int iGCRefPoint=GCHeap::GetGCHeap()->CollectionCount(GCHeap::GetGCHeap()->GetMaxGeneration());
-        if (GCHeap::GetGCHeap()->IsGCInProgress())
+        int iGCRefPoint=GCHeapUtilities::GetGCHeap()->CollectionCount(GCHeapUtilities::GetGCHeap()->GetMaxGeneration());
+        if (GCHeapUtilities::IsGCInProgress())
             iGCRefPoint++;
         pAllocator->SetGCRefPoint(iGCRefPoint);
     }

--- a/src/vm/arm/asmconstants.h
+++ b/src/vm/arm/asmconstants.h
@@ -225,10 +225,10 @@ ASMCONSTANTS_C_ASSERT(UnmanagedToManagedFrame__m_pvDatum == offsetof(UnmanagedTo
 
 #ifndef CROSSGEN_COMPILE
 #define               Thread__m_alloc_context__alloc_limit   0x44
-ASMCONSTANTS_C_ASSERT(Thread__m_alloc_context__alloc_limit == offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_limit));
+ASMCONSTANTS_C_ASSERT(Thread__m_alloc_context__alloc_limit == offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_limit));
 
 #define               Thread__m_alloc_context__alloc_ptr   0x40
-ASMCONSTANTS_C_ASSERT(Thread__m_alloc_context__alloc_ptr == offsetof(Thread, m_alloc_context) + offsetof(alloc_context, alloc_ptr));
+ASMCONSTANTS_C_ASSERT(Thread__m_alloc_context__alloc_ptr == offsetof(Thread, m_alloc_context) + offsetof(gc_alloc_context, alloc_ptr));
 #endif // CROSSGEN_COMPILE
 
 #define               Thread__m_fPreemptiveGCDisabled   0x08

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -2650,7 +2650,7 @@ void InitJITHelpers1()
         ))
     {
 
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(GCHeapUtilities::UseAllocationContexts());
         // If the TLS for Thread is low enough use the super-fast helpers
         if (gThreadTLSIndex < TLS_MINIMUM_AVAILABLE)
         {

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -3427,8 +3427,8 @@ void Module::EnumRegularStaticGCRefs(AppDomain* pAppDomain, promote_func* fn, Sc
     }
     CONTRACT_END;
 
-    _ASSERTE(GCHeap::IsGCInProgress() && 
-         GCHeap::IsServerHeap() && 
+    _ASSERTE(GCHeapUtilities::IsGCInProgress() && 
+         GCHeapUtilities::IsServerHeap() && 
          IsGCSpecialThread());
 
 
@@ -6264,7 +6264,7 @@ Module *Module::GetModuleIfLoaded(mdFile kFile, BOOL onlyLoadedInAppDomain, BOOL
 #ifndef DACCESS_COMPILE
 #if defined(FEATURE_MULTIMODULE_ASSEMBLIES)
     // check if actually loaded, unless happens during GC (GC works only with loaded assemblies)
-    if (!GCHeap::IsGCInProgress() && onlyLoadedInAppDomain && pModule && !pModule->IsManifest())
+    if (!GCHeapUtilities::IsGCInProgress() && onlyLoadedInAppDomain && pModule && !pModule->IsManifest())
     {
         DomainModule *pDomainModule = pModule->FindDomainModule(GetAppDomain());
         if (pDomainModule == NULL || !pDomainModule->IsLoaded())

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -150,7 +150,7 @@
 #include "frames.h"
 #include "threads.h"
 #include "stackwalk.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "interoputil.h"
 #include "security.h"
 #include "fieldmarshaler.h"
@@ -640,7 +640,7 @@ void InitializeStartupFlags()
         g_fEnableARM = TRUE;
 #endif // !FEATURE_CORECLR
 
-    GCHeap::InitializeHeapType((flags & STARTUP_SERVER_GC) != 0);
+    InitializeHeapType((flags & STARTUP_SERVER_GC) != 0);
 
 #ifdef FEATURE_LOADER_OPTIMIZATION            
     g_dwGlobalSharePolicy = (flags&STARTUP_LOADER_OPTIMIZATION_MASK)>>1;
@@ -3719,7 +3719,8 @@ void InitializeGarbageCollector()
     g_pFreeObjectMethodTable->SetBaseSize(ObjSizeOf (ArrayBase));
     g_pFreeObjectMethodTable->SetComponentSize(1);
 
-    GCHeap *pGCHeap = GCHeap::CreateGCHeap();
+    IGCHeap *pGCHeap = InitializeGarbageCollector(nullptr);
+    g_pGCHeap = pGCHeap;
     if (!pGCHeap)
         ThrowOutOfMemory();
 
@@ -3833,7 +3834,7 @@ BOOL STDMETHODCALLTYPE EEDllMain( // TRUE on success, FALSE on error.
                 {
                     // GetThread() may be set to NULL for Win9x during shutdown.
                     Thread *pThread = GetThread();
-                    if (GCHeap::IsGCInProgress() &&
+                    if (GCHeapUtilities::IsGCInProgress() &&
                         ( (pThread && (pThread != ThreadSuspend::GetSuspensionThread() ))
                             || !g_fSuspendOnShutdown))
                     {

--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -31,7 +31,7 @@
 #include "log.h"
 #include "fieldmarshaler.h"
 #include "cgensys.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "security.h"
 #include "dbginterface.h"
 #include "comdelegate.h"

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -3397,7 +3397,7 @@ void ExecutionManager::CleanupCodeHeaps()
     }
     CONTRACTL_END;
 
-    _ASSERTE (g_fProcessDetach || (GCHeap::IsGCInProgress()  && ::IsGCThread()));
+    _ASSERTE (g_fProcessDetach || (GCHeapUtilities::IsGCInProgress()  && ::IsGCThread()));
 
     GetEEJitManager()->CleanupCodeHeaps();
 }
@@ -3411,7 +3411,7 @@ void EEJitManager::CleanupCodeHeaps()
     }
     CONTRACTL_END;
 
-    _ASSERTE (g_fProcessDetach || (GCHeap::IsGCInProgress() && ::IsGCThread()));
+    _ASSERTE (g_fProcessDetach || (GCHeapUtilities::IsGCInProgress() && ::IsGCThread()));
 
     CrstHolder ch(&m_CodeHeapCritSec);
 
@@ -4451,7 +4451,7 @@ RangeSection* ExecutionManager::GetRangeSection(TADDR addr)
     // Unless we are on an MP system with many cpus
     // where this sort of caching actually diminishes scaling during server GC
     // due to many processors writing to a common location
-    if (g_SystemInfo.dwNumberOfProcessors < 4 || !GCHeap::IsServerHeap() || !GCHeap::IsGCInProgress())
+    if (g_SystemInfo.dwNumberOfProcessors < 4 || !GCHeapUtilities::IsServerHeap() || !GCHeapUtilities::IsGCInProgress())
         pHead->pLastUsed = pLast;
 #endif
 

--- a/src/vm/commemoryfailpoint.cpp
+++ b/src/vm/commemoryfailpoint.cpp
@@ -26,7 +26,7 @@ FCIMPL2(void, COMMemoryFailPoint::GetMemorySettings, UINT64* pMaxGCSegmentSize, 
 {
     FCALL_CONTRACT;
 
-    GCHeap * pGC = GCHeap::GetGCHeap();
+    IGCHeap * pGC = GCHeapUtilities::GetGCHeap();
     size_t segment_size = pGC->GetValidSegmentSize(FALSE);
     size_t large_segment_size = pGC->GetValidSegmentSize(TRUE);
     _ASSERTE(segment_size < SIZE_T_MAX && large_segment_size < SIZE_T_MAX);

--- a/src/vm/common.h
+++ b/src/vm/common.h
@@ -177,7 +177,7 @@ typedef DPTR(class StringBufferObject)  PTR_StringBufferObject;
 typedef DPTR(class TypeHandle)          PTR_TypeHandle;
 typedef VPTR(class VirtualCallStubManager) PTR_VirtualCallStubManager;
 typedef VPTR(class VirtualCallStubManagerManager) PTR_VirtualCallStubManagerManager;
-typedef VPTR(class GCHeap)              PTR_GCHeap;
+typedef VPTR(class IGCHeap)             PTR_IGCHeap;
 
 //
 // _UNCHECKED_OBJECTREF is for code that can't deal with DEBUG OBJECTREFs

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -27,7 +27,7 @@
 #include "frames.h"
 #include "field.h"
 #include "winwrap.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "fcall.h"
 #include "invokeutil.h"
 #include "eeconfig.h"
@@ -1638,7 +1638,7 @@ FCIMPL0(int, GCInterface::GetGcLatencyMode)
 
     FC_GC_POLL_NOT_NEEDED();
 
-    int result = (INT32)GCHeap::GetGCHeap()->GetGcLatencyMode();
+    int result = (INT32)GCHeapUtilities::GetGCHeap()->GetGcLatencyMode();
     return result;
 }
 FCIMPLEND
@@ -1649,7 +1649,7 @@ FCIMPL1(int, GCInterface::SetGcLatencyMode, int newLatencyMode)
 
     FC_GC_POLL_NOT_NEEDED();
     
-    return GCHeap::GetGCHeap()->SetGcLatencyMode(newLatencyMode);
+    return GCHeapUtilities::GetGCHeap()->SetGcLatencyMode(newLatencyMode);
 }
 FCIMPLEND
 
@@ -1659,7 +1659,7 @@ FCIMPL0(int, GCInterface::GetLOHCompactionMode)
 
     FC_GC_POLL_NOT_NEEDED();
 
-    int result = (INT32)GCHeap::GetGCHeap()->GetLOHCompactionMode();
+    int result = (INT32)GCHeapUtilities::GetGCHeap()->GetLOHCompactionMode();
     return result;
 }
 FCIMPLEND
@@ -1670,7 +1670,7 @@ FCIMPL1(void, GCInterface::SetLOHCompactionMode, int newLOHCompactionyMode)
 
     FC_GC_POLL_NOT_NEEDED();
     
-    GCHeap::GetGCHeap()->SetLOHCompactionMode(newLOHCompactionyMode);
+    GCHeapUtilities::GetGCHeap()->SetLOHCompactionMode(newLOHCompactionyMode);
 }
 FCIMPLEND
 
@@ -1681,7 +1681,7 @@ FCIMPL2(FC_BOOL_RET, GCInterface::RegisterForFullGCNotification, UINT32 gen2Perc
 
     FC_GC_POLL_NOT_NEEDED();
 
-    FC_RETURN_BOOL(GCHeap::GetGCHeap()->RegisterForFullGCNotification(gen2Percentage, lohPercentage));
+    FC_RETURN_BOOL(GCHeapUtilities::GetGCHeap()->RegisterForFullGCNotification(gen2Percentage, lohPercentage));
 }
 FCIMPLEND
 
@@ -1690,7 +1690,7 @@ FCIMPL0(FC_BOOL_RET, GCInterface::CancelFullGCNotification)
     FCALL_CONTRACT;
 
     FC_GC_POLL_NOT_NEEDED();
-    FC_RETURN_BOOL(GCHeap::GetGCHeap()->CancelFullGCNotification());
+    FC_RETURN_BOOL(GCHeapUtilities::GetGCHeap()->CancelFullGCNotification());
 }
 FCIMPLEND
 
@@ -1711,7 +1711,7 @@ FCIMPL1(int, GCInterface::WaitForFullGCApproach, int millisecondsTimeout)
     HELPER_METHOD_FRAME_BEGIN_RET_0();
 
     DWORD dwMilliseconds = ((millisecondsTimeout == -1) ? INFINITE : millisecondsTimeout);
-    result = GCHeap::GetGCHeap()->WaitForFullGCApproach(dwMilliseconds);
+    result = GCHeapUtilities::GetGCHeap()->WaitForFullGCApproach(dwMilliseconds);
 
     HELPER_METHOD_FRAME_END();
 
@@ -1736,7 +1736,7 @@ FCIMPL1(int, GCInterface::WaitForFullGCComplete, int millisecondsTimeout)
     HELPER_METHOD_FRAME_BEGIN_RET_0();
 
     DWORD dwMilliseconds = ((millisecondsTimeout == -1) ? INFINITE : millisecondsTimeout);
-    result = GCHeap::GetGCHeap()->WaitForFullGCComplete(dwMilliseconds);
+    result = GCHeapUtilities::GetGCHeap()->WaitForFullGCComplete(dwMilliseconds);
 
     HELPER_METHOD_FRAME_END();
 
@@ -1757,7 +1757,7 @@ FCIMPL1(int, GCInterface::GetGeneration, Object* objUNSAFE)
     if (objUNSAFE == NULL)
         FCThrowArgumentNull(W("obj"));
 
-    int result = (INT32)GCHeap::GetGCHeap()->WhichGeneration(objUNSAFE);
+    int result = (INT32)GCHeapUtilities::GetGCHeap()->WhichGeneration(objUNSAFE);
     FC_GC_POLL_RET();
     return result;
 }
@@ -1777,7 +1777,7 @@ FCIMPL2(int, GCInterface::CollectionCount, INT32 generation, INT32 getSpecialGCC
     _ASSERTE(generation >= 0);
 
     //We don't need to check the top end because the GC will take care of that.
-    int result = (INT32)GCHeap::GetGCHeap()->CollectionCount(generation, getSpecialGCCount);
+    int result = (INT32)GCHeapUtilities::GetGCHeap()->CollectionCount(generation, getSpecialGCCount);
     FC_GC_POLL_RET();
     return result;
 }
@@ -1793,7 +1793,7 @@ int QCALLTYPE GCInterface::StartNoGCRegion(INT64 totalSize, BOOL lohSizeKnown, I
 
     GCX_COOP();
 
-    retVal = GCHeap::GetGCHeap()->StartNoGCRegion((ULONGLONG)totalSize, 
+    retVal = GCHeapUtilities::GetGCHeap()->StartNoGCRegion((ULONGLONG)totalSize, 
                                                   lohSizeKnown,
                                                   (ULONGLONG)lohSize,
                                                   disallowFullBlockingGC);
@@ -1811,7 +1811,7 @@ int QCALLTYPE GCInterface::EndNoGCRegion()
 
     BEGIN_QCALL;
 
-    retVal = GCHeap::GetGCHeap()->EndNoGCRegion();
+    retVal = GCHeapUtilities::GetGCHeap()->EndNoGCRegion();
 
     END_QCALL;
 
@@ -1837,7 +1837,7 @@ FCIMPL1(int, GCInterface::GetGenerationWR, LPVOID handle)
     if (temp == NULL)
         COMPlusThrowArgumentNull(W("weak handle"));
 
-    iRetVal = (INT32)GCHeap::GetGCHeap()->WhichGeneration(OBJECTREFToObject(temp));
+    iRetVal = (INT32)GCHeapUtilities::GetGCHeap()->WhichGeneration(OBJECTREFToObject(temp));
 
     HELPER_METHOD_FRAME_END();
 
@@ -1860,7 +1860,7 @@ INT64 QCALLTYPE GCInterface::GetTotalMemory()
     BEGIN_QCALL;
 
     GCX_COOP();
-    iRetVal = (INT64) GCHeap::GetGCHeap()->GetTotalBytesInUse();
+    iRetVal = (INT64) GCHeapUtilities::GetGCHeap()->GetTotalBytesInUse();
 
     END_QCALL;
 
@@ -1885,7 +1885,7 @@ void QCALLTYPE GCInterface::Collect(INT32 generation, INT32 mode)
     //We don't need to check the top end because the GC will take care of that.
 
     GCX_COOP();
-    GCHeap::GetGCHeap()->GarbageCollect(generation, FALSE, mode);
+    GCHeapUtilities::GetGCHeap()->GarbageCollect(generation, FALSE, mode);
 
     END_QCALL;
 }
@@ -1918,7 +1918,7 @@ FCIMPL0(int, GCInterface::GetMaxGeneration)
 {
     FCALL_CONTRACT;
 
-    return(INT32)GCHeap::GetGCHeap()->GetMaxGeneration();
+    return(INT32)GCHeapUtilities::GetGCHeap()->GetMaxGeneration();
 }
 FCIMPLEND
 
@@ -1934,7 +1934,7 @@ FCIMPL0(INT64, GCInterface::GetAllocatedBytesForCurrentThread)
 
     INT64 currentAllocated = 0;
     Thread *pThread = GetThread();
-    alloc_context* ac = pThread->GetAllocContext();
+    gc_alloc_context* ac = pThread->GetAllocContext();
     currentAllocated = ac->alloc_bytes + ac->alloc_bytes_loh - (ac->alloc_limit - ac->alloc_ptr);
 
     return currentAllocated;
@@ -1956,7 +1956,7 @@ FCIMPL1(void, GCInterface::SuppressFinalize, Object *obj)
     if (!obj->GetMethodTable ()->HasFinalizer())
         return;
 
-    GCHeap::GetGCHeap()->SetFinalizationRun(obj);
+    GCHeapUtilities::GetGCHeap()->SetFinalizationRun(obj);
     FC_GC_POLL();
 }
 FCIMPLEND
@@ -1977,7 +1977,7 @@ FCIMPL1(void, GCInterface::ReRegisterForFinalize, Object *obj)
     if (obj->GetMethodTable()->HasFinalizer())
     {
         HELPER_METHOD_FRAME_BEGIN_1(obj);
-        GCHeap::GetGCHeap()->RegisterForFinalization(-1, obj);
+        GCHeapUtilities::GetGCHeap()->RegisterForFinalization(-1, obj);
         HELPER_METHOD_FRAME_END();
     }
 }
@@ -2079,7 +2079,7 @@ void GCInterface::AddMemoryPressure(UINT64 bytesAllocated)
             m_ulThreshold = (addMethod > multMethod) ? addMethod : multMethod;
             for (int i = 0; i <= 1; i++)
             {
-                if ((GCHeap::GetGCHeap()->CollectionCount(i) / RELATIVE_GC_RATIO) > GCHeap::GetGCHeap()->CollectionCount(i + 1))
+                if ((GCHeapUtilities::GetGCHeap()->CollectionCount(i) / RELATIVE_GC_RATIO) > GCHeapUtilities::GetGCHeap()->CollectionCount(i + 1))
                 {
                     gen_collect = i + 1;
                     break;
@@ -2089,14 +2089,14 @@ void GCInterface::AddMemoryPressure(UINT64 bytesAllocated)
 
         PREFIX_ASSUME(gen_collect <= 2);
 
-        if ((gen_collect == 0) || (m_gc_counts[gen_collect] == GCHeap::GetGCHeap()->CollectionCount(gen_collect)))
+        if ((gen_collect == 0) || (m_gc_counts[gen_collect] == GCHeapUtilities::GetGCHeap()->CollectionCount(gen_collect)))
         {
             GarbageCollectModeAny(gen_collect);
         }
 
         for (int i = 0; i < 3; i++) 
         {
-            m_gc_counts [i] = GCHeap::GetGCHeap()->CollectionCount(i);
+            m_gc_counts [i] = GCHeapUtilities::GetGCHeap()->CollectionCount(i);
         }
     }
 }
@@ -2115,7 +2115,7 @@ void GCInterface::CheckCollectionCount()
 {
     LIMITED_METHOD_CONTRACT;
 
-    GCHeap * pHeap = GCHeap::GetGCHeap();
+    IGCHeap * pHeap = GCHeapUtilities::GetGCHeap();
     
     if (m_gc_counts[2] != pHeap->CollectionCount(2))
     {
@@ -2200,7 +2200,7 @@ void GCInterface::NewAddMemoryPressure(UINT64 bytesAllocated)
         // If still over budget, check current managed heap size
         if (newMemValue >= budget)
         {
-            GCHeap *pGCHeap = GCHeap::GetGCHeap();
+            IGCHeap *pGCHeap = GCHeapUtilities::GetGCHeap();
             UINT64 heapOver3 = pGCHeap->GetCurrentObjSize() / 3;
 
             if (budget < heapOver3) // Max
@@ -2274,7 +2274,7 @@ void GCInterface::RemoveMemoryPressure(UINT64 bytesAllocated)
 
         for (int i = 0; i < 3; i++) 
         {
-            m_gc_counts [i] = GCHeap::GetGCHeap()->CollectionCount(i);
+            m_gc_counts [i] = GCHeapUtilities::GetGCHeap()->CollectionCount(i);
         }
     }
 }
@@ -2348,7 +2348,7 @@ NOINLINE void GCInterface::GarbageCollectModeAny(int generation)
     CONTRACTL_END;
 
     GCX_COOP();
-    GCHeap::GetGCHeap()->GarbageCollect(generation, FALSE, collection_non_blocking);
+    GCHeapUtilities::GetGCHeap()->GarbageCollect(generation, FALSE, collection_non_blocking);
 }
 
 //

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -5170,7 +5170,7 @@ public:
 
         HRESULT     hr = S_OK;
 
-        if (Generation > (int) GCHeap::GetGCHeap()->GetMaxGeneration())
+        if (Generation > (int) GCHeapUtilities::GetGCHeap()->GetMaxGeneration())
             hr = E_INVALIDARG;
 
         if (SUCCEEDED(hr))
@@ -5188,7 +5188,7 @@ public:
                 EX_TRY
                 {
                     STRESS_LOG0(LF_GC, LL_INFO100, "Host triggers GC\n");
-                    hr = GCHeap::GetGCHeap()->GarbageCollect(Generation);
+                    hr = GCHeapUtilities::GetGCHeap()->GarbageCollect(Generation);
                 }
                 EX_CATCH
                 {
@@ -5354,7 +5354,7 @@ HRESULT CCLRGCManager::_SetGCSegmentSize(SIZE_T SegmentSize)
     HRESULT hr = S_OK;
 
     // Sanity check the value, it must be a power of two and big enough.
-    if (!GCHeap::IsValidSegmentSize(SegmentSize))
+    if (!GCHeapUtilities::GetGCHeap()->IsValidSegmentSize(SegmentSize))
     {
         hr = E_INVALIDARG;
     }
@@ -5380,7 +5380,7 @@ HRESULT CCLRGCManager::_SetGCMaxGen0Size(SIZE_T MaxGen0Size)
     HRESULT hr = S_OK;
 
     // Sanity check the value is at least large enough.
-    if (!GCHeap::IsValidGen0MaxSize(MaxGen0Size))
+    if (!GCHeapUtilities::GetGCHeap()->IsValidGen0MaxSize(MaxGen0Size))
     {
         hr = E_INVALIDARG;
     }
@@ -6408,7 +6408,7 @@ HRESULT CCLRDebugManager::SetConnectionTasks(
             }
 
             // Check for Finalizer thread
-            if (GCHeap::IsGCHeapInitialized() && (pThread == FinalizerThread::GetFinalizerThread()))
+            if (GCHeapUtilities::IsGCHeapInitialized() && (pThread == FinalizerThread::GetFinalizerThread()))
             {
                 // _ASSERTE(!"Host should not try to schedule user code on our Finalizer Thread");
                 IfFailGo(E_INVALIDARG);

--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -130,7 +130,7 @@ BOOL __SwitchToThread(DWORD, DWORD)
 // Globals and misc other
 //
 
-GPTR_IMPL(GCHeap,g_pGCHeap);
+GPTR_IMPL(IGCHeap,g_pGCHeap);
 
 BOOL g_fEEOtherStartup=FALSE;
 BOOL g_fEEComActivatedStartup=FALSE;
@@ -138,7 +138,7 @@ BOOL g_fEEComActivatedStartup=FALSE;
 GVAL_IMPL_INIT(DWORD, g_fHostConfig, 0);
 
 #ifdef FEATURE_SVR_GC
-SVAL_IMPL_INIT(uint32_t,GCHeap,gcHeapType,GCHeap::GC_HEAP_WKS);
+SVAL_IMPL_INIT(uint32_t,IGCHeap,gcHeapType,IGCHeap::GC_HEAP_WKS);
 #endif
 
 void UpdateGCSettingFromHost()

--- a/src/vm/crst.cpp
+++ b/src/vm/crst.cpp
@@ -627,7 +627,7 @@ void CrstBase::PreEnter()
                           || (pThread != NULL && pThread->PreemptiveGCDisabled())
                            // If GC heap has not been initialized yet, there is no need to synchronize with GC.
                            // This check is mainly for code called from EEStartup.
-                          || (pThread == NULL && !GCHeap::IsGCHeapInitialized()) );
+                          || (pThread == NULL && !GCHeapUtilities::IsGCHeapInitialized()) );
     }
     
     if ((pThread != NULL) && 
@@ -910,7 +910,7 @@ BOOL CrstBase::IsSafeToTake()
     _ASSERTE(pThread == NULL ||
              (pThread->PreemptiveGCDisabled() == ((m_dwFlags & CRST_UNSAFE_COOPGC) != 0)) ||
              ((m_dwFlags & (CRST_UNSAFE_ANYMODE | CRST_GC_NOTRIGGER_WHEN_TAKEN)) != 0) ||
-             (GCHeap::IsGCInProgress() && pThread == ThreadSuspend::GetSuspensionThread()));
+             (GCHeapUtilities::IsGCInProgress() && pThread == ThreadSuspend::GetSuspensionThread()));
     END_GETTHREAD_ALLOWED;
 
     if (m_holderthreadid.IsCurrentThread())

--- a/src/vm/debugdebugger.cpp
+++ b/src/vm/debugdebugger.cpp
@@ -22,7 +22,7 @@
 #include "frames.h"
 #include "vars.hpp"
 #include "field.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "jitinterface.h"
 #include "debugdebugger.h"
 #include "dbginterface.h"

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -4140,8 +4140,8 @@ void DomainAssembly::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
     }
     CONTRACT_END;
 
-    _ASSERTE(GCHeap::IsGCInProgress() &&
-         GCHeap::IsServerHeap()   &&
+    _ASSERTE(GCHeapUtilities::IsGCInProgress() &&
+         GCHeapUtilities::IsServerHeap()   &&
          IsGCSpecialThread());
 
     DomainModuleIterator i = IterateModules(kModIterIncludeLoaded);

--- a/src/vm/dwreport.cpp
+++ b/src/vm/dwreport.cpp
@@ -3212,7 +3212,7 @@ FaultReportResult DoFaultReport(            // Was Watson attempted, successful?
             // thread under Coop mode, this will let the new generated DoFaultReportCallBack 
             // thread trigger a deadlock. So in this case, we should directly abort the fault 
             // report to avoid the deadlock.
-            ((IsGCThread() || pThread->PreemptiveGCDisabled()) && GCHeap::IsGCInProgress()) ||
+            ((IsGCThread() || pThread->PreemptiveGCDisabled()) && GCHeapUtilities::IsGCInProgress()) ||
              FAILED(g_pDebugInterface->RequestFavor(DoFaultReportFavorWorker, pData)))
         {
             // If we can't initialize the debugger helper thread or we are running on the debugger helper

--- a/src/vm/eetoprofinterfaceimpl.cpp
+++ b/src/vm/eetoprofinterfaceimpl.cpp
@@ -2294,7 +2294,7 @@ HRESULT EEToProfInterfaceImpl::SetEventMask(DWORD dwEventMask, DWORD dwEventMask
             // in this function
             if (g_profControlBlock.curProfStatus.Get() == kProfStatusInitializingForAttachLoad)
             {
-                if (GCHeap::GetGCHeap()->IsConcurrentGCEnabled())
+                if (GCHeapUtilities::GetGCHeap()->IsConcurrentGCEnabled())
                 {
                     // We only allow turning off concurrent GC in the profiler attach thread inside
                     // InitializeForAttach, otherwise we would be vulnerable to weird races such as 
@@ -2316,7 +2316,7 @@ HRESULT EEToProfInterfaceImpl::SetEventMask(DWORD dwEventMask, DWORD dwEventMask
                 // Fail if concurrent GC is enabled
                 // This should only happen for attach profilers if user didn't turn on COR_PRF_MONITOR_GC 
                 // at attach time
-                if (GCHeap::GetGCHeap()->IsConcurrentGCEnabled())
+                if (GCHeapUtilities::GetGCHeap()->IsConcurrentGCEnabled())
                 {
                     return CORPROF_E_CONCURRENT_GC_NOT_PROFILABLE;
                 }        
@@ -2384,7 +2384,7 @@ HRESULT EEToProfInterfaceImpl::SetEventMask(DWORD dwEventMask, DWORD dwEventMask
     if (fNeedToTurnOffConcurrentGC)
     {
         // Turn off concurrent GC if it is on so that user can walk the heap safely in GC callbacks
-        GCHeap * pGCHeap = GCHeap::GetGCHeap();
+        IGCHeap * pGCHeap = GCHeapUtilities::GetGCHeap();
         
         LOG((LF_CORPROF, LL_INFO10, "**PROF: Turning off concurrent GC at attach.\n"));
         
@@ -5609,7 +5609,7 @@ HRESULT EEToProfInterfaceImpl::MovedReferences(GCReferencesData *pData)
         LL_INFO10000, 
         "**PROF: MovedReferences.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsConcurrentGCEnabled());
     
     if (pData->curIdx == 0)
     {
@@ -5805,7 +5805,7 @@ HRESULT EEToProfInterfaceImpl::ObjectReference(ObjectID objId,
         LL_INFO100000, 
         "**PROF: ObjectReferences.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsConcurrentGCEnabled());
     
     {                
         // All callbacks are really NOTHROW, but that's enforced partially by the profiler,
@@ -5844,7 +5844,7 @@ HRESULT EEToProfInterfaceImpl::FinalizeableObjectQueued(BOOL isCritical, ObjectI
                                 LL_INFO100, 
                                 "**PROF: Notifying profiler of finalizeable object.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsConcurrentGCEnabled());
     
     {                
         // All callbacks are really NOTHROW, but that's enforced partially by the profiler,
@@ -5883,7 +5883,7 @@ HRESULT EEToProfInterfaceImpl::RootReferences2(GCReferencesData *pData)
         LL_INFO10000, 
         "**PROF: RootReferences2.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsConcurrentGCEnabled());
     
     HRESULT hr = S_OK;
 
@@ -5948,7 +5948,7 @@ HRESULT EEToProfInterfaceImpl::ConditionalWeakTableElementReferences(GCReference
         LL_INFO10000, 
         "**PROF: ConditionalWeakTableElementReferences.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsConcurrentGCEnabled());
     
     HRESULT hr = S_OK;
 
@@ -6082,7 +6082,7 @@ HRESULT EEToProfInterfaceImpl::GarbageCollectionStarted(int cGenerations, BOOL g
         LL_INFO10000, 
         "**PROF: GarbageCollectionStarted.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsConcurrentGCEnabled());
     
     {            
         // All callbacks are really NOTHROW, but that's enforced partially by the profiler,
@@ -6120,7 +6120,7 @@ HRESULT EEToProfInterfaceImpl::GarbageCollectionFinished()
         LL_INFO10000, 
         "**PROF: GarbageCollectionFinished.\n"));
 
-    _ASSERTE(!GCHeap::GetGCHeap()->IsConcurrentGCEnabled());
+    _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsConcurrentGCEnabled());
     
     {        
         // All callbacks are really NOTHROW, but that's enforced partially by the profiler,

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -20,7 +20,7 @@
 #include "cgensys.h"
 #include "comutilnative.h"
 #include "siginfo.hpp"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "eedbginterfaceimpl.h" //so we can clearexception in RealCOMPlusThrow
 #include "perfcounters.h"
 #include "dllimportcallback.h"

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -295,7 +295,7 @@ Object * FinalizerThread::FinalizeAllObjects(Object* fobj, int bitToCheck)
         {
             return NULL;
         }
-        fobj = GCHeap::GetGCHeap()->GetNextFinalizable();
+        fobj = GCHeapUtilities::GetGCHeap()->GetNextFinalizable();
     }
 
     Thread *pThread = GetThread();
@@ -320,7 +320,7 @@ Object * FinalizerThread::FinalizeAllObjects(Object* fobj, int bitToCheck)
             {
                 return NULL;
             }
-            fobj = GCHeap::GetGCHeap()->GetNextFinalizable();
+            fobj = GCHeapUtilities::GetGCHeap()->GetNextFinalizable();
         }
         else
         {
@@ -337,7 +337,7 @@ Object * FinalizerThread::FinalizeAllObjects(Object* fobj, int bitToCheck)
                 {
                     return NULL;
                 }
-                fobj = GCHeap::GetGCHeap()->GetNextFinalizable();
+                fobj = GCHeapUtilities::GetGCHeap()->GetNextFinalizable();
             }
         }
     }
@@ -533,7 +533,7 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
             case (WAIT_OBJECT_0 + kLowMemoryNotification):
                 //short on memory GC immediately
                 GetFinalizerThread()->DisablePreemptiveGC();
-                GCHeap::GetGCHeap()->GarbageCollect(0, TRUE);
+                GCHeapUtilities::GetGCHeap()->GarbageCollect(0, TRUE);
                 GetFinalizerThread()->EnablePreemptiveGC();
                 //wait only on the event for 2s 
                 switch (event->Wait(2000, FALSE))
@@ -584,7 +584,7 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
                 if (WaitForSingleObject(MHandles[kLowMemoryNotification], 0) == WAIT_OBJECT_0) {
                     //short on memory GC immediately
                     GetFinalizerThread()->DisablePreemptiveGC();
-                    GCHeap::GetGCHeap()->GarbageCollect(0, TRUE);
+                    GCHeapUtilities::GetGCHeap()->GarbageCollect(0, TRUE);
                     GetFinalizerThread()->EnablePreemptiveGC();
                 }
                 //wait only on the event for 2s
@@ -604,7 +604,7 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
                         if (sLastLowMemoryFromHost != 0)
                         {
                             GetFinalizerThread()->DisablePreemptiveGC();
-                            GCHeap::GetGCHeap()->GarbageCollect(0, TRUE);
+                            GCHeapUtilities::GetGCHeap()->GarbageCollect(0, TRUE);
                             GetFinalizerThread()->EnablePreemptiveGC();
                         }
                     }
@@ -677,7 +677,7 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
         {
             s_forcedGCInProgress = true;
             GetFinalizerThread()->DisablePreemptiveGC();
-            GCHeap::GetGCHeap()->GarbageCollect(2, FALSE, collection_blocking);
+            GCHeapUtilities::GetGCHeap()->GarbageCollect(2, FALSE, collection_blocking);
             GetFinalizerThread()->EnablePreemptiveGC();
             s_forcedGCInProgress = false;
             
@@ -710,14 +710,14 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
 
             do
             {
-                last_gc_count = GCHeap::GetGCHeap()->CollectionCount(0);
+                last_gc_count = GCHeapUtilities::GetGCHeap()->CollectionCount(0);
                 GetFinalizerThread()->m_GCOnTransitionsOK = FALSE; 
                 GetFinalizerThread()->EnablePreemptiveGC();
                 __SwitchToThread (0, ++dwSwitchCount);
                 GetFinalizerThread()->DisablePreemptiveGC();             
                 // If no GCs happended, then we assume we are quiescent
                 GetFinalizerThread()->m_GCOnTransitionsOK = TRUE; 
-            } while (GCHeap::GetGCHeap()->CollectionCount(0) - last_gc_count > 0);
+            } while (GCHeapUtilities::GetGCHeap()->CollectionCount(0) - last_gc_count > 0);
         }
 #endif //_DEBUG
 
@@ -747,7 +747,7 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
             }
             else if (UnloadingAppDomain == NULL)
                 break;
-            else if (!GCHeap::GetGCHeap()->FinalizeAppDomain(UnloadingAppDomain, fRunFinalizersOnUnload))
+            else if (!GCHeapUtilities::GetGCHeap()->FinalizeAppDomain(UnloadingAppDomain, fRunFinalizersOnUnload))
             {
                 break;
             }
@@ -916,7 +916,7 @@ DWORD __stdcall FinalizerThread::FinalizerThreadStart(void *args)
             if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_FinalizeOnShutdown) != 0)
             {
                 // Finalize all registered objects during shutdown, even they are still reachable.
-                GCHeap::GetGCHeap()->SetFinalizeQueueForShutdown(FALSE);
+                GCHeapUtilities::GetGCHeap()->SetFinalizeQueueForShutdown(FALSE);
 
                 // This will apply any policy for swallowing exceptions during normal
                 // processing, without allowing the finalizer thread to disappear on us.
@@ -1380,7 +1380,7 @@ BOOL FinalizerThread::FinalizerThreadWatchDogHelper()
     }
     else
     {
-        prevCount = GCHeap::GetGCHeap()->GetNumberOfFinalizable();
+        prevCount = GCHeapUtilities::GetGCHeap()->GetNumberOfFinalizable();
     }
 
     DWORD maxTry = (DWORD)(totalWaitTimeout*1.0/FINALIZER_WAIT_TIMEOUT + 0.5);
@@ -1447,11 +1447,11 @@ BOOL FinalizerThread::FinalizerThreadWatchDogHelper()
         }
         else
         {
-            curCount = GCHeap::GetGCHeap()->GetNumberOfFinalizable();
+            curCount = GCHeapUtilities::GetGCHeap()->GetNumberOfFinalizable();
         }
 
         if ((prevCount <= curCount)
-            && !GCHeap::GetGCHeap()->ShouldRestartFinalizerWatchDog()
+            && !GCHeapUtilities::GetGCHeap()->ShouldRestartFinalizerWatchDog()
             && (pThread == NULL || !(pThread->m_State & (Thread::TS_UserSuspendPending | Thread::TS_DebugSuspendPending)))){
             if (nTry == maxTry) {
                 if (!s_fRaiseExitProcessEvent) {

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -18,7 +18,7 @@
 #include "fieldmarshaler.h"
 #include "objecthandle.h"
 #include "siginfo.hpp"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "dllimportcallback.h"
 #include "stackwalk.h"
 #include "dbginterface.h"

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1234,8 +1234,8 @@ void checkAndUpdateReg(DWORD& origVal, DWORD curVal, bool gcHappened) {
     // the validation infrastructure has got a bug.
 
     _ASSERTE(gcHappened);    // If the register values are different, a GC must have happened
-    _ASSERTE(GCHeap::GetGCHeap()->IsHeapPointer((BYTE*) size_t(origVal)));    // And the pointers involved are on the GCHeap
-    _ASSERTE(GCHeap::GetGCHeap()->IsHeapPointer((BYTE*) size_t(curVal)));
+    _ASSERTE(GCHeapUtilities::GetGCHeap()->IsHeapPointer((BYTE*) size_t(origVal)));    // And the pointers involved are on the GCHeap
+    _ASSERTE(GCHeapUtilities::GetGCHeap()->IsHeapPointer((BYTE*) size_t(curVal)));
     origVal = curVal;       // this is now the best estimate of what should be returned. 
 }
 
@@ -1478,7 +1478,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
             if (gcCover->callerThread == 0) {
                 if (FastInterlockCompareExchangePointer(&gcCover->callerThread, pThread, 0) == 0) {
                     gcCover->callerRegs = *regs;
-                    gcCover->gcCount = GCHeap::GetGCHeap()->GetGcCount();
+                    gcCover->gcCount = GCHeapUtilities::GetGCHeap()->GetGcCount();
                     bShouldUpdateProlog = false;
                 }
             }    
@@ -1564,13 +1564,13 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
             // instruction in the epilog  (TODO: fix it for the first instr Case)
             
             _ASSERTE(pThread->PreemptiveGCDisabled());    // Epilogs should be in cooperative mode, no GC can happen right now. 
-            bool gcHappened = gcCover->gcCount != GCHeap::GetGCHeap()->GetGcCount();
+            bool gcHappened = gcCover->gcCount != GCHeapUtilities::GetGCHeap()->GetGcCount();
             checkAndUpdateReg(gcCover->callerRegs.Edi, *regDisp.pEdi, gcHappened);
             checkAndUpdateReg(gcCover->callerRegs.Esi, *regDisp.pEsi, gcHappened);
             checkAndUpdateReg(gcCover->callerRegs.Ebx, *regDisp.pEbx, gcHappened);
             checkAndUpdateReg(gcCover->callerRegs.Ebp, *regDisp.pEbp, gcHappened);
             
-            gcCover->gcCount = GCHeap::GetGCHeap()->GetGcCount();
+            gcCover->gcCount = GCHeapUtilities::GetGCHeap()->GetGcCount();
 
         }        
         return;
@@ -1777,7 +1777,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
     // Do the actual stress work
     //
 
-    if (!GCHeap::GetGCHeap()->StressHeap())
+    if (!GCHeapUtilities::GetGCHeap()->StressHeap())
         UpdateGCStressInstructionWithoutGC ();
 
     // Must flush instruction cache before returning as instruction has been modified.

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -550,7 +550,7 @@ void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, 
     STRESS_LOG1(LF_GCROOTS, LL_INFO10, "GCScan: Promotion Phase = %d\n", sc->promotion);
 
     // In server GC, we should be competing for marking the statics
-    if (GCHeap::MarkShouldCompeteForStatics())
+    if (GCHeapUtilities::MarkShouldCompeteForStatics())
     {
         if (condemned == max_gen && sc->promotion)
         {
@@ -563,7 +563,7 @@ void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, 
     {
         STRESS_LOG2(LF_GC | LF_GCROOTS, LL_INFO100, "{ Starting scan of Thread %p ID = %x\n", pThread, pThread->GetThreadId());
 
-        if (GCHeap::GetGCHeap()->IsThreadUsingAllocationContextHeap(
+        if (GCHeapUtilities::GetGCHeap()->IsThreadUsingAllocationContextHeap(
             GCToEEInterface::GetAllocContext(pThread), sc->thread_number))
         {
             sc->thread_under_crawl = pThread;
@@ -693,7 +693,7 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int max_gen)
     SyncBlockCache::GetSyncBlockCache()->GCDone(FALSE, max_gen);
 }
 
-alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
+gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
 {
     WRAPPER_NO_CONTRACT;
     return pThread->GetAllocContext();

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "common.h"
+#include "gcheaputilities.h"
+
+// This is the global GC heap, maintained by the VM.
+GPTR_IMPL(IGCHeap, g_pGCHeap);

--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef _GCHEAPUTILITIES_H_
+#define _GCHEAPUTILITIES_H_
+
+#include "gcinterface.h"
+
+// The singular heap instance.
+GPTR_DECL(IGCHeap, g_pGCHeap);
+
+// GCHeapUtilities provides a number of static methods
+// that operate on the global heap instance. It can't be
+// instantiated.
+class GCHeapUtilities {
+public:
+    // Retrieves the GC heap.
+    inline static IGCHeap* GetGCHeap() 
+    {
+        assert(g_pGCHeap != nullptr);
+        return g_pGCHeap;
+    }
+
+    // Returns true if the heap has been initialized, false otherwise.
+    inline static bool IsGCHeapInitialized()
+    {
+        return g_pGCHeap != nullptr;
+    }
+
+    // Returns true if a the heap is initialized and a garbage collection
+    // is in progress, false otherwise.
+    inline static BOOL IsGCInProgress(BOOL bConsiderGCStart = FALSE)
+    {
+        WRAPPER_NO_CONTRACT;
+
+        return (IsGCHeapInitialized() ? GetGCHeap()->IsGCInProgressHelper(bConsiderGCStart) : false);
+    }
+
+    // Returns true if we should be competing marking for statics. This
+    // influences the behavior of `GCToEEInterface::GcScanRoots`.
+    inline static BOOL MarkShouldCompeteForStatics()
+    {
+        WRAPPER_NO_CONTRACT;
+
+        return IsServerHeap() && g_SystemInfo.dwNumberOfProcessors >= 2;
+    }
+
+    // Waits until a GC is complete, if the heap has been initialized.
+    inline static void WaitForGCCompletion(BOOL bConsiderGCStart = FALSE)
+    {
+        WRAPPER_NO_CONTRACT;
+
+        if (IsGCHeapInitialized())
+            GetGCHeap()->WaitUntilGCComplete(bConsiderGCStart);
+    }
+
+    // Returns true if we should be using allocation contexts, false otherwise.
+    inline static bool UseAllocationContexts()
+    {
+        WRAPPER_NO_CONTRACT;
+#ifdef FEATURE_REDHAWK
+        // SIMPLIFY:  only use allocation contexts
+        return true;
+#else
+#if defined(_TARGET_ARM_) || defined(FEATURE_PAL)
+        return true;
+#else
+        return ((IsServerHeap() ? true : (g_SystemInfo.dwNumberOfProcessors >= 2)));
+#endif 
+#endif 
+    }
+
+    // Returns true if the held GC heap is a Server GC heap, false otherwise.
+    inline static bool IsServerHeap()
+    {
+        LIMITED_METHOD_CONTRACT;
+#ifdef FEATURE_SVR_GC
+        _ASSERTE(IGCHeap::gcHeapType != IGCHeap::GC_HEAP_INVALID);
+        return (IGCHeap::gcHeapType == IGCHeap::GC_HEAP_SVR);
+#else // FEATURE_SVR_GC
+        return false;
+#endif // FEATURE_SVR_GC
+    }
+
+    // Gets the maximum generation number by reading the static field
+    // on IGCHeap. This should only be done by the DAC code paths - all other code
+    // should go through IGCHeap::GetMaxGeneration.
+    //
+    // The reason for this is that, while we are in the early stages of
+    // decoupling the GC, the GC and the DAC still remain tightly coupled
+    // and, in particular, the DAC needs to know how many generations the GC
+    // has. However, it is not permitted to invoke virtual methods on g_pGCHeap
+    // while on a DAC code path. Therefore, we need to determine the max generation
+    // non-virtually, while still in a manner consistent with the interface - 
+    // therefore, a static field is used.
+    //
+    // This is not without precedent - IGCHeap::gcHeapType is a static field used
+    // for a similar reason (the DAC needs to know what kind of heap it's looking at).
+    inline static unsigned GetMaxGeneration()
+    {
+        return IGCHeap::maxGeneration;
+    }
+
+private:
+    // This class should never be instantiated.
+    GCHeapUtilities() = delete;
+};
+
+#endif // _GCHEAPUTILITIES_H_

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -16,7 +16,7 @@
 #include "threads.h"
 #include "eetwain.h"
 #include "eeconfig.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "corhost.h"
 #include "threads.h"
 #include "fieldmarshaler.h"
@@ -51,11 +51,11 @@
             orObject = (ArrayBase *) OBJECTREFToObject(objref);
 
 
-inline alloc_context* GetThreadAllocContext()
+inline gc_alloc_context* GetThreadAllocContext()
 {
     WRAPPER_NO_CONTRACT;
 
-    assert(GCHeap::UseAllocationContexts());
+    assert(GCHeapUtilities::UseAllocationContexts());
 
     return & GetThread()->m_alloc_context;
 }
@@ -102,10 +102,10 @@ inline Object* Alloc(size_t size, BOOL bFinalize, BOOL bContainsPointers )
     // We don't want to throw an SO during the GC, so make sure we have plenty
     // of stack before calling in.
     INTERIOR_STACK_PROBE_FOR(GetThread(), static_cast<unsigned>(DEFAULT_ENTRY_PROBE_AMOUNT * 1.5));
-    if (GCHeap::UseAllocationContexts())
-        retVal = GCHeap::GetGCHeap()->Alloc(GetThreadAllocContext(), size, flags);
+    if (GCHeapUtilities::UseAllocationContexts())
+        retVal = GCHeapUtilities::GetGCHeap()->Alloc(GetThreadAllocContext(), size, flags);
     else
-        retVal = GCHeap::GetGCHeap()->Alloc(size, flags);
+        retVal = GCHeapUtilities::GetGCHeap()->Alloc(size, flags);
     END_INTERIOR_STACK_PROBE;
     return retVal;
 }
@@ -130,10 +130,10 @@ inline Object* AllocAlign8(size_t size, BOOL bFinalize, BOOL bContainsPointers, 
     // We don't want to throw an SO during the GC, so make sure we have plenty
     // of stack before calling in.
     INTERIOR_STACK_PROBE_FOR(GetThread(), static_cast<unsigned>(DEFAULT_ENTRY_PROBE_AMOUNT * 1.5));
-    if (GCHeap::UseAllocationContexts())
-        retVal = GCHeap::GetGCHeap()->AllocAlign8(GetThreadAllocContext(), size, flags);
+    if (GCHeapUtilities::UseAllocationContexts())
+        retVal = GCHeapUtilities::GetGCHeap()->AllocAlign8(GetThreadAllocContext(), size, flags);
     else
-        retVal = GCHeap::GetGCHeap()->AllocAlign8(size, flags);
+        retVal = GCHeapUtilities::GetGCHeap()->AllocAlign8(size, flags);
 
     END_INTERIOR_STACK_PROBE;
     return retVal;
@@ -173,7 +173,7 @@ inline Object* AllocLHeap(size_t size, BOOL bFinalize, BOOL bContainsPointers )
     // We don't want to throw an SO during the GC, so make sure we have plenty
     // of stack before calling in.
     INTERIOR_STACK_PROBE_FOR(GetThread(), static_cast<unsigned>(DEFAULT_ENTRY_PROBE_AMOUNT * 1.5));
-    retVal = GCHeap::GetGCHeap()->AllocLHeap(size, flags);
+    retVal = GCHeapUtilities::GetGCHeap()->AllocLHeap(size, flags);
     END_INTERIOR_STACK_PROBE;
     return retVal;
 }
@@ -427,7 +427,7 @@ OBJECTREF AllocateArrayEx(TypeHandle arrayType, INT32 *pArgs, DWORD dwNumArgs, B
     if (bAllocateInLargeHeap || 
         (totalSize >= LARGE_OBJECT_SIZE))
     {
-        GCHeap::GetGCHeap()->PublishObject((BYTE*)orArray);
+        GCHeapUtilities::GetGCHeap()->PublishObject((BYTE*)orArray);
     }
 
 #ifdef  _LOGALLOC
@@ -651,7 +651,7 @@ OBJECTREF   FastAllocatePrimitiveArray(MethodTable* pMT, DWORD cElements, BOOL b
 
     if (bPublish)
     {
-        GCHeap::GetGCHeap()->PublishObject((BYTE*)orObject);
+        GCHeapUtilities::GetGCHeap()->PublishObject((BYTE*)orObject);
     }
 
     // Notify the profiler of the allocation
@@ -860,7 +860,7 @@ STRINGREF SlowAllocateString( DWORD cchStringLength )
 
     if (ObjectSize >= LARGE_OBJECT_SIZE)
     {
-        GCHeap::GetGCHeap()->PublishObject((BYTE*)orObject);
+        GCHeapUtilities::GetGCHeap()->PublishObject((BYTE*)orObject);
     }
 
     // Notify the profiler of the allocation
@@ -1000,7 +1000,7 @@ OBJECTREF AllocateObject(MethodTable *pMT
         if ((baseSize >= LARGE_OBJECT_SIZE))
         {
             orObject->SetMethodTableForLargeObject(pMT);
-            GCHeap::GetGCHeap()->PublishObject((BYTE*)orObject);
+            GCHeapUtilities::GetGCHeap()->PublishObject((BYTE*)orObject);
         }
         else
         {
@@ -1234,7 +1234,7 @@ extern "C" HCIMPL2_RAW(VOID, JIT_WriteBarrier, Object **dst, Object *ref)
     *dst = ref;
 
     // If the store above succeeded, "dst" should be in the heap.
-   assert(GCHeap::GetGCHeap()->IsHeapPointer((void*)dst));
+   assert(GCHeapUtilities::GetGCHeap()->IsHeapPointer((void*)dst));
 
 #ifdef WRITE_BARRIER_CHECK
     updateGCShadow(dst, ref);     // support debugging write barrier
@@ -1280,7 +1280,7 @@ extern "C" HCIMPL2_RAW(VOID, JIT_WriteBarrierEnsureNonHeapTarget, Object **dst, 
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_NOTRIGGER;
 
-    assert(!GCHeap::GetGCHeap()->IsHeapPointer((void*)dst));
+    assert(!GCHeapUtilities::GetGCHeap()->IsHeapPointer((void*)dst));
 
     // no HELPER_METHOD_FRAME because we are MODE_COOPERATIVE, GC_NOTRIGGER
     

--- a/src/vm/gchost.cpp
+++ b/src/vm/gchost.cpp
@@ -22,7 +22,7 @@
 #include "corhost.h"
 #include "excep.h"
 #include "field.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 
 #if !defined(FEATURE_CORECLR)
 inline size_t SizeInKBytes(size_t cbSize)
@@ -48,7 +48,7 @@ HRESULT CorGCHost::_SetGCSegmentSize(SIZE_T SegmentSize)
     HRESULT hr = S_OK;
 
     // Sanity check the value, it must be a power of two and big enough.
-    if (!GCHeap::IsValidSegmentSize(SegmentSize))
+    if (!GCHeapUtilities::IsValidSegmentSize(SegmentSize))
     {
         hr = E_INVALIDARG;
     }
@@ -74,7 +74,7 @@ HRESULT CorGCHost::_SetGCMaxGen0Size(SIZE_T MaxGen0Size)
     HRESULT hr = S_OK;
 
     // Sanity check the value is at least large enough.
-    if (!GCHeap::IsValidGen0MaxSize(MaxGen0Size))
+    if (!GCHeapUtilities::IsValidGen0MaxSize(MaxGen0Size))
     {
         hr = E_INVALIDARG;
     }
@@ -151,7 +151,7 @@ HRESULT CorGCHost::Collect(
     
     HRESULT     hr = E_FAIL;
     
-    if (Generation > (int) GCHeap::GetGCHeap()->GetMaxGeneration())
+    if (Generation > (int) GCHeapUtilities::GetGCHeap()->GetMaxGeneration())
         hr = E_INVALIDARG;
     else
     {
@@ -170,7 +170,7 @@ HRESULT CorGCHost::Collect(
 
             EX_TRY
             {			
-                hr = GCHeap::GetGCHeap()->GarbageCollect(Generation);
+                hr = GCHeapUtilities::GetGCHeap()->GarbageCollect(Generation);
             }
             EX_CATCH
             {
@@ -268,7 +268,7 @@ HRESULT CorGCHost::SetVirtualMemLimit(
     }
     CONTRACTL_END;
 
-    GCHeap::GetGCHeap()->SetReservedVMLimit (sztMaxVirtualMemMB);
+    GCHeapUtilities::GetGCHeap()->SetReservedVMLimit (sztMaxVirtualMemMB);
     return (S_OK);
 }
 #endif // !defined(FEATURE_CORECLR)

--- a/src/vm/gcinterface.h
+++ b/src/vm/gcinterface.h
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#include "../gc/gc.h"
+#include "../gc/gcinterface.h"

--- a/src/vm/gcstress.h
+++ b/src/vm/gcstress.h
@@ -280,17 +280,17 @@ namespace _GCStress
     // GC Trigger policy classes define how a garbage collection is triggered
 
     // This is the default GC Trigger policy that simply calls 
-    // GCHeap::StressHeap
+    // IGCHeap::StressHeap
     class StressGcTriggerPolicy
     {
     public:
         FORCEINLINE
         static void Trigger()
-        { GCHeap::GetGCHeap()->StressHeap(); }
+        { GCHeapUtilities::GetGCHeap()->StressHeap(); }
 
         FORCEINLINE
-        static void Trigger(::alloc_context* acontext)
-        { GCHeap::GetGCHeap()->StressHeap(acontext); }
+        static void Trigger(::gc_alloc_context* acontext)
+        { GCHeapUtilities::GetGCHeap()->StressHeap(acontext); }
     };
 
     // This is an overriding GC Trigger policy that triggers a GC by calling
@@ -403,7 +403,7 @@ namespace _GCStress
         // Additionally it switches the GC mode as specified by GcModePolicy, and it 
         // uses GcTriggerPolicy::Trigger(alloc_context*) to actually trigger the GC
         FORCEINLINE
-        static void MaybeTrigger(::alloc_context* acontext, DWORD minFastGc = 0)
+        static void MaybeTrigger(::gc_alloc_context* acontext, DWORD minFastGc = 0)
         {
             if (IsEnabled(minFastGc) && GCStressPolicy::IsEnabled())
             {
@@ -455,7 +455,7 @@ namespace _GCStress
     public:
 
         FORCEINLINE
-        static void MaybeTrigger(::alloc_context* acontext)
+        static void MaybeTrigger(::gc_alloc_context* acontext)
         {
             GcStressBase::MaybeTrigger(acontext);
 

--- a/src/vm/hash.cpp
+++ b/src/vm/hash.cpp
@@ -547,8 +547,8 @@ UPTR HashMap::LookupValue(UPTR key, UPTR value)
 
     // BROKEN: This is called for the RCWCache on the GC thread
     // Also called by AppDomain::FindCachedAssembly to resolve AssemblyRef -- this is used by stack walking on the GC thread.
-    // See comments in GCHeap::RestartEE (above the call to SyncClean::CleanUp) for reason to enter COOP mode.
-    // However, if the current thread is the GC thread, we know we're not going to call GCHeap::RestartEE
+    // See comments in GCHeapUtilities::RestartEE (above the call to SyncClean::CleanUp) for reason to enter COOP mode.
+    // However, if the current thread is the GC thread, we know we're not going to call GCHeapUtilities::RestartEE
     // while accessing the HashMap, so it's safe to proceed.
     // (m_fAsyncMode && !IsGCThread() is the condition for entering COOP mode.  I.e., enable COOP GC only if
     // the HashMap is in async mode and this is not a GC thread.)

--- a/src/vm/i386/excepx86.cpp
+++ b/src/vm/i386/excepx86.cpp
@@ -19,7 +19,7 @@
 #include "comutilnative.h"
 #include "sigformat.h"
 #include "siginfo.hpp"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "eedbginterfaceimpl.h" //so we can clearexception in COMPlusThrow
 #include "perfcounters.h"
 #include "eventtrace.h"

--- a/src/vm/i386/virtualcallstubcpu.hpp
+++ b/src/vm/i386/virtualcallstubcpu.hpp
@@ -695,7 +695,7 @@ BOOL isDelegateCall(BYTE *interiorPtr)
 {
     LIMITED_METHOD_CONTRACT;
 
-    if (GCHeap::GetGCHeap()->IsHeapPointer((void*)interiorPtr))
+    if (GCHeapUtilities::GetGCHeap()->IsHeapPointer((void*)interiorPtr))
     {
         Object *delegate = (Object*)(interiorPtr - DelegateObject::GetOffsetOfMethodPtrAux());
         VALIDATEOBJECTREF(ObjectToOBJECTREF(delegate));

--- a/src/vm/interoputil.cpp
+++ b/src/vm/interoputil.cpp
@@ -2130,7 +2130,7 @@ void MinorCleanupSyncBlockComData(InteropSyncBlockInfo* pInteropInfo)
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION( GCHeap::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ) );
+        PRECONDITION( GCHeapUtilities::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ) );
     }
     CONTRACTL_END;
 

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -14,7 +14,7 @@
 #include "openum.h"
 #include "fcall.h"
 #include "frames.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include <float.h>
 #include "jitinterface.h"
 #include "safemath.h"

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -23,7 +23,7 @@
 #include "security.h"
 #include "securitymeta.h"
 #include "dllimport.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "comdelegate.h"
 #include "jitperf.h" // to track jit perf
 #include "corprof.h"
@@ -2858,7 +2858,7 @@ HCIMPL1(Object*, JIT_NewS_MP_FastPortable, CORINFO_CLASS_HANDLE typeHnd_)
 
     do
     {
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(GCHeapUtilities::UseAllocationContexts());
 
         // This is typically the only call in the fast path. Making the call early seems to be better, as it allows the compiler
         // to use volatile registers for intermediate values. This reduces the number of push/pop instructions and eliminates
@@ -2872,7 +2872,7 @@ HCIMPL1(Object*, JIT_NewS_MP_FastPortable, CORINFO_CLASS_HANDLE typeHnd_)
         SIZE_T size = methodTable->GetBaseSize();
         _ASSERTE(size % DATA_ALIGNMENT == 0);
 
-        alloc_context *allocContext = thread->GetAllocContext();
+        gc_alloc_context *allocContext = thread->GetAllocContext();
         BYTE *allocPtr = allocContext->alloc_ptr;
         _ASSERTE(allocPtr <= allocContext->alloc_limit);
         if (size > static_cast<SIZE_T>(allocContext->alloc_limit - allocPtr))
@@ -2997,7 +2997,7 @@ HCIMPL1(StringObject*, AllocateString_MP_FastPortable, DWORD stringLength)
 
     do
     {
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(GCHeapUtilities::UseAllocationContexts());
 
         // Instead of doing elaborate overflow checks, we just limit the number of elements. This will avoid all overflow
         // problems, as well as making sure big string objects are correctly allocated in the big object heap.
@@ -3021,7 +3021,7 @@ HCIMPL1(StringObject*, AllocateString_MP_FastPortable, DWORD stringLength)
         _ASSERTE(alignedTotalSize >= totalSize);
         totalSize = alignedTotalSize;
 
-        alloc_context *allocContext = thread->GetAllocContext();
+        gc_alloc_context *allocContext = thread->GetAllocContext();
         BYTE *allocPtr = allocContext->alloc_ptr;
         _ASSERTE(allocPtr <= allocContext->alloc_limit);
         if (totalSize > static_cast<SIZE_T>(allocContext->alloc_limit - allocPtr))
@@ -3161,7 +3161,7 @@ HCIMPL2(Object*, JIT_NewArr1VC_MP_FastPortable, CORINFO_CLASS_HANDLE arrayTypeHn
 
     do
     {
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(GCHeapUtilities::UseAllocationContexts());
 
         // Do a conservative check here.  This is to avoid overflow while doing the calculations.  We don't
         // have to worry about "large" objects, since the allocation quantum is never big enough for
@@ -3198,7 +3198,7 @@ HCIMPL2(Object*, JIT_NewArr1VC_MP_FastPortable, CORINFO_CLASS_HANDLE arrayTypeHn
         _ASSERTE(alignedTotalSize >= totalSize);
         totalSize = alignedTotalSize;
 
-        alloc_context *allocContext = thread->GetAllocContext();
+        gc_alloc_context *allocContext = thread->GetAllocContext();
         BYTE *allocPtr = allocContext->alloc_ptr;
         _ASSERTE(allocPtr <= allocContext->alloc_limit);
         if (totalSize > static_cast<SIZE_T>(allocContext->alloc_limit - allocPtr))
@@ -3238,7 +3238,7 @@ HCIMPL2(Object*, JIT_NewArr1OBJ_MP_FastPortable, CORINFO_CLASS_HANDLE arrayTypeH
 
     do
     {
-        _ASSERTE(GCHeap::UseAllocationContexts());
+        _ASSERTE(GCHeapUtilities::UseAllocationContexts());
 
         // Make sure that the total size cannot reach LARGE_OBJECT_SIZE, which also allows us to avoid overflow checks. The
         // "256" slack is to cover the array header size and round-up, using a constant value here out of laziness.
@@ -3266,7 +3266,7 @@ HCIMPL2(Object*, JIT_NewArr1OBJ_MP_FastPortable, CORINFO_CLASS_HANDLE arrayTypeH
 
         _ASSERTE(ALIGN_UP(totalSize, DATA_ALIGNMENT) == totalSize);
 
-        alloc_context *allocContext = thread->GetAllocContext();
+        gc_alloc_context *allocContext = thread->GetAllocContext();
         BYTE *allocPtr = allocContext->alloc_ptr;
         _ASSERTE(allocPtr <= allocContext->alloc_limit);
         if (totalSize > static_cast<SIZE_T>(allocContext->alloc_limit - allocPtr))
@@ -6431,7 +6431,7 @@ HCIMPL0(VOID, JIT_StressGC)
     bool fSkipGC = false;
 
     if (!fSkipGC)
-        GCHeap::GetGCHeap()->GarbageCollect();
+        GCHeapUtilities::GetGCHeap()->GarbageCollect();
 
 // <TODO>@TODO: the following ifdef is in error, but if corrected the
 // compiler complains about the *__ms->pRetAddr() saying machine state

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -27,7 +27,7 @@
 #include "security.h"
 #include "securitymeta.h"
 #include "dllimport.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "comdelegate.h"
 #include "jitperf.h" // to track jit perf
 #include "corprof.h"

--- a/src/vm/jitinterfacegen.cpp
+++ b/src/vm/jitinterfacegen.cpp
@@ -221,7 +221,7 @@ void InitJITHelpers1()
         ))
     {
         // if (multi-proc || server GC)
-        if (GCHeap::UseAllocationContexts())
+        if (GCHeapUtilities::UseAllocationContexts())
         {
 #ifdef FEATURE_IMPLICIT_TLS
             SetJitHelperFunction(CORINFO_HELP_NEWSFAST, JIT_NewS_MP_FastPortable);

--- a/src/vm/marshalnative.cpp
+++ b/src/vm/marshalnative.cpp
@@ -27,7 +27,7 @@
 #include "log.h"
 #include "fieldmarshaler.h"
 #include "cgensys.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "security.h"
 #include "dbginterface.h"
 #include "objecthandle.h"

--- a/src/vm/mdaassistants.cpp
+++ b/src/vm/mdaassistants.cpp
@@ -137,7 +137,7 @@ void TriggerGCForMDAInternal()
 
     EX_TRY
     {
-        GCHeap::GetGCHeap()->GarbageCollect();
+        GCHeapUtilities::GetGCHeap()->GarbageCollect();
 
 #ifdef FEATURE_SYNCHRONIZATIONCONTEXT_WAIT
         //
@@ -868,7 +868,7 @@ LPVOID MdaInvalidOverlappedToPinvoke::CheckOverlappedPointer(UINT index, LPVOID 
 
         {
             GCX_COOP();
-            GCHeap *pHeap = GCHeap::GetGCHeap();
+            GCHeap *pHeap = GCHeapUtilities::GetGCHeap();
             fHeapPointer = pHeap->IsHeapPointer(pOverlapped);
         }
 

--- a/src/vm/memberload.cpp
+++ b/src/vm/memberload.cpp
@@ -30,7 +30,7 @@
 #include "log.h"
 #include "fieldmarshaler.h"
 #include "cgensys.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "security.h"
 #include "dbginterface.h"
 #include "comdelegate.h"

--- a/src/vm/message.cpp
+++ b/src/vm/message.cpp
@@ -249,7 +249,7 @@ void CMessage::GetObjectFromStack(OBJECTREF* ppDest, PVOID val, const CorElement
 
         _ASSERTE(ty.GetMethodTable()->IsValueType() || ty.GetMethodTable()->IsEnum());
 
-        _ASSERTE(!GCHeap::GetGCHeap()->IsHeapPointer((BYTE *) ppDest) ||
+        _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsHeapPointer((BYTE *) ppDest) ||
              !"(pDest) can not point to GC Heap");
         MethodTable* pMT = ty.GetMethodTable();
 

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -33,7 +33,7 @@
 #include "log.h"
 #include "fieldmarshaler.h"
 #include "cgensys.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "security.h"
 #include "dbginterface.h"
 #include "comdelegate.h"
@@ -9804,11 +9804,11 @@ BOOL MethodTable::Validate()
     }
 
     DWORD dwLastVerifiedGCCnt = m_pWriteableData->m_dwLastVerifedGCCnt;
-    // Here we used to assert that (dwLastVerifiedGCCnt <= GCHeap::GetGCHeap()->GetGcCount()) but 
+    // Here we used to assert that (dwLastVerifiedGCCnt <= GCHeapUtilities::GetGCHeap()->GetGcCount()) but 
     // this is no longer true because with background gc. Since the purpose of having 
     // m_dwLastVerifedGCCnt is just to only verify the same method table once for each GC
     // I am getting rid of the assert.
-    if (g_pConfig->FastGCStressLevel () > 1 && dwLastVerifiedGCCnt == GCHeap::GetGCHeap()->GetGcCount())
+    if (g_pConfig->FastGCStressLevel () > 1 && dwLastVerifiedGCCnt == GCHeapUtilities::GetGCHeap()->GetGcCount())
         return TRUE;
 #endif //_DEBUG
 
@@ -9835,7 +9835,7 @@ BOOL MethodTable::Validate()
     // It is not a fatal error to fail the update the counter. We will run slower and retry next time, 
     // but the system will function properly.
     if (EnsureWritablePagesNoThrow(m_pWriteableData, sizeof(MethodTableWriteableData)))
-        m_pWriteableData->m_dwLastVerifedGCCnt = GCHeap::GetGCHeap()->GetGcCount();
+        m_pWriteableData->m_dwLastVerifedGCCnt = GCHeapUtilities::GetGCHeap()->GetGcCount();
 #endif //_DEBUG
 
     return TRUE;

--- a/src/vm/nativeoverlapped.h
+++ b/src/vm/nativeoverlapped.h
@@ -62,7 +62,7 @@ public:
         STATIC_CONTRACT_SO_TOLERANT;
         
         _ASSERTE (nativeOverlapped != NULL);
-        _ASSERTE (GCHeap::GetGCHeap()->IsHeapPointer((BYTE *) nativeOverlapped));
+        _ASSERTE (GCHeapUtilities::GetGCHeap()->IsHeapPointer((BYTE *) nativeOverlapped));
         
         return (OverlappedDataObject*)((BYTE*)nativeOverlapped - offsetof(OverlappedDataObject, Internal));
     }

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1175,7 +1175,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
     if (g_pConfig->ShouldPrestubGC(this))
     {
         GCX_COOP();
-        GCHeap::GetGCHeap()->GarbageCollect(-1);
+        GCHeapUtilities::GetGCHeap()->GarbageCollect(-1);
     }
 #endif // _DEBUG
 

--- a/src/vm/profattach.cpp
+++ b/src/vm/profattach.cpp
@@ -806,7 +806,7 @@ void ProfilingAPIAttachDetach::InitializeAttachThreadingMode()
     // Environment variable trumps all, so check it first
     DWORD dwAlwaysOn = g_pConfig->GetConfigDWORD_DontUse_(
         CLRConfig::EXTERNAL_AttachThreadAlwaysOn,
-        GCHeap::IsServerHeap() ? 1 : 0);      // Default depends on GC server mode
+        GCHeapUtilities::IsServerHeap() ? 1 : 0);      // Default depends on GC server mode
 
     if (dwAlwaysOn == 0)
     {

--- a/src/vm/profilinghelper.cpp
+++ b/src/vm/profilinghelper.cpp
@@ -1413,7 +1413,7 @@ void ProfilingAPIUtility::TerminateProfiling()
         {
             // We know for sure GC has been fully initialized as we've turned off concurrent GC before
             _ASSERTE(IsGarbageCollectorFullyInitialized());
-            GCHeap::GetGCHeap()->TemporaryEnableConcurrentGC();
+            GCHeapUtilities::GetGCHeap()->TemporaryEnableConcurrentGC();
             g_profControlBlock.fConcurrentGCDisabledForAttach = FALSE;
         }
 

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -754,7 +754,7 @@ struct GenerationTable
 
 //---------------------------------------------------------------------------------------
 //
-// This is a callback used by the GC when we call GCHeap::DescrGenerationsToProfiler
+// This is a callback used by the GC when we call GCHeapUtilities::DescrGenerationsToProfiler
 // (from UpdateGenerationBounds() below).  The GC gives us generation information through
 // this callback, which we use to update the GenerationDesc in the corresponding
 // GenerationTable
@@ -874,7 +874,7 @@ void __stdcall UpdateGenerationBounds()
 #endif
         // fill in the values by calling back into the gc, which will report
         // the ranges by calling GenWalkFunc for each one
-        GCHeap *hp = GCHeap::GetGCHeap();
+        IGCHeap *hp = GCHeapUtilities::GetGCHeap();
         hp->DescrGenerationsToProfiler(GenWalkFunc, newGenerationTable);
 
         // remember the old table and plug in the new one
@@ -1018,7 +1018,7 @@ ClassID SafeGetClassIDFromObject(Object * pObj)
 
 //---------------------------------------------------------------------------------------
 //
-// Callback of type walk_fn used by GCHeap::WalkObject.  Keeps a count of each
+// Callback of type walk_fn used by GCHeapUtilities::WalkObject.  Keeps a count of each
 // object reference found.
 //
 // Arguments:
@@ -1040,7 +1040,7 @@ BOOL CountContainedObjectRef(Object * pBO, void * context)
 
 //---------------------------------------------------------------------------------------
 //
-// Callback of type walk_fn used by GCHeap::WalkObject.  Stores each object reference
+// Callback of type walk_fn used by GCHeapUtilities::WalkObject.  Stores each object reference
 // encountered into an array.
 //
 // Arguments:
@@ -1113,7 +1113,7 @@ BOOL HeapWalkHelper(Object * pBO, void * pvContext)
     if (pMT->ContainsPointersOrCollectible())
     {
         // First round through calculates the number of object refs for this class
-        GCHeap::GetGCHeap()->WalkObject(pBO, &CountContainedObjectRef, (void *)&cNumRefs);
+        GCHeapUtilities::GetGCHeap()->WalkObject(pBO, &CountContainedObjectRef, (void *)&cNumRefs);
 
         if (cNumRefs > 0)
         {
@@ -1138,7 +1138,7 @@ BOOL HeapWalkHelper(Object * pBO, void * pvContext)
 
             // Second round saves off all of the ref values
             OBJECTREF * pCurObjRef = arrObjRef;
-            GCHeap::GetGCHeap()->WalkObject(pBO, &SaveContainedObjectRef, (void *)&pCurObjRef);
+            GCHeapUtilities::GetGCHeap()->WalkObject(pBO, &SaveContainedObjectRef, (void *)&pCurObjRef);
         }
     }
 
@@ -9461,7 +9461,7 @@ FCIMPL2(void, ProfilingFCallHelper::FC_RemotingClientSendingMessage, GUID *pId, 
     // it is a value class declared on the stack and so GC doesn't
     // know about it.
 
-    _ASSERTE (!GCHeap::GetGCHeap()->IsHeapPointer(pId));     // should be on the stack, not in the heap
+    _ASSERTE (!GCHeapUtilities::GetGCHeap()->IsHeapPointer(pId));     // should be on the stack, not in the heap
     HELPER_METHOD_FRAME_BEGIN_NOPOLL();
 
     {

--- a/src/vm/rcwwalker.cpp
+++ b/src/vm/rcwwalker.cpp
@@ -129,10 +129,10 @@ STDMETHODIMP CLRServicesImpl::GarbageCollect(DWORD dwFlags)
     {
         GCX_COOP_THREAD_EXISTS(GET_THREAD());
         if (dwFlags & GC_FOR_APPX_SUSPEND) {
-            GCHeap::GetGCHeap()->GarbageCollect(2, TRUE, collection_blocking | collection_optimized);
+            GCHeapUtilities::GetGCHeap()->GarbageCollect(2, TRUE, collection_blocking | collection_optimized);
         }
         else
-            GCHeap::GetGCHeap()->GarbageCollect();
+            GCHeapUtilities::GetGCHeap()->GarbageCollect();
     }
     END_EXTERNAL_ENTRYPOINT;
     return hr;

--- a/src/vm/runtimecallablewrapper.cpp
+++ b/src/vm/runtimecallablewrapper.cpp
@@ -1591,7 +1591,7 @@ public:
 
         if (pRCW->IsValid())
         {
-            if (!GCHeap::GetGCHeap()->IsPromoted(OBJECTREFToObject(pRCW->GetExposedObject())) &&
+            if (!GCHeapUtilities::GetGCHeap()->IsPromoted(OBJECTREFToObject(pRCW->GetExposedObject())) &&
                 !pRCW->IsDetached())
             {
                 // No need to use InterlockedOr here since every other place that modifies the flags
@@ -1612,7 +1612,7 @@ void RCWCache::DetachWrappersWorker()
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION(GCHeap::IsGCInProgress()); // GC is in progress and the runtime is suspended
+        PRECONDITION(GCHeapUtilities::IsGCInProgress()); // GC is in progress and the runtime is suspended
     }
     CONTRACTL_END;
 
@@ -2808,7 +2808,7 @@ void RCW::MinorCleanup()
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION(GCHeap::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ));
+        PRECONDITION(GCHeapUtilities::IsGCInProgress() || ( (g_fEEShutDown & ShutDown_SyncBlock) && g_fProcessDetach ));
     }
     CONTRACTL_END;
     

--- a/src/vm/safehandle.cpp
+++ b/src/vm/safehandle.cpp
@@ -246,7 +246,7 @@ void SafeHandle::Dispose()
     // Suppress finalization on this object (we may be racing here but the
     // operation below is idempotent and a dispose should never race a
     // finalization).
-    GCHeap::GetGCHeap()->SetFinalizationRun(OBJECTREFToObject(sh));
+    GCHeapUtilities::GetGCHeap()->SetFinalizationRun(OBJECTREFToObject(sh));
     GCPROTECT_END();
 }
 
@@ -394,7 +394,7 @@ FCIMPL1(void, SafeHandle::SetHandleAsInvalid, SafeHandle* refThisUNSAFE)
 
     } while (InterlockedCompareExchange((LONG*)&sh->m_state, newState, oldState) != oldState);
 
-    GCHeap::GetGCHeap()->SetFinalizationRun(OBJECTREFToObject(sh));
+    GCHeapUtilities::GetGCHeap()->SetFinalizationRun(OBJECTREFToObject(sh));
 }
 FCIMPLEND
 

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -14,7 +14,7 @@
 #include "clsload.hpp"
 #include "vars.hpp"
 #include "excep.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "field.h"
 #include "eeconfig.h"
 #include "runtimehandles.h" // for SignatureNative

--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -19,7 +19,7 @@
 #include "security.h"
 #include "eventtrace.h"
 #include "comdatetime.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "interoputil.h"
 #include "gcscan.h"
 #ifdef FEATURE_REMOTING
@@ -70,7 +70,7 @@ void StubHelpers::ValidateObjectInternal(Object *pObjUNSAFE, BOOL fValidateNextO
 	// and the next object as required
 	if (fValidateNextObj)
 	{
-		Object *nextObj = GCHeap::GetGCHeap()->NextObj(pObjUNSAFE);
+		Object *nextObj = GCHeapUtilities::GetGCHeap()->NextObj(pObjUNSAFE);
 		if (nextObj != NULL)
 		{
 			// Note that the MethodTable of the object (i.e. the pointer at offset 0) can change from
@@ -162,7 +162,7 @@ void StubHelpers::ProcessByrefValidationList()
         {
             entry = s_ByrefValidationEntries[i];
 
-            Object *pObjUNSAFE = GCHeap::GetGCHeap()->GetGCHeap()->GetContainingObject(entry.pByref);
+            Object *pObjUNSAFE = GCHeapUtilities::GetGCHeap()->GetContainingObject(entry.pByref);
             ValidateObjectInternal(pObjUNSAFE, TRUE);
         }
     }
@@ -2004,7 +2004,7 @@ FCIMPL3(void, StubHelpers::ValidateObject, Object *pObjUNSAFE, MethodDesc *pMD, 
         AVInRuntimeImplOkayHolder AVOkay;
 		// don't validate the next object if a BGC is in progress.  we can race with background
 	    // sweep which could make the next object a Free object underneath us if it's dead.
-        ValidateObjectInternal(pObjUNSAFE, !(GCHeap::GetGCHeap()->IsConcurrentGCInProgress()));
+        ValidateObjectInternal(pObjUNSAFE, !(GCHeapUtilities::GetGCHeap()->IsConcurrentGCInProgress()));
     }
     EX_CATCH
     {
@@ -2031,7 +2031,7 @@ FCIMPL3(void, StubHelpers::ValidateByref, void *pByref, MethodDesc *pMD, Object 
     // perform the validation on next GC (see code:StubHelpers.ProcessByrefValidationList).
 
     // Skip byref if is not pointing inside managed heap
-    if (!GCHeap::GetGCHeap()->IsHeapPointer(pByref))
+    if (!GCHeapUtilities::GetGCHeap()->IsHeapPointer(pByref))
     {
         return;
     }
@@ -2066,7 +2066,7 @@ FCIMPL3(void, StubHelpers::ValidateByref, void *pByref, MethodDesc *pMD, Object 
     if (NumOfEntries > BYREF_VALIDATION_LIST_MAX_SIZE)
     {
         // if the list is too big, trigger GC now
-        GCHeap::GetGCHeap()->GarbageCollect(0);
+        GCHeapUtilities::GetGCHeap()->GarbageCollect(0);
     }
 
     HELPER_METHOD_FRAME_END();

--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -1372,7 +1372,7 @@ void SyncBlockCache::GCWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintp
        STRESS_LOG0 (LF_GC | LF_SYNC, LL_INFO100, "GCWeakPtrScan starting\n");
 #endif
 
-   if (GCHeap::GetGCHeap()->GetCondemnedGeneration() < GCHeap::GetGCHeap()->GetMaxGeneration())
+   if (GCHeapUtilities::GetGCHeap()->GetCondemnedGeneration() < GCHeapUtilities::GetGCHeap()->GetMaxGeneration())
    {
 #ifdef VERIFY_HEAP
         //for VSW 294550: we saw stale obeject reference in SyncBlkCache, so we want to make sure the card 
@@ -1416,7 +1416,7 @@ void SyncBlockCache::GCWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintp
                                 Object* o = SyncTableEntry::GetSyncTableEntry()[nb].m_Object;
                                 if (o && !((size_t)o & 1))
                                 {
-                                    if (GCHeap::GetGCHeap()->IsEphemeral (o))
+                                    if (GCHeapUtilities::GetGCHeap()->IsEphemeral (o))
                                     {
                                         clear_card = FALSE;
 
@@ -1615,8 +1615,8 @@ void SyncBlockCache::GCDone(BOOL demoting, int max_gen)
     CONTRACTL_END;
 
     if (demoting && 
-        (GCHeap::GetGCHeap()->GetCondemnedGeneration() == 
-         GCHeap::GetGCHeap()->GetMaxGeneration()))
+        (GCHeapUtilities::GetGCHeap()->GetCondemnedGeneration() == 
+         GCHeapUtilities::GetGCHeap()->GetMaxGeneration()))
     {
         //scan the bitmap
         size_t dw = 0;
@@ -1643,7 +1643,7 @@ void SyncBlockCache::GCDone(BOOL demoting, int max_gen)
                                 Object* o = SyncTableEntry::GetSyncTableEntry()[nb].m_Object;
                                 if (o && !((size_t)o & 1))
                                 {
-                                    if (GCHeap::GetGCHeap()->WhichGeneration (o) < (unsigned int)max_gen)
+                                    if (GCHeapUtilities::GetGCHeap()->WhichGeneration (o) < (unsigned int)max_gen)
                                     {
                                         SetCard (card);
                                         break;
@@ -1713,7 +1713,7 @@ void SyncBlockCache::VerifySyncTableEntry()
             
             DWORD idx = o->GetHeader()->GetHeaderSyncBlockIndex();
             _ASSERTE(idx == nb || ((0 == idx) && (loop == max_iterations)));
-            _ASSERTE(!GCHeap::GetGCHeap()->IsEphemeral(o) || CardSetP(CardOf(nb)));
+            _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsEphemeral(o) || CardSetP(CardOf(nb)));
         }
     }
 }
@@ -2498,10 +2498,10 @@ BOOL ObjHeader::Validate (BOOL bVerifySyncBlkIndex)
     //BIT_SBLK_GC_RESERVE (0x20000000) is only set during GC. But for frozen object, we don't clean the bit
     if (bits & BIT_SBLK_GC_RESERVE)
     {
-        if (!GCHeap::GetGCHeap()->IsGCInProgress () && !GCHeap::GetGCHeap()->IsConcurrentGCInProgress ())
+        if (!GCHeapUtilities::IsGCInProgress () && !GCHeapUtilities::GetGCHeap()->IsConcurrentGCInProgress ())
         {
 #ifdef FEATURE_BASICFREEZE
-            ASSERT_AND_CHECK (GCHeap::GetGCHeap()->IsInFrozenSegment(obj));
+            ASSERT_AND_CHECK (GCHeapUtilities::GetGCHeap()->IsInFrozenSegment(obj));
 #else //FEATURE_BASICFREEZE
             _ASSERTE(!"Reserve bit not cleared");
             return FALSE;

--- a/src/vm/syncclean.cpp
+++ b/src/vm/syncclean.cpp
@@ -73,7 +73,7 @@ void SyncClean::CleanUp ()
     // Only GC thread can call this.
     _ASSERTE (g_fProcessDetach || 
               IsGCSpecialThread() ||
-              (GCHeap::IsGCInProgress()  && GetThread() == ThreadSuspend::GetSuspensionThread()));
+              (GCHeapUtilities::IsGCInProgress()  && GetThread() == ThreadSuspend::GetSuspensionThread()));
     if (m_HashMap)
     {
         Bucket * pTempBucket = FastInterlockExchangePointer(m_HashMap.GetPointer(), NULL);

--- a/src/vm/testhookmgr.cpp
+++ b/src/vm/testhookmgr.cpp
@@ -655,7 +655,7 @@ HRESULT CLRTestHookManager::GC(int generation)
     CONTRACTL_END;
 
     _ASSERTE(GetThread()==NULL || !GetThread()->PreemptiveGCDisabled());
-    GCHeap::GetGCHeap()->GarbageCollect(generation);
+    GCHeapUtilities::GetGCHeap()->GarbageCollect(generation);
     FinalizerThread::FinalizerThreadWait();
     return S_OK;
 }

--- a/src/vm/threadpoolrequest.cpp
+++ b/src/vm/threadpoolrequest.cpp
@@ -517,11 +517,11 @@ void UnManagedPerAppDomainTPCount::DispatchWorkItem(bool* foundWork, bool* wasNo
         firstIteration = false;
         *foundWork = true;
 
-        if (GCHeap::IsGCInProgress(TRUE))
+        if (GCHeapUtilities::IsGCInProgress(TRUE))
         {
             // GC is imminent, so wait until GC is complete before executing next request.
             // this reduces in-flight objects allocated right before GC, easing the GC's work
-            GCHeap::WaitForGCCompletion(TRUE);
+            GCHeapUtilities::WaitForGCCompletion(TRUE);
         }
 
         PREFIX_ASSUME(pWorkRequest != NULL);

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -18,7 +18,7 @@
 #include "excep.h"
 #include "comsynchronizable.h"
 #include "log.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "mscoree.h"
 #include "dbginterface.h"
 #include "corprof.h"                // profiling
@@ -3889,14 +3889,14 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
 #endif
     }
 
-    if  (GCHeap::IsGCHeapInitialized())
+    if  (GCHeapUtilities::IsGCHeapInitialized())
     {
         // Guaranteed to NOT be a shutdown case, because we tear down the heap before
         // we tear down any threads during shutdown.
         if (ThisThreadID == CurrentThreadID)
         {
             GCX_COOP();
-            GCHeap::GetGCHeap()->FixAllocContext(&m_alloc_context, FALSE, NULL, NULL);
+            GCHeapUtilities::GetGCHeap()->FixAllocContext(&m_alloc_context, FALSE, NULL, NULL);
             m_alloc_context.init();
         }
     }
@@ -3957,11 +3957,11 @@ void Thread::OnThreadTerminate(BOOL holdingLock)
 #endif
         }
 
-        if  (GCHeap::IsGCHeapInitialized() && ThisThreadID != CurrentThreadID)
+        if  (GCHeapUtilities::IsGCHeapInitialized() && ThisThreadID != CurrentThreadID)
         {
             // We must be holding the ThreadStore lock in order to clean up alloc context.
             // We should never call FixAllocContext during GC.
-            GCHeap::GetGCHeap()->FixAllocContext(&m_alloc_context, FALSE, NULL, NULL);
+            GCHeapUtilities::GetGCHeap()->FixAllocContext(&m_alloc_context, FALSE, NULL, NULL);
             m_alloc_context.init();
         }
 
@@ -9846,7 +9846,7 @@ void Thread::DoExtraWorkForFinalizer()
         Thread::CleanupDetachedThreads();
     }
     
-    if(ExecutionManager::IsCacheCleanupRequired() && GCHeap::GetGCHeap()->GetCondemnedGeneration()>=1)
+    if(ExecutionManager::IsCacheCleanupRequired() && GCHeapUtilities::GetGCHeap()->GetCondemnedGeneration()>=1)
     {
         ExecutionManager::ClearCaches();
     }
@@ -11186,7 +11186,7 @@ void Thread::SetHasPromotedBytes ()
 
     m_fPromoted = TRUE;
 
-    _ASSERTE(GCHeap::IsGCInProgress()  && IsGCThread ());
+    _ASSERTE(GCHeapUtilities::IsGCInProgress()  && IsGCThread ());
 
     if (!m_fPreemptiveGCDisabled)
     {

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -142,7 +142,7 @@
 #include "regdisp.h"
 #include "mscoree.h"
 #include "appdomainstack.h"
-#include "gc.h"
+#include "gcheaputilities.h"
 #include "gcinfotypes.h"
 #include <clrhost.h>
 
@@ -1739,9 +1739,9 @@ public:
 
     // on MP systems, each thread has its own allocation chunk so we can avoid
     // lock prefixes and expensive MP cache snooping stuff
-    alloc_context        m_alloc_context;
+    gc_alloc_context        m_alloc_context;
 
-    inline alloc_context *GetAllocContext() { LIMITED_METHOD_CONTRACT; return &m_alloc_context; }
+    inline gc_alloc_context *GetAllocContext() { LIMITED_METHOD_CONTRACT; return &m_alloc_context; }
 
     // This is the type handle of the first object in the alloc context at the time 
     // we fire the AllocationTick event. It's only for tooling purpose.
@@ -4884,7 +4884,7 @@ private:
 private:
     // When we create an object, or create an OBJECTREF, or create an Interior Pointer, or enter EE from managed
     // code, we will set this flag.
-    // Inside GCHeap::StressHeap, we only do GC if this flag is TRUE.  Then we reset it to zero.
+    // Inside GCHeapUtilities::StressHeap, we only do GC if this flag is TRUE.  Then we reset it to zero.
     BOOL m_fStressHeapCount;
 public:
     void EnableStressHeap()

--- a/src/vm/vars.hpp
+++ b/src/vm/vars.hpp
@@ -81,7 +81,7 @@ typedef unsigned short wchar_t;
 
 class ClassLoader;
 class LoaderHeap;
-class GCHeap;
+class IGCHeap;
 class Object;
 class StringObject;
 class TransparentProxyObject;

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -2367,11 +2367,11 @@ Work:
         counts = oldCounts;
     }
 
-    if (GCHeap::IsGCInProgress(TRUE))
+    if (GCHeapUtilities::IsGCInProgress(TRUE))
     {
         // GC is imminent, so wait until GC is complete before executing next request.
         // this reduces in-flight objects allocated right before GC, easing the GC's work
-        GCHeap::WaitForGCCompletion(TRUE);
+        GCHeapUtilities::WaitForGCCompletion(TRUE);
     }
 
     {
@@ -3986,7 +3986,7 @@ Top:
 
             if (key != 0)
             {
-                if (GCHeap::IsGCInProgress(TRUE))
+                if (GCHeapUtilities::IsGCInProgress(TRUE))
                 {
                     //Indicate that this thread is free, and waiting on GC, not doing any user work.
                     //This helps in threads not getting injected when some threads have woken up from the
@@ -4003,7 +4003,7 @@ Top:
 
                     // GC is imminent, so wait until GC is complete before executing next request.
                     // this reduces in-flight objects allocated right before GC, easing the GC's work
-                    GCHeap::WaitForGCCompletion(TRUE);
+                    GCHeapUtilities::WaitForGCCompletion(TRUE);
 
                     while (true)
                     {
@@ -4217,7 +4217,7 @@ BOOL ThreadpoolMgr::ShouldGrowCompletionPortThreadpool(ThreadCounter::Counts cou
 
     if (counts.NumWorking >= counts.NumActive 
         && NumCPInfrastructureThreads == 0
-        && (counts.NumActive == 0 ||  !GCHeap::IsGCInProgress(TRUE))
+        && (counts.NumActive == 0 ||  !GCHeapUtilities::IsGCInProgress(TRUE))
         )
     {
         // adjust limit if neeeded
@@ -4618,7 +4618,7 @@ DWORD __stdcall ThreadpoolMgr::GateThreadStart(LPVOID lpArgs)
             EX_END_CATCH(SwallowAllExceptions);
         }
 
-        if (!GCHeap::IsGCInProgress(FALSE) )
+        if (!GCHeapUtilities::IsGCInProgress(FALSE) )
         {
             if (IgnoreNextSample)
             {
@@ -4660,7 +4660,7 @@ DWORD __stdcall ThreadpoolMgr::GateThreadStart(LPVOID lpArgs)
                 oldCounts.NumActive < MaxLimitTotalCPThreads &&
                 !g_fCompletionPortDrainNeeded &&
                 NumCPInfrastructureThreads == 0 &&       // infrastructure threads count as "to be free as needed"
-                !GCHeap::IsGCInProgress(TRUE))
+                !GCHeapUtilities::IsGCInProgress(TRUE))
 
             {
                 BOOL status;


### PR DESCRIPTION
This PR is an extension of my first one (https://github.com/dotnet/coreclr/pull/6693), done as a separate PR because the commits are structured differently to make the change more reviewable, since there are a large number of trivial changes together with non-trivial ones. Force-pushing to the other PR would probably obliterate all of the existing comments.

First, a note about reviewing: this PR consists of sixcommits. The first (`fefd452`) and fourth (`b5f8699`) are commits that do little more than renaming, so they are less interesting to review than the second, third, and fifth commits. The second commit is the introduction of `IGCHeap` and the required changes to the GC to make it compile, while the third commit is the movement of the responsibility of maintaining the global heap instance to the VM (more on that below). The fifth commit groups the interface functions into categories and documents them. I can also split these commits into individual PRs if it proves to be too much of a pain to code review.

The changes presented here are quite similar to the last PR, except it addresses the feedback received:

* The `GCHeap` class was renamed to `IGCHeapInternal` and made to be a mostly* pure virtual class. The inheritance tree of the `GCHeaps` now looks like

```
IGCHeap
|
+-- ::IGCHeapInternal
        |
        +-- SVR::GCHeap
        |
        +-- WKS::GCHeap
```

`IGCHeapInternal` is an internal-only interface that the GC will use to call into itself and is a superset of the functionality exposed by `IGCHeap`. As a part of this change, all of the static methods on both `IGCHeap` and `IGCHeapInternal` were eliminated and replaced by free functions when appropriate.

(* I say "mostly" pure virtual because it overrides a few methods present on `IGCHeap`, because the implementation is the same across `SVR::GCHeap` and `WKS::GCHeap`.)

* The VM is now responsible for creating and maintaining the global heap instance. This means that `g_pGCHeap`, which has traditionally resided on the GC side of the interface, will be located in the VM instead (`src\vm\gcholder.cpp`). As a part of this change, the VM calls `InitializeGarbageCollector` on EE startup and [saves the return value](https://github.com/swgillespie/coreclr/blob/gc-interface-3/src/vm/ceemain.cpp#L3722) that it gets from it into `g_pGCHeap`. Inside `InitializeGarbageCollector`, the GC itself saves that same pointer into `g_theGcHeap`. In this way, each component can operate on the heap independently of the other without having to ask other components for a reference to the GC heap, as was done in the past with `GCHeap::GetGCHeap()`.
* Static methods on `IGCHeap` were moved to a VM-only class [`GCHeapHolder`](https://github.com/swgillespie/coreclr/blob/gc-interface-3/src/vm/gcholder.h#L16), which "wraps" the global heap instance. This ensures that there are no static methods on the interface itself, keeping the interface a pure virtual class.
