### PR TITLE
Add the IsSecurityXX properties omitted from Type base class

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -8456,6 +8456,9 @@
       <Member Name="get_IsPrimitive" />
       <Member Name="get_IsPublic" />
       <Member Name="get_IsSealed" />
+      <Member Name="get_IsSecurityCritical" />
+      <Member Name="get_IsSecuritySafeCritical" />
+      <Member Name="get_IsSecurityTransparent" />      
       <Member Name="get_IsSerializable" />
       <Member Name="get_IsSpecialName" />
       <Member Name="get_IsUnicodeClass" />


### PR DESCRIPTION
These were masked by corefx/.. /src/system.runtime/src/apicompatbaseline.txt. 

@sepidehMS 