### PR TITLE
DateTimeFormat: Avoid intermediate char[] allocation

### DIFF
--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -1009,7 +1009,7 @@ namespace System {
                 case 'O':
                 case 's':
                 case 'u':            
-                    results = new String[] {Format(dateTime, new String(new char[] {format}), dtfi)};
+                    results = new String[] {Format(dateTime, new String(format, 1), dtfi)};
                     break;   
                 default:
                     throw new FormatException(Environment.GetResourceString("Format_InvalidString"));


### PR DESCRIPTION
An unnecessary intermediate `char[]` allocation can be avoided by calling `new string(c, 1)` instead of `new string(new char[] { c })`.