### PR TITLE
Fix funceval of a function returning 16 byte value type.

### DIFF
--- a/src/ToolBox/SOS/NETCore/SymbolReader.cs
+++ b/src/ToolBox/SOS/NETCore/SymbolReader.cs
@@ -389,23 +389,30 @@ namespace SOS
         /// <remarks>used by the gdb JIT support (not SOS). Does not support in-memory PEs or PDBs</remarks>
         internal static bool GetInfoForMethod(string assemblyPath, int methodToken, ref MethodDebugInfo debugInfo)
         {
-            List<DebugInfo> points = null;
-
-            if (!GetDebugInfoForMethod(assemblyPath, methodToken, out points))
+            try
             {
-                return false;
+                List<DebugInfo> points = null;
+
+                if (!GetDebugInfoForMethod(assemblyPath, methodToken, out points))
+                {
+                    return false;
+                }
+                var structSize = Marshal.SizeOf<DebugInfo>();
+
+                debugInfo.size = points.Count;
+                var ptr = debugInfo.points;
+
+                foreach (var info in points)
+                {
+                    Marshal.StructureToPtr(info, ptr, false);
+                    ptr = (IntPtr)(ptr.ToInt64() + structSize);
+                }
+                return true;
             }
-            var structSize = Marshal.SizeOf<DebugInfo>();
-
-            debugInfo.size = points.Count;
-            var ptr = debugInfo.points;
-
-            foreach (var info in points)
+            catch
             {
-                Marshal.StructureToPtr(info, ptr, false);
-                ptr = (IntPtr)(ptr.ToInt64() + structSize);
             }
-            return true;
+            return false;
         }
 
         /// <summary>

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -1463,7 +1463,7 @@ DebuggerEval::DebuggerEval(CONTEXT * pContext, DebuggerIPCE_FuncEvalInfo * pEval
     m_genericArgsNodeCount = pEvalInfo->genericArgsNodeCount;
     m_successful = false;
     m_argData = NULL;
-    m_result = 0;
+    memset(m_result, 0, sizeof(m_result));
     m_md = NULL;
     m_resultType = TypeHandle();
     m_aborting = FE_ABORT_NONE;
@@ -1519,7 +1519,7 @@ DebuggerEval::DebuggerEval(CONTEXT * pContext, Thread * pThread, Thread::ThreadA
     m_successful = false;
     m_argData = NULL;
     m_targetCodeAddr = NULL;
-    m_result = 0;
+    memset(m_result, 0, sizeof(m_result));
     m_md = NULL;
     m_resultType = TypeHandle();
     m_aborting = FE_ABORT_NONE;
@@ -10353,7 +10353,7 @@ void Debugger::FuncEvalComplete(Thread* pThread, DebuggerEval *pDE)
     if (CORDBUnrecoverableError(this))
         return;
 
-    LOG((LF_CORDB, LL_INFO10000, "D::FEC: func eval complete pDE:%08x evalType:%d %s %s\n",
+    LOG((LF_CORDB, LL_INFO1000, "D::FEC: func eval complete pDE:%p evalType:%d %s %s\n",
         pDE, pDE->m_evalType, pDE->m_successful ? "Success" : "Fail", pDE->m_aborted ? "Abort" : "Completed"));
 
 
@@ -10386,11 +10386,11 @@ void Debugger::FuncEvalComplete(Thread* pThread, DebuggerEval *pDE)
     ipce->FuncEvalComplete.funcEvalKey = pDE->m_funcEvalKey;
     ipce->FuncEvalComplete.successful = pDE->m_successful;
     ipce->FuncEvalComplete.aborted = pDE->m_aborted;
-    ipce->FuncEvalComplete.resultAddr = &(pDE->m_result);
+    ipce->FuncEvalComplete.resultAddr = pDE->m_result;
     ipce->FuncEvalComplete.vmAppDomain.SetRawPtr(pResultDomain);
     ipce->FuncEvalComplete.vmObjectHandle = pDE->m_vmObjectHandle;
 
-    LOG((LF_CORDB, LL_INFO10000, "D::FEC: TypeHandle is :%08x\n", pDE->m_resultType.AsPtr()));
+    LOG((LF_CORDB, LL_INFO1000, "D::FEC: TypeHandle is %p\n", pDE->m_resultType.AsPtr()));
 
     Debugger::TypeHandleToExpandedTypeInfo(pDE->m_retValueBoxing, // whether return values get boxed or not depends on the particular FuncEval we're doing...
                                            pResultDomain,
@@ -10399,11 +10399,12 @@ void Debugger::FuncEvalComplete(Thread* pThread, DebuggerEval *pDE)
 
     _ASSERTE(ipce->FuncEvalComplete.resultType.elementType != ELEMENT_TYPE_VALUETYPE);
 
-    LOG((LF_CORDB, LL_INFO10000, "D::FEC: returned from call\n"));
-
     // We must adjust the result address to point to the right place
     ipce->FuncEvalComplete.resultAddr = ArgSlotEndianessFixup((ARG_SLOT*)ipce->FuncEvalComplete.resultAddr, 
         GetSizeForCorElementType(ipce->FuncEvalComplete.resultType.elementType));
+
+    LOG((LF_CORDB, LL_INFO1000, "D::FEC: returned el %04x resultAddr %p\n", 
+        ipce->FuncEvalComplete.resultType.elementType, ipce->FuncEvalComplete.resultAddr));
 
     m_pRCThread->SendIPCEvent();
 

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -3431,7 +3431,7 @@ public:
     BYTE                              *m_argData;
     MethodDesc                        *m_md;
     PCODE                              m_targetCodeAddr;
-    INT64                              m_result;
+    ARG_SLOT                           m_result[NUMBER_RETURNVALUE_SLOTS];
     TypeHandle                         m_resultType;
     SIZE_T                             m_arrayRank;
     FUNC_EVAL_ABORT_TYPE               m_aborting;          // Has an abort been requested, and what type.

--- a/src/vm/callhelpers.h
+++ b/src/vm/callhelpers.h
@@ -41,6 +41,8 @@ struct CallDescrData
 #endif
 };
 
+#define NUMBER_RETURNVALUE_SLOTS (ENREGISTERED_RETURNTYPE_MAXSIZE / sizeof(ARG_SLOT))
+
 #if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 
 extern "C" void STDCALL CallDescrWorkerInternal(CallDescrData * pCallDescrData);
@@ -131,9 +133,9 @@ private:
 
 #ifdef FEATURE_INTERPRETER
 public:
-    ARG_SLOT CallTargetWorker(const ARG_SLOT *pArguments, bool transitionToPreemptive = false);
+    void CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *pReturnValue, int cbReturnValue, bool transitionToPreemptive = false);
 #else
-    ARG_SLOT CallTargetWorker(const ARG_SLOT *pArguments);
+    void CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *pReturnValue, int cbReturnValue);
 #endif
 
 public:
@@ -309,8 +311,19 @@ public:
                                   eltype == m_methodSig.GetReturnType());           \
             }                                                                       \
             ARG_SLOT retval;                                                        \
