### PR TITLE
Enable FunctionEnter/FunctionLeave callbacks on ARM

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -7583,7 +7583,7 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper /*= CORINFO_HELP_PROF_FC
     emitAttr attr = EA_UNKNOWN;
 
     if (compiler->info.compRetType == TYP_VOID ||
-        (!compiler->info.compIsVarArgs && (varTypeIsFloating(compiler->info.compRetType) ||
+        (!compiler->info.compIsVarArgs && !compiler->opts.compUseSoftFP && (varTypeIsFloating(compiler->info.compRetType) ||
                                            compiler->IsHfa(compiler->info.compMethodInfo->args.retTypeClass))))
     {
         r0Trashed = false;

--- a/src/vm/arm/asmhelpers.S
+++ b/src/vm/arm/asmhelpers.S
@@ -636,6 +636,92 @@ ThePreStubPatchLabel:
 
         .endm
 
+//
+// EXTERN_C void ProfileEnterNaked(FunctionIDOrClientID functionIDOrClientID);
+//
+NESTED_ENTRY ProfileEnterNaked, _TEXT, NoHandler
+    PROLOG_PUSH "{r4, r5, r7, r11, lr}"
+    PROLOG_STACK_SAVE_OFFSET r7, #8
+
+    // fields of PLATFORM_SPECIFIC_DATA, in reverse order
+
+    // UINT32      r0;         // Keep r0 & r1 contiguous to make returning 64-bit results easier
+    // UINT32      r1;
+    // void       *R11;
+    // void       *Pc;
+    // union                   // Float arg registers as 32-bit (s0-s15) and 64-bit (d0-d7)
+    // {
+    //     UINT32  s[16];
+    //     UINT64  d[8];
+    // };
+    // FunctionID  functionId;
+    // void       *probeSp;    // stack pointer of managed function 
+    // void       *profiledSp; // location of arguments on stack
+    // LPVOID      hiddenArg;
+    // UINT32      flags;
+    movw        r4, #1
+    push        { /* flags      */ r4 }
+    movw        r4, #0
+    push        { /* hiddenArg  */ r4 }
+    add         r5, r11, #8
+    push        { /* profiledSp */ r5 }
+    add         r5, sp, #32
+    push        { /* probeSp    */ r5 }
+    push        { /* functionId */ r0 }
+    vpush.64    { d0 - d7 }
+    push        { lr }
+    push        { r11 }
+    push        { /* return value, r4 is NULL */ r4 }
+    push        { /* return value, r4 is NULL */ r4 }
+    mov         r1, sp
+    bl          C_FUNC(ProfileEnter)
+    EPILOG_STACK_RESTORE_OFFSET r7, #8
+    EPILOG_POP "{r4, r5, r7, r11, pc}"
+NESTED_END ProfileEnterNaked, _TEXT
+
+//
+// EXTERN_C void ProfileLeaveNaked(FunctionIDOrClientID functionIDOrClientID);
+//
+NESTED_ENTRY ProfileLeaveNaked, _TEXT, NoHandler
+    PROLOG_PUSH "{r1, r2, r4, r5, r7, r11, lr}"
+    PROLOG_STACK_SAVE_OFFSET r7, #16
+
+    // fields of PLATFORM_SPECIFIC_DATA, in reverse order
+
+    // UINT32      r0;         // Keep r0 & r1 contiguous to make returning 64-bit results easier
+    // UINT32      r1;
+    // void       *R11;
+    // void       *Pc;
+    // union                   // Float arg registers as 32-bit (s0-s15) and 64-bit (d0-d7)
+    // {
+    //     UINT32  s[16];
+    //     UINT64  d[8];
+    // };
+    // FunctionID  functionId;
+    // void       *probeSp;    // stack pointer of managed function 
+    // void       *profiledSp; // location of arguments on stack
+    // LPVOID      hiddenArg;
+    // UINT32      flags;
+    movw        r4, #2
+    push        { /* flags      */ r4 }
+    movw        r4, #0
+    push        { /* hiddenArg  */ r4 }
+    add         r5, r11, #8
+    push        { /* profiledSp */ r5 }
+    add         r5, sp, #40
+    push        { /* probeSp    */ r5 }
+    push        { /* functionId */ r0 }
+    vpush.64    { d0 - d7 }
+    push        { lr }
+    push        { r11 }
+    push        { r1 }
+    push        { r2 }
+    mov         r1, sp
+    bl          C_FUNC(ProfileLeave)
+    EPILOG_STACK_RESTORE_OFFSET r7, #16
+    EPILOG_POP "{r1, r2, r4, r5, r7, r11, pc}"
+NESTED_END ProfileLeaveNaked, _TEXT
+
 // EXTERN_C int __fastcall HelperMethodFrameRestoreState(
 //         INDEBUG_COMMA(HelperMethodFrame *pFrame)
 //         MachState *pState

--- a/src/vm/arm/unixstubs.cpp
+++ b/src/vm/arm/unixstubs.cpp
@@ -21,16 +21,6 @@ extern "C"
         PORTABILITY_ASSERT("Implement for PAL");
     }
 
-    void ProfileEnterNaked(FunctionIDOrClientID functionIDOrClientID)
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
-    void ProfileLeaveNaked(FunctionIDOrClientID functionIDOrClientID)
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
     void ProfileTailcallNaked(FunctionIDOrClientID functionIDOrClientID)
     {
         PORTABILITY_ASSERT("Implement for PAL");


### PR DESCRIPTION
This PR enables profiler enter/leave callbacks on ARM. These helper functions need two arguments: function id and the location of arguments on the stack. Previously only functionId was passed. This attempts to resolve it by passing the second argument in r1. For ProfileLeave it also involves moving the retval from r1 to r3 and restoring it to r1 after the callback returns.
@noahfalk @rahku @myungjoo @Dmitri-Botcharnikov 