### PR TITLE
Fix DevDiv bug 255263

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -75,7 +75,8 @@ bool emitter::IsThreeOperandBinaryAVXInstruction(instruction ins)
             ins == INS_maxss || ins == INS_maxsd || ins == INS_andnps || ins == INS_andnpd || ins == INS_paddb ||
             ins == INS_paddw || ins == INS_paddd || ins == INS_paddq || ins == INS_psubb || ins == INS_psubw ||
             ins == INS_psubd || ins == INS_psubq || ins == INS_pmuludq || ins == INS_pxor || ins == INS_pmaxub ||
-            ins == INS_pminub || ins == INS_pmaxsw || ins == INS_pminsw || ins == INS_insertps || ins == INS_vinsertf128
+            ins == INS_pminub || ins == INS_pmaxsw || ins == INS_pminsw || ins == INS_insertps || ins == INS_vinsertf128 ||
+            ins == INS_punpckldq
 
             );
 }

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -311,6 +311,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlstack\*">
              <Issue>6553</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_255263\DevDiv_255263\DevDiv_255263.cmd">
+             <Issue>6940</Issue>
+        </ExcludeList>
     </ItemGroup>
     
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_255263/DevDiv_255263.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_255263/DevDiv_255263.il
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern legacy library mscorlib {}
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+.assembly initblk.exe{}
+
+.class public sealed Foo
+    extends [mscorlib]System.ValueType
+{
+    .field public int64 i1
+    .field public int64 i2
+    .field public int64 i3
+    .field public uint8 b
+}
+
+.class DevDiv_255263 {
+
+
+//    .data d = int32(0x00000000)
+	.field static valuetype Foo f
+        .field static float64 d
+
+//-------------------------
+// Entry point - Main
+//-------------------------
+.method static int32 Main(class [mscorlib]System.String[])
+{
+.entrypoint
+    .maxstack  10
+    .locals init (class [mscorlib]System.Random V_0,
+             float64 V_1,
+             float64 V_2,
+             int32 V_3)
+
+        // Get some floating point values and keep them live to avoid
+        // ymm0 being available.
+        newobj     instance void [mscorlib]System.Random::.ctor()
+        stloc.0
+        ldloc.0
+        callvirt   instance float64 [mscorlib]System.Random::NextDouble()
+        stloc.1
+        ldloc.0
+        callvirt   instance float64 [mscorlib]System.Random::NextDouble()
+        stloc.2
+
+	// -- init 25 bytes of memory to 0xAA
+	ldsflda		valuetype Foo DevDiv_255263::f
+	ldc.i4		0xAA
+	ldc.i4		25
+	unaligned. 0x1
+	initblk
+
+        // Now use the floating point values.
+        ldloc.1
+        ldloc.2
+        add
+        stsfld          float64 DevDiv_255263::d
+        ldc.i4.s        100
+        stloc.3
+
+	// -- load the 25 bytes of memory _and be sure they are all 0xAA
+	ldsflda		valuetype Foo DevDiv_255263::f
+        ldfld           int64 Foo::i1
+	ldc.i8		0xAAAAAAAAAAAAAAAA
+	ceq
+	brfalse		FAIL
+
+	ldsflda		valuetype Foo DevDiv_255263::f
+        ldfld           int64 Foo::i2
+	ldc.i8		0xAAAAAAAAAAAAAAAA
+	ceq
+	brfalse		FAIL
+	ldsflda		valuetype Foo DevDiv_255263::f
+        ldfld           int64 Foo::i3
+	ldc.i8		0xAAAAAAAAAAAAAAAA
+	ceq
+	brfalse		FAIL
+	ldsflda		valuetype Foo DevDiv_255263::f
+        ldfld           uint8 Foo::b
+	ldc.i4		0x000000AA
+	ceq
+	brfalse		FAIL
+
+//----------------
+PASS:
+	ldc.i4	0x64
+	ret
+//----------------
+FAIL:
+	ldc.i4	0xFFFFFFFF
+	ret
+}
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_255263/DevDiv_255263.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_255263/DevDiv_255263.ilproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_255263.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
This issue arose because we were not considering punpckldq as
one of the 3-operand AVX instructions (which require us to duplicate
the source register when encoding an SSE 2-operand form).
This bug showed up in managed C++, so the test is in IL.