### PR TITLE
Enable long multiply

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -8520,6 +8520,9 @@ int cTreeFlagsIR(Compiler* comp, GenTree* tree)
                 break;
 
             case GT_MUL:
+#if defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
+            case GT_MUL_LONG:
+#endif
 
                 if (tree->gtFlags & GTF_MUL_64RSLT)
                 {

--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -51,10 +51,12 @@ private:
     GenTree* DecomposeNeg(LIR::Use& use);
     GenTree* DecomposeArith(LIR::Use& use);
     GenTree* DecomposeShift(LIR::Use& use);
+    GenTree* DecomposeMul(LIR::Use& use);
 
     // Helper functions
     GenTree* FinalizeDecomposition(LIR::Use& use, GenTree* loResult, GenTree* hiResult);
 
+    GenTree* StoreNodeToVar(LIR::Use& use);
     static genTreeOps GetHiOper(genTreeOps oper);
     static genTreeOps GetLoOper(genTreeOps oper);
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -9747,6 +9747,9 @@ void Compiler::gtDispNode(GenTreePtr tree, IndentStack* indentStack, __in __in_z
                 goto DASH;
 
             case GT_MUL:
+#if defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
+            case GT_MUL_LONG:
+#endif
                 if (tree->gtFlags & GTF_MUL_64RSLT)
                 {
                     printf("L");

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1270,7 +1270,6 @@ public:
         {
             case GT_ADD_HI:
             case GT_SUB_HI:
-            case GT_MUL_HI:
             case GT_DIV_HI:
             case GT_MOD_HI:
                 return true;

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -116,6 +116,9 @@ GTNODE(RSZ        , ">>>"        ,0,GTK_BINOP)
 GTNODE(ROL        , "rol"        ,0,GTK_BINOP)
 GTNODE(ROR        , "ror"        ,0,GTK_BINOP)
 GTNODE(MULHI      , "mulhi"      ,1,GTK_BINOP) // returns high bits (top N bits of the 2N bit result of an NxN multiply)
+                                               // GT_MULHI is used in division by a constant (fgMorphDivByConst). We turn
+                                               // the div into a MULHI + some adjustments. In codegen, we only use the
+                                               // results of the high register, and we drop the low results.
 
 GTNODE(ASG        , "="          ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
 GTNODE(ASG_ADD    , "+="         ,0,GTK_BINOP|GTK_ASGOP|GTK_NOTLIR)
@@ -159,16 +162,23 @@ GTNODE(LEA        , "lea"        ,0,GTK_BINOP|GTK_EXOP)
 // nodes such as calls, returns and stores of long lclVars.
 GTNODE(LONG       , "gt_long"    ,0,GTK_BINOP)
 
-// The following are nodes representing the upper half of a 64-bit operation
-// that requires a carry/borrow.  However, they are all named GT_XXX_HI for
-// consistency.
+// The following are nodes representing x86 specific long operators, including
+// high operators of a 64-bit operations that requires a carry/borrow, which are
+// named GT_XXX_HI for consistency, low operators of 64-bit operations that need
+// to not be modified in phases post-decompose, and operators that return 64-bit
+// results in one instruction.
 GTNODE(ADD_LO     , "+Lo"          ,1,GTK_BINOP)
 GTNODE(ADD_HI     , "+Hi"          ,1,GTK_BINOP)
 GTNODE(SUB_LO     , "-Lo"          ,0,GTK_BINOP)
 GTNODE(SUB_HI     , "-Hi"          ,0,GTK_BINOP)
-GTNODE(MUL_HI     , "*Hi"          ,1,GTK_BINOP)
 GTNODE(DIV_HI     , "/Hi"          ,0,GTK_BINOP)
 GTNODE(MOD_HI     , "%Hi"          ,0,GTK_BINOP)
+GTNODE(MUL_LONG   , "*long"        ,1,GTK_BINOP) // A mul that returns the 2N bit result of an NxN multiply. This op
+                                                 // is used for x86 multiplies that take two ints and return a long
+                                                 // result. All other multiplies with long results are morphed into
+                                                 // helper calls. It is similar to GT_MULHI, the difference being that
+                                                 // GT_MULHI drops the lo part of the result, whereas GT_MUL_LONG keeps
+                                                 // both parts of the result.
 #endif // !defined(LEGACY_BACKEND) && !defined(_TARGET_64BIT_)
 
 #ifdef FEATURE_SIMD

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2510,6 +2510,9 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
             break;
 
         case GT_MULHI:
+#if defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
+        case GT_MUL_LONG:
+#endif
             killMask = RBM_RAX | RBM_RDX;
             break;
 


### PR DESCRIPTION
Most long multiplies are converted in morph to helper calls. However,
GT_MULs of the form long = (long)int * (long)int are passed through to be
handled in codegen. In decompose, we convert these multiplies to
GT_MUL_HIs to be handled in a similar manner at GT_MULHI. Since mul and
imul take two ints and return a long in edx:eax, we can handle them
similarly to GT_CALLs, where we save them to lclvars if they aren't
already saved. In codegen, we generate a mul (or imul for signed
multiply), which produces the output in edx:eax, and then we store those
locations when we handle the storelclvar.