-            retval = CallTargetWorker(pArguments);                                  \
+            CallTargetWorker(pArguments, &retval, sizeof(retval));                  \
             return *(rettype *)ArgSlotEndianessFixup(&retval, sizeof(rettype));     \
+        }
+
+#define MDCALLDEF_ARGSLOT(wrappedmethod, ext)                                       \
+        FORCEINLINE void wrappedmethod##ext (const ARG_SLOT* pArguments, ARG_SLOT *pReturnValue, int cbReturnValue) \
+        {                                                                           \
+            WRAPPER_NO_CONTRACT;                                                    \
+            {                                                                       \
+                GCX_FORBID();  /* arg array is not protected */                     \
+            }                                                                       \
+            CallTargetWorker(pArguments, pReturnValue, cbReturnValue);              \
+            /* Bigendian layout not support */                                      \
         }
 
 #define MDCALLDEF_REFTYPE(wrappedmethod,  permitvaluetypes, ext, ptrtype, reftype)              \
@@ -322,7 +335,7 @@ public:
                 CONSISTENCY_CHECK(MetaSig::RETOBJ == m_pMD->ReturnsObject(true));               \
             }                                                                                   \
             ARG_SLOT retval;                                                                    \
-            retval = CallTargetWorker(pArguments);                                              \
+            CallTargetWorker(pArguments, &retval, sizeof(retval));                              \
             return ObjectTo##reftype(*(ptrtype *)                                               \
                         ArgSlotEndianessFixup(&retval, sizeof(ptrtype)));                       \
         }
