### PR TITLE
Implement indirect VSD calls for x86.

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -865,6 +865,10 @@ public:
 #define GTF_IND_TLS_REF 0x08000000       // GT_IND   -- the target is accessed via TLS
 #define GTF_IND_ASG_LHS 0x04000000       // GT_IND   -- this GT_IND node is (the effective val) of the LHS of an
                                          //             assignment; don't evaluate it independently.
+#define GTF_IND_VSD_TGT GTF_IND_ASG_LHS  // GT_IND   -- this GT_IND node represents the target of an indirect virtual
+                                         //             stub call. This is only valid in the backend, where
+                                         //             GTF_IND_ASG_LHS is not necessary (all such indirections will
+                                         //             be lowered to GT_STOREIND).
 #define GTF_IND_UNALIGNED 0x02000000     // GT_IND   -- the load or store is unaligned (we assume worst case
                                          //             alignment of 1 byte)
 #define GTF_IND_INVARIANT 0x01000000     // GT_IND   -- the target is invariant (a prejit indirection)

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -194,6 +194,10 @@ void LIR::Use::ReplaceWith(Compiler* compiler, GenTree* replacement)
     {
         m_user->ReplaceOperand(m_edge, replacement);
     }
+    else
+    {
+        *m_edge = replacement;
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3140,14 +3140,10 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
     }
 #endif
 
-    // TODO-Cleanup: Disable emitting random NOPs
-
     // This is code to set up an indirect call to a stub address computed
     // via dictionary lookup.
     if (call->gtCallType == CT_INDIRECT)
     {
-        NYI_X86("Virtual Stub dispatched call lowering via dictionary lookup");
-
         // The importer decided we needed a stub call via a computed
         // stub dispatch address, i.e. an address which came from a dictionary lookup.
         //   - The dictionary lookup produces an indirected address, suitable for call

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3156,6 +3156,8 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
         // All we have to do here is add an indirection to generate the actual call target.
 
         GenTree* ind = Ind(call->gtCallAddr);
+        ind->gtFlags |= GTF_IND_VSD_TGT;
+
         BlockRange().InsertAfter(call->gtCallAddr, ind);
         call->gtCallAddr = ind;
     }
@@ -3194,7 +3196,9 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
 #ifndef _TARGET_X86_
             // on x64 we must materialize the target using specific registers.
             addr->gtRegNum  = REG_VIRTUAL_STUB_PARAM;
+
             indir->gtRegNum = REG_JUMP_THUNK_PARAM;
+            indir->gtFlags |= GTF_IND_VSD_TGT;
 #endif
             result = indir;
         }

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1099,7 +1099,7 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
 #ifdef _TARGET_X86_
         // Fast tail calls aren't currently supported on x86, but if they ever are, the code
         // below that handles indirect VSD calls will need to be fixed.
-        assert(!call->IsFastTailCall() || ((call->gtFlags & GTF_CALL_VIRT_KIND_MASK) != GTF_CALL_VIRT_STUB));
+        assert(!call->IsFastTailCall() || !call->IsVirtualStub());
 #endif // _TARGET_X86_
     }
 
@@ -1124,11 +1124,11 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
             //
             // Where EAX is also used as an argument to the stub dispatch helper. Make
             // sure that the call target address is computed into EAX in this case.
-            if (((call->gtFlags & GTF_CALL_VIRT_KIND_MASK) == GTF_CALL_VIRT_STUB) && (call->gtCallType == CT_INDIRECT))
+            if (call->IsVirtualStub() && (call->gtCallType == CT_INDIRECT))
             {
                 assert(ctrlExpr->isIndir());
 
-                ctrlExpr->gtGetOp1()->gtLsraInfo.setDstCandidates(l, RBM_EAX);
+                ctrlExpr->gtGetOp1()->gtLsraInfo.setSrcCandidates(l, REG_VIRTUAL_STUB_TARGET);
                 MakeSrcContained(call, ctrlExpr);
             }
             else

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2789,7 +2789,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
         // *********** END NOTE *********
         CLANG_FORMAT_COMMENT_ANCHOR;
 
-#if !defined(LEGACY_BACKEND) && defined(_TARGET_X86_)
+#if !defined(LEGACY_BACKEND)
+#if defined(_TARGET_X86_)
         // The x86 CORINFO_HELP_INIT_PINVOKE_FRAME helper has a custom calling convention. Set the argument registers
         // correctly here.
         if (call->IsHelperCall(this, CORINFO_HELP_INIT_PINVOKE_FRAME))
