### PR TITLE
Enable additional functionality for OS X CI dumps.

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -120,9 +120,8 @@ esac
 dumplingsListPath="$PWD/dumplings.txt"
 if [ -f "$dumplingsListPath" ]; then
     rm "$dumplingsListPath"
-fi  
+fi
 
-touch $dumplingsListPath
 find . -type f -name "local_dumplings.txt" -exec rm {} \;
 
 function xunit_output_begin {
@@ -1158,7 +1157,11 @@ print_results
 echo "constructing $dumplingsListPath"
 find . -type f -name "local_dumplings.txt" -exec cat {} \; > $dumplingsListPath
 
-cat $dumplingsListPath
+if [ -s $dumplingsListPath ]; then
+    cat $dumplingsListPath
+else
+    rm $dumplingsListPath
+fi
 
 time_end=$(date +"%s")
 time_diff=$(($time_end-$time_start))


### PR DESCRIPTION
Our CI Macs are being modified so that generated core dumps will no longer be placed in the /cores directory. Instead, they will be put in the test's directory just like they are on Linux.

This change modifies the infrastructure used in CI runs to take advantage of this and unify how we handle dumps on Linux and OS X/macOS. For instance, we should now start uploading dumps from our OS X runs to dumpling, and the retention model for saving them locally will match what we do on Linux.

_I'd like to test this end-to-end before merging, so expect this PR to be open for a while._

cc: @mmitche @bryanar