### PR TITLE
[ARM] Generate direct call instructions for recursive calls

### DIFF
--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1455,6 +1455,9 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define JMP_DIST_SMALL_MAX_NEG  (-2048)
   #define JMP_DIST_SMALL_MAX_POS  (+2046)
 
+  #define CALL_DIST_MAX_NEG (-16777216)
+  #define CALL_DIST_MAX_POS (+16777214)
+
   #define JCC_DIST_SMALL_MAX_NEG  (-256)
   #define JCC_DIST_SMALL_MAX_POS  (+254)
 


### PR DESCRIPTION
Direct Call Instruction   : (movw, movt, blx reg)
Indirect Call Instruction : (bl +-imm24)

It is pretty hard to determine direct/indirect instructions for general case.
However for recursive calls we can safely estimate the jump distance
as we know relative distance between jump source and destination.
So this change will generate direct call instructions for recursive calls
when jump distance is close enough.

Plus, it directly jumps to the function without the prestub.

For #7002