### PR TITLE
Respect JitNoRangeChks flag in RyuJit

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -493,7 +493,7 @@ CONFIG_DWORD_INFO_EX(INTERNAL_JitNoStructPromotion, W("JitNoStructPromotion"), 0
 CONFIG_DWORD_INFO_EX(INTERNAL_JitNoUnroll, W("JitNoUnroll"), 0, "", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_JitNoMemoryBarriers, W("JitNoMemoryBarriers"), 0, "If 1, don't generate memory barriers", CLRConfig::REGUTIL_default)
 #ifdef FEATURE_ENABLE_NO_RANGE_CHECKS
-RETAIL_CONFIG_DWORD_INFO(PRIVATE_JitNoRangeChks, W("JitNoRngChks"), 0, "If 1, don't generate range checks")
+RETAIL_CONFIG_DWORD_INFO_EX(PRIVATE_JitNoRangeChks, W("JitNoRngChks"), 0, "If 1, don't generate range checks", CLRConfig::REGUTIL_default)
 #endif
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(EXTERNAL_JitOptimizeType, W("JitOptimizeType"), "")
 CONFIG_DWORD_INFO_EX(INTERNAL_JitOrder, W("JitOrder"), 0, "", CLRConfig::REGUTIL_default)

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -3700,6 +3700,21 @@ GenTreePtr Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, const
 
     assert(tree->gtOper == GT_ARR_BOUNDS_CHECK);
 
+#ifdef FEATURE_ENABLE_NO_RANGE_CHECKS
+	if (JitConfig.JitNoRangeChks())
+	{
+#ifdef DEBUG
+		if (verbose)
+		{
+			printf("\nFlagging check redundant due to JitNoRangeChks in BB%02u:\n", compCurBB->bbNum);
+			gtDispTree(tree, nullptr, nullptr, true);
+		}
+#endif // DEBUG
+		tree->gtFlags |= GTF_ARR_BOUND_INBND;
+		return nullptr;
+	}
+#endif // FEATURE_ENABLE_NO_RANGE_CHECKS
+
     BitVecOps::Iter iter(apTraits, assertions);
     unsigned        index = 0;
     while (iter.NextElem(apTraits, &index))

--- a/src/jit/jitconfig.h
+++ b/src/jit/jitconfig.h
@@ -5,6 +5,8 @@
 #ifndef _JITCONFIG_H_
 #define _JITCONFIG_H_
 
+#include "switches.h"
+
 struct CORINFO_SIG_INFO;
 class ICorJitHost;
 

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -92,6 +92,9 @@ CONFIG_INTEGER(JitNoMemoryBarriers, W("JitNoMemoryBarriers"), 0) // If 1, don't 
 CONFIG_INTEGER(JitNoRegLoc, W("JitNoRegLoc"), 0)
 CONFIG_INTEGER(JitNoStructPromotion, W("JitNoStructPromotion"), 0) // Disables struct promotion in Jit32
 CONFIG_INTEGER(JitNoUnroll, W("JitNoUnroll"), 0)
+#ifdef FEATURE_ENABLE_NO_RANGE_CHECKS
+CONFIG_INTEGER(JitNoRangeChks, W("JitNoRngChks"), 0) // If 1, don't generate range checks
+#endif
 CONFIG_INTEGER(JitOrder, W("JitOrder"), 0)
 CONFIG_INTEGER(JitPInvokeCheckEnabled, W("JITPInvokeCheckEnabled"), 0)
 CONFIG_INTEGER(JitPInvokeEnabled, W("JITPInvokeEnabled"), 1)


### PR DESCRIPTION
Honor this config flag by having assertion prop treat all bounds check
nodes as redundant when it is set.

Also change the flag's lookup options to `REGUTIL_default` to match the
rest of the jit-focused flags.

Note that support for this flag is conditional on having the preprocessor
flag `FEATURE_ENABLE_NO_RANGE_CHECKS` defined, which requires a custom
build with line 199 of inc/switches.h un-commented (or with compile flags
altered to include `-DFEATURE_ENABLE_NO_RANGE_CHECKS`) -- the purpose of
the flag is to facilitate experiments to estimate the cumulative cost of
bounds checking in various workloads.