### PR TITLE
Avoid unnecessary indirection in char.ToString

### DIFF
--- a/src/mscorlib/src/System/Char.cs
+++ b/src/mscorlib/src/System/Char.cs
@@ -163,10 +163,7 @@ namespace System {
       ==============================================================================*/
       // Provides a string representation of a character.
       [Pure]
-      public static String ToString(char c) {
-          Contract.Ensures(Contract.Result<String>() != null);
-          return new String(c, 1);
-      }
+      public static string ToString(char c) => string.CreateFromChar(c);
 
       public static char Parse(String s) {
           if (s==null) {

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -25,6 +25,7 @@ namespace System {
     using System.Runtime.Versioning;
     using Microsoft.Win32;
     using System.Diagnostics.Contracts;
+    using System.Security;
 
     //
     // For Information on these methods, please see COMString.cpp
@@ -1367,16 +1368,6 @@ namespace System {
             }
             return TrimHelper(trimChars,TrimTail);
         }
-
-        // This is only intended to be used by char.ToString.
-        // It is necessary to put the code in this class instead of Char, since m_firstChar is a private member.
-        // Making m_firstChar internal would be dangerous since it would make it much easier to break String's immutability.
-        internal static string CreateFromChar(char c)
-        {
-            string result = FastAllocateString(1);
-            result.m_firstChar = c;
-            return result;
-        }
     
         // Creates a new string with the characters copied in from ptr. If
         // ptr is null, a 0-length string (like String.Empty) is returned.
@@ -1455,6 +1446,17 @@ namespace System {
             }
 
             return s;
+        }
+
+        // This is only intended to be used by char.ToString.
+        // It is necessary to put the code in this class instead of Char, since m_firstChar is a private member.
+        // Making m_firstChar internal would be dangerous since it would make it much easier to break String's immutability.
+        [SecuritySafeCritical]
+        internal static string CreateFromChar(char c)
+        {
+            string result = FastAllocateString(1);
+            result.m_firstChar = c;
+            return result;
         }
                 
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1367,7 +1367,16 @@ namespace System {
             }
             return TrimHelper(trimChars,TrimTail);
         }
-    
+
+        // This is only intended to be used by char.ToString.
+        // It is necessary to put the code in this class instead of Char, since m_firstChar is a private member.
+        // Making m_firstChar internal would be dangerous since it would make it much easier to break String's immutability.
+        internal static string CreateFromChar(char c)
+        {
+            string result = FastAllocateString(1);
+            result.m_firstChar = c;
+            return result;
+        }
     
         // Creates a new string with the characters copied in from ptr. If
         // ptr is null, a 0-length string (like String.Empty) is returned.


### PR DESCRIPTION
It's not really necessary to call the string constructor in `char.ToString`; we can just call `FastAllocateString` directly with 1, set `m_firstChar` to the char, and then return it. This makes the method on average more than twice as fast (~0.68 to ~0.31), and it's still being inlined. It also leaves us free to optimize the `string(char, int)` constructor for larger strings w/o worrying about degrading perf for this method, which I may be doing in the future.

cc @jkotas