### PR TITLE
Module.Name: Avoid unnecessary char[] allocation

### DIFF
--- a/src/mscorlib/src/System/Reflection/Module.cs
+++ b/src/mscorlib/src/System/Reflection/Module.cs
@@ -1187,7 +1187,7 @@ namespace System.Reflection
                 if (i == -1)
                     return s;
 
-                return new String(s.ToCharArray(), i + 1, s.Length - i - 1);
+                return s.Substring(i + 1);
             }
         }
 


### PR DESCRIPTION
Instead of `new string(s.ToCharArray(), i + 1, s.Length - i - 1)`, use the simpler `string.Substring(i + 1)` to avoid the unnecessary intermediate `char[]` allocation.