### PR TITLE
Jitted Code Dropping Feature implemented

### DIFF
--- a/src/debug/daccess/fntableaccess.h
+++ b/src/debug/daccess/fntableaccess.h
@@ -54,6 +54,9 @@ typedef struct _FakeHpRealCodeHdr
 #if defined (FEATURE_GDBJIT)
     LPVOID              pCalledMethods;
 #endif
+#if defined(FEATURE_JIT_DROPPING)
+    LPVOID              phdrHeapList;
+#endif
     LPVOID              hdrMDesc;       // changed from MethodDesc*
     DWORD               nUnwindInfos;
     T_RUNTIME_FUNCTION  unwindInfos[0];

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -136,6 +136,9 @@ RETAIL_CONFIG_DWORD_INFO(EXTERNAL_FinalizeOnShutdown, W("FinalizeOnShutdown"), D
 // ARM
 //
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_ARMEnabled, W("ARMEnabled"), (DWORD)0, "Set it to 1 to enable ARM")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_JitDropEnabled, W("JitDropEnabled"), (DWORD)0, "Set it to 1 to enable Jit Dropping")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_JitDropMemThreshold, W("JitDropMemThreshold"), (DWORD)0, "Dropping jits when code heap usage is larger than this (in bytes)")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_JitDropMethodSizeThreshold, W("JitDropMethodSizeThreshold"), (DWORD)0, "Dropping jit for methods whose native code size larger than this (in bytes)")
 
 //
 // Assembly Loader

--- a/src/inc/corjit.h
+++ b/src/inc/corjit.h
@@ -352,6 +352,9 @@ public:
             struct CORINFO_METHOD_INFO  *info,               /* IN */
             unsigned /* code:CorJitFlag */   flags,          /* IN */
             BYTE                        **nativeEntry,       /* OUT */
+#if defined(FEATURE_JIT_DROPPING)
+            ULONG                       *totalNCSize,        /* OUT */
+#endif
             ULONG                       *nativeSizeOfCode    /* OUT */
             ) = 0;
 

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -17,6 +17,10 @@ if(WIN32)
   set(JIT_RESOURCES Native.rc)
 endif(WIN32)
 
+if(FEATURE_JIT_DROPPING)
+   add_definitions(-DFEATURE_JIT_DROPPING)
+endif(FEATURE_JIT_DROPPING)
+
 set( JIT_SOURCES
   alloc.cpp
   assertionprop.cpp

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -32,7 +32,11 @@ public:
     // This could use further abstraction
     CodeGen(Compiler* theCompiler);
 
+#if defined(FEATURE_JIT_DROPPING)
+    virtual void genGenerateCode(void** codePtr, ULONG* totalNCSize, ULONG* nativeSizeOfCode);
+#else
     virtual void genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode);
+#endif
     // TODO-Cleanup: Abstract out the part of this that finds the addressing mode, and
     // move it to Lower
     virtual bool genCreateAddrMode(GenTreePtr  addr,

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -54,7 +54,11 @@ class CodeGenInterface
 
 public:
     CodeGenInterface(Compiler* theCompiler);
+#if defined(FEATURE_JIT_DROPPING)
+    virtual void genGenerateCode(void** codePtr, ULONG* totalNCSize, ULONG* nativeSizeOfCode) = 0;
+#else
     virtual void genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode) = 0;
+#endif
 
 #ifndef LEGACY_BACKEND
     // genSpillVar is called by compUpdateLifeVar in the RyuJIT backend case.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8103,6 +8103,9 @@ public:
                     COMP_HANDLE           compHnd,
                     CORINFO_METHOD_INFO*  methodInfo,
                     void**                methodCodePtr,
+#if defined(FEATURE_JIT_DROPPING)
+                    ULONG*                totalNCSize,
+#endif
                     ULONG*                methodCodeSize,
                     CORJIT_FLAGS*         compileFlags);
     void compCompileFinish();
@@ -8110,6 +8113,9 @@ public:
                           COMP_HANDLE                      compHnd,
                           CORINFO_METHOD_INFO*             methodInfo,
                           void**                           methodCodePtr,
+#if defined(FEATURE_JIT_DROPPING)
+                          ULONG*                           totalNCSize,
+#endif
                           ULONG*                           methodCodeSize,
                           CORJIT_FLAGS*                    compileFlags,
                           CorInfoInstantiationVerification instVerInfo);
@@ -8355,7 +8361,11 @@ protected:
 #ifdef _TARGET_ARMARCH_
     bool compRsvdRegCheck(FrameLayoutState curState);
 #endif
+#if defined(FEATURE_JIT_DROPPING)
+    void compCompile(void** methodCodePtr, ULONG* totalNCSize,ULONG* methodCodeSize, CORJIT_FLAGS* compileFlags);
+#else
     void compCompile(void** methodCodePtr, ULONG* methodCodeSize, CORJIT_FLAGS* compileFlags);
