### PR TITLE
LTO build: fix perf regression from strict alias violation and incorrect inline assembly

### DIFF
--- a/src/vm/amd64/unixstubs.cpp
+++ b/src/vm/amd64/unixstubs.cpp
@@ -52,7 +52,7 @@ extern "C"
               "  mov %%edx, 12(%[result])\n" \
             : "=a"(eax) /*output in eax*/\
             : "a"(arg), [result]"r"(result) /*inputs - arg in eax, result in any register*/\
-            : "eax", "rbx", "ecx", "edx" /* registers that are clobbered*/
+            : "eax", "rbx", "ecx", "edx", "memory" /* registers that are clobbered, *result is clobbered */
           );
         return eax;
     }

--- a/src/vm/amd64/unixstubs.cpp
+++ b/src/vm/amd64/unixstubs.cpp
@@ -67,7 +67,7 @@ extern "C"
               "  mov %%edx, 12(%[result])\n" \
             : "=a"(eax) /*output in eax*/\
             : "c"(arg1), "a"(arg2), [result]"r"(result) /*inputs - arg1 in ecx, arg2 in eax, result in any register*/\
-            : "eax", "rbx", "ecx", "edx" /* registers that are clobbered*/
+            : "eax", "rbx", "ecx", "edx", "memory" /* registers that are clobbered, *result is clobbered */
           );
         return eax;
     }

--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -2089,10 +2089,11 @@ size_t GetIntelDeterministicCacheEnum()
     LIMITED_METHOD_CONTRACT;
     size_t retVal = 0;
     unsigned char buffer[16];
+    size_t buflen = ARRAYSIZE(buffer);
 
     DWORD maxCpuid = getextcpuid(0,0,buffer);
     DWORD dwBuffer[4];
-    memcpy(dwBuffer, buffer, 16);
+    memcpy(dwBuffer, buffer, buflen);
 
     if( (maxCpuid > 3) && (maxCpuid < 0x80000000) ) // Deterministic Cache Enum is Supported
     {
@@ -2108,7 +2109,7 @@ size_t GetIntelDeterministicCacheEnum()
         // cache levels are supported.
 
         getextcpuid(loopECX, 4, buffer);       
-        memcpy(dwBuffer, buffer, 16);
+        memcpy(dwBuffer, buffer, buflen);
         retEAX = dwBuffer[0];       // get EAX
 
         int i = 0;
@@ -2127,7 +2128,7 @@ size_t GetIntelDeterministicCacheEnum()
 
             loopECX++;
             getextcpuid(loopECX, 4, buffer);  
-            memcpy(dwBuffer, buffer, 16);
+            memcpy(dwBuffer, buffer, buflen);
             retEAX = dwBuffer[0] ;      // get EAX[4:0];        
             i++;
             if (i > 16) {               // prevent infinite looping

--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -2091,8 +2091,8 @@ size_t GetIntelDeterministicCacheEnum()
     unsigned char buffer[16];
 
     DWORD maxCpuid = getextcpuid(0,0,buffer);
-
-    DWORD* dwBuffer = (DWORD*)buffer;
+    DWORD dwBuffer[4];
+    memcpy(dwBuffer, buffer, 16);
 
     if( (maxCpuid > 3) && (maxCpuid < 0x80000000) ) // Deterministic Cache Enum is Supported
     {
@@ -2108,10 +2108,11 @@ size_t GetIntelDeterministicCacheEnum()
         // cache levels are supported.
 
         getextcpuid(loopECX, 4, buffer);       
+        memcpy(dwBuffer, buffer, 16);
         retEAX = dwBuffer[0];       // get EAX
 
         int i = 0;
-        while(retEAX  & 0x1f)       // Crack cache enums and loop while EAX > 0
+        while(retEAX & 0x1f)       // Crack cache enums and loop while EAX > 0
         {
 
             dwCacheWays = (dwBuffer[1] & CACHE_WAY_BITS) >> 22;
@@ -2126,14 +2127,15 @@ size_t GetIntelDeterministicCacheEnum()
 
             loopECX++;
             getextcpuid(loopECX, 4, buffer);  
+            memcpy(dwBuffer, buffer, 16);
             retEAX = dwBuffer[0] ;      // get EAX[4:0];        
             i++;
-            if (i > 16)                // prevent infinite looping
-                return 0;
+            if (i > 16) {               // prevent infinite looping
+              return 0;
+            }
         }
         retVal = maxSize;
     }
-
     return retVal ;
 }
 


### PR DESCRIPTION
There was a perf regression (measured throughput was ~10% of non-LTO throughput) on TechEmpower Json benchmark with LTO enabled build. 

The root cause was that when getextcpuid was inlined, there appears to have been bad transformations that corrupted the result, which is an unsigned char array. The problem was that the content of result is read as a DWORD(=uint32_t) array which is a strict aliasing violation. In addition, the inline assembly implementations in unixstubs.cpp lacked "memory" in the clobber list which is needed per [documentation](https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html).

The end result was that GetIntelDeterministicCacheEnum() was returning 0 for post-inlined build and I believe this affected GC to set much lower cache size than available. GC was kicking in way more often (~50x gen0) and caused higher load in spin loop when it needed to "stop the world".