### PR TITLE
Exclude smallFrame.sh test for ARM

### DIFF
--- a/tests/testsUnsupportedOnARM32.txt
+++ b/tests/testsUnsupportedOnARM32.txt
@@ -1,4 +1,5 @@
 JIT/Directed/tailcall/tailcall/tailcall.sh
 JIT/Methodical/tailcall_v4/hijacking/hijacking.sh
 JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271/DevDiv_902271.sh
+JIT/Methodical/tailcall_v4/smallFrame/smallFrame.sh
 JIT/jit64/opt/cse/HugeArray1/HugeArray1.sh


### PR DESCRIPTION
JIT/Methodical/tailcall_v4/smallFrame/smallFrame.sh contains
"tail.call, pop, ret" pattern. The pattern is not allowed in ECMA and
is only supported on x64 for compatibility. (issue #7036)

Fix #7036 