### PR TITLE
Fix Issue dumping GC heap with ETW more than once

### DIFF
--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4468,6 +4468,12 @@ extern "C"
 
         BOOLEAN bIsRundownTraceHandle = (context->RegistrationHandle==Microsoft_Windows_DotNETRuntimeRundownHandle);
 
+		// TypeSystemLog needs a notification when certain keywords are modified, so
+		// give it a hook here.
+		if (g_fEEStarted && !g_fEEShutDown && bIsPublicTraceHandle)
+		{
+			ETW::TypeSystemLog::OnKeywordsChanged();
+		}
 
         // A manifest based provider can be enabled to multiple event tracing sessions
         // As long as there is atleast 1 enabled session, IsEnabled will be TRUE
@@ -4478,13 +4484,6 @@ extern "C"
              (ControlCode == EVENT_CONTROL_CODE_CAPTURE_STATE));
         if(bEnabled)
         {
-            // TypeSystemLog needs a notification when certain keywords are modified, so
-            // give it a hook here.
-            if (g_fEEStarted && !g_fEEShutDown && bIsPublicTraceHandle)
-            {
-                ETW::TypeSystemLog::OnKeywordsChanged();
-            }
-
             if (bIsPrivateTraceHandle)
             {
                 ETW::GCLog::GCSettingsEvent();


### PR DESCRIPTION
The symptom is that if you dump the GC heap with ETW on the same process more
than once, on all but the first dump you do not get the events that assign a name
to each of the type IDs.   The resulting dump is not very useful.  

The issue is that a table that remembers which types have been dumped is only
flushed when the 'Types' ETW keyword is disabled, but we only check this when
and ENABLE command is executed.  We should do so on DISABLE a well so that
each time a dump is done the table is empty to begin with (and thus all type names
will be emitted.  