### PR TITLE
Fix to issue #7167.

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -504,6 +504,8 @@ private:
     {
         return (LsraStressLimitRegs)(lsraStressMask & LSRA_LIMIT_MASK);
     }
+
+    regMaskTP getConstrainedRegMask(regMaskTP regMaskActual, regMaskTP regMaskConstrain, unsigned minRegCount);
     regMaskTP stressLimitRegs(RefPosition* refPosition, regMaskTP mask);
 
     // This controls the heuristics used to select registers


### PR DESCRIPTION
JitStressRegs= 1 or 8 would constrain the candidates to callee saved set { ebx, esi, edi }.
On x86, a byte type binary oper could constrain src  candidates of its operands to bytable registers i.e. {eax, ebx, ecx, edx}.  That is under JitStressRegs=1 or 8, candidate set will be constrained to a single register {ebx} which is not sufficient to reg allocate a byte  type binary oper.

Fix: 
Ensure that under these stress modes there are minimum 2 regs after the intersection.

I have added a new method getConstrainedRegMask() to avoid code duplication, since similar logic is needed at 3 places.

I also took this opportunity to examine whether JitStressRegs=3 (Limit to small Int Set) has similar issue.  SmallIntSet on x86 is defined as { eax, ecx, edi}. That is, there are min 2 byteable registers in the set and hence similar issue should not arise under JitStressRegs=3.

Fix #7167 