### PR TITLE
Allow enums defined by RefEmit to actually set IntPtr and UIntPtr values

### DIFF
--- a/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -470,7 +470,30 @@ namespace System.Reflection.Emit {
                         fixed (byte* pData = &JitHelpers.GetPinningHelper(value).m_data)
                             SetConstantValue(module.GetNativeHandle(), tk, (int)corType, pData);
                         break;
-
+                    case CorElementType.I:
+                        if (IntPtr.Size == 8)
+                        {
+                            long longRepresentation = ((IntPtr)value).ToInt64();
+                            SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.I8, &longRepresentation);
+                        }
+                        else
+                        {
+                            int intRepresentation = ((IntPtr)value).ToInt32();
+                            SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.I4, &intRepresentation);
+                        }
+                        break;
+                    case CorElementType.U:
+                        if (UIntPtr.Size == 8)
+                        {
+                            ulong ulongRepresentation = ((UIntPtr)value).ToUInt64();
+                            SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.U8, &ulongRepresentation);
+                        }
+                        else
+                        {
+                            uint uintRepresentation = ((UIntPtr)value).ToUInt32();
+                            SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.U8, &uintRepresentation);
+                        }
+                        break;
                     default:
                         if (type == typeof(String))
                         {

--- a/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -471,28 +471,12 @@ namespace System.Reflection.Emit {
                             SetConstantValue(module.GetNativeHandle(), tk, (int)corType, pData);
                         break;
                     case CorElementType.I:
-                        if (IntPtr.Size == 8)
-                        {
-                            long longRepresentation = ((IntPtr)value).ToInt64();
-                            SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.I8, &longRepresentation);
-                        }
-                        else
-                        {
-                            int intRepresentation = ((IntPtr)value).ToInt32();
-                            SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.I4, &intRepresentation);
-                        }
+                        long longRepresentation = ((IntPtr)value).ToInt64();
+                        SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.I8, &longRepresentation);
                         break;
                     case CorElementType.U:
-                        if (UIntPtr.Size == 8)
-                        {
-                            ulong ulongRepresentation = ((UIntPtr)value).ToUInt64();
-                            SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.U8, &ulongRepresentation);
-                        }
-                        else
-                        {
-                            uint uintRepresentation = ((UIntPtr)value).ToUInt32();
-                            SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.U8, &uintRepresentation);
-                        }
+                        ulong ulongRepresentation = ((UIntPtr)value).ToUInt64();
+                        SetConstantValue(module.GetNativeHandle(), tk, (int)CorElementType.U8, &ulongRepresentation);
                         break;
                     default:
                         if (type == typeof(String))


### PR DESCRIPTION
This is a request for comments on what you all think about the implementation (not on the merits/demerits of IntPtr and UIntPtr enums ;) ).
Currently, coreclr supports defining enums of IntPtr and UIntPtr. However, trying to define a value for that enum, an ArgumentException is thrown, as IntPtr and UIntPtr constants are not supported.

We can, however, convert IntPtr and UIntPtr explicitly into int/long/uint/ulong depending on the architecture.

The following code now works
```
AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.Run);
ModuleBuilder module = assembly.DefineDynamicModule("Name");

EnumBuilder enumBuilder = module.DefineEnum("TestName", TypeAttributes.Public, typeof(IntPtr));
FieldBuilder field1 = enumBuilder.DefineLiteral("Value1", (IntPtr)1);

Type t = enumBuilder.CreateTypeInfo().AsType();

string[] names = Enum.GetNames(t);
Console.WriteLine(names[0]); // Prints: "Value1"

Array values = Enum.GetValues(t);
Enum value = (Enum)values.GetValue(0);
Console.WriteLine(value.ToString("D")); // Prints: "1"
``` 

This starts to make the feature of supporting IntPtr and UIntPtr enums actually useful!

### Open questions:
I'm no computer architecture expert, but something tells me I might be doing something wrong that has side effects.

- What happens if an x86 program uses x64 mscorlib or vice versa (is this even possible)?
- Is the above mitigated by using IntPtr.Size?

I'm going to tag @jkotas for discussion, or to help me triage this PR (thanks!), as well as @mikedn (I forsee some useful honest criticism!)