### PR TITLE
Stop groveling for project.json files when building every test.

### DIFF
--- a/tests/build.proj
+++ b/tests/build.proj
@@ -35,6 +35,11 @@
   <!-- Tasks from buildtools for easy project.json dependency updates -->
   <UsingTask TaskName="UpdatePackageDependencyVersion" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
+  <!-- Create a collection of all project.json files for dependency updates. -->
+  <ItemGroup>
+    <ProjectJsonFiles Include="$(SourceDir)**\project.json" />
+  </ItemGroup>
+
   <Target Name="UpdatePackageDependencyVersion">
     <UpdatePackageDependencyVersion ProjectJsons="@(ProjectJsonFiles)"
                                     PackageId="$(PackageId)"

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -82,11 +82,6 @@
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))" $(DnuRestoreSource)</DnuRestoreCommand>
   </PropertyGroup>
 
-  <!-- Create a collection of all project.json files for dependency updates. -->
-  <ItemGroup>
-    <ProjectJsonFiles Include="$(SourceDir)**\project.json" />
-  </ItemGroup>
-
   <!-- Which tests shall we build? Default: Priority 0 tests.
     At the command-line, the user can specify /p:CLRTestPriorityToBuild=666 (for example), and
     all tests with CLRTestPriority 666,..., 1 AND 0 will build. 


### PR DESCRIPTION
This information is only needed by build.proj. Do not compute it in dir.props,
which is included by every test project.