@@ -336,7 +349,7 @@ public:
         FORCEINLINE void wrappedmethod (const ARG_SLOT* pArguments)     \
         {                                                               \
             WRAPPER_NO_CONTRACT;                                        \
-            CallTargetWorker(pArguments);                               \
+            CallTargetWorker(pArguments, NULL, 0);                      \
         }
 
 #define MDCALLDEFF_STD_RETTYPES(wrappedmethod,permitvaluetypes)                                         \
@@ -426,7 +439,7 @@ public:
 
         // XXX CallWithValueTypes_RetXXX(const ARG_SLOT* pArguments);
         MDCALLDEF_VOID(     CallWithValueTypes, TRUE)
-        MDCALLDEF(          CallWithValueTypes, TRUE,   _RetArgSlot,    ARG_SLOT,   OTHER_ELEMENT_TYPE)
+        MDCALLDEF_ARGSLOT(  CallWithValueTypes, _RetArgSlot)
         MDCALLDEF_REFTYPE(  CallWithValueTypes, TRUE,   _RetOBJECTREF,  Object*,    OBJECTREF)
         MDCALLDEF(          CallWithValueTypes, TRUE,   _RetOleColor,   OLE_COLOR,  OTHER_ELEMENT_TYPE)
 #undef OTHER_ELEMENT_TYPE

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -9578,6 +9578,7 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
 
     // This is the argument slot that will be used to hold the return value.
     ARG_SLOT retVal = 0;
+    _ASSERTE (NUMBER_RETURNVALUE_SLOTS == 1);
 
     // If the return type is a structure, then these will be initialized.
     CORINFO_CLASS_HANDLE retTypeClsHnd = NULL;
@@ -9853,7 +9854,7 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
 #if INTERP_ILCYCLE_PROFILE
             bool b = CycleTimer::GetThreadCyclesS(&startCycles); assert(b);
 #endif // INTERP_ILCYCLE_PROFILE
-            retVal = mdcs.CallTargetWorker(args);
+            mdcs.CallTargetWorker(args, &retVal, sizeof(retVal));
 
             if (pCscd != NULL)
             {
@@ -10323,7 +10324,7 @@ void Interpreter::CallI()
             // to be a managed calling convention.)
             MethodDesc* pStubContextMD = reinterpret_cast<MethodDesc*>(m_stubContext);
             bool transitionToPreemptive = (pStubContextMD != NULL && !pStubContextMD->IsIL());
-            retVal = mdcs.CallTargetWorker(args, transitionToPreemptive);
+            mdcs.CallTargetWorker(args, &retVal, sizeof(retVal), transitionToPreemptive);
         }
         // retVal is now vulnerable.
         GCX_FORBID();

--- a/src/vm/mngstdinterfaces.cpp
+++ b/src/vm/mngstdinterfaces.cpp
@@ -228,7 +228,7 @@ LPVOID MngStdItfBase::ForwardCallToManagedView(
             MethodDescCallSite mngItf(pMngItfMD, CRemotingServices::GetStubForInterfaceMethod(pMngItfMD));
 
             // Call the stub with the args we were passed originally.
-            Result = (Object*)mngItf.CallWithValueTypes_RetArgSlot(pArgs);
+            Result = (Object*)mngItf.Call_RetArgSlot(pArgs);
             if (mngItf.GetMetaSig()->IsObjectRefReturnType()) 
             {
                 Lr.Result = ObjectToOBJECTREF(Result);


### PR DESCRIPTION
Fixes issue #6935.

On Linux and OS X, structs less or equal to 16 bytes (instead of 8 bytes
on Windows) are enregistered. Only 8 bytes is being passed back to
debugger during a funceval of a property or method that returns a 16
byte value type.

To fix this, the 16 byte return value (which is only used for enregistered
structures of that size on xplat) needed to be plumbed from CallTargetWorker
through the MethodDescCallSite macros to the func eval code.

The func eval code needed to also deal with 16 byte results.

NUMBER_RETURNVALUE_SLOTS is the number of ARG_SLOTs that will contain the
maximum enregistered return value.

CordbEval:m_result is now ARG_SLOT[NUMBER_RETURNVALUE_SLOTS].

CallTargetWorker is now passed a pointer and the count of bytes to/of the
return value buffer.

Minor fix to SOS SymbolReader function.