### PR TITLE
Micro-optimization for IList.Contains array implementation

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2799,7 +2799,7 @@ namespace System {
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
             T[] _this = JitHelpers.UnsafeCast<T[]>(this);
-            return Array.IndexOf(_this, value) != -1;
+            return Array.IndexOf(_this, value, 0, _this.Length) >= 0;
         }
         
         bool get_IsReadOnly<T>() {
@@ -2818,7 +2818,7 @@ namespace System {
             //! Warning: "this" is an array, not an SZArrayHelper. See comments above
             //! or you may introduce a security hole!
             T[] _this = JitHelpers.UnsafeCast<T[]>(this);
-            return Array.IndexOf(_this, value);
+            return Array.IndexOf(_this, value, 0, _this.Length);
         }
         
         void Insert<T>(int index, T value) {


### PR DESCRIPTION
The overload of `Array.IndexOf` that doesn't take a startIndex/count is slightly less efficient since it includes an extra null check. We know that `_this` isn't null, so just call the most general overload.

This may also let us avoid 1 function call, but I have not checked whether the JIT was actually inlining the method before.

@jkotas