### PR TITLE
Implement long compare lowering for x86.

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -5147,7 +5147,7 @@ void CodeGen::genConsumeRegs(GenTree* tree)
         }
         else if (tree->OperGet() == GT_AND)
         {
-            // This is the special contained GT_AND that we created in Lowering::LowerCmp()
+            // This is the special contained GT_AND that we created in Lowering::TreeNodeInfoInitCmp()
             // Now we need to consume the operands of the GT_AND node.
             genConsumeOperands(tree->AsOp());
         }

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -53,7 +53,6 @@ void genCompareInt(GenTreePtr treeNode);
 
 #if !defined(_TARGET_64BIT_)
 void genCompareLong(GenTreePtr treeNode);
-void genJTrueLong(GenTreePtr treeNode);
 #endif
 
 #ifdef FEATURE_SIMD

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2460,23 +2460,11 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             // X86 Long comparison
             else if (varTypeIsLong(op1Type))
             {
-                // When not materializing the result in a register, the compare logic is generated
-                // when we generate the GT_JTRUE.
-                if (treeNode->gtRegNum != REG_NA)
-                {
-                    genCompareLong(treeNode);
-                }
-                else
-                {
-                    if ((treeNode->gtNext != nullptr) && (treeNode->gtNext->OperGet() != GT_JTRUE))
-                    {
-                        NYI("Long compare/reload/jtrue sequence");
-                    }
-
-                    // We generate the compare when we generate the GT_JTRUE, but we need to consume
-                    // the operands now.
-                    genConsumeOperands(treeNode->AsOp());
-                }
+#ifdef DEBUG
+                LIR::Use use;
+                assert((treeNode->gtRegNum != REG_NA) || !LIR::AsRange(compiler->compCurBB).TryGetUse(treeNode, &use));
+#endif
+                genCompareLong(treeNode);
             }
 #endif // !defined(_TARGET_64BIT_)
             else
@@ -2497,7 +2485,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             // For long compares, we emit special logic
             if (varTypeIsLong(cmp->gtGetOp1()))
             {
-                genJTrueLong(cmp);
+                unreached();
             }
             else
 #endif
@@ -7034,8 +7022,6 @@ void CodeGen::genCompareLong(GenTreePtr treeNode)
 
     genConsumeOperands(tree);
 
-    assert(targetReg != REG_NA);
-
     GenTreePtr loOp1 = op1->gtGetOp1();
     GenTreePtr hiOp1 = op1->gtGetOp2();
     GenTreePtr loOp2 = op2->gtGetOp1();
@@ -7048,6 +7034,12 @@ void CodeGen::genCompareLong(GenTreePtr treeNode)
 
     // Emit the compare instruction
     getEmitter()->emitInsBinary(ins, cmpAttr, hiOp1, hiOp2);
+
+    // If the result is not being materialized in a register, we're done.
+    if (targetReg == REG_NA)
+    {
+        return;
+    }
 
     // Generate the first jump for the high compare
     CompareKind compareKind = ((tree->gtFlags & GTF_UNSIGNED) != 0) ? CK_UNSIGNED : CK_SIGNED;
@@ -7118,152 +7110,6 @@ void CodeGen::genCompareLong(GenTreePtr treeNode)
         inst_RV_RV(ins_Move_Extend(TYP_UBYTE, true), targetReg, targetReg, TYP_UBYTE, emitTypeSize(TYP_UBYTE));
         genProduceReg(tree);
     }
