### PR TITLE
Fix several serialization issues

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6450,6 +6450,7 @@
       <Member Name="#ctor" />
       <Member Name="#ctor(System.String)" />
       <Member Name="#ctor(System.String,System.Exception)" />
+      <Member Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
     </Type>
     <Type Name="System.Security.SecurityState">
       <Member Name="#ctor" />
@@ -9900,6 +9901,7 @@
       <Member Name="#ctor" />
       <Member Name="#ctor(System.String)" />
       <Member Name="#ctor(System.String,System.Exception)" />
+      <Member Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
     </Type>
     <Type Status="ImplRoot" Name="System.SharedStatics">
       <Member MemberType="Field"  Name="_sharedStatics" /> <!-- EE -->

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -11267,6 +11267,7 @@ namespace System.Security
         public SecurityException() { }
         public SecurityException(string message) { }
         public SecurityException(string message, System.Exception inner) { }
+        protected SecurityException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         [System.Security.SecurityCriticalAttribute]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
@@ -11301,6 +11302,7 @@ namespace System.Security
         public VerificationException() { }
         public VerificationException(string message) { }
         public VerificationException(string message, System.Exception innerException) { }
+        protected VerificationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 }
 namespace System.Security.Permissions

--- a/src/mscorlib/src/System/Action.cs
+++ b/src/mscorlib/src/System/Action.cs
@@ -12,65 +12,47 @@ namespace System {
     // Action/Func delegates first shipped with .NET Framework 3.5 in System.Core.dll as part of LINQ
     // These were type forwarded to mscorlib.dll in .NET Framework 4.0 and in Silverlight 5.0
 
-#if FEATURE_CORECLR
-    [TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
-#else
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public delegate void Action();
 
-#if FEATURE_CORECLR
-    [TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
-#else
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public delegate void Action<in T1,in T2>(T1 arg1, T2 arg2);
 
-#if FEATURE_CORECLR
-    [TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
-#else
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public delegate void Action<in T1,in T2,in T3>(T1 arg1, T2 arg2, T3 arg3);
 
-#if FEATURE_CORECLR
-    [TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
-#else
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public delegate void Action<in T1,in T2,in T3,in T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4);
 
-#if FEATURE_CORECLR
-    [TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
-#else
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public delegate TResult Func<out TResult>();
 
-#if FEATURE_CORECLR
-    [TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
-#else
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public delegate TResult Func<in T, out TResult>(T arg);
 
-#if FEATURE_CORECLR
-    [TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
-#else
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public delegate TResult Func<in T1, in T2, out TResult>(T1 arg1, T2 arg2);
 
-#if FEATURE_CORECLR
-    [TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
-#else
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public delegate TResult Func<in T1, in T2, in T3, out TResult>(T1 arg1, T2 arg2, T3 arg3);
 
-#if FEATURE_CORECLR
-    [TypeForwardedFrom("System.Core, Version=2.0.5.0, Culture=Neutral, PublicKeyToken=7cec85d7bea7798e")]
-#else
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
 #endif
     public delegate TResult Func<in T1, in T2, in T3, in T4, out TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4);

--- a/src/mscorlib/src/System/DelegateSerializationHolder.cs
+++ b/src/mscorlib/src/System/DelegateSerializationHolder.cs
@@ -221,7 +221,7 @@ namespace System
 #if FEATURE_REMOTING                
                     Object target = de.target != null ? RemotingServices.CheckCast(de.target, targetType) : null;
 #else
-                    if(!targetType.IsInstanceOfType(de.target))
+                    if(de.target != null && !targetType.IsInstanceOfType(de.target))
                         throw new InvalidCastException();
                     Object target=de.target;
 #endif

--- a/src/mscorlib/src/System/InvalidTimeZoneException.cs
+++ b/src/mscorlib/src/System/InvalidTimeZoneException.cs
@@ -8,7 +8,9 @@ namespace System {
 
    [Serializable]
    [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
+#if !FEATURE_CORECLR
    [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
    public class InvalidTimeZoneException : Exception {
        public InvalidTimeZoneException(String message)
            : base(message) { }

--- a/src/mscorlib/src/System/Security/SecurityException.cs
+++ b/src/mscorlib/src/System/Security/SecurityException.cs
@@ -600,7 +600,15 @@ namespace System.Security
         
         internal SecurityException(string message, Object deny, Object permitOnly, MethodInfo method, Object demanded, IPermission permThatFailed)
                     : this(){}
-                    
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        protected SecurityException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            if (info == null)
+                throw new ArgumentNullException("info");
+            Contract.EndContractBlock();
+        }
+
         public override String ToString() 
                 {
                     return base.ToString();

--- a/src/mscorlib/src/System/Threading/LockRecursionException.cs
+++ b/src/mscorlib/src/System/Threading/LockRecursionException.cs
@@ -20,7 +20,9 @@ namespace System.Threading
 
     [Serializable]
     [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class LockRecursionException : System.Exception
     {
         public LockRecursionException() { }

--- a/src/mscorlib/src/System/Threading/SemaphoreFullException.cs
+++ b/src/mscorlib/src/System/Threading/SemaphoreFullException.cs
@@ -9,7 +9,9 @@ namespace System.Threading {
 
     [Serializable]
     [ComVisibleAttribute(false)]
+#if !FEATURE_CORECLR
     [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     public class SemaphoreFullException : SystemException {
     
         public SemaphoreFullException() : base(Environment.GetResourceString("Threading_SemaphoreFullException")){

--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -52,7 +52,9 @@ namespace System {
 
     [Serializable]
     [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
+#if !FEATURE_CORECLR
     [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
     sealed public class TimeZoneInfo : IEquatable<TimeZoneInfo>, ISerializable, IDeserializationCallback
     {
         // ---- SECTION:  members supporting exposed properties -------------*
@@ -4452,7 +4454,9 @@ namespace System {
 ============================================================*/
         [Serializable]
         [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
+#if !FEATURE_CORECLR
         [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
         sealed public class AdjustmentRule : IEquatable<AdjustmentRule>, ISerializable, IDeserializationCallback
             {
 
@@ -4760,7 +4764,9 @@ namespace System {
 ============================================================*/
         [Serializable]
         [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
+#if !FEATURE_CORECLR
         [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
         public struct TransitionTime : IEquatable<TransitionTime>, ISerializable, IDeserializationCallback
         {
             // ---- SECTION:  members supporting exposed properties -------------*

--- a/src/mscorlib/src/System/TimeZoneNotFoundException.cs
+++ b/src/mscorlib/src/System/TimeZoneNotFoundException.cs
@@ -7,7 +7,9 @@ namespace System {
    using  System.Runtime.CompilerServices;
 
    [Serializable]
+#if !FEATURE_CORECLR
    [TypeForwardedFrom("System.Core, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
    [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
    public class TimeZoneNotFoundException : Exception {
        public TimeZoneNotFoundException(String message)


### PR DESCRIPTION
- VerificationException's deserialization ctor was getting tree-shaken away
- SecurityException's deserialization ctor was ifdef'd out
- Delegates without targets (e.g. static methods) were failing to deserialize with an invalid cast exception due to a missing null check when FEATURE_REMOTING wasn't set
- TypeForwardedFrom attributes were referencing System and System.Core, which don't exist in .NET Core, causing deserialization failures of such attributed types

cc: @jkotas, @weshaggard 