### PR TITLE
SpinLock.TryEnter fail fast for timeout 0

### DIFF
--- a/src/mscorlib/src/System/Threading/SpinLock.cs
+++ b/src/mscorlib/src/System/Threading/SpinLock.cs
@@ -346,6 +346,12 @@ namespace System.Threading
                     return;
                 }
 
+                // Failed to acquire lock
+                if (millisecondsTimeout == 0)
+                {
+                    // If timeout is zero, fail fast, don't spin to attempt acquire, exit
+                    return;
+                }
 #if !FEATURE_CORECLR
                 Thread.EndCriticalRegion();
 #endif
@@ -355,7 +361,7 @@ namespace System.Threading
                 // Lock owned, haven't acquired the lock
                 if (millisecondsTimeout == 0)
                 {
-                    // If timeout is zero fail fast, don't update waiters, don't spin to attempt acquire, exit
+                    // If timeout is zero, fail fast, don't update waiters, don't spin to attempt acquire, exit
                     return;
                 }
 
@@ -363,13 +369,6 @@ namespace System.Threading
                 if ((observedOwner & WAITERS_MASK) != MAXIMUM_WAITERS)
                     turn = (Interlocked.Add(ref m_owner, 2) & WAITERS_MASK) >> 1 ;
             }
-
-            if (millisecondsTimeout == 0)
-            {
-                // If timeout is zero here, attempted aquire but failed. Fail fast, don't spin to attempt acquire, exit
-                return;
-            }
-
 
             // Check the timeout.
             if ((millisecondsTimeout != Timeout.Infinite &&

--- a/src/mscorlib/src/System/Threading/SpinLock.cs
+++ b/src/mscorlib/src/System/Threading/SpinLock.cs
@@ -77,13 +77,13 @@ namespace System.Threading
         private const int SPINNING_FACTOR = 100;
 
         // After how many yields, call Sleep(1)
-        private const int SLEEP_ONE_FREQUENCY = 40;
+        private const int SLEEP_ONE_FREQUENCY_MASK = 64;
 
         // After how many yields, call Sleep(0)
-        private const int SLEEP_ZERO_FREQUENCY = 10;
+        private const int SLEEP_ZERO_FREQUENCY_MASK = 16;
 
         // After how many yields, check the timeout
-        private const int TIMEOUT_CHECK_FREQUENCY = 10;
+        private const int TIMEOUT_CHECK_FREQUENCY_MASK = 16;
 
         // Thr thread tracking disabled mask
         private const int LOCK_ID_DISABLE_MASK = unchecked((int)0x80000000);        //1000 0000 0000 0000 0000 0000 0000 0000
@@ -105,7 +105,7 @@ namespace System.Threading
         // The maximum number of waiters (only used if the thread tracking is disabled)
         // The actual maximum waiters count is this number divided by two because each waiter increments the waiters count by 2
         // The waiters count is calculated by m_owner & WAITERS_MASK 01111....110
-        private static int MAXIMUM_WAITERS = WAITERS_MASK;
+        private static int MAXIMUM_WAITERS_LOW_WATERMARK = unchecked((int)0x40000000);        //0100 0000 0000 0000 0000 0000 0000 0000
 
 
         /// <summary>
@@ -330,9 +330,11 @@ namespace System.Threading
 
             int observedOwner;
             int turn = int.MaxValue;
-            //***Step 1, take the lock or update the waiters
 
-            // try to acquire the lock directly if possible or update the waiters count
+            //*** Step 1: Take the lock or update the waiters
+
+            //**  1.1 Try to acquire the lock directly if possible
+
             observedOwner = m_owner;
             if ((observedOwner & LOCK_ANONYMOUS_OWNED) == LOCK_UNOWNED)
             {
@@ -345,60 +347,54 @@ namespace System.Threading
                     // Acquired the lock, exit
                     return;
                 }
-
-                // Failed to acquire lock
-                if (millisecondsTimeout == 0)
-                {
-                    // If timeout is zero, fail fast, don't spin to attempt acquire, exit
-                    return;
-                }
 #if !FEATURE_CORECLR
                 Thread.EndCriticalRegion();
 #endif
             }
-            else
-            {
-                // Lock owned, haven't acquired the lock
-                if (millisecondsTimeout == 0)
-                {
-                    // If timeout is zero, fail fast, don't update waiters, don't spin to attempt acquire, exit
-                    return;
-                }
 
-                // Try to update the waiters. If the waiters count reached the maximum, just break the loop to avoid overflow
-                if ((observedOwner & WAITERS_MASK) != MAXIMUM_WAITERS)
-                    turn = (Interlocked.Add(ref m_owner, 2) & WAITERS_MASK) >> 1 ;
-            }
+            //**  1.2 Lock owned, haven't acquired the lock
 
-            // Check the timeout.
-            if ((millisecondsTimeout != Timeout.Infinite &&
-                TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout) <= 0))
+            if (millisecondsTimeout == 0)
             {
-                DecrementWaiters();
+                // If timeout is zero, fail fast, don't spin to attempt acquire, exit
                 return;
             }
 
