### PR TITLE
Improve decomp throughput.

### DIFF
--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -36,7 +36,7 @@ private:
 
     // Driver functions
     void DecomposeRangeHelper();
-    GenTree* DecomposeNode(LIR::Use& use);
+    GenTree* DecomposeNode(GenTree* tree);
 
     // Per-node type decompose cases
     GenTree* DecomposeLclVar(LIR::Use& use);


### PR DESCRIPTION
Don't find uses unless necessary. This saves about 50 milliseconds while
crossgen'ing mscorlib.