### PR TITLE
Fix GTF_ flag collision

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -13865,9 +13865,9 @@ bool Compiler::gtNodeHasSideEffects(GenTreePtr tree, unsigned flags)
                     return true;
                 }
 
-                // with GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE we will CSE helper calls that can run cctors.
+                // with GTF_IS_IN_CSE we will CSE helper calls that can run cctors.
                 //
-                if ((flags != GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE) && (s_helperCallProperties.MayRunCctor(helper)))
+                if (((flags & GTF_IS_IN_CSE) == 0) && (s_helperCallProperties.MayRunCctor(helper)))
                 {
                     return true;
                 }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -740,7 +740,7 @@ public:
 //
 // The only requirement of this flag is that it not overlap any of the
 // side-effect flags. The actual bit used is otherwise arbitrary.
-#define GTF_IS_IN_CSE GTF_MAKE_CSE
+#define GTF_IS_IN_CSE GTF_BOOLEAN
 #define GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE (GTF_ASG | GTF_CALL | GTF_IS_IN_CSE)
 
 // Can any side-effects be observed externally, say by a caller method?


### PR DESCRIPTION
Define flag `GTF_IS_IN_CSE` (which is used only to communicate in a call to
`gtNodeHasSideEffects` that the caller wants to disregard the side-effect
of running a .cctor) as `GTF_BOOLEAN` rather than `GTF_MAKE_CSE` -- as the
comment at the definition of `GTF_IS_IN_CSE` indicates, the only
requirement on its value is that it not conflict with one of the
side-effect flags, but `gtNodeHasSideEffects` does in fact check for
`GTF_MAKE_CSE`, so the current value conflicts.

Also update the code in `gtNodeHasSideEffects` that is dictated by
`GTF_IS_IN_CSE` to check just for that bit, instead of checking that the
caller passed in exactly `GTF_PERSISTENT_SIDE_EFFECTS_IN_CSE` -- no need
to entangle conceptually independent parameters.

Fixes #7042.