### PR TITLE
Update the GC from CoreRT

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -447,7 +447,7 @@ extern bool g_fFinalizerRunOnShutDown;
 // Locks
 //
 
-struct alloc_context;
+struct gc_alloc_context;
 class Thread;
 
 Thread * GetThread();

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -25,19 +25,6 @@ typedef void enum_func (Object*);
 // callback functions for heap walkers
 typedef void object_callback_func(void * pvContext, void * pvDataLoc);
 
-// stub type to abstract a heap segment
-struct gc_heap_segment_stub;
-typedef gc_heap_segment_stub *segment_handle;
-
-struct segment_info
-{
-    void * pvMem; // base of the allocation, not the first object (must add ibFirstObject)
-    size_t ibFirstObject;   // offset to the base of the first object in the segment
-    size_t ibAllocated; // limit of allocated memory in the segment (>= firstobject)
-    size_t ibCommit; // limit of committed memory in the segment (>= alllocated)
-    size_t ibReserved; // limit of reserved memory in the segment (>= commit)
-};
-
 /*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
 /* If you modify failure_get_memory and         */
 /* oom_reason be sure to make the corresponding */
@@ -261,14 +248,6 @@ public:
         return mt->GetBaseSize() >= LARGE_OBJECT_SIZE;
     }
 
-public:
-
-#ifdef FEATURE_BASICFREEZE
-    // frozen segment management functions
-    virtual segment_handle RegisterFrozenSegment(segment_info *pseginfo) = 0;
-    virtual void UnregisterFrozenSegment(segment_handle seg) = 0;
-#endif //FEATURE_BASICFREEZE
-
 protected: 
 public:
 #if defined(FEATURE_BASICFREEZE) && defined(VERIFY_HEAP)
@@ -291,14 +270,14 @@ extern MethodTable  *pWeakReferenceOfTCanonMT;
 extern void FinalizeWeakReference(Object * obj);
 
 // The single GC heap instance, shared with the VM.
-extern IGCHeapInternal* g_theGcHeap;
+extern IGCHeapInternal* g_theGCHeap;
 
 #ifndef DACCESS_COMPILE
 inline BOOL IsGCInProgress(bool bConsiderGCStart = FALSE)
 {
     WRAPPER_NO_CONTRACT;
 
-    return g_theGcHeap != nullptr ? g_theGcHeap->IsGCInProgressHelper(bConsiderGCStart) : false;
+    return g_theGCHeap != nullptr ? g_theGCHeap->IsGCInProgressHelper(bConsiderGCStart) : false;
 }
 #endif // DACCESS_COMPILE
 

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -20,7 +20,7 @@ SVAL_IMPL_INIT(uint32_t,IGCHeap,gcHeapType,IGCHeap::GC_HEAP_INVALID);
 
 SVAL_IMPL_INIT(uint32_t,IGCHeap,maxGeneration,2);
 
-IGCHeapInternal* g_theGcHeap;
+IGCHeapInternal* g_theGCHeap;
 
 /* global versions of the card table and brick table */ 
 GPTR_IMPL(uint32_t,g_card_table);
@@ -147,7 +147,7 @@ IGCHeap* InitializeGarbageCollector(IGCToCLR* clrToGC)
     heap = WKS::CreateGCHeap();
 #endif
 
-    g_theGcHeap = heap;
+    g_theGCHeap = heap;
     return heap;
 }
 

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -830,9 +830,9 @@ void GCHeap::DescrGenerationsToProfiler (gen_walk_fn fn, void *context)
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 }
 
-#ifdef FEATURE_BASICFREEZE
 segment_handle GCHeap::RegisterFrozenSegment(segment_info *pseginfo)
 {
+#ifdef FEATURE_BASICFREEZE
     heap_segment * seg = new (nothrow) heap_segment;
     if (!seg)
     {
@@ -863,10 +863,15 @@ segment_handle GCHeap::RegisterFrozenSegment(segment_info *pseginfo)
     }
 
     return reinterpret_cast< segment_handle >(seg);
+#else
+    assert(!"Should not call GCHeap::RegisterFrozenSegment without FEATURE_BASICFREEZE defined!");
+    return NULL;
+#endif // FEATURE_BASICFREEZE
 }
 
 void GCHeap::UnregisterFrozenSegment(segment_handle seg)
 {
+#ifdef FEATURE_BASICFREEZE
 #if defined (MULTIPLE_HEAPS) && !defined (ISOLATED_HEAPS)
     gc_heap* heap = gc_heap::g_heaps[0];
 #else
@@ -874,8 +879,10 @@ void GCHeap::UnregisterFrozenSegment(segment_handle seg)
 #endif //MULTIPLE_HEAPS && !ISOLATED_HEAPS
 
     heap->remove_ro_segment(reinterpret_cast<heap_segment*>(seg));
-}
+#else
+    assert(!"Should not call GCHeap::UnregisterFrozenSegment without FEATURE_BASICFREEZE defined!");
 #endif // FEATURE_BASICFREEZE