-}
-
-//------------------------------------------------------------------------
-// genJTrueLong: Generate code for comparing two longs on x86 for the case where the result
-// is not manifested in a register.
-//
-// Arguments:
-//    treeNode - the compare tree
-//
-// Return Value:
-//    None.
-// Comments:
-// For long compares, we need to compare the high parts of operands first, then the low parts.
-// We only have to do the low compare if the high parts of the operands are equal.
-//
-// In the case where the result of a rel-op is not realized in a register, we generate:
-//
-//    Opcode            x86 equivalent          Comment
-//    ------            --------------          -------
-//
-//    GT_LT; unsigned   cmp hiOp1,hiOp2
-//                      jb  trueLabel
-//                      ja  falseLabel
-//                      cmp loOp1,loOp2
-//                      jb  trueLabel
-//                      falseLabel:
-//
-//    GT_LE; unsigned   cmp hiOp1,hiOp2
-//                      jb  trueLabel
-//                      ja  falseLabel
-//                      cmp loOp1,loOp2
-//                      jbe trueLabel
-//                      falseLabel:
-//
-//    GT_GT; unsigned   cmp hiOp1,hiOp2
-//                      ja  trueLabel
-//                      jb  falseLabel
-//                      cmp loOp1,loOp2
-//                      ja  trueLabel
-//                      falseLabel:
-//
-//    GT_GE; unsigned   cmp hiOp1,hiOp2
-//                      ja  trueLabel
-//                      jb  falseLabel
-//                      cmp loOp1,loOp2
-//                      jae trueLabel
-//                      falseLabel:
-//
-//    GT_LT; signed     cmp hiOp1,hiOp2
-//                      jl  trueLabel
-//                      jg  falseLabel
-//                      cmp loOp1,loOp2
-//                      jb  trueLabel
-//                      falseLabel:
-//
-//    GT_LE; signed     cmp hiOp1,hiOp2
-//                      jl  trueLabel
-//                      jg  falseLabel
-//                      cmp loOp1,loOp2
-//                      jbe trueLabel
-//                      falseLabel:
-//
-//    GT_GT; signed     cmp hiOp1,hiOp2
-//                      jg  trueLabel
-//                      jl  falseLabel
-//                      cmp loOp1,loOp2
-//                      ja  trueLabel
-//                      falseLabel:
-//
-//    GT_GE; signed     cmp hiOp1,hiOp2
-//                      jg  trueLabel
-//                      jl  falseLabel
-//                      cmp loOp1,loOp2
-//                      jae trueLabel
-//                      falseLabel:
-//
-//    GT_EQ;            cmp hiOp1,hiOp2
-//                      jne falseLabel
-//                      cmp loOp1,loOp2
-//                      je  trueLabel
-//                      falseLabel:
-//
-//    GT_NE;            cmp hiOp1,hiOp2
-//                      jne labelTrue
-//                      cmp loOp1,loOp2
-//                      jne trueLabel
-//                      falseLabel:
-//
-// TODO-X86-CQ: Check if hi or lo parts of op2 are 0 and change the compare to a test.
-void CodeGen::genJTrueLong(GenTreePtr treeNode)
-{
-    assert(treeNode->OperIsCompare());
-
-    GenTreeOp* tree = treeNode->AsOp();
-    GenTreePtr op1  = tree->gtOp1;
-    GenTreePtr op2  = tree->gtOp2;
-
-    assert(varTypeIsLong(op1->TypeGet()));
-    assert(varTypeIsLong(op2->TypeGet()));
-
-    regNumber targetReg = treeNode->gtRegNum;
-
-    assert(targetReg == REG_NA);
-
-    GenTreePtr loOp1 = op1->gtGetOp1();
-    GenTreePtr hiOp1 = op1->gtGetOp2();
-    GenTreePtr loOp2 = op2->gtGetOp1();
-    GenTreePtr hiOp2 = op2->gtGetOp2();
-
-    // Emit the compare instruction
-    getEmitter()->emitInsBinary(INS_cmp, EA_4BYTE, hiOp1, hiOp2);
-
-    // Generate the first jump for the high compare
-    CompareKind compareKind = ((tree->gtFlags & GTF_UNSIGNED) != 0) ? CK_UNSIGNED : CK_SIGNED;
-
-    // TODO-X86-CQ: If the next block is a BBJ_ALWAYS, we can set falseLabel = compiler->compCurBB->bbNext->bbJumpDest.
-    BasicBlock* falseLabel = genCreateTempLabel();
-
-    emitJumpKind jumpKindHi[2];
-
-    // Generate the jumps for the high compare
-    genJumpKindsForTreeLongHi(tree, jumpKindHi);
-
-    BasicBlock* trueLabel = compiler->compCurBB->bbJumpDest;
-
-    if (jumpKindHi[0] != EJ_NONE)
-    {
-        inst_JMP(jumpKindHi[0], trueLabel);
-    }
-
-    if (jumpKindHi[1] != EJ_NONE)
-    {
-        inst_JMP(jumpKindHi[1], falseLabel);
-    }
-
-    // The low jump must be unsigned
-    emitJumpKind jumpKindLo = genJumpKindForOper(tree->gtOper, CK_UNSIGNED);
-
-    // Emit the comparison and the jump to the trueLabel
-    getEmitter()->emitInsBinary(INS_cmp, EA_4BYTE, loOp1, loOp2);
-
-    inst_JMP(jumpKindLo, trueLabel);
-
-    // Generate falseLabel, which is the false path. We will jump here if the high compare is false
-    // or fall through if the low compare is false.
-    genDefineTempLabel(falseLabel);
 }
 #endif //! defined(_TARGET_64BIT_)
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2531,6 +2531,19 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         }
         break;
 
