### PR TITLE
Stop maintaining cost estimates in the RyuJIT backend.

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -174,8 +174,6 @@ void CodeGen::genCodeForBBlist()
 
 #ifdef DEBUG
     genInterruptibleUsed = true;
-    unsigned totalCostEx = 0;
-    unsigned totalCostSz = 0;
 
     // You have to be careful if you create basic blocks from now on
     compiler->fgSafeBasicBlockCreation = false;
@@ -515,14 +513,6 @@ void CodeGen::genCodeForBBlist()
                     }
                 }
             }
-
-            // TODO-LIR: the cost accounting performed below is incorrect: each operator's cost includes the
-            //           cost of its operands, so the total cost of the block is grossly overestimated. Fixing
-            //           this requires the ability to calculate the cost of the operator itself.
-            //
-            // totalCostEx += (UINT64)node->gtCostEx * block->getBBWeight(compiler);
-            // totalCostSz += (UINT64)node->gtCostSz;
-
 #endif // DEBUG
 
             genCodeForTreeNode(node);
@@ -859,7 +849,7 @@ void CodeGen::genCodeForBBlist()
     if (compiler->verbose)
     {
         printf("\n# ");
-        printf("totalCostEx = %6d, totalCostSz = %5d ", totalCostEx, totalCostSz);
+        printf("compCycleEstimate = %6d, compSizeEstimate = %5d ", compiler->compCycleEstimate, compiler->compSizeEstimate);
         printf("%s\n", compiler->info.compFullName);
     }
 #endif

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1419,8 +1419,6 @@ void CodeGen::genCodeForBBlist()
 
 #ifdef DEBUG
     genInterruptibleUsed = true;
-    UINT64 totalCostEx   = 0;
-    UINT64 totalCostSz   = 0;
 
     // You have to be careful if you create basic blocks from now on
     compiler->fgSafeBasicBlockCreation = false;
@@ -1741,14 +1739,6 @@ void CodeGen::genCodeForBBlist()
                     }
                 }
             }
-
-            // TODO-LIR: the cost accounting performed below is incorrect: each operator's cost includes the
-            //           cost of its operands, so the total cost of the block is grossly overestimated. Fixing
-            //           this requires the ability to calculate the cost of the operator itself.
-            //
-            // totalCostEx += (UINT64)node->gtCostEx * block->getBBWeight(compiler);
-            // totalCostSz += (UINT64)node->gtCostSz;
-
 #endif // DEBUG
 
             genCodeForTreeNode(node);
@@ -2077,7 +2067,7 @@ void CodeGen::genCodeForBBlist()
     if (compiler->verbose)
     {
         printf("\n# ");
-        printf("totalCostEx = %6d, totalCostSz = %5d ", totalCostEx, totalCostSz);
+        printf("compCycleEstimate = %6d, compSizeEstimate = %5d ", compiler->compCycleEstimate, compiler->compSizeEstimate);
         printf("%s\n", compiler->info.compFullName);
     }
 #endif

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -331,9 +331,6 @@ void CodeGen::genCodeForBBlist()
 
 #ifdef DEBUG
     genInterruptibleUsed = true;
-    unsigned stmtNum     = 0;
-    UINT64   totalCostEx = 0;
-    UINT64   totalCostSz = 0;
 
     // You have to be careful if you create basic blocks from now on
     compiler->fgSafeBasicBlockCreation = false;
@@ -663,14 +660,6 @@ void CodeGen::genCodeForBBlist()
                     }
                 }
             }
-
-            // TODO-LIR: the cost accounting performed below is incorrect: each operator's cost includes the
-            //           cost of its operands, so the total cost of the block is grossly overestimated. Fixing
-            //           this requires the ability to calculate the cost of the operator itself.
-            //
-            // totalCostEx += (UINT64)node->gtCostEx * block->getBBWeight(compiler);
-            // totalCostSz += (UINT64)node->gtCostSz;
-
 #endif // DEBUG
 
             genCodeForTreeNode(node);
