### PR TITLE
[WIP]Allow both the non-contained operands of a bin-op to be marked as reg-optional instead of lower fixing one of the operands as reg optional.

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -555,13 +555,16 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             info->dstCount = 0;
 
             GenTreePtr other;
+            bool hasContainedImmed = false;
             if (CheckImmedAndMakeContained(tree, node->gtIndex))
             {
                 other = node->gtArrLen;
+                hasContainedImmed = true;
             }
             else if (CheckImmedAndMakeContained(tree, node->gtArrLen))
             {
                 other = node->gtIndex;
+                hasContainedImmed = true;
             }
             else if (node->gtIndex->isMemoryOp())
             {
@@ -578,10 +581,17 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 {
                     MakeSrcContained(tree, other);
                 }
-                else
+                else if (hasContainedImmed)
                 {
                     // We can mark 'other' as reg optional, since it is not contained.
-                    SetRegOptional(other);
+                    SetRegOptional(tree, other);
+                }
+                else
+                {
+                    // We can mark both the operands as reg optional since
+                    // both the operands are contained.
+                    SetRegOptional(tree, node->gtIndex);
+                    SetRegOptional(tree, node->gtArrLen);
                 }
             }
         }
@@ -2083,7 +2093,7 @@ void Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
                 {
                     // If there are no containable operands, we can make an operand reg optional.
                     // SSE2 allows only op2 to be a memory-op.
-                    SetRegOptional(op2);
+                    SetRegOptional(tree, op2);
                 }
 
                 return;
@@ -2125,7 +2135,7 @@ void Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
 
         // If there are no containable operands, we can make an operand reg optional.
         // Div instruction allows only op2 to be a memory op.
-        SetRegOptional(op2);
+        SetRegOptional(tree, op2);
     }
 }
 
@@ -2162,7 +2172,7 @@ void Lowering::TreeNodeInfoInitIntrinsic(GenTree* tree)
             {
                 // Mark the operand as reg optional since codegen can still
                 // generate code if op1 is on stack.
-                SetRegOptional(op1);
+                SetRegOptional(tree, op1);
             }
             break;
 
@@ -2495,7 +2505,7 @@ void Lowering::TreeNodeInfoInitCast(GenTree* tree)
             {
                 // Mark castOp as reg optional to indicate codegen
                 // can still generate code if it is on stack.
-                SetRegOptional(castOp);
+                SetRegOptional(tree, castOp);
             }
         }
     }
@@ -2856,7 +2866,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
         {
             // SSE2 allows only otherOp to be a memory-op. Since otherOp is not
             // contained, we can mark it reg-optional.
-            SetRegOptional(otherOp);
+            SetRegOptional(tree, otherOp);
         }
 
         return;
@@ -3156,7 +3166,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
                 // If not made contained, op1 can be marked as reg-optional.
                 if (!op1IsMadeContained)
                 {
-                    SetRegOptional(op1);
+                    SetRegOptional(tree, op1);
                 }
             }
         }
@@ -3173,10 +3183,10 @@ void Lowering::LowerCmp(GenTreePtr tree)
         }
         else
         {
-            // One of op1 or op2 could be marked as reg optional
-            // to indicate that codgen can still generate code
-            // if one of them is on stack.
-            SetRegOptional(PreferredRegOptionalOperand(tree));
+            // op1 and op2 could be marked as reg optional since
+            // both of them are not contained.
+            SetRegOptional(tree, op1);
+            SetRegOptional(tree, op2);
         }
 
         if (varTypeIsSmall(op1Type) && varTypeIsUnsigned(op1Type))
@@ -3779,16 +3789,16 @@ void Lowering::SetMulOpCounts(GenTreePtr tree)
             // Has a contained immediate operand.
             // Only 'other' operand can be marked as reg optional.
             assert(other != nullptr);
-            SetRegOptional(other);
+            SetRegOptional(tree, other);
         }
         else if (hasImpliedFirstOperand)
         {
             // Only op2 can be marke as reg optional.
-            SetRegOptional(op2);
+            SetRegOptional(tree, op2);
         }
         else
         {
-            // If there are no containable operands, we can make either of op1 or op2
+            // Since there are no containable operands, we can mark op1 and op2
             // as reg optional.
             SetRegOptionalForBinOp(tree);
         }
