### PR TITLE
Exclude two more tests from ARM

### DIFF
--- a/tests/testsUnsupportedOnARM32.txt
+++ b/tests/testsUnsupportedOnARM32.txt
@@ -1,2 +1,4 @@
 JIT/Directed/tailcall/tailcall/tailcall.sh
+JIT/Methodical/tailcall_v4/hijacking/hijacking.sh
+JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271/DevDiv_902271.sh
 JIT/jit64/opt/cse/HugeArray1/HugeArray1.sh


### PR DESCRIPTION
According to issue #6217,  following three tests fail, because FEATURE_FASTTAILCALL is not supported in ARM.

  JIT/Directed/tailcall/tailcall/tailcall.sh
  JIT/Methodical/tailcall_v4/hijacking/hijacking.sh
  JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271/DevDiv_902271.sh

Signed-off-by: Hyung-Kyu Choi <hk0110.choi@samsung.com>