### PR TITLE
Make Lazy initialization of TextInfo::m_IsAsciiCasingSameAsInvariant thread safe

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
@@ -10,15 +10,8 @@ namespace System.Globalization
 {
     public partial class TextInfo
     {
-        enum TurkishCasing
-        {
-            NotInitialized,
-            NotNeeded,
-            Needed
-        }
-
         [NonSerialized]
-        private TurkishCasing _needsTurkishCasing = TurkishCasing.NotInitialized;
+        private Tristate _needsTurkishCasing = Tristate.NotInitialized;
 
         //////////////////////////////////////////////////////////////////////////
         ////
@@ -115,11 +108,11 @@ namespace System.Globalization
             }
             else
             {
-                if (_needsTurkishCasing == TurkishCasing.NotInitialized)
+                if (_needsTurkishCasing == Tristate.NotInitialized)
                 {
-                    _needsTurkishCasing = NeedsTurkishCasing(_textInfoName) ? TurkishCasing.Needed : TurkishCasing.NotNeeded;
+                    _needsTurkishCasing = NeedsTurkishCasing(_textInfoName) ? Tristate.True : Tristate.False;
                 }
-                if ( _needsTurkishCasing == TurkishCasing.Needed)
+                if (_needsTurkishCasing == Tristate.True)
                 {
                     Interop.GlobalizationInterop.ChangeCaseTurkish(src, srcLen, dstBuffer, dstBufferCapacity, bToUpper);
                 }

--- a/src/mscorlib/corefx/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.cs
@@ -31,6 +31,13 @@ namespace System.Globalization
         ////                        Internal Information                        //
         ////--------------------------------------------------------------------//
 
+        private enum Tristate : byte
+        {
+            NotInitialized,
+            True,
+            False,
+        }
+
         ////
         ////  Variables.
         ////
@@ -57,7 +64,7 @@ namespace System.Globalization
         [NonSerialized]
         private String _textInfoName;     // Name of the text info we're using (ie: _cultureData.STEXTINFO)
         [NonSerialized]
-        private bool? _isAsciiCasingSameAsInvariant;
+        private Tristate _isAsciiCasingSameAsInvariant = Tristate.NotInitialized;
 
         // Invariant text info
         internal static TextInfo Invariant
@@ -355,13 +362,13 @@ namespace System.Globalization
         {
             get
             {
-                if (_isAsciiCasingSameAsInvariant == null)
+                if (_isAsciiCasingSameAsInvariant == Tristate.NotInitialized)
                 {
                     _isAsciiCasingSameAsInvariant = CultureInfo.GetCultureInfo(_textInfoName).CompareInfo.Compare("abcdefghijklmnopqrstuvwxyz",
                                                                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-                                                                             CompareOptions.IgnoreCase) == 0;
+                                                                             CompareOptions.IgnoreCase) == 0 ? Tristate.True : Tristate.False;
                 }
-                return (bool)_isAsciiCasingSameAsInvariant;
+                return _isAsciiCasingSameAsInvariant == Tristate.True ? true : false;
             }
         }
 

--- a/src/mscorlib/corefx/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.cs
@@ -368,7 +368,7 @@ namespace System.Globalization
                                                                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
                                                                              CompareOptions.IgnoreCase) == 0 ? Tristate.True : Tristate.False;
                 }
-                return _isAsciiCasingSameAsInvariant == Tristate.True ? true : false;
+                return _isAsciiCasingSameAsInvariant == Tristate.True;
             }
         }
 

--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -611,7 +611,7 @@ namespace System.Globalization {
                                                                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
                                                                              CompareOptions.IgnoreCase) == 0 ? Tristate.True : Tristate.False;
                 }
-                return m_IsAsciiCasingSameAsInvariant == Tristate.True ? true : false;
+                return m_IsAsciiCasingSameAsInvariant == Tristate.True;
             }
         }
 

--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -35,6 +35,12 @@ namespace System.Globalization {
         //                        Internal Information                        //
         //--------------------------------------------------------------------//
 
+        private enum Tristate : byte
+        {
+            NotInitialized,
+            True,
+            False,
+        }
 
         //
         //  Variables.
@@ -72,7 +78,7 @@ namespace System.Globalization {
         [NonSerialized]private String           m_textInfoName;     // Name of the text info we're using (ie: m_cultureData.STEXTINFO)
         [NonSerialized]private IntPtr           m_dataHandle;       // Sort handle
         [NonSerialized]private IntPtr           m_handleOrigin;
-        [NonSerialized]private bool?            m_IsAsciiCasingSameAsInvariant;
+        [NonSerialized]private Tristate         m_IsAsciiCasingSameAsInvariant = Tristate.NotInitialized;
 
 
         // Invariant text info
@@ -598,14 +604,14 @@ namespace System.Globalization {
         {
             get
             {
-                if (m_IsAsciiCasingSameAsInvariant == null)
+                if (m_IsAsciiCasingSameAsInvariant == Tristate.NotInitialized)
                 {
                     m_IsAsciiCasingSameAsInvariant =
                         CultureInfo.GetCultureInfo(m_textInfoName).CompareInfo.Compare("abcdefghijklmnopqrstuvwxyz",
                                                                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-                                                                             CompareOptions.IgnoreCase) == 0;
+                                                                             CompareOptions.IgnoreCase) == 0 ? Tristate.True : Tristate.False;
                 }
-                return (bool)m_IsAsciiCasingSameAsInvariant;
+                return m_IsAsciiCasingSameAsInvariant == Tristate.True ? true : false;
             }
         }
 


### PR DESCRIPTION
Creating a Tristate enum to use instead of bool? for  m_IsAsciiCasingSameAsInvariant  and instead of TurkishCasing for _needsTurkishCasing.

/cc @jkotas 

Fixes #6794 