+        case GT_JCC:
+        {
+            GenTreeJumpCC* jcc = treeNode->AsJumpCC();
+
+            assert(compiler->compCurBB->bbJumpKind == BBJ_COND);
+
+            CompareKind compareKind = ((jcc->gtFlags & GTF_UNSIGNED) != 0) ? CK_UNSIGNED : CK_SIGNED;
+            emitJumpKind jumpKind   = genJumpKindForOper(jcc->gtCondition, compareKind);
+
+            inst_JMP(jumpKind, compiler->compCurBB->bbJumpDest);
+        }
+        break;
+
         case GT_RETURNTRAP:
         {
             // this is nothing but a conditional call to CORINFO_HELP_STOP_FOR_GC

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2489,51 +2489,46 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             assert(compiler->compCurBB->bbJumpKind == BBJ_COND);
 
 #if !defined(_TARGET_64BIT_)
-            // For long compares, we emit special logic
-            if (varTypeIsLong(cmp->gtGetOp1()))
-            {
-                unreached();
-            }
-            else
+            // Long-typed compares should have been handled by Lowering::LowerCompare.
+            assert(!varTypeIsLong(cmp->gtGetOp1()));
 #endif
+
+            // Get the "kind" and type of the comparison.  Note that whether it is an unsigned cmp
+            // is governed by a flag NOT by the inherent type of the node
+            // TODO-XArch-CQ: Check if we can use the currently set flags.
+            emitJumpKind jumpKind[2];
+            bool         branchToTrueLabel[2];
+            genJumpKindsForTree(cmp, jumpKind, branchToTrueLabel);
+
+            BasicBlock* skipLabel = nullptr;
+            if (jumpKind[0] != EJ_NONE)
             {
-                // Get the "kind" and type of the comparison.  Note that whether it is an unsigned cmp
-                // is governed by a flag NOT by the inherent type of the node
-                // TODO-XArch-CQ: Check if we can use the currently set flags.
-                emitJumpKind jumpKind[2];
-                bool         branchToTrueLabel[2];
-                genJumpKindsForTree(cmp, jumpKind, branchToTrueLabel);
-
-                BasicBlock* skipLabel = nullptr;
-                if (jumpKind[0] != EJ_NONE)
+                BasicBlock* jmpTarget;
+                if (branchToTrueLabel[0])
                 {
-                    BasicBlock* jmpTarget;
-                    if (branchToTrueLabel[0])
-                    {
-                        jmpTarget = compiler->compCurBB->bbJumpDest;
-                    }
-                    else
-                    {
-                        // This case arises only for ordered GT_EQ right now
-                        assert((cmp->gtOper == GT_EQ) && ((cmp->gtFlags & GTF_RELOP_NAN_UN) == 0));
-                        skipLabel = genCreateTempLabel();
-                        jmpTarget = skipLabel;
-                    }
-
-                    inst_JMP(jumpKind[0], jmpTarget);
+                    jmpTarget = compiler->compCurBB->bbJumpDest;
+                }
+                else
+                {
+                    // This case arises only for ordered GT_EQ right now
+                    assert((cmp->gtOper == GT_EQ) && ((cmp->gtFlags & GTF_RELOP_NAN_UN) == 0));
+                    skipLabel = genCreateTempLabel();
+                    jmpTarget = skipLabel;
                 }
 
-                if (jumpKind[1] != EJ_NONE)
-                {
-                    // the second conditional branch always has to be to the true label
-                    assert(branchToTrueLabel[1]);
-                    inst_JMP(jumpKind[1], compiler->compCurBB->bbJumpDest);
-                }
+                inst_JMP(jumpKind[0], jmpTarget);
+            }
 
-                if (skipLabel != nullptr)
-                {
-                    genDefineTempLabel(skipLabel);
-                }
+            if (jumpKind[1] != EJ_NONE)
+            {
+                // the second conditional branch always has to be to the true label
+                assert(branchToTrueLabel[1]);
+                inst_JMP(jumpKind[1], compiler->compCurBB->bbJumpDest);
+            }
+
+            if (skipLabel != nullptr)
+            {
+                genDefineTempLabel(skipLabel);
             }
         }
         break;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4072,7 +4072,7 @@ public:
 
     void fgUnreachableBlock(BasicBlock* block);
 
