### PR TITLE
Fix Unix issue with string address below 64kB

### DIFF
--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -2121,9 +2121,11 @@ STRINGREF __stdcall StringObject::StringInitCharHelper(LPCSTR pszSource, int len
     if (!pszSource || length == 0) {
         return StringObject::GetEmptyString();
     }
+#ifndef FEATURE_PAL
     else if ((size_t)pszSource < 64000) {
         COMPlusThrow(kArgumentException, W("Arg_MustBeStringPtrNotAtom"));
     }    
+#endif // FEATURE_PAL
 
     // Make sure we can read from the pointer.
     // This is better than try to read from the pointer and catch the access violation exceptions.


### PR DESCRIPTION
This change fixes a problem that has started to occur in the ARM32 Linux CI
tests. A string located below 64KB in the address space is passed to the
StringObject::StringInitCharHelper and the code throws an exception since
on Windows, values below 64kB represent atoms and not strings.
This check should not be done for FEATURE_PAL though.