### PR TITLE
added AsBytes() and NonPortableCast() to Span and ReadOnlySpan API

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -12094,5 +12094,11 @@
       <Member Name="Equals(System.ReadOnlySpan&lt;T&gt;)" />
       <Member Name="TryCopyTo(System.Span&lt;T&gt;)" />
     </Type>
+    <Type Name="System.SpanExtensions">
+      <Member Name="AsBytes&lt;T&gt;(System.Span&lt;T&gt;)" />
+      <Member Name="AsBytes&lt;T&gt;(System.ReadOnlySpan&lt;T&gt;)" />
+      <Member Name="NonPortableCast&lt;TFrom,TTo&gt;(System.Span&lt;TFrom&gt;)" />
+      <Member Name="NonPortableCast&lt;TFrom,TTo&gt;(System.ReadOnlySpan&lt;TFrom&gt;)" />
+    </Type>
   </Assembly>
 </ThinModel>

--- a/src/mscorlib/src/System.Private.CoreLib.txt
+++ b/src/mscorlib/src/System.Private.CoreLib.txt
@@ -631,7 +631,7 @@ Argument_UnrecognizedLoaderOptimization = Unrecognized LOADER_OPTIMIZATION prope
 ArgumentException_NotAllCustomSortingFuncsDefined = Implementations of all the NLS functions must be provided.
 ArgumentException_MinSortingVersion = The runtime does not support a version of "{0}" less than {1}.
 #if FEATURE_SPAN_OF_T
-Argument_InvalidTypeForUnmanagedMemory = '{0}' is reference type or contains pointers and hence can not be stored in unmanaged memory.
+Argument_InvalidTypeWithPointersNotSupported = Cannot use type '{0}'. Only value types without pointers are supported.
 #endif // FEATURE_SPAN_OF_T
 
 ;

--- a/src/mscorlib/src/System/ReadOnlySpan.cs
+++ b/src/mscorlib/src/System/ReadOnlySpan.cs
@@ -68,7 +68,7 @@ namespace System
         /// <param name="ptr">An unmanaged pointer to memory.</param>
         /// <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
         /// <exception cref="System.ArgumentException">
-        /// Thrown when <typeparamref name="T"/> is reference type or contains pointers and hence can not be stored in unmanaged memory.
+        /// Thrown when <typeparamref name="T"/> is reference type or contains pointers and hence cannot be stored in unmanaged memory.
         /// </exception>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="length"/> is negative.
