### PR TITLE
Extend the coreclr Windows perf run result lifetime

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -49,6 +49,17 @@ def static getOSGroup(def os) {
         Utilities.addArchival(newJob, archiveSettings)
 
         Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+
+        // For perf, we need to keep the run results longer
+        newJob.with {
+            // Enable the log rotator
+            logRotator {
+                artifactDaysToKeep(7)
+                daysToKeep(300)
+                artifactNumToKeep(25)
+                numToKeep(1000)
+            }
+        }
         if (isPR) {
             TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
             builder.setGithubContext("${os} Perf Tests")


### PR DESCRIPTION
JitCI uploader requires coreclr Windows perf run results to be kept longer than 14 days. So I'm extending it to 300 days, and also extending the max number of perf run results to 1000.

Keep the artifact lifetime and number unchanged, as they are no longer needed once being uploaded to http://benchview. It'll be too expensive to keep them too long.