### PR TITLE
Use the "open" key for strong-name signing SOS.NETCore.dll.

### DIFF
--- a/src/ToolBox/SOS/NETCore/SOS.NETCore.csproj
+++ b/src/ToolBox/SOS/NETCore/SOS.NETCore.csproj
@@ -11,6 +11,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <NoStdLib>true</NoStdLib>
     <NoCompilerStandardLib>true</NoCompilerStandardLib>
+    <UseOpenKey Condition="'$(UseOpenKey)'==''">true</UseOpenKey>
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the options -->


### PR DESCRIPTION
Switch to using the OSS strong name instead of the default MSFT one.