### PR TITLE
Print an error, in DEBUG, if we fail to open the JitFuncInfoLogFile

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4774,6 +4774,12 @@ int Compiler::compCompile(CORINFO_METHOD_HANDLE methodHnd,
         {
             assert(compJitFuncInfoFile == nullptr);
             compJitFuncInfoFile = _wfopen(compJitFuncInfoFilename, W("a"));
+            if (compJitFuncInfoFile == nullptr)
+            {
+#if defined(DEBUG) && !defined(FEATURE_PAL) // no 'perror' in the PAL
+                perror("Failed to open JitFuncInfoLogFile");
+#endif // defined(DEBUG) && !defined(FEATURE_PAL)
+            }
         }
     }
 #endif // FUNC_INFO_LOGGING


### PR DESCRIPTION
@dotnet/jit-contrib PTAL
