### PR TITLE
Fix #6893.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1933,8 +1933,9 @@ public:
     GenTreePtr gtNewIndexRef(var_types typ, GenTreePtr arrayOp, GenTreePtr indexOp);
 
     GenTreeArgList* gtNewArgList(GenTreePtr op);
-
     GenTreeArgList* gtNewArgList(GenTreePtr op1, GenTreePtr op2);
+
+    GenTreeArgList* gtNewAggregate(GenTree* element);
 
     static fgArgTabEntryPtr gtArgEntryByArgNum(GenTreePtr call, unsigned argNum);
     static fgArgTabEntryPtr gtArgEntryByNode(GenTreePtr call, GenTreePtr node);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17975,7 +17975,7 @@ void Compiler::fgSetTreeSeqFinish(GenTreePtr tree, bool isLIR)
 {
     // If we are sequencing a node that does not appear in LIR,
     // do not add it to the list.
-    if (isLIR && ((tree->OperGet() == GT_LIST) || tree->OperGet() == GT_ARGPLACE))
+    if (isLIR && (((tree->OperGet() == GT_LIST) && !tree->AsArgList()->IsAggregate()) || tree->OperGet() == GT_ARGPLACE))
     {
         return;
     }

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -176,7 +176,7 @@ GTNODE(SIMD       , "simd"       ,0,GTK_BINOP|GTK_EXOP)   // SIMD functions/oper
 
 GTNODE(JTRUE      , "jmpTrue"    ,0,GTK_UNOP|GTK_NOVALUE)
 
-GTNODE(LIST       , "<list>"     ,0,GTK_BINOP|GTK_NOVALUE)
+GTNODE(LIST       , "<list>"     ,0,GTK_BINOP)
 
 //-----------------------------------------------------------------------------
 //  Other nodes that have special structure:

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1264,7 +1264,6 @@ LIR::ReadOnlyRange LIR::Range::GetMarkedRange(unsigned  markCount,
             for (GenTree* operand : firstNode->Operands())
             {
                 // Do not mark nodes that do not appear in the execution order
-                assert(operand->OperGet() != GT_LIST);
                 if (operand->OperGet() == GT_ARGPLACE)
                 {
                     continue;

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -819,7 +819,9 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
                 // clang-format on
 
                 assert(arg->OperGet() == GT_LIST);
+
                 GenTreeArgList* argListPtr = arg->AsArgList();
+                assert(argListPtr->IsAggregate());
 
                 for (unsigned ctr = 0; argListPtr != nullptr; argListPtr = argListPtr->Rest(), ctr++)
                 {
@@ -850,7 +852,9 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
         if ((info->numRegs > 1) && (arg->OperGet() == GT_LIST))
         {
             assert(arg->OperGet() == GT_LIST);
+
             GenTreeArgList* argListPtr = arg->AsArgList();
+            assert(argListPtr->IsAggregate());
 
             for (unsigned ctr = 0; argListPtr != nullptr; argListPtr = argListPtr->Rest(), ctr++)
             {
@@ -1060,7 +1064,6 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
         // If an extra node is returned, splice it in the right place in the tree.
         if (arg != putArg)
         {
-            // putArg and arg are equals if arg is GT_LIST (a list of multiple LCL_FLDs to be passed in registers.)
             ReplaceArgWithPutArgOrCopy(ppArg, putArg);
         }
     }
@@ -3726,9 +3729,14 @@ void Lowering::CheckCallArg(GenTree* arg)
 #endif
 
         case GT_LIST:
-            for (GenTreeArgList* list = arg->AsArgList(); list != nullptr; list = list->Rest())
             {
-                assert(list->Current()->OperIsPutArg());
+                GenTreeArgList* list = arg->AsArgList();
+                assert(list->IsAggregate());
+
+                for (; list != nullptr; list = list->Rest())
+                {
+                    assert(list->Current()->OperIsPutArg());
+                }
             }
             break;
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3206,7 +3206,7 @@ static int ComputeOperandDstCount(GenTree* operand)
     }
     else
     {
-        // If an aggregate or non-void-types operand is not an unsued value and does not have source registers,
+        // If an aggregate or non-void-typed operand is not an unsued value and does not have source registers,
         // that argument is contained within its parent and produces `sum(operand_dst_count)` registers.
         int dstCount = 0;
         for (GenTree* op : operand->Operands())

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3198,7 +3198,7 @@ static int ComputeOperandDstCount(GenTree* operand)
                operand->OperIsCompare());
         return 0;
     }
-    else if (operand->OperIsStore() || operand->TypeGet() == TYP_VOID)
+    else if (!operand->OperIsAggregate() && (operand->OperIsStore() || operand->TypeGet() == TYP_VOID))
     {
         // Stores and void-typed operands may be encountered when processing call nodes, which contain
         // pointers to argument setup stores.
@@ -3206,10 +3206,10 @@ static int ComputeOperandDstCount(GenTree* operand)
     }
     else
     {
-        // If a non-void-types operand is not an unsued value and does not have source registers, that
-        // argument is contained within its parent and produces `sum(operand_dst_count)` registers.
+        // If an aggregate or non-void-types operand is not an unsued value and does not have source registers,
+        // that argument is contained within its parent and produces `sum(operand_dst_count)` registers.
         int dstCount = 0;
-        for (GenTree* op : operand->Operands(true))
+        for (GenTree* op : operand->Operands())
         {
             dstCount += ComputeOperandDstCount(op);
         }
@@ -3234,7 +3234,7 @@ static int ComputeOperandDstCount(GenTree* operand)
 static int ComputeAvailableSrcCount(GenTree* node)
 {
     int numSources = 0;
-    for (GenTree* operand : node->Operands(true))
+    for (GenTree* operand : node->Operands())
     {
         numSources += ComputeOperandDstCount(operand);
     }
@@ -3253,11 +3253,9 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
     assert(!isRegPairType(tree->TypeGet()));
 #endif // _TARGET_ARM_
 
-    // The tree traversal doesn't visit GT_LIST or GT_ARGPLACE nodes
-    if (tree->OperGet() == GT_LIST || tree->OperGet() == GT_ARGPLACE)
-    {
-        return;
-    }
+    // The LIR traversal doesn't visit non-aggregate GT_LIST or GT_ARGPLACE nodes
+    assert(tree->OperGet() != GT_ARGPLACE);
+    assert((tree->OperGet() != GT_LIST) || tree->AsArgList()->IsAggregate());
 
     // These nodes are eliminated by the Rationalizer.
     if (tree->OperGet() == GT_CLS_VAR)
@@ -3410,7 +3408,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             {
                 // Get the location info for the register defined by the first operand.
                 LocationInfoList operandDefs;
-                bool found = operandToLocationInfoMap.TryGetValue(*(tree->OperandsBegin(true)), &operandDefs);
+                bool found = operandToLocationInfoMap.TryGetValue(*(tree->OperandsBegin()), &operandDefs);
                 assert(found);
 
                 // Since we only expect to consume one register, we should only have a single register to
@@ -3514,7 +3512,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
 
         // Get the register information for the first operand of the node.
         LocationInfoList operandDefs;
-        bool             found = operandToLocationInfoMap.TryGetValue(*(tree->OperandsBegin(true)), &operandDefs);
+        bool             found = operandToLocationInfoMap.TryGetValue(*(tree->OperandsBegin()), &operandDefs);
         assert(found);
 
         // Preference the destination to the interval of the first register defined by the first operand.
@@ -3531,7 +3529,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
     int internalCount = buildInternalRegisterDefsForNode(tree, currentLoc, internalRefs);
 
     // pop all ref'd tree temps
-    GenTreeOperandIterator iterator = tree->OperandsBegin(true);
+    GenTreeOperandIterator iterator = tree->OperandsBegin();
 
     // `operandDefs` holds the list of `LocationInfo` values for the registers defined by the current
     // operand. `operandDefsIterator` points to the current `LocationInfo` value in `operandDefs`.
@@ -3796,11 +3794,11 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 
     bool isContainedNode =
-        !noAdd && consume == 0 && produce == 0 && tree->TypeGet() != TYP_VOID && !tree->OperIsStore();
+        !noAdd && consume == 0 && produce == 0 && (tree->OperIsAggregate() || (tree->TypeGet() != TYP_VOID && !tree->OperIsStore()));
     if (isContainedNode)
     {
         // Contained nodes map to the concatenated lists of their operands.
-        for (GenTree* op : tree->Operands(true))
+        for (GenTree* op : tree->Operands())
         {
             if (!op->gtLsraInfo.definesAnyRegisters)
             {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4696,8 +4696,6 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
     // We should still have a TYP_STRUCT
     assert(argValue->TypeGet() == TYP_STRUCT);
 
-    // TODO(pdg): below is where we'll need to create aggregate nodes.
-
     GenTreeArgList* newArg = nullptr;
 
     // Are we passing a struct LclVar?

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4373,9 +4373,9 @@ void Compiler::fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgumen
                                                                                 .eightByteClassifications[1],
                                                                             fgEntryPtr->structDesc.eightByteSizes[1]),
                                           lclCommon->gtLclNum, fgEntryPtr->structDesc.eightByteOffsets[1]);
-                        // Note this should actually be: secondNode = gtNewArgList(newLclField)
-                        GenTreeArgList* secondNode = gtNewListNode(newLclField, nullptr);
-                        secondNode->gtType         = originalType; // Preserve the type. It is a special case.
+
+                        GenTreeArgList* aggregate  = gtNewAggregate(newLclField);
+                        aggregate->gtType          = originalType; // Preserve the type. It is a special case.
                         newLclField->gtFieldSeq    = FieldSeqStore::NotAField();
 
                         // First field
@@ -4383,7 +4383,7 @@ void Compiler::fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgumen
                         arg->gtType =
                             GetTypeFromClassificationAndSizes(fgEntryPtr->structDesc.eightByteClassifications[0],
                                                               fgEntryPtr->structDesc.eightByteSizes[0]);
-                        arg         = gtNewListNode(arg, secondNode);
+                        arg         = aggregate->Prepend(this, arg);
                         arg->gtType = type; // Preserve the type. It is a special case.
                     }
                     else
@@ -4696,6 +4696,8 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
     // We should still have a TYP_STRUCT
     assert(argValue->TypeGet() == TYP_STRUCT);
 
+    // TODO(pdg): below is where we'll need to create aggregate nodes.
+
     GenTreeArgList* newArg = nullptr;
 
     // Are we passing a struct LclVar?
@@ -4800,7 +4802,7 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
                     //    replace the existing LDOBJ(ADDR(LCLVAR))
                     //    with a LIST(LCLVAR-LO, LIST(LCLVAR-HI, nullptr))
                     //
-                    newArg = gtNewListNode(loLclVar, gtNewArgList(hiLclVar));
+                    newArg = gtNewAggregate(hiLclVar)->Prepend(this, loLclVar);
                 }
             }
         }
@@ -4881,11 +4883,11 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
                 GenTreePtr nextLclFld = gtNewLclFldNode(varNum, type[inx], offset);
                 if (newArg == nullptr)
                 {
-                    newArg = gtNewArgList(nextLclFld);
+                    newArg = gtNewAggregate(nextLclFld);
                 }
                 else
                 {
-                    newArg = gtNewListNode(nextLclFld, newArg);
+                    newArg = newArg->Prepend(this, nextLclFld);
                 }
             }
         }
@@ -4924,26 +4926,24 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
                 GenTreePtr curItem = gtNewOperNode(GT_IND, type[inx], curAddr);
                 if (newArg == nullptr)
                 {
-                    newArg = gtNewArgList(curItem);
+                    newArg = gtNewAggregate(curItem);
                 }
                 else
                 {
-                    newArg = gtNewListNode(curItem, newArg);
+                    newArg = newArg->Prepend(this, curItem);
                 }
             }
         }
     }
 
