### PR TITLE
Enable building the RootFS for cross-compiling on Ubuntu 16.04

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -64,6 +64,7 @@ for i in "$@"
         xenial)
         if [ "$__UbuntuCodeName" != "jessie" ]; then
             __UbuntuCodeName=xenial
+			__LLDB_Package="liblldb-3.8-dev"
         fi
         ;;
         jessie)


### PR DESCRIPTION
This PR adds support for building the RootFS for cross-compiling using Ubuntu 16.04

This should be a first step towards getting .NET Core running on, amongst others, a Raspberry Pi 3, on which Ubuntu Mate 16.04 is the only supported Ubuntu version.

Note that because the xenial) clause sets `__LLDB_Package` variable, you must specify `xenial` first and then `arm` in the parameter list, for example:

```
sudo ./cross/build-rootfs.sh xenial arm
```

If this PR gets accepted into `coreclr`, I'll prepare a similar one for `corefx`, too.