@@ -2813,9 +2814,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             assert(arg2 != nullptr);
             nonStandardArgs.Add(arg2, REG_LNGARG_HI);
         }
-#endif // !defined(LEGACY_BACKEND) && defined(_TARGET_X86_)
-
-#if !defined(LEGACY_BACKEND) && !defined(_TARGET_X86_)
+#else // defined(_TARGET_X86_)
         // TODO-X86-CQ: Currently RyuJIT/x86 passes args on the stack, so this is not needed.
         // If/when we change that, the following code needs to be changed to correctly support the (TBD) managed calling
         // convention for x86/SSE.
@@ -2880,11 +2879,12 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
 
             nonStandardArgs.Add(arg, REG_VIRTUAL_STUB_PARAM);
         }
-        else if (call->gtCallType == CT_INDIRECT && call->gtCallCookie)
+        else
+#endif // !defined(_TARGET_X86_)
+        if (call->gtCallType == CT_INDIRECT && call->gtCallCookie)
         {
             assert(!call->IsUnmanaged());
 
-            // put cookie into R11
             GenTree* arg = call->gtCallCookie;
             noway_assert(arg != nullptr);
             call->gtCallCookie = nullptr;
@@ -2892,9 +2892,13 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             call->gtCallArgs = gtNewListNode(arg, call->gtCallArgs);
             numArgs++;
 
+            // x86 passes the cookie on the stack.
+#if !defined(_TARGET_X86_)
+            // put cookie into R11
             nonStandardArgs.Add(arg, REG_PINVOKE_COOKIE_PARAM);
+#endif
 
-            // put destination into R10
+            // put destination into R10/EAX
             arg              = gtClone(call->gtCallAddr, true);
             call->gtCallArgs = gtNewListNode(arg, call->gtCallArgs);
             numArgs++;
@@ -2905,7 +2909,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             call->gtCallType    = CT_HELPER;
             call->gtCallMethHnd = eeFindHelper(CORINFO_HELP_PINVOKE_CALLI);
         }
-#endif // !defined(LEGACY_BACKEND) && !defined(_TARGET_X86_)
+#endif // !defined(LEGACY_BACKEND)
 
         // Allocate the fgArgInfo for the call node;
         //

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2814,7 +2814,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             assert(arg2 != nullptr);
             nonStandardArgs.Add(arg2, REG_LNGARG_HI);
         }
-#else // defined(_TARGET_X86_)
+#else // !defined(_TARGET_X86_)
         // TODO-X86-CQ: Currently RyuJIT/x86 passes args on the stack, so this is not needed.
         // If/when we change that, the following code needs to be changed to correctly support the (TBD) managed calling
         // convention for x86/SSE.
@@ -2880,7 +2880,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             nonStandardArgs.Add(arg, REG_VIRTUAL_STUB_PARAM);
         }
         else