-    void fgRemoveJTrue(BasicBlock* block);
+    void fgRemoveConditionalJump(BasicBlock* block);
 
     BasicBlock* fgLastBBInMainFunction();
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -19945,7 +19945,7 @@ void                Compiler::fgDebugCheckBBlist(bool checkBBNum  /* = false */,
 
         // If the block is a BBJ_COND, a BBJ_SWITCH or a
         // lowered GT_SWITCH_TABLE node then make sure it
-        // ends with a jump or a GT_SWITCH
+        // ends with a conditional jump or a GT_SWITCH
 
         if (block->bbJumpKind == BBJ_COND)
         {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9339,6 +9339,7 @@ inline bool OperIsControlFlow(genTreeOps oper)
     switch (oper)
     {
         case GT_JTRUE:
+        case GT_JCC:
         case GT_SWITCH:
         case GT_LABEL:
 
@@ -10019,10 +10020,10 @@ void Compiler::fgUnreachableBlock(BasicBlock* block)
 
 /*****************************************************************************************************
  *
- *  Function called to remove or morph a GT_JTRUE statement when we jump to the same
+ *  Function called to remove or morph a jump when we jump to the same
  *  block when both the condition is true or false.
  */
-void Compiler::fgRemoveJTrue(BasicBlock* block)
+void Compiler::fgRemoveConditionalJump(BasicBlock* block)
 {
     noway_assert(block->bbJumpKind == BBJ_COND && block->bbJumpDest == block->bbNext);
     assert(compRationalIRForm == block->IsLIR());
@@ -10053,7 +10054,7 @@ void Compiler::fgRemoveJTrue(BasicBlock* block)
         LIR::Range& blockRange = LIR::AsRange(block);
 
         GenTree* test = blockRange.LastNode();
-        assert(test->OperGet() == GT_JTRUE);
+        assert(test->OperIsConditionalJump());
 
         bool               isClosed;
         unsigned           sideEffects;
@@ -10109,7 +10110,7 @@ void Compiler::fgRemoveJTrue(BasicBlock* block)
         {
             test->gtStmtExpr = sideEffList;
 
-            fgMorphBlockStmt(block, test DEBUGARG("fgRemoveJTrue"));
+            fgMorphBlockStmt(block, test DEBUGARG("fgRemoveConditionalJump"));
         }
     }
 }
@@ -10545,7 +10546,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
                         // Make sure we are replacing "block" with "succBlock" in predBlock->bbJumpDest.
                         noway_assert(predBlock->bbJumpDest == block);
                         predBlock->bbJumpDest = succBlock;
-                        fgRemoveJTrue(predBlock);
+                        fgRemoveConditionalJump(predBlock);
                         break;
                     }
 
@@ -10605,7 +10606,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
                 /* Check for branch to next block */
                 if (bPrev->bbJumpDest == bPrev->bbNext)
                 {
-                    fgRemoveJTrue(bPrev);
+                    fgRemoveConditionalJump(bPrev);
                 }
                 break;
 
@@ -13793,7 +13794,7 @@ bool Compiler::fgOptimizeBranchToNext(BasicBlock* block, BasicBlock* bNext, Basi
         {
             LIR::Range& blockRange = LIR::AsRange(block);
             GenTree*    jmp        = blockRange.LastNode();
-            assert(jmp->OperGet() == GT_JTRUE);
+            assert(jmp->OperIsConditionalJump());
 
             bool               isClosed;
             unsigned           sideEffects;
@@ -15879,11 +15880,18 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication)
                         /* Reverse the jump condition */
 
                         GenTree* test = block->lastNode();
-                        noway_assert(test->gtOper == GT_JTRUE);
+                        noway_assert(test->OperIsConditionalJump());
 
-                        GenTree* cond = gtReverseCond(test->gtOp.gtOp1);
-                        assert(cond == test->gtOp.gtOp1); // Ensure `gtReverseCond` did not create a new node.
-                        test->gtOp.gtOp1 = cond;
+                        if (test->OperGet() == GT_JTRUE)
+                        {
+                            GenTree* cond = gtReverseCond(test->gtOp.gtOp1);
+                            assert(cond == test->gtOp.gtOp1); // Ensure `gtReverseCond` did not create a new node.
+                            test->gtOp.gtOp1 = cond;
+                        }
+                        else
+                        {
+                            gtReverseCond(test);
+                        }
 
                         // Optimize the Conditional JUMP to go to the new target
                         block->bbJumpDest = bNext->bbJumpDest;
@@ -19937,11 +19945,11 @@ void                Compiler::fgDebugCheckBBlist(bool checkBBNum  /* = false */,
 
         // If the block is a BBJ_COND, a BBJ_SWITCH or a
         // lowered GT_SWITCH_TABLE node then make sure it
-        // ends with a GT_JTRUE or a GT_SWITCH
+        // ends with a jump or a GT_SWITCH
 
         if (block->bbJumpKind == BBJ_COND)
         {
-            noway_assert(block->lastNode()->gtNext == nullptr && block->lastNode()->gtOper == GT_JTRUE);
+            noway_assert(block->lastNode()->gtNext == nullptr && block->lastNode()->OperIsConditionalJump());
         }
         else if (block->bbJumpKind == BBJ_SWITCH)
         {

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -3171,6 +3171,11 @@ GenTreePtr Compiler::gtReverseCond(GenTree* tree)
             tree->gtFlags ^= GTF_RELOP_NAN_UN;
         }
     }
+    else if (tree->OperGet() == GT_JCC)
+    {
+        GenTreeJumpCC* jcc = tree->AsJumpCC();
+        jcc->gtCondition = GenTree::ReverseRelop(jcc->gtCondition);
+    }
     else
     {
         tree = gtNewOperNode(GT_NOT, TYP_INT, tree);
@@ -10763,6 +10768,10 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
             }
             break;
 
+        case GT_JCC:
+            printf(" cond=%s", GenTree::NodeName(tree->AsJumpCC()->gtCondition));
+            break;
+
         default:
             assert(!"don't know how to display tree leaf node");
     }
@@ -15381,6 +15390,7 @@ bool GenTree::isContained() const
     {
         case GT_STOREIND:
         case GT_JTRUE:
+        case GT_JCC:
         case GT_RETURN:
         case GT_RETFILT:
         case GT_STORE_LCL_FLD:

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1428,7 +1428,7 @@ public:
         return (gtOper == GT_LIST) && ((gtFlags & GTF_LIST_AGGREGATE) != 0);
     }
 
-    bool OperIsConditionalJump()
+    bool OperIsConditionalJump() const
     {
         return (gtOper == GT_JTRUE) || (gtOper == GT_JCC);
     }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1428,6 +1428,11 @@ public:
         return (gtOper == GT_LIST) && ((gtFlags & GTF_LIST_AGGREGATE) != 0);
     }
 
+    bool OperIsConditionalJump()
+    {
+        return (gtOper == GT_JTRUE) || (gtOper == GT_JCC);
+    }
+
     // Requires that "op" is an op= operator.  Returns
     // the corresponding "op".
     static genTreeOps OpAsgToOper(genTreeOps op);