-            //***Step 2. Spinning
-            //lock acquired failed and waiters updated
+            // Try to update the waiters. If the waiters count reached watermark don't increment to avoid overflow
+            if ((observedOwner & WAITERS_MASK) < MAXIMUM_WAITERS_LOW_WATERMARK)
+            {
+                // Owner count updates in 2s as first bit is whether lock is owned
+                turn = (Interlocked.Add(ref m_owner, 2) & WAITERS_MASK) >> 1;
+            }
+            else
+            {
+                // Logic stub: Watermark for waiters reached so turn == int.MaxValue 
+                // which means step 2 (spinning) is skipped as lock heavily contended. 
+            }
+
+            //*** Step 2: Spinning
             int processorCount = PlatformHelper.ProcessorCount;
+            // If turn is less than processorCount, we will try spinning to acquire the lock.
             if (turn < processorCount)
             {
+                //**  2.1 Spin to acquire
                 int processFactor = 1;
                 for (int i = 1; i <= turn * SPINNING_FACTOR; i++)
                 {
+                    // Spin, yeilding processor on HT
                     Thread.SpinWait((turn + i) * SPINNING_FACTOR * processFactor);
                     if (processFactor < processorCount)
+                    {
                         processFactor++;
+                    }
                     observedOwner = m_owner;
                     if ((observedOwner & LOCK_ANONYMOUS_OWNED) == LOCK_UNOWNED)
                     {
+                        // Lock is not owned, attempt to acquire lock
 #if !FEATURE_CORECLR
                         Thread.BeginCriticalRegion();
 #endif
-
-                        int newOwner = (observedOwner & WAITERS_MASK) == 0 ? // Gets the number of waiters, if zero
-                            observedOwner | 1 // don't decrement it. just set the lock bit, it is zero because a previous call of Exit(false) which corrupted the waiters
-                            : (observedOwner - 2) | 1; // otherwise decrement the waiters and set the lock bit
+                        int newOwner = (observedOwner - 2) | 1; // decrement the waiters and set the lock bit
                         Contract.Assert((newOwner & WAITERS_MASK) >= 0);
 
                         if (Interlocked.CompareExchange(ref m_owner, newOwner, observedOwner, ref lockTaken) == observedOwner)
@@ -411,29 +407,54 @@ namespace System.Threading
 #endif
                     }
                 }
+
+                //**  2.2 Time was spent spinning, check the timeout.
+                if (millisecondsTimeout != Timeout.Infinite && TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout) <= 0)
+                {
+                    // Timed out
+                    if (turn != int.MaxValue)
+                    {
+                        // We incremented the waiters so decrement it
+                        DecrementWaiters();
+                    }
+                    return;
+                }
             }
 
