### PR TITLE
Stop treating sine/cosine/round as target intrinsics on x86.

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17899,6 +17899,13 @@ bool Compiler::IsTargetIntrinsic(CorInfoIntrinsics intrinsicId)
     switch (intrinsicId)
     {
         // Amd64 only has SSE2 instruction to directly compute sqrt/abs.
+        //
+        // TODO: Because the x86 backend only targets SSE for floating-point code,
+        //       it does not treat Sine, Cosine, or Round as intrinsics (JIT32
+        //       implemented those intrinsics as x87 instructions). If this poses
+        //       a CQ problem, it may be necessary to change the implementation of
+        //       the helper calls to decrease call overhead or switch back to the
+        //       x87 instructions. This is tracked by #7097.
         case CORINFO_INTRINSIC_Sqrt:
         case CORINFO_INTRINSIC_Abs:
             return true;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17895,7 +17895,7 @@ void Compiler::impMarkInlineCandidate(GenTreePtr             callNode,
 
 bool Compiler::IsTargetIntrinsic(CorInfoIntrinsics intrinsicId)
 {
-#if defined(_TARGET_AMD64_)
+#if defined(_TARGET_AMD64_) || (defined(_TARGET_X86_) && !defined(LEGACY_BACKEND))
     switch (intrinsicId)
     {
         // Amd64 only has SSE2 instruction to directly compute sqrt/abs.


### PR DESCRIPTION
These intrinsics were supported by JIT32 using the corresponding
x87 instructions. There are a few downsides to doing the same in
RyuJIT, however, because it uses SSE for all other floating-point
math:
- The mix of precisions used by the combination of SSE + x87
  instructions matches neither the JIT32 nor the RyuJIT/x64
  behavior.
- Using the x87 instructions is more expensive, as the result of
  the instruction may need to be moved via memory to an SSE
  register.
- The RA would need to be udpated in order to better understand
  that each x87 instruction may require a spill temp in order to
  retrieve the result.

Issue #7097 tracks investigating a custom calling convention for
the appropriate helper calls if necessasry.