### PR TITLE
Add option for showing GT_xxx operator counts.

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -870,6 +870,10 @@ inline GenTree::GenTree(genTreeOps oper, var_types type DEBUGARG(bool largeNode)
 #endif
 #endif
 
+#if COUNT_AST_OPERS
+    InterlockedIncrement(&s_gtNodeCounts[oper]);
+#endif
+
 #ifdef DEBUG
     gtSeqNum = 0;
     gtTreeID = JitTls::GetCompiler()->compGenTreeID++;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -222,7 +222,7 @@ const char* GenTree::NodeName(genTreeOps op)
 
 #endif
 
-#if defined(DEBUG) || NODEBASH_STATS
+#if defined(DEBUG) || NODEBASH_STATS || COUNT_AST_OPERS
 
 static const char* opNames[] = {
 #define GTNODE(en, sn, st, cm, ok) #en,
@@ -251,7 +251,7 @@ const char* GenTree::OpName(genTreeOps op)
 /* static */
 unsigned char GenTree::s_gtNodeSizes[GT_COUNT + 1];
 
-#if NODEBASH_STATS
+#if NODEBASH_STATS || COUNT_AST_OPERS
 
 unsigned char GenTree::s_gtTrueSizes[GT_COUNT+1]
 {
@@ -259,7 +259,11 @@ unsigned char GenTree::s_gtTrueSizes[GT_COUNT+1]
     #include "gtlist.h"
 };
 
-#endif//NODEBASH_STATS
+#endif // NODEBASH_STATS || COUNT_AST_OPERS
+
+#if COUNT_AST_OPERS
+LONG GenTree::s_gtNodeCounts[GT_COUNT+1] = {0};
+#endif // COUNT_AST_OPERS
 
 /* static */
 void GenTree::InitNodeSize()

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1540,11 +1540,13 @@ public:
 public:
 #if SMALL_TREE_NODES
     static unsigned char s_gtNodeSizes[];
-#if NODEBASH_STATS
+#if NODEBASH_STATS || COUNT_AST_OPERS
     static unsigned char s_gtTrueSizes[];
-    static const char*   s_gtNodeRawNames[];
 #endif
+#if COUNT_AST_OPERS
+    static LONG s_gtNodeCounts[];
 #endif
+#endif // SMALL_TREE_NODES
 
     static void InitNodeSize();
 
@@ -1568,7 +1570,7 @@ public:
     static const char* NodeName(genTreeOps op);
 #endif
 
-#if defined(DEBUG) || NODEBASH_STATS
+#if defined(DEBUG) || NODEBASH_STATS || COUNT_AST_OPERS
     static const char* OpName(genTreeOps op);
 #endif
 

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -466,6 +466,7 @@ typedef ptrdiff_t ssize_t;
 #define MEASURE_PTRTAB_SIZE 0 // Collect stats about GC pointer table allocations.
 #define EMITTER_STATS 0       // Collect stats on the emitter.
 #define NODEBASH_STATS 0      // Collect stats on changed gtOper values in GenTree's.
+#define COUNT_AST_OPERS 0     // Display use counts for GenTree operators.
 
 #define VERBOSE_SIZES 0       // Always display GC info sizes. If set, DISPLAY_SIZES must also be set.
 #define VERBOSE_VERIFY 0      // Dump additional information when verifying code. Useful to debug verification bugs.


### PR DESCRIPTION
Enable "COUNT_AST_OPERS" in jit.h to get the output below (the example is from ASP.NET / MusicStore).

PTAL ... @pgavlin @BruceForstall @CarolEidt
/cc @dotnet/jit-contrib

```
GenTree operator counts (approximate):

    GT_LCL_VAR              130511 (17.7%)  80 bytes each
    GT_RET_EXPR               4497 ( 0.6%)  72 bytes each
    GT_CNS_INT               67868 ( 9.2%)  80 bytes each
    GT_NOP                   10421 ( 1.4%)  56 bytes each
    GT_ARR_LENGTH             3820 ( 0.5%)  72 bytes each
    GT_CAST                   5623 ( 0.8%)  80 bytes each
    GT_ADDR                  12450 ( 1.7%)  72 bytes each
    GT_IND                   14414 ( 2.0%)  72 bytes each
    GT_STOREIND               6624 ( 0.9%)  80 bytes each
    GT_ADD                   35041 ( 4.8%)  72 bytes each
    GT_ASG                   47145 ( 6.4%)  72 bytes each
    GT_EQ                     4179 ( 0.6%)  72 bytes each
    GT_NE                     4946 ( 0.7%)  72 bytes each
    GT_COMMA                  9311 ( 1.3%)  72 bytes each
    GT_LEA                   29109 ( 3.9%)  80 bytes each
    GT_JTRUE                 10412 ( 1.4%)  72 bytes each
    GT_LIST                  79883 (10.8%)  72 bytes each
    GT_FIELD                 25498 ( 3.5%)  96 bytes each
    GT_CALL                  25396 ( 3.4%) 152 bytes each
    GT_BEG_STMTS             28349 ( 3.8%)  56 bytes each
    GT_STMT                  67424 ( 9.1%)  88 bytes each
    GT_RETURN                 4674 ( 0.6%)  72 bytes each
    GT_PHI                    4830 ( 0.7%)  72 bytes each
    GT_PHI_ARG               12166 ( 1.6%)  80 bytes each
    GT_ARGPLACE              30033 ( 4.1%)  64 bytes each
    GT_PUTARG_REG            31697 ( 4.3%)  72 bytes each
    All other GT_xxx ...     31039 ( 4.2%) ...  3.7% small +  0.5% large
    -----------------------------------------------------
    Total    .......        737360 --ALL-- ... 92.6% small +  7.4% large

```