+#endif
 
     // Data required for generating profiler Enter/Leave/TailCall hooks
     CLANG_FORMAT_COMMENT_ANCHOR;
@@ -9038,7 +9048,6 @@ const unsigned TYPE_REF_TYPEMASK = 0x7F; // bits that represent the type
 
 extern size_t grossVMsize;
 extern size_t grossNCsize;
-extern size_t totalNCsize;
 
 extern unsigned genMethodICnt;
 extern unsigned genMethodNCnt;
@@ -9048,6 +9057,10 @@ extern size_t   gcHeaderNSize;
 extern size_t   gcPtrMapNSize;
 
 #endif // DISPLAY_SIZES
+
+#if DISPLAY_SIZES || defined(FEATURE_JIT_DROPPING)
+extern size_t totalNCsize;
+#endif
 
 /*****************************************************************************
  *

--- a/src/jit/ee_il_dll.hpp
+++ b/src/jit/ee_il_dll.hpp
@@ -10,6 +10,9 @@ class CILJit : public ICorJitCompiler
                                          CORINFO_METHOD_INFO* methodInfo,      /* IN */
                                          unsigned             flags,           /* IN */
                                          BYTE**               nativeEntry,     /* OUT */
+#if defined(FEATURE_JIT_DROPPING)
+                                         ULONG*               totalNCSize,     /* OUT */
+#endif
                                          ULONG*               nativeSizeOfCode /* OUT */
                                          );
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21540,6 +21540,9 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
                           pParam->pThis->info.compCompHnd,
                           &pParam->inlineCandidateInfo->methInfo,
                           (void**)pParam->inlineInfo,
+#if defined(FEATURE_JIT_DROPPING)
+                          nullptr,
+#endif
                           nullptr,
                           &compileFlagsForInlinee,
                           pParam->inlineInfo);

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -836,6 +836,9 @@ extern int jitNativeCode(CORINFO_METHOD_HANDLE methodHnd,
                          COMP_HANDLE           compHnd,
                          CORINFO_METHOD_INFO*  methodInfo,
                          void**                methodCodePtr,
+#if defined(FEATURE_JIT_DROPPING)
+                         ULONG*                totalNCSize,
+#endif
                          ULONG*                methodCodeSize,
                          CORJIT_FLAGS*         compileFlags,
                          void*                 inlineInfoPtr);

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -34,6 +34,10 @@ if(FEATURE_GDBJIT)
     add_definitions(-DFEATURE_GDBJIT)
 endif(FEATURE_GDBJIT)
 
+if(FEATURE_JIT_DROPPING)
+   add_definitions(-DFEATURE_JIT_DROPPING)
+endif(FEATURE_JIT_DROPPING)
+
 set(VM_SOURCES_DAC_AND_WKS_COMMON
     appdomain.cpp
     array.cpp

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -2645,7 +2645,7 @@ CodeHeader* EEJitManager::allocCode(MethodDesc* pMD, size_t blockSize, CorJitAll
     if (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropEnabled) != 0 &&
         CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropMemThreshold) != 0 &&
         CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropMethodSizeThreshold) < blockSize &&
-        !pMD->IsLCGMethod() && !pMD->IsFCall())
+        !pMD->IsNotForDropping())
     {
         requestInfo.SetJitDroppedDomain();
     }

--- a/src/vm/hosting.cpp
+++ b/src/vm/hosting.cpp
@@ -672,12 +672,15 @@ BOOL EEHeapFree(HANDLE hHeap, DWORD dwFlags, LPVOID lpMem)
 #ifdef _DEBUG
         GlobalAllocStore::RemoveAlloc (lpMem);
 
-        // Check the heap handle to detect heap contamination
-        lpMem = (BYTE*)lpMem - OS_HEAP_ALIGN;
-        HANDLE storedHeapHandle = *((HANDLE*)lpMem);
-        if(storedHeapHandle != hHeap)
-            _ASSERTE(!"Heap contamination detected! HeapFree was called on a heap other than the one that memory was allocated from.\n"
-                      "Possible cause: you used new (executable) to allocate the memory, but didn't use DeleteExecutable() to free it.");
+        if (lpMem != NULL)
+        {
+            // Check the heap handle to detect heap contamination
+            lpMem = (BYTE*)lpMem - OS_HEAP_ALIGN;
+            HANDLE storedHeapHandle = *((HANDLE*)lpMem);
+            if(storedHeapHandle != hHeap)
+                _ASSERTE(!"Heap contamination detected! HeapFree was called on a heap other than the one that memory was allocated from.\n"
+                         "Possible cause: you used new (executable) to allocate the memory, but didn't use DeleteExecutable() to free it.");
+        }
 #endif
         // DON'T REMOVE THIS SEEMINGLY USELESS CAST
         //

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -11476,7 +11476,6 @@ void CEEJitInfo::allocMem (
                                            , &m_moduleBase
 #endif
                                            );
