### PR TITLE
Fix various CustomAttributeBuilder bugs

### DIFF
--- a/src/mscorlib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -159,23 +159,13 @@ namespace System.Reflection.Emit {
                 object constructorArg = constructorArgs[i];
                 if (constructorArg == null)
                 {
-                    if (paramTypes[i].IsPrimitive)
+                    if (paramTypes[i].IsValueType)
                     {
-                        throw new ArgumentNullException("constructorArgs[" + i + "]");
+                        throw new ArgumentNullException($"{nameof(constructorArgs)}[{i}]");
                     }
                     continue;
                 }
-                Type constructorArgType = constructorArg.GetType();
-                TypeCode paramTC = Type.GetTypeCode(paramTypes[i]);
-                if (paramTC != Type.GetTypeCode(constructorArgType))
-                {
-                    if (paramTC != TypeCode.Object || !ValidateType(constructorArgType))
-                        throw new ArgumentException(Environment.GetResourceString("Argument_BadParameterTypeForConstructor", i));
-                }
-                if (constructorArgType == typeof(IntPtr) || constructorArgType == typeof(UIntPtr))
-                {
-                    throw new ArgumentException(Environment.GetResourceString("Argument_BadParameterTypeForConstructor", i), "constructorArgs[" + i + "]");
-                }
+                VerifyTypeAndPassedObjectType(paramTypes[i], constructorArg.GetType(), $"{nameof(constructorArgs)}[{i}]");
             }
 
             // Allocate a memory stream to represent the CA blob in the metadata and a binary writer to help format it.
