### PR TITLE
Update _MSC_FULL_VER check for constexpr handling

### DIFF
--- a/src/inc/debugreturn.h
+++ b/src/inc/debugreturn.h
@@ -27,9 +27,11 @@
 
 #else // !_PREFAST_
 
-// This is disabled in VS2015 Update 3 and earlier because only C++11 constexpr is supported,
-// which doesn't allow the use of 'if' statements within the body of a constexpr function.
-#if defined(_DEBUG) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024210)
+// This is disabled in build 190024315 (a pre-release build after VS 2015 Update 3) and
+// earlier because those builds only support C++11 constexpr,  which doesn't allow the
+// use of 'if' statements within the body of a constexpr function.  Later builds support
+// C++14 constexpr.
+#if defined(_DEBUG) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024315)
 
 // Code to generate a compile-time error if return statements appear where they
 // shouldn't.
@@ -110,7 +112,7 @@ typedef __SafeToReturn __ReturnOK;
 #define DEBUG_OK_TO_RETURN_BEGIN(arg) { typedef __SafeToReturn __ReturnOK; if (0 && __ReturnOK::used()) { } else {
 #define DEBUG_OK_TO_RETURN_END(arg) } }
 
-#else // defined(_DEBUG) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024210)
+#else // defined(_DEBUG) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024315)
 
 #define DEBUG_ASSURE_SAFE_TO_RETURN TRUE
 
@@ -120,7 +122,7 @@ typedef __SafeToReturn __ReturnOK;
 #define DEBUG_OK_TO_RETURN_BEGIN(arg) {
 #define DEBUG_OK_TO_RETURN_END(arg) }
 
-#endif // defined(_DEBUG) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024210)
+#endif // defined(_DEBUG) && (!defined(_MSC_FULL_VER) || _MSC_FULL_VER > 190024315)
 
 #endif // !_PREFAST_
 


### PR DESCRIPTION
Previously the code was comparing against 190024210 (VS2015 Update 3).
Update it to instead compare against 190024315, the last pre-release build
before C++14 constexpr support got added; this fixes compilation using
pre-release MSVC compilers between 24210 and 24315.

Fixes #6642.