-
     BYTE* current = (BYTE *)m_CodeHeader->GetCodeStartAddress();
 
     *codeBlock = current;
@@ -11660,6 +11659,9 @@ static CorJitResult CompileMethodWithEtwWrapper(EEJitManager *jitMgr,
                                                       struct CORINFO_METHOD_INFO *info,
                                                       unsigned flags,
                                                       BYTE **nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                                      ULONG *totalNCSize,
+#endif
                                                       ULONG *nativeSizeOfCode)
 {
     STATIC_CONTRACT_THROWS;
@@ -11671,7 +11673,11 @@ static CorJitResult CompileMethodWithEtwWrapper(EEJitManager *jitMgr,
     // Fire an ETW event to mark the beginning of JIT'ing
     ETW::MethodLog::MethodJitting(reinterpret_cast<MethodDesc*>(info->ftn), &namespaceOrClassName, &methodName, &methodSignature);
 
+#if defined(FEATURE_JIT_DROPPING)
+    CorJitResult ret = jitMgr->m_jit->compileMethod(comp, info, flags, nativeEntry, totalNCSize, nativeSizeOfCode);
+#else
     CorJitResult ret = jitMgr->m_jit->compileMethod(comp, info, flags, nativeEntry, nativeSizeOfCode);
+#endif
 
     // Logically, it would seem that the end-of-JITting ETW even should go here, but it must come after the native code has been
     // set for the given method desc, which happens in a caller.
@@ -11689,6 +11695,9 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
                                  unsigned flags,
                                  unsigned flags2,
                                  BYTE **nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                 ULONG *totalNCSize,
+#endif
                                  ULONG *nativeSizeOfCode)
 {
     STATIC_CONTRACT_THROWS;
@@ -11722,6 +11731,9 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
                                    info,
                                    CORJIT_FLG_CALL_GETJITFLAGS,
                                    nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                   totalNCSize,
+#endif
                                    nativeSizeOfCode);
 
 #else // defined(CROSSGEN_COMPILE) && !defined(FEATURE_CORECLR)
@@ -11737,6 +11749,9 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
                                                      info,
                                                      CORJIT_FLG_CALL_GETJITFLAGS,
                                                      nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                                     totalNCSize,
+#endif
                                                      nativeSizeOfCode );
 
 #ifdef FEATURE_STACK_SAMPLING
@@ -11780,6 +11795,9 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
                                           info,
                                           CORJIT_FLG_CALL_GETJITFLAGS,
                                           nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                          totalNCSize,
+#endif
                                           nativeSizeOfCode);
     }
 
@@ -11799,6 +11817,9 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
                                             info,
                                             CORJIT_FLG_CALL_GETJITFLAGS,
                                             nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                            totalNCSize,
+#endif
                                             nativeSizeOfCode);
     }
 #endif // FEATURE_INTERPRETER
