### PR TITLE
[Linux] [ARM] Enable Debian Jessie for ARM rootfs build

### DIFF
--- a/cross/arm/sources.list.jessie
+++ b/cross/arm/sources.list.jessie
@@ -1,0 +1,3 @@
+# Debian (sid)   # UNSTABLE
+deb http://ftp.debian.org/debian/ sid main contrib non-free
+deb-src http://ftp.debian.org/debian/ sid main contrib non-free

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -61,6 +61,10 @@ for i in "$@"
             __UbuntuCodeName=wily
         fi
         ;;
+        jessie)
+        __UbuntuCodeName=jessie
+        __UbuntuRepo="http://ftp.debian.org/debian/"
+        ;;
         *)
         __UnprocessedBuildArgs="$__UnprocessedBuildArgs $i"
         ;;


### PR DESCRIPTION
This PR adds Debian Jessie variant for  ARM (hrdfp) rootfs build. We want to enable event tracing for Linux/ARM, however Ubunu's /usr/include/urcu/uatomic/generic.h is broken, so we need the one from Debian. The same repo is currently used for ARM/SoftFP.
To build jessie rootfs, run:
```
$ sudo cross/build-rootfs.sh arm jessie
```
