### PR TITLE
SpinLock.TryEnter fail fast for timeout 0

### DIFF
--- a/src/mscorlib/src/System/Threading/SpinLock.cs
+++ b/src/mscorlib/src/System/Threading/SpinLock.cs
@@ -337,20 +337,24 @@ namespace System.Threading
                 Thread.BeginCriticalRegion();
 #endif
 
-                if (Interlocked.CompareExchange(ref m_owner, observedOwner | 1, observedOwner, ref lockTaken) == observedOwner ||
-                    millisecondsTimeout == 0)
+                if (Interlocked.CompareExchange(ref m_owner, observedOwner | 1, observedOwner, ref lockTaken) == observedOwner)
                 {
-                    // Aquired lock, or did not but timeout is 0 so fail fast
+                    // Aquired lock
                     return;
                 }
 
 #if !FEATURE_CORECLR
                 Thread.EndCriticalRegion();
 #endif
+                if (millisecondsTimeout == 0)
+                {
+                    // Did not aquire lock in CompareExchange and timeout is 0 so fail fast
+                    return;
+                }
             }
             else if (millisecondsTimeout == 0)
             {
-                // Did not aquire lock and timeout is 0 so fail fast
+                // Did not aquire lock as owned and timeout is 0 so fail fast
                 return;
             }
             else //failed to acquire the lock,then try to update the waiters. If the waiters count reached the maximum, jsut break the loop to avoid overflow

--- a/src/mscorlib/src/System/Threading/SpinLock.cs
+++ b/src/mscorlib/src/System/Threading/SpinLock.cs
@@ -359,14 +359,6 @@ namespace System.Threading
                     turn = (Interlocked.Add(ref m_owner, 2) & WAITERS_MASK) >> 1 ;
             }
 
-            // Check the timeout.
-            if ((millisecondsTimeout != Timeout.Infinite &&
-                TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout) <= 0))
-            {
-                DecrementWaiters();
-                return;
-            }
-
             //***Step 2. Spinning
             //lock acquired failed and waiters updated
             int processorCount = PlatformHelper.ProcessorCount;
@@ -400,14 +392,15 @@ namespace System.Threading
 #endif
                     }
                 }
+
+                // Check the timeout.
+                if (millisecondsTimeout != Timeout.Infinite && TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout) <= 0)
+                {
+                    DecrementWaiters();
+                    return;
+                }
             }
 
-            // Check the timeout.
-            if (millisecondsTimeout != Timeout.Infinite && TimeoutHelper.UpdateTimeOut(startTime, millisecondsTimeout) <= 0)
-            {
-                DecrementWaiters();
-                return;
-            }
 
             //*** Step 3, Yielding
             //Sleep(1) every 50 yields


### PR DESCRIPTION
Previously the timeout 0 would Interlocked.Add to set the waiters then CAS spin to unset it immediately after; now it exits before trying to set the waiters so skips both.

As timeout zero is tested early, removed the first time check as the next minimum time of 1ms is unlikely to have passed.

Moved the second time check into the spinning `if`, as if not spinning, again, 1ms is unlikely to have passed by this point.

Passes corefx tests

1M iters (single thread, uncontended but locked) for [code](https://gist.github.com/benaadams/a8de9032ae5f6ff89370842fb495d5fa)

```csharp
bool lockTaken = false;
var s = new SpinLock(false);
s.Enter(ref lockTaken);
```

method | pre (ms) | post (ms) | improvement
-------- |------- |------- |------ |
s.TryEnter(0, ref lockTaken) | 24.40 | 5.87 | x 4.1