### PR TITLE
Random.Sample() uses Next().

### DIFF
--- a/src/mscorlib/src/System/Random.cs
+++ b/src/mscorlib/src/System/Random.cs
@@ -91,7 +91,7 @@ namespace System {
       protected virtual double Sample() {
           //Including this division at the end gives us significantly improved
           //random number distribution.
-          return (InternalSample()*(1.0/MBIG));
+          return (Next()*(1.0/MBIG));
       }
     
       private int InternalSample() {


### PR DESCRIPTION
`Next()` is public, virtual and equivelant to `InternalSample()`, while the latter is private.
By using `Next()` in `Sample()`, one can subclass `Random`, without having to override `Sample()`.