### PR TITLE
Reenable superpmi test for x86

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -247,7 +247,7 @@
              <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Roslyn\CscBench\CscBench.cmd">
-             <Issue>needs triage</Issue>
+             <Issue>6844</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b103058\b103058\b103058.cmd">
              <Issue>needs triage</Issue>
@@ -397,9 +397,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\superlong\_il_relsuperlong\_il_relsuperlong.cmd">
              <Issue>6778</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\superpmi\superpmicollect\superpmicollect.cmd">
-             <Issue>6830</Issue>
         </ExcludeList>
     </ItemGroup>
     

--- a/tests/src/JIT/superpmi/superpmicollect.cs
+++ b/tests/src/JIT/superpmi/superpmicollect.cs
@@ -259,9 +259,13 @@ namespace SuperPMICollection
             // is changed.
             //
             // TODO: this should probably be loaded dynamically from a .json/.xml file.
+            //
+            // Note: We previously used
+            //      JIT\Performance\CodeQuality\Roslyn\CscBench\CscBench.cmd
+            // but it doesn't currently run on x86 due to this issue: https://github.com/dotnet/coreclr/issues/6844.
             string[] SuperPMICollectionTestProgramsList =
             {
-                @"JIT\Performance\CodeQuality\Roslyn\CscBench\CscBench.cmd",
+                @"JIT\Performance\CodeQuality\Bytemark\Bytemark\Bytemark.cmd",
                 @"JIT\Methodical\fp\exgen\10w5d_cs_do\10w5d_cs_do.cmd",
                 @"JIT\Generics\Coverage\chaos65204782cs\chaos65204782cs.cmd"
             };

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -284,7 +284,7 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Roslyn\CscBench\CscBench.cmd">
-      <Issue>needs triage</Issue>
+      <Issue>6844</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\delegate\_simpleoddpower_il_r\_simpleoddpower_il_r.cmd">
       <Issue>needs triage</Issue>
@@ -369,9 +369,6 @@
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\baseservices\threading\waithandle\waitall\waitallex8a\*">
       <Issue>3832</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\superpmi\superpmicollect\superpmicollect.cmd">
-         <Issue>6830</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\smallFrame\smallFrame.cmd">
       <Issue>tail. call pop ret is only supported on amd64</Issue>


### PR DESCRIPTION
Replace Roslyn CscBench with Bytemark, since CscBench fails with
an inlining assert (opened as issue #6844) on x86.