@@ -3858,131 +3868,6 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
 
     return true;
 }
-
-//-----------------------------------------------------------------------
-// PreferredRegOptionalOperand: returns one of the operands of given
-// binary oper that is to be preferred for marking as reg optional.
-//
-// Since only one of op1 or op2 can be a memory operand on xarch, only
-// one of  them have to be marked as reg optional.  Since Lower doesn't
-// know apriori which of op1 or op2 is not likely to get a register, it
-// has to make a guess. This routine encapsulates heuristics that
-// guess whether it is likely to be beneficial to mark op1 or op2 as
-// reg optional.
-//
-//
-// Arguments:
-//     tree  -  a binary-op tree node that is either commutative
-//              or a compare oper.
-//
-// Returns:
-//     Returns op1 or op2 of tree node that is preferred for
-//     marking as reg optional.
-//
-// Note: if the tree oper is neither commutative nor a compare oper
-// then only op2 can be reg optional on xarch and hence no need to
-// call this routine.
-GenTree* Lowering::PreferredRegOptionalOperand(GenTree* tree)
-{
-    assert(GenTree::OperIsBinary(tree->OperGet()));
-    assert(tree->OperIsCommutative() || tree->OperIsCompare());
-
-    GenTree* op1         = tree->gtGetOp1();
-    GenTree* op2         = tree->gtGetOp2();
-    GenTree* preferredOp = nullptr;
-
-    // This routine uses the following heuristics:
-    //
-    // a) If both are tracked locals, marking the one with lower weighted
-    // ref count as reg-optional would likely be beneficial as it has
-    // higher probability of not getting a register.
-    //
-    // b) op1 = tracked local and op2 = untracked local: LSRA creates two
-    // ref positions for op2: a def and use position. op2's def position
-    // requires a reg and it is allocated a reg by spilling another
-    // interval (if required) and that could be even op1.  For this reason
-    // it is beneficial to mark op1 as reg optional.
-    //
-    // TODO: It is not always mandatory for a def position of an untracked
-    // local to be allocated a register if it is on rhs of an assignment
-    // and its use position is reg-optional and has not been assigned a
-    // register.  Reg optional def positions is currently not yet supported.
-    //
-    // c) op1 = untracked local and op2 = tracked local: marking op1 as
-    // reg optional is beneficial, since its use position is less likely
-    // to get a register.
-    //
-    // d) If both are untracked locals (i.e. treated like tree temps by
-    // LSRA): though either of them could be marked as reg optional,
-    // marking op1 as reg optional is likely to be beneficial because
-    // while allocating op2's def position, there is a possibility of
-    // spilling op1's def and in which case op1 is treated as contained
-    // memory operand rather than requiring to reload.
-    //
-    // e) If only one of them is a local var, prefer to mark it as
-    // reg-optional.  This is heuristic is based on the results
-    // obtained against CQ perf benchmarks.
-    //
-    // f) If neither of them are local vars (i.e. tree temps), prefer to
-    // mark op1 as reg optional for the same reason as mentioned in (d) above.
-    if (op1->OperGet() == GT_LCL_VAR && op2->OperGet() == GT_LCL_VAR)
-    {
-        LclVarDsc* v1 = comp->lvaTable + op1->AsLclVarCommon()->GetLclNum();
-        LclVarDsc* v2 = comp->lvaTable + op2->AsLclVarCommon()->GetLclNum();
-
-        if (v1->lvTracked && v2->lvTracked)
-        {
-            // Both are tracked locals.  The one with lower weight is less likely
-            // to get a register and hence beneficial to mark the one with lower
-            // weight as reg optional.
-            if (v1->lvRefCntWtd < v2->lvRefCntWtd)
-            {
-                preferredOp = op1;
-            }
-            else
-            {
-                preferredOp = op2;
-            }
-        }
-        else if (v2->lvTracked)
-        {
-            // v1 is an untracked lcl and it is use position is less likely to
-            // get a register.
-            preferredOp = op1;
-        }
-        else if (v1->lvTracked)
-        {
-            // v2 is an untracked lcl and its def position always
-            // needs a reg.  Hence it is better to mark v1 as
-            // reg optional.
-            preferredOp = op1;
-        }
-        else
-        {
-            preferredOp = op1;
-            ;
-        }
-    }
-    else if (op1->OperGet() == GT_LCL_VAR)
-    {
-        preferredOp = op1;
-    }
-    else if (op2->OperGet() == GT_LCL_VAR)
-    {
-        preferredOp = op2;
-    }
-    else
-    {
-        // Neither of the operands is a local, prefer marking
-        // operand that is evaluated first as reg optional
-        // since its use position is less likely to get a register.
-        bool reverseOps = ((tree->gtFlags & GTF_REVERSE_OPS) != 0);
-        preferredOp     = reverseOps ? op2 : op1;
-    }
-
-    return preferredOp;
-}
-
 #endif // _TARGET_XARCH_
 
 #endif // !LEGACY_BACKEND

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -188,6 +188,71 @@ unsigned LinearScan::getWeight(RefPosition* refPos)
     return weight;
 }
 
