### PR TITLE
Fix the srcCount for an unused GT_LONG.

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -239,9 +239,9 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 #if !defined(_TARGET_64BIT_)
 
         case GT_LONG:
-            if (tree->gtNext == nullptr)
+            if ((tree->gtLIRFlags & LIR::Flags::IsUnusedValue) != 0)
             {
-                // An uncontained GT_LONG node needs to consume its source operands
+                // An unused GT_LONG node needs to consume its sources.
                 info->srcCount = 2;
             }
             else
@@ -249,6 +249,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 // Passthrough
                 info->srcCount = 0;
             }
+
             info->dstCount = 0;
             break;
 


### PR DESCRIPTION
GT_LONG nodes that do not have a corresponding use need to
consume their operands. There was already code in lowerxarch
that attempted to do so, but this code was no longer valid in
LIR.