+}
 
 
 #endif // !DACCESS_COMPILE

--- a/src/gc/gcimpl.h
+++ b/src/gc/gcimpl.h
@@ -222,11 +222,9 @@ public:	// FIX
     // Interface with gc_heap
     size_t  GarbageCollectTry (int generation, BOOL low_memory_p=FALSE, int mode=collection_blocking);
 
-#ifdef FEATURE_BASICFREEZE
     // frozen segment management functions
     virtual segment_handle RegisterFrozenSegment(segment_info *pseginfo);
     virtual void UnregisterFrozenSegment(segment_handle seg);
-#endif // FEATURE_BASICFREEZE
 
     void    WaitUntilConcurrentGCComplete ();                               // Use in managd threads
 #ifndef DACCESS_COMPILE    

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -2978,7 +2978,7 @@ protected:
     PER_HEAP
     VOLATILE(int) alloc_context_count;
 #else //MULTIPLE_HEAPS
-#define vm_heap ((GCHeap*) g_theGcHeap)
+#define vm_heap ((GCHeap*) g_theGCHeap)
 #define heap_number (0)
 #endif //MULTIPLE_HEAPS
 

--- a/src/gc/gcscan.cpp
+++ b/src/gc/gcscan.cpp
@@ -129,7 +129,7 @@ static void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t * /*
     LOG((LF_GC, LL_INFO100000, LOG_HANDLE_OBJECT_CLASS("Checking referent of Weak-", pObjRef, "to ", *pObjRef)));
 
     Object **pRef = (Object **)pObjRef;
-    if (!g_theGcHeap->IsPromoted(*pRef))
+    if (!g_theGCHeap->IsPromoted(*pRef))
     {
         LOG((LF_GC, LL_INFO100, LOG_HANDLE_OBJECT_CLASS("Severing Weak-", pObjRef, "to unreachable ", *pObjRef)));
 

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -755,7 +755,7 @@ void HndLogSetEvent(OBJECTHANDLE handle, _UNCHECKED_OBJECTREF value)
         uint32_t hndType = HandleFetchType(handle);
         ADIndex appDomainIndex = HndGetHandleADIndex(handle);   
         AppDomain* pAppDomain = SystemDomain::GetAppDomainAtIndex(appDomainIndex);
-        uint32_t generation = value != 0 ? g_theGcHeap->WhichGeneration(value) : 0;
+        uint32_t generation = value != 0 ? g_theGCHeap->WhichGeneration(value) : 0;
         FireEtwSetGCHandle((void*) handle, value, hndType, generation, (int64_t) pAppDomain, GetClrInstanceId());
         FireEtwPrvSetGCHandle((void*) handle, value, hndType, generation, (int64_t) pAppDomain, GetClrInstanceId());
 
@@ -774,14 +774,14 @@ void HndLogSetEvent(OBJECTHANDLE handle, _UNCHECKED_OBJECTREF value)
                     for (size_t i = 0; i < num; i ++)
                     {
                         value = ppObj[i];
-                        uint32_t generation = value != 0 ? g_theGcHeap->WhichGeneration(value) : 0;
+                        uint32_t generation = value != 0 ? g_theGCHeap->WhichGeneration(value) : 0;
                         FireEtwSetGCHandle(overlapped, value, HNDTYPE_PINNED, generation, (int64_t) pAppDomain, GetClrInstanceId());
                     }
                 }
                 else
                 {
                     value = OBJECTREF_TO_UNCHECKED_OBJECTREF(overlapped->m_userObject);
-                    uint32_t generation = value != 0 ? g_theGcHeap->WhichGeneration(value) : 0;
+                    uint32_t generation = value != 0 ? g_theGCHeap->WhichGeneration(value) : 0;
                     FireEtwSetGCHandle(overlapped, value, HNDTYPE_PINNED, generation, (int64_t) pAppDomain, GetClrInstanceId());
                 }
             }
@@ -838,7 +838,7 @@ void HndWriteBarrier(OBJECTHANDLE handle, OBJECTREF objref)
     if (*pClumpAge != 0) // Perf optimization: if clumpAge is 0, nothing more to do
     {
         // find out generation
-        int generation = g_theGcHeap->WhichGeneration(value);
+        int generation = g_theGCHeap->WhichGeneration(value);
         uint32_t uType = HandleFetchType(handle);
 
 #ifndef FEATURE_REDHAWK

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -1112,13 +1112,13 @@ SLOW_PATH:
         // we have the lock held but the part we care about (the async table scan) takes the table lock during
         // a preparation step so we'll be able to complete our segment moves before the async scan has a
         // chance to interfere with us (or vice versa).
-        if (g_theGcHeap->IsConcurrentGCInProgress())
+        if (g_theGCHeap->IsConcurrentGCInProgress())
         {
             // A concurrent GC is in progress so someone might be scanning our segments asynchronously.
             // Release the lock, wait for the GC to complete and try again. The order is important; if we wait
             // before releasing the table lock we can deadlock with an async table scan.
             ch.Release();
-            g_theGcHeap->WaitUntilConcurrentGCComplete();
+            g_theGCHeap->WaitUntilConcurrentGCComplete();
             continue;
         }
 

--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -818,7 +818,7 @@ void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sca
             {
                 if (!HndIsNullOrDestroyedHandle(*pValue))
                 {
-                    int thisAge = g_theGcHeap->WhichGeneration(*pValue);
+                    int thisAge = g_theGCHeap->WhichGeneration(*pValue);
                     if (minAge > thisAge)
                         minAge = thisAge;
 
@@ -830,7 +830,7 @@ void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sca
                         if (pOverlapped->m_userObject != NULL)
                         {
                             Object * pUserObject = OBJECTREFToObject(pOverlapped->m_userObject);
-                            thisAge = g_theGcHeap->WhichGeneration(pUserObject);
+                            thisAge = g_theGCHeap->WhichGeneration(pUserObject);
                             if (minAge > thisAge)
                                 minAge = thisAge;
                             if (pOverlapped->m_isArray)
@@ -840,7 +840,7 @@ void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sca
                                 size_t num = pUserArrayObject->GetNumComponents();
                                 for (size_t i = 0; i < num; i ++)
                                 {
-                                     thisAge = g_theGcHeap->WhichGeneration(pObj[i]);
+                                     thisAge = g_theGCHeap->WhichGeneration(pObj[i]);
                                      if (minAge > thisAge)
                                          minAge = thisAge;
                                  }                                    
@@ -925,10 +925,10 @@ static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTRE
     UNREFERENCED_PARAMETER(pValue);
     VerifyObject(from, obj);
 
-    int thisAge = g_theGcHeap->WhichGeneration(obj);
+    int thisAge = g_theGCHeap->WhichGeneration(obj);
 
     //debugging code
-    //if (minAge > thisAge && thisAge < g_theGcHeap->GetMaxGeneration())
+    //if (minAge > thisAge && thisAge < g_theGCHeap->GetMaxGeneration())
     //{
     //    if ((*pValue) == obj)
     //        printf("Handle (age %u) %p -> %p (age %u)", minAge, pValue, obj, thisAge);
@@ -946,7 +946,7 @@ static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTRE
     //    }
     //}
 
-    if (minAge >= GEN_MAX_AGE || (minAge > thisAge && thisAge < static_cast<int>(g_theGcHeap->GetMaxGeneration())))
+    if (minAge >= GEN_MAX_AGE || (minAge > thisAge && thisAge < static_cast<int>(g_theGCHeap->GetMaxGeneration())))
     {
         _ASSERTE(!"Fatal Error in HandleTable.");
         EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -95,7 +95,7 @@ void CALLBACK PromoteRefCounted(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtra
     Object *pOldObj = pObj;
 #endif
 
-    if (!HndIsNullOrDestroyedHandle(pObj) && !g_theGcHeap->IsPromoted(pObj))
+    if (!HndIsNullOrDestroyedHandle(pObj) && !g_theGCHeap->IsPromoted(pObj))
     {
         if (GCToEEInterface::RefCountedHandleCallbacks(pObj))
         {
@@ -186,9 +186,9 @@ void CALLBACK PromoteDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *p
     ScanContext *sc = (ScanContext*)lp1;
     DhContext *pDhContext = Ref_GetDependentHandleContext(sc);
 
-    if (*pObjRef && g_theGcHeap->IsPromoted(*pPrimaryRef))
+    if (*pObjRef && g_theGCHeap->IsPromoted(*pPrimaryRef))
     {
-        if (!g_theGcHeap->IsPromoted(*pSecondaryRef))
+        if (!g_theGCHeap->IsPromoted(*pSecondaryRef))
         {
             LOG((LF_GC|LF_ENC, LL_INFO10000, "\tPromoting secondary " LOG_OBJECT_CLASS(*pSecondaryRef)));
             _ASSERTE(lp2);
@@ -221,7 +221,7 @@ void CALLBACK ClearDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pEx
     LOG((LF_GC|LF_ENC, LL_INFO1000, LOG_HANDLE_OBJECT_CLASS("\tPrimary:\t", pPrimaryRef, "to ", *pPrimaryRef)));
     LOG((LF_GC|LF_ENC, LL_INFO1000, LOG_HANDLE_OBJECT_CLASS("\tSecondary\t", pSecondaryRef, "to ", *pSecondaryRef)));
 
-    if (!g_theGcHeap->IsPromoted(*pPrimaryRef))
+    if (!g_theGCHeap->IsPromoted(*pPrimaryRef))
     {
         LOG((LF_GC|LF_ENC, LL_INFO1000, "\tunreachable ", LOG_OBJECT_CLASS(*pPrimaryRef)));
         LOG((LF_GC|LF_ENC, LL_INFO1000, "\tunreachable ", LOG_OBJECT_CLASS(*pSecondaryRef)));
@@ -230,7 +230,7 @@ void CALLBACK ClearDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pEx
     }
     else
     {
-        _ASSERTE(g_theGcHeap->IsPromoted(*pSecondaryRef));
+        _ASSERTE(g_theGCHeap->IsPromoted(*pSecondaryRef));
         LOG((LF_GC|LF_ENC, LL_INFO10000, "\tPrimary is reachable " LOG_OBJECT_CLASS(*pPrimaryRef)));
         LOG((LF_GC|LF_ENC, LL_INFO10000, "\tSecondary is reachable " LOG_OBJECT_CLASS(*pSecondaryRef)));
     }
@@ -330,7 +330,7 @@ void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo
     LOG((LF_GC, LL_INFO100000, LOG_HANDLE_OBJECT_CLASS("Checking referent of Weak-", pObjRef, "to ", *pObjRef)));
 
     Object **ppRef = (Object **)pObjRef;
-    if (!g_theGcHeap->IsPromoted(*ppRef))
+    if (!g_theGCHeap->IsPromoted(*ppRef))
     {
         LOG((LF_GC, LL_INFO100, LOG_HANDLE_OBJECT_CLASS("Severing Weak-", pObjRef, "to unreachable ", *pObjRef)));
 
@@ -355,9 +355,9 @@ void CALLBACK CalculateSizedRefSize(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pE
     ScanContext* sc = (ScanContext *)lp1;
     promote_func* callback = (promote_func*) lp2;
 
-    size_t sizeBegin = g_theGcHeap->GetPromotedBytes(sc->thread_number);
+    size_t sizeBegin = g_theGCHeap->GetPromotedBytes(sc->thread_number);
     callback(ppSizedRef, (ScanContext *)lp1, 0);
-    size_t sizeEnd = g_theGcHeap->GetPromotedBytes(sc->thread_number);
+    size_t sizeEnd = g_theGCHeap->GetPromotedBytes(sc->thread_number);
     *pSize = sizeEnd - sizeBegin;
 }
 
@@ -1152,7 +1152,7 @@ void Ref_TraceNormalRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, 
     // promote objects pointed to by strong handles
     // during ephemeral GCs we also want to promote the ones pointed to by sizedref handles.
     uint32_t types[2] = {HNDTYPE_STRONG, HNDTYPE_SIZEDREF};
-    uint32_t uTypeCount = (((condemned >= maxgen) && !g_theGcHeap->IsConcurrentGCInProgress()) ? 1 : _countof(types));
+    uint32_t uTypeCount = (((condemned >= maxgen) && !g_theGCHeap->IsConcurrentGCInProgress()) ? 1 : _countof(types));
     uint32_t flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
 
     HandleTableMap *walk = &g_HandleTableMap;
@@ -1454,7 +1454,7 @@ void ScanSizedRefByAD(uint32_t maxgen, HANDLESCANPROC scanProc, ScanContext* sc,
     HandleTableMap *walk = &g_HandleTableMap;
     uint32_t type = HNDTYPE_SIZEDREF;
     int uCPUindex = getSlotNumber(sc);
-    int n_slots = g_theGcHeap->GetNumberOfHeaps();
+    int n_slots = g_theGCHeap->GetNumberOfHeaps();
 
     while (walk)
     {
@@ -1577,8 +1577,8 @@ void Ref_UpdatePointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Re
     if (IsServerHeap()) 
     {
         bDo = (Interlocked::Increment(&uCount) == 1);
-        Interlocked::CompareExchange (&uCount, 0, g_theGcHeap->GetNumberOfHeaps());
-        _ASSERTE (uCount <= g_theGcHeap->GetNumberOfHeaps());
+        Interlocked::CompareExchange (&uCount, 0, g_theGCHeap->GetNumberOfHeaps());
+        _ASSERTE (uCount <= g_theGCHeap->GetNumberOfHeaps());
     }
 
     if (bDo)   
@@ -1906,9 +1906,9 @@ int GetCurrentThreadHomeHeapNumber()
 {
     WRAPPER_NO_CONTRACT;
 
-    if (g_theGcHeap == nullptr)
+    if (g_theGCHeap == nullptr)
         return 0;
-    return g_theGcHeap->GetHomeHeapNumber();
+    return g_theGCHeap->GetHomeHeapNumber();
 }
 
 bool HandleTableBucket::Contains(OBJECTHANDLE handle)
@@ -1921,7 +1921,7 @@ bool HandleTableBucket::Contains(OBJECTHANDLE handle)
     }
     
     HHANDLETABLE hTable = HndGetHandleTable(handle);
-    for (int uCPUindex=0; uCPUindex < g_theGcHeap->GetNumberOfHeaps(); uCPUindex++)
+    for (int uCPUindex=0; uCPUindex < g_theGCHeap->GetNumberOfHeaps(); uCPUindex++)
     {
         if (hTable == this->pTable[uCPUindex]) 
         {

--- a/src/gc/sample/GCSample.cpp
+++ b/src/gc/sample/GCSample.cpp
@@ -68,7 +68,7 @@ Object * AllocateObject(MethodTable * pMT)
     }
     else
     {
-        pObject = g_theGcHeap->Alloc(acontext, size, 0);
+        pObject = g_theGCHeap->Alloc(acontext, size, 0);
         if (pObject == NULL)
             return NULL;
     }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -131,7 +131,7 @@ void ThreadStore::AttachCurrentThread()
 
 void GCToEEInterface::SuspendEE(GCToEEInterface::SUSPEND_REASON reason)
 {
-    g_theGcHeap->SetGCInProgress(TRUE);
+    g_theGCHeap->SetGCInProgress(TRUE);
 
     // TODO: Implement
 }
@@ -140,7 +140,7 @@ void GCToEEInterface::RestartEE(bool bFinishedGC)
 {
     // TODO: Implement
 
-    g_theGcHeap->SetGCInProgress(FALSE);
+    g_theGCHeap->SetGCInProgress(FALSE);
 }
 
 void GCToEEInterface::GcScanRoots(promote_func* fn,  int condemned, int max_gen, ScanContext* sc)


### PR DESCRIPTION
This PR contains all of the changes done to the gc directory to integrate dotnet/coreclr#6764 to CoreRT. The most notable change is the exposure of `RegisterFrozenSegment` and `UnregisterFrozenSegment` past the GC interface, which has no effect on the full framework or CoreCLR (see https://github.com/dotnet/coreclr/issues/568#issuecomment-86609429). Other changes include adding `UNREFERENCED_PARAMETER` macros to avoid build warnings and the renaming of `g_theGcHeap` to `g_theGCHeap` to adhere to naming conventions.