### PR TITLE
Fix Concat(object) bug returning null, if arg0.ToString() is null

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -3279,9 +3279,18 @@ namespace System {
 
             if (arg0 == null)
             {
-                return String.Empty;
+                arg0 = string.Empty;
             }
+
+#if !FEATURE_CORECLR
+            // 'Bug' in the framework: we were inconsistent with other
+            // Concat() overloads, and returned null if ToString() was null.
+            // Other overloads would substitute string.Empty for null values.
             return arg0.ToString();
+#else // !FEATURE_CORECLR
+
+            return arg0.ToString() ?? string.Empty;
+#endif // !FEATURE_CORECLR
         }
     
         public static String Concat(Object arg0, Object arg1) {


### PR DESCRIPTION
Currently `string.Concat(null)` returns "", but `string.Concat(new ObjectWithNullToString())` returns null. This behavior seems rather unintuitive, and is mentioned [nowhere](https://msdn.microsoft.com/en-us/library/khca9w90(v=vs.110).aspx) in the MSDN docs.

This PR fixes it for `FEATURE_CORECLR`, and adds a comment explaining the ifdef.

cc @jkotas