@@ -4638,6 +4643,26 @@ struct GenTreeAllocObj final : public GenTreeUnOp
     {
     }
 #endif
+};
+
+
+struct GenTreeJumpCC final : public GenTree
+{
+    genTreeOps gtCondition; // any relop
+
+    GenTreeJumpCC(genTreeOps condition)
+        : GenTree(GT_JCC, TYP_VOID DEBUGARG(/*largeNode*/ FALSE))
+        , gtCondition(condition)
+    {
+        assert(OperIsCompare(condition));
+    }
+
+#if DEBUGGABLE_GENTREE
+    GenTreeJumpCC()
+        : GenTree()
+    {
+    }
+#endif // DEBUGGABLE_GENTREE
 };
 
 //------------------------------------------------------------------------

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -190,6 +190,7 @@ GTNODE(SIMD       , "simd"       ,0,GTK_BINOP|GTK_EXOP)   // SIMD functions/oper
 //-----------------------------------------------------------------------------
 
 GTNODE(JTRUE      , "jmpTrue"    ,0,GTK_UNOP|GTK_NOVALUE)
+GTNODE(JCC        , "jcc"        ,0,GTK_LEAF|GTK_NOVALUE)
 
 GTNODE(LIST       , "<list>"     ,0,GTK_BINOP)
 

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -189,6 +189,9 @@ GTNODE(SIMD       , "simd"       ,0,GTK_BINOP|GTK_EXOP)   // SIMD functions/oper
 //  Other nodes that look like unary/binary operators:
 //-----------------------------------------------------------------------------
 
+// The following are both conditional branches. GT_JTRUE has a single operand that computes a condition. GT_JCC
+// implicitly reads the condition bits from a previous operation. The latter is allowed only in the LIR form
+// used in the RyuJIT backend.
 GTNODE(JTRUE      , "jmpTrue"    ,0,GTK_UNOP|GTK_NOVALUE)
 GTNODE(JCC        , "jcc"        ,0,GTK_LEAF|GTK_NOVALUE)
 

--- a/src/jit/gtstructs.h
+++ b/src/jit/gtstructs.h
@@ -100,6 +100,7 @@ GTSTRUCT_1(PhysReg     , GT_PHYSREG)
 GTSTRUCT_1(SIMD        , GT_SIMD) 
 #endif // FEATURE_SIMD
 GTSTRUCT_1(AllocObj    , GT_ALLOCOBJ)
+GTSTRUCT_1(JumpCC      , GT_JCC)
 /*****************************************************************************/
 #undef  GTSTRUCT_0
 #undef  GTSTRUCT_1

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1617,7 +1617,7 @@ void LIR::InsertBeforeTerminator(BasicBlock* block, LIR::Range&& range)
         switch (block->bbJumpKind)
         {
         case BBJ_COND:
-            assert(insertionPoint->OperGet() == GT_JTRUE);
+            assert(insertionPoint->OperIsConditionalJump());
             break;
 
         case BBJ_SWITCH:

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1872,6 +1872,72 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     return result;
 }
 
