### PR TITLE
Expose new methods in System.Activator

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -66,9 +66,12 @@
     </Type>
     <Type Name="System.Activator">
       <Member Name="CreateInstance(System.Type)" />
+      <Member Name="CreateInstance(System.Type,System.Boolean)" />
       <Member Name="CreateInstance(System.Type,System.Object[])" />
+      <Member Name="CreateInstance(System.Type,System.Object[],System.Object[])" />
+      <Member Name="CreateInstance(System.Type,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)" />
+      <Member Name="CreateInstance(System.Type,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[])" />
       <Member Name="CreateInstance&lt;T&gt;" />
-      <Member Name="CreateInstance(System.Type,System.Boolean)"/>
     </Type>
     <Type Name="System.AppDomain">
       <Member Name="get_CurrentDomain" />


### PR DESCRIPTION
Below two methods were excluded as they are related to remoting which is not fully supported in coreclr
public static object GetObject(System.Type type, string url) { return default(object); } 
public static object GetObject(System.Type type, string url, object state) { return default(object); } 
