### PR TITLE
Fixing the Facade's double typeforward to CultureTypes

### DIFF
--- a/src/mscorlib/facade/TypeForwards.cs
+++ b/src/mscorlib/facade/TypeForwards.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Resources.PRIExceptionInfo))]
 [assembly: TypeForwardedTo(typeof(System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeImportAttribute))]
 [assembly: TypeForwardedTo(typeof(System.Runtime.InteropServices.WindowsRuntime.IRestrictedErrorInfo))]
-[assembly: TypeForwardedTo(typeof(System.Globalization.CultureTypes))]
 [assembly: TypeForwardedTo(typeof(System.StubHelpers.EventArgsMarshaler))]
 [assembly: TypeForwardedTo(typeof(System.StubHelpers.InterfaceMarshaler))]
 #endif


### PR DESCRIPTION
When merging #6694 CultureTypes was moved from internal to public because it was needed by one of the methods of CultureInfo. CultureTypes was already being type-forwarded in the facade project before GenFacades even ran, so after GenFacades this was causing the facade to have two different typeforwards to CultureTypes. Because of this, Microsoft.CCI was basically off by one in the type table ref, which was causing all nested types to have the wrong forwarder.

cc: @weshaggard @danmosemsft @stephentoub 
FYI: @hann013 @sepidehMS @tarekgh 