### PR TITLE
Remove usages of FillStringChecked from String

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -3471,15 +3471,8 @@ namespace System {
 
             fixed (char* pResult = &result.m_firstChar)
             {
-                fixed (char* pSource = &str0.m_firstChar)
-                {
-                    wstrcpy(pResult, pSource, str0.Length);
-                }
-
-                fixed (char* pSource = &str1.m_firstChar)
-                {
-                    wstrcpy(pResult + str0.Length, pSource, str1.Length);
-                }
+                str0.CopyToPointer(pResult);
+                str1.CopyToPointer(pResult + str0.Length);
             }
             
             return result;
@@ -3514,20 +3507,9 @@ namespace System {
 
             fixed (char* pResult = &result.m_firstChar)
             {
-                fixed (char* pSource = &str0.m_firstChar)
-                {
-                    wstrcpy(pResult, pSource, str0.Length);
-                }
-                
-                fixed (char* pSource = &str1.m_firstChar)
-                {
-                    wstrcpy(pResult + str0.Length, pSource, str1.Length);
-                }
-
-                fixed (char* pSource = &str2.m_firstChar)
-                {
-                    wstrcpy(pResult + str0.Length + str1.Length, pSource, str2.Length);
-                }
+                str0.CopyToPointer(pResult);
+                str1.CopyToPointer(pResult + str0.Length);
+                str2.CopyToPointer(pResult + str0.Length + str1.Length);
             }
 
             return result;
@@ -3568,28 +3550,30 @@ namespace System {
 
             fixed (char* pResult = &result.m_firstChar)
             {
-                fixed (char* pSource = &str0.m_firstChar)
-                {
-                    wstrcpy(pResult, pSource, str0.Length);
-                }
-                
-                fixed (char* pSource = &str1.m_firstChar)
-                {
-                    wstrcpy(pResult + str0.Length, pSource, str1.Length);
-                }
-
-                fixed (char* pSource = &str2.m_firstChar)
-                {
-                    wstrcpy(pResult + str0.Length + str1.Length, pSource, str2.Length);
-                }
-
-                fixed (char* pSource = &str3.m_firstChar)
-                {
-                    wstrcpy(pResult + str0.Length + str1.Length + str2.Length, pSource, str3.Length);
-                }
+                str0.CopyToPointer(pResult);
+                str1.CopyToPointer(pResult + str0.Length);
+                str2.CopyToPointer(pResult + str0.Length + str1.Length);
+                str3.CopyToPointer(pResult + str0.Length + str1.Length + str2.Length);
             }
 
             return result;
+        }
+
+        // This is separated out into a different method since
+        // it seems to improve performance/code size for certain
+        // Concat() overloads as opposed to when it is written inline.
+        // Please do not use this method for other purposes unless
+        // you can be sure that it is benefiting your use case.
+        // Please make thorough (repeated) microbenchmarks of how
+        // this will affect the Concat() overloads before making changes.
+        private unsafe void CopyToPointer(char* destination)
+        {
+            Contract.Assert(destination != null);
+
+            fixed (char* pThis = &m_firstChar)
+            {
+                wstrcpy(destination, pThis, Length);
+            }
         }
 
         [System.Security.SecuritySafeCritical]

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -3469,14 +3469,14 @@ namespace System {
             int totalLength = str0.Length + str1.Length;
             string result = FastAllocateString(totalLength);
 
-            fixed (char* pResult = result)
+            fixed (char* pResult = &result.m_firstChar)
             {
-                fixed (char* pSource = str0)
+                fixed (char* pSource = &str0.m_firstChar)
                 {
                     wstrcpy(pResult, pSource, str0.Length);
                 }
 
-                fixed (char* pSource = str1)
+                fixed (char* pSource = &str1.m_firstChar)
                 {
                     wstrcpy(pResult + str0.Length, pSource, str1.Length);
                 }
@@ -3512,19 +3512,19 @@ namespace System {
             int totalLength = str0.Length + str1.Length + str2.Length;
             string result = FastAllocateString(totalLength);
 
-            fixed (char* pResult = result)
+            fixed (char* pResult = &result.m_firstChar)
             {
-                fixed (char* pSource = str0)
+                fixed (char* pSource = &str0.m_firstChar)
                 {
                     wstrcpy(pResult, pSource, str0.Length);
                 }
                 
-                fixed (char* pSource = str1)
+                fixed (char* pSource = &str1.m_firstChar)
                 {
                     wstrcpy(pResult + str0.Length, pSource, str1.Length);
                 }
 
-                fixed (char* pSource = str2)
+                fixed (char* pSource = &str2.m_firstChar)
                 {
                     wstrcpy(pResult + str0.Length + str1.Length, pSource, str2.Length);
                 }
@@ -3566,24 +3566,24 @@ namespace System {
             int totalLength = str0.Length + str1.Length + str2.Length + str3.Length;
             string result = FastAllocateString(totalLength);
 
-            fixed (char* pResult = result)
+            fixed (char* pResult = &result.m_firstChar)
             {
-                fixed (char* pSource = str0)
+                fixed (char* pSource = &str0.m_firstChar)
                 {
                     wstrcpy(pResult, pSource, str0.Length);
                 }
                 
-                fixed (char* pSource = str1)
+                fixed (char* pSource = &str1.m_firstChar)
                 {
                     wstrcpy(pResult + str0.Length, pSource, str1.Length);
                 }
 
-                fixed (char* pSource = str2)
+                fixed (char* pSource = &str2.m_firstChar)
                 {
                     wstrcpy(pResult + str0.Length + str1.Length, pSource, str2.Length);
                 }
 
-                fixed (char* pSource = str3)
+                fixed (char* pSource = &str3.m_firstChar)
                 {
                     wstrcpy(pResult + str0.Length + str1.Length + str2.Length, pSource, str3.Length);
                 }

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -3564,6 +3564,9 @@ namespace System {
         // Concat() overloads as opposed to when it is written inline.
         // Please do not use this method for other purposes unless
         // you can be sure that it is benefiting your use case.
+        // In Concat's use case, this was beneficial since the result
+        // of fixed on the destination could be cached, while there
+        // were multiple sources that had to be fixed on.
         // Please make thorough (repeated) microbenchmarks of how
         // this will affect the Concat() overloads before making changes.
         private unsafe void CopyToPointer(char* destination)

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -3449,36 +3449,44 @@ namespace System {
 
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public static String Concat(String str0, String str1) {
+        public unsafe static String Concat(String str0, String str1) {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.Ensures(Contract.Result<String>().Length ==
                 (str0 == null ? 0 : str0.Length) +
                 (str1 == null ? 0 : str1.Length));
             Contract.EndContractBlock();
 
-            if (IsNullOrEmpty(str0)) {
-                if (IsNullOrEmpty(str1)) {
-                    return String.Empty;
-                }
-                return str1;
+            if (IsNullOrEmpty(str0))
+            {
+                return str1 ?? string.Empty;
             }
 
-            if (IsNullOrEmpty(str1)) {
+            if (IsNullOrEmpty(str1))
+            {
                 return str0;
             }
 
-            int str0Length = str0.Length;
-            
-            String result = FastAllocateString(str0Length + str1.Length);
-            
-            FillStringChecked(result, 0,        str0);
-            FillStringChecked(result, str0Length, str1);
+            int totalLength = str0.Length + str1.Length;
+            string result = FastAllocateString(totalLength);
+
+            fixed (char* pResult = result)
+            {
+                fixed (char* pSource = str0)
+                {
+                    wstrcpy(pResult, pSource, str0.Length);
+                }
+
+                fixed (char* pSource = str1)
+                {
+                    wstrcpy(pResult + str0.Length, pSource, str1.Length);
+                }
+            }
             
             return result;
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public static String Concat(String str0, String str1, String str2) {
+        public unsafe static String Concat(String str0, String str1, String str2) {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.Ensures(Contract.Result<String>().Length ==
                 (str0 == null ? 0 : str0.Length) +
@@ -3502,17 +3510,31 @@ namespace System {
             }
 
             int totalLength = str0.Length + str1.Length + str2.Length;
+            string result = FastAllocateString(totalLength);
 
-            String result = FastAllocateString(totalLength);
-            FillStringChecked(result, 0, str0);
-            FillStringChecked(result, str0.Length, str1);
-            FillStringChecked(result, str0.Length + str1.Length, str2);
+            fixed (char* pResult = result)
+            {
+                fixed (char* pSource = str0)
+                {
+                    wstrcpy(pResult, pSource, str0.Length);
+                }
+                
+                fixed (char* pSource = str1)
+                {
+                    wstrcpy(pResult + str0.Length, pSource, str1.Length);
+                }
+
+                fixed (char* pSource = str2)
+                {
+                    wstrcpy(pResult + str0.Length + str1.Length, pSource, str2.Length);
+                }
+            }
 
             return result;
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public static String Concat(String str0, String str1, String str2, String str3) {
+        public unsafe static String Concat(String str0, String str1, String str2, String str3) {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.Ensures(Contract.Result<String>().Length == 
                 (str0 == null ? 0 : str0.Length) +
@@ -3542,12 +3564,30 @@ namespace System {
             }
 
             int totalLength = str0.Length + str1.Length + str2.Length + str3.Length;
+            string result = FastAllocateString(totalLength);
 
-            String result = FastAllocateString(totalLength);
-            FillStringChecked(result, 0, str0);
-            FillStringChecked(result, str0.Length, str1);
-            FillStringChecked(result, str0.Length + str1.Length, str2);
-            FillStringChecked(result, str0.Length + str1.Length + str2.Length, str3);
+            fixed (char* pResult = result)
+            {
+                fixed (char* pSource = str0)
+                {
+                    wstrcpy(pResult, pSource, str0.Length);
+                }
+                
+                fixed (char* pSource = str1)
+                {
+                    wstrcpy(pResult + str0.Length, pSource, str1.Length);
+                }
+
+                fixed (char* pSource = str2)
+                {
+                    wstrcpy(pResult + str0.Length + str1.Length, pSource, str2.Length);
+                }
+
+                fixed (char* pSource = str3)
+                {
+                    wstrcpy(pResult + str0.Length + str1.Length + str2.Length, pSource, str3.Length);
+                }
+            }
 
             return result;
         }


### PR DESCRIPTION
There are some very-frequently called `String.Concat` overloads that call a helper method `FillStringChecked`, which pins both the source/destination strings and does a `wstrcpy`. This is somewhat inefficient since in all of the callers, the destination is the same string (and so the result of `fixed` can be cached), however it's not being cached.

This PR introduces a new method `CopyToPointer` and uses that instead. Something that looked like this before:

```cs
string result = FastAllocateString(len);

FillStringChecked(result, pos1, str1);
FillStringChecked(result, pos2, str2);
```

will now look like this:

```cs
string result = FastAllocateString(len);

fixed (char* pResult = result)
{
    str1.CopyToPointer(pResult + pos1);
    str2.CopyToPointer(pResult + pos2);
}
```

The `fixed` is now done inline in the caller, so the string is pinned only once. The source strings are each individually pinned by `CopyToPointer`.

## Perf results

- [`string.Concat(string[])`](https://gist.github.com/jamesqo/b8b778bf4c76dff7e78698e9487cbbc4)
- [`string.Concat(object[])`](https://gist.github.com/jamesqo/f8e70dc79d16c768dbf86bf250577c14)

If you look at the timings for length 20/50/100 string arrays, there is a consistent speedup of about 5%. (Take into account the fact that these methods also do a lot of other work, incl. a double pass over the array.)

<s>I accidentally deleted</s> [Here is](https://gist.github.com/jamesqo/4ccda07f8e2ce06b7392a56d25d466dd) the source code for the `Concat(string, string, ...)`-based overloads, but I still have the results (times are what most frequently appeared):

| **Method** | **Baseline** | **Experimental**
--- | --- | ---
| Concat(string, string) | ~1.5s | ~1.5s
| Concat(3 strings) | ~2.1s | ~2.0s
| Concat(4 strings) | ~2.8s | ~2.6s

So for those overloads there is about a 5-7% speedup.

I know this isn't that much, especially considering that in the first two tests I used `"1"` for all the strings, but IMO the changes aren't too earth-shattering and I took the time to cleanup some of the code.

cc @jkotas @bbowyersmyth @mikedn 

Tests are coming to CoreFX.