### PR TITLE
Fix dstCount of GT_RETURNTRAP for Arm64

### DIFF
--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -342,7 +342,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             // this just turns into a compare of its child with an int
             // + a conditional call
             info->srcCount = 1;
-            info->dstCount = 1;
+            info->dstCount = 0;
             break;
 
         case GT_MOD:


### PR DESCRIPTION
GT_RETURNTRAP doesn't generate a result so its dstCount needs to be 0.