### PR TITLE
Fix Issue 7196: No extra internal regs for block nodes

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -8270,7 +8270,7 @@ void LinearScan::resolveRegisters()
             {
                 JITDUMP(" internal");
                 GenTreePtr indNode = nullptr;
-                if (treeNode->OperIsIndir())
+                if (treeNode->OperGet() == GT_IND)
                 {
                     indNode = treeNode;
                     JITDUMP(" allocated at GT_IND");


### PR DESCRIPTION
There is some possibly obsolete code that copies the internal registers
for a GT_IND onto the address node as well. With the struct IR changes,
the block nodes (e.g. GT_STORE_BLK) also return true for OperIsIndir(),
so they were getting the internal registers copied over from their address
node. This led to an assert on Arm64.

Fix #7196