### PR TITLE
Copy directly to the internal buffer in List.InsertRange

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -719,9 +719,7 @@ namespace System.Collections.Generic {
                         Array.Copy(_items, index+count, _items, index*2, _size-index);
                     }
                     else {
-                        T[] itemsToInsert = new T[count];
-                        c.CopyTo(itemsToInsert, 0);
-                        itemsToInsert.CopyTo(_items, index);                    
+                        c.CopyTo(_items, index);
                     }
                     _size += count;
                 }                


### PR DESCRIPTION
`List.InsertRange` currently allocates an intermediary array to copy the items into, then copies it into the List's buffer. This changes it to copy directly into the List's buffer.

I realize that this was probably intentionally done in case a bad `ICollection` implementation held on to the array in `CopyTo`. However, List is already mutable as-is, so the only thing this would let such an implementation do is modify the array's contents without changing `_version`.

@jkotas Do you think this is a change worth making? I understand it could cause problems with such a faulty implementation, but for other collections (esp. large ones) it seems worth it.

also cc'ing: @omariom @mikedn 