@@ -77,7 +77,7 @@ namespace System
         public unsafe ReadOnlySpan(void* ptr, int length)
         {
             if (JitHelpers.ContainsReferences<T>())
-                ThrowHelper.ThrowInvalidTypeForUnmanagedMemory(typeof(T));
+                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 

--- a/src/mscorlib/src/System/ReadOnlySpan.cs
+++ b/src/mscorlib/src/System/ReadOnlySpan.cs
@@ -88,7 +88,7 @@ namespace System
         /// <summary>
         /// An internal helper for creating spans. Not for public use.
         /// </summary>
-        private ReadOnlySpan(ref T ptr, int length)
+        internal ReadOnlySpan(ref T ptr, int length)
         {
             JitHelpers.SetByRef(out _rawPointer, ref ptr);
             _length = length;

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -78,7 +78,7 @@ namespace System
         /// <param name="ptr">An unmanaged pointer to memory.</param>
         /// <param name="length">The number of <typeparamref name="T"/> elements the memory contains.</param>
         /// <exception cref="System.ArgumentException">
-        /// Thrown when <typeparamref name="T"/> is reference type or contains pointers and hence can not be stored in unmanaged memory.
+        /// Thrown when <typeparamref name="T"/> is reference type or contains pointers and hence cannot be stored in unmanaged memory.
         /// </exception>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="length"/> is negative.
@@ -87,7 +87,7 @@ namespace System
         public unsafe Span(void* ptr, int length)
         {
             if (JitHelpers.ContainsReferences<T>())
-                ThrowHelper.ThrowInvalidTypeForUnmanagedMemory(typeof(T));
+                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
@@ -234,11 +234,14 @@ namespace System
         /// That type may not contain pointers. This is checked at runtime in order to preserve type safety.
         /// </summary>
         /// <param name="source">The source slice, of type <typeparamref name="T"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="T"/> contains pointers.
+        /// </exception>
         public static Span<byte> AsBytes<T>(this Span<T> source)
             where T : struct
         {
             if (JitHelpers.ContainsReferences<T>())
-                return Span<byte>.Empty;
+                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
 
             return new Span<byte>(
                 ref JitHelpers.GetByRef<byte>(ref source._rawPointer),
@@ -250,11 +253,14 @@ namespace System
         /// That type may not contain pointers. This is checked at runtime in order to preserve type safety.
         /// </summary>
         /// <param name="source">The source slice, of type <typeparamref name="T"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="T"/> contains pointers.
+        /// </exception>
         public static ReadOnlySpan<byte> AsBytes<T>(this ReadOnlySpan<T> source)
             where T : struct
         {
             if (JitHelpers.ContainsReferences<T>())
-                return ReadOnlySpan<byte>.Empty;
+                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(T));
 
             return new ReadOnlySpan<byte>(
                 ref JitHelpers.GetByRef<byte>(ref source._rawPointer),
@@ -269,12 +275,17 @@ namespace System
         /// Supported only for platforms that support misaligned memory access.
         /// </remarks>
         /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
+        /// </exception>
         public static unsafe Span<TTo> NonPortableCast<TFrom, TTo>(this Span<TFrom> source)
             where TFrom : struct
             where TTo : struct
         {
-            if (JitHelpers.ContainsReferences<TFrom>() || JitHelpers.ContainsReferences<TTo>())
-                return Span<TTo>.Empty;
+            if (JitHelpers.ContainsReferences<TFrom>())
+                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TFrom));
+            if (JitHelpers.ContainsReferences<TTo>())
+                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TTo));
 
             return new Span<TTo>(
                 ref JitHelpers.GetByRef<TTo>(ref source._rawPointer),
@@ -289,12 +300,17 @@ namespace System
         /// Supported only for platforms that support misaligned memory access.
         /// </remarks>
         /// <param name="source">The source slice, of type <typeparamref name="TFrom"/>.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
+        /// </exception>
         public static unsafe ReadOnlySpan<TTo> NonPortableCast<TFrom, TTo>(this ReadOnlySpan<TFrom> source)
             where TFrom : struct
             where TTo : struct
         {
-            if (JitHelpers.ContainsReferences<TFrom>() || JitHelpers.ContainsReferences<TTo>())
-                return ReadOnlySpan<TTo>.Empty;
+            if (JitHelpers.ContainsReferences<TFrom>())
+                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TFrom));
+            if (JitHelpers.ContainsReferences<TTo>())
+                ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TTo));
 
             return new ReadOnlySpan<TTo>(
                 ref JitHelpers.GetByRef<TTo>(ref source._rawPointer),

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -47,8 +47,8 @@ namespace System {
             throw new ArrayTypeMismatchException();
         }
 
-        internal static void ThrowInvalidTypeForUnmanagedMemory(Type targetType) {
-            throw new ArgumentException(Environment.GetResourceString("Argument_InvalidTypeForUnmanagedMemory", targetType));
+        internal static void ThrowInvalidTypeWithPointersNotSupported(Type targetType) {
+            throw new ArgumentException(Environment.GetResourceString("Argument_InvalidTypeWithPointersNotSupported", targetType));
         }
 
         internal static void ThrowIndexOutOfRangeException() {

--- a/src/mscorlib/src/mscorlib.txt
+++ b/src/mscorlib/src/mscorlib.txt
@@ -631,7 +631,7 @@ Argument_UnrecognizedLoaderOptimization = Unrecognized LOADER_OPTIMIZATION prope
 ArgumentException_NotAllCustomSortingFuncsDefined = Implementations of all the NLS functions must be provided.
 ArgumentException_MinSortingVersion = The runtime does not support a version of "{0}" less than {1}.
 #if FEATURE_SPAN_OF_T
-Argument_InvalidTypeForUnmanagedMemory = '{0}' is reference type or contains pointers and hence can not be stored in unmanaged memory.
+Argument_InvalidTypeWithPointersNotSupported = Cannot use type '{0}'. Only value types without pointers are supported.
 #endif // FEATURE_SPAN_OF_T
 
 

--- a/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
+++ b/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
@@ -115,7 +115,7 @@ class My
         }
         catch (System.ArgumentException ex)
         {
-            AssertTrue(ex.Message == "'ValueTypeWithPointers' is reference type or contains pointers and hence can not be stored in unmanaged memory.",
+            AssertTrue(ex.Message == "Cannot use type 'ValueTypeWithPointers'. Only value types without pointers are supported.",
                 "Exception message is incorrect");
         }
 
@@ -126,7 +126,7 @@ class My
         }
         catch (System.ArgumentException ex)
         {
-            AssertTrue(ex.Message == "'ReferenceType' is reference type or contains pointers and hence can not be stored in unmanaged memory.",
+            AssertTrue(ex.Message == "Cannot use type 'ReferenceType'. Only value types without pointers are supported.",
                 "Exception message is incorrect");
         }
     }
@@ -491,10 +491,41 @@ class My
 
     static void MustNotCastSpanOfValueTypesWithPointers()
     {
-        var source = new Span<ValueTypeWithPointers>(new[] { new ValueTypeWithPointers(new object()) });
+        var spanOfValueTypeWithPointers = new Span<ValueTypeWithPointers>(new[] { new ValueTypeWithPointers(new object()) });
 
-        AssertTrue(source.AsBytes().IsEmpty, "Invalid operation should return empty span");
-        AssertTrue(source.NonPortableCast<ValueTypeWithPointers, byte>().IsEmpty, "Invalid operation should return empty span");
+        try
+        {
+            var impossible = spanOfValueTypeWithPointers.AsBytes();
+            AssertTrue(false, "Expected exception for wrong type not thrown");
+        }
+        catch (System.ArgumentException ex)
+        {
+            AssertTrue(ex.Message == "Cannot use type 'ValueTypeWithPointers'. Only value types without pointers are supported.",
+                "Exception message is incorrect");
+        }
+
+        try
+        {
+            var impossible = spanOfValueTypeWithPointers.NonPortableCast<ValueTypeWithPointers, byte>();
+            AssertTrue(false, "Expected exception for wrong type not thrown");
+        }
+        catch (System.ArgumentException ex)
+        {
+            AssertTrue(ex.Message == "Cannot use type 'ValueTypeWithPointers'. Only value types without pointers are supported.",
+                "Exception message is incorrect");
+        }
+
+        var spanOfBytes = new Span<byte>(new byte[10]);
+        try
+        {
+            var impossible = spanOfBytes.NonPortableCast<byte, ValueTypeWithPointers>();
+            AssertTrue(false, "Expected exception for wrong type not thrown");
+        }
+        catch (System.ArgumentException ex)
+        {
+            AssertTrue(ex.Message == "Cannot use type 'ValueTypeWithPointers'. Only value types without pointers are supported.",
+                "Exception message is incorrect");
+        }
     }
 
     static void IntArraySpanCastedToByteArraySpanHasSameBytesAsOriginalArray()


### PR DESCRIPTION
I took the tests from [corefxlab repo](https://github.com/dotnet/corefxlab/blob/master/tests/System.Slices.Tests/CastTests.cs).

I was not sure what should I do when `T` contains pointers so I decided to follow the corefxlab way: return empty span.

@KrzysztofCwalina @jkotas Please take a look