### PR TITLE
Further optimizations for String.Join, String.Concat

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -107,6 +107,15 @@ namespace System {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
+            // This can be called with T == string if someone
+            // has a GenericMethod<T> which calls here, and
+            // then someone calls that with string
+            if (typeof(T) == typeof(string))
+            {
+                var strings = values as IEnumerable<string>;
+                return Join(separator, strings); // call the IEnumerable<string> overload
+            }
+
             using (IEnumerator<T> en = values.GetEnumerator())
             {
                 if (!en.MoveNext())
@@ -3416,6 +3425,15 @@ namespace System {
                 throw new ArgumentNullException("values");
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
+
+            // This can be called with T == string if someone
+            // has a GenericMethod<T> which calls here, and
+            // then someone calls that with string
+            if (typeof(T) == typeof(string))
+            {
+                var strings = values as IEnumerable<string>;
+                return Concat(strings); // call the IEnumerable<string> overload
+            }
 
             StringBuilder result = StringBuilderCache.Acquire();
             using(IEnumerator<T> en = values.GetEnumerator()) {

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -3377,6 +3377,13 @@ namespace System {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
+            if (args.Length <= 1)
+            {
+                return args.Length == 0 ?
+                    string.Empty :
+                    args[0]?.ToString() ?? string.Empty;
+            }
+
             // We need to get an intermediary string array
             // to fill with each of the args' ToString(),
             // and then just concat that in one operation.
@@ -3632,6 +3639,13 @@ namespace System {
                 throw new ArgumentNullException("values");
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
+
+            if (values.Length <= 1)
+            {
+                return values.Length == 0 ?
+                    string.Empty :
+                    values[0] ?? string.Empty;
+            }
 
             // It's possible that the input values array could be changed concurrently on another
             // thread, such that we can't trust that each read of values[i] will be equivalent.

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -118,15 +118,6 @@ namespace System {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
-            // This can be called with T == string if someone
-            // has a GenericMethod<T> which calls here, and
-            // then someone calls that with string
-            if (typeof(T) == typeof(string))
-            {
-                var strings = values as IEnumerable<string>;
-                return Join(separator, strings); // call the IEnumerable<string> overload
-            }
-
             using (IEnumerator<T> en = values.GetEnumerator())
             {
                 if (!en.MoveNext())
@@ -3442,15 +3433,6 @@ namespace System {
                 throw new ArgumentNullException("values");
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
-
-            // This can be called with T == string if someone
-            // has a GenericMethod<T> which calls here, and
-            // then someone calls that with string
-            if (typeof(T) == typeof(string))
-            {
-                var strings = values as IEnumerable<string>;
-                return Concat(strings); // call the IEnumerable<string> overload
-            }
 
             using (IEnumerator<T> en = values.GetEnumerator())
             {

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -106,7 +106,7 @@ namespace System {
                     result.Append(value.ToString());
                 }
             }
-            
+
             return StringBuilderCache.GetStringAndRelease(result);
         }
 
@@ -169,8 +169,6 @@ namespace System {
                 return StringBuilderCache.GetStringAndRelease(result);
             }
         }
-
-
 
         [ComVisible(false)]
         public static String Join(String separator, IEnumerable<String> values) {
@@ -3461,19 +3459,36 @@ namespace System {
 
 
         [ComVisible(false)]
-        public static String Concat(IEnumerable<String> values) {
+        public static string Concat(IEnumerable<string> values)
+        {
             if (values == null)
                 throw new ArgumentNullException("values");
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
-            StringBuilder result = StringBuilderCache.Acquire();
-            using(IEnumerator<String> en = values.GetEnumerator()) {
-                while (en.MoveNext()) {
-                     result.Append(en.Current);
-                }            
+            using (IEnumerator<string> en = values.GetEnumerator())
+            {
+                if (!en.MoveNext())
+                    return string.Empty;
+                
+                string firstValue = en.Current;
+
+                if (!en.MoveNext())
+                {
+                    return firstValue ?? string.Empty;
+                }
+
+                StringBuilder result = StringBuilderCache.Acquire();
+                result.Append(firstValue);
+
+                do
+                {
+                    result.Append(en.Current);
+                }
+                while (en.MoveNext());
+
+                return StringBuilderCache.GetStringAndRelease(result);
             }
-            return StringBuilderCache.GetStringAndRelease(result);            
         }
 
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -78,24 +78,35 @@ namespace System {
         }
 
         [ComVisible(false)]
-        public static String Join(String separator, params Object[] values) {
-            if (values==null)
+        public static string Join(string separator, params object[] values)
+        {
+            if (values == null)
                 throw new ArgumentNullException("values");
             Contract.EndContractBlock();
 
             if (values.Length == 0 || values[0] == null)
-                return String.Empty;
+                return string.Empty;
+
+            string firstString = values[0].ToString();
+
+            if (values.Length == 1)
+            {
+                return firstString ?? string.Empty;
+            }
 
             StringBuilder result = StringBuilderCache.Acquire();
+            result.Append(firstString);
 
-            result.Append(values[0].ToString());
-
-            for (int i = 1; i < values.Length; i++) {
+            for (int i = 1; i < values.Length; i++)
+            {
                 result.Append(separator);
-                if (values[i] != null) {
-                    result.Append(values[i].ToString());
+                object value = values[i];
+                if (value != null)
+                {
+                    result.Append(value.ToString());
                 }
             }
+            
             return StringBuilderCache.GetStringAndRelease(result);
         }
 


### PR DESCRIPTION
Changes:

- We call the `IEnumerable<string>` based overload in the generic overloads, if `typeof(T) == typeof(string)`. This can happen practically if someone has a `GenericMethod<T>` that calls Concat/Join, and then someone calls that method with T == string.

- Optimize more Join/Concat overloads for length 0-and-1 collections by not allocating anything.

- Cleanup some of the code.

cc @jkotas, @bbowyersmyth 

Tests are dotnet/corefx#10966