### PR TITLE
Allow GT_OBJ for Arm64

### DIFF
--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -523,12 +523,12 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         break;
 
         case GT_BLK:
-        case GT_OBJ:
         case GT_DYN_BLK:
             // These should all be eliminated prior to Lowering.
             assert(!"Non-store block node in Lowering");
             info->srcCount = 0;
             info->dstCount = 0;
+            break;
 
         case GT_STORE_BLK:
         case GT_STORE_OBJ:


### PR DESCRIPTION
GT_OBJ is used on Arm64 for struct passing, but was inadvertently flagged
as an illegal node in Lowering.
Fix #7160