### PR TITLE
[WIP]Allow either of op1 or op2 of a bin-op to be treated as reg-optional instead of lower fixing one of the operands as reg optional.

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -582,13 +582,16 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             info->dstCount = 0;
 
             GenTreePtr other;
+            bool hasContainedImmed = false;
             if (CheckImmedAndMakeContained(tree, node->gtIndex))
             {
                 other = node->gtArrLen;
+                hasContainedImmed = true;
             }
             else if (CheckImmedAndMakeContained(tree, node->gtArrLen))
             {
                 other = node->gtIndex;
+                hasContainedImmed = true;
             }
             else if (node->gtIndex->isMemoryOp())
             {
@@ -605,10 +608,17 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 {
                     MakeSrcContained(tree, other);
                 }
-                else
+                else if (hasContainedImmed)
                 {
                     // We can mark 'other' as reg optional, since it is not contained.
-                    SetRegOptional(other);
+                    SetRegOptional(other DEBUG_ARG(tree));
+                }
+                else
+                {
+                    // We can mark both the operands as reg optional since
+                    // both the operands are contained.
+                    SetRegOptional(node->gtIndex DEBUG_ARG(tree));
+                    SetRegOptional(node->gtArrLen DEBUG_ARG(tree));
                 }
             }
         }
@@ -2160,7 +2170,7 @@ void Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
                 {
                     // If there are no containable operands, we can make an operand reg optional.
                     // SSE2 allows only op2 to be a memory-op.
-                    SetRegOptional(op2);
+                    SetRegOptional(op2 DEBUG_ARG(tree));
                 }
 
                 return;
@@ -2202,7 +2212,7 @@ void Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
 
         // If there are no containable operands, we can make an operand reg optional.
         // Div instruction allows only op2 to be a memory op.
-        SetRegOptional(op2);
+        SetRegOptional(op2 DEBUG_ARG(tree));
     }
 }
 
@@ -2239,7 +2249,7 @@ void Lowering::TreeNodeInfoInitIntrinsic(GenTree* tree)
             {
                 // Mark the operand as reg optional since codegen can still
                 // generate code if op1 is on stack.
-                SetRegOptional(op1);
+                SetRegOptional(op1 DEBUG_ARG(tree));
             }
             break;
 
@@ -2572,7 +2582,7 @@ void Lowering::TreeNodeInfoInitCast(GenTree* tree)
             {
                 // Mark castOp as reg optional to indicate codegen
                 // can still generate code if it is on stack.
-                SetRegOptional(castOp);
+                SetRegOptional(castOp DEBUG_ARG(tree));
             }
         }
     }
@@ -2939,7 +2949,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
         {
             // SSE2 allows only otherOp to be a memory-op. Since otherOp is not
             // contained, we can mark it reg-optional.
-            SetRegOptional(otherOp);
+            SetRegOptional(otherOp DEBUG_ARG(tree));
         }
 
         return;
@@ -3239,7 +3249,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
                 // If not made contained, op1 can be marked as reg-optional.
                 if (!op1IsMadeContained)
                 {
-                    SetRegOptional(op1);
+                    SetRegOptional(op1 DEBUG_ARG(tree));
                 }
             }
         }
@@ -3256,10 +3266,10 @@ void Lowering::LowerCmp(GenTreePtr tree)
         }
         else
         {
-            // One of op1 or op2 could be marked as reg optional
-            // to indicate that codgen can still generate code
-            // if one of them is on stack.
-            SetRegOptional(PreferredRegOptionalOperand(tree));
+            // op1 and op2 could be marked as reg optional since
+            // neither of them are contained.
+            SetRegOptional(op1 DEBUG_ARG(tree));
+            SetRegOptional(op2 DEBUG_ARG(tree));
         }
 
         if (varTypeIsSmall(op1Type) && varTypeIsUnsigned(op1Type))
@@ -3862,16 +3872,16 @@ void Lowering::SetMulOpCounts(GenTreePtr tree)
             // Has a contained immediate operand.
             // Only 'other' operand can be marked as reg optional.
             assert(other != nullptr);
-            SetRegOptional(other);
+            SetRegOptional(other DEBUG_ARG(tree));
         }
         else if (hasImpliedFirstOperand)
         {
             // Only op2 can be marke as reg optional.
-            SetRegOptional(op2);
+            SetRegOptional(op2 DEBUG_ARG(tree));
         }
         else
         {
-            // If there are no containable operands, we can make either of op1 or op2
+            // Since there are no containable operands, we can mark op1 and op2
             // as reg optional.
             SetRegOptionalForBinOp(tree);
         }