@@ -11845,6 +11866,9 @@ CorJitResult invokeCompileMethod(EEJitManager *jitMgr,
                                  unsigned flags,
                                  unsigned flags2,
                                  BYTE **nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                 ULONG *totalNCSize,
+#endif
                                  ULONG *nativeSizeOfCode)
 {
     CONTRACTL {
@@ -11858,7 +11882,11 @@ CorJitResult invokeCompileMethod(EEJitManager *jitMgr,
 
     GCX_PREEMP();
 
+#if defined(FEATURE_JIT_DROPPING)
+    CorJitResult ret = invokeCompileMethodHelper(jitMgr, comp, info, flags, flags2, nativeEntry, totalNCSize, nativeSizeOfCode);
+#else
     CorJitResult ret = invokeCompileMethodHelper(jitMgr, comp, info, flags, flags2, nativeEntry, nativeSizeOfCode);
+#endif
 
     //
     // Verify that we are still in preemptive mode when we return
@@ -11883,6 +11911,9 @@ CorJitResult CallCompileMethodWithSEHWrapper(EEJitManager *jitMgr,
                                 unsigned flags,
                                 unsigned flags2,
                                 BYTE **nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                ULONG *totalNCSize,
+#endif
                                 ULONG *nativeSizeOfCode,
                                 MethodDesc *ftn)
 {
@@ -11900,6 +11931,9 @@ CorJitResult CallCompileMethodWithSEHWrapper(EEJitManager *jitMgr,
         unsigned flags;
         unsigned flags2;
         BYTE **nativeEntry;
+#if defined(FEATURE_JIT_DROPPING)
+        ULONG *totalNCSize;
+#endif
         ULONG *nativeSizeOfCode;
         MethodDesc *ftn;
         CorJitResult res;
@@ -11910,6 +11944,9 @@ CorJitResult CallCompileMethodWithSEHWrapper(EEJitManager *jitMgr,
     param.flags = flags;
     param.flags2 = flags2;
     param.nativeEntry = nativeEntry;
+#if defined(FEATURE_JIT_DROPPING)
+    param.totalNCSize = totalNCSize;
+#endif
     param.nativeSizeOfCode = nativeSizeOfCode;
     param.ftn = ftn;
     param.res = CORJIT_INTERNALERROR;
@@ -11926,6 +11963,9 @@ CorJitResult CallCompileMethodWithSEHWrapper(EEJitManager *jitMgr,
                                            pParam->flags,
                                            pParam->flags2,
                                            pParam->nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                           pParam->totalNCSize,
+#endif
                                            pParam->nativeSizeOfCode);
     }
     PAL_FINALLY
@@ -12361,8 +12401,13 @@ BOOL g_fAllowRel32 = TRUE;
 // Calls to this method that occur to check if inlining can occur on x86,
 // are OK since they discard the return value of this method.
 
+#if defined(FEATURE_JIT_DROPPING)
+PCODE UnsafeJitFunction(MethodDesc* ftn, COR_ILMETHOD_DECODER* ILHeader,
+                        DWORD flags, DWORD flags2, ULONG * totalNCSize, ULONG * pSizeOfCode)
+#else
 PCODE UnsafeJitFunction(MethodDesc* ftn, COR_ILMETHOD_DECODER* ILHeader,
                         DWORD flags, DWORD flags2, ULONG * pSizeOfCode)
+#endif
 {
     STANDARD_VM_CONTRACT;
 
@@ -12610,6 +12655,9 @@ PCODE UnsafeJitFunction(MethodDesc* ftn, COR_ILMETHOD_DECODER* ILHeader,
                                                   flags,
                                                   flags2,
                                                   &nativeEntry,
+#if defined(FEATURE_JIT_DROPPING)
+                                                  totalNCSize,
+#endif
                                                   &sizeOfCode,
                                                   (MethodDesc*)ftn);
             LOG((LF_CORDB, LL_EVERYTHING, "Got through CallCompile MethodWithSEHWrapper\n"));
@@ -12718,6 +12766,7 @@ PCODE UnsafeJitFunction(MethodDesc* ftn, COR_ILMETHOD_DECODER* ILHeader,
 
         //DbgPrintf("Jitted Entry at" FMT_ADDR "method %s::%s %s size %08x\n", DBG_ADDR(nativeEntry),
         //          pszDebugClassName, pszDebugMethodName, pszDebugMethodSignature, sizeOfCode);
+
 #endif
 
         ClrFlushInstructionCache(nativeEntry, sizeOfCode); 

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -53,8 +53,13 @@ bool SigInfoFlagsAreValid (CORINFO_SIG_INFO *sig)
 void InitJITHelpers1();
 void InitJITHelpers2();
 
+#if defined(FEATURE_JIT_DROPPING)
+PCODE UnsafeJitFunction(MethodDesc* ftn, COR_ILMETHOD_DECODER* header,
+                        DWORD flags, DWORD flags2, ULONG* totalNCSize = NULL, ULONG* sizeOfCode = NULL);
+#else
 PCODE UnsafeJitFunction(MethodDesc* ftn, COR_ILMETHOD_DECODER* header,
                         DWORD flags, DWORD flags2, ULONG* sizeOfCode = NULL);
+#endif
 
 void getMethodInfoHelper(MethodDesc * ftn,
                          CORINFO_METHOD_HANDLE ftnHnd,

--- a/src/vm/loaderallocator.hpp
+++ b/src/vm/loaderallocator.hpp
@@ -114,6 +114,9 @@ public:
     // ExecutionManager caches
     void * m_pLastUsedCodeHeap;
     void * m_pLastUsedDynamicCodeHeap;
+#if defined(FEATURE_JIT_DROPPING)
+    void * m_pLastUsedJitDroppedCodeHeap;
+#endif
     void * m_pJumpStubCache;
 
     // LoaderAllocator GC Structures

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1406,6 +1406,10 @@ public:
     // - ngened code if IsPreImplemented()
     PCODE GetNativeCode();
 
+#if defined(FEATURE_JIT_DROPPING)
+    void DropNativeCode();
+#endif
+
     //================================================================
     // FindOrCreateAssociatedMethodDesc
     //
@@ -1647,9 +1651,17 @@ public:
     //
     PCODE DoBackpatch(MethodTable * pMT, MethodTable * pDispatchingMT, BOOL fFullBackPatch);
 
+#if defined(FEATURE_JIT_DROPPING)
+    PCODE DoPrestub(MethodTable *pDispatchingMT, BOOL fDoJitDropping = FALSE);
+#else
     PCODE DoPrestub(MethodTable *pDispatchingMT);
+#endif
 
+#if defined(FEATURE_JIT_DROPPING)
+    PCODE MakeJitWorker(COR_ILMETHOD_DECODER* ILHeader, DWORD  flags, DWORD flags2, BOOL fDoJitDropping = FALSE);
+#else
     PCODE MakeJitWorker(COR_ILMETHOD_DECODER* ILHeader, DWORD  flags, DWORD flags2);
+#endif
 
     VOID GetMethodInfo(SString &namespaceOrClassName, SString &methodName, SString &methodSignature);
     VOID GetMethodInfoWithNewSig(SString &namespaceOrClassName, SString &methodName, SString &methodSignature);

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1407,6 +1407,7 @@ public:
     PCODE GetNativeCode();
 
 #if defined(FEATURE_JIT_DROPPING)
+    bool IsNotForDropping();
     void DropNativeCode();
 #endif
 

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -52,7 +52,166 @@
 #include "perfmap.h"
 #endif
 
-#ifndef DACCESS_COMPILE 
+#if defined(FEATURE_JIT_DROPPING)
+#include "threadsuspend.h"
+#endif
+
+#ifndef DACCESS_COMPILE
+
+#if defined(FEATURE_JIT_DROPPING)
+static PtrHashMap* s_pCalledMethods = NULL;
+static SimpleRWLock* s_pCalledMethodsLock = NULL;
+
+static PtrHashMap* s_pExecutedMethods = NULL;
+static SimpleRWLock* s_pExecutedMethodsLock = NULL;
+
+static ULONG jitDroppedBytes = 0;
+
+static BOOL IsOwnerOfRWLock(LPVOID lock)
+{
+  // @TODO - SimpleRWLock does not have knowledge of which thread gets the writer
+  // lock, so no way to verify
+  return TRUE;
+}
+
+static void LookupOrCreateInCalledMethods(MethodDesc* pMD)
+{
+    CONTRACTL
+    {
+        MODE_COOPERATIVE;
+        GC_TRIGGERS;
+        THROWS;
+    }
+    CONTRACTL_END;
+
+    if (pMD->IsLCGMethod() || pMD->IsFCall())
+        return;
+    PCODE pCode = pMD->GetPreImplementedCode();
+    if (pCode != NULL)
+        return;
+
+    // We lazily allocate the reader/writer lock we synchronize access to the hash with.
+    if (s_pCalledMethodsLock == NULL)
+    {
+        void *pLockSpace = SystemDomain::GetGlobalLoaderAllocator()->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(SimpleRWLock)));
+        SimpleRWLock *pLock = new (pLockSpace) SimpleRWLock(COOPERATIVE_OR_PREEMPTIVE, LOCK_TYPE_DEFAULT);
+
+        if (FastInterlockCompareExchangePointer(&s_pCalledMethodsLock, pLock, NULL) != NULL)
+           // We lost the race, give up our copy.
+           SystemDomain::GetGlobalLoaderAllocator()->GetLowFrequencyHeap()->BackoutMem(pLockSpace, sizeof(SimpleRWLock));
+    }
+
+    // Now we have a lock we can use to synchronize the remainder of the init.
+
+    UPTR key = pMD->GetStableHash();
+
+    if (s_pCalledMethods == NULL)
+    {
+        SimpleWriteLockHolder swlh(s_pCalledMethodsLock);
+        if (s_pCalledMethods == NULL)
+        {
+            PtrHashMap *pMap = new (SystemDomain::GetGlobalLoaderAllocator()->GetLowFrequencyHeap()) PtrHashMap();
+            LockOwner lock = {s_pCalledMethodsLock, IsOwnerOfRWLock};
+            pMap->Init(32, NULL, FALSE, &lock);
+            s_pCalledMethods = pMap;
+        }
+    }
+    else
+    {
+        // Try getting an existing value first.
+        SimpleReadLockHolder srlh(s_pCalledMethodsLock);
+        MethodDesc *pFound = (MethodDesc *)s_pCalledMethods->LookupValue(key, (LPVOID)pMD);
+        if (pFound != (MethodDesc *)INVALIDENTRY)
+            return;
+    }
+
+    SimpleWriteLockHolder swlh(s_pCalledMethodsLock);
+    s_pCalledMethods->InsertValue(key, (LPVOID)pMD);
+}
+
+static void DeleteFromCalledMethods(MethodDesc* pMD)
+{
+    CONTRACTL
+    {
+        MODE_COOPERATIVE;
+        GC_TRIGGERS;
+        THROWS;
+    }
+    CONTRACTL_END;
+
+    if (pMD->IsLCGMethod() || pMD->IsFCall())
+        return;
+    PCODE pCode = pMD->GetPreImplementedCode();
+    if (pCode != NULL)
+        return;
+
+    _ASSERTE((s_pCalledMethodsLock == NULL && s_pCalledMethods == NULL) ||
+             (s_pCalledMethodsLock != NULL && s_pCalledMethods != NULL));
+
+    if (s_pCalledMethodsLock == NULL || s_pCalledMethods == NULL)
+        return;
+
+    UPTR key = pMD->GetStableHash();
+
+    {
+        SimpleReadLockHolder srlh(s_pCalledMethodsLock);
+        MethodDesc *pFound = (MethodDesc *)s_pCalledMethods->LookupValue(key, (LPVOID)pMD);
+        if (pFound == (MethodDesc *)INVALIDENTRY)
+            return;
+    }
+
+    {
+        SimpleWriteLockHolder swlh(s_pCalledMethodsLock);
+        s_pCalledMethods->DeleteValue(key, (LPVOID)pMD);
+    }
+}
+
+StackWalkAction CrawlFrameVisitor(CrawlFrame* pCf, Thread* pMdThread)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        SO_TOLERANT;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    MethodDesc* pMD = pCf->GetFunction();
+
+    // Filter out methods we don't care about
+    if (pMD == nullptr || !pMD->IsIL() || pMD->IsUnboxingStub() || pMD->GetMethodTable()->Collectible())
+    {
+        return SWA_CONTINUE;
+    }
+
+    if (s_pExecutedMethods == NULL)
+    {
+        PtrHashMap *pMap = new (SystemDomain::GetGlobalLoaderAllocator()->GetLowFrequencyHeap()) PtrHashMap();
+        pMap->Init(TRUE, NULL);
+        s_pExecutedMethods = pMap;
+    }
+
+    UPTR key = pMD->GetStableHash();
+    MethodDesc *pFound = (MethodDesc *)s_pExecutedMethods->LookupValue(key, (LPVOID)pMD);
+    if (pFound == (MethodDesc *)INVALIDENTRY)
+    {
+        s_pExecutedMethods->InsertValue(key, (LPVOID)pMD);
+    }
+
+    return SWA_CONTINUE;
+}
+
+// Visitor for stack walk callback.
+StackWalkAction StackWalkCallback(CrawlFrame* pCf, VOID* data)
+{
+    WRAPPER_NO_CONTRACT;
+
+    // WalkInfo* info = (WalkInfo*) data;
+    return CrawlFrameVisitor(pCf, (Thread *)data);
+}
+
+#endif
 
 EXTERN_C void STDCALL ThePreStub();
 EXTERN_C void STDCALL ThePreStubPatch();
@@ -244,6 +403,53 @@ void DACNotifyCompilationFinished(MethodDesc *methodDesc)
 // </TODO>
 
 
+#if defined(FEATURE_JIT_DROPPING)
+void MethodDesc::DropNativeCode()
+{
+    WRAPPER_NO_CONTRACT;
+    SUPPORTS_DAC;
+
+    g_IBCLogger.LogMethodDescAccess(this);
+
+    if (IsLCGMethod() || IsFCall())
+        return;
+
+    PCODE pCode;
+    if (HasNativeCodeSlot())
+    {
+        pCode = PCODE(NativeCodeSlot::GetValueMaybeNullAtPtr(GetAddrOfNativeCodeSlot()) & ~FIXUP_LIST_MASK);
+    }
+    else
+    {
+        if (!HasStableEntryPoint() || HasPrecode())
+            return;
+        pCode = GetStableEntryPoint();
+    }
+
+    _ASSERTE(pCode != NULL);
+
+    CodeHeader* pCH = ((CodeHeader*)pCode) - 1;
+    _ASSERTE(pCH->GetMethodDesc() == this);
+
+    HeapList* pHp = pCH->GetHeapList();
+
+    _ASSERTE(pHp != NULL && pHp->cBlocks == 1 && pHp->bFull && pHp->bFullForJumpStubs);
+
+    jitDroppedBytes += ((BYTE*)pHp->endAddress - (BYTE*)pHp->startAddress);
+
+    pHp->endAddress = pHp->startAddress;
+    pHp->cBlocks = 0;
+    pHp->bFull = false;
+    pHp->bFullForJumpStubs = false;
+
+#ifdef FEATURE_INTERPRETER
+    SetNativeCodeInterlocked(NULL, NULL, FALSE);
+#else
+    SetNativeCodeInterlocked(NULL, NULL);
+#endif
+}
+#endif
+
 // ********************************************************************
 //                  README!!
 // ********************************************************************
@@ -256,7 +462,11 @@ void DACNotifyCompilationFinished(MethodDesc *methodDesc)
 // which prevents us from trying to JIT the same method more that once.
 
 
+#if defined(FEATURE_JIT_DROPPING)
+PCODE MethodDesc::MakeJitWorker(COR_ILMETHOD_DECODER* ILHeader, DWORD flags, DWORD flags2, BOOL fDoJitDropping)
+#else
 PCODE MethodDesc::MakeJitWorker(COR_ILMETHOD_DECODER* ILHeader, DWORD flags, DWORD flags2)
+#endif
 {
     STANDARD_VM_CONTRACT;
 
@@ -271,6 +481,9 @@ PCODE MethodDesc::MakeJitWorker(COR_ILMETHOD_DECODER* ILHeader, DWORD flags, DWO
 
     PCODE pCode = NULL;
     ULONG sizeOfCode = 0;
+#if defined(FEATURE_JIT_DROPPING)
+    ULONG totalNCSize = 0;
+#endif
 #ifdef FEATURE_INTERPRETER
     PCODE pPreviousInterpStub = NULL;
     BOOL fInterpreted = FALSE;
@@ -463,7 +676,11 @@ PCODE MethodDesc::MakeJitWorker(COR_ILMETHOD_DECODER* ILHeader, DWORD flags, DWO
 
             EX_TRY
             {
+#if defined(FEATURE_JIT_DROPPING)
+                pCode = UnsafeJitFunction(this, ILHeader, flags, flags2, &totalNCSize, &sizeOfCode);
+#else
                 pCode = UnsafeJitFunction(this, ILHeader, flags, flags2, &sizeOfCode);
+#endif
             }
             EX_CATCH
             {
@@ -642,6 +859,70 @@ Done:
 
     LOG((LF_CORDB, LL_EVERYTHING, "MethodDesc::MakeJitWorker finished. Stub is" FMT_ADDR "\n",
          DBG_ADDR(pCode)));
+
+#if defined(FEATURE_JIT_DROPPING)
+    CodeHeader* pCH = ((CodeHeader*)pCode) - 1;
+    _ASSERTE(pCH->GetMethodDesc() == this);
+
+    HeapList* pHL = pCH->GetHeapList();
+
+    if ((CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropEnabled) != 0) &&
+        (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropMemThreshold) != 0))
+    {
+        if (fDoJitDropping && (totalNCSize - jitDroppedBytes) > CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropMemThreshold) && s_pCalledMethods != NULL)
+        {
+            EX_TRY
+            {
+                // Suspend the runtime.
+                ThreadSuspend::SuspendEE(ThreadSuspend::SUSPEND_OTHER);
+
+                // Walk all other threads.
+                Thread* pThread = nullptr;
+                while ((pThread = ThreadStore::GetThreadList(pThread)) != nullptr)
+                {
+                    pThread->StackWalkFrames(StackWalkCallback, (VOID *)pThread, FUNCTIONSONLY | ALLOW_ASYNC_STACK_WALK);
+                }
+
+                PtrHashMap::PtrIterator i = s_pCalledMethods->begin();
+                while (!i.end())
+                {
+                    MethodDesc *pMD = (MethodDesc *) i.GetValue();
+                    UPTR key = pMD->GetStableHash();
+                    MethodDesc *pFound = (MethodDesc *)s_pExecutedMethods->LookupValue(key, (LPVOID)pMD);
+                    ++i;
+                    if (pFound == (MethodDesc *)INVALIDENTRY)
+                    {
+                        pMD->DropNativeCode();
+                        SimpleWriteLockHolder swlh(s_pCalledMethodsLock);
+                        s_pCalledMethods->DeleteValue(key, (LPVOID)pMD);
+                    }
+                }
+                for (PtrHashMap::PtrIterator i = s_pExecutedMethods->begin(); !i.end();)
+                {
+                    MethodDesc *pMD = (MethodDesc *) i.GetValue();
+                    UPTR key = (UPTR)pMD->GetStableHash();
+                    ++i;
+                    s_pExecutedMethods->DeleteValue(key, (LPVOID)pMD);
+                }
+                delete s_pExecutedMethods;
+                s_pExecutedMethods = NULL;
+                ThreadSuspend::RestartEE(FALSE, TRUE);
+            }
+            EX_CATCH
+            {
+            }
+            EX_END_CATCH(SwallowAllExceptions);
+        }
+    }
+
+    if ((CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropEnabled) != 0) &&
+        (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropMemThreshold) != 0) &&
+        CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropMethodSizeThreshold) < sizeOfCode &&
+        !IsLCGMethod() && !IsFCall())
+    {
+        LookupOrCreateInCalledMethods(this);
+    }
+#endif
 
     return pCode;
 }
@@ -1042,7 +1323,11 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock * pTransitionBlock, Metho
     }
 
     GCX_PREEMP_THREAD_EXISTS(CURRENT_THREAD);
+#if defined(FEATURE_JIT_DROPPING)
+    pbRetVal = pMD->DoPrestub(pDispatchingMT, TRUE);
+#else
     pbRetVal = pMD->DoPrestub(pDispatchingMT);
+#endif
 
     UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
     UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
@@ -1109,7 +1394,11 @@ static void TestSEHGuardPageRestore()
 // the case of methods that require stubs to be executed first (e.g., remoted methods
 // that require remoting stubs to be executed first), this stable entrypoint would be a
 // pointer to the stub, and not a pointer directly to the JITted code.
+#if defined(FEATURE_JIT_DROPPING)
+PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, BOOL fDoJitDropping)
+#else
 PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