@@ -196,13 +186,14 @@ namespace System.Reflection.Emit {
             for (i = 0; i < namedProperties.Length; i++)
             {
                 // Validate the property.
-                if (namedProperties[i] == null)
+                PropertyInfo property = namedProperties[i];
+                if (property == null)
                     throw new ArgumentNullException("namedProperties[" + i + "]");
 
                 // Allow null for non-primitive types only.
-                Type propType = namedProperties[i].PropertyType;
+                Type propType = property.PropertyType;
                 object propertyValue = propertyValues[i];
-                if (propertyValue == null && propType.IsPrimitive)
+                if (propertyValue == null && propType.IsValueType)
                     throw new ArgumentNullException("propertyValues[" + i + "]");
 
                 // Validate property type.
@@ -210,25 +201,25 @@ namespace System.Reflection.Emit {
                     throw new ArgumentException(Environment.GetResourceString("Argument_BadTypeInCustomAttribute"));
 
                 // Property has to be writable.
-                if (!namedProperties[i].CanWrite)
+                if (!property.CanWrite)
                     throw new ArgumentException(Environment.GetResourceString("Argument_NotAWritableProperty"));
 
                 // Property has to be from the same class or base class as ConstructorInfo.
-                if (namedProperties[i].DeclaringType != con.DeclaringType
+                if (property.DeclaringType != con.DeclaringType
                     && (!(con.DeclaringType is TypeBuilderInstantiation))
-                    && !con.DeclaringType.IsSubclassOf(namedProperties[i].DeclaringType))
+                    && !con.DeclaringType.IsSubclassOf(property.DeclaringType))
                 {
                     // Might have failed check because one type is a XXXBuilder
                     // and the other is not. Deal with these special cases
                     // separately.
-                    if (!TypeBuilder.IsTypeEqual(namedProperties[i].DeclaringType, con.DeclaringType))
+                    if (!TypeBuilder.IsTypeEqual(property.DeclaringType, con.DeclaringType))
                     {
                         // IsSubclassOf is overloaded to do the right thing if
                         // the constructor is a TypeBuilder, but we still need
                         // to deal with the case where the property's declaring
                         // type is one.
-                        if (!(namedProperties[i].DeclaringType is TypeBuilder) ||
-                            !con.DeclaringType.IsSubclassOf(((TypeBuilder)namedProperties[i].DeclaringType).BakedRuntimeType))
+                        if (!(property.DeclaringType is TypeBuilder) ||
+                            !con.DeclaringType.IsSubclassOf(((TypeBuilder)property.DeclaringType).BakedRuntimeType))
                             throw new ArgumentException(Environment.GetResourceString("Argument_BadPropertyForConstructorBuilder"));
                     }
                 }
@@ -237,15 +228,7 @@ namespace System.Reflection.Emit {
                 // Note that there will be no coersion.
                 if (propertyValue != null)
                 {
-                    Type propertyValueType = propertyValue.GetType();
-                    if (propType != typeof(Object) && Type.GetTypeCode(propertyValueType) != Type.GetTypeCode(propType))
-                    {
-                        throw new ArgumentException(Environment.GetResourceString("Argument_ConstantDoesntMatch"));
-                    }
-                    else if (propertyValueType == typeof(IntPtr) || propertyValueType == typeof(UIntPtr))
-                    {
-                        throw new ArgumentException(Environment.GetResourceString("Argument_BadParameterTypeForCAB"), "propertyValues[" + i + "]");
-                    }
+                    VerifyTypeAndPassedObjectType(propType, propertyValue.GetType(), $"{nameof(propertyValues)}[{i}]");
                 }
 
                 // First a byte indicating that this is a property.
@@ -261,13 +244,14 @@ namespace System.Reflection.Emit {
             for (i = 0; i < namedFields.Length; i++)
             {
                 // Validate the field.
-                if (namedFields[i] == null)
+                FieldInfo namedField = namedFields[i];
+                if (namedField == null)
                     throw new ArgumentNullException("namedFields[" + i + "]");
 
                 // Allow null for non-primitive types only.
-                Type fldType = namedFields[i].FieldType;
+                Type fldType = namedField.FieldType;
                 object fieldValue = fieldValues[i];
-                if (fieldValue == null && fldType.IsPrimitive)
+                if (fieldValue == null && fldType.IsValueType)
                     throw new ArgumentNullException("fieldValues[" + i + "]");
 
                 // Validate field type.
@@ -275,20 +259,20 @@ namespace System.Reflection.Emit {
                     throw new ArgumentException(Environment.GetResourceString("Argument_BadTypeInCustomAttribute"));
 
                 // Field has to be from the same class or base class as ConstructorInfo.
-                if (namedFields[i].DeclaringType != con.DeclaringType
+                if (namedField.DeclaringType != con.DeclaringType
                     && (!(con.DeclaringType is TypeBuilderInstantiation))
-                    && !con.DeclaringType.IsSubclassOf(namedFields[i].DeclaringType))
+                    && !con.DeclaringType.IsSubclassOf(namedField.DeclaringType))
                 {
                     // Might have failed check because one type is a XXXBuilder
                     // and the other is not. Deal with these special cases
                     // separately.
-                    if (!TypeBuilder.IsTypeEqual(namedFields[i].DeclaringType, con.DeclaringType))
+                    if (!TypeBuilder.IsTypeEqual(namedField.DeclaringType, con.DeclaringType))
                     {
                         // IsSubclassOf is overloaded to do the right thing if
                         // the constructor is a TypeBuilder, but we still need
                         // to deal with the case where the field's declaring
                         // type is one.
-                        if (!(namedFields[i].DeclaringType is TypeBuilder) ||
+                        if (!(namedField.DeclaringType is TypeBuilder) ||
                             !con.DeclaringType.IsSubclassOf(((TypeBuilder)namedFields[i].DeclaringType).BakedRuntimeType))
                             throw new ArgumentException(Environment.GetResourceString("Argument_BadFieldForConstructorBuilder"));
                     }
@@ -298,15 +282,7 @@ namespace System.Reflection.Emit {
                 // Note that there will be no coersion.
                 if (fieldValue != null)
                 {
-                    Type fieldValueType = fieldValue.GetType();
-                    if (fldType != typeof(Object) && Type.GetTypeCode(fieldValueType) != Type.GetTypeCode(fldType))
-                    {
-                        throw new ArgumentException(Environment.GetResourceString("Argument_ConstantDoesntMatch"));
-                    }
-                    else if (fieldValueType == typeof(IntPtr) || fieldValueType == typeof(UIntPtr))
-                    {
-                        throw new ArgumentException(Environment.GetResourceString("Argument_BadParameterTypeForCAB"), "fieldValues[" + i + "]");
-                    }
+                    VerifyTypeAndPassedObjectType(fldType, fieldValue.GetType(), $"{nameof(fieldValues)}[{i}]");
                 }
                 
                 // First a byte indicating that this is a field.
@@ -314,12 +290,24 @@ namespace System.Reflection.Emit {
 
                 // Emit the field type, name and value.
                 EmitType(writer, fldType);
-                EmitString(writer, namedFields[i].Name);
+                EmitString(writer, namedField.Name);
                 EmitValue(writer, fldType, fieldValue);
             }
 
             // Create the blob array.
             m_blob = ((MemoryStream)writer.BaseStream).ToArray();
+        }
+
+        private static void VerifyTypeAndPassedObjectType(Type type, Type passedType, string paramName)
+        {
+            if (type != typeof(object) && Type.GetTypeCode(passedType) != Type.GetTypeCode(type))
+            {
+                throw new ArgumentException(Environment.GetResourceString("Argument_ConstantDoesntMatch"));
+            }
+            if (passedType == typeof(IntPtr) || passedType == typeof(UIntPtr))
+            {
+                throw new ArgumentException(Environment.GetResourceString("Argument_BadParameterTypeForCAB"), paramName);
+            }
         }
 
         private void EmitType(BinaryWriter writer, Type type)

--- a/src/mscorlib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -151,7 +151,13 @@ namespace System.Reflection.Emit {
             for (i = 0; i < paramTypes.Length; i++)
             {
                 if (constructorArgs[i] == null)
+                {
+                    if (paramTypes[i].IsPrimitive)
+                    {
+                        throw new ArgumentNullException("constructorArgs[" + i + "]");
+                    }
                     continue;
+                }
                 TypeCode paramTC = Type.GetTypeCode(paramTypes[i]);
                 if (paramTC != Type.GetTypeCode(constructorArgs[i].GetType()))
                     if (paramTC != TypeCode.Object || !ValidateType(constructorArgs[i].GetType())) 


### PR DESCRIPTION
- NullReferenceException if passing null to primitive constructor; now consistent with error checking of properties and fields
- Assertion in Debug or CustomAttributeFormatException iin release if a constructor/property/field has a IntPtr/UIntPtr type/value
- CustomAttributeFormatException if a field is constant; now consistent with error checking of properties

Fixes dotnet/corefx#11702, dotnet/corefx#11703

Tests at dotnet/corefx#11749
