### PR TITLE
Add fedora24 native packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -235,6 +235,9 @@ isMSBuildOnNETCoreSupported()
                 "fedora.23-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
+                "fedora.24-x64")
+                    __isMSBuildOnNETCoreSupported=1
+                    ;;
                 "opensuse.13.2-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;

--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
@@ -35,6 +35,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora/24/Microsoft.NETCore.ILAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.ILAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj
@@ -29,6 +29,9 @@
     <ProjectReference Include="fedora\23\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\24\Microsoft.NETCore.ILAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.ILAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/fedora/24/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/fedora/24/Microsoft.NETCore.ILAsm.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.24-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ilasm" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
@@ -35,6 +35,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora/24/Microsoft.NETCore.ILDAsm.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.ILDAsm.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj
@@ -29,6 +29,9 @@
     <ProjectReference Include="fedora\23\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\24\Microsoft.NETCore.ILDAsm.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.ILDAsm.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/fedora/24/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/fedora/24/Microsoft.NETCore.ILDAsm.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.24-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)ildasm" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
@@ -35,6 +35,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora/24/Microsoft.NETCore.Jit.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.Jit.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.pkgproj
@@ -28,6 +28,9 @@
     <ProjectReference Include="fedora\23\Microsoft.NETCore.Jit.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\24\Microsoft.NETCore.Jit.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.Jit.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.Jit/fedora/24/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/fedora/24/Microsoft.NETCore.Jit.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.24-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
@@ -35,6 +35,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora/24/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -41,6 +41,9 @@
     <ProjectReference Include="fedora\23\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\24\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/fedora/24/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/fedora/24/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.24-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libcoreclr.so" />
+    <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so" />
+    <NativeSplittableBinary Include="$(BinDir)libdbgshim.so" />
+    <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so" />
+    <NativeSplittableBinary Include="$(BinDir)libmscordbi.so" />
+    <NativeSplittableBinary Include="$(BinDir)libsos.so" />
+    <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
+    <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll" />
+    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
+    <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
+    <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
+    <File Include="@(ArchitectureSpecificLibFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
+    </File>
+    <!-- No reference: don't permit reference to the implementation from lib -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/netstandard1.0</TargetPath>
+    </File>
+    <File Include="@(ArchitectureSpecificToolFile)">
+      <TargetPath>tools</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds
+++ b/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds
@@ -35,6 +35,10 @@
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora/24/Microsoft.NETCore.TestHost.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.TestHost.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
@@ -33,6 +33,9 @@
     <ProjectReference Include="fedora\23\Microsoft.NETCore.TestHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>
+    <ProjectReference Include="fedora\24\Microsoft.NETCore.TestHost.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.TestHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.TestHost/fedora/24/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/fedora/24/Microsoft.NETCore.TestHost.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Version>1.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.24-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)corerun" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Same as the previous PR for Ubuntu 16.10 and openSUSE 42.1, but this time for Fedora 24.