### PR TITLE
Implement long to int casts without overflow for x86

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -158,8 +158,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
             break;
 
         case GT_CAST:
-            LowerCast(node);
-            break;
+            return LowerCast(node);
 
         case GT_ARR_ELEM:
             return LowerArrElem(node);

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -219,7 +219,7 @@ private:
     void AddrModeCleanupHelper(GenTreeAddrMode* addrMode, GenTree* node);
 
     GenTree* LowerSwitch(GenTree* node);
-    void LowerCast(GenTree* node);
+    GenTree* LowerCast(GenTree* node);
 
 #if defined(_TARGET_XARCH_)
     void SetMulOpCounts(GenTreePtr tree);

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -32,9 +32,10 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "lsra.h"
 
 /* Lowering of GT_CAST nodes */
-void Lowering::LowerCast(GenTree* tree)
+GenTree* Lowering::LowerCast(GenTree* tree)
 {
     NYI_ARM("ARM Lowering for cast");
+    return tree->gtNext;
 }
 
 void Lowering::LowerRotate(GenTreePtr tree)

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1896,7 +1896,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
  * i) GT_CAST(float/double, int type with overflow detection)
  *
  */
-void Lowering::LowerCast(GenTree* tree)
+GenTree* Lowering::LowerCast(GenTree* tree)
 {
     assert(tree->OperGet() == GT_CAST);
 
@@ -1937,6 +1937,8 @@ void Lowering::LowerCast(GenTree* tree)
         tree->gtOp.gtOp1 = tmp;
         BlockRange().InsertAfter(op1, tmp);
     }
+
+    return tree->gtNext;
 }
 
 void Lowering::LowerRotate(GenTreePtr tree)


### PR DESCRIPTION
Simply replace the cast with the low part of its source. The high part of the source remains unused, we could try to remove it but morph does that already if there are no side effects.

I also added a bunch of asserts and new NYIs in attempt to clarify what's left to do in this area. There are all kinds of casts and they're handled in many places so it's easy to miss something.

Contributes to #4169 
Replaces #6466