@@ -1106,7 +1095,7 @@ void CodeGen::genCodeForBBlist()
     if (compiler->verbose)
     {
         printf("\n# ");
-        printf("totalCostEx = %6d, totalCostSz = %5d ", totalCostEx, totalCostSz);
+        printf("compCycleEstimate = %6d, compSizeEstimate = %5d ", compiler->compCycleEstimate, compiler->compSizeEstimate);
         printf("%s\n", compiler->info.compFullName);
     }
 #endif

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4424,6 +4424,18 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, CORJIT_F
 
 #ifdef DEBUG
     fgDebugCheckLinks(compStressCompile(STRESS_REMORPH_TREES, 50));
+
+    // Stash the current estimate of the function's size.
+    compSizeEstimate = 0;
+    compCycleEstimate = 0;
+    for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
+    {
+        for (GenTreeStmt* statement = block->firstStmt(); statement != nullptr; statement = statement->getNextStmt())
+        {
+            compSizeEstimate += statement->GetCostSz();
+            compCycleEstimate += statement->GetCostEx();
+        }
+    }
 #endif
 
 #ifndef LEGACY_BACKEND

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4425,15 +4425,18 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, CORJIT_F
 #ifdef DEBUG
     fgDebugCheckLinks(compStressCompile(STRESS_REMORPH_TREES, 50));
 
-    // Stash the current estimate of the function's size.
-    compSizeEstimate = 0;
-    compCycleEstimate = 0;
-    for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
+    // Stash the current estimate of the function's size if necessary.
+    if (verbose)
     {
-        for (GenTreeStmt* statement = block->firstStmt(); statement != nullptr; statement = statement->getNextStmt())
+        compSizeEstimate = 0;
+        compCycleEstimate = 0;
+        for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
         {
-            compSizeEstimate += statement->GetCostSz();
-            compCycleEstimate += statement->GetCostEx();
+            for (GenTreeStmt* statement = block->firstStmt(); statement != nullptr; statement = statement->getNextStmt())
+            {
+                compSizeEstimate += statement->GetCostSz();
+                compCycleEstimate += statement->GetCostEx();
+            }
         }
     }
 #endif

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7336,6 +7336,8 @@ public:
     bool    compCodeGenDone;
     int64_t compNumStatementLinksTraversed; // # of links traversed while doing debug checks
     bool    fgNormalizeEHDone;              // Has the flowgraph EH normalization phase been done?
+    size_t  compSizeEstimate;               // The estimated size of the method as per `gtSetEvalOrder`.
+    size_t  compCycleEstimate;              // The estimated cycle count of the method as per `gtSetEvalOrder`
 #endif                                      // DEBUG
 
     bool fgLocalVarLivenessDone; // Note that this one is used outside of debug.

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -707,8 +707,6 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
     storeIndHigh->gtFlags = (storeIndLow->gtFlags & (GTF_ALL_EFFECT | GTF_LIVENESS_MASK));
     storeIndHigh->gtFlags |= GTF_REVERSE_OPS;
 
-    m_compiler->gtPrepareCost(storeIndHigh);
-
     BlockRange().InsertAfter(storeIndLow, dataHigh, addrBaseHigh, addrHigh, storeIndHigh);
 
     return storeIndHigh;
@@ -784,8 +782,6 @@ GenTree* DecomposeLongs::DecomposeInd(LIR::Use& use)
     GenTreePtr addrHigh =
         new (m_compiler, GT_LEA) GenTreeAddrMode(TYP_REF, addrBaseHigh, nullptr, 0, genTypeSize(TYP_INT));
     GenTreePtr indHigh = new (m_compiler, GT_IND) GenTreeIndir(GT_IND, TYP_INT, addrHigh, nullptr);
-
-    m_compiler->gtPrepareCost(indHigh);
 
     BlockRange().InsertAfter(indLow, addrBaseHigh, addrHigh, indHigh);
 
@@ -865,9 +861,6 @@ GenTree* DecomposeLongs::DecomposeNeg(LIR::Use& use)
     GenTree* hiAdjust = m_compiler->gtNewOperNode(GT_ADD_HI, TYP_INT, hiOp1, zero);
     GenTree* hiResult = m_compiler->gtNewOperNode(GT_NEG, TYP_INT, hiAdjust);
     hiResult->gtFlags = tree->gtFlags;
