### PR TITLE
Remove unnecessary NYIs in Decompose

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -235,18 +235,6 @@ GenTree* DecomposeLongs::DecomposeNode(GenTree* tree)
             nextNode = DecomposeMul(use);
             break;
 
-        case GT_DIV:
-            NYI("Arithmetic binary operators on TYP_LONG - GT_DIV");
-            break;
-
-        case GT_MOD:
-            NYI("Arithmetic binary operators on TYP_LONG - GT_MOD");
-            break;
-
-        case GT_UDIV:
-            NYI("Arithmetic binary operators on TYP_LONG - GT_UDIV");
-            break;
-
         case GT_UMOD:
             nextNode = DecomposeUMod(use);
             break;
@@ -255,15 +243,6 @@ GenTree* DecomposeLongs::DecomposeNode(GenTree* tree)
         case GT_RSH:
         case GT_RSZ:
             nextNode = DecomposeShift(use);
-            break;
-
-        case GT_ROL:
-        case GT_ROR:
-            NYI("Arithmetic binary operators on TYP_LONG - ROTATE");
-            break;
-
-        case GT_MULHI:
-            NYI("Arithmetic binary operators on TYP_LONG - MULHI");
             break;
 
         case GT_LOCKADD:


### PR DESCRIPTION
GT_DIV, GT_MOD, GT_UDIV, GT_ROL, GT_ROR, and GT_MULHI will never make it
to decompose, so remove the case statements for those operations. They
will fall through to the default case, which noway_asserts that we haven't
gotten to decompose with an oper that we don't recognize.