### PR TITLE
Remove a field from the CopyToAsync async state machine

### DIFF
--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -176,9 +176,10 @@ namespace System.IO {
             Contract.Requires(destination.CanWrite);
 
             byte[] buffer = new byte[bufferSize];
-            int bytesRead;
-            while ((bytesRead = await ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) != 0)
+            while (true)
             {
+                int bytesRead = await ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                if (bytesRead == 0) break;
                 await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
The compiler is lifting the local ```bytesRead``` into a field on the async state machine, even though its value need not be preserved across any await.

https://github.com/dotnet/roslyn/issues/13759

cc: @jkotas, @JeremyKuhne, @davidfowl 