+#ifdef DEBUG
     // If we reach here we should have set newArg to something
     if (newArg == nullptr)
     {
-#ifdef DEBUG
         gtDispTree(argValue);
-#endif
         assert(!"Missing case in fgMorphMultiregStructArg");
     }
 
-#ifdef DEBUG
     if (verbose)
     {
         printf("fgMorphMultiregStructArg created tree:\n");

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -55528,7 +55528,7 @@ RelativePath=JIT\Performance\CodeQuality\Roslyn\CscBench\CscBench.cmd
 WorkingDir=JIT\Performance\CodeQuality\Roslyn\CscBench
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_6893;LONG_RUNNING
+Categories=Pri0;EXPECTED_PASS;LONG_RUNNING
 HostStyle=0
 [SciMark.cmd_8027]
 RelativePath=JIT\Performance\CodeQuality\SciMark\SciMark\SciMark.cmd
@@ -67652,7 +67652,7 @@ RelativePath=managed\Compilation\Compilation\Compilation.cmd
 WorkingDir=managed\Compilation\Compilation
 Expected=0
 MaxAllowedDurationSeconds=800
-Categories=Pri0;RT;EXPECTED_FAIL;ISSUE_6893;NATIVE_INTEROP;LONG_RUNNING
+Categories=Pri0;RT;EXPECTED_PASS;NATIVE_INTEROP;LONG_RUNNING
 HostStyle=0
 [generics.cmd_9787]
 RelativePath=readytorun\generics\generics.cmd


### PR DESCRIPTION
Aggregate arguments to calls (i.e. arguments that are made up
of multiple, independent values such as those to be passed in
multiple registers) are represented by GT_LIST nodes that are
not distiguishable from normal GT_LIST nodes without the extra
context of the call. GT_LIST nodes, however, are disallowed in
LIR ranges. The intersection of these two design choices causes
problems for code that operates on LIR but wants to observe
aggregate arguments as a whole (rather than piecewise). In the
case of #6893, this caused lowering to attempt to insert a
PUTARG_STK node after the GT_LIST node that represented the
aggregate argument that was being forced to the stack, which
caused an assertion in the LIR utilities to fail (the GT_LIST
node was passed as the insertion point to `LIR::Range::InsertAfter`,
which requires that the insertion point be a part of the given
range).

Conceptually, the fix is simple: the nodes that represent
aggregate arguments must be allowed to be part of LIR ranges.
The implementation, however, is complicated somewhat by the
need to distinguish the nodes used for aggregate arguments from
normal GT_LIST nodes. These changes implement a short-term
fix that distiguished these nodes by adding a node-specific flag,
`GTF_LIST_AGGREGATE`, to indicate that a GT_LIST node is in fact
an aggregate argument. In the long term, a more palatable
implementation would be the introduction of a new node and operator
type to represent aggregate arguments, but this is likely to
require broader changes to the compiler.