-            // Check the timeout.
-            if (millisecondsTimeout != Timeout.Infinite && TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout) <= 0)
-            {
-                DecrementWaiters();
-                return;
-            }
-
-            //*** Step 3, Yielding
-            //Sleep(1) every 50 yields
-            int yieldsoFar = 0;
+            //*** Step 3: Yielding
+            // If we didn't set the waiters as were too many, skip straight to Sleep(1) due to heavy contention
+            int yieldsoFar = (turn == int.MaxValue) ? SLEEP_ONE_FREQUENCY_MASK : 0;
             while (true)
             {
+                //**  3.1 Yield first, as we have alreay checked faster routes to acquire the lock 
+                if ((yieldsoFar & SLEEP_ONE_FREQUENCY_MASK) == SLEEP_ONE_FREQUENCY_MASK)
+                {
+                    Thread.Sleep(1);
+                }
+                else if ((yieldsoFar & SLEEP_ZERO_FREQUENCY_MASK) == SLEEP_ZERO_FREQUENCY_MASK)
+                {
+                    Thread.Sleep(0);
+                }
+                else
+                {
+                    if (!Thread.Yield())
+                    {
+                        // The Thread didn't yield so yield the processor in case it is HT
+                        Thread.SpinWait(1);
+                    }
+                }
+
+                //**  3.2 Attempt lock
                 observedOwner = m_owner;
                 if ((observedOwner & LOCK_ANONYMOUS_OWNED) == LOCK_UNOWNED)
                 {
+                    // Lock is not owned, attempt to acquire lock
 #if !FEATURE_CORECLR
                     Thread.BeginCriticalRegion();
 #endif
-                    int newOwner = (observedOwner & WAITERS_MASK) == 0 ? // Gets the number of waiters, if zero
-                           observedOwner | 1 // don't decrement it. just set the lock bit, it is zero because a previous call of Exit(false) which corrupted the waiters
-                           : (observedOwner - 2) | 1; // otherwise decrement the waiters and set the lock bit
+                    int newOwner = (turn == int.MaxValue) ? // Check if we set the waiters
+                           observedOwner | 1 // We didn't, just set the lock bit
+                           : (observedOwner - 2) | 1; // We did, decrement waiters and set the lock bit
                     Contract.Assert((newOwner & WAITERS_MASK) >= 0);
 
                     if (Interlocked.CompareExchange(ref m_owner, newOwner, observedOwner, ref lockTaken) == observedOwner)
@@ -446,25 +467,18 @@ namespace System.Threading
 #endif
                 }
 
-                if (yieldsoFar % SLEEP_ONE_FREQUENCY == 0)
+                //**  3.3 Should we check timeout?
+                if ((yieldsoFar & TIMEOUT_CHECK_FREQUENCY_MASK) == TIMEOUT_CHECK_FREQUENCY_MASK && millisecondsTimeout != Timeout.Infinite)
                 {
-                    Thread.Sleep(1);
-                }
-                else if (yieldsoFar % SLEEP_ZERO_FREQUENCY == 0)
-                {
-                    Thread.Sleep(0);
-                }
-                else
-                {
-                    Thread.Yield();
-                }
-
-                if (yieldsoFar % TIMEOUT_CHECK_FREQUENCY == 0)
-                {
-                    //Check the timeout.
-                    if (millisecondsTimeout != Timeout.Infinite && TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout) <= 0)
+                    // Yes, check if timed out
+                    if (TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout) <= 0)
                     {
-                        DecrementWaiters();
+                        // Timed out
+                        if (turn != int.MaxValue)
+                        {
+                            // We incremented the waiters so decrement them
+                            DecrementWaiters();
+                        }
                         return;
                     }
                 }
@@ -478,19 +492,7 @@ namespace System.Threading
         /// </summary>
         private void DecrementWaiters()
         {
-            SpinWait spinner = new SpinWait();
-            while (true)
-            {
-                int observedOwner = m_owner;
-                if ((observedOwner & WAITERS_MASK) == 0) return; // don't decrement the waiters if it's corrupted by previous call of Exit(false)
-                if (Interlocked.CompareExchange(ref m_owner, observedOwner - 2, observedOwner) == observedOwner)
-                {
-                    Contract.Assert(!IsThreadOwnerTrackingEnabled); // Make sure the waiters never be negative which will cause the thread tracking bit to be flipped
-                    break;
-                }
-                spinner.SpinOnce();
-            }
-
+            Interlocked.Add(ref m_owner, -2);
         }
 
         /// <summary>


### PR DESCRIPTION
Passes corefx tests

1M iters (single thread, uncontended but locked) for [code](https://gist.github.com/benaadams/a8de9032ae5f6ff89370842fb495d5fa)

```csharp
bool lockTaken = false;
var s = new SpinLock(false);
s.Enter(ref lockTaken);
```

method | pre (ms) | post (ms) | improvement
-------- |------- |------- |------ |
s.TryEnter(0, ref lockTaken) | 24.55 | 6.09 | x 4.0


Need to do the threadpool timing tests I have (on a couple environments), as TrySteal uses this path; and they introduce parallel contention. Hopefully will improve, but will see.

Also corrected some strange spellings.