### PR TITLE
Fix #7092

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1575,6 +1575,17 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
                     blkNode->gtLsraInfo.setInternalCandidates(l, l->internalFloatRegCandidates());
                 }
                 blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
+
+#ifdef _TARGET_X86_
+                if ((size & 1) != 0)
+                {
+                    // On x86, you can't address the lower byte of ESI, EDI, ESP, or EBP when doing
+                    // a "mov byte ptr [dest], val". If the fill size is odd, we will try to do this
+                    // when unrolling, so only allow byteable registers as the source value. (We could
+                    // consider just using BlkOpKindRepInstr instead.)
+                    sourceRegMask = RBM_BYTE_REGS;
+                }
+#endif // _TARGET_X86_
             }
             else
             {


### PR DESCRIPTION
The problem is genCodeForInitBlkUnroll() is trying to generate:
```
mov byte ptr [edi], si
```
which is not legal: ebp/esi/edi/esp don't have byte register versions on x86.

This change requires the source register to be an x86 byteable register in
this case.
