### PR TITLE
GcInfo: Report Struct containing one GcPointer correctly

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -906,7 +906,7 @@ var_types Compiler::getArgTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
 //         that multiple registers are used to return this struct.
 //
 var_types Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
-                                           structPassingKind*   wbReturnStruct,
+                                           structPassingKind*   wbReturnStruct /* = nullptr */,
                                            unsigned             structSize /* = 0 */)
 {
     var_types         useType           = TYP_UNKNOWN;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3839,7 +3839,7 @@ public:
     // If you have already retrieved the struct size then pass it as the optional third argument
     //
     var_types getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
-                                     structPassingKind*   wbPassStruct,
+                                     structPassingKind*   wbPassStruct = nullptr,
                                      unsigned             structSize = 0);
 
 #ifdef DEBUG


### PR DESCRIPTION
This change fixes a bug in the the GcInfo header,
where the ReturnKind is reported incorrectly for certain structs.

Structs that contain only one GCPointer or ByRef, can be returned
in a single register (Windows/Unix/OSX). The ReturnKind for these
struct-returns should be RT_Object/RT_ByRef, but they are currently
incorrectly reported as RT_Scalar. This change fixes the problem.

Fixes: dotnet/corefx#11260