### PR TITLE
[GDB/JIT]Prevent source line info from being released

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -531,6 +531,8 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
 
     memcpy(elfFile.MemPtr + offset, sectHeaders.MemPtr, sectHeaders.MemSize);
 
+    elfFile.MemPtr.SuppressRelease();
+
 #ifdef GDBJIT_DUMPELF
     DumpElf(methodName, elfFile);
 #endif    


### PR DESCRIPTION
Debug information stored in NewArrayHolder was incorrectly released on function exit, which sometimes lead to undefined behavior. This PR fixes the problem.
@Dmitri-Botcharnikov @lucenticus @noahfalk 