+//------------------------------------------------------------------------
+// Lowering::LowerCompare: lowers a compare node.
+//
+// For 64-bit targets, this doesn't do much of anything: all comparisons
+// that we support can be handled in code generation on such targets.
+//
+// For 32-bit targets, however, any comparison that feeds a `GT_JTRUE`
+// node must be lowered such that the liveness of the operands to the
+// comparison is properly visible to the rest of the backend. As such,
+// a 64-bit comparison is lowered from something like this:
+//
+//    ------------ BB02 [004..014) -> BB02 (cond), preds={BB02,BB01} succs={BB03,BB02}
+//    N001 (  1,  1) [000006] ------------        t6 =    lclVar    int    V02 loc0         u:5 $148
+//
+//                                                     /--*  t6     int
+//    N002 (  2,  3) [000007] ---------U--        t7 = *  cast      long <- ulong <- uint $3c0
+//
+//    N003 (  3, 10) [000009] ------------        t9 =    lconst    long   0x0000000000000003 $101
+//
+//                                                     /--*  t7     long
+//                                                     +--*  t9     long
+//    N004 (  9, 17) [000010] N------N-U--       t10 = *  <         int    $149
+//
+//                                                     /--*  t10    int
+//    N005 ( 11, 19) [000011] ------------             *  jmpTrue   void
+//
+// To something like this:
+//
+//    ------------ BB02 [004..014) -> BB03 (cond), preds={BB06,BB07,BB01} succs={BB06,BB03}
+//                   [000099] ------------       t99 =    const     int    0
+//
+//                   [000101] ------------      t101 =    const     int    0
+//
+//                                                     /--*  t99    int
+//                                                     +--*  t101   int
+//    N004 (  9, 17) [000010] N------N-U--       t10 = *  >         int    $149
+//
+//                                                     /--*  t10    int
+//    N005 ( 11, 19) [000011] ------------             *  jmpTrue   void
+//
+//
+//    ------------ BB06 [???..???) -> BB02 (cond), preds={BB02} succs={BB07,BB02}
+//                   [000105] -------N-U--                jcc       void   cond=<
+//
+//
+//    ------------ BB07 [???..???) -> BB02 (cond), preds={BB06} succs={BB03,BB02}
+//    N001 (  1,  1) [000006] ------------        t6 =    lclVar    int    V02 loc0         u:5 $148
+//
+//    N003 (  3, 10) [000009] ------------        t9 =    const     int    3
+//
+//                                                     /--*  t6     int
+//                                                     +--*  t9     int
+//                   [000106] N------N-U--      t106 = *  <         int
+//
+//                                                     /--*  t106   int
+//                   [000107] ------------             *  jmpTrue   void
+//
+// Which will eventually generate code similar to the following:
+//
+//    33DB         xor      ebx, ebx
+//    85DB         test     ebx, ebx
+//    7707         ja       SHORT G_M50523_IG04
+//    72E7         jb       SHORT G_M50523_IG03
+//    83F803       cmp      eax, 3
+//    72E2         jb       SHORT G_M50523_IG03
+//
 void Lowering::LowerCompare(GenTree* cmp)
 {
 #ifndef _TARGET_64BIT_
@@ -1914,6 +1980,28 @@ void Lowering::LowerCompare(GenTree* cmp)
 
     if (cmp->OperGet() == GT_EQ || cmp->OperGet() == GT_NE)
     {
+        // 64-bit equality comparisons (no matter the polarity) require two 32-bit comparisons: one for the upper 32
+        // bits and one for the lower 32 bits. As such, we update the flow graph like so:
+        //
+        //     Before:
+        //                 BB0: cond
+        //                   /   \
+        //                false  true
+        //                  |     |
+        //                 BB1   BB2
+        //
+        //     After:
+        //                  BB0: cond(hi)
+        //                   /        \
+        //                false       true
+        //                  |          |
+        //                  |     BB3: cond(lo)
+        //                  |      /       \
+        //                  |   false      true
+        //                  \    /          |
+        //                    BB1          BB2
+        //
+
         BlockRange().Remove(loSrc1.Def());
         BlockRange().Remove(loSrc2.Def());
         GenTree* loCmp = comp->gtNewOperNode(cmp->OperGet(), TYP_INT, loSrc1.Def(), loSrc2.Def());
@@ -1941,6 +2029,37 @@ void Lowering::LowerCompare(GenTree* cmp)
     }
     else
     {
+        // 64-bit ordinal comparisons are more complicated: they require two comparisons for the upper 32 bits and one
+        // comparison for the lower 32 bits. We update the flowgraph as such:
+        //
+        //     Before:
+        //                 BB0: cond
+        //                   /   \
+        //                false  true
+        //                  |     |
+        //                 BB1   BB2
+        //
+        //     After:
+        //           BB0: (!cond(hi) && !eq(hi))
+        //               /                \
+        //             true              false
+        //              |                  |
+        //              |      BB3: (cond(hi) && !eq(hi))
+        //              |             /        \
+        //              |          false      true
+        //              |            |          |
+        //              |      BB4: cond(lo)    |
+        //              |       /         \     |
+        //              |    false        true  |
+        //              \     /             \   /
+        //                BB1                BB2
+        //
+        //
+        // Note that the actual comparisons used to implement "(!cond(hi) && !eq(hi))" and "(cond(hi) && !eq(hi))"
+        // differ based on the original condition, and all consist of a single node. The switch statement below
+        // performs the necessary mapping.
+        //
+
         genTreeOps hiCmpOper;
         genTreeOps loCmpOper;
         

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1892,28 +1892,16 @@ void Lowering::LowerCompare(GenTree* cmp)
     unsigned weight = m_block->getBBWeight(comp);
 
     LIR::Use loSrc1(BlockRange(), &(src1->gtOp.gtOp1), src1);
-    LIR::Use hiSrc1(BlockRange(), &(src1->gtOp.gtOp2), src1);
     LIR::Use loSrc2(BlockRange(), &(src2->gtOp.gtOp1), src2);
-    LIR::Use hiSrc2(BlockRange(), &(src2->gtOp.gtOp2), src2);
 
     if (loSrc1.Def()->OperGet() != GT_CNS_INT && loSrc1.Def()->OperGet() != GT_LCL_VAR)
     {
         loSrc1.ReplaceWithLclVar(comp, weight);
     }
     
-    if (hiSrc1.Def()->OperGet() != GT_CNS_INT && hiSrc1.Def()->OperGet() != GT_LCL_VAR)
-    {
-        hiSrc1.ReplaceWithLclVar(comp, weight);
-    }
-    
     if (loSrc2.Def()->OperGet() != GT_CNS_INT && loSrc2.Def()->OperGet() != GT_LCL_VAR)
     {
         loSrc2.ReplaceWithLclVar(comp, weight);
-    }
-    
-    if (hiSrc2.Def()->OperGet() != GT_CNS_INT && hiSrc2.Def()->OperGet() != GT_LCL_VAR)
-    {
-        hiSrc2.ReplaceWithLclVar(comp, weight);
     }
 
     BasicBlock* jumpDest = m_block->bbJumpDest;
@@ -1921,8 +1909,8 @@ void Lowering::LowerCompare(GenTree* cmp)
     BasicBlock* newBlock = comp->fgSplitBlockAtEnd(m_block);
 
     cmp->gtType     = TYP_INT;
-    cmp->gtOp.gtOp1 = hiSrc1.Def();
-    cmp->gtOp.gtOp2 = hiSrc2.Def();
+    cmp->gtOp.gtOp1 = src1->gtOp.gtOp2;
+    cmp->gtOp.gtOp2 = src2->gtOp.gtOp2;
 
     if (cmp->OperGet() == GT_EQ || cmp->OperGet() == GT_NE)
     {
@@ -1930,8 +1918,8 @@ void Lowering::LowerCompare(GenTree* cmp)
         BlockRange().Remove(loSrc2.Def());
         GenTree* loCmp = comp->gtNewOperNode(cmp->OperGet(), TYP_INT, loSrc1.Def(), loSrc2.Def());
         loCmp->gtFlags = cmp->gtFlags;
-        GenTree* loJcc = comp->gtNewOperNode(GT_JTRUE, TYP_VOID, loCmp);
-        LIR::AsRange(newBlock).InsertAfter(nullptr, loSrc1.Def(), loSrc2.Def(), loCmp, loJcc);
+        GenTree* loJtrue = comp->gtNewOperNode(GT_JTRUE, TYP_VOID, loCmp);
+        LIR::AsRange(newBlock).InsertAfter(nullptr, loSrc1.Def(), loSrc2.Def(), loCmp, loJtrue);
 
         m_block->bbJumpKind = BBJ_COND;
 
@@ -1984,19 +1972,16 @@ void Lowering::LowerCompare(GenTree* cmp)
 
         BasicBlock* newBlock2 = comp->fgSplitBlockAtEnd(newBlock);
 
-        GenTree* hiSrc1Def = comp->gtClone(hiSrc1.Def());
-        GenTree* hiSrc2Def = comp->gtClone(hiSrc2.Def());
-        GenTree* hiCmp = comp->gtNewOperNode(hiCmpOper, TYP_INT, hiSrc1Def, hiSrc2Def);
-        hiCmp->gtFlags = cmp->gtFlags;
-        GenTree* hiJcc = comp->gtNewOperNode(GT_JTRUE, TYP_VOID, hiCmp);
-        LIR::AsRange(newBlock).InsertAfter(nullptr, hiSrc1Def, hiSrc2Def, hiCmp, hiJcc);
+        GenTree* hiJcc = new (comp, GT_JCC) GenTreeJumpCC(hiCmpOper);
+        hiJcc->gtFlags = cmp->gtFlags;
+        LIR::AsRange(newBlock).InsertAfter(nullptr, hiJcc);
 
         BlockRange().Remove(loSrc1.Def());
         BlockRange().Remove(loSrc2.Def());
         GenTree* loCmp = comp->gtNewOperNode(loCmpOper, TYP_INT, loSrc1.Def(), loSrc2.Def());
         loCmp->gtFlags = cmp->gtFlags | GTF_UNSIGNED;
-        GenTree* loJcc = comp->gtNewOperNode(GT_JTRUE, TYP_VOID, loCmp);
-        LIR::AsRange(newBlock2).InsertAfter(nullptr, loSrc1.Def(), loSrc2.Def(), loCmp, loJcc);
+        GenTree* loJtrue = comp->gtNewOperNode(GT_JTRUE, TYP_VOID, loCmp);
+        LIR::AsRange(newBlock2).InsertAfter(nullptr, loSrc1.Def(), loSrc2.Def(), loCmp, loJtrue);
 
         m_block->bbJumpKind = BBJ_COND;
         m_block->bbJumpDest = nextDest;

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -64,6 +64,7 @@ private:
     // Call Lowering
     // ------------------------------
     void LowerCall(GenTree* call);
+    void LowerCompare(GenTree* tree);
     void LowerJmpMethod(GenTree* jmp);
     void LowerRet(GenTree* ret);
     GenTree* LowerDelegateInvoke(GenTreeCall* call);

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -190,6 +190,7 @@ private:
     void TreeNodeInfoInitReturn(GenTree* tree);
     void TreeNodeInfoInitShiftRotate(GenTree* tree);
     void TreeNodeInfoInitCall(GenTreeCall* call);
+    void TreeNodeInfoInitCmp(GenTreePtr tree);
     void TreeNodeInfoInitStructArg(GenTreePtr structArg);
     void TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode);
     void TreeNodeInfoInitLogicalOp(GenTree* tree);
@@ -225,8 +226,6 @@ private:
 #if defined(_TARGET_XARCH_)
     void SetMulOpCounts(GenTreePtr tree);
 #endif // defined(_TARGET_XARCH_)
-
-    void LowerCmp(GenTreePtr tree);
 
 #if !CPU_LOAD_STORE_ARCH
     bool IsBinOpInRMWStoreInd(GenTreePtr tree);

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -484,7 +484,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_LE:
         case GT_GE:
         case GT_GT:
-            LowerCmp(tree);
+            TreeNodeInfoInitCmp(tree);
             break;
 
         case GT_CKFINITE:
@@ -1859,7 +1859,7 @@ void Lowering::SetIndirAddrOpCounts(GenTreePtr indirTree)
     }
 }
 
