### PR TITLE
Implement DecomposeShift

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1935,6 +1935,7 @@ public:
     GenTreeArgList* gtNewArgList(GenTreePtr op);
 
     GenTreeArgList* gtNewArgList(GenTreePtr op1, GenTreePtr op2);
+    GenTreeArgList* gtNewArgList(GenTreePtr op1, GenTreePtr op2, GenTreePtr op3);
 
     static fgArgTabEntryPtr gtArgEntryByArgNum(GenTreePtr call, unsigned argNum);
     static fgArgTabEntryPtr gtArgEntryByNode(GenTreePtr call, GenTreePtr node);

--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -47,6 +47,7 @@ private:
     GenTree* DecomposeNot(LIR::Use& use);
     GenTree* DecomposeNeg(LIR::Use& use);
     GenTree* DecomposeArith(LIR::Use& use);
+    GenTree* DecomposeShift(LIR::Use& use);
 
     // Helper functions
     GenTree* FinalizeDecomposition(LIR::Use& use, GenTree* loResult, GenTree* hiResult);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6388,6 +6388,16 @@ GenTreeArgList* Compiler::gtNewArgList(GenTreePtr arg1, GenTreePtr arg2)
 
 /*****************************************************************************
  *
+ *  Create a list out of the three values.
+ */
+
+GenTreeArgList* Compiler::gtNewArgList(GenTreePtr arg1, GenTreePtr arg2, GenTreePtr arg3)
+{
+    return new (this, GT_LIST) GenTreeArgList(arg1, gtNewArgList(arg2, arg3));
+}
+
+/*****************************************************************************
+ *
  *  Given a GT_CALL node, access the fgArgInfo and find the entry
  *  that has the matching argNum and return the fgArgTableEntryPtr
  */

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2785,6 +2785,20 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             assert(arg1 != nullptr);
             nonStandardArgs.Add(arg1, REG_PINVOKE_FRAME);
         }
+        // The x86 shift helpers have custom calling conventions and expect the lo part of the long to be in EAX and the
+        // hi part to be in EDX. This sets the argument registers up correctly.
+        else if (call->IsHelperCall(this, CORINFO_HELP_LLSH) || call->IsHelperCall(this, CORINFO_HELP_LRSH) || call->IsHelperCall(this, CORINFO_HELP_LRSZ))
+        {
+            GenTreeArgList* args = call->gtCallArgs;
+            GenTree* arg1 = args->Current();
+            assert(arg1 != nullptr);
+            nonStandardArgs.Add(arg1, REG_LNGARG_LO);
+
+            args = args->Rest();
+            GenTree* arg2 = args->Current();
+            assert(arg2 != nullptr);
+            nonStandardArgs.Add(arg2, REG_LNGARG_HI);
+        }
 #endif // !defined(LEGACY_BACKEND) && defined(_TARGET_X86_)
 
 #if !defined(LEGACY_BACKEND) && !defined(_TARGET_X86_)

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -549,6 +549,10 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_LNGARG_0            (RBM_EAX|RBM_EDX)
   #define PREDICT_PAIR_LNGARG_0    PREDICT_PAIR_EAXEDX
 
+  #define REG_LNGARG_LO             REG_EAX
+  #define RBM_LNGARG_LO             RBM_EAX
+  #define REG_LNGARG_HI             REG_EDX
+  #define RBM_LNGARG_HI             RBM_EDX
   // register to hold shift amount
   #define REG_SHIFT                REG_ECX
   #define RBM_SHIFT                RBM_ECX


### PR DESCRIPTION
This change adds support for GT_LSH, GT_RSH, and GT_RSZ for x86 longs.
These nodes are implemented via helpers, so in decompose, we must remove
the shift node from the tree and replace it with a call to the helper.
Additionally, these helpers require that the long operand is in EAX:EDX,
so rather than adding a GT_LONG to the call arg list like we would
normally, we split the high and low parts of the arg and mark them as
non-standard args in gtMorphArgs to force the low part to be in EAX and
the high part to be in EDX. The shift amount is already defaulted to ECX,
which is where the helper expects it to be.