### PR TITLE
Optimize codegen for SIMDIntrinsicGetItem when SIMD vector is a memory-op.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5434,13 +5434,13 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
 // Do liveness update for an address tree: one of GT_LEA, GT_LCL_VAR, or GT_CNS_INT (for call indirect).
 void CodeGen::genConsumeAddress(GenTree* addr)
 {
-    if (addr->OperGet() == GT_LEA)
-    {
-        genConsumeAddrMode(addr->AsAddrMode());
-    }
-    else if (!addr->isContained())
+    if (!addr->isContained())
     {
         genConsumeReg(addr);
+    }
+    else if (addr->OperGet() == GT_LEA)
+    {
+        genConsumeAddrMode(addr->AsAddrMode());
     }
 }
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -867,16 +867,18 @@ public:
 #define GTF_IND_TLS_REF 0x08000000       // GT_IND   -- the target is accessed via TLS
 #define GTF_IND_ASG_LHS 0x04000000       // GT_IND   -- this GT_IND node is (the effective val) of the LHS of an
                                          //             assignment; don't evaluate it independently.
-#define GTF_IND_VSD_TGT GTF_IND_ASG_LHS  // GT_IND   -- this GT_IND node represents the target of an indirect virtual
-                                         //             stub call. This is only valid in the backend, where
-                                         //             GTF_IND_ASG_LHS is not necessary (all such indirections will
-                                         //             be lowered to GT_STOREIND).
-#define GTF_IND_UNALIGNED 0x02000000     // GT_IND   -- the load or store is unaligned (we assume worst case
-                                         //             alignment of 1 byte)
-#define GTF_IND_INVARIANT 0x01000000     // GT_IND   -- the target is invariant (a prejit indirection)
-#define GTF_IND_ARR_LEN 0x80000000       // GT_IND   -- the indirection represents an array length (of the REF
-                                         //             contribution to its argument).
-#define GTF_IND_ARR_INDEX 0x00800000     // GT_IND   -- the indirection represents an (SZ) array index
+#define GTF_IND_REQ_ADDR_IN_REG GTF_IND_ASG_LHS // GT_IND  -- requires its addr operand to be evaluated
+                                                // into a register. This flag is useful in cases where it
+                                                // is required to generate register indirect addressing mode.
+                                                // One such case is virtual stub calls on xarch.  This is only
+                                                // valid in the backend, where GTF_IND_ASG_LHS is not necessary
+                                                // (all such indirections will be lowered to GT_STOREIND).
+#define GTF_IND_UNALIGNED 0x02000000            // GT_IND   -- the load or store is unaligned (we assume worst case
+                                                //             alignment of 1 byte)
+#define GTF_IND_INVARIANT 0x01000000            // GT_IND   -- the target is invariant (a prejit indirection)
+#define GTF_IND_ARR_LEN 0x80000000              // GT_IND   -- the indirection represents an array length (of the REF
+                                                //             contribution to its argument).
+#define GTF_IND_ARR_INDEX 0x00800000            // GT_IND   -- the indirection represents an (SZ) array index
 
 #define GTF_IND_FLAGS                                                                                                  \
     (GTF_IND_VOLATILE | GTF_IND_REFARR_LAYOUT | GTF_IND_TGTANYWHERE | GTF_IND_NONFAULTING | GTF_IND_TLS_REF |          \

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2420,12 +2420,13 @@ void Lowering::TreeNodeInfoInitSIMD(GenTree* tree)
     info->dstCount         = 1;
     switch (simdTree->gtSIMDIntrinsicID)
     {
+        GenTree* op1;
         GenTree* op2;
 
         case SIMDIntrinsicInit:
         {
             info->srcCount = 1;
-            GenTree* op1   = tree->gtOp.gtOp1;
+            op1            = tree->gtOp.gtOp1;
 
             // This sets all fields of a SIMD struct to the given value.
             // Mark op1 as contained if it is either zero or int constant of all 1's,
@@ -2558,11 +2559,13 @@ void Lowering::TreeNodeInfoInitSIMD(GenTree* tree)
             break;
 
         case SIMDIntrinsicGetItem:
+        {
             // This implements get_Item method. The sources are:
             //  - the source SIMD struct
             //  - index (which element to get)
             // The result is baseType of SIMD struct.
             info->srcCount = 2;
+            op1            = tree->gtOp.gtOp1;
             op2            = tree->gtOp.gtOp2;
 
             // If the index is a constant, mark it as contained.
@@ -2571,39 +2574,55 @@ void Lowering::TreeNodeInfoInitSIMD(GenTree* tree)
                 info->srcCount = 1;
             }
 
-            // If the index is not a constant, we will use the SIMD temp location to store the vector.
-            // Otherwise, if the baseType is floating point, the targetReg will be a xmm reg and we
-            // can use that in the process of extracting the element.
-            //
-            // If the index is a constant and base type is a small int we can use pextrw, but on AVX
-            // we will need a temp if are indexing into the upper half of the AVX register.
-            // In all other cases with constant index, we need a temp xmm register to extract the
-            // element if index is other than zero.
+            if (op1->isMemoryOp())
+            {
+                MakeSrcContained(tree, op1);
 
-            if (!op2->IsCnsIntOrI())
-            {
-                (void)comp->getSIMDInitTempVarNum();
+                // Although GT_IND of TYP_SIMD12 reserves an internal float
+                // register for reading 4 and 8 bytes from memory and
+                // assembling them into target XMM reg, it is not required
+                // in this case.
+                op1->gtLsraInfo.internalIntCount   = 0;
+                op1->gtLsraInfo.internalFloatCount = 0;
             }
-            else if (!varTypeIsFloating(simdTree->gtSIMDBaseType))
+            else
             {
-                bool needFloatTemp;
-                if (varTypeIsSmallInt(simdTree->gtSIMDBaseType) &&
-                    (comp->getSIMDInstructionSet() == InstructionSet_AVX))
+                // If the index is not a constant, we will use the SIMD temp location to store the vector.
+                // Otherwise, if the baseType is floating point, the targetReg will be a xmm reg and we
+                // can use that in the process of extracting the element.
+                //
+                // If the index is a constant and base type is a small int we can use pextrw, but on AVX
+                // we will need a temp if are indexing into the upper half of the AVX register.
+                // In all other cases with constant index, we need a temp xmm register to extract the
+                // element if index is other than zero.
+
+                if (!op2->IsCnsIntOrI())
                 {
-                    int byteShiftCnt = (int)op2->AsIntCon()->gtIconVal * genTypeSize(simdTree->gtSIMDBaseType);
-                    needFloatTemp    = (byteShiftCnt >= 16);
+                    (void)comp->getSIMDInitTempVarNum();
                 }
-                else
+                else if (!varTypeIsFloating(simdTree->gtSIMDBaseType))
                 {
-                    needFloatTemp = !op2->IsIntegralConst(0);
-                }
-                if (needFloatTemp)
-                {
-                    info->internalFloatCount = 1;
-                    info->setInternalCandidates(lsra, lsra->allSIMDRegs());
+                    bool needFloatTemp;
+                    if (varTypeIsSmallInt(simdTree->gtSIMDBaseType) &&
+                        (comp->getSIMDInstructionSet() == InstructionSet_AVX))
+                    {
+                        int byteShiftCnt = (int)op2->AsIntCon()->gtIconVal * genTypeSize(simdTree->gtSIMDBaseType);
+                        needFloatTemp    = (byteShiftCnt >= 16);
+                    }
+                    else
+                    {
+                        needFloatTemp = !op2->IsIntegralConst(0);
+                    }
+
+                    if (needFloatTemp)
+                    {
+                        info->internalFloatCount = 1;
+                        info->setInternalCandidates(lsra, lsra->allSIMDRegs());
+                    }
                 }
             }
-            break;
+        }
+        break;
 
         case SIMDIntrinsicSetX:
         case SIMDIntrinsicSetY:
@@ -2854,11 +2873,10 @@ void Lowering::SetIndirAddrOpCounts(GenTreePtr indirTree)
     }
 #endif // FEATURE_SIMD
 
-    if ((indirTree->gtFlags & GTF_IND_VSD_TGT) != 0)
+    if ((indirTree->gtFlags & GTF_IND_REQ_ADDR_IN_REG) != 0)
     {
-        // The address of an indirection that is marked as the target of a VSD call must
-        // be computed into a register. Skip any further processing that might otherwise
-        // make it contained.
+        // The address of an indirection that requires its address in a reg.
+        // Skip any further processing that might otherwise make it contained.
     }
     else if ((addr->OperGet() == GT_CLS_VAR_ADDR) || (addr->OperGet() == GT_LCL_VAR_ADDR))
     {

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -662,7 +662,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
             break;
 
         case GT_IND:
-            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_VSD_TGT`.
+            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_REQ_ADDR_IN_REG`.
             node->gtFlags &= ~GTF_IND_ASG_LHS;
             break;
 


### PR DESCRIPTION
This issue was surfaced as part of TechEmPower analysis by Intel against .NetCore 1.0 RTM.  As per that analysis Kestrel.Internal.Infrastructure.MemoryPoolIterator.Seek() is one of the hot methods that has the following in-efficient codegen pattern:

```
// Access 0th element of ref Vector<byte>.
// Here byte0Vector, byte1Vector and byte2Vector are of ‘ref Vector<byte>’
Var byte0 = byte0Vector[0]
Var byte1 = byte1Vector[0]
Var byte2 = byte2Vector[0]
```

Currently we are generating

```
Vmovd ymm0, ymmword ptr[rbx]
Vpextrw edi, xmm0, 0x0
Movz edi, dil
And edi, 0xff
```

Instead we should be able to generate
`Movzx, edi, byte ptr [rbx]`

Though Seek() method requires that we optimize 0th element access, in general we should be able to optimize GetItem SIMD intrinsic when SIMD vector is a memory-op irrespective of whether index is const or in reg.  GetItem intrinsic has two operands: op1 = SIMD Vector, op2 = index.  GetItemX/Y/Z/W SIMD intrinsics on fixed vectors also get materialized in terms of GetItem intrinsic.  That is, even GetItem operations on fixed vectors will benefit fixing this issue.

When op1 is a memory-op (GT_IND or GT_LCL_FLD),  we should be able generate [baseReg] or [base+offset] or [base+sizeof(SIMD baseType)*indexReg+offset] addressing modes to directly access required element from memory.  The addr operand of GT_IND could be a GT_LEA, GT_CLS_VAR_ADDR or lclvar or const.  All of these are handled by always evaluating addr into a reg.  For that, op1 of GT_IND should not be marked as contained in Lowering.  We already have a similar case of Virtual stub calls on xarch flag GT_INDs.  This flag is now renamed to indicate that addr should be evaluated to a reg and used for flagging GT_IND operand of GetItem intrinsic as well.

genConsumeAddress() - this routine was implemented with the assumption that GT_LEA are always contained.  It is no longer true with this change.  First this routine needs to check whether addr is contained.  This is required in GetItem codegen path as we can have a case of GT_IND is marked as contained but not its addr.

SuperPMI asm diffs indicate that there many cases in SIMD tests that benefited with this optimization.

SIMD sse tests: 308 methods impacted with 6370 bytes of code size improvement (9.77%)
SIMD avx tests:  308 methods impacted with 9585 bytes of code size improvement (13.65%)
Cq Perf: One helper method from Console Mandelbrot benchmark had 21 bytes of size improvement.
Since that method was not in hot path, it didn't move execution perf number.

Apart from code size improvement, this change also results in stack frame saving since, we no longer allocate a stack temp to copy SIMD vector to memory.


Fix #7239