### PR TITLE
Fix OSX build break in PAL tests

### DIFF
--- a/src/pal/tests/palsuite/threading/ExitThread/test1/test1.cpp
+++ b/src/pal/tests/palsuite/threading/ExitThread/test1/test1.cpp
@@ -48,7 +48,7 @@ BOOL ExitThreadTest()
     LPSECURITY_ATTRIBUTES lpThreadAttributes = NULL;
     DWORD dwStackSize = 0; 
     LPTHREAD_START_ROUTINE lpStartAddress =  &ExitThreadTestThread;
-    LPVOID lpParameter = lpStartAddress;
+    LPVOID lpParameter = (LPVOID)lpStartAddress;
     DWORD dwCreationFlags = 0;  //run immediately
     DWORD dwThreadId = 0;
 

--- a/src/pal/tests/palsuite/threading/ResumeThread/test1/test1.cpp
+++ b/src/pal/tests/palsuite/threading/ResumeThread/test1/test1.cpp
@@ -38,7 +38,7 @@ BOOL ResumeThreadTest()
     LPSECURITY_ATTRIBUTES lpThreadAttributes = NULL;
     DWORD dwStackSize = 0; 
     LPTHREAD_START_ROUTINE lpStartAddress =  &ResumeThreadTestThread;
-    LPVOID lpParameter = lpStartAddress;
+    LPVOID lpParameter = (LPVOID)lpStartAddress;
     DWORD dwCreationFlags = CREATE_SUSPENDED;
     DWORD dwThreadId = 0;
 


### PR DESCRIPTION
This fixes a build break in PAL tests introduced by a recent checkin
that converted PAL tests to C++.