### PR TITLE
Add Enum.TryParse and Enum.Parse<TEnum>

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -1957,6 +1957,8 @@
       <Member Name="IsDefined(System.Type,System.Object)" />
       <Member Name="Parse(System.Type,System.String)" />
       <Member Name="Parse(System.Type,System.String,System.Boolean)" />
+      <Member Name="Parse&lt;TEnum&gt;(System.String)" />
+      <Member Name="Parse&lt;TEnum&gt;(System.String,System.Boolean)" />
       <Member Name="ToObject(System.Type,System.Byte)" />
       <Member Name="ToObject(System.Type,System.Int16)" />
       <Member Name="ToObject(System.Type,System.Int32)" />
@@ -1970,6 +1972,8 @@
       <Member Name="ToString(System.IFormatProvider)" />
       <Member Name="ToString(System.String)" />
       <Member Name="ToString(System.String,System.IFormatProvider)" />
+      <Member Name="TryParse(System.Type,System.String,System.Object@)" />
+      <Member Name="TryParse(System.Type,System.String,System.Boolean,System.Object@)" />
       <Member Name="TryParse&lt;TEnum&gt;(System.String,TEnum@)" />
       <Member Name="TryParse&lt;TEnum&gt;(System.String,System.Boolean,TEnum@)" />
     </Type>

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -334,6 +334,22 @@ namespace System
             }
         }
 
+        public static bool TryParse(Type enumType, String value, out Object result)
+        {
+            return TryParse(enumType, value, false, out result);
+        }
+
+        public static bool TryParse(Type enumType, String value, bool ignoreCase, out Object result)
+        {
+            result = null;
+            EnumResult parseResult = new EnumResult();
+            bool retValue;
+
+            if (retValue = TryParseEnum(enumType, value, ignoreCase, ref parseResult))
+                result = parseResult.parsedEnum;
+            return retValue;
+        }
+
         public static bool TryParse<TEnum>(String value, out TEnum result) where TEnum : struct
         {
             return TryParse(value, false, out result);
@@ -362,6 +378,20 @@ namespace System
             EnumResult parseResult = new EnumResult() { canThrow = true };
             if (TryParseEnum(enumType, value, ignoreCase, ref parseResult))
                 return parseResult.parsedEnum;
+            else
+                throw parseResult.GetEnumParseException();
+        }
+
+        public static TEnum Parse<TEnum>(String value)
+        {
+            return Parse<TEnum>(value, false);
+        }
+
+        public static TEnum Parse<TEnum>(String value, bool ignoreCase)
+        {
+            EnumResult parseResult = new EnumResult() { canThrow = true };
+            if (TryParseEnum(typeof(TEnum), value, ignoreCase, ref parseResult))
+                return (TEnum)parseResult.parsedEnum;
             else
                 throw parseResult.GetEnumParseException();
         }


### PR DESCRIPTION
Original api addition request approved here https://github.com/dotnet/corefx/issues/692

This is the corresponding PR that make `Enum.Parse` / `Enum.TryParse` have both generic and non-generic versions.

Changes to corert and corefx will follow when this one is merged.