### PR TITLE
Remove unwanted String.Split methods from Reference assembly

### DIFF
--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -3255,24 +3255,12 @@ namespace System
         [System.Security.SecuritySafeCriticalAttribute]
         public System.String Replace(char oldChar, char newChar) { throw null; }
         public System.String Replace(System.String oldValue, System.String newValue) { throw null; }
-        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
-        public string[] Split(char separator) { throw null; }
-        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
-        public string[] Split(char separator, int count, System.StringSplitOptions options) { throw null; }
-        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
-        public string[] Split(char separator, System.StringSplitOptions options) { throw null; }
         public string[] Split(params char[] separator) { throw null; }
         public string[] Split(char[] separator, int count) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public string[] Split(char[] separator, int count, System.StringSplitOptions options) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public string[] Split(char[] separator, System.StringSplitOptions options) { throw null; }
-        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
-        public string[] Split(System.String separator) { throw null; }
-        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
-        public string[] Split(System.String separator, int count, System.StringSplitOptions options) { throw null; }
-        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
-        public string[] Split(System.String separator, System.StringSplitOptions options) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public string[] Split(string[] separator, int count, System.StringSplitOptions options) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -3255,12 +3255,20 @@ namespace System
         [System.Security.SecuritySafeCriticalAttribute]
         public System.String Replace(char oldChar, char newChar) { throw null; }
         public System.String Replace(System.String oldValue, System.String newValue) { throw null; }
+        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+        public string[] Split(char separator, int count, System.StringSplitOptions options = (System.StringSplitOptions)(0)) { throw null; }
+        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+        public string[] Split(char separator, System.StringSplitOptions options = (System.StringSplitOptions)(0)) { throw null; }
         public string[] Split(params char[] separator) { throw null; }
         public string[] Split(char[] separator, int count) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public string[] Split(char[] separator, int count, System.StringSplitOptions options) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public string[] Split(char[] separator, System.StringSplitOptions options) { throw null; }
+        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+        public string[] Split(System.String separator, int count, System.StringSplitOptions options = (System.StringSplitOptions)(0)) { throw null; }
+        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+        public string[] Split(System.String separator, System.StringSplitOptions options = (System.StringSplitOptions)(0)) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public string[] Split(string[] separator, int count, System.StringSplitOptions options) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]


### PR DESCRIPTION
When merging #7142 I added some Split overloads to string that we really didn't wanted to so this change is removing them. We caught this because I only added them to the reference assembly and didn't add them to model.xml, so these methods were not found at runtime. This is the reason why tests in dotnet/corefx#11706 are failing.

cc: @tarekgh