### PR TITLE
Monitor.TryEnter asm timeout != 0 before spin

### DIFF
--- a/src/vm/amd64/JitHelpers_InlineGetThread.asm
+++ b/src/vm/amd64/JitHelpers_InlineGetThread.asm
@@ -960,6 +960,10 @@ endif
         ret
 
     PrepareToWaitThinLock:
+        ; Return failure if timeout is zero
+        cmp     dword ptr [rsp + 10h], 0
+        je      TimeoutZero
+ 
         ; If we are on an MP system, we try spinning for a certain number of iterations
         cmp     dword ptr [g_SystemInfo + OFFSETOF__g_SystemInfo__dwNumberOfProcessors], 1
         jle     FramedLockHelper
@@ -981,6 +985,16 @@ endif
 
     RetryHelperThinLock:
         jmp     RetryThinLock
+
+	TimeoutZero:
+        ; Did not acquire, return FALSE
+        mov     byte ptr [r8], 0
+ifdef MON_DEBUG
+ifdef TRACK_SYNC
+        add     rsp, MON_ENTER_STACK_SIZE_INLINEGETTHREAD
+endif
+endif
+        ret
 
     HaveHashOrSyncBlockIndex:
         ; If we have a hash code already, we need to create a sync block
@@ -1067,9 +1081,21 @@ endif
         ret
 
     PrepareToWait:
+        ; Return failure if timeout is zero
+        cmp     dword ptr [rsp + 10h], 0
+ifdef MON_DEBUG
+ifdef TRACK_SYNC
+        ; if we are using the _DEBUG stuff then rsp has been adjusted
+        ; so compare the value at the adjusted position
+        ; there's really little harm in the extra stack read
+        cmp     dword ptr [rsp + MON_ENTER_STACK_SIZE_INLINEGETTHREAD + 10h]
+endif
+endif
+        je      TimeoutZero
+
         ; If we are on an MP system, we try spinning for a certain number of iterations
         cmp     dword ptr [g_SystemInfo + OFFSETOF__g_SystemInfo__dwNumberOfProcessors], 1
-        jle     WouldBlock
+        jle     Block
     
         ; Exponential backoff; delay by approximately 2*r10d clock cycles
         mov     eax, r10d
@@ -1084,29 +1110,7 @@ endif
         cmp     r10d, dword ptr [g_SpinConstants + OFFSETOF__g_SpinConstants__dwMaximumDuration]
         jle     RetrySyncBlock
 
-        ; We would need to block to enter the section. Return failure if
-        ; timeout is zero, else call the farmed helper to do the blocking
-        ; form of TryEnter.
-    WouldBlock:
-        mov     rdx, [rsp + 10h]
-        ; if we are using the _DEBUG stuff then rsp has been adjusted
-        ; just overwrite the wrong RDX value that we already retrieved
-        ; there's really little harm in the extra stack read
-ifdef MON_DEBUG
-ifdef TRACK_SYNC
-        mov     rdx, [rsp + MON_ENTER_STACK_SIZE_INLINEGETTHREAD + 10h]
-endif
-endif
-        test    rdx, rdx
-        jnz     Block
-        ; Return FALSE
-        mov		byte ptr [r8], 0
-ifdef MON_DEBUG
-ifdef TRACK_SYNC
-        add     rsp, MON_ENTER_STACK_SIZE_INLINEGETTHREAD
-endif
-endif
-        ret
+        jmp     Block
 
     RetryHelperSyncBlock:
         jmp     RetrySyncBlock

--- a/src/vm/amd64/JitHelpers_Slow.asm
+++ b/src/vm/amd64/JitHelpers_Slow.asm
@@ -1452,6 +1452,10 @@ NESTED_ENTRY JIT_MonTryEnter_Slow, _TEXT
         ret
 
     PrepareToWaitThinLock:
+        ; Return failure if timeout is zero
+        test    rsi, rsi
+        jz     TimeoutZero
+
         ; If we are on an MP system, we try spinning for a certain number of iterations
         cmp     dword ptr [g_SystemInfo + OFFSETOF__g_SystemInfo__dwNumberOfProcessors], 1
         jle     FramedLockHelper
@@ -1553,9 +1557,13 @@ endif
         ret
 
     PrepareToWait:
+        ; Return failure if timeout is zero
+        test    rsi, rsi
+        jz      TimeoutZero
+
         ; If we are on an MP system, we try spinning for a certain number of iterations
         cmp     dword ptr [g_SystemInfo + OFFSETOF__g_SystemInfo__dwNumberOfProcessors], 1
-        jle     WouldBlock
+        jle     Block
     
         ; Exponential backoff; delay by approximately 2*r10d clock cycles
         mov     eax, r10d
@@ -1570,15 +1578,11 @@ endif
         cmp     r10d, dword ptr [g_SpinConstants + OFFSETOF__g_SpinConstants__dwMaximumDuration]
         jle     RetrySyncBlock
 
-        ; We would need to block to enter the section. Return failure if
-        ; timeout is zero, else call the farmed helper to do the blocking
-        ; form of TryEnter.
-    WouldBlock:
-        test    rsi, rsi
-        jnz     Block
+        jmp     Block
 
+    TimeoutZero:
         ; Return FALSE
-        mov		byte ptr [r8], 0
+        mov     byte ptr [r8], 0
         add     rsp, MON_ENTER_STACK_SIZE
         pop     rsi
         ret


### PR DESCRIPTION
With this change Monitor.TryEnter(o, 0) moves from the slowest opportunistic locking to the fastest (when using the inline asm path)

corefx tests pass, not sure how to trigger the `TRACK_SYNC` flag?

1M iterations:

method | pre (ms) | post (ms) | improvement
-------- |------- |------- |------ |
Monitor.TryEnter(o, 0) | 221,739.76 | 5.49 | x 40389.8

Usage [from apisof.net](https://apisof.net/catalog/System.Threading.Monitor.TryEnter%28Object%2CInt32%29)

method | API port | nuget
-------- |------- |------- |------ |
Monitor.TryEnter(object) | 1.5% | 0.8%
Monitor.TryEnter(object, bool) | 1.2% | 0.3%
Monitor.TryEnter(object, int) | 2.1% | 1.0%
Monitor.TryEnter(object, int, bool) | 0.2% | 0.1% 
Monitor.TryEnter(object, timespan) | 0.4% | 0.3% 
Monitor.TryEnter(object, timespan, bool) | 0.1% | 0.1%


Resolves https://github.com/dotnet/coreclr/issues/6950
Resolves https://github.com/aspnet/KestrelHttpServer/issues/1068