+#endif
 {
     CONTRACT(PCODE)
     {
@@ -1258,6 +1547,14 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
         LOG((LF_CLASSLOADER, LL_INFO10000,
                 "    In PreStubWorker, method already jitted, backpatching call point\n"));
 
+#if defined(FEATURE_JIT_DROPPING)
+        if ((CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropEnabled) != 0) &&
+            (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitDropMemThreshold) != 0) &&
+            !IsLCGMethod() && !IsFCall())
+        {
+            DeleteFromCalledMethods(this);
+        }
+#endif
         RETURN DoBackpatch(pMT, pDispatchingMT, TRUE);
     }
 
@@ -1455,7 +1752,11 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
             // Mark the code as hot in case the method ends up in the native image
             g_IBCLogger.LogMethodCodeAccess(this);
 
+#if defined(FEATURE_JIT_DROPPING)
+            pCode = MakeJitWorker(pHeader, 0, 0, fDoJitDropping);
+#else
             pCode = MakeJitWorker(pHeader, 0, 0);
+#endif
 
 #ifdef FEATURE_INTERPRETER
             if ((pCode != NULL) && !HasStableEntryPoint())

--- a/src/zap/crossgen/CMakeLists.txt
+++ b/src/zap/crossgen/CMakeLists.txt
@@ -24,5 +24,9 @@ if (FEATURE_READYTORUN)
     )
 endif (FEATURE_READYTORUN)
 
