### PR TITLE
Fix constructors in System.Reflection.AssemblyNameProxy and System.Reflection.Pointer

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -4129,9 +4129,6 @@
       <Member MemberType="Field" Name="Retargetable" />
       <Member MemberType="Field" Name="value__" />
     </Type>
-    <Type Name="System.Reflection.AssemblyNameProxy">
-      <Member Name="#ctor" />
-    </Type>
     <Type Name="System.Reflection.AssemblyProductAttribute">
       <Member Name="#ctor(System.String)" />
       <Member Name="get_Product" />
@@ -5912,7 +5909,6 @@
       <Member MemberType="Property" Name="Item(System.Int32)" />
     </Type>
     <Type Name="System.Reflection.Pointer" >
-      <Member Name="#ctor" />
       <Member Name="Box(System.Void*,System.Type)" />
       <Member Name="Unbox(System.Object)" />
       <Member Name="System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -7341,11 +7341,6 @@ namespace System.Reflection
         PublicKey = 1,
         Retargetable = 256,
     }
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public class AssemblyNameProxy : System.MarshalByRefObject
-    {
-        internal AssemblyNameProxy() { }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class AssemblyProductAttribute : System.Attribute
@@ -8083,6 +8078,7 @@ namespace System.Reflection
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed class Pointer : System.Runtime.Serialization.ISerializable
     {
+        private Pointer() { }
         [System.Security.SecurityCriticalAttribute]
         public static unsafe Object Box(void *ptr, System.Type type) { throw null; }
         [System.Security.SecurityCriticalAttribute]


### PR DESCRIPTION
This is an addition to https://github.com/dotnet/coreclr/pull/6614, where these two changes were missed. This is to match the mscorelib in Xamarin.

cc: @danmosemsft @weshaggard @AtsushiKan 