### PR TITLE
[WIP] Optimize codegen for SIMDIntrinsicGetItem when SIMD vector is a memory-op

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5434,13 +5434,13 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
 // Do liveness update for an address tree: one of GT_LEA, GT_LCL_VAR, or GT_CNS_INT (for call indirect).
 void CodeGen::genConsumeAddress(GenTree* addr)
 {
-    if (addr->OperGet() == GT_LEA)
-    {
-        genConsumeAddrMode(addr->AsAddrMode());
-    }
-    else if (!addr->isContained())
+    if (!addr->isContained())
     {
         genConsumeReg(addr);
+    }
+    else if (addr->OperGet() == GT_LEA)
+    {
+        genConsumeAddrMode(addr->AsAddrMode());
     }
 }
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -867,16 +867,18 @@ public:
 #define GTF_IND_TLS_REF 0x08000000       // GT_IND   -- the target is accessed via TLS
 #define GTF_IND_ASG_LHS 0x04000000       // GT_IND   -- this GT_IND node is (the effective val) of the LHS of an
                                          //             assignment; don't evaluate it independently.
-#define GTF_IND_VSD_TGT GTF_IND_ASG_LHS  // GT_IND   -- this GT_IND node represents the target of an indirect virtual
-                                         //             stub call. This is only valid in the backend, where
-                                         //             GTF_IND_ASG_LHS is not necessary (all such indirections will
-                                         //             be lowered to GT_STOREIND).
-#define GTF_IND_UNALIGNED 0x02000000     // GT_IND   -- the load or store is unaligned (we assume worst case
-                                         //             alignment of 1 byte)
-#define GTF_IND_INVARIANT 0x01000000     // GT_IND   -- the target is invariant (a prejit indirection)
-#define GTF_IND_ARR_LEN 0x80000000       // GT_IND   -- the indirection represents an array length (of the REF
-                                         //             contribution to its argument).
-#define GTF_IND_ARR_INDEX 0x00800000     // GT_IND   -- the indirection represents an (SZ) array index
+#define GTF_IND_REQ_ADDR_IN_REG GTF_IND_ASG_LHS // GT_IND  -- requires its addr operand to be evaluated
+                                                // into a register. This flag is useful in cases where it
+                                                // is required to generate register indirect addressing mode.
+                                                // One such case is virtual stub calls on xarch.  This is only
+                                                // valid in the backend, where GTF_IND_ASG_LHS is not necessary
+                                                // (all such indirections will be lowered to GT_STOREIND).
+#define GTF_IND_UNALIGNED 0x02000000            // GT_IND   -- the load or store is unaligned (we assume worst case
+                                                //             alignment of 1 byte)
+#define GTF_IND_INVARIANT 0x01000000            // GT_IND   -- the target is invariant (a prejit indirection)
+#define GTF_IND_ARR_LEN 0x80000000              // GT_IND   -- the indirection represents an array length (of the REF
+                                                //             contribution to its argument).
+#define GTF_IND_ARR_INDEX 0x00800000            // GT_IND   -- the indirection represents an (SZ) array index
 
 #define GTF_IND_FLAGS                                                                                                  \
     (GTF_IND_VOLATILE | GTF_IND_REFARR_LAYOUT | GTF_IND_TGTANYWHERE | GTF_IND_NONFAULTING | GTF_IND_TLS_REF |          \

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -192,6 +192,28 @@ GenTree* Lowering::LowerNode(GenTree* node)
                 // produces a TYP_SIMD16 result
                 node->gtType = TYP_SIMD16;
             }
