### PR TITLE
Implement DecomposeUMod

### DIFF
--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -52,6 +52,7 @@ private:
     GenTree* DecomposeArith(LIR::Use& use);
     GenTree* DecomposeShift(LIR::Use& use);
     GenTree* DecomposeMul(LIR::Use& use);
+    GenTree* DecomposeUMod(LIR::Use& use);
 
     // Helper functions
     GenTree* FinalizeDecomposition(LIR::Use& use, GenTree* loResult, GenTree* hiResult);

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3220,8 +3220,13 @@ void Lowering::LowerUnsignedDivOrMod(GenTree* node)
     assert((node->OperGet() == GT_UDIV) || (node->OperGet() == GT_UMOD));
 
     GenTree* divisor = node->gtGetOp2();
+    GenTree* dividend = node->gtGetOp1();
 
-    if (divisor->IsCnsIntOrI())
+    if (divisor->IsCnsIntOrI()
+#ifdef _TARGET_X86_
+            && (dividend->OperGet() != GT_LONG)
+#endif
+            )
     {
         size_t divisorValue = static_cast<size_t>(divisor->gtIntCon.IconValue());
 


### PR DESCRIPTION
This change implements DecomposeUMod for x86 RyuJIT. The only GT_UMOD
nodes that make it to decompose are ones where op2 is a cast from a
constant int to long. Because op2 is an int, we can guarantee that the
result will be an int. Therefore, in decompose, we change the type of the
GT_UMOD to be TYP_INT, and replace op2 with its lo part. In lower, we need
to make sure that loOp1 is in RAX and hiOp1 is in RDX, which is where
idiv expects them to be. We also increase the number of sources since
there are now three sources. In codegen, we need to make sure that the hi
and lo parts of the dividend are in the correct registers for idiv, then
we can just use the normal logic for GT_UMOD.