+if(FEATURE_JIT_DROPPING)
+  add_definitions(-DFEATURE_JIT_DROPPING)
+endif(FEATURE_JIT_DROPPING)
+
 add_precompiled_header(common.h ../common.cpp ZAP_SOURCES)
 add_library_clr(corzap_crossgen STATIC ${ZAP_SOURCES})

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -477,6 +477,9 @@ void ZapInfo::CompileMethod()
     CorJitResult res = CORJIT_SKIPPED;
     
     BYTE *pCode;
+#if defined(FEATURE_JIT_DROPPING)
+    ULONG tCode;
+#endif
     ULONG cCode;
 
 #ifdef ALLOW_SXS_JIT_NGEN
@@ -488,6 +491,9 @@ void ZapInfo::CompileMethod()
                                                      &m_currentMethodInfo,
                                                      CORJIT_FLG_CALL_GETJITFLAGS,
                                                      &pCode,
+#if defined(FEATURE_JIT_DROPPING)
+                                                     &tCode,
+#endif
                                                      &cCode );
         if (FAILED(res))
         {
@@ -506,6 +512,9 @@ void ZapInfo::CompileMethod()
                                     &m_currentMethodInfo,
                                     CORJIT_FLG_CALL_GETJITFLAGS,
                                     &pCode,
+#if defined(FEATURE_JIT_DROPPING)
+                                    &tCode,
+#endif
                                     &cCode);
 
         if (FAILED(res))