-void Lowering::LowerCmp(GenTreePtr tree)
+void Lowering::TreeNodeInfoInitCmp(GenTreePtr tree)
 {
     TreeNodeInfo* info = &(tree->gtLsraInfo);
 

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -323,6 +323,11 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             l->clearDstCount(tree->gtOp.gtOp1);
             break;
 
+        case GT_JCC:
+            info->srcCount = 0;
+            info->dstCount = 0;
+            break;
+
         case GT_JMP:
             info->srcCount = 0;
             info->dstCount = 0;

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -506,7 +506,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_LE:
         case GT_GE:
         case GT_GT:
-            LowerCmp(tree);
+            TreeNodeInfoInitCmp(tree);
             break;
 
         case GT_CKFINITE:
@@ -2899,7 +2899,7 @@ void Lowering::SetIndirAddrOpCounts(GenTreePtr indirTree)
     }
 }
 
-void Lowering::LowerCmp(GenTreePtr tree)
+void Lowering::TreeNodeInfoInitCmp(GenTreePtr tree)
 {
     TreeNodeInfo* info = &(tree->gtLsraInfo);
 
@@ -3265,7 +3265,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
 #ifdef DEBUG
                         if (comp->verbose)
                         {
-                            printf("LowerCmp: Removing a GT_CAST to TYP_UBYTE and changing castOp1->gtType to "
+                            printf("TreeNodeInfoInitCmp: Removing a GT_CAST to TYP_UBYTE and changing castOp1->gtType to "
                                    "TYP_UBYTE\n");
                             comp->gtDispTreeRange(BlockRange(), tree);
                         }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -8529,7 +8529,7 @@ void LinearScan::insertMove(
             noway_assert(!blockRange.IsEmpty());
 
             GenTree* branch = blockRange.LastNode();
-            assert(branch->OperGet() == GT_JTRUE || branch->OperGet() == GT_SWITCH_TABLE ||
+            assert(branch->OperIsConditionalJump() || branch->OperGet() == GT_SWITCH_TABLE ||
                    branch->OperGet() == GT_SWITCH);
 
             blockRange.InsertBefore(branch, std::move(treeRange));
@@ -8600,7 +8600,7 @@ void LinearScan::insertSwap(
             noway_assert(!blockRange.IsEmpty());
 
             GenTree* branch = blockRange.LastNode();
-            assert(branch->OperGet() == GT_JTRUE || branch->OperGet() == GT_SWITCH_TABLE ||
+            assert(branch->OperIsConditionalJump() || branch->OperGet() == GT_SWITCH_TABLE ||
                    branch->OperGet() == GT_SWITCH);
 
             blockRange.InsertBefore(branch, std::move(swapRange));

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -931,6 +931,8 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
 #endif // FEATURE_SIMD
 
         default:
+            // JCC nodes should not be present in HIR.
+            assert(node->OperGet() != GT_JCC);
             break;
     }
 


### PR DESCRIPTION
Comparisons between long-typed values on x86 require at least two and
at most three separate branches: one or two to compare the high 32
bits and one to compare the low 32 bits. In essence, each long
compare introduces two additional basic blocks into the flow graph,
but these blocks were not reified until code generation. Furthermore,
code generation of a long comparison used by a JTRUE was deferred
until the JTRUE itself without marking the inputs to the compare as
live at the JTRUE. Taken together, these representational issues
caused bugs like the one seen in the the following assembly:

       33DB         xor      ebx, ebx
       BE03000000   mov      esi, 3
       33FF         xor      edi, edi
       8B75F0       mov      esi, dword ptr [ebp-10H] ; these 2 are reloads inserted by LSRA
       8B7DEC       mov      edi, dword ptr [ebp-14H] ; between the compare and the branch
       3BDF         cmp      ebx, edi
       72D6         jb       SHORT G_M51005_IG03
       7704         ja       SHORT G_M51005_IG04
       3BC6         cmp      eax, esi
       72D0         jb       SHORT G_M51005_IG03

The reloads that LSRA has inserted have killed the registers assigned
to the inputs to the compare, thus causing the compare instructions
to read unexpected values (GH #7038).

Although a number of alternatives were discussed, the best solution
seems to be to expose the control flow via the flow graph rather than
leaving it until code generation; this PR incorporates @mikedn 's
implementation of that approach.

In order to reduce register pressure, this PR also introduces a new
conditional jump node into the RyuJIT LIR: `GT_JCC`. This is a nilary
node with a single field, `gtCondition`, that indicates the condition
used for the jump. There is an implicit use of the target's condition
code register (e.g. `EFLAGS` on x86) associated with this node, as
with `GT_JTRUE`. The code generator will generate an appropriate
conditional jump when it encounters this node. For x86, this allows
the second conditional jump associated with the comparison of the
high 32 bits to reuse the flags produced by the `cmp` instruction
generated for the first conditional jump.

Fixes #7038, replaces #7165.