@@ -3943,131 +3953,6 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
 
     return true;
 }
-
-//-----------------------------------------------------------------------
-// PreferredRegOptionalOperand: returns one of the operands of given
-// binary oper that is to be preferred for marking as reg optional.
-//
-// Since only one of op1 or op2 can be a memory operand on xarch, only
-// one of  them have to be marked as reg optional.  Since Lower doesn't
-// know apriori which of op1 or op2 is not likely to get a register, it
-// has to make a guess. This routine encapsulates heuristics that
-// guess whether it is likely to be beneficial to mark op1 or op2 as
-// reg optional.
-//
-//
-// Arguments:
-//     tree  -  a binary-op tree node that is either commutative
-//              or a compare oper.
-//
-// Returns:
-//     Returns op1 or op2 of tree node that is preferred for
-//     marking as reg optional.
-//
-// Note: if the tree oper is neither commutative nor a compare oper
-// then only op2 can be reg optional on xarch and hence no need to
-// call this routine.
-GenTree* Lowering::PreferredRegOptionalOperand(GenTree* tree)
-{
-    assert(GenTree::OperIsBinary(tree->OperGet()));
-    assert(tree->OperIsCommutative() || tree->OperIsCompare());
-
-    GenTree* op1         = tree->gtGetOp1();
-    GenTree* op2         = tree->gtGetOp2();
-    GenTree* preferredOp = nullptr;
-
-    // This routine uses the following heuristics:
-    //
-    // a) If both are tracked locals, marking the one with lower weighted
-    // ref count as reg-optional would likely be beneficial as it has
-    // higher probability of not getting a register.
-    //
-    // b) op1 = tracked local and op2 = untracked local: LSRA creates two
-    // ref positions for op2: a def and use position. op2's def position
-    // requires a reg and it is allocated a reg by spilling another
-    // interval (if required) and that could be even op1.  For this reason
-    // it is beneficial to mark op1 as reg optional.
-    //
-    // TODO: It is not always mandatory for a def position of an untracked
-    // local to be allocated a register if it is on rhs of an assignment
-    // and its use position is reg-optional and has not been assigned a
-    // register.  Reg optional def positions is currently not yet supported.
-    //
-    // c) op1 = untracked local and op2 = tracked local: marking op1 as
-    // reg optional is beneficial, since its use position is less likely
-    // to get a register.
-    //
-    // d) If both are untracked locals (i.e. treated like tree temps by
-    // LSRA): though either of them could be marked as reg optional,
-    // marking op1 as reg optional is likely to be beneficial because
-    // while allocating op2's def position, there is a possibility of
-    // spilling op1's def and in which case op1 is treated as contained
-    // memory operand rather than requiring to reload.
-    //
-    // e) If only one of them is a local var, prefer to mark it as
-    // reg-optional.  This is heuristic is based on the results
-    // obtained against CQ perf benchmarks.
-    //
-    // f) If neither of them are local vars (i.e. tree temps), prefer to
-    // mark op1 as reg optional for the same reason as mentioned in (d) above.
-    if (op1->OperGet() == GT_LCL_VAR && op2->OperGet() == GT_LCL_VAR)
-    {
-        LclVarDsc* v1 = comp->lvaTable + op1->AsLclVarCommon()->GetLclNum();
-        LclVarDsc* v2 = comp->lvaTable + op2->AsLclVarCommon()->GetLclNum();
-
-        if (v1->lvTracked && v2->lvTracked)
-        {
-            // Both are tracked locals.  The one with lower weight is less likely
-            // to get a register and hence beneficial to mark the one with lower
-            // weight as reg optional.
-            if (v1->lvRefCntWtd < v2->lvRefCntWtd)
-            {
-                preferredOp = op1;
-            }
-            else
-            {
-                preferredOp = op2;
-            }
-        }
-        else if (v2->lvTracked)
-        {
-            // v1 is an untracked lcl and it is use position is less likely to
-            // get a register.
-            preferredOp = op1;
-        }
-        else if (v1->lvTracked)
-        {
-            // v2 is an untracked lcl and its def position always
-            // needs a reg.  Hence it is better to mark v1 as
-            // reg optional.
-            preferredOp = op1;
-        }
-        else
-        {
-            preferredOp = op1;
-            ;
-        }
-    }
-    else if (op1->OperGet() == GT_LCL_VAR)
-    {
-        preferredOp = op1;
-    }
-    else if (op2->OperGet() == GT_LCL_VAR)
-    {
-        preferredOp = op2;
-    }
-    else
-    {
-        // Neither of the operands is a local, prefer marking
-        // operand that is evaluated first as reg optional
-        // since its use position is less likely to get a register.
-        bool reverseOps = ((tree->gtFlags & GTF_REVERSE_OPS) != 0);
-        preferredOp     = reverseOps ? op2 : op1;
-    }
-
-    return preferredOp;
-}
-
 #endif // _TARGET_XARCH_
 
 #endif // !LEGACY_BACKEND

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -188,6 +188,38 @@ unsigned LinearScan::getWeight(RefPosition* refPos)
     return weight;
 }
 
