### PR TITLE
Add Math.Clamp methods

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3579,6 +3579,17 @@
       <Member Name="BigMul(System.Int32,System.Int32)" />
       <Member Name="Ceiling(System.Decimal)"  />
       <Member Name="Ceiling(System.Double)"/>
+      <Member Name="Clamp(System.Byte,System.Byte,System.Byte)" />
+      <Member Name="Clamp(System.Decimal,System.Decimal,System.Decimal)" />
+      <Member Name="Clamp(System.Double,System.Double,System.Double)" />
+      <Member Name="Clamp(System.Int16,System.Int16,System.Int16)" />
+      <Member Name="Clamp(System.Int32,System.Int32,System.Int32)" />
+      <Member Name="Clamp(System.Int64,System.Int64,System.Int64)" />
+      <Member Name="Clamp(System.SByte,System.SByte,System.SByte)" />
+      <Member Name="Clamp(System.Single,System.Single,System.Single)" />
+      <Member Name="Clamp(System.UInt16,System.UInt16,System.UInt16)" />
+      <Member Name="Clamp(System.UInt32,System.UInt32,System.UInt32)" />
+      <Member Name="Clamp(System.UInt64,System.UInt64,System.UInt64)" />
       <Member Name="Cos(System.Double)" />
       <Member Name="Cosh(System.Double)" />
       <Member Name="DivRem(System.Int32,System.Int32,System.Int32@)" />

--- a/src/mscorlib/src/System/Math.cs
+++ b/src/mscorlib/src/System/Math.cs
@@ -616,7 +616,7 @@ namespace System {
             return value;
         }
 
-        private static void ThrowMinMaxException(object min, object max)
+        private static void ThrowMinMaxException<T>(T min, T max)
         {
             throw new ArgumentException(Environment.GetResourceString("Argument_MinMaxValue", min, max));
         }

--- a/src/mscorlib/src/System/Math.cs
+++ b/src/mscorlib/src/System/Math.cs
@@ -476,7 +476,151 @@ namespace System {
       public static Decimal Min(Decimal val1, Decimal val2) {
         return Decimal.Min(val1,val2);
       }
-    
+
+        /*=====================================Clamp====================================
+        **
+        ==============================================================================*/
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Byte Clamp(Byte value, Byte min, Byte max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Decimal Clamp(Decimal value, Decimal min, Decimal max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Double Clamp(Double value, Double min, Double max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Int16 Clamp(Int16 value, Int16 min, Int16 max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Int32 Clamp(Int32 value, Int32 min, Int32 max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Int64 Clamp(Int64 value, Int64 min, Int64 max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static SByte Clamp(SByte value, SByte min, SByte max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Single Clamp(Single value, Single min, Single max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static UInt16 Clamp(UInt16 value, UInt16 min, UInt16 max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static UInt32 Clamp(UInt32 value, UInt32 min, UInt32 max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static UInt64 Clamp(UInt64 value, UInt64 min, UInt64 max)
+        {
+            if (min > max)
+                ThrowMinMaxException(min, max);
+            if (value < min)
+                return min;
+            else if (value > max)
+                return max;
+            return value;
+        }
+
+        private static void ThrowMinMaxException(object min, object max)
+        {
+            throw new ArgumentException(Environment.GetResourceString("Argument_MinMaxValue", min, max));
+        }
+
       /*=====================================Log======================================
       **
       ==============================================================================*/


### PR DESCRIPTION
## Open Questions
- Argument validation: should we check and enforce that max > min? Would this have a negative perf impact (that the old MaxMin approach didn't have)
- Double and Single: currently, any NaN argument means that NaN is returned - the clamp implementation in VC++ is undefined for NaN btw
- MathMin: I decided to implement Clamp without `Math.Max(Math.Min(value, max), min)` as I was unsure whether the JIT would inline these method calls (plus the code reads more easily IMO)
- Have I exposed the new APIs in the right place(model.xml)?

dotnet/corefx#467

/cc @sgtfrankieboy @weshaggard @mellinoe @mikedn