### PR TITLE
Added constructor to System.Version

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -8146,6 +8146,7 @@
       <Member Name="#ctor(System.Int32,System.Int32,System.Int32)" />
       <Member Name="#ctor(System.Int32,System.Int32,System.Int32,System.Int32)" />
       <Member Name="#ctor(System.String)" />
+      <Member Name="#ctor" />
       <Member Name="Clone" />
       <Member Name="CompareTo(System.Object)" />
       <Member Name="CompareTo(System.Version)" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -3904,6 +3904,7 @@ namespace System
         public Version(int major, int minor, int build) { }
         public Version(int major, int minor, int build, int revision) { }
         public Version(string version) { }
+        public Version() { }
         public int Build { get { throw null; } }
         public int Major { get { throw null; } }
         public short MajorRevision { get { throw null; } }


### PR DESCRIPTION
For [corefx #10998](https://github.com/dotnet/corefx/issues/10998), added `M:System.Version.#ctor`