### PR TITLE
Fix Arm64 codegen to use GT_FIELD_LIST

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -5333,7 +5333,7 @@ void CodeGen::genCallInstruction(GenTreePtr node)
             continue;
 
         // Deal with multi register passed struct args.
-        if (argNode->OperGet() == GT_LIST)
+        if (argNode->OperGet() == GT_FIELD_LIST)
         {
             GenTreeArgList* argListPtr   = argNode->AsArgList();
             unsigned        iterationNum = 0;
@@ -6760,7 +6760,7 @@ void CodeGen::genPutArgStk(GenTreePtr treeNode)
         varNumOut    = compiler->lvaOutgoingArgSpaceVar;
         argOffsetMax = compiler->lvaOutgoingArgSpaceSize;
     }
-    bool isStruct = (targetType == TYP_STRUCT) || (source->OperGet() == GT_LIST);
+    bool isStruct = (targetType == TYP_STRUCT) || (source->OperGet() == GT_FIELD_LIST);
 
     if (!isStruct) // a normal non-Struct argument
     {


### PR DESCRIPTION
In #7252 changing GT_LIST to GT_FIELD_LIST when passing struct fields,
I omitted some required changes to codegenarm64.cpp. This caused the
crossgen of System.Private.CoreLib.dll to fail.