### PR TITLE
Remove NYI for x86 long rotate

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -14238,10 +14238,10 @@ GenTreePtr Compiler::fgRecognizeAndMorphBitwiseRotation(GenTreePtr tree)
 #ifndef _TARGET_64BIT_
                             if (!shiftIndexWithoutAdd->IsCnsIntOrI() && (rotatedValueBitSize == 64))
                             {
-                                // TODO: we need to handle variable-sized long shifts specially on x86.
+                                // TODO-X86-CQ: we need to handle variable-sized long shifts specially on x86.
                                 // GT_LSH, GT_RSH, and GT_RSZ have helpers for this case. We may need
                                 // to add helpers for GT_ROL and GT_ROR.
-                                NYI("Rotation of a long value by variable amount");
+                                return tree;
                             }
 #endif
 


### PR DESCRIPTION
For x86 rotate a long by a variable amount, we will just default to what
legacy backend does, which ultimately will generate two helper calls. In
the future, we may want to write a helper function for rotate for these
cases to eliminate one of the helper calls.