### PR TITLE
Add pkgproj's for openSUSE 42.1 and Ubuntu 16.10

### DIFF
--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
@@ -39,6 +39,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.42.1-x64'" Include="opensuse/42.1/Microsoft.NETCore.ILAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.ILAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
@@ -55,6 +55,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.10-x64'" Include="ubuntu/16.10/Microsoft.NETCore.ILAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx/Microsoft.NETCore.ILAsm.pkgproj">
       <OSGroup>OSX</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
@@ -32,6 +32,9 @@
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.1\Microsoft.NETCore.ILAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
@@ -44,6 +44,9 @@
     <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\16.10\Microsoft.NETCore.ILAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/opensuse/42.1/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/opensuse/42.1/Microsoft.NETCore.ILAsm.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.42.1-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ilasm" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/16.10/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/16.10/Microsoft.NETCore.ILAsm.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ilasm" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
@@ -39,6 +39,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.42.1-x64'" Include="opensuse/42.1/Microsoft.NETCore.ILDAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.ILDAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
@@ -55,6 +55,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.10-x64'" Include="ubuntu/16.10/Microsoft.NETCore.ILDAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx/Microsoft.NETCore.ILDAsm.pkgproj">
       <OSGroup>OSX</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
@@ -32,6 +32,9 @@
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.1\Microsoft.NETCore.ILDAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
@@ -44,6 +44,9 @@
     <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\16.10\Microsoft.NETCore.ILDAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/opensuse/42.1/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/opensuse/42.1/Microsoft.NETCore.ILDAsm.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.42.1-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ildasm" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/16.10/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/16.10/Microsoft.NETCore.ILDAsm.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ildasm" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
@@ -39,6 +39,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.42.1-x64'" Include="opensuse/42.1/Microsoft.NETCore.Jit.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.Jit.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
@@ -55,6 +55,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.10-x64'" Include="ubuntu/16.10/Microsoft.NETCore.Jit.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx/Microsoft.NETCore.Jit.pkgproj">
       <OSGroup>OSX</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
@@ -31,6 +31,9 @@
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.Jit.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.1\Microsoft.NETCore.Jit.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\Microsoft.NETCore.Jit.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
@@ -43,6 +43,9 @@
     <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.Jit.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\16.10\Microsoft.NETCore.Jit.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\Microsoft.NETCore.Jit.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.Jit/opensuse/42.1/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/opensuse/42.1/Microsoft.NETCore.Jit.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.42.1-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/ubuntu/16.10/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/ubuntu/16.10/Microsoft.NETCore.Jit.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
@@ -39,6 +39,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.42.1-x64'" Include="opensuse/42.1/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
@@ -55,6 +55,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.10-x64'" Include="ubuntu/16.10/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <OSGroup>OSX</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -44,6 +44,9 @@
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.1\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -56,6 +56,9 @@
     <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\16.10\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/42.1/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/42.1/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.42.1-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libcoreclr.so" />
+    <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so" />
+    <NativeSplittableBinary Include="$(BinDir)libdbgshim.so" />
+    <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so" />
+    <NativeSplittableBinary Include="$(BinDir)libmscordbi.so" />
+    <NativeSplittableBinary Include="$(BinDir)libsos.so" />
+    <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
+    <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll" />
+    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
+    <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
+    <File Include="@(ArchitectureSpecificLibFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
+    </File>
+    <!-- No reference: don't permit reference to the implementation from lib -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/netstandard1.0</TargetPath>
+    </File>
+    <File Include="@(ArchitectureSpecificToolFile)">
+      <TargetPath>tools</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/16.10/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/16.10/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libcoreclr.so" />
+    <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so" />
+    <NativeSplittableBinary Include="$(BinDir)libdbgshim.so" />
+    <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so" />
+    <NativeSplittableBinary Include="$(BinDir)libmscordbi.so" />
+    <NativeSplittableBinary Include="$(BinDir)libsos.so" />
+    <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
+    <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll" />
+    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
+    <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
+    <File Include="@(ArchitectureSpecificLibFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
+    </File>
+    <!-- No reference: don't permit reference to the implementation from lib -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/netstandard1.0</TargetPath>
+    </File>
+    <File Include="@(ArchitectureSpecificToolFile)">
+      <TargetPath>tools</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds
+++ b/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds
@@ -39,6 +39,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.42.1-x64'" Include="opensuse/42.1/Microsoft.NETCore.TestHost.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.TestHost.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds
+++ b/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds
@@ -55,6 +55,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.10-x64'" Include="ubuntu/16.10/Microsoft.NETCore.TestHost.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx/Microsoft.NETCore.TestHost.pkgproj">
       <OSGroup>OSX</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
@@ -36,6 +36,9 @@
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.TestHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="opensuse\42.1\Microsoft.NETCore.TestHost.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="rhel\Microsoft.NETCore.TestHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
@@ -48,6 +48,9 @@
     <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.TestHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="ubuntu\16.10\Microsoft.NETCore.TestHost.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="osx\Microsoft.NETCore.TestHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.TestHost/opensuse/42.1/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/opensuse/42.1/Microsoft.NETCore.TestHost.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.42.1-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)corerun" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/ubuntu/16.10/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/ubuntu/16.10/Microsoft.NETCore.TestHost.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)corerun" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
@ericstj 

The official build is already running for these distros. Once merged, we should get published packages in the next build.