### PR TITLE
DynBlk assert fixes for Arm64

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -4339,10 +4339,10 @@ void CodeGen::genCodeForCpBlk(GenTreeBlk* cpBlkNode)
 
     assert(!dstAddr->isContained());
     assert(!srcAddr->isContained());
-    assert(cpBlkNode->gtRsvdRegs == RBM_ARG_2);
 
     if (blockSize != 0)
     {
+        assert(cpBlkNode->gtRsvdRegs == RBM_ARG_2);
 #if 0
     // Enable this when we support cpblk loop unrolling.
 
@@ -4353,7 +4353,7 @@ void CodeGen::genCodeForCpBlk(GenTreeBlk* cpBlkNode)
     }
     else
     {
-        noway_assert(cpBlkNode->gtOper == GT_DYN_BLK);
+        noway_assert(cpBlkNode->gtOper == GT_STORE_DYN_BLK);
         genConsumeRegAndCopy(cpBlkNode->AsDynBlk()->gtDynamicSize, REG_ARG_2);
     }
     genConsumeRegAndCopy(srcAddr, REG_ARG_1);

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1282,7 +1282,7 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
         else
 #endif // 0
         {
-            // The helper follows the regular AMD64 ABI.
+            // The helper follows the regular ABI.
             dstAddr->gtLsraInfo.setSrcCandidates(l, RBM_ARG_0);
             initVal->gtLsraInfo.setSrcCandidates(l, RBM_ARG_1);
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
@@ -1447,7 +1447,6 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
                     noway_assert(blkNode->gtOper == GT_STORE_DYN_BLK);
                     blkNode->gtLsraInfo.setSrcCount(3);
                     GenTree* blockSize = blkNode->AsDynBlk()->gtDynamicSize;
-                    assert(!blockSize->IsIconHandle());
                     blockSize->gtLsraInfo.setSrcCandidates(l, RBM_ARG_2);
                 }
                 blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;


### PR DESCRIPTION
In the case where the block size is not a constant, there were some incorrect asserts. The size register is on the size node itself, the node is a store, and the check for whether the size is a handle used to be guarded by a check that it is GT_CNS_INT, but since it was really intended to assert that there are no gc pointers, according to the comment on the old code, it doesn't really seem to be a useful assert (we could never get a size node in that case, in the new IR form).

Fix #7195