### PR TITLE
X86 GcEncode: Support V1 and V2 encodings

### DIFF
--- a/src/inc/gcdecoder.cpp
+++ b/src/inc/gcdecoder.cpp
@@ -92,12 +92,11 @@ PTR_CBYTE FASTCALL decodeHeader(PTR_CBYTE table, UINT32 version, InfoHdr* header
 
     BYTE nextByte = *table++;
     BYTE encoding = nextByte & 0x7f;
-    const BYTE maskHaveMoreBytesBit = MORE_BYTES_TO_FOLLOW - 1;
     GetInfoHdr(encoding, header);
     while (nextByte & MORE_BYTES_TO_FOLLOW)
     {
         nextByte = *table++;
-        encoding = nextByte & maskHaveMoreBytesBit;
+        encoding = nextByte & ADJ_ENCODING_MAX;
         // encoding here always corresponds to codes in InfoHdrAdjust set
 
         if (encoding < NEXT_FOUR_START)
@@ -199,7 +198,7 @@ PTR_CBYTE FASTCALL decodeHeader(PTR_CBYTE table, UINT32 version, InfoHdr* header
             case NEXT_OPCODE:
                 _ASSERTE((nextByte & MORE_BYTES_TO_FOLLOW) && "Must have another code");
                 nextByte = *table++;
-                encoding = nextByte & maskHaveMoreBytesBit;
+                encoding = nextByte & ADJ_ENCODING_MAX;
                 // encoding here always corresponds to codes in InfoHdrAdjust2 set
 
                 if (encoding < SET_RET_KIND_MAX)

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -378,6 +378,8 @@ enum infoHdrAdjustConstants {
     SET_EPILOGCNT_MAX = 4,
     SET_UNTRACKED_MAX = 3,
     SET_RET_KIND_MAX = 4,   // 2 bits for ReturnKind
+    ADJ_ENCODING_MAX = 0x7f, // Maximum valid encoding in a byte
+                             // Also used to mask off next bit from each encoding byte.
     MORE_BYTES_TO_FOLLOW = 0x80 // If the High-bit of a header or adjustment byte 
                                // is set, then there are more adjustments to follow.
 };


### PR DESCRIPTION
The RYU+LegacyBackend Desktop JIT for X86 is still on V1.
So, permit both V1 and V2 encodings in gcencode.cpp.