### PR TITLE
Fixed miss casting void * value in IntPtr::ToInt64()

### DIFF
--- a/src/mscorlib/src/System/IntPtr.cs
+++ b/src/mscorlib/src/System/IntPtr.cs
@@ -138,7 +138,7 @@ namespace System {
 #if BIT64
                 return (long)m_value;
 #else // !BIT64 (32)
-                return (long)(int)m_value;
+                return (long)(uint)m_value;
 #endif
         }
 


### PR DESCRIPTION
The long value can use the signed bit to express a big number in 32bit machine.
Just because the long value uses the signed bit, it doesn't mean that the
value is a negative. So ToInt64() function should return the original value
without changing.

==========================================================
This issue is related to  System.Diagnostics.Tests.ProcessModuleTests.TestModuleProperties  TC in CoreFX.
In 32bit machine, the address can use the all 32bit including the signed bit(the 31th bit).
But this value currently is interpreted in negative value while converting long to void * because the signed bit is true.

Here is the example code:
```
            long val = 2891657216;                                              
            unsafe {                                                               
                IntPtr val2 = new IntPtr((void *)val);                          
                Console.WriteLine("val {0} val2.ToInt64 {1}", val, val2.ToInt64());
            }  
```
And results:
```
val 2891657216 val2.ToInt64 -1403310080
```
2891657216 = AC5B3000
-1403310080 = FFFFFFFFAC5B3000

Just because the long value uses the signed bit in 32bit machine, it doesn't mean that the value is a negative. So ToInt64() function should return the original value without changing.

After applying this patch, the result is like below:
```
val 2891657216 val2.ToInt64 2891657216
```

Fix #6854 