### PR TITLE
Update build to optionally configure with nmake

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -101,6 +101,7 @@ if /i "%1" == "skipmscorlib"        (set __BuildCoreLib=0&set __BuildNativeCoreL
 if /i "%1" == "skipnative"          (set __BuildNative=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skiptests"           (set __BuildTests=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skipbuildpackages"   (set __BuildPackages=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "usenmakemakefiles"   (set __NMakeMakefiles=1&set __ConfigureOnly=1&set __BuildNative=1&set __BuildNativeCoreLib=0&set __BuildCoreLib=0&set __BuildTests=0&set __BuildPackages=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "buildjit32"          (set __BuildJit32="-DBUILD_JIT32=1"&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "toolset_dir"         (set __ToolsetDir=%2&set __PassThroughArgs=%__PassThroughArgs% %2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 
@@ -143,6 +144,7 @@ set __RunArgs=-BuildOS=%__BuildOS% -BuildType=%__BuildType% -BuildArch=%__BuildA
 :: Set the remaining variables based upon the determined build configuration
 set "__BinDir=%__RootBinDir%\Product\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__IntermediatesDir=%__RootBinDir%\obj\%__BuildOS%.%__BuildArch%.%__BuildType%"
+if "%__NMakeMakefiles%"=="1" (set "__IntermediatesDir=%__RootBinDir%\nmakeobj\%__BuildOS%.%__BuildArch%.%__BuildType%")
 set "__PackagesBinDir=%__BinDir%\.nuget"
 set "__TestRootDir=%__RootBinDir%\tests"
 set "__TestBinDir=%__TestRootDir%\%__BuildOS%.%__BuildArch%.%__BuildType%"

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include_directories("./jitstd")
 include_directories("../inc")

--- a/src/pal/tools/gen-buildsys-win.bat
+++ b/src/pal/tools/gen-buildsys-win.bat
@@ -24,6 +24,8 @@ if /i "%__Arch%" == "x64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
 if /i "%__Arch%" == "arm64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
 if /i "%__Arch%" == "arm" (set __CmakeGenerator=%__CmakeGenerator% ARM)
 
+if /i "%__NMakeMakefiles%" == "1" (set __CmakeGenerator=NMake Makefiles)
+
 :loop
 if [%4] == [] goto end_loop
 set __ExtraCmakeParams=%__ExtraCmakeParams% %4


### PR DESCRIPTION
For formatting, we want to be able to obtain the compile_commands.json
file so that we do not have to 1) do a full build of coreclr and 2)
generate it ourselves from the build log. This change modifies build.cmd
to take an option "usenmakemakefiles." This option will set
__NMakeMakefiles to 1, which is used by the gen-buildsys-win.bat script.
This option also sets all the same options as configureonly, as we cannot
do a full build using NMake Makefiles, and we only want to use this to
force CMake to generate a compile_commands.json file for the jit
directory, which it can do using NMake Makefiles, but not Visual Studio.
The update to gen-buildsys-win.bat checks the value of __NMakeMakefiles,
and if it is set to 1, it sets the CMake Generator to NMake Makefiles.