+
+#ifdef _TARGET_XARCH_
+            if ((node->AsSIMD()->gtSIMDIntrinsicID == SIMDIntrinsicGetItem) && (node->gtGetOp1()->OperGet() == GT_IND))
+            {
+                // If SIMD vector is already in memory, we force its
+                // addr to be evaluated into a reg.  This would allow
+                // us to generate [regBase] or [regBae+offset] or
+                // [regBase+sizeOf(SIMD vector baseType)*regIndex]
+                // to access the required SIMD vector element directly
+                // from memory.
+                //
+                // TODO-CQ-XARCH: If addr of GT_IND is GT_LEA, we
+                // might be able update GT_LEA to fold the regIndex
+                // or offset in some cases.  Instead with the above
+                // approach we always evaluate GT_LEA into a reg.
+                // Ideally, we should be able to lower GetItem intrinsic
+                // into GT_IND(newAddr) where newAddr combines
+                // the addr of SIMD vector with the given index where
+                // possible.
+                node->gtOp.gtOp1->gtFlags |= GTF_IND_REQ_ADDR_IN_REG;
+            }
+#endif
             break;
 
         case GT_LCL_VAR:
@@ -3154,7 +3176,7 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
         // All we have to do here is add an indirection to generate the actual call target.
 
         GenTree* ind = Ind(call->gtCallAddr);
-        ind->gtFlags |= GTF_IND_VSD_TGT;
+        ind->gtFlags |= GTF_IND_REQ_ADDR_IN_REG;
 
         BlockRange().InsertAfter(call->gtCallAddr, ind);
         call->gtCallAddr = ind;
@@ -3196,7 +3218,7 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
             addr->gtRegNum = REG_VIRTUAL_STUB_PARAM;
 
             indir->gtRegNum = REG_JUMP_THUNK_PARAM;
-            indir->gtFlags |= GTF_IND_VSD_TGT;
+            indir->gtFlags |= GTF_IND_REQ_ADDR_IN_REG;
 #endif
             result = indir;
         }

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -662,7 +662,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
             break;
 
         case GT_IND:
-            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_VSD_TGT`.
+            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_REQ_ADDR_IN_REG`.
             node->gtFlags &= ~GTF_IND_ASG_LHS;
             break;
 

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -1440,6 +1440,57 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
     genConsumeOperands(simdNode);
     regNumber srcReg = op1->gtRegNum;
 
+    // Optimize the case of op1 is in memory and trying to access ith element.
+    if (op1->isMemoryOp())
+    {
+        assert(op1->isContained());
+
+        regNumber baseReg;
+        regNumber indexReg;
+        int       offset = 0;
+
+        if (op1->OperGet() == GT_LCL_FLD)
+        {
+            unsigned varNum = op1->gtLclVarCommon.gtLclNum;
+            offset += op1->gtLclFld.gtLclOffs;
+
+            bool isEBPbased;
+            offset += compiler->lvaFrameAddress(varNum, &isEBPbased);
+            baseReg = (isEBPbased) ? REG_EBP : REG_ESP;
+        }
+        else
+        {
+            // Require GT_IND addr to be not contained.
+            assert(op1->OperGet() == GT_IND);
+
+            GenTree* addr = op1->AsIndir()->Addr();
+            assert(!addr->isContained());
+            baseReg = addr->gtRegNum;
+        }
+
+        if (op2->isContainedIntOrIImmed())
+        {
+            indexReg = REG_NA;
+            offset += (int)op2->AsIntConCommon()->IconValue() * genTypeSize(baseType);
+        }
+        else
+        {
+            indexReg = op2->gtRegNum;
+            assert(genIsValidIntReg(indexReg));
+        }
+
+        // Now, load the desired element.
+        getEmitter()->emitIns_R_ARX(ins_Move_Extend(baseType, false), // Load
+                                    emitTypeSize(baseType),           // Of the vector baseType
+                                    targetReg,                        // To targetReg
+                                    baseReg,                          // Base Reg
+                                    indexReg,                         // Indexed
+                                    genTypeSize(baseType),            // by the size of the baseType
+                                    offset);
+        genProduceReg(simdNode);
+        return;
+    }
+
     // SSE2 doesn't have an instruction to implement this intrinsic if the index is not a constant.
     // For the non-constant case, we will use the SIMD temp location to store the vector, and
     // the load the desired element.


### PR DESCRIPTION
DO NOT REVIEW OR MERGE THIS YET.

Fix #7239