### PR TITLE
Fix enregistered max size constants on Unix AMD64

### DIFF
--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -65,14 +65,16 @@ EXTERN_C void FastCallFinalizeWorker(Object *obj, PCODE funcPtr);
 #define CACHE_LINE_SIZE                         64   // Current AMD64 processors have 64-byte cache lines as per AMD64 optmization manual
 #define LOG2SLOT                                LOG2_PTRSIZE
 
-#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE 8    // bytes
-#define ENREGISTERED_PARAMTYPE_MAXSIZE          8    // bytes
 
 #ifdef UNIX_AMD64_ABI
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE 16   // bytes
+#define ENREGISTERED_PARAMTYPE_MAXSIZE          16   // bytes
 #define ENREGISTERED_RETURNTYPE_MAXSIZE         16   // bytes
 #define CALLDESCR_ARGREGS                       1    // CallDescrWorker has ArgumentRegister parameter
 #define CALLDESCR_FPARGREGS                     1    // CallDescrWorker has FloatArgumentRegisters parameter
 #else
+#define ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE 8    // bytes
+#define ENREGISTERED_PARAMTYPE_MAXSIZE          8    // bytes
 #define ENREGISTERED_RETURNTYPE_MAXSIZE         8    // bytes
 #define COM_STUBS_SEPARATE_FP_LOCATIONS
 #define CALLDESCR_REGTYPEMAP                    1


### PR DESCRIPTION
This change fixes ENREGISTERED_PARAMTYPE_MAXSIZE and ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
constants that were not updated properly for the Unix AMD64 ABI. The values are used
for Unix/AMD64 for marshalling and typedbyref parameters and our tests probably don't
execute those code paths with structs larger than 8 bytes.