### PR TITLE
Enable archive for coreclr perf Linux runs, and fix a few bugs.

### DIFF
--- a/tests/scripts/perf-prep.sh
+++ b/tests/scripts/perf-prep.sh
@@ -44,6 +44,18 @@ echo "branch = $perfBranch"
 echo "architecture = $perfArch"
 echo "configuration = $perfConfig"
 
+# Install nuget to download benchview package, which includes the script machinedata.py for machine data collection
+wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+chmod u+x ./nuget.exe
+./nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory ./tests/scripts -Prerelease
+
+# Install python 3.5.2 to run machinedata.py for machine data collection
+sudo add-apt-repository ppa:fkrull/deadsnakes
+sudo apt-get update
+sudo apt-get --assume-yes install python3.5
+python3.5 --version
+python3.5 ./tests/scripts/Microsoft.BenchView.JSONFormat.0.1.0-pre010/tools/machinedata.py
+
 # Set up the copies
 # Coreclr build containing the tests and mscorlib
 curl http://dotnet-ci.cloudapp.net/job/$perfBranch/job/master/job/release_windows_nt/lastSuccessfulBuild/artifact/bin/tests/tests.zip -o tests.zip

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -386,18 +386,9 @@ echo "CORE_ROOT dir = $CORE_ROOT"
 
 DO_SETUP=TRUE
 
-dir $testNativeBinDir/../../../../..
-echo 'dir $testNativeBinDir/../../../../..'
-dir $testNativeBinDir/../../../../../packages
-echo 'dir $testNativeBinDir/../../../../../packages'
-dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli
-echo 'dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli'
-dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035
-echo 'dir $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035'
-
 if [ ${DO_SETUP} == "TRUE" ]; then
-cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0035/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.runner.cli.dll .
-cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.run.core/1.0.0-alpha-build0035/lib/dotnet/*.dll .
+cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0040/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.runner.cli.dll .
+cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.run.core/1.0.0-alpha-build0040/lib/dotnet/*.dll .
 fi
 
 # Run coreclr performance tests
@@ -414,5 +405,7 @@ cp $testcase .
 
 chmod u+x ./corerun
 ./corerun Microsoft.DotNet.xunit.performance.runner.cli.dll $test -runner xunit.console.netcore.exe -runnerhost ./corerun -verbose -runid perf-$testname
-
 done
+
+mkdir ../../../../../sandbox
+cp *.xml ../../../../../sandbox


### PR DESCRIPTION
1. Latest Linux runs passes at http://dotnet-ci2.cloudapp.net/job/smile21prc_coreclr/job/coreclr-perf/job/perf_Ubuntu/7/consoleFull.
2. Perf logs are automatically stored at: http://dotnet-ci2.cloudapp.net/job/smile21prc_coreclr/job/coreclr-perf/job/perf_Ubuntu/7/artifact/