### PR TITLE
Remove the dependency of using config.json in cwd

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -30,8 +30,8 @@ if NOT [%ERRORLEVEL%]==[0] (
 set _toolRuntime=%~dp0Tools
 set _dotnet=%_toolRuntime%\dotnetcli\dotnet.exe
 
-echo Running: %_dotnet% %_toolRuntime%\run.exe %*
-call %_dotnet% %_toolRuntime%\run.exe %*
+echo Running: %_dotnet% %_toolRuntime%\run.exe %~dp0config.json %*
+call %_dotnet% %_toolRuntime%\run.exe %~dp0config.json %*
 if NOT [%ERRORLEVEL%]==[0] (
   exit /b 1
 )

--- a/run.sh
+++ b/run.sh
@@ -8,8 +8,8 @@ $working_tree_root/init-tools.sh
 toolRuntime=$working_tree_root/Tools
 dotnet=$toolRuntime/dotnetcli/dotnet
 
-echo "Running: $dotnet $toolRuntime/run.exe $*"
-$dotnet $toolRuntime/run.exe $*
+echo "Running: $dotnet $toolRuntime/run.exe $working_tree_root/config.json $*"
+$dotnet $toolRuntime/run.exe $working_tree_root/config.json $*
 if [ $? -ne 0 ]
 then
     echo "ERROR: An error occured in $dotnet $toolRuntime/run $#. Check $# logs under $working_tree_root."


### PR DESCRIPTION
Currently the config.json file is looked for in the current working
directory. This change forces run.exe to use the relative path of
the file relative to the build script.