### PR TITLE
GcInfo: Don't use slim header for methods with struct-returns

### DIFF
--- a/src/gcinfo/gcinfoencoder.cpp
+++ b/src/gcinfo/gcinfoencoder.cpp
@@ -1019,7 +1019,8 @@ void GcInfoEncoder::Build()
     BOOL slimHeader = (!m_IsVarArg && !hasSecurityObject && !hasGSCookie && (m_PSPSymStackSlot == NO_PSP_SYM) &&
         !hasContextParamType && !m_WantsReportOnlyLeaf && (m_InterruptibleRanges.Count() == 0) && !hasReversePInvokeFrame &&
         ((m_StackBaseRegister == NO_STACK_BASE_REGISTER) || (NORMALIZE_STACK_BASE_REGISTER(m_StackBaseRegister) == 0))) &&
-        (m_SizeOfEditAndContinuePreservedArea == NO_SIZE_OF_EDIT_AND_CONTINUE_PRESERVED_AREA);
+        (m_SizeOfEditAndContinuePreservedArea == NO_SIZE_OF_EDIT_AND_CONTINUE_PRESERVED_AREA) && 
+        !IsStructReturnKind(m_ReturnKind);
 
     // All new code is generated for the latest GCINFO_VERSION.
     // So, always encode RetunrKind and encode ReversePInvokeFrameSlot where applicable.

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -289,6 +289,13 @@ inline bool IsValidReturnRegister(size_t regNo)
         ;
 }
 
+inline bool IsStructReturnKind(ReturnKind returnKind)
+{
+    // Two bits encode integer/ref/float return-kinds.
+    // Encodings needing more than two bits are (non-scalar) struct-returns.
+    return returnKind > 3;
+}
+
 // Helpers for combining/extracting individual ReturnKinds from/to Struct ReturnKinds.
 // Encoding is two bits per register
 

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -7286,7 +7286,7 @@ ReturnKind GetReturnKind(Thread *pThread, EECodeInfo *codeInfo)
     if (gcInfoToken.IsReturnKindAvailable()) 
     {
         GcInfoDecoder gcInfoDecoder(gcInfoToken, DECODE_RETURN_KIND);
-        ReturnKind returnKind = gcInfoDecoder.GetReturnKind();
+        returnKind = gcInfoDecoder.GetReturnKind();
     }
 #endif // _TARGET_X86_
 


### PR DESCRIPTION
This checkin has two changes:
1) Add a check to ensure that methods with struct-returns are
use the fat header which encodes ReturnKind in 4 bits.
2) Fix a bug in GetReturnKind().

Fixes #6862