### PR TITLE
Optimize Join, Concat taking an IEnumerable<string> for ICollections

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -162,31 +162,37 @@ namespace System {
         }
 
         [ComVisible(false)]
-        public static String Join(String separator, IEnumerable<String> values) {
+        public static string Join(string separator, IEnumerable<string> values)
+        {
             if (values == null)
                 throw new ArgumentNullException("values");
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
-            using(IEnumerator<String> en = values.GetEnumerator()) {
+            using (IEnumerator<string> en = values.GetEnumerator())
+            {
                 if (!en.MoveNext())
-                    return String.Empty;
+                    return string.Empty;
 
-                String firstValue = en.Current;
+                string firstValue = en.Current;
 
-                if (!en.MoveNext()) {
+                if (!en.MoveNext())
+                {
                     // Only one value available
-                    return firstValue ?? String.Empty;
+                    return firstValue ?? string.Empty;
                 }
 
                 // Null separator and values are handled by the StringBuilder
                 StringBuilder result = StringBuilderCache.Acquire();
                 result.Append(firstValue);
 
-                do {
+                do
+                {
                     result.Append(separator);
                     result.Append(en.Current);
-                } while (en.MoveNext());
+                }
+                while (en.MoveNext());
+                
                 return StringBuilderCache.GetStringAndRelease(result);
             }
         }

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -169,6 +169,22 @@ namespace System {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
+#if FEATURE_CORECLR
+            var collection = values as ICollection<string>;
+
+            if (collection != null)
+            {
+                int count = collection.Count; // cache the result of the interface method
+                if (count == 0)
+                    return string.Empty;
+                
+                var valuesArray = new string[count];
+                collection.CopyTo(valuesArray, 0);
+                return Join(separator, valuesArray); // This calls the overload accepting a string[]
+            }
+
+#endif // FEATURE_CORECLR
+
             using (IEnumerator<string> en = values.GetEnumerator())
             {
                 if (!en.MoveNext())
@@ -192,7 +208,7 @@ namespace System {
                     result.Append(en.Current);
                 }
                 while (en.MoveNext());
-                
+
                 return StringBuilderCache.GetStringAndRelease(result);
             }
         }
@@ -3581,6 +3597,22 @@ namespace System {
                 throw new ArgumentNullException("values");
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
+
+#if FEATURE_CORECLR
+            var collection = values as ICollection<string>;
+
+            if (collection != null)
+            {
+                int count = collection.Count; // cache the result of the interface method
+                if (count == 0)
+                    return string.Empty;
+                
+                var valuesArray = new string[count];
+                collection.CopyTo(valuesArray, 0);
+                return Concat(valuesArray); // This calls the overload accepting a string[]
+            }
+
+#endif // FEATURE_CORECLR
 
             using (IEnumerator<string> en = values.GetEnumerator())
             {

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -180,7 +180,7 @@ namespace System {
                 
                 var valuesArray = new string[count];
                 collection.CopyTo(valuesArray, 0);
-                return Join(separator, valuesArray); // This calls the overload accepting a string[]
+                return Join(separator, valuesArray); // This calls the overload accepting a string[], which handles Length == 1
             }
 
 #endif // FEATURE_CORECLR
@@ -3609,7 +3609,7 @@ namespace System {
                 
                 var valuesArray = new string[count];
                 collection.CopyTo(valuesArray, 0);
-                return Concat(valuesArray); // This calls the overload accepting a string[]
+                return Concat(valuesArray); // This calls the overload accepting a string[], which handles Length == 1
             }
 
 #endif // FEATURE_CORECLR


### PR DESCRIPTION
As of right now, `Join` and `Concat` which take an `IEnumerable<string>` use a StringBuilder to append all the items of the enumerable. This is quite slow, since even for length 1 collections where we just return the first string we are incurring the cost of 5 interface calls (`GetEnumerator`, `MoveNext`, `Current`, `MoveNext`, `Dispose`) as well as a heap allocation for the enumerator. Larger collections are even more costly, since in addition to those we are doing 3 thread-static field accesses to `StringBuilderCache`, in addition to 2 interface calls (`MoveNext`, `Current`) and calls to `StringBuilder.Append` and `Buffer.Memmove` per iteration.

I have changed it to try and detect first if the enumerable is an `ICollection`, and allocate an intermediary string array and `CopyTo` that. Then, we just call `Join(string, string[])` or `Concat(string[])`. This means we will only ever invoke 2 virtual calls (`Count` and `CopyTo`), and we don't have to copy the chars into an intermediary buffer.

The downside of this approach is we are now making 3 passes over the strings (1 for `CopyTo`, 1 to calculate the result's length, 1 to copy them into the result string) whereas before we were only making 1. Additionally, we are making more allocations than we were previously; assuming the StringBuilder was cached and the result string fit into the buffer, the only allocation we were making before was the enumerator, whereas now we are allocating a new `string[]` of length N.

## Performance results

In spite of these additional allocations/passes, the new implementation is consistently faster than the old one. You can see the perf test/results I have here: https://gist.github.com/jamesqo/7f1509d899396b0c724d2b73e402e19b

As you can see there are increased gen0 allocations for collections of length 3 and above, however all of the times are consistently faster.

/cc @jkotas, @bbowyersmyth, @benaadams 

edit: Also cc'ing @justinvp 