+//-------------------------------------------------------------------
+// IsAllocateIfProfitable - Returns true whether this ref position is
+// to be allocated a reg only if it is profitable.
+//
+// Arguments:
+//   refPos  -  Ref position
+//
+// Returns:
+//   true if the ref position is marked as 'AllocateIfProfitable'
+//   and srcRegOptional count of consuming node isn't exceeded.
+//   False otherwise.
+//
+bool LinearScan::IsAllocateIfProfitable(RefPosition* refPos)
+{
+    // TODO-CQ: Right now if a ref position is marked as
+    // copyreg or movereg, then it is not treated as
+    // 'allocate if profitable'. This is an implementation
+    // limitation that needs to be addressed.
+    if (refPos->allocRegIfProfitable &&
+        !refPos->copyReg &&
+        !refPos->moveReg)
+    {
+        assert(refPositionToGenTreeMap != nullptr);
+
+        GenTree* consumingTreeNode;
+        bool found = refPositionToGenTreeMap->Lookup(refPos, &consumingTreeNode);
+
+        if (!found)
+        {
+            // If there is no mapping from refPos to its consuming node,
+            // it implies that refPos wasn't allocated a reg by treating
+            // it as reg optional operand.
+            return true;
+        }
+
+        // If there exists a mapping, refPos can be treated as 'Allocate if
+        // profitable' if srcMemOpCount of its consuming tree node is
+        // non-zero.
+        assert(consumingTreeNode != nullptr);
+        return consumingTreeNode->gtLsraInfo.srcMemOpCount > 0;
+    }
+
+    return false;
+}
+
+//--------------------------------------------------------------
+// RequiresRegister: Returns true if the given refPos requires
+// a register to be allocated.
+//
+// Arguments:
+//    refPos  -  Ref position
+//
+// Returns:
+//    True if the ref position requires a register to be
+//    allocated. False otherwise.
+bool LinearScan::RequiresRegister(RefPosition* refPos)
+{
+    return (refPos->IsActualRef()
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+            || refPos->refType == RefTypeUpperVectorSaveDef || refPos->refType == RefTypeUpperVectorSaveUse
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+           ) &&
+           !IsAllocateIfProfitable(refPos);
+}
+
 // allRegs represents a set of registers that can
 // be used to allocate the specified type in any point
 // in time (more of a 'bank' of registers).
@@ -1659,6 +1724,7 @@ void LinearScan::doLinearScan()
 #endif // DEBUG
 
     splitBBNumToTargetBBNumMap = nullptr;
+    refPositionToGenTreeMap = nullptr;
 
     // This is complicated by the fact that physical registers have refs associated
     // with locations where they are killed (e.g. calls), but we don't want to
@@ -3358,6 +3424,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             pos->isLocalDefUse = true;
             bool isLastUse     = ((tree->gtFlags & GTF_VAR_DEATH) != 0);
             pos->lastUse       = isLastUse;
+
             pos->setAllocateIfProfitable(tree->IsRegOptional());
             DBEXEC(VERBOSE, pos->dump());
             return;
