### PR TITLE
Remove NYI for helper calls with long return types

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -100,8 +100,6 @@ GenTreePtr Compiler::fgMorphIntoHelperCall(GenTreePtr tree, int helper, GenTreeA
         retTypeDesc->Reset();
         retTypeDesc->InitializeLongReturnType(this);
         callNode->ClearOtherRegs();
-
-        NYI("Helper with TYP_LONG return type");
     }
 #endif
 


### PR DESCRIPTION
The LIR changes fixed the bug in the decomp and the dumper for morphing
nodes into helper calls with long return types, so this NYI can be
removed.