+//-------------------------------------------------------------------------
+// MarkSiblingRefPosIfAny: Marks the sibling ref pos associated with the
+// given ref pos as non-RegOptional and also removes the mapping between
+// the two ref positions.
+//
+// Arguments:
+//    refPos   -   ref position that is marked as 'Alloc if profitable'
+//
+// Returns:
+//    Nothing.
+void LinearScan::MarkSiblingRefPosIfAny(RefPosition* refPos)
+{
+    assert(refPos->AllocateIfProfitable());
+
+    // It is possible that refPos mapping table was not created
+    // if there were no mappings added (e.g. nodes have max
+    // one reg optional operand).
+    if (refPosToSiblingRefPosMap != nullptr)
+    {
+        RefPosition* siblingRefPos = nullptr;
+        bool found = refPosToSiblingRefPosMap->Lookup(refPos, &siblingRefPos);
+        if (found)
+        {
+            assert(siblingRefPos != nullptr);
+            assert(siblingRefPos->AllocateIfProfitable());
+            siblingRefPos->setAllocateIfProfitable(0);
+            refPosToSiblingRefPosMap->Remove(refPos);
+            refPosToSiblingRefPosMap->Remove(siblingRefPos);
+        }
+    }
+}
+
 // allRegs represents a set of registers that can
 // be used to allocate the specified type in any point
 // in time (more of a 'bank' of registers).
@@ -1659,6 +1691,7 @@ void LinearScan::doLinearScan()
 #endif // DEBUG
 
     splitBBNumToTargetBBNumMap = nullptr;
+    refPosToSiblingRefPosMap = nullptr;
 
     // This is complicated by the fact that physical registers have refs associated
     // with locations where they are killed (e.g. calls), but we don't want to
@@ -3359,7 +3392,11 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
             pos->isLocalDefUse = true;
             bool isLastUse     = ((tree->gtFlags & GTF_VAR_DEATH) != 0);
             pos->lastUse       = isLastUse;
-            pos->setAllocateIfProfitable(tree->IsRegOptional());
+
+            // Ref positions marked as isLocalDefUse should never
+            // be marked as reg optional.
+            assert(!tree->IsRegOptional());
+            pos->setAllocateIfProfitable(0);
             DBEXEC(VERBOSE, pos->dump());
             return;
         }
@@ -3532,6 +3569,10 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
     // pop all ref'd tree temps
     GenTreeOperandIterator iterator = tree->OperandsBegin();
 
+    // Reg-optional RefTypeUse positions of operands that are consumed.
+    RefPosition* firstRefPos = nullptr;
+    RefPosition* secondRefPos = nullptr;
+
     // `operandDefs` holds the list of `LocationInfo` values for the registers defined by the current
     // operand. `operandDefsIterator` points to the current `LocationInfo` value in `operandDefs`.
     LocationInfoList      operandDefs;
@@ -3666,6 +3707,37 @@ void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
         if (regOptionalAtUse)
         {
             pos->setAllocateIfProfitable(1);
+
+            if (firstRefPos == nullptr)
+            {
+                firstRefPos = pos;
+            }
+            else
+            {
+                // Assumption 1: A node can have max two of its operands
+                // marked as reg-optional.  On Xarch where reg-optional
+                // operands are used, there is no need to allow more
+                // than two of its operands to be marked as reg-optional.
+                assert(secondRefPos == nullptr);
+                secondRefPos = pos;
+
+                // Assumption 2: Even if both the operands of a node are
+                // marked as reg-optional, at the most one can end up
+                // in memory.  This assumption holds on Xarch currently.
+                // 
+                // We take advantage of assumption 1 and 2 to simplify
+                // the implementation by maintaining the mapping
+                // between sibling ref positions.  If one of the ref
+                // position ends up in memory, then the other sibling is
+                // marked as non-regOptional and the mapping is removed.
+                //
+                // In future when either of assumption 1 or 2 changes,
+                // we need to revisit how ref positions are maintained
+                // as reg-optional.
+                RefPositionToSiblingRefPositionMap* refPosMap = getRefPositonToSiblingRefPosMap();
+                refPosMap->Set(firstRefPos, secondRefPos);
+                refPosMap->Set(secondRefPos, firstRefPos);
+            }
         }
     }
     JITDUMP("\n");