@@ -3665,6 +3732,7 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
         if (regOptionalAtUse)
         {
             pos->setAllocateIfProfitable(1);
+            getRefPositonToGenTreeMap()->Set(pos, tree);
         }
     }
     JITDUMP("\n");
@@ -5536,8 +5604,6 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
             }
             else
             {
-                isBetterLocation = (nextLocation > farthestLocation);
-
                 if (nextLocation > farthestLocation)
                 {
                     isBetterLocation = true;
@@ -5549,8 +5615,9 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
                     // allocate if profitable.  These ref positions don't need
                     // need to be spilled as they are already in memory and
                     // codegen considers them as contained memory operands.
-                    isBetterLocation = (recentAssignedRef != nullptr) && recentAssignedRef->reload &&
-                                       recentAssignedRef->AllocateIfProfitable();
+                    isBetterLocation = (recentAssignedRef != nullptr) && 
+                                       recentAssignedRef->reload &&
+                                       IsAllocateIfProfitable(recentAssignedRef);
                 }
                 else
                 {
@@ -5720,7 +5787,7 @@ void LinearScan::spillInterval(Interval* interval, RefPosition* fromRefPosition,
     {
         // If not allocated a register, Lcl var def/use ref positions even if reg optional
         // should be marked as spillAfter.
-        if (!fromRefPosition->RequiresRegister() && !(interval->isLocalVar && fromRefPosition->IsActualRef()))
+        if (!RequiresRegister(fromRefPosition) && !(interval->isLocalVar && fromRefPosition->IsActualRef()))
         {
             fromRefPosition->registerAssignment = RBM_NONE;
         }
@@ -7001,8 +7068,9 @@ void LinearScan::allocateRegisters()
         if (assignedRegister == REG_NA)
         {
             bool allocateReg = true;
+            bool allocIfProfitable = IsAllocateIfProfitable(currentRefPosition);
 
-            if (currentRefPosition->AllocateIfProfitable())
+            if (allocIfProfitable)
             {
                 // We can avoid allocating a register if it is a the last use requiring a reload.
                 if (currentRefPosition->lastUse && currentRefPosition->reload)
@@ -7047,12 +7115,13 @@ void LinearScan::allocateRegisters()
                 }
                 else
 #endif // FEATURE_SIMD
-                    if (currentRefPosition->RequiresRegister() || currentRefPosition->AllocateIfProfitable())
+                if (RequiresRegister(currentRefPosition) || allocIfProfitable)
                 {
                     if (allocateReg)
                     {
-                        assignedRegister = allocateBusyReg(currentInterval, currentRefPosition,
-                                                           currentRefPosition->AllocateIfProfitable());
+                        assignedRegister = allocateBusyReg(currentInterval, 
+                                                           currentRefPosition,
+                                                           allocIfProfitable);
                     }
 
                     if (assignedRegister != REG_NA)
@@ -7064,10 +7133,15 @@ void LinearScan::allocateRegisters()
                     {
                         // This can happen only for those ref positions that are to be allocated
                         // only if profitable.
-                        noway_assert(currentRefPosition->AllocateIfProfitable());
+                        noway_assert(allocIfProfitable);
 
                         currentRefPosition->registerAssignment = RBM_NONE;
                         currentRefPosition->reload             = false;
+
+                        // Decrement srcMemOpCount of consuming node since one of
+                        // its operand's use position is not allocated a reg and
+                        // will be a memory-op.
+                        DecrsrcMemOpCount(currentRefPosition);
 
                         INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NO_REG_ALLOCATED, currentInterval));
                     }
@@ -7262,7 +7336,7 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreePtr treeNode, RefPosi
 
     if (currentRefPosition->registerAssignment == RBM_NONE)
     {
-        assert(!currentRefPosition->RequiresRegister());
+        assert(!RequiresRegister(currentRefPosition));
 
         interval->isSpilled = true;
         varDsc->lvRegNum    = REG_STK;
@@ -7328,7 +7402,7 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreePtr treeNode, RefPosi
             treeNode->gtFlags |= GTF_SPILLED;
             if (spillAfter)
             {
-                if (currentRefPosition->AllocateIfProfitable())
+                if (IsAllocateIfProfitable(currentRefPosition))
                 {
                     // This is a use of lclVar that is flagged as reg-optional
                     // by lower/codegen and marked for both reload and spillAfter.
@@ -7341,6 +7415,8 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreePtr treeNode, RefPosi
                     interval->physReg  = REG_NA;
                     treeNode->gtRegNum = REG_NA;
                     treeNode->gtFlags &= ~GTF_SPILLED;
+
+                    DecrsrcMemOpCount(currentRefPosition);
                 }
                 else
                 {
@@ -7785,7 +7861,7 @@ void LinearScan::updateMaxSpill(RefPosition* refPosition)
     RefType refType = refPosition->refType;
 
     if (refPosition->spillAfter || refPosition->reload ||
-        (refPosition->AllocateIfProfitable() && refPosition->assignedReg() == REG_NA))
+        (IsAllocateIfProfitable(refPosition) && refPosition->assignedReg() == REG_NA))
     {
         Interval* interval = refPosition->getInterval();
         if (!interval->isLocalVar)
@@ -7841,7 +7917,7 @@ void LinearScan::updateMaxSpill(RefPosition* refPosition)
                 assert(currentSpill[typ] > 0);
                 currentSpill[typ]--;
             }
-            else if (refPosition->AllocateIfProfitable() && refPosition->assignedReg() == REG_NA)
+            else if (IsAllocateIfProfitable(refPosition) && refPosition->assignedReg() == REG_NA)
             {
                 // A spill temp not getting reloaded into a reg because it is
                 // marked as allocate if profitable and getting used from its
@@ -8186,12 +8262,13 @@ void LinearScan::resolveRegisters()
                             }
                             else
                             {
-                                assert(nextRefPosition->AllocateIfProfitable());
+                                assert(IsAllocateIfProfitable(nextRefPosition));
 
                                 // In case of tree temps, if def is spilled and use didn't
                                 // get a register, set a flag on tree node to be treated as
                                 // contained at the point of its use.
-                                if (currentRefPosition->spillAfter && currentRefPosition->refType == RefTypeDef &&
+                                if (currentRefPosition->spillAfter && 
+                                    currentRefPosition->refType == RefTypeDef &&
                                     nextRefPosition->refType == RefTypeUse)
                                 {
                                     assert(nextRefPosition->treeNode == nullptr);
@@ -11402,7 +11479,7 @@ void LinearScan::verifyFinalAllocation()
                     }
                     else
                     {
-                        assert(currentRefPosition->AllocateIfProfitable());
+                        assert(IsAllocateIfProfitable(currentRefPosition));
                     }
                 }
             }

--- a/src/jit/nodeinfo.h
+++ b/src/jit/nodeinfo.h
@@ -20,6 +20,7 @@ public:
         _srcCount           = 0;
         _internalIntCount   = 0;
         _internalFloatCount = 0;
+        _srcMemOpCount      = 0;
 
         srcCandsIndex         = 0;
         dstCandsIndex         = 0;
@@ -59,6 +60,18 @@ public:
     int getSrcCount()
     {
         return _srcCount;
+    }
+
+    // srcMemOpCount
+    __declspec(property(put = setSrcMemOpCount, get = getSrcMemOpCount)) int srcMemOpCount;
+    void setSrcMemOpCount(int count)
+    {
+        _srcMemOpCount = (char)count;
+        assert(_srcMemOpCount == count);
+    }
+    int getSrcMemOpCount()
+    {
+        return _srcMemOpCount;
     }
 
     // internalInt
@@ -110,6 +123,15 @@ public:
     unsigned char dstCandsIndex;
     unsigned char internalCandsIndex;
 
+private:
+    // Maximum number of source operands that could be in memory.
+    // On xarch at the most one operand could be a memory-op.
+    // That is _srcMemOpCount doesn't exceed 1. In future when
+    // there is a need to exceed this limit, the bit size
+    // width of this member needs to be adjusted accordingly.
+    unsigned char _srcMemOpCount : 1;
+
+public:
     // isLocalDefUse identifies trees that produce a value that is not consumed elsewhere.
     // Examples include stack arguments to a call (they are immediately stored), lhs of comma
     // nodes, or top-level nodes that are non-void.


### PR DESCRIPTION
DO NOT REVIEW NOR MERGE THIS YET.