### PR TITLE
Exposing Type.GetTypeFromHandleUnsafe from model.xml

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -8476,7 +8476,7 @@
       <Member Name="GetTypeFromCLSID(System.Guid,System.String)" />
       <Member Name="GetTypeFromCLSID(System.Guid,System.String,System.Boolean)" />
       <Member Name="GetTypeFromHandle(System.RuntimeTypeHandle)" />
-      <Member Name="GetTypeFromHandleUnsafe(System.IntPtr)" />
+      <Member Status="ImplRoot" Name="GetTypeFromHandleUnsafe(System.IntPtr)" /> <!-- Used by System.Linq.Expressions tests -->
       <Member Name="GetTypeFromProgID(System.String)" />
       <Member Name="GetTypeFromProgID(System.String,System.Boolean)" />
       <Member Name="GetTypeFromProgID(System.String,System.String)" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -8476,6 +8476,7 @@
       <Member Name="GetTypeFromCLSID(System.Guid,System.String)" />
       <Member Name="GetTypeFromCLSID(System.Guid,System.String,System.Boolean)" />
       <Member Name="GetTypeFromHandle(System.RuntimeTypeHandle)" />
+      <Member Name="GetTypeFromHandleUnsafe(System.IntPtr)" />
       <Member Name="GetTypeFromProgID(System.String)" />
       <Member Name="GetTypeFromProgID(System.String,System.Boolean)" />
       <Member Name="GetTypeFromProgID(System.String,System.String)" />


### PR DESCRIPTION
This addresses issue #7248. See the issue for more context on the need for this addition. CC @jkotas.