### PR TITLE
Restrict x86 legacy JIT struct promotion

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1450,10 +1450,14 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE    typeHnd,
 
         // This method has two callers. The one in Importer.cpp passes sortFields == false
         // and the other passes sortFields == true.
-        // This is a workaround that leave the inlining behavior the same and before while still
+        // This is a workaround that leaves the inlining behavior the same as before while still
         // performing extra struct promotions when compiling the method.
         //
+        // The x86 legacy back-end can't handle the more general RyuJIT struct promotion (notably structs
+        // with holes), in genPushArgList(), so in that case always check for custom layout.
+#if FEATURE_FIXED_OUT_ARGS || !defined(LEGACY_BACKEND)
         if (!sortFields) // the condition "!sortFields" really means "we are inlining"
+#endif
         {
             treatAsOverlapping = StructHasCustomLayout(typeFlags);
         }


### PR DESCRIPTION
Don't allow struct promotion for custom layout structs. RyuJIT started
supporting this, but the legacy x86 JIT doesn't properly push such promoted
structs as arguments for calls.

Fixes the assert in #7127, but the test fails with a crash in a later test case.