### PR TITLE
SpanOfT: Fix reference types

### DIFF
--- a/src/mscorlib/src/System/Runtime/CompilerServices/jithelpers.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/jithelpers.cs
@@ -60,10 +60,10 @@ namespace System.Runtime.CompilerServices {
         public byte m_data;
     }
 
-    internal class ArrayPinningHelper<T>
+    internal class ArrayPinningHelper
     {
         public IntPtr m_lengthAndPadding;
-        public T m_arrayData;
+        public byte m_arrayData;
     }
 
     [FriendAccessAllowed]
@@ -230,41 +230,40 @@ namespace System.Runtime.CompilerServices {
 #if FEATURE_SPAN_OF_T
         static internal ref T GetByRef<T>(ref IntPtr byref)
         {
-            // The body of this function will be replaced by the EE with unsafe code that just returns o!!!
-            // See getILIntrinsicImplementation for how this happens.  
+            // The body of this function will be replaced by the EE with unsafe code!!!
+            // See getILIntrinsicImplementation for how this happens.
             throw new InvalidOperationException();
         }
 
         static internal void SetByRef<T>(out IntPtr byref, ref T value)
         {
-            // The body of this function will be replaced by the EE with unsafe code that just returns o!!!
-            // See getILIntrinsicImplementation for how this happens.  
+            // The body of this function will be replaced by the EE with unsafe code!!!
+            // See getILIntrinsicImplementation for how this happens.
             throw new InvalidOperationException();
         }
 
         static internal ref T AddByRef<T>(ref T pointer, int count)
         {
-            // The body of this function will be replaced by the EE with unsafe code that just returns o!!!
-            // See getILIntrinsicImplementation for how this happens.  
+            // The body of this function will be replaced by the EE with unsafe code!!!
+            // See getILIntrinsicImplementation for how this happens.
+            typeof(T).ToString(); // Type used by the actual method body
             throw new InvalidOperationException();
         }
 
         static internal bool ByRefEquals<T>(ref T refA, ref T refB)
         {
-            // The body of this function will be replaced by the EE with unsafe code that just returns o!!!
+            // The body of this function will be replaced by the EE with unsafe code!!!
             // See getILIntrinsicImplementation for how this happens.  
             throw new InvalidOperationException();
         }
-#endif
 
         static internal ref T GetArrayData<T>(T[] array)
         {
-            // This cast is really unsafe - call the private version that does not assert in debug
-#if _DEBUG
-            return ref UnsafeCastInternal<ArrayPinningHelper<T>>(array).m_arrayData;
-#else
-            return ref UnsafeCast<ArrayPinningHelper<T>>(array).m_arrayData;
-#endif
+            // The body of this function will be replaced by the EE with unsafe code!!!
+            // See getILIntrinsicImplementation for how this happens.
+            typeof(ArrayPinningHelper).ToString(); // Type used by the actual method body
+            throw new InvalidOperationException();
         }
+#endif // FEATURE_SPAN_OF_T
     }
 }

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -27,6 +27,12 @@ namespace System
         /// <param name="array">The target array.</param>
         public Span(T[] array)
         {
+            if (default(T) == null) // Arrays of valuetypes are never covariant
+            {
+                if (array.GetType() != typeof(T[]))
+                    ThrowHelper.ThrowArrayTypeMismatchException();
+            }
+
             JitHelpers.SetByRef(out _rawPointer, ref JitHelpers.GetArrayData(array));
             _length = array.Length;
         }
