### PR TITLE
Allow Ubuntu 16.10 to use MSBuild

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -250,6 +250,9 @@ isMSBuildOnNETCoreSupported()
                 "ubuntu.16.04-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
+                "ubuntu.16.10-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
                 *)
             esac
         elif [ "$__HostOS" == "OSX" ]; then


### PR DESCRIPTION
Allow Ubuntu 16.10 to build with MSBuild. There is an initial CLI uploaded to azure which can be used to boostrap us for now. An alternative `__PUBLISH_RID` must still be used until nuget packages are available for `ubuntu.16.10-x64`. netci.groovy is set up to use `ubuntu.16.04-x64`.