### PR TITLE
Specify packages.builds by default in build-packages command

### DIFF
--- a/config.json
+++ b/config.json
@@ -499,7 +499,8 @@
           "__BuildOS": "default",
           "maxcpucount": "default",
           "MsBuildFileLogging": "/flp:v=detailed;Append;LogFile=build-packages.log",
-          "MsBuildEventLogging": "default"
+          "MsBuildEventLogging": "default",
+          "Project": "src/.nuget/packages.builds"
         }
       }
     }


### PR DESCRIPTION
This command wasn't working unless you specified the `-project` parameter. @Priya91 , @maririos 