### PR TITLE
Remove CoreCLR's dependency on the diasymreader.dll installed as part of the full .NET Framework on Desktop

### DIFF
--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -4280,7 +4280,11 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
             // On desktop, the framework installer is supposed to install diasymreader.dll as well
             // and so this shouldn't happen.
             hr = FakeCoCreateInstanceEx(CLSID_CorSymBinder_SxS,
+#ifdef FEATURE_CORECLR
+                                        NATIVE_SYMBOL_READER_DLL,
+#else
                                         GetInternalSystemDirectory(),
+#endif
                                         IID_ISymUnmanagedBinder,
                                         (void**)&pBinder,
                                         NULL);

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -100,8 +100,10 @@ class PersistentInlineTrackingMap;
 #define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.amd64.dll")
 #elif defined(_TARGET_X86_)
 #define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.x86.dll")
-#elif defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
+#elif defined(_TARGET_ARM_)
 #define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.arm.dll")
+#elif defined(_TARGET_ARM64_)
+#define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.arm64.dll")
 #endif
 #else
 #define NATIVE_SYMBOL_READER_DLL W("diasymreader.dll")

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -93,7 +93,19 @@ class PersistentInlineTrackingMap;
 #define PARAMMETHODS_HASH_BUCKETS 11
 #define METHOD_STUBS_HASH_BUCKETS 11
 #define GUID_TO_TYPE_HASH_BUCKETS 16
-
+            
+// The native symbol reader dll name
+#ifdef FEATURE_CORECLR
+#if defined(_TARGET_AMD64_)
+#define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.amd64.dll")
+#elif defined(_TARGET_X86_)
+#define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.x86.dll")
+#elif defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
+#define NATIVE_SYMBOL_READER_DLL W("Microsoft.DiaSymReader.Native.arm.dll")
+#endif
+#else
+#define NATIVE_SYMBOL_READER_DLL W("diasymreader.dll")
+#endif
 
 typedef DPTR(PersistentInlineTrackingMap) PTR_PersistentInlineTrackingMap;
 

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -2909,28 +2909,30 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
     }
-            
+
+#ifdef FEATURE_CORECLR
+#define WRITER_LOAD_ERROR_MESSAGE W("Unable to load ") NATIVE_SYMBOL_READER_DLL W(".  Please ensure that ") NATIVE_SYMBOL_READER_DLL W(" is on the path.  Error='%d'\n")
+#else
+#define WRITER_LOAD_ERROR_MESSAGE W("Unable to load diasymreader.dll.  Please ensure that version 11 or greater of diasymreader.dll is on the path.  You can typically find this DLL in the desktop .NET install directory for 4.5 or greater.  Error='%d'\n")
+#endif
+
     HRESULT Load(LPCWSTR wszDiasymreaderPath = nullptr)
     {
         STANDARD_VM_CONTRACT;
 
         HRESULT hr = S_OK;
 
-        m_hModule = WszLoadLibrary(wszDiasymreaderPath != nullptr ? wszDiasymreaderPath : W("diasymreader.dll"));
+        m_hModule = WszLoadLibrary(wszDiasymreaderPath != nullptr ? wszDiasymreaderPath : (LPCWSTR)NATIVE_SYMBOL_READER_DLL);
         if (m_hModule == NULL)
         {
-            GetSvcLogger()->Printf(
-                W("Unable to load diasymreader.dll.  Please ensure that version 11 or greater of diasymreader.dll is on the path.  You can typically find this DLL in the desktop .NET install directory for 4.5 or greater.  Error='%d'\n"),
-                GetLastError());
+            GetSvcLogger()->Printf(WRITER_LOAD_ERROR_MESSAGE, GetLastError());
             return HRESULT_FROM_WIN32(GetLastError());
         }
 
         m_Create = reinterpret_cast<CreateNGenPdbWriter_t>(GetProcAddress(m_hModule, "CreateNGenPdbWriter"));
         if (m_Create == NULL)
         {
-            GetSvcLogger()->Printf(
-                W("An incorrect version of diasymreader.dll was found.  Please ensure that version 11 or greater of diasymreader.dll is on the path.  You can typically find this DLL in the desktop .NET install directory for 4.5 or greater.  Error='%d'\n"),
-                GetLastError());
+            GetSvcLogger()->Printf(WRITER_LOAD_ERROR_MESSAGE, GetLastError());
             return HRESULT_FROM_WIN32(GetLastError());
         }
 
@@ -2938,7 +2940,11 @@ public:
         {
             hr = FakeCoCreateInstanceEx(
                 CLSID_CorSymBinder_SxS,
-                NULL,
+#ifdef FEATURE_CORECLR
+                wszDiasymreaderPath != nullptr ? wszDiasymreaderPath : (LPCWSTR)NATIVE_SYMBOL_READER_DLL,
+#else
+                wszDiasymreaderPath,
+#endif
                 IID_ISymUnmanagedBinder,
                 (void**)&m_pBinder,
                 NULL);

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -2925,15 +2925,17 @@ public:
         m_hModule = WszLoadLibrary(wszDiasymreaderPath != nullptr ? wszDiasymreaderPath : (LPCWSTR)NATIVE_SYMBOL_READER_DLL);
         if (m_hModule == NULL)
         {
+            hr = HRESULT_FROM_WIN32(GetLastError());
             GetSvcLogger()->Printf(WRITER_LOAD_ERROR_MESSAGE, GetLastError());
-            return HRESULT_FROM_WIN32(GetLastError());
+            return hr;
         }
 
         m_Create = reinterpret_cast<CreateNGenPdbWriter_t>(GetProcAddress(m_hModule, "CreateNGenPdbWriter"));
         if (m_Create == NULL)
         {
+            hr = HRESULT_FROM_WIN32(GetLastError());
             GetSvcLogger()->Printf(WRITER_LOAD_ERROR_MESSAGE, GetLastError());
-            return HRESULT_FROM_WIN32(GetLastError());
+            return hr;
         }
 
         if ((m_dwExtraData & kPDBLines) != 0)


### PR DESCRIPTION
Change the stacktrace and cross compile code to load/use the Microsoft.DiaSymReader.Native dll instead of depending COM interface being registered.

This depends on a change in the core-setup repo to add the Microsoft.DiaSymReader.Native package to Microsoft.NETCore.App shared framework package.

Issue #5922