### PR TITLE
 Support Lower to reserve internal register(s) different from targetReg.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4689,22 +4689,22 @@ void CodeGen::genCodeForArrOffset(GenTreeArrOffs* arrOffset)
     GenTreePtr arrObj     = arrOffset->gtArrObj;
 
     regNumber tgtReg = arrOffset->gtRegNum;
-
-    noway_assert(tgtReg != REG_NA);
+    assert(tgtReg != REG_NA);
 
     unsigned  dim      = arrOffset->gtCurrDim;
     unsigned  rank     = arrOffset->gtArrRank;
     var_types elemType = arrOffset->gtArrElemType;
 
-    // We will use a temp register for the offset*scale+effectiveIndex computation.
-    regMaskTP tmpRegMask = arrOffset->gtRsvdRegs;
-    regNumber tmpReg     = genRegNumFromMask(tmpRegMask);
-
     // First, consume the operands in the correct order.
     regNumber offsetReg = REG_NA;
+    regNumber tmpReg    = REG_NA;
     if (!offsetNode->IsIntegralConst(0))
     {
         offsetReg = genConsumeReg(offsetNode);
+
+        // We will use a temp register for the offset*scale+effectiveIndex computation.
+        regMaskTP tmpRegMask = arrOffset->gtRsvdRegs;
+        tmpReg               = genRegNumFromMask(tmpRegMask);
     }
     else
     {
@@ -4725,6 +4725,9 @@ void CodeGen::genCodeForArrOffset(GenTreeArrOffs* arrOffset)
 
     if (!offsetNode->IsIntegralConst(0))
     {
+        assert(tmpReg != REG_NA);
+        assert(arrReg != REG_NA);
+
         // Evaluate tgtReg = offsetReg*dim_size + indexReg.
         // tmpReg is used to load dim_size and the result of the multiplication.
         // Note that dim_size will never be negative.

--- a/src/jit/nodeinfo.h
+++ b/src/jit/nodeinfo.h
@@ -21,17 +21,18 @@ public:
         _internalIntCount   = 0;
         _internalFloatCount = 0;
 
-        srcCandsIndex         = 0;
-        dstCandsIndex         = 0;
-        internalCandsIndex    = 0;
-        isLocalDefUse         = false;
-        isHelperCallWithKills = false;
-        isLsraAdded           = false;
-        isDelayFree           = false;
-        hasDelayFreeSrc       = false;
-        isTgtPref             = false;
-        regOptional           = false;
-        definesAnyRegisters   = false;
+        srcCandsIndex          = 0;
+        dstCandsIndex          = 0;
+        internalCandsIndex     = 0;
+        isLocalDefUse          = false;
+        isHelperCallWithKills  = false;
+        isLsraAdded            = false;
+        isDelayFree            = false;
+        hasDelayFreeSrc        = false;
+        isTgtPref              = false;
+        regOptional            = false;
+        definesAnyRegisters    = false;
+        isInternalRegDelayFree = false;
 #ifdef DEBUG
         isInitialized = false;
 #endif
@@ -99,41 +100,53 @@ public:
 
     LsraLocation loc;
 
-private:
-    unsigned char _dstCount;
-    unsigned char _srcCount;
-    unsigned char _internalIntCount;
-    unsigned char _internalFloatCount;
-
 public:
     unsigned char srcCandsIndex;
     unsigned char dstCandsIndex;
     unsigned char internalCandsIndex;
 
+private:
+    unsigned char _srcCount : 5;
+    unsigned char _dstCount : 3;
+    unsigned char _internalIntCount : 3;
+    unsigned char _internalFloatCount : 3;
+
+public:
     // isLocalDefUse identifies trees that produce a value that is not consumed elsewhere.
     // Examples include stack arguments to a call (they are immediately stored), lhs of comma
     // nodes, or top-level nodes that are non-void.
     unsigned char isLocalDefUse : 1;
+
     // isHelperCallWithKills is set when this is a helper call that kills more than just its in/out regs.
     unsigned char isHelperCallWithKills : 1;
+
     // Is this node added by LSRA, e.g. as a resolution or copy/reload move.
     unsigned char isLsraAdded : 1;
+
     // isDelayFree is set when the register defined by this node will interfere with the destination
     // of the consuming node, and therefore it must not be freed immediately after use.
     unsigned char isDelayFree : 1;
+
     // hasDelayFreeSrc is set when this node has sources that are marked "isDelayFree".  This is because,
     // we may eventually "contain" this node, in which case we don't want it's children (which have
     // already been marked "isDelayFree" to be handled that way when allocating.
     unsigned char hasDelayFreeSrc : 1;
+
     // isTgtPref is set to true when we have a rmw op, where we would like the result to be allocated
     // in the same register as op1.
     unsigned char isTgtPref : 1;
+
     // Whether a spilled second src can be treated as a contained operand
     unsigned char regOptional : 1;
+
     // Whether or not a node defines any registers, whether directly (for nodes where dstCout is non-zero)
     // or indirectly (for contained nodes, which propagate the transitive closure of the registers
     // defined by their inputs). Used during buildRefPositionsForNode in order to avoid unnecessary work.
     unsigned char definesAnyRegisters : 1;
+
+    // Whether internal register needs to be different from targetReg
+    // in which result is produced.
+    unsigned char isInternalRegDelayFree : 1;
 
 #ifdef DEBUG
     // isInitialized is set when the tree node is handled.

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -1282,24 +1282,9 @@ void CodeGen::genSIMDIntrinsicDotProduct(GenTreeSIMD* simdNode)
     if ((compiler->getSIMDInstructionSet() == InstructionSet_SSE2) || (simdEvalType == TYP_SIMD32))
     {
         assert(simdNode->gtRsvdRegs != RBM_NONE);
-        assert(genCountBits(simdNode->gtRsvdRegs) == 2);
+        assert(genCountBits(simdNode->gtRsvdRegs) == 1);
 
-        regMaskTP tmpRegsMask = simdNode->gtRsvdRegs;
-        regMaskTP tmpReg1Mask = genFindLowestBit(tmpRegsMask);
-        tmpRegsMask &= ~tmpReg1Mask;
-        regNumber tmpReg1 = genRegNumFromMask(tmpReg1Mask);
-        regNumber tmpReg2 = genRegNumFromMask(tmpRegsMask);
-
-        // Choose any register different from targetReg as tmpReg
-        if (tmpReg1 != targetReg)
-        {
-            tmpReg = tmpReg1;
-        }
-        else
-        {
-            assert(targetReg != tmpReg2);
-            tmpReg = tmpReg2;
-        }
+        tmpReg = genRegNumFromMask(simdNode->gtRsvdRegs);
         assert(tmpReg != REG_NA);
         assert(tmpReg != targetReg);
     }
@@ -1838,26 +1823,9 @@ void CodeGen::genLoadIndTypeSIMD12(GenTree* treeNode)
 
     // Need an addtional Xmm register to read upper 4 bytes, which is different from targetReg
     assert(treeNode->gtRsvdRegs != RBM_NONE);
-    assert(genCountBits(treeNode->gtRsvdRegs) == 2);
+    assert(genCountBits(treeNode->gtRsvdRegs) == 1);
 
-    regNumber tmpReg      = REG_NA;
-    regMaskTP tmpRegsMask = treeNode->gtRsvdRegs;
-    regMaskTP tmpReg1Mask = genFindLowestBit(tmpRegsMask);
-    tmpRegsMask &= ~tmpReg1Mask;
-    regNumber tmpReg1 = genRegNumFromMask(tmpReg1Mask);
-    regNumber tmpReg2 = genRegNumFromMask(tmpRegsMask);
-
-    // Choose any register different from targetReg as tmpReg
-    if (tmpReg1 != targetReg)
-    {
-        tmpReg = tmpReg1;
-    }
-    else
-    {
-        assert(targetReg != tmpReg2);
-        tmpReg = tmpReg2;
-    }
-    assert(tmpReg != REG_NA);
+    regNumber tmpReg = genRegNumFromMask(treeNode->gtRsvdRegs);
     assert(tmpReg != targetReg);
 
     // Load upper 4 bytes in tmpReg
@@ -1930,28 +1898,12 @@ void CodeGen::genLoadLclFldTypeSIMD12(GenTree* treeNode)
     unsigned  varNum    = treeNode->gtLclVarCommon.gtLclNum;
     assert(varNum < compiler->lvaCount);
 
-    // Need an addtional Xmm register to read upper 4 bytes
+    // Need an addtional Xmm register that is different from
+    // targetReg to read upper 4 bytes.
     assert(treeNode->gtRsvdRegs != RBM_NONE);
-    assert(genCountBits(treeNode->gtRsvdRegs) == 2);
+    assert(genCountBits(treeNode->gtRsvdRegs) == 1);
 
-    regNumber tmpReg      = REG_NA;
-    regMaskTP tmpRegsMask = treeNode->gtRsvdRegs;
-    regMaskTP tmpReg1Mask = genFindLowestBit(tmpRegsMask);
-    tmpRegsMask &= ~tmpReg1Mask;
-    regNumber tmpReg1 = genRegNumFromMask(tmpReg1Mask);
-    regNumber tmpReg2 = genRegNumFromMask(tmpRegsMask);
-
-    // Choose any register different from targetReg as tmpReg
-    if (tmpReg1 != targetReg)
-    {
-        tmpReg = tmpReg1;
-    }
-    else
-    {
-        assert(targetReg != tmpReg2);
-        tmpReg = tmpReg2;
-    }
-    assert(tmpReg != REG_NA);
+    regNumber tmpReg = genRegNumFromMask(treeNode->gtRsvdRegs);
     assert(tmpReg != targetReg);
 
     // Read upper 4 bytes to tmpReg


### PR DESCRIPTION
There are quite a few cases in codegen that need internal registers (float or int).  In some cases, lower/codegen need an internal register(s) to be different from target reg.  To achieve it lower/codegen reserve two internal registers.  The reason is that internal register uses end before the target reg gets defined and hence there is no guarantee that a single internal register requested is different from target reg.   Reserving more registers than required in some cases lead to wasting a register.

These code changes are meant to allow lower/codegen to specify if it needs a register different from target reg while reserving internal registers.  This is achieved by making Use position of internal register to interfere with Def of target Reg by marking Use position as isDelayRegFree=true.

I have made the Lower/Codegen side changes for xarch.  It turns out most of the reg savings are in SIMD codegen paths.  I am going to open a git issue for doing lower/codegen side changes for arm64.

Asm Diffs:
Fx assemblies show no diff as expected.
CqPerf - Ray tracer and one method of SharpChess got impacted. Overall 10 bytes of size win.
SIMD tests - some code size wins and some losses due to additional moves that materialized due to register allocation changing.  Overall a minor 21 bytes of code size loss across all SIMD tests.

Perf Execution numbers:
Raytracer - improved by 3% (Before: 5911 After: 5717)
SharpChess - execution number within noise and remained the same.