### PR TITLE
Fix for issue #6768: NullRef when access Level property and EventSource Reports errors

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -4893,7 +4893,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                if (EventId < 0)      // TraceLogging convention EventID == -1
+                if (EventId <= 0)      // TraceLogging convention EventID == -1
                     return m_opcode;
                 return (EventOpcode)m_eventSource.m_eventData[EventId].Descriptor.Opcode;
             }
@@ -4906,7 +4906,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                if (EventId < 0)      // TraceLogging convention EventID == -1
+                if (EventId <= 0)      // TraceLogging convention EventID == -1
                     return EventTask.None;
 
                 return (EventTask)m_eventSource.m_eventData[EventId].Descriptor.Task;
@@ -4920,7 +4920,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                if (EventId < 0)      // TraceLogging convention EventID == -1
+                if (EventId <= 0)      // TraceLogging convention EventID == -1
                     return m_tags;
                 return m_eventSource.m_eventData[EventId].Tags;
             }
@@ -4933,7 +4933,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                if (EventId < 0)      // TraceLogging convention EventID == -1
+                if (EventId <= 0)      // TraceLogging convention EventID == -1
                     return m_message;
                 else
                     return m_eventSource.m_eventData[EventId].Message;
@@ -4953,7 +4953,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                if (EventId < 0)      // TraceLogging convention EventID == -1
+                if (EventId <= 0)      // TraceLogging convention EventID == -1
                     return EventChannel.None;
                 return (EventChannel)m_eventSource.m_eventData[EventId].Descriptor.Channel;
             }
@@ -4967,7 +4967,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                if (EventId < 0)      // TraceLogging convention EventID == -1
+                if (EventId <= 0)      // TraceLogging convention EventID == -1
                     return 0;
                 return m_eventSource.m_eventData[EventId].Descriptor.Version;
             }
@@ -4980,7 +4980,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                if (EventId < 0)      // TraceLogging convention EventID == -1
+                if (EventId <= 0)      // TraceLogging convention EventID == -1
                     return m_level;
                 return (EventLevel)m_eventSource.m_eventData[EventId].Descriptor.Level;
             }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -1390,11 +1390,12 @@ namespace System.Diagnostics.Tracing
                 }
                 else
                 {
-                    List<object> arg = new List<object>();
-                    arg.Add(msg);
                     EventWrittenEventArgs eventCallbackArgs = new EventWrittenEventArgs(this);
                     eventCallbackArgs.EventId = 0;
-                    eventCallbackArgs.Payload = new ReadOnlyCollection<object>(arg);
+                    eventCallbackArgs.Message = msg;
+                    eventCallbackArgs.Payload = new ReadOnlyCollection<object>(new List<object>() { msg });
+                    eventCallbackArgs.PayloadNames = new ReadOnlyCollection<string>(new List<string> { "message" });
+                    eventCallbackArgs.EventName = "EventSourceMessage";
                     listener.OnEventWritten(eventCallbackArgs);
                 }
             }


### PR DESCRIPTION
See #6768  https://github.com/dotnet/coreclr/issues/6768 for more details on the bug.

The issue is that EventSource is firing events (to report errors) before the EventSource
is completely initialized.   We dealt with many of the issues associated with this but
not all of them.   This change makes these special eventSource events (with ID of 0
 take the same codepath as for TraceLogging events (with negative IDs) when the
EventWrittenArgs properies are accessed.

Note that standard testing will not test this change properly.   I will do that by hand before
merging the pull request.  