### PR TITLE
Change RyuJIT/x86 GC encoder to handle LSRA flexibility

### DIFF
--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -1777,7 +1777,11 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
                      */
 
                     /* Has this argument been enregistered? */
+#ifndef LEGACY_BACKEND
+                    if (!varDsc->lvOnFrame)
+#else  // LEGACY_BACKEND
                     if (varDsc->lvRegister)
+#endif // LEGACY_BACKEND
                     {
                         /* if a CEE_JMP has been used, then we need to report all the arguments
                            even if they are enregistered, since we will be using this value

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -266,9 +266,6 @@
     <!-- The following x86 failures only occur with RyuJIT/x86 -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x86'">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Serialization\Serialize\Serialize.cmd">
-             <Issue>3597</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\stringarr_cs_do\stringarr_cs_do.cmd">
              <Issue>4844</Issue>
         </ExcludeList>


### PR DESCRIPTION
LSRA allows a variable to have multiple registers over its lifetimes.
The x86 GC encoder did not understand this. It turns out the non-x86
encoder already had fixed this logic in its own copy of the logic.
This change simply checks the lvRegister and lvOnFrame variables
correctly for LSRA.

Fixes #3597