### PR TITLE
Allow inlining with volatile actual argument exprs

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17011,18 +17011,10 @@ void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
 #endif // FEATURE_SIMD
     }
 
-    if (curArgVal->gtFlags & GTF_ORDER_SIDEEFF)
-    {
-        // Right now impInlineSpillLclRefs and impInlineSpillGlobEffects don't take
-        // into account special side effects, so we disallow them during inlining.
-        inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_HAS_SIDE_EFFECT);
-        return;
-    }
-
-    if (curArgVal->gtFlags & GTF_GLOB_EFFECT)
+    if (curArgVal->gtFlags & GTF_ALL_EFFECT)
     {
         inlCurArgInfo->argHasGlobRef = (curArgVal->gtFlags & GTF_GLOB_REF) != 0;
-        inlCurArgInfo->argHasSideEff = (curArgVal->gtFlags & GTF_SIDE_EFFECT) != 0;
+        inlCurArgInfo->argHasSideEff = (curArgVal->gtFlags & (GTF_ALL_EFFECT & ~GTF_GLOB_REF)) != 0;
     }
 
     if (curArgVal->gtOper == GT_LCL_VAR)

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2091,8 +2091,6 @@ bool Compiler::impSpillStackEntry(unsigned level,
     guard.Init(&impNestedStackSpill, bAssertOnRecursion);
 #endif
 
-    assert(!fgGlobalMorph); // use impInlineSpillStackEntry() during inlining
-
     GenTreePtr tree = verCurrentState.esStack[level].val;
 
     /* Allocate a temp if we haven't been asked to use a particular one */
@@ -2187,8 +2185,6 @@ void Compiler::impSpillStackEnsure(bool spillLeaves)
 
 void Compiler::impSpillEvalStack()
 {
-    assert(!fgGlobalMorph); // use impInlineSpillEvalStack() during inlining
-
     for (unsigned level = 0; level < verCurrentState.esStackDepth; level++)
     {
         impSpillStackEntry(level, BAD_VAR_NUM DEBUGARG(false) DEBUGARG("impSpillEvalStack"));
@@ -2326,8 +2322,6 @@ Compiler::fgWalkResult Compiler::impFindValueClasses(GenTreePtr* pTree, fgWalkDa
 
 void Compiler::impSpillLclRefs(ssize_t lclNum)
 {
-    assert(!fgGlobalMorph); // use impInlineSpillLclRefs() during inlining
-
     /* Before we make any appends to the tree list we must spill the
      * "special" side effects (GTF_ORDER_SIDEEFF) - GT_CATCH_ARG */
 

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -112,7 +112,6 @@ INLINE_OBSERVATION(HAS_NEWOBJ,                bool,   "has newobj",             
 // ------ Call Site Correctness ------- 
 
 INLINE_OBSERVATION(ARG_HAS_NULL_THIS,         bool,   "this pointer argument is null", FATAL,       CALLSITE)
-INLINE_OBSERVATION(ARG_HAS_SIDE_EFFECT,       bool,   "argument has side effect",      FATAL,       CALLSITE)
 INLINE_OBSERVATION(ARG_IS_MKREFANY,           bool,   "argument is mkrefany",          FATAL,       CALLSITE)
 INLINE_OBSERVATION(ARG_NO_BASH_TO_INT,        bool,   "argument can't bash to int",    FATAL,       CALLSITE)
 INLINE_OBSERVATION(ARG_NO_BASH_TO_REF,        bool,   "argument can't bash to ref",    FATAL,       CALLSITE)


### PR DESCRIPTION
When presented with an argument marked `GFT_ORDER_SIDEEFF`, mark the
argument `argHasSideEff` and allow inlining.  Remove the vestigial code to
disallow inlining in these cases; it corresponded to a prior inliner
implementation with a different import path that has since been removed;
the inliner now re-uses the main import path, which can handle the
necessary stack spilling in the presence of `GTF_ORDER_SIDEEFF`.

Also remove some related stale/bogus assertions.

Fixes #7054.