### PR TITLE
Pass /p:Platform to msbuild in runtest.cmd.

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -134,7 +134,7 @@ if not defined VSINSTALLDIR (
 ::       The issue is that we extend the build with our own targets which
 ::       means that that rebuilding cannot successfully delete the task
 ::       assembly. 
-set __msbuildCommonArgs=/nologo /nodeReuse:false %__msbuildExtraArgs%
+set __msbuildCommonArgs=/nologo /nodeReuse:false %__msbuildExtraArgs% /p:Platform=%__MSBuildBuildArch%
 
 if not defined __Sequential (
     set __msbuildCommonArgs=%__msbuildCommonArgs% /maxcpucount


### PR DESCRIPTION
Otherwise, the tests will use the ambient setting of the Platform
variable, which might not match the architecture specified on the
command line. This results in the wrong build of the tests running
against the correct runtime, which e.g. causes failures in tests
with native components.