### PR TITLE
Fix to #7091 - Assert failure 'currentInterval && (currentInterval->isLocalVar || currentRefPosition->isFixedRegRef || currentInterval->hasConflictingDefUse)'

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6968,10 +6968,7 @@ void LinearScan::allocateRegisters()
             }
             else
             {
-                // This must be a localVar or a single-reg fixed use or a tree temp with conflicting def & use.
-
-                assert(currentInterval && (currentInterval->isLocalVar || currentRefPosition->isFixedRegRef ||
-                                           currentInterval->hasConflictingDefUse));
+                assert(currentInterval != nullptr);
 
                 // It's already in a register, but not one we need.
                 // If it is a fixed use that is not marked "delayRegFree", there is already a FixedReg to ensure that


### PR DESCRIPTION
Though this happens in JitStressRegs=8 mode, it could potentially happen even in a non-stress mode.

Repro program has the following IR

GT_CAST.ovf(GT_SUB)

Cast is from ubyte to int.  Hence Lower constrains the use candidates of GT_SUB to bytable regs { eax, ebx, ecx, edx }.  But the def candidates of GT_SUB is allInt regs.  Under stress mode, candidates are constrained to callee saved regs { ebx, esi, edi }.  As a result, 

Def candidates of GT_SUB becomes { ebx, esi, edi }
Use candidates of GT_SUB becomes {ebx}

For Def position of GT_SUB, esi is allocated.  Later while allocating a reg to use position of GT_SUB the following assert is hit

currentInterval && (currentInterval->isLocalVar || currentRefPosition->isFixedRegRef || currentInterval->hasConflictingDefUse)

Essentially, in this case currentInterval is neither a local var nor FixedRegRef nor marked ConflictingDefUse.  Interval cannot be marked as FixedRegRef since its candidates has more than one register (from codegen perspective).  Neither it has conflicting Def and use because its use and def candidates are overlapping.

This case could arise even in non-stress mode if def candidates are constrained to callee saved regs { ebx, esi, edi} and use candidates are constrained to bytable registers { eax, ebx, ecx, edx }.  Both the sets are overlapping and the intersection is a single reg { ebx }.  In this case LSRA needs to generate a GT_COPY after allocating a bytable register to use position of GT_SUB.

Fix: We should permit even tree temps in this case so that a GT_COPY gets generated.  Which essentially means, everything.  Hence the assert is modified to assert that current interval is non-null.

Fix #7091 