### PR TITLE
Make Stream.CopyTo virtual

### DIFF
--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -186,7 +186,7 @@ namespace System.IO {
         // Reads the bytes from the current stream and writes the bytes to
         // the destination stream until all bytes are read, starting at
         // the current position.
-        public void CopyTo(Stream destination)
+        public virtual void CopyTo(Stream destination)
         {
             int bufferSize = _DefaultCopyBufferSize;
 


### PR DESCRIPTION
dotnet/corefx#11342 has been approved, so this is the corresponding change to make `Stream.CopyTo` virtual. The overrides of this method that have also been approved, such as in `MemoryStream` / `FileStream`, will come in a separate PR once this is merged.

/cc @jkotas, @weshaggard 