-#endif // !defined(_TARGET_X86_)
+#endif // defined(_TARGET_X86_)
         if (call->gtCallType == CT_INDIRECT && call->gtCallCookie)
         {
             assert(!call->IsUnmanaged());
@@ -2893,10 +2893,12 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             numArgs++;
 
             // x86 passes the cookie on the stack.
+            CLANG_FORMAT_COMMENT_ANCHOR;
+
 #if !defined(_TARGET_X86_)
             // put cookie into R11
             nonStandardArgs.Add(arg, REG_PINVOKE_COOKIE_PARAM);
-#endif
+#endif // !defined(_TARGET_X86_)
 
             // put destination into R10/EAX
             arg              = gtClone(call->gtCallAddr, true);

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -662,6 +662,11 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
             RewriteAddress(use);
             break;
 
+        case GT_IND:
+            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_VSD_TGT`.
+            node->gtFlags &= ~GTF_IND_ASG_LHS;
+            break;
+
         case GT_NOP:
             // fgMorph sometimes inserts NOP nodes between defs and uses
             // supposedly 'to prevent constant folding'. In this case, remove the

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -600,6 +600,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
 
   // VSD target address register
   #define REG_VIRTUAL_STUB_TARGET  REG_EAX
+  #define RBM_VIRTUAL_STUB_TARGET  RBM_EAX
 
   // Registers used by PInvoke frame setup
   #define REG_PINVOKE_FRAME        REG_EDI      // EDI is p/invoke "Frame" pointer argument to CORINFO_HELP_INIT_PINVOKE_FRAME helper

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -598,6 +598,9 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_VIRTUAL_STUB_PARAM   RBM_EAX
   #define PREDICT_REG_VIRTUAL_STUB_PARAM  PREDICT_REG_EAX
 
+  // VSD target address register
+  #define REG_VIRTUAL_STUB_TARGET  REG_EAX
+
   // Registers used by PInvoke frame setup
   #define REG_PINVOKE_FRAME        REG_EDI      // EDI is p/invoke "Frame" pointer argument to CORINFO_HELP_INIT_PINVOKE_FRAME helper
   #define RBM_PINVOKE_FRAME        RBM_EDI

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -585,6 +585,10 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_CALLEE_TRASH_NOGC    RBM_EDX
 #endif // NOGC_WRITE_BARRIERS
 
+  // GenericPInvokeCalliHelper unmanaged target parameter
+  #define REG_PINVOKE_TARGET_PARAM REG_EAX
+  #define RBM_PINVOKE_TARGET_PARAM RBM_EAX
+
   // IL stub's secret parameter (CORJIT_FLG_PUBLISH_SECRET_PARAM)
   #define REG_SECRET_STUB_PARAM    REG_EAX
   #define RBM_SECRET_STUB_PARAM    RBM_EAX


### PR DESCRIPTION
Indirect VSD calls on x86 require not only that the address of the
VSD indirection cell is passed to the stub in EAX, but also that the
call instruction is
a) preceeded by a 3-byte NOP, and
b) exactly `call [eax]`.

On x64, these types of calls only require that the indirection cell
address is passed in R11 (i.e. they do not require the generation of
a specific call instruction encoding). The RyuJIT IR is therefore
able to represent such calls succinctly as something like:

    t72 =    lclVar    ref    V04 loc1         u:3 (last use) $240

           /--*  t72    ref
    t295 = *  putarg_reg ref

    t202 =    lclVar    long   V09 tmp4         u:4 $382

           /--*  t202   long
    t296 = *  putarg_reg long

    t106 =    lclVar    long   V09 tmp4         u:4 (last use) $382

           /--*  t106   long
    t297 = *  indir     long

           /--*  t295   ref    this in rcx
           +--*  t296   long   arg1 in r11
           +--*  t297   long   calli tgt
    t107 = *  call ind stub ref    $24a

In this form, the address of the indirection cell is in the lclVar
`tmp4`, which is then used by both a `putarg_reg` to move the
argument into R11 and by the indirection that generates the call
target. Because there are a relatively large number of registers on
x64, this works out nicely: the address of the indirection cell is
frequently allocated to R11, few extraneous copies are required,
and the code generator produces `call [r11]` for the call instruction.

Unfortunately, the situation is not so straightforward on x86: not
only must the code generator both pass the address of the indirection
cell in EAX and produce the specific call form mentioned earlier,
but there are also far fewer available registers. As a result, the
address of the indirection cell is infrequently allocated to EAX and
(barring an implicit understanding in the code generator that a
previous `putarg_reg` has placed the address of the indirection cell
into EAX) requires a redundant `mov eax, ...` before the call.

Ideally, we would be able to store the address of the indirection cell
to a local with a very short lifetime and pre-allocate that local to
EAX, but the IR does not have that capability, and adding it now
seems to be prohibitively expensive. Instead, this change omits the
`putarg_reg` used to put the the indirection cell address into the
required register on other platforms and simply uses the `calli tgt`
operand to the call to represent both the non-standard argument and
the call target:

    t40 =    lclVar    ref    V04 loc1         u:3 $1c0

           /--*  t40    ref
    t280 = *  putarg_reg ref

    t70 =    lclVar    int    V06 loc3         u:4 (last use) $2c1

           /--*  t70    int
    t281 = *  indir     int

           /--*  t280   ref    this in ecx
           +--*  t281   int    calli tgt
    t71 = *  call ind stub ref    $1c6

Lowering then marks the indirection as contained and sets the
destination candidates for its operand to EAX.

Fixes #4186.