### PR TITLE
Add missing volatile annotation to test

### DIFF
--- a/tests/src/GC/Scenarios/FinalizeTimeout/FinalizeTimeout.cs
+++ b/tests/src/GC/Scenarios/FinalizeTimeout/FinalizeTimeout.cs
@@ -17,6 +17,7 @@ public class FinalizeTimeout
         do
         {
             finalizableObject = new BlockingFinalizerOnShutdown();
+            GC.KeepAlive(finalizableObject);
         } while (!BlockingFinalizerOnShutdown.finalizerCompletedOnce);
 
         // Start a bunch of threads that allocate continuously, to increase the chance that when Main returns, one of the
@@ -42,12 +43,15 @@ public class FinalizeTimeout
     {
         byte[] b;
         while (true)
+        {
             b = new byte[1024];
+            GC.KeepAlive(b);
+        }
     }
 
     private class BlockingFinalizerOnShutdown
     {
-        public static bool finalizerCompletedOnce = false;
+        public volatile static bool finalizerCompletedOnce = false;
         public bool isLastObject = false;
 
         ~BlockingFinalizerOnShutdown()
@@ -68,6 +72,7 @@ public class FinalizeTimeout
             do
             {
                 o = new object();
+                GC.KeepAlive(o);
             } while ((++i & 0xff) != 0 || (elapsed = DateTime.Now - start) < timeout);
 
             Console.WriteLine("Finalizer end");


### PR DESCRIPTION
Declare static field `finalizerCompletedOnce` volatile -- this test has a
side-effect-free busy-loop which checks that static variable for a change it
expects a finalizer to make to it; this static field must be volatile to
ensure the jit doesn't hoist the load from the loop.