### PR TITLE
Allow long->int "struct promotion" of do-not-enregister long locals

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1775,6 +1775,12 @@ void Compiler::lvaPromoteLongVars()
             continue;
         }
 
+        if (varDsc->lvDoNotEnregister)
+        {
+            JITDUMP("Not promoting long local V%02u: marked lvDoNotEnregister\n", lclNum);
+            continue;
+        }
+
         if (varDsc->lvIsMultiRegArgOrRet())
         {
             JITDUMP("Not promoting long local V%02u: marked lvIsMultiRegArgOrRet()\n", lclNum);

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1982,6 +1982,14 @@ VARSET_VALRET_TP Compiler::fgComputeLifeLIR(VARSET_VALARG_TP lifeArg, BasicBlock
             bool isDeadStore = fgComputeLifeLocal(life, keepAliveVars, node, node);
             if (isDeadStore)
             {
+#ifdef DEBUG
+                if (verbose)
+                {
+                    printf("Node is a dead store:\n");
+                    DISPNODE(node);
+                    printf("\n");
+                }
+#endif // DEBUG
                 fgTryRemoveDeadLIRStore(blockRange, node, &next);
             }
         }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16861,11 +16861,13 @@ void Compiler::fgPromoteStructs()
 
     if (!opts.OptEnabled(CLFLG_STRUCTPROMOTE))
     {
+        JITDUMP("CLFLG_STRUCTPROMOTE not set; not doing struct promotion\n");
         return;
     }
 
     if (fgNoStructPromotion)
     {
+        JITDUMP("fgNoStructPromotion set; not doing struct promotion\n");
         return;
     }
 
@@ -16902,11 +16904,13 @@ void Compiler::fgPromoteStructs()
 
     if (info.compIsVarArgs)
     {
+        JITDUMP("Function has varargs parameters; not doing struct promotion\n");
         return;
     }
 
     if (getNeedsGSSecurityCookie())
     {
+        JITDUMP("Function needs a GS security cookie; not doing struct promotion\n");
         return;
     }
 
@@ -16920,6 +16924,7 @@ void Compiler::fgPromoteStructs()
 
     lvaStructPromotionInfo structPromotionInfo;
     bool                   tooManyLocals = false;
+    bool                   anyPromotedStructs = false;
 
     for (unsigned lclNum = 0; lclNum < startLvaCount; lclNum++)
     {
@@ -16968,7 +16973,6 @@ void Compiler::fgPromoteStructs()
 
             if (canPromote)
             {
-
                 // We *can* promote; *should* we promote?
                 // We should only do so if promotion has potential savings.  One source of savings
                 // is if a field of the struct is accessed, since this access will be turned into
@@ -17066,6 +17070,7 @@ void Compiler::fgPromoteStructs()
                     // Promote the this struct local var.
                     lvaPromoteStructVar(lclNum, &structPromotionInfo);
                     promotedVar = true;
+                    anyPromotedStructs = true;
 
 #ifdef _TARGET_ARM_
                     if (structPromotionInfo.requiresScratchVar)
@@ -17093,6 +17098,14 @@ void Compiler::fgPromoteStructs()
         }
 #endif // FEATURE_SIMD
     }
+
+#ifdef DEBUG
+    if (verbose && anyPromotedStructs)
+    {
+        printf("lvaTable after fgPromoteStructs\n");
+        lvaTableDump();
+    }
+#endif // DEBUG
 }
 
 Compiler::fgWalkResult Compiler::fgMorphStructField(GenTreePtr tree, fgWalkData* fgWalkPre)

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -239,12 +239,6 @@
     <!-- The following x86 failures only occur with RyuJIT/x86 -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x86'">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\basics\loopEH\loopEH.cmd">
-            <Issue>6778</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\superlong\_il_relsuperlong\_il_relsuperlong.cmd">
-            <Issue>6778</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlstack\*">
             <Issue>6553</Issue>
         </ExcludeList>


### PR DESCRIPTION
Also, add more dumping of (1) the reasons a long local is not promoted,
(2) the results of the local variable table after normal struct promotion,
and (3) when an LIR dead store node is found during liveness.

Fixes #6778