### PR TITLE
Handle multi-reg PUTARG_STK nodes.

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1916,6 +1916,9 @@ class GenTreeUseEdgeIterator final
 #ifdef FEATURE_SIMD
     void MoveToNextSIMDUseEdge();
 #endif
+#if FEATURE_MULTIREG_ARGS
+    void MoveToNextPutArgStkUseEdge();
+#endif
 
 public:
     GenTreeUseEdgeIterator();

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -55528,7 +55528,7 @@ RelativePath=JIT\Performance\CodeQuality\Roslyn\CscBench\CscBench.cmd
 WorkingDir=JIT\Performance\CodeQuality\Roslyn\CscBench
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_6583;LONG_RUNNING
+Categories=Pri0;EXPECTED_FAIL;ISSUE_6893;LONG_RUNNING
 HostStyle=0
 [SciMark.cmd_8027]
 RelativePath=JIT\Performance\CodeQuality\SciMark\SciMark\SciMark.cmd
@@ -67652,7 +67652,7 @@ RelativePath=managed\Compilation\Compilation\Compilation.cmd
 WorkingDir=managed\Compilation\Compilation
 Expected=0
 MaxAllowedDurationSeconds=800
-Categories=Pri0;RT;EXPECTED_FAIL;ISSUE_6583;NATIVE_INTEROP;LONG_RUNNING
+Categories=Pri0;RT;EXPECTED_FAIL;ISSUE_6893;NATIVE_INTEROP;LONG_RUNNING
 HostStyle=0
 [generics.cmd_9787]
 RelativePath=readytorun\generics\generics.cmd


### PR DESCRIPTION
When FEATURE_MULTIREG_ARGS is true, a GT_PUTARG_STK node may have a
GT_LIST as a child if the child was originally a multi-reg argument.
Handle this case in `GenTreeUseEdgeIterator`.

Fixes #6583.