### PR TITLE
Fix local var ref counts in IND/STOREIND decomposition

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -707,6 +707,8 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
     storeIndHigh->gtFlags = (storeIndLow->gtFlags & (GTF_ALL_EFFECT | GTF_LIVENESS_MASK));
     storeIndHigh->gtFlags |= GTF_REVERSE_OPS;
 
+    m_compiler->lvaIncRefCnts(addrBaseHigh);
+
     BlockRange().InsertAfter(storeIndLow, dataHigh, addrBaseHigh, addrHigh, storeIndHigh);
 
     return storeIndHigh;
@@ -782,6 +784,8 @@ GenTree* DecomposeLongs::DecomposeInd(LIR::Use& use)
     GenTreePtr addrHigh =
         new (m_compiler, GT_LEA) GenTreeAddrMode(TYP_REF, addrBaseHigh, nullptr, 0, genTypeSize(TYP_INT));
     GenTreePtr indHigh = new (m_compiler, GT_IND) GenTreeIndir(GT_IND, TYP_INT, addrHigh, nullptr);
+
+    m_compiler->lvaIncRefCnts(addrBaseHigh);
 
     BlockRange().InsertAfter(indLow, addrBaseHigh, addrHigh, indHigh);
 

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -329,9 +329,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\mixed1_cs_do\mixed1_cs_do.cmd">
              <Issue>6097</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44410\b44410\b44410.cmd">
-             <Issue>6588</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\basics\loopEH\loopEH.cmd">
              <Issue>6778</Issue>
         </ExcludeList>


### PR DESCRIPTION
When creating new references to a local variable in long decomposition,
the variable reference count must be incremented.

Fixes #6588