### PR TITLE
Add generic overloads of Array.Copy

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -334,13 +334,17 @@ namespace System {
             Array.Copy(sourceArray, (int) sourceIndex, destinationArray, (int) destinationIndex, (int) length);
         }
 
+        [ReliabilityContract(Consistency.MayCorruptInstance, Cer.MayFail)]
         public static void Copy<T>(T[] sourceArray, T[] destinationArray, int length)
         {
-            Copy(sourceArray, 0, destinationArray, 0, length);
+            // TODO: Investigate perf benefits of using a for-loop for small lengths.
+            Copy(sourceArray, 0, destinationArray, 0, length, reliable: false);
         }
 
+        [ReliabilityContract(Consistency.MayCorruptInstance, Cer.MayFail)]
         public static void Copy<T>(T[] sourceArray, int sourceIndex, T[] destinationArray, int destinationIndex, int length)
         {
+            // TODO: Investigate perf benefits of using a for-loop for small lengths.
             Copy(sourceArray, sourceIndex, destinationArray, destinationIndex, length, reliable: false);
         }
     

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -334,6 +334,15 @@ namespace System {
             Array.Copy(sourceArray, (int) sourceIndex, destinationArray, (int) destinationIndex, (int) length);
         }
 
+        public static void Copy<T>(T[] sourceArray, T[] destinationArray, int length)
+        {
+            Copy(sourceArray, 0, destinationArray, 0, length);
+        }
+
+        public static void Copy<T>(T[] sourceArray, int sourceIndex, T[] destinationArray, int destinationIndex, int length)
+        {
+            Copy(sourceArray, sourceIndex, destinationArray, destinationIndex, length, reliable: false);
+        }
     
         // Sets length elements in array to 0 (or null for Object arrays), starting
         // at index.


### PR DESCRIPTION
This PR adds generic overloads of `Array.Copy<T>`, which has been marked api-approved by dotnet/corefx#11588. Adding an generic overload that does not accept indices will significantly increase perf since we don't have to call `GetLowerBound` anymore, and as a nice side-effect we don't have to check source/dest for null and the method can be inlined.

/cc @benaadams, @jkotas, @weshaggard 

FYI @terrajobst 
