### PR TITLE
Avoid creating zh-CHS/zh-CHT durng culture enumeration

### DIFF
--- a/src/mscorlib/src/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.cs
@@ -322,10 +322,12 @@ namespace System.Globalization {
             get
             {
                 Contract.Assert(m_name != null, "CompareInfo.Name Expected m_name to be set");
+#if !FEATURE_CORECLR
                 if (m_name == "zh-CHT" || m_name == "zh-CHS")
                 {
                     return m_name;
                 }
+#endif // FEATURE_CORECLR
 
                 return (m_sortName);
             }

--- a/src/mscorlib/src/System/Globalization/CultureData.cs
+++ b/src/mscorlib/src/System/Globalization/CultureData.cs
@@ -972,10 +972,12 @@ namespace System.Globalization
 
             int arrayLength = cultureNames.Length;
 
+#if !FEATURE_CORECLR
             if ((types & (CultureTypes.NeutralCultures | CultureTypes.FrameworkCultures)) != 0) // add zh-CHT and zh-CHS
             {
                 arrayLength += 2;
             }
+#endif // FEATURE_CORECLR
 
             CultureInfo[] cultures = new CultureInfo[arrayLength];
 
@@ -984,12 +986,14 @@ namespace System.Globalization
                 cultures[i] = new CultureInfo(cultureNames[i]);
             }
 
+#if !FEATURE_CORECLR
             if ((types & (CultureTypes.NeutralCultures | CultureTypes.FrameworkCultures)) != 0) // add zh-CHT and zh-CHS
             {
                 Contract.Assert(arrayLength == cultureNames.Length + 2, "CultureData.nativeEnumCultureNames() Incorrect array size");
                 cultures[cultureNames.Length] = new CultureInfo("zh-CHS");
                 cultures[cultureNames.Length + 1] = new CultureInfo("zh-CHT");
             }
+#endif // FEATURE_CORECLR
 
 #pragma warning restore 618
 


### PR DESCRIPTION
zh-CHS and zh-CHT are old names that is not really supported in the standards. when we enabled CultureInfo.GetCultures() there was some code that create cultures for zh-CHS and zh-CHT. The fix here is disable that otherwise we'll have to enable a good chunk of legacy code to support it while it never supported by coreclr and in same time are not names used in standards.