### PR TITLE
Move TailcallVerifyWithPrefix test to "baseline x86" exclusion section

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -261,14 +261,14 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\smallFrame\smallFrame.cmd">
              <Issue>tail. call pop ret is only supported on amd64</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
+            <Issue>x86 JIT doesn't support implicit tail call optimization or tail. call pop ret sequence</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following x86 failures only occur with RyuJIT/x86 -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x86'">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
-            <Issue>x86 JIT doesn't support tail call opt</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\basics\loopEH\loopEH.cmd">
              <Issue>6778</Issue>
         </ExcludeList>


### PR DESCRIPTION
This test fails for both legacy x86 JIT as well as RyuJIT. Make that more
clear by moving the exclusion to the "x86 baseline failures" section.