### PR TITLE
Replace uses of Dictionary.FindEntry with TryGetValue

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -192,12 +192,16 @@ namespace System.Collections.Generic {
             }
         }
 
-        public TValue this[TKey key] {
-            get {
-                int i = FindEntry(key);
-                if (i >= 0) return entries[i].value;
-                ThrowHelper.ThrowKeyNotFoundException();
-                return default(TValue);
+        public TValue this[TKey key]
+        {
+            get
+            {
+                TValue result;
+                if (!TryGetValue(key, out result))
+                {
+                    ThrowHelper.ThrowKeyNotFoundException();
+                }
+                return result;
             }
             set {
                 Insert(key, value, false);
@@ -212,17 +216,16 @@ namespace System.Collections.Generic {
             Add(keyValuePair.Key, keyValuePair.Value);
         }
 
-        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) {
-            int i = FindEntry(keyValuePair.Key);
-            if( i >= 0 && EqualityComparer<TValue>.Default.Equals(entries[i].value, keyValuePair.Value)) {
-                return true;
-            }
-            return false;
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            TValue value;
+            return TryGetValue(keyValuePair.Key, out value) && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value);
         }
 
-        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) {
-            int i = FindEntry(keyValuePair.Key);
-            if( i >= 0 && EqualityComparer<TValue>.Default.Equals(entries[i].value, keyValuePair.Value)) {
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            if (TryGetValue(keyValuePair.Key, out value) && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
+            {
                 Remove(keyValuePair.Key);
                 return true;
             }
@@ -240,8 +243,10 @@ namespace System.Collections.Generic {
             }
         }
 
-        public bool ContainsKey(TKey key) {
-            return FindEntry(key) >= 0;
+        public bool ContainsKey(TKey key)
+        {
+            TValue unused;
+            return TryGetValue(key, out unused);
         }
 
         public bool ContainsValue(TValue value) {
@@ -308,20 +313,6 @@ namespace System.Collections.Generic {
                 CopyTo(array, 0);
                 info.AddValue(KeyValuePairsName, array, typeof(KeyValuePair<TKey, TValue>[]));
             }
-        }
-
-        private int FindEntry(TKey key) {
-            if( key == null) {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
-            }
-
-            if (buckets != null) {
-                int hashCode = comparer.GetHashCode(key) & 0x7FFFFFFF;
-                for (int i = buckets[hashCode % buckets.Length]; i >= 0; i = entries[i].next) {
-                    if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key)) return i;
-                }
-            }
-            return -1;
         }
 
         private void Initialize(int capacity) {
@@ -515,12 +506,26 @@ namespace System.Collections.Generic {
             return false;
         }
 
-        public bool TryGetValue(TKey key, out TValue value) {
-            int i = FindEntry(key);
-            if (i >= 0) {
-                value = entries[i].value;
-                return true;
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            if (key == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
+
+            if (buckets != null)
+            {
+                int hashCode = comparer.GetHashCode(key) & 0x7FFFFFFF;
+                for (int i = buckets[hashCode % buckets.Length]; i >= 0; i = entries[i].next)
+                {
+                    if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
+                    {
+                        value = entries[i].value;
+                        return true;
+                    }
+                }
+            }
+
             value = default(TValue);
             return false;
         }
@@ -529,12 +534,11 @@ namespace System.Collections.Generic {
         // Many were combining key doesn't exist and key exists but null value (for non-value types) checks.
         // This allows them to continue getting that behavior with minimal code delta. This is basically
         // TryGetValue without the out param
-        internal TValue GetValueOrDefault(TKey key) {
-            int i = FindEntry(key);
-            if (i >= 0) {
-                return entries[i].value;
-            }
-            return default(TValue);
+        internal TValue GetValueOrDefault(TKey key)
+        {
+            TValue result;
+            TryGetValue(key, out result);
+            return result;
         }
 
         bool ICollection<KeyValuePair<TKey,TValue>>.IsReadOnly {
@@ -633,14 +637,18 @@ namespace System.Collections.Generic {
             get { return (ICollection)Values; }
         }
     
-        object IDictionary.this[object key] {
-            get { 
-                if( IsCompatibleKey(key)) {                
-                    int i = FindEntry((TKey)key);
-                    if (i >= 0) { 
-                        return entries[i].value;                
+        object IDictionary.this[object key]
+        {
+            get
+            {
+                if (IsCompatibleKey(key))
+                {
+                    TValue result;
+                    if (TryGetValue((TKey)key, out result))
+                    {
+                        return result;
                     }
-                }
+                } 
                 return null;
             }
             set {                 

--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -224,6 +224,7 @@ namespace System.Collections.Generic {
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
         {
+            TValue value;
             if (TryGetValue(keyValuePair.Key, out value) && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
             {
                 Remove(keyValuePair.Key);


### PR DESCRIPTION
Currently, there is a method `FindEntry` in `Dictionary`. It returns the index of the given key's entry in the dictionary's `entries` field, returning -1 if not found. At all of its call sites (including `TryGetValue` and the indexer), it's being used like this:

```cs
int i = FindEntry(key);
if (i >= 0)
{
    TValue value = entries[i].value;
}
```

This has the downside that since the JIT doesn't know anything about the properties of i, it needs to generate a range check when accessing the array, which bloats the callers enough so that they're not inlined. As a result, every time someone calls `get_Item` or `TryGetValue`, there are 2 method calls: 1 to the method itself (since it's not inlined due to this range check), and 1 to `FindEntry`.

This change eliminates `FindEntry` entirely, replacing all such usages with `TryGetValue`. This has the effect of making the code more readable, and reducing code bloat. As for `TryGetValue` itself, all of the hashing/entry-searching code is now written inline in there so there is only 1 method call.

## Performance impact

There is about a 4.5% improvement from ~1.10s to ~1.05s, assuming `int` is the key type and there are no collisions. ([source code](https://gist.github.com/jamesqo/d5504834a17a5f18818a80e038332897)) I know the difference is small, but it's still there and IMO the new code is cleaner/higher-level.

The reason the difference is so small is presumably due to all of the other stuff going on in the method; there are at least 2 interface calls to `comparer.GetHashCode` and `comparer.Equals`, not to mention the % operator being used on the hashcode which is quite slow. With a `string` key the difference becomes almost immeasurable since the randomized string hashing takes almost as long as the dictionary lookup itself.

I examined the assembly for ContainsKey, the indexer (get_Item), and TryGetValue and made sure all of them were jitted to calls to TryGetValue. I also tested the first 2 and made sure there were no regressions.

cc @jkotas, @benaadams, @omariom, @GSPP, @mikedn 