@@ -5537,8 +5609,6 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
             }
             else
             {
-                isBetterLocation = (nextLocation > farthestLocation);
-
                 if (nextLocation > farthestLocation)
                 {
                     isBetterLocation = true;
@@ -5550,7 +5620,8 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
                     // allocate if profitable.  These ref positions don't need
                     // need to be spilled as they are already in memory and
                     // codegen considers them as contained memory operands.
-                    isBetterLocation = (recentAssignedRef != nullptr) && recentAssignedRef->reload &&
+                    isBetterLocation = (recentAssignedRef != nullptr) && 
+                                       recentAssignedRef->reload &&
                                        recentAssignedRef->AllocateIfProfitable();
                 }
                 else
@@ -7048,11 +7119,12 @@ void LinearScan::allocateRegisters()
                 }
                 else
 #endif // FEATURE_SIMD
-                    if (currentRefPosition->RequiresRegister() || currentRefPosition->AllocateIfProfitable())
+                if (currentRefPosition->RequiresRegister() || currentRefPosition->AllocateIfProfitable())
                 {
                     if (allocateReg)
                     {
-                        assignedRegister = allocateBusyReg(currentInterval, currentRefPosition,
+                        assignedRegister = allocateBusyReg(currentInterval, 
+                                                           currentRefPosition,
                                                            currentRefPosition->AllocateIfProfitable());
                     }
 
@@ -7069,6 +7141,14 @@ void LinearScan::allocateRegisters()
 
                         currentRefPosition->registerAssignment = RBM_NONE;
                         currentRefPosition->reload             = false;
+
+                        // Assumption: Even if more than one operand of a node is
+                        // marked as reg-optional, at the most only one operand
+                        // can end up in memory.
+                        // 
+                        // Mark the sibling ref pos as non-RegOptional and remove
+                        // the mapping.
+                        MarkSiblingRefPosIfAny(currentRefPosition);
 
                         INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NO_REG_ALLOCATED, currentInterval));
                     }
@@ -7342,6 +7422,8 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTreePtr treeNode, RefPosi
                     interval->physReg  = REG_NA;
                     treeNode->gtRegNum = REG_NA;
                     treeNode->gtFlags &= ~GTF_SPILLED;
