### PR TITLE
Fix 6667: Constant folding for unsigned long divide operation

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -7062,10 +7062,10 @@ VNFunc Compiler::fgValueNumberHelperMethVNFunc(CorInfoHelpFunc helpFunc)
             break;
         case CORINFO_HELP_ULDIV:
             vnf = VNFunc(GT_UDIV);
-            break; // Is this the right thing?
+            break;
         case CORINFO_HELP_ULMOD:
             vnf = VNFunc(GT_UMOD);
-            break; // Is this the right thing?
+            break;
 
         case CORINFO_HELP_LNG2DBL:
             vnf = VNF_Lng2Dbl;

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -7061,10 +7061,10 @@ VNFunc Compiler::fgValueNumberHelperMethVNFunc(CorInfoHelpFunc helpFunc)
             vnf = VNFunc(GT_MOD);
             break;
         case CORINFO_HELP_ULDIV:
-            vnf = VNFunc(GT_DIV);
+            vnf = VNFunc(GT_UDIV);
             break; // Is this the right thing?
         case CORINFO_HELP_ULMOD:
-            vnf = VNFunc(GT_MOD);
+            vnf = VNFunc(GT_UMOD);
             break; // Is this the right thing?
 
         case CORINFO_HELP_LNG2DBL:


### PR DESCRIPTION
Rrelated issue: #6667

For correctness of constant folding in 32bit architecture (ARM32) that use helper function - unsigned long divide or modulo operation.