-
-    // Annotate new nodes with costs. This will re-cost the hiOp1 tree as well.
-    m_compiler->gtPrepareCost(hiResult);
 
     BlockRange().InsertAfter(loResult, zero, hiAdjust, hiResult);
 

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -316,7 +316,6 @@ GenTree* DecomposeLongs::DecomposeLclVar(LIR::Use& use)
     loResult->gtType  = TYP_INT;
 
     GenTree* hiResult = m_compiler->gtNewLclLNode(varNum, TYP_INT);
-    hiResult->CopyCosts(loResult);
     BlockRange().InsertAfter(loResult, hiResult);
 
     if (varDsc->lvPromoted)
@@ -365,7 +364,6 @@ GenTree* DecomposeLongs::DecomposeLclFld(LIR::Use& use)
     loResult->gtType        = TYP_INT;
 
     GenTree* hiResult = m_compiler->gtNewLclFldNode(loResult->gtLclNum, TYP_INT, loResult->gtLclOffs + 4);
-    hiResult->CopyCosts(loResult);
     BlockRange().InsertAfter(loResult, hiResult);
 
     return FinalizeDecomposition(use, loResult, hiResult);
@@ -439,7 +437,6 @@ GenTree* DecomposeLongs::DecomposeStoreLclVar(LIR::Use& use)
     m_compiler->lvaIncRefCnts(tree);
     m_compiler->lvaIncRefCnts(hiStore);
 
-    hiStore->CopyCosts(tree);
     BlockRange().InsertAfter(tree, hiStore);
 
     return hiStore->gtNext;
@@ -474,7 +471,6 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
                 BlockRange().Remove(tree);
 
                 hiResult = new (m_compiler, GT_CNS_INT) GenTreeIntCon(TYP_INT, 0);
-                hiResult->CopyCosts(loResult);
                 BlockRange().InsertAfter(loResult, hiResult);
             }
             else
@@ -513,7 +509,6 @@ GenTree* DecomposeLongs::DecomposeCnsLng(LIR::Use& use)
     loResult->gtType = TYP_INT;
 
     GenTree* hiResult = new (m_compiler, GT_CNS_INT) GenTreeIntCon(TYP_INT, hiVal);
-    hiResult->CopyCosts(loResult);
     BlockRange().InsertAfter(loResult, hiResult);
 
     return FinalizeDecomposition(use, loResult, hiResult);
@@ -824,7 +819,6 @@ GenTree* DecomposeLongs::DecomposeNot(LIR::Use& use)
     loResult->gtOp.gtOp1 = loOp1;
 
     GenTree* hiResult = new (m_compiler, GT_NOT) GenTreeOp(GT_NOT, TYP_INT, hiOp1, nullptr);
-    hiResult->CopyCosts(loResult);
     BlockRange().InsertAfter(loResult, hiResult);
 
     return FinalizeDecomposition(use, loResult, hiResult);
@@ -940,7 +934,6 @@ GenTree* DecomposeLongs::DecomposeArith(LIR::Use& use)
     loResult->gtOp.gtOp2 = loOp2;
 
     GenTree* hiResult = new (m_compiler, oper) GenTreeOp(GetHiOper(oper), TYP_INT, hiOp1, hiOp2);
