### PR TITLE
[ARM/Linux] avoid inlining: struct type return method

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17565,6 +17565,14 @@ void Compiler::impMarkInlineCandidate(GenTreePtr             callNode,
     GenTreeCall* call = callNode->AsCall();
     InlineResult inlineResult(this, call, nullptr, "impMarkInlineCandidate");
 
+#ifdef _TARGET_ARM_
+    // When inlining methods that return type is struct, 
+    // legacy JIT for ARM fails to assign correct value for struct return
+    if (call->gtReturnType == TYP_STRUCT) {
+        return;
+    }
+#endif
+
     // Don't inline if not optimizing root method
     if (opts.compDbgCode)
     {


### PR DESCRIPTION
related issue: #6567
ARM32: avoid method inlining when callee method's return type is struct