### PR TITLE
Preparatory changes for Blk Ops IR

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -1100,6 +1100,11 @@ Compiler::AssertionIndex Compiler::optCreateAssertion(GenTreePtr       op1,
 
                 CNS_COMMON:
                 {
+                    // TODO-1stClassStructs: handle constant propagation to struct types.
+                    if (varTypeIsStruct(lclVar))
+                    {
+                        goto DONE_ASSERTION;
+                    }
                     //
                     // Must either be an OAK_EQUAL or an OAK_NOT_EQUAL assertion
                     //
@@ -2029,7 +2034,12 @@ void Compiler::optAssertionGen(GenTreePtr tree)
     {
         case GT_ASG:
             // VN takes care of non local assertions for assignments and data flow.
-            if (optLocalAssertionProp)
+            // TODO-1stClassStructs: Enable assertion prop for struct types.
+            if (varTypeIsStruct(tree))
+            {
+                // Do nothing.
+            }
+            else if (optLocalAssertionProp)
             {
                 assertionIndex = optCreateAssertion(tree->gtOp.gtOp1, tree->gtOp.gtOp2, OAK_EQUAL);
             }
@@ -2040,8 +2050,18 @@ void Compiler::optAssertionGen(GenTreePtr tree)
             break;
 
         case GT_IND:
+            // TODO-1stClassStructs: All indirections should be considered to create a non-null
+            // assertion, but previously, when these indirections were implicit due to a block
+            // copy or init, they were not being considered to do so.
+            if (tree->gtType == TYP_STRUCT)
+            {
+                GenTree* parent = tree->gtGetParent(nullptr);
+                if ((parent != nullptr) && (parent->gtOper == GT_ASG))
+                {
+                    break;
+                }
+            }
         case GT_NULLCHECK:
-        // An indirection can create a non-null assertion
         case GT_ARR_LENGTH:
             // An array length can create a non-null assertion
             assertionIndex = optCreateAssertion(tree->gtOp.gtOp1, nullptr, OAK_NOT_EQUAL);
@@ -4221,7 +4241,7 @@ void Compiler::optImpliedByCopyAssertion(AssertionDsc* copyAssertion, AssertionD
                 break;
 
             case O2K_IND_CNS_INT:
-                // This is the ngen case where we have a GT_IND of an address.
+                // This is the ngen case where we have an indirection of an address.
                 noway_assert((impAssertion->op1.kind == O1K_EXACT_TYPE) || (impAssertion->op1.kind == O1K_SUBTYPE));
 
                 __fallthrough;
@@ -4784,7 +4804,7 @@ Compiler::fgWalkResult Compiler::optVNConstantPropCurStmt(BasicBlock* block, Gen
 //
 // Description:
 //    Performs value number based non-null propagation on GT_CALL and
-//    GT_IND/GT_NULLCHECK. This is different from flow based assertions and helps
+//    indirections. This is different from flow based assertions and helps
 //    unify VN based constant prop and non-null prop in a single pre-order walk.
 //
 void Compiler::optVnNonNullPropCurStmt(BasicBlock* block, GenTreePtr stmt, GenTreePtr tree)
@@ -4797,6 +4817,9 @@ void Compiler::optVnNonNullPropCurStmt(BasicBlock* block, GenTreePtr stmt, GenTr
     }
     else if (tree->OperGet() == GT_IND || tree->OperGet() == GT_NULLCHECK)
     {
+        // TODO-1stClassStructs: All indirections should be handled here, but
+        // previously, when these indirections were GT_OBJ, or implicit due to a block
+        // copy or init, they were not being handled.
         newTree = optAssertionProp_Ind(empty, tree, stmt);
     }
     if (newTree)

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -724,17 +724,13 @@ void Compiler::compUpdateLifeVar(GenTreePtr tree, VARSET_TP* pLastUseVars)
     LclVarDsc*   varDsc = lvaTable + lclNum;
 
 #ifdef DEBUG
-#if !defined(_TARGET_AMD64_) // no addr nodes on AMD and experimenting with with encountering vars in 'random' order
+#if !defined(_TARGET_AMD64_)
+    // There are no addr nodes on ARM and we are experimenting with encountering vars in 'random' order.
     // Struct fields are not traversed in a consistent order, so ignore them when
     // verifying that we see the var nodes in execution order
     if (ForCodeGen)
     {
-        if (tree->gtOper == GT_OBJ)
-        {
-            // The tree must have the particular form OBJ(ADDR(LCL)); no need to do the check below.
-            assert(indirAddrLocal != NULL);
-        }
-        else if (tree->OperIsIndir())
+        if (tree->OperIsIndir())
         {
             assert(indirAddrLocal != NULL);
         }

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2176,6 +2176,17 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
                     break;
                 }
 #endif // !defined(_TARGET_64BIT_)
+                
+#ifdef FEATURE_SIMD
+                if (varTypeIsSIMD(targetType) && (targetReg != REG_NA) && op1->IsCnsIntOrI())
+                {
+                    // This is only possible for a zero-init.
+                    noway_assert(op1->IsIntegralConst(0));
+                    genSIMDZero(targetType, varDsc->lvBaseType, targetReg);
+                    genProduceReg(treeNode);
+                    break;
+                }
+#endif // FEATURE_SIMD
 
                 genConsumeRegs(op1);
 
@@ -2183,7 +2194,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
                 {
                     // stack store
                     emit->emitInsMov(ins_Store(targetType, compiler->isSIMDTypeLocalAligned(lclNum)),
-                                     emitTypeSize(treeNode), treeNode);
+                                     emitTypeSize(targetType), treeNode);
                     varDsc->lvRegNum = REG_STK;
                 }
                 else

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -238,8 +238,12 @@ bool Compiler::optEarlyPropRewriteTree(GenTreePtr tree)
         objectRefPtr = tree->gtOp.gtOp1;
         propKind     = optPropKind::OPK_ARRAYLEN;
     }
-    else if (tree->OperGet() == GT_IND)
+    else if ((tree->OperGet() == GT_IND) && !varTypeIsStruct(tree))
     {
+        // TODO-1stClassStructs: The above condition should apply equally to all indirections,
+        // but previously the implicit indirections due to a struct assignment were not
+        // considered, so we are currently limiting it to non-structs to preserve existing
+        // behavior.
         // optFoldNullCheck takes care of updating statement info if a null check is removed.
         optFoldNullCheck(tree);
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1080,6 +1080,17 @@ public:
     bool OperIsInitBlkOp() const;
     bool OperIsDynBlkOp();
 
+    static
+    bool OperIsBlk(genTreeOps gtOper)
+    {
+        return (gtOper == GT_OBJ);
+    }
+
+    bool OperIsBlk() const
+    {
+        return OperIsBlk(OperGet());
+    }
+
     bool OperIsPutArgStk() const
     {
         return gtOper == GT_PUTARG_STK;
@@ -1491,6 +1502,19 @@ public:
     // set gtOper and only keep GTF_COMMON_MASK flags
     void ChangeOper(genTreeOps oper, ValueNumberUpdate vnUpdate = CLEAR_VN);
     void ChangeOperUnchecked(genTreeOps oper);
+
+    void                        ChangeType(var_types newType)
+    {
+        var_types oldType = gtType;
+        gtType = newType;
+        GenTree* node = this;
+        while (node->gtOper == GT_COMMA)
+        {
+            node = node->gtGetOp2();
+            assert(node->gtType == oldType);
+            node->gtType = newType;
+        }
+    }
 
     bool IsLocal() const
     {

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3319,14 +3319,15 @@ void Lowering::LowerAdd(GenTreePtr* pTree, Compiler::fgWalkData* data)
         return;
     }
 
-    // if this is a child of an indir, let the parent handle it
-    if (data->parentStack->Index(1)->OperIsIndir())
+    // If this is a child of an indir, and it is not a block op, let the parent handle it.
+    GenTree* parent = data->parentStack->Index(1);
+    if (parent->OperIsIndir() && !varTypeIsStruct(parent))
     {
         return;
     }
 
     // if there is a chain of adds, only look at the topmost one
-    if (data->parentStack->Index(1)->gtOper == GT_ADD)
+    if (parent->gtOper == GT_ADD)
     {
         return;
     }

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -1568,6 +1568,7 @@ Compiler::fgWalkResult Rationalizer::SimpleTransformHelper(GenTree** ppTree, Com
 
             case GT_LCL_FLD:
             case GT_STORE_LCL_FLD:
+                // TODO-1stClassStructs: Eliminate this.
                 FixupIfSIMDLocal(comp, tree->AsLclVarCommon());
                 break;
 
@@ -1590,7 +1591,9 @@ Compiler::fgWalkResult Rationalizer::SimpleTransformHelper(GenTree** ppTree, Com
                 GenTreeSIMD* simdTree = (*ppTree)->AsSIMD();
                 simdSize              = simdTree->gtSIMDSize;
                 var_types simdType    = comp->getSIMDTypeForSize(simdSize);
-                // TODO-Cleanup: This is no-longer required once we plumb SIMD types thru front-end
+                // TODO-1stClassStructs: This should be handled more generally for enregistered or promoted
+                // structs that are passed or returned in a different register type than their enregistered
+                // type(s).
                 if (simdTree->gtType == TYP_I_IMPL && simdTree->gtSIMDSize == TARGET_POINTER_SIZE)
                 {
                     // This happens when it is consumed by a GT_RET_EXPR.
@@ -1676,8 +1679,9 @@ Compiler::fgWalkResult Rationalizer::SimpleTransformHelper(GenTree** ppTree, Com
 // Return Value:
 //    None.
 //
-// TODO-Cleanup: Once SIMD types are plumbed through the frontend, this will no longer
-// be required.
+// TODO-1stClassStructs: This is now only here to preserve existing behavior. It is actually not
+// desirable to change the lclFld nodes back to TYP_SIMD (it will cause them to be loaded
+// into a vector register, and then moved to an int register).
 
 void Rationalizer::FixupIfSIMDLocal(Compiler* comp, GenTreeLclVarCommon* tree)
 {

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -917,7 +917,7 @@ void SsaBuilder::TreeRenameVariables(GenTree* tree, BasicBlock* block, SsaRename
     {
         GenTreePtr lhs     = tree->gtOp.gtOp1->gtEffectiveVal(/*commaOnly*/ true);
         GenTreePtr trueLhs = lhs->gtEffectiveVal(/*commaOnly*/ true);
-        if (trueLhs->OperGet() == GT_IND)
+        if (trueLhs->OperIsIndir())
         {
             trueLhs->gtFlags |= GTF_IND_ASG_LHS;
         }


### PR DESCRIPTION
These are mostly refactoring changes, in preparation for the change to the IR for block assignments.
The most substantive changes are in morph, where I cleaned up and combined some of the cases for `fgMakeTmpArgNode` and refactored `fgMorphOneAsgBlockOp` to eliminate the gotos and unify the size handling.