### PR TITLE
Fix ConfigureOnly option in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -196,6 +196,11 @@ build_coreclr()
 
     # Build CoreCLR
 
+    if [ $__ConfigureOnly == 1 ]; then
+        echo "Skipping CoreCLR build."
+        return
+    fi
+
     echo "Executing $buildTool install -j $NumProc"
 
     $buildTool install -j $NumProc
@@ -537,8 +542,8 @@ while :; do
 
         configureonly)
             __ConfigureOnly=1
-            __SkipCoreCLR=1
             __SkipMSCorLib=1
+            __SkipNuget=1
             __IncludeTests=
             ;;
 


### PR DESCRIPTION
ConfigureOnly is intended to run the CMake to configure the build, but
nothing else. However, when you passed configureonly to build.sh, it set
__SkipConfigure=1, which made it skip the configure step of the build.
This change fixes that by removing that option from the options set my
configureonly, and adds a check right after configure and right before
running the build to exit if we are only configuring.