-    hiResult->CopyCosts(loResult);
     BlockRange().InsertAfter(loResult, hiResult);
 
     if ((oper == GT_ADD) || (oper == GT_SUB))

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -268,11 +268,9 @@ unsigned LIR::Use::ReplaceWithLclVar(Compiler* compiler, unsigned blockWeight, u
     compiler->lvaTable[lclNum].incRefCnts(blockWeight, compiler);
 
     GenTreeLclVar* store = compiler->gtNewTempAssign(lclNum, node)->AsLclVar();
-    store->CopyCosts(node);
 
     GenTree* load =
         new (compiler, GT_LCL_VAR) GenTreeLclVar(store->TypeGet(), store->AsLclVarCommon()->GetLclNum(), BAD_IL_OFFSET);
-    compiler->gtPrepareCost(load);
 
     m_range->InsertAfter(node, store, load);
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3493,10 +3493,6 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     GenTreePtr leaNode = new (comp, GT_LEA) GenTreeAddrMode(arrElem->TypeGet(), leaBase, leaIndexNode, scale, offset);
     leaNode->gtFlags |= GTF_REVERSE_OPS;
 
-    // Set the costs for all of the new nodes. Depends on the new nodes all participating in the
-    // dataflow tree rooted at `leaNode`.
-    comp->gtPrepareCost(leaNode);
-
     BlockRange().InsertBefore(insertionPoint, leaNode);
 
     LIR::Use arrElemUse;

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -830,9 +830,6 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
                                                                 info->structDesc.eightByteSizes[ctr]),
                         argListPtr->gtOp.gtOp1);
 
-                    // CopyCosts
-                    newOper->CopyCosts(argListPtr->gtOp.gtOp1);
-
                     // Splice in the new GT_PUTARG_REG node in the GT_LIST
                     ReplaceArgWithPutArgOrCopy(&argListPtr->gtOp.gtOp1, newOper);
                 }
@@ -862,9 +859,6 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
 
                 // Create a new GT_PUTARG_REG node with op1
                 GenTreePtr newOper = comp->gtNewOperNode(GT_PUTARG_REG, curTyp, curOp);
-
-                // CopyCosts
-                newOper->CopyCosts(argListPtr->gtOp.gtOp1);
 
                 // Splice in the new GT_PUTARG_REG node in the GT_LIST
                 ReplaceArgWithPutArgOrCopy(&argListPtr->gtOp.gtOp1, newOper);
@@ -931,8 +925,6 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
         }
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
     }
-
-    putArg->CopyCosts(arg);
 
     if (arg->InReg())
     {
@@ -1052,7 +1044,6 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
             var_types  intType = (type == TYP_DOUBLE) ? TYP_LONG : TYP_INT;
             GenTreePtr intArg  = comp->gtNewOperNode(GT_COPY, intType, arg);
 
-            intArg->CopyCosts(arg);
             info->node = intArg;
             ReplaceArgWithPutArgOrCopy(ppArg, intArg);
 
@@ -2068,7 +2059,6 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
         GenTreeAddrMode(TYP_REF, originalThisExpr, nullptr, 0, comp->eeGetEEInfo()->offsetOfDelegateInstance);
 
     GenTree* newThis = comp->gtNewOperNode(GT_IND, TYP_REF, newThisAddr);
-    newThis->SetCosts(IND_COST_EX, 2);
 
     BlockRange().InsertAfter(originalThisExpr, newThisAddr, newThis);
 
@@ -3078,7 +3068,6 @@ GenTree* Lowering::TryCreateAddrMode(LIR::Use&& use, bool isIndir)
 
     GenTreeAddrMode* addrMode = new (comp, GT_LEA) GenTreeAddrMode(addrModeType, base, index, scale, offset);
 
-    addrMode->CopyCosts(addr);
     addrMode->gtRsvdRegs = addr->gtRsvdRegs;
     addrMode->gtFlags |= (addr->gtFlags & (GTF_ALL_EFFECT | GTF_IND_FLAGS));
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7601,7 +7601,6 @@ void LinearScan::insertCopyOrReload(BasicBlock* block, GenTreePtr tree, unsigned
 
         GenTreeCopyOrReload* newNode = new (compiler, oper) GenTreeCopyOrReload(oper, treeType, tree);
         assert(refPosition->registerAssignment != RBM_NONE);
-        newNode->CopyCosts(tree);
         newNode->SetRegNumByIdx(refPosition->assignedReg(), multiRegIdx);
         newNode->gtLsraInfo.isLsraAdded   = true;
         newNode->gtLsraInfo.isLocalDefUse = false;


### PR DESCRIPTION
The backend does not use the tree cost estimates.

Because it can be useful to double-check the estimates as made using the HIR
for a function against that function's actual emitted size, stash the cost estimates
before converting the function to LIR and report them at the end of compilation.