### PR TITLE
Implement the IEquatable interfaces on IntPtr and UIntPtr

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3434,7 +3434,7 @@
       <Member Status="ImplRoot" Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
       <Member Name="Add(System.IntPtr,System.Int32)" />
       <Member Name="Equals(System.Object)" />
-      <Member Status="ImplRoot" Name="System.IEquatable&lt;System.IntPtr&gt;.Equals(System.IntPtr)" />
+      <Member Name="System.IEquatable&lt;System.IntPtr&gt;.Equals(System.IntPtr)" />
       <Member Name="get_Size" />
       <Member Name="GetHashCode" />
       <Member Name="op_Addition(System.IntPtr,System.Int32)" />
@@ -8655,7 +8655,7 @@
       <Member Status="ImplRoot" Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
       <Member Name="Add(System.UIntPtr,System.Int32)" />
       <Member Name="Equals(System.Object)" />
-      <Member Status="ImplRoot" Name="System.IEquatable&lt;System.UIntPtr&gt;.Equals(System.UIntPtr)" />
+      <Member Name="System.IEquatable&lt;System.UIntPtr&gt;.Equals(System.UIntPtr)" />
       <Member Name="get_Size" />
       <Member Name="GetHashCode" />
       <Member Name="op_Addition(System.UIntPtr,System.Int32)" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3434,7 +3434,6 @@
       <Member Status="ImplRoot" Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
       <Member Name="Add(System.IntPtr,System.Int32)" />
       <Member Name="Equals(System.Object)" />
-      <Member Name="System.IEquatable&lt;System.IntPtr&gt;.Equals(System.IntPtr)" />
       <Member Name="get_Size" />
       <Member Name="GetHashCode" />
       <Member Name="op_Addition(System.IntPtr,System.Int32)" />
@@ -8655,7 +8654,6 @@
       <Member Status="ImplRoot" Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
       <Member Name="Add(System.UIntPtr,System.Int32)" />
       <Member Name="Equals(System.Object)" />
-      <Member Name="System.IEquatable&lt;System.UIntPtr&gt;.Equals(System.UIntPtr)" />
       <Member Name="get_Size" />
       <Member Name="GetHashCode" />
       <Member Name="op_Addition(System.UIntPtr,System.Int32)" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3434,6 +3434,7 @@
       <Member Status="ImplRoot" Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
       <Member Name="Add(System.IntPtr,System.Int32)" />
       <Member Name="Equals(System.Object)" />
+      <Member Status="ImplRoot" Name="System.IEquatable&lt;System.IntPtr&gt;.Equals(System.IntPtr)" />
       <Member Name="get_Size" />
       <Member Name="GetHashCode" />
       <Member Name="op_Addition(System.IntPtr,System.Int32)" />
@@ -8654,6 +8655,7 @@
       <Member Status="ImplRoot" Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
       <Member Name="Add(System.UIntPtr,System.Int32)" />
       <Member Name="Equals(System.Object)" />
+      <Member Status="ImplRoot" Name="System.IEquatable&lt;System.UIntPtr&gt;.Equals(System.UIntPtr)" />
       <Member Name="get_Size" />
       <Member Name="GetHashCode" />
       <Member Name="op_Addition(System.UIntPtr,System.Int32)" />

--- a/src/mscorlib/src/System/IntPtr.cs
+++ b/src/mscorlib/src/System/IntPtr.cs
@@ -24,7 +24,7 @@ namespace System {
 
     [Serializable]
     [System.Runtime.InteropServices.ComVisible(true)]
-    public struct IntPtr : ISerializable
+    public struct IntPtr : IEquatable<IntPtr>, ISerializable
     {
         [SecurityCritical]
         unsafe private void* m_value; // The compiler treats void* closest to uint hence explicit casts are required to preserve int behavior
@@ -103,6 +103,12 @@ namespace System {
                 return (m_value == ((IntPtr)obj).m_value);
             }
             return false;
+        }
+
+        [SecuritySafeCritical]
+        unsafe bool IEquatable<IntPtr>.Equals(IntPtr other)
+        {
+            return m_value == other.m_value;
         }
     
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/mscorlib/src/System/UIntPtr.cs
+++ b/src/mscorlib/src/System/UIntPtr.cs
@@ -22,7 +22,7 @@ namespace System {
     [Serializable]
     [CLSCompliant(false)] 
     [System.Runtime.InteropServices.ComVisible(true)]
-    public struct UIntPtr : ISerializable
+    public struct UIntPtr : IEquatable<UIntPtr>, ISerializable
     {
         [SecurityCritical]
         unsafe private void* m_value;
@@ -83,6 +83,12 @@ namespace System {
                 return (m_value == ((UIntPtr)obj).m_value);
             }
             return false;
+        }
+
+        [SecuritySafeCritical]
+        unsafe bool IEquatable<UIntPtr>.Equals(UIntPtr other)
+        {
+            return m_value == other.m_value;
         }
     
         [System.Security.SecuritySafeCritical]  // auto-generated


### PR DESCRIPTION
This implements the `IEquatable<>` interface on IntPtr and UIntPtr, since the API was approved in dotnet/corefx#8592.

I chose to implement the interfaces explicitly since that's how it's done in CoreRT.

cc @jkotas @weshaggard 