### PR TITLE
Due to comdat folding some fcalls are pointing to same code. This fix…

### DIFF
--- a/src/vm/runtimehandles.cpp
+++ b/src/vm/runtimehandles.cpp
@@ -328,7 +328,10 @@ FCIMPL3(void, RuntimeMethodHandle::CheckLinktimeDemands, ReflectMethodObject *pM
     CONTRACTL_END;
 
     if(!Security::IsTransparencyEnforcementEnabled())
+    {
+        FCUnique(0xb0);
         return;
+    }
 
     REFLECTMETHODREF refMethod = (REFLECTMETHODREF)ObjectToOBJECTREF(pMethodUNSAFE);
     REFLECTMODULEBASEREF refModule = (REFLECTMODULEBASEREF)ObjectToOBJECTREF(pModuleUNSAFE);
@@ -846,7 +849,10 @@ void QCALLTYPE RuntimeFieldHandle::CheckAttributeAccess(FieldDesc *pFD, QCall::M
     CONTRACTL_END;
     
     if(!Security::IsTransparencyEnforcementEnabled())
+    {
+        FCUnique(0xb1);
         return;
+    }
 
     BEGIN_QCALL;
 

--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -2170,6 +2170,7 @@ FCIMPLEND
 FCIMPL2(void, StubHelpers::MulticastDebuggerTraceHelper, Object* element, INT32 count)
 {
     FCALL_CONTRACT;
+    FCUnique(0xa5);
 }
 FCIMPLEND
 #endif // FEATURE_STUBS_AS_IL


### PR DESCRIPTION
Due to comdat folding some fcalls are pointing to same code. This fix ensures that these fcall has a unique code address.

Some arm64 corefx tests started to fail after PR #6662 . This fixes that.