### PR TITLE
Allow to use clang 3.9 in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -543,6 +543,11 @@ while :; do
             __ClangMinorVersion=8
             ;;
 
+        clang3.9)
+            __ClangMajorVersion=3
+            __ClangMinorVersion=9
+            ;;
+
         ninja)
             __UseNinja=1
             ;;


### PR DESCRIPTION
Can be found e.g. in Debian Sid.