### PR TITLE
Move genIncRegBy() to codegenclassic.h

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -48,8 +48,6 @@ public:
                                    unsigned* cnsPtr,
                                    bool      nogen = false);
 
-    // This should move to CodeGenClassic.h after genCreateAddrMode() is no longer dependent upon it
-    void genIncRegBy(regNumber reg, ssize_t ival, GenTreePtr tree, var_types dstType = TYP_INT, bool ovfl = false);
 
 private:
 #if defined(_TARGET_XARCH_) && !FEATURE_STACK_FP_X87

--- a/src/jit/codegenclassic.h
+++ b/src/jit/codegenclassic.h
@@ -38,6 +38,7 @@ void genSetRegToIcon(regNumber reg, ssize_t val, var_types type = TYP_INT, insFl
 
 regNumber genGetRegSetToIcon(ssize_t val, regMaskTP regBest = 0, var_types type = TYP_INT);
 void genDecRegBy(regNumber reg, ssize_t ival, GenTreePtr tree);
+void genIncRegBy(regNumber reg, ssize_t ival, GenTreePtr tree, var_types dstType = TYP_INT, bool ovfl = false);
 
 void genMulRegBy(regNumber reg, ssize_t ival, GenTreePtr tree, var_types dstType = TYP_INT, bool ovfl = false);
 


### PR DESCRIPTION
We don't have to keep genIncRegBy() in codegen.h anymore,
since genIncRegBy() is defined in codegenlegacy.cpp and only used in LEGACY_BACKEND code.

Similar refactoring was made at PR #4903, where genFlagsEqualToNone () and other functions are moved to codegenclassic.h.
