### PR TITLE
added implicit cast operator from ArraySegment to Spans

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -12066,6 +12066,7 @@
       <Member Name="#ctor(T[],System.Int32,System.Int32)" />
       <Member Name="#ctor(System.Void*,System.Int32)" />
       <Member Name="op_Implicit(T[])" ReturnType="System.Span&lt;T&gt;" />
+      <Member Name="op_Implicit(System.ArraySegment&lt;T&gt;)" ReturnType="System.Span&lt;T&gt;" />
       <Member Name="get_Length" />
       <Member Name="get_Empty" />
       <Member Name="get_IsEmpty" />
@@ -12084,6 +12085,7 @@
       <Member Name="#ctor(System.Void*,System.Int32)" />
       <Member Name="op_Implicit(System.Span&lt;T&gt;)" ReturnType="System.ReadOnlySpan&lt;T&gt;" />
       <Member Name="op_Implicit(T[])" ReturnType="System.ReadOnlySpan&lt;T&gt;" />
+      <Member Name="op_Implicit(System.ArraySegment&lt;T&gt;)" ReturnType="System.ReadOnlySpan&lt;T&gt;" />
       <Member Name="get_Length" />
       <Member Name="get_Empty" />
       <Member Name="get_IsEmpty" />

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -28,9 +28,9 @@ namespace System
     [Serializable]
     public struct ArraySegment<T> : IList<T>, IReadOnlyList<T>
     {
-        internal T[] _array;
-        internal int _offset;
-        internal int _count;
+        private T[] _array;
+        private int _offset;
+        private int _count;
         
         public ArraySegment(T[] array)
         {

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -28,9 +28,9 @@ namespace System
     [Serializable]
     public struct ArraySegment<T> : IList<T>, IReadOnlyList<T>
     {
-        private T[] _array;
-        private int _offset;
-        private int _count;
+        internal T[] _array;
+        internal int _offset;
+        internal int _count;
         
         public ArraySegment(T[] array)
         {

--- a/src/mscorlib/src/System/ReadOnlySpan.cs
+++ b/src/mscorlib/src/System/ReadOnlySpan.cs
@@ -104,6 +104,11 @@ namespace System
             return new ReadOnlySpan<T>(array);
         }
 
+        public static implicit operator ReadOnlySpan<T>(ArraySegment<T> arraySegment)
+        {
+            return new ReadOnlySpan<T>(arraySegment._array, arraySegment._offset, arraySegment._count);
+        }
+
         public int Length
         {
             get { return _length; }

--- a/src/mscorlib/src/System/ReadOnlySpan.cs
+++ b/src/mscorlib/src/System/ReadOnlySpan.cs
@@ -106,7 +106,7 @@ namespace System
 
         public static implicit operator ReadOnlySpan<T>(ArraySegment<T> arraySegment)
         {
-            return new ReadOnlySpan<T>(arraySegment._array, arraySegment._offset, arraySegment._count);
+            return new ReadOnlySpan<T>(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
         }
 
         public int Length

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -109,6 +109,11 @@ namespace System
             return new Span<T>(array);
         }
 
+        public static implicit operator Span<T>(ArraySegment<T> arraySegment)
+        {
+            return new Span<T>(arraySegment._array, arraySegment._offset, arraySegment._count);
+        }
+
         public int Length
         {
             get { return _length; }

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -111,7 +111,7 @@ namespace System
 
         public static implicit operator Span<T>(ArraySegment<T> arraySegment)
         {
-            return new Span<T>(arraySegment._array, arraySegment._offset, arraySegment._count);
+            return new Span<T>(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
         }
 
         public int Length


### PR DESCRIPTION
[Discussion](https://github.com/dotnet/corefxlab/issues/832), [corefxlab PR](https://github.com/dotnet/corefxlab/pull/833)

I did not use public getter's of ArraySegment (Array, Offset, Count) because they contain code contracts that would be duplicated by the constructors of Spans. Moreover the ctor of Span is more demanding because it additionaly checks for covariance. That's why I decided to avoid double checks and made the fields of ArraySegment internal. 

@jkotas @KrzysztofCwalina 