### PR TITLE
Remove the new string.Split(string) overload

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -7128,7 +7128,6 @@
       <Member Name="Split(System.Char[],System.Int32)" />
       <Member Name="Split(System.Char[],System.Int32,System.StringSplitOptions)" />
       <Member Name="Split(System.Char[],System.StringSplitOptions)"/>
-      <Member Name="Split(System.String)" />
       <Member Name="Split(System.String,System.Int32,System.StringSplitOptions)" />
       <Member Name="Split(System.String,System.StringSplitOptions)"/>
       <Member Name="Split(System.String[],System.Int32,System.StringSplitOptions)" />

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1116,12 +1116,6 @@ namespace System {
         }
 
         [ComVisible(false)]
-        public String[] Split(String separator) {
-            Contract.Ensures(Contract.Result<String[]>() != null);
-            return SplitInternal(separator ?? String.Empty, null, Int32.MaxValue, StringSplitOptions.None);
-        }
-
-        [ComVisible(false)]
         public String[] Split(String separator, StringSplitOptions options) {
             Contract.Ensures(Contract.Result<String[]>() != null);
             return SplitInternal(separator ?? String.Empty, null, Int32.MaxValue, options);


### PR DESCRIPTION
The new `Split(string)` overload breaks source compat with uses of `Split(null)`, which is documented to split based on white space, because it makes the call ambiguous between `Split(char[])` and `Split(string)`. To maintain source compatibilty, we'll remove the new `Split(string)` overload.

That leaves us with the following new overloads:

- `Split(char);`
- `Split(char, StringSplitOptions);`
- `Split(char, int, StringSplitOptions);`
- `Split(string, StringSplitOptions);`
- `Split(string, int, StringSplitOptions);`

cc: @weshaggard @terrajobst