### PR TITLE
Revises 'JitTimer::PrintCsvHeader' to use 'append' mode

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -7224,7 +7224,8 @@ void JitTimer::PrintCsvHeader()
 
     CritSecHolder csvLock(s_csvLock);
 
-    if (FILE* fp = _wfopen(jitTimeLogCsv, W("a")))
+    FILE* fp = _wfopen(jitTimeLogCsv, W("a"));
+    if (fp != nullptr)
     {
         // Write the header if the file is empty
         if (ftell(fp) == 0)

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -7224,15 +7224,10 @@ void JitTimer::PrintCsvHeader()
 
     CritSecHolder csvLock(s_csvLock);
 
-    FILE* fp = _wfopen(jitTimeLogCsv, W("r"));
-    if (fp == nullptr)
+    if (FILE* fp = _wfopen(jitTimeLogCsv, W("a")))
     {
-        // File doesn't exist, so create it and write the header
-
-        // Use write mode, so we rewrite the file, and retain only the last compiled process/dll.
-        // Ex: ngen install mscorlib won't print stats for "ngen" but for "mscorsvw"
-        fp = _wfopen(jitTimeLogCsv, W("w"));
-        if (fp != nullptr)
+        // Write the header if the file is empty
+        if (ftell(fp) == 0)
         {
             fprintf(fp, "\"Method Name\",");
             fprintf(fp, "\"Method Index\",");
@@ -7251,8 +7246,8 @@ void JitTimer::PrintCsvHeader()
             fprintf(fp, "\"Total Cycles\",");
             fprintf(fp, "\"CPS\"\n");
         }
+        fclose(fp);
     }
-    fclose(fp);
 }
 
 extern ICorJitHost* g_jitHost;


### PR DESCRIPTION
The current implementation of 'JitTimer::PrintCsvHeader' opens a CSV
file with 'read' mode and re-opens it with 'write' mode if it is absent.

The current implementation has two problems:
First, "read" file pointer will be closed even if it is null,
which is reported in #7072.
Second, "write" file pointer will be leaked as there is no corresponding
fclose.

This commit rewrites 'JitTimer::PrintCsvHeader' to fix #7072.
