### PR TITLE
Re-enable stringarr test

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -266,12 +266,6 @@
     <!-- The following x86 failures only occur with RyuJIT/x86 -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x86'">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\stringarr_cs_do\stringarr_cs_do.cmd">
-             <Issue>4844</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\stringarr_cs_ro\stringarr_cs_ro.cmd">
-             <Issue>4844</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
             <Issue>x86 JIT doesn't support tail call opt</Issue>
         </ExcludeList>

--- a/tests/src/JIT/Methodical/MDArray/basics/stringarr.cs
+++ b/tests/src/JIT/Methodical/MDArray/basics/stringarr.cs
@@ -165,15 +165,17 @@ public class string1
             m++;
         }
 
+        pass = true;
         for (int i = 0; i < size; i++)
         {
-            pass = true;
             for (int j = 0; j < size; j++)
+            {
                 if (ima2d[i, j] != refa2d[i][j])
                 {
                     Console.WriteLine("i={0}, j={1}, imr[i,j] {2}!=refr[i][j] {3}", i, j, ima2d[i, j], refa2d[i][j]);
                     pass = false;
                 }
+            }
         }
 
         if (pass)
@@ -214,15 +216,17 @@ public class string1
             m++;
         }
 
+        pass = true;
         for (int i = 0; i < size; i++)
         {
-            pass = true;
             for (int j = 0; j < size; j++)
+            {
                 if (ima3d[i, size, j] != refa3d[i][j])
                 {
                     Console.WriteLine("i={0}, j={1}, imr[i,{4},j] {2}!=refr[i][j] {3}", i, j, ima3d[i, size, j], refa3d[i][j], size);
                     pass = false;
                 }
+            }
         }
 
         if (pass)


### PR DESCRIPTION
I can't get this to fail locally despite thousands of runs. Perhaps there was a bug fixed after the bug was opened.

I fixed the test to detect failure when checking all indices, not
just when checking the last index of the first rank.

Fixes #4844.