### PR TITLE
Assert that any node with a non-zero dstCount produces a value.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -14809,6 +14809,7 @@ bool GenTree::isContained() const
         case GT_STOREIND:
         case GT_JTRUE:
         case GT_RETURN:
+        case GT_RETFILT:
         case GT_STORE_LCL_FLD:
         case GT_STORE_LCL_VAR:
         case GT_ARR_BOUNDS_CHECK:
@@ -14857,13 +14858,6 @@ bool GenTree::isContained() const
             //
             assert(gtType == TYP_VOID);
             return false;
-        case GT_RETFILT:
-            if (gtType == TYP_VOID)
-            {
-                return false; // endfinally case
-            }
-
-            __fallthrough;
 
         default:
             // if it's contained it better have a parent

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3685,6 +3685,9 @@ void Lowering::DoPhase()
         {
             TreeNodeInfoInit(node);
 
+            // Only nodes that produce values should have a non-zero dstCount.
+            assert((node->gtLsraInfo.dstCount == 0) || node->IsValue());
+
             // If the node produces an unused value, mark it as a local def-use
             if ((node->gtLIRFlags & LIR::Flags::IsUnusedValue) != 0)
             {

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -250,7 +250,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 assert(tree->TypeGet() == TYP_INT);
 
                 info->srcCount = 1;
-                info->dstCount = 1;
+                info->dstCount = 0;
 
                 info->setSrcCandidates(l, RBM_INTRET);
                 tree->gtOp.gtOp1->gtLsraInfo.setSrcCandidates(l, RBM_INTRET);

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -276,7 +276,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 assert(tree->TypeGet() == TYP_INT);
 
                 info->srcCount = 1;
-                info->dstCount = 1;
+                info->dstCount = 0;
 
                 info->setSrcCandidates(l, RBM_INTRET);
                 tree->gtOp.gtOp1->gtLsraInfo.setSrcCandidates(l, RBM_INTRET);


### PR DESCRIPTION
The register allocator will otherwise misallocate, as such nodes will
produce an unconsumed value.