### PR DESCRIPTION
The given pull request proposes a way for resolving issue "Jitted Code Dropping Support" #6757
Its distinctive features and algorithm are:
1. All its code is under #if defined(FEATURE_JIT_DROPPING) and doesn't mess up with other code
2. This feature is working only if the options INTERNAL_JitDropEnabled != 0 and  INTERNAL_JitDropMemThreshold > 0
3. Jitted code can be dropped only for methods that are not Dynamic or FCall
4. If the size of the generated native code exceeds the value of INTERNAL_JitDropMethodSizeThreshold this code is placed in the special heap code list.  Each heap block in this list stores the code for only one method and has the sufficient size for the code of a method aligned to 4K. The pointers to such methods are stored in the "CalledMethods" hash map.
5. If the entrypoint of a method is backpatched this method is excluded from the "CalledMethods" hash map.
6. When the total size of the generated native code exceeds the value of  INTERNAL_JitDropMemThreshold option, the execution of the program is stopped and stack frames for all the threads are inspected and pointers to methods being executed are stored in the "ExecutedMethods" hash map
7. The code for all the methods from the "CalledMethods" that are not in the "ExecutedMethods" is dropped. (All heap blocks for these methods are set in the initial state and can be reused for newly compiled methods,  pointers to the code for non-executed methods are set to NULL).
8. The coreclr code with this feature is built by the option

./build.sh cmakeargs -DFEATURE_JIT_DROPPING=true