+
+                    MarkSiblingRefPosIfAny(currentRefPosition);
                 }
                 else
                 {
@@ -8192,7 +8274,8 @@ void LinearScan::resolveRegisters()
                                 // In case of tree temps, if def is spilled and use didn't
                                 // get a register, set a flag on tree node to be treated as
                                 // contained at the point of its use.
-                                if (currentRefPosition->spillAfter && currentRefPosition->refType == RefTypeDef &&
+                                if (currentRefPosition->spillAfter && 
+                                    currentRefPosition->refType == RefTypeDef &&
                                     nextRefPosition->refType == RefTypeUse)
                                 {
                                     assert(nextRefPosition->treeNode == nullptr);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -837,6 +837,26 @@ private:
 
     unsigned getWeight(RefPosition* refPos);
 
+    // Map from a reg optional marked RefTypeUse position to RefTypeUse
+    // position of its reg-optional sibling if any. This info is set up
+    // while creating ref positions and used while allocating registers
+    // to ensure that at most one RefTypeUse position ends up in memory.
+    typedef SimplerHashTable<RefPosition*, PtrKeyFuncs<RefPosition>, RefPosition*, JitSimplerHashBehavior>
+        RefPositionToSiblingRefPositionMap;
+    RefPositionToSiblingRefPositionMap* refPosToSiblingRefPosMap;
+
+    RefPositionToSiblingRefPositionMap* getRefPositonToSiblingRefPosMap()
+    {
+        if (refPosToSiblingRefPosMap == nullptr)
+        {
+            refPosToSiblingRefPosMap =
+                new (getAllocator(compiler)) RefPositionToSiblingRefPositionMap(getAllocator(compiler));
+        }
+        return refPosToSiblingRefPosMap;
+    }
+
+    void MarkSiblingRefPosIfAny(RefPosition* refPos);
+
     /*****************************************************************************
      * Register management
      ****************************************************************************/
@@ -1457,10 +1477,10 @@ public:
     {
         return (IsActualRef()
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-                || refType == RefTypeUpperVectorSaveDef || refType == RefTypeUpperVectorSaveUse
+            || refType == RefTypeUpperVectorSaveDef || refType == RefTypeUpperVectorSaveUse
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-                ) &&
-               !AllocateIfProfitable();
+            ) &&
+            !AllocateIfProfitable();
     }
 
     // Indicates whether this ref position is to be allocated

--- a/src/jit/nodeinfo.h
+++ b/src/jit/nodeinfo.h
@@ -34,7 +34,11 @@ public:
         definesAnyRegisters   = false;
 #ifdef DEBUG
         isInitialized = false;
-#endif
+
+#ifdef _TARGET_XARCH_
+        srcRegOptionalCount = 0;
+#endif // _TARGET_XARCH_
+#endif // DEBUG
     }
 
     // dst
@@ -102,14 +106,21 @@ public:
 private:
     unsigned char _dstCount;
     unsigned char _srcCount;
-    unsigned char _internalIntCount;
-    unsigned char _internalFloatCount;
 
 public:
     unsigned char srcCandsIndex;
     unsigned char dstCandsIndex;
     unsigned char internalCandsIndex;
 
+private: 
+    // So far there has not been a need to specificy an internal count
+    // of more than 3 or 4 across all arch.  Therefore to save space
+    // max internal count is capped at 7.  Based on the need this could
+    // be adjusted in future.
+    unsigned char _internalIntCount : 3;
+    unsigned char _internalFloatCount : 3;
+
+public:
     // isLocalDefUse identifies trees that produce a value that is not consumed elsewhere.
     // Examples include stack arguments to a call (they are immediately stored), lhs of comma
     // nodes, or top-level nodes that are non-void.
@@ -138,6 +149,14 @@ public:
 #ifdef DEBUG
     // isInitialized is set when the tree node is handled.
     unsigned char isInitialized : 1;
+
+#ifdef _TARGET_XARCH_
+    // Number of operands that are marked as reg-optional.
+    // On Xarch, right now there is no need to mark more than two
+    // operands of a node as reg-optional.  Further of the two operands
+    // that are marked, at the most only one can end up in memory.
+    unsigned char srcRegOptionalCount : 2;
+#endif 
 #endif
 
 public:


### PR DESCRIPTION
This corresponds to issue #6361

In the existing implementation, Lower register specification fixes one of op1 or op2 to as reg-optional based on heuristics.  As a result, RyuJIT will miss those opportunities where marking the other operand as reg-optional is beneficial.

These code changes are meant to allow Lower to mark all operands that could be in memory as reg-optional and also indicate source memory operand count.  Based on this info, Lsra will treat an operand's RefTypeUse position as reg-optional as long it is marked as such and memory operand count of its consuming node is non-zero. Whenever a RefTypeUse position is determined to be beneficial to not to allocate a register, source memory operand count of its consuming node is decremented and which in turn will impact whether other operands of the consuming node are treated as reg-optional.

Here is the summary of code changes:
Nodeinfo.h: srcMemOpCount indicates, the number of memory operands a Gentree node can have.  This field is set by Lower register specification.

Lower.h/lowerxarch.cpp - now all non-contained operands that could be in memory are marked as reg-optional.

lsra.h/lsra.cpp: 
- Definition of AllocateIfBeneficial() has changed since it also depends on srcMemOpCount of its consuming node.
- A Hashtable is used to store the mapping from a RefTypeUse position to its corresponding consuming GenTree node. This mapping allows to obtain srcMemOpCount of consuming node given a RefTypeUse position of its operand that is marked as reg-optional by Lower.
- If a marked RefTypeUse position ends up in memory, then srcMemOpCount of its consuming node is decremented and mapping from that RefTypeUse position to its consuming GenTree node is removed.  Afterwards, such a RefTypeUse position is treated as reg-optional without any regard to srcMemOpCount of its consuming node.  

Asm Diffs on Amd64:
SuperPMI asm diffs on desktop Fx assemblies: 
214 bytes of code size (0.07%) improvement with 145 methods impacted.
CqPerf Benchmarks:

214 bytes of code size (0.37%) improvement with 25 methods impacted.

CqPerf Execution numbers:
There is no change in these numbers. These numbers are within the noise range.

Throughput and memory foot print:
Yet to measure these.  Will update once done.