### PR TITLE
Generate CrossGen Pdbs as part of bulid

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -40,7 +40,7 @@
     <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)mscorrc.dll" />
     <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)sos.dll" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />

--- a/src/zap/zapheaders.cpp
+++ b/src/zap/zapheaders.cpp
@@ -288,16 +288,47 @@ void ZapDebugDirectory::Save(ZapWriter * pZapWriter)
     _ASSERTE(pZapWriter);
 
     if (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_NGenEnableCreatePdb)) {
-
         SaveOriginalDebugDirectoryEntry(pZapWriter);
         SaveNGenDebugDirectoryEntry(pZapWriter);
-
     } else {
-
         SaveNGenDebugDirectoryEntry(pZapWriter);
         SaveOriginalDebugDirectoryEntry(pZapWriter);
-
     }
+}
+
+ZapPEExports::ZapPEExports(LPCWSTR dllPath) 
+{
+	m_dllFileName = wcsrchr(dllPath, '\\');
+	if (m_dllFileName != NULL)
+		m_dllFileName++;
+	else 
+		m_dllFileName = dllPath;
+}
+
+DWORD ZapPEExports::GetSize()
+{
+	return DWORD(sizeof(IMAGE_EXPORT_DIRECTORY) + wcslen(m_dllFileName) + 1);
+}
+
+void ZapPEExports::Save(ZapWriter * pZapWriter)
+{
+	_ASSERTE(pZapWriter);
+
+	IMAGE_EXPORT_DIRECTORY exports;
+	ZeroMemory(&exports, sizeof(exports));
+
+	exports.Name = pZapWriter->GetCurrentRVA() + sizeof(exports);
+
+	// Write out exports header 
+	pZapWriter->Write(&exports, sizeof(exports));
+
+	// Write out string that exports.Name points at.  
+	for (LPCWSTR ptr = m_dllFileName; ; ptr++)
+	{
+		pZapWriter->Write((PVOID) ptr, 1);
+		if (*ptr == 0)
+			break;
+	}
 }
 
 // If the IL image has IMAGE_DIRECTORY_ENTRY_DEBUG with information about the PDB,

--- a/src/zap/zapheaders.cpp
+++ b/src/zap/zapheaders.cpp
@@ -298,7 +298,7 @@ void ZapDebugDirectory::Save(ZapWriter * pZapWriter)
 
 ZapPEExports::ZapPEExports(LPCWSTR dllPath) 
 {
-	m_dllFileName = wcsrchr(dllPath, '\\');
+	m_dllFileName = wcsrchr(dllPath, DIRECTORY_SEPARATOR_CHAR_W);
 	if (m_dllFileName != NULL)
 		m_dllFileName++;
 	else 

--- a/src/zap/zapheaders.h
+++ b/src/zap/zapheaders.h
@@ -269,6 +269,23 @@ public:
 };
 
 //
+// PE Style exports.  Currently can only save an empty list of exports
+// but this is useful because it avoids the DLL being seen as Resource Only
+// (which then causes SymServer to avoid copying its PDB to the cloud).  
+//
+
+class ZapPEExports : public ZapNode
+{
+	LPCWSTR m_dllFileName;	// Just he DLL name without the path.
+
+public:
+	ZapPEExports(LPCWSTR dllPath);
+	virtual DWORD GetSize();
+	virtual UINT GetAlignment() { return sizeof(DWORD);  }
+	virtual void Save(ZapWriter * pZapWriter);
+};
+
+//
 // List of all sections for diagnostic purposes
 
 class ZapVirtualSectionsTable : public ZapNode

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1167,7 +1167,7 @@ HANDLE ZapImage::SaveImage(LPCWSTR wszOutputFileName, CORCOMPILE_NGEN_SIGNATURE 
 	// that native images are resoure-only DLLs.  It is important to NOT
 	// be a resource-only DLL because those DLL's PDBS are not put up on the
 	// symbol server and we want NEN PDBS to be placed there.  
-	ZapPEExports* exports = new ZapPEExports(wszOutputFileName);
+	ZapPEExports* exports = new(GetHeap()) ZapPEExports(wszOutputFileName);
 	m_pDebugSection->Place(exports);
 	SetDirectoryEntry(IMAGE_DIRECTORY_ENTRY_EXPORT, exports);
 

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1163,6 +1163,14 @@ HANDLE ZapImage::SaveImage(LPCWSTR wszOutputFileName, CORCOMPILE_NGEN_SIGNATURE 
 
     OutputTables();
 
+	// Create a empty export table.  This makes tools like symchk not think
+	// that native images are resoure-only DLLs.  It is important to NOT
+	// be a resource-only DLL because those DLL's PDBS are not put up on the
+	// symbol server and we want NEN PDBS to be placed there.  
+	ZapPEExports* exports = new ZapPEExports(wszOutputFileName);
+	m_pDebugSection->Place(exports);
+	SetDirectoryEntry(IMAGE_DIRECTORY_ENTRY_EXPORT, exports);
+
     ComputeRVAs();
 
     if (!IsReadyToRunCompilation())


### PR DESCRIPTION
This change has two parts.  The first part changes build.cmd and the pkgproj
so that as part of generating a .NET Core package we also generate the PDBS
for the Native System.Private.Corelib.ni.dll.

The second part changes crossgen so that it marks the Native Images as having
a list of 0 exports.   This is important because we want the generated PDBs
to be naturally published on the symbol server, and currently the symbol server
skips DLLs what are 'resource only' (no imports or exports).   Because native
images don't use 'normal' PE imports and exports, they get optimized away
by the symbol server.  Making a empty list of exports fixes this.

@jkotas,  @JohnChen0 