### PR TITLE
Update new String.Split methods to use optional params

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -7123,14 +7123,12 @@
       <Member Name="Remove(System.Int32,System.Int32)" />
       <Member Name="Replace(System.Char,System.Char)" />
       <Member Name="Replace(System.String,System.String)" />
-      <Member Name="Split(System.Char)" />
       <Member Name="Split(System.Char,System.Int32,System.StringSplitOptions)" />
       <Member Name="Split(System.Char,System.StringSplitOptions)"/>
       <Member Name="Split(System.Char[])" />
       <Member Name="Split(System.Char[],System.Int32)" />
       <Member Name="Split(System.Char[],System.Int32,System.StringSplitOptions)" />
       <Member Name="Split(System.Char[],System.StringSplitOptions)"/>
-      <Member Name="Split(System.String)" />
       <Member Name="Split(System.String,System.Int32,System.StringSplitOptions)" />
       <Member Name="Split(System.String,System.StringSplitOptions)"/>
       <Member Name="Split(System.String[],System.Int32,System.StringSplitOptions)" />

--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -944,19 +944,13 @@ namespace System
         }
 
         [ComVisible(false)]
-        public String[] Split(char separator) {
-            Contract.Ensures(Contract.Result<String[]>() != null);
-            return SplitInternal(separator, Int32.MaxValue, StringSplitOptions.None);
-        }
-
-        [ComVisible(false)]
-        public String[] Split(char separator, StringSplitOptions options) {
+        public String[] Split(char separator, StringSplitOptions options = StringSplitOptions.None) {
             Contract.Ensures(Contract.Result<String[]>() != null);
             return SplitInternal(separator, Int32.MaxValue, options);
         }
 
         [ComVisible(false)]
-        public String[] Split(char separator, int count, StringSplitOptions options) {
+        public String[] Split(char separator, int count, StringSplitOptions options = StringSplitOptions.None) {
             Contract.Ensures(Contract.Result<String[]>() != null);
             return SplitInternal(separator, count, options);
         }
@@ -1075,19 +1069,13 @@ namespace System
         }
 
         [ComVisible(false)]
-        public String[] Split(String separator) {
-            Contract.Ensures(Contract.Result<String[]>() != null);
-            return SplitInternal(separator ?? String.Empty, null, Int32.MaxValue, StringSplitOptions.None);
-        }
-
-        [ComVisible(false)]
-        public String[] Split(String separator, StringSplitOptions options) {
+        public String[] Split(String separator, StringSplitOptions options = StringSplitOptions.None) {
             Contract.Ensures(Contract.Result<String[]>() != null);
             return SplitInternal(separator ?? String.Empty, null, Int32.MaxValue, options);
         }
 
         [ComVisible(false)]
-        public String[] Split(String separator, Int32 count, StringSplitOptions options) {
+        public String[] Split(String separator, Int32 count, StringSplitOptions options = StringSplitOptions.None) {
             Contract.Ensures(Contract.Result<String[]>() != null);
             return SplitInternal(separator ?? String.Empty, null, count, options);
         }


### PR DESCRIPTION
The new `Split(string)` overload broke source compat with uses of `Split(null)`, which is documented to split based on white space, because it makes the call ambiguous between `Split(char[])` and `Split(string)`.

To maintain source compatibilty, `Split(string)` has been removed, leaving just the overloads with `StringSplitOptions` parameters, which are now optional. Making `StringSplitOptions` optional allows calls to `Split(string)` (which binds to `Split(string, StringSplitOptions.None)`) while maintaining source compat with calls to `Split(null)` which still binds to `Split(char[])` in C#, VB, and F#.

The new `Split(char)` overloads get the same changes for consistency with `Split(string)`.

https://github.com/dotnet/corefx/issues/1513 (these modifications are api-approved)

cc: @weshaggard, @jkotas, @terrajobst