### PR TITLE
Fix Arm64 build breaks

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3523,6 +3523,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             {
                 assert(treeNode->AsObj()->gtGcPtrCount != 0);
                 genCodeForCpObj(treeNode->AsObj());
+                break;
             }
             __fallthrough;
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -2535,6 +2535,10 @@ AGAIN:
                                                     reinterpret_cast<uintptr_t>(tree->gtAllocObj.gtAllocObjClsHnd)));
                     hash = genTreeHashAdd(hash, tree->gtAllocObj.gtNewHelper);
                     break;
+                case GT_OBJ:
+                    hash = genTreeHashAdd(hash, static_cast<unsigned>(
+                                                    reinterpret_cast<uintptr_t>(tree->gtObj.gtClass)));
+                    break;
 
                 // For the ones below no extra argument matters for comparison.
                 case GT_BOX:
@@ -15829,7 +15833,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleIfPresent(GenTree* tree)
                 info.compCompHnd->getFieldType(tree->gtField.gtFldHnd, &structHnd);
                 break;
             case GT_ASG:
-                structHnd = gtGetStructHandle(tree->gtGetOp1());
+                structHnd = gtGetStructHandleIfPresent(tree->gtGetOp1());
                 break;
             case GT_LCL_VAR:
             case GT_LCL_FLD:

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2045,8 +2045,13 @@ GenTreePtr Compiler::fgMakeTmpArgNode(
             {
                 // ToDo-ARM64: Consider using:  arg->ChangeOper(GT_LCL_FLD);
                 // as that is how FEATURE_UNIX_AMD64_STRUCT_PASSING works.
+                // We will create a GT_OBJ for the argument below.
+                // This will be passed by value in two registers.
+                assert(addrNode != nullptr);
 
-                // Pass by value in two registers, using a regular GT_OBJ node, created below.
+                // Create an Obj of the temp to use it as a call argument.
+                arg = gtNewObjNode(lvaGetStruct(tmpVarNum), arg);
+
                 // TODO-1stClassStructs: We should not need to set the GTF_DONT_CSE flag here;
                 // this is only to preserve former behavior (though some CSE'ing of struct
                 // values can be pessimizing, so enabling this may require some additional tuning).


### PR DESCRIPTION
The `GT_STORE_OBJ` case in codegen was missing a break.
`getStructHandleIfPresent` wasn't correctly handling `GT_ASG'.
The `srcCount` was not being set correctly for block ops with a constant size.
And I lost some code in `fgMakeTmpArgNode` with a merge.
Also, I had introduced a dumping issue in gentree.cpp when I made `GT_OBJ` a `GTK_UNOP` as a result of some PR comments.