### PR TITLE
Improve perf of Encoding.GetEncoding(int)

### DIFF
--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -34,9 +34,10 @@ namespace System.Text
             Real Unicode value = (HighSurrogate - 0xD800) * 0x400 + (LowSurrogate - 0xDC00) + 0x10000
         */
 
-        // Used by Encoding.UTF32 for lazy initialization
+        // Used by Encoding.UTF32/BigEndianUTF32 for lazy initialization
         // The initialization code will not be run until a static member of the class is referenced
         internal static readonly UTF32Encoding s_default = new UTF32Encoding(bigEndian: false, byteOrderMark: true);
+        internal static readonly UTF32Encoding s_bigEndianDefault = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
 
         private bool emitUTF32ByteOrderMark = false;
         private bool isThrowException = false;


### PR DESCRIPTION
`Encoding.GetEncoding(int)` caches encoding instances in a `Hashtable`. This involves locking and boxing the codepage (potentially multiple times). For the encodings that are already cached in static fields (e.g. UTF8, Unicode, ASCII, etc.), this is unnecessary overhead -- these instances do not need to be stored in the `Hashtable` because they are already stored in static fields.

It turns out the only instance that would be stored in the `Hashtable` in CoreCLR is UTF32BE. Thus, on CoreCLR, we can remove the use of the `Hashtable` altogether, and instead store the UTF32BE instance in a static field. This means the `Hashtable` static field, lock object, and box allocations go away entirely on CoreCLR.

We now check for the encodings that can be cached in static fields in a switch statement up-front. On Desktop, it then falls back to doing the `Hashtable`-based lookup/storage, and only boxes codepage once.

---

CoreFX `System.Text.Encoding` tests pass on top of these changes.

---

<details>
  <summary>Microbenchmark (10,000,000 iterations)</summary>

```c#
using System;
using System.Diagnostics;
using System.Text;

public class Program
{
    public static void Main()
    {
        TimeAction("GetEncoding", () => Encoding.GetEncoding(28591));
    }

    private static void TimeAction(string prefix, Action action, int times = 5, int iterations = 10000000)
    {
        var sw = new Stopwatch();
        for (int i = 0; i < times; i++)
        {
            int gen0 = GC.CollectionCount(0);
            sw.Restart();
            for (int iter = 0; iter < iterations; iter++)
            {
                action();
            }
            sw.Stop();
            Console.WriteLine($"{prefix}: Time: {sw.Elapsed.TotalSeconds}\tGC0: {GC.CollectionCount(0) - gen0}");
        }
    }
}
```
</details>

Results Before (Windows 10 x64):

```
GetEncoding: Time: 0.3538864    GC0: 57
GetEncoding: Time: 0.3457689    GC0: 57
GetEncoding: Time: 0.349028     GC0: 57
GetEncoding: Time: 0.3465488    GC0: 57
GetEncoding: Time: 0.3464975    GC0: 58
```

Results After (Windows 10 x64):

```
GetEncoding: Time: 0.0692138    GC0: 0
GetEncoding: Time: 0.0679936    GC0: 0
GetEncoding: Time: 0.0672836    GC0: 0
GetEncoding: Time: 0.0733325    GC0: 0
GetEncoding: Time: 0.0680139    GC0: 0
```