@@ -42,6 +48,12 @@ namespace System
         {
             if ((uint)start >= (uint)array.Length || (uint)length > (uint)(array.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
+
+            if (default(T) == null) // Arrays of valuetypes are nnever covariant
+            {
+                if (array.GetType() != typeof(T[]))
+                    ThrowHelper.ThrowArrayTypeMismatchException();
+            }
 
             JitHelpers.SetByRef(out _rawPointer, ref JitHelpers.AddByRef(ref JitHelpers.GetArrayData(array), start));
             _length = length;

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -41,7 +41,13 @@ namespace System {
     using System.Diagnostics.Contracts;
 
     [Pure]
-    internal static class ThrowHelper {    
+    internal static class ThrowHelper {
+#if FEATURE_SPAN_OF_T
+        internal static void ThrowArrayTypeMismatchException() {
+            throw new ArrayTypeMismatchException();
+        }
+#endif
+
         internal static void ThrowArgumentOutOfRangeException() {        
             ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_Index);            
         }

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -1348,6 +1348,7 @@ DEFINE_METHOD(JIT_HELPERS,          GET_BYREF,              GetByRef, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          SET_BYREF,              SetByRef, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          ADD_BYREF,              AddByRef, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          BYREF_EQUALS,           ByRefEquals, NoSig)
+DEFINE_METHOD(JIT_HELPERS,          GET_ARRAY_DATA,         GetArrayData, NoSig)
 #endif
 
 DEFINE_CLASS(INTERLOCKED,           Threading,              Interlocked)
@@ -1356,6 +1357,9 @@ DEFINE_METHOD(INTERLOCKED,          COMPARE_EXCHANGE_OBJECT,CompareExchange, SM_
 
 DEFINE_CLASS(PINNING_HELPER,        CompilerServices,       PinningHelper)
 DEFINE_FIELD(PINNING_HELPER,        M_DATA,                 m_data)
+
+DEFINE_CLASS(ARRAY_PINNING_HELPER,  CompilerServices,       ArrayPinningHelper)
+DEFINE_FIELD(ARRAY_PINNING_HELPER,  M_ARRAY_DATA,           m_arrayData)
 
 DEFINE_CLASS(RUNTIME_WRAPPED_EXCEPTION, CompilerServices,   RuntimeWrappedException)
 DEFINE_METHOD(RUNTIME_WRAPPED_EXCEPTION, OBJ_CTOR,          .ctor,                      IM_Obj_RetVoid)

--- a/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
+++ b/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
@@ -5,8 +5,23 @@
 using System;
 using System.Collections.Generic;
 
+class ReferenceType
+{
+    internal byte Value;
+    public ReferenceType(byte value) { Value = value; }
+}
+
 class My
 {
+    static void AssertTrue(bool condition, string message)
+    {
+        if (!condition)
+        {
+            Console.WriteLine(message);
+            Environment.Exit(1);
+        }
+    }
+
     static int Sum(Span<int> span)
     {
         int sum = 0;
@@ -15,12 +30,67 @@ class My
         return sum;
     }
 
+    static void TestSum()
+    {
+        int[] a = new int[] { 1, 2, 3, 4 };
+        Span<int> span = new Span<int>(a);
+        AssertTrue(Sum(span) == 10, "Unexpected sum of array");
+        Span<int> slice = span.Slice(1, 2);
+        AssertTrue(Sum(slice) == 5, "Unexpected sum of slice");
+    }
+
+    static void TestReferenceTypes()
+    {
+        var underlyingArray = new ReferenceType[] { new ReferenceType(0), new ReferenceType(1), new ReferenceType(2) };
+        var slice = new Span<ReferenceType>(underlyingArray);
+
+        for (int i = 0; i < underlyingArray.Length; i++)
+        {
+            AssertTrue(underlyingArray[i].Value == slice[i].Value, "Values are different");
+            AssertTrue(object.ReferenceEquals(underlyingArray[i], slice[i]), "References are broken");
+        }
+    }
+
+    static void TestArrayCoVariance()
+    {
+        var array = new ReferenceType[1];
+        var objArray = (object[])array;
+        try
+        {
+            new Span<object>(objArray);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+
+        var objEmptyArray = Array.Empty<ReferenceType>();
+        try
+        {
+            new Span<object>(objEmptyArray);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+    }
+
+    static void TestArrayCoVarianceReadOnly()
+    {
+        var array = new ReferenceType[1];
+        var objArray = (object[])array;
+        AssertTrue(new ReadOnlySpan<object>(objArray).Length == 1, "Unexpected length");
+
+        var objEmptyArray = Array.Empty<ReferenceType>();
+        AssertTrue(new ReadOnlySpan<object>(objEmptyArray).Length == 0, "Unexpected length");
+   }
+
     static void Main()
     {
-        int[] a = new int[] { 1, 2, 3 };
-        Span<int> span = new Span<int>(a);
-        Console.WriteLine(Sum(span).ToString());
-        Span<int> slice = span.Slice(1, 2);
-        Console.WriteLine(Sum(slice).ToString());
+        TestSum();
+        TestReferenceTypes();
+        TestArrayCoVariance();
+        TestArrayCoVarianceReadOnly();
+        Console.WriteLine("All tests passed");
     }
 }


### PR DESCRIPTION
- Generic ArrayPinningHelper resulted into incorrect array data offset for reference types. Use non-generic one instead.
- Add array covariance checks to guarantee type safety.