### PR TITLE
Create coreclr perf jobs for Linux.

### DIFF
--- a/tests/scripts/perf-prep.sh
+++ b/tests/scripts/perf-prep.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+function print_usage {
+    echo ''
+    echo 'CoreCLR perf test environment set up script on Linux.'
+    echo ''
+    echo 'Typical command line:'
+    echo ''
+    echo 'coreclr/tests/scripts/perf-perp.sh'
+    echo '    --branch="dotnet_coreclr"'
+    echo ''
+    echo 'Required arguments:'
+    echo '  --branch=<path>             : branch where coreclr/corefx/test bits are copied from (e.g. dotnet_coreclr).'
+}
+
+# Exit code constants
+readonly EXIT_CODE_SUCCESS=0       # Script ran normally.
+
+# Argument variables
+perfArch="x64"
+perfConfig="Release"
+perfBranch=
+
+for i in "$@"
+do
+    case $i in
+        -h|--help)
+            print_usage
+            exit $EXIT_CODE_SUCCESS
+            ;;
+        --branch=*)
+            perfBranch=${i#*=}
+            ;;
+        *)
+            echo "Unknown switch: $i"
+            print_usage
+            exit $EXIT_CODE_SUCCESS
+            ;;
+    esac
+done
+
+perfBranch="dotnet_coreclr"
+echo "branch = $perfBranch"
+echo "architecture = $perfArch"
+echo "configuration = $perfConfig"
+
+# Set up the copies
+# Coreclr build containing the tests and mscorlib
+curl http://dotnet-ci.cloudapp.net/job/$perfBranch/job/master/job/release_windows_nt/lastSuccessfulBuild/artifact/bin/tests/tests.zip -o tests.zip
+
+# Coreclr build we are trying to test
+curl http://dotnet-ci.cloudapp.net/job/$perfBranch/job/master/job/release_ubuntu/lastSuccessfulBuild/artifact/*zip*/archive.zip -o bin.zip
+
+# Corefx components.  We now have full stack builds on all distros we test here, so we can copy straight from CoreFX jobs.
+curl http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/master/job/ubuntu14.04_release/lastSuccessfulBuild/artifact/bin/build.tar.gz -o build.tar.gz
+
+# Unpack the corefx binaries
+tar -xf build.tar.gz
+
+# Unzip the coreclr binaries
+unzip -q -o bin.zip
+
+# Copy coreclr binaries to the right dir
+cp -R ./archive/bin/obj ./bin
+cp -R ./archive/bin/Product ./bin
+
+# Unzip the tests first.  Exit with 0
+mkdir ./bin/tests
+unzip -q -o tests.zip -d ./bin/tests/Windows_NT.$perfArch.$perfConfig || exit 0
+echo "unzip tests to ./bin/tests/Windows_NT.$perfArch.$perfConfig"

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -371,11 +371,6 @@ fi
 export NUGET_PACKAGES=$testNativeBinDir/../../../../packages
 echo "NUGET_PACKAGES = $NUGET_PACKAGES"
 
-echo "dir $testNativeBinDir/../../../../Tools"
-dir $testNativeBinDir/../../../../Tools
-echo "dir $testNativeBinDir/../../../../Tools/dotnetcli"
-dir $testNativeBinDir/../../../../Tools/dotnetcli
-
 pushd $testNativeBinDir/../../../../tests/scripts
 $testNativeBinDir/../../../../Tools/dotnetcli/dotnet restore --fallbacksource https://dotnet.myget.org/F/dotnet-buildtools/ --fallbacksource https://dotnet.myget.org/F/dotnet-core/
 popd
@@ -385,35 +380,24 @@ create_core_overlay
 precompile_overlay_assemblies
 copy_test_native_bin_to_test_root
 
-echo "find $testNativeBinDir/../../../../../../ -name 'Microsoft.DotNet.xunit.performance.runner.cli.dll'"
-find $testNativeBinDir/../../../../../../ -name 'Microsoft.DotNet.xunit.performance.runner.cli.dll'
-echo "find $testNativeBinDir/../../../../../ -name 'Microsoft.DotNet.xunit.performance.runner.cli.dll'"
-find $testNativeBinDir/../../../../../ -name 'Microsoft.DotNet.xunit.performance.runner.cli.dll'
-
 # Deploy xunit performance packages
 cd $CORE_ROOT
+echo "CORE_ROOT dir = $CORE_ROOT"
 
 DO_SETUP=TRUE
 
-if [ ${DO_SETUP} == "TRUE" ]; then
-
-echo "dir $testNativeBinDir/../../../../../"
-dir $testNativeBinDir/../../../../../
-echo "dir $testNativeBinDir/../../../../../packages"
+dir $testNativeBinDir/../../../../..
+echo 'dir $testNativeBinDir/../../../../..'
 dir $testNativeBinDir/../../../../../packages
-echo "dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli"
+echo 'dir $testNativeBinDir/../../../../../packages'
 dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli
-echo "dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035"
+echo 'dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli'
 dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035
-echo "dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035/lib"
-dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035/lib
-echo "dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035/lib/netstandard1.3"
-dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035/lib/netstandard1.3
+echo 'dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035'
 
-sudo cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.runner.cli.dll .
-
-sudo cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.run.core/1.0.0-alpha-build0035/lib/dotnet/*.dll .
-
+if [ ${DO_SETUP} == "TRUE" ]; then
+cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.runner.cli.dll .
+cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.run.core/1.0.0-alpha-build0035/lib/dotnet/*.dll .
 fi
 
 # Run coreclr performance tests
@@ -428,6 +412,7 @@ echo "....Running $testname"
 
 cp $testcase .
 
+chmod u+x ./corerun
 ./corerun Microsoft.DotNet.xunit.performance.runner.cli.dll $test -runner xunit.console.netcore.exe -runnerhost ./corerun -verbose -runid perf-$testname
 
 done


### PR DESCRIPTION
1. Added job generator in perf.groovy to automatically generate coreclr Jenkins perf jobs for Linux. http://dotnet-ci2.cloudapp.net/job/smile21prc_coreclr/job/coreclr-perf/job/generator/.

2. Implement scripts to successfully set up and execute coreclr Jenkins perf jobs on Linux.