### PR TITLE
Refactor call arg table updates. 

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4381,13 +4381,6 @@ private:
     GenTree* fgInsertCommaFormTemp(GenTree** ppTree, CORINFO_CLASS_HANDLE structType = nullptr);
     GenTree* fgMakeMultiUse(GenTree** ppTree);
 
-    //                  After replacing oldChild with newChild, fixup the fgArgTabEntryPtr
-    //                  if it happens to be an argument to a call.
-    void fgFixupIfCallArg(ArrayStack<GenTree*>* parentStack, GenTree* oldChild, GenTree* newChild);
-
-public:
-    void fgFixupArgTabEntryPtr(GenTreePtr parentCall, GenTreePtr oldArg, GenTreePtr newArg);
-
 private:
     //                  Recognize a bitwise rotation pattern and convert into a GT_ROL or a GT_ROR node.
     GenTreePtr fgRecognizeAndMorphBitwiseRotation(GenTreePtr tree);

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1511,6 +1511,8 @@ public:
     // Get the parent of this node, and optionally capture the pointer to the child so that it can be modified.
     GenTreePtr gtGetParent(GenTreePtr** parentChildPtrPtr);
 
+    void ReplaceOperand(GenTree** useEdge, GenTree* replacement);
+
     inline GenTreePtr gtEffectiveVal(bool commaOnly = false);
 
     // Return the child of this node if it is a GT_RELOAD or GT_COPY; otherwise simply return the node itself
@@ -3360,6 +3362,8 @@ struct GenTreeCall final : public GenTree
     }
 
     bool IsHelperCall(Compiler* compiler, unsigned helper) const;
+
+    void ReplaceCallOperand(GenTree** operandUseEdge, GenTree* replacement);
 
     GenTreeCall(var_types type) : GenTree(GT_CALL, type)
     {

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -190,12 +190,9 @@ void LIR::Use::ReplaceWith(Compiler* compiler, GenTree* replacement)
     assert(IsDummyUse() || m_range->Contains(m_user));
     assert(m_range->Contains(replacement));
 
-    GenTree* replacedNode = *m_edge;
-
-    *m_edge = replacement;
-    if (!IsDummyUse() && m_user->IsCall())
+    if (!IsDummyUse())
     {
-        compiler->fgFixupArgTabEntryPtr(m_user, replacedNode, replacement);
+        m_user->ReplaceOperand(m_edge, replacement);
     }
 }
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3314,9 +3314,9 @@ GenTree* Lowering::TryCreateAddrMode(LIR::Use&& use, bool isIndir)
         {
             // We can have an indirection on the rhs of a block copy (it is the source
             // object). This is not a "regular" indirection.
-            // (Note that the parent check could be costly.)
-            GenTree* parent = indir->gtGetParent(nullptr);
-            if ((parent != nullptr) && parent->OperIsIndir())
+            // (Note that the user check could be costly.)
+            LIR::Use indirUse;
+            if (BlockRange().TryGetUse(indir, &indirUse) && indirUse.User()->OperIsIndir())
             {
                 isIndir = false;
             }


### PR DESCRIPTION
When a call argument is replaced by a new node, the corresponding entry
in the call's argument table must be replaced. Managing this replacement
was a bit ad-hoc: there were a (small) number of places throughout the
compiler that needed to do so, and each determined whether or not to
call the udpate method (`fgFixupArgTabEntryPtr`) independently. The
update method has been removed and its functionality replaced with a
new method, `GenTree::ReplaceOperand`, which will update the call
argument table iff the replaced node is a call argument.

Fixes #7144.