### PR TITLE
Fix #7100

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2499,8 +2499,9 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
         // Absolute addresses marked as contained should fit within the base of addr mode.
         assert(memBase->AsIntConCommon()->FitsInAddrBase(emitComp));
 
-        // Either not generating relocatable code or addr must be an icon handle
-        assert(!emitComp->opts.compReloc || memBase->IsIconHandle());
+        // Either not generating relocatable code, or addr must be an icon handle, or the
+        // constant is zero (which we won't generate a relocation for).
+        assert(!emitComp->opts.compReloc || memBase->IsIconHandle() || memBase->IsIntegralConst(0));
 
         if (memBase->AsIntConCommon()->AddrNeedsReloc(emitComp))
         {


### PR DESCRIPTION
This issue is the following assert:
```
Assert failure '!emitComp->opts.compReloc || memBase->IsIconHandle()'
```
while ngen'ing mscorlib on desktop.

We're trying to generate
```
cmp ebx, dword ptr [0000H]
```
(due to inlining). But, emitInsBinary() doesn't expect a zero address that
is not a relocatable handle.

Simply change the assert to allow this. The code then generates the correct
zero base address.