### PR TITLE
Add missing System.Security ns types.

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6994,6 +6994,25 @@
     </Type>
     <Type Name="System.Security.AllowPartiallyTrustedCallersAttribute">
       <Member Name="#ctor" />
+      <Member Name="get_PartialTrustVisibilityLevel" />
+      <Member Name="set_PartialTrustVisibilityLevel(System.Security.PartialTrustVisibilityLevel)" />
+      <Member MemberType="Property" Name="PartialTrustVisibilityLevel" />
+    </Type>
+    <Type Name="System.Security.PartialTrustVisibilityLevel">
+      <Member MemberType="Field" Name="NotVisibleByDefault" />
+      <Member MemberType="Field" Name="value__" />
+      <Member MemberType="Field" Name="VisibleToAllHosts" />
+    </Type>
+    <Type Name="System.Security.SecurityCriticalAttribute">
+      <Member Name="#ctor" />
+      <Member Name="#ctor(System.Security.SecurityCriticalScope)" />
+      <Member Name="get_Scope" />
+      <Member MemberType="Property" Name="Scope" />
+    </Type>
+    <Type Name="System.Security.SecurityCriticalScope">
+      <Member MemberType="Field" Name="Everything" />
+      <Member MemberType="Field" Name="Explicit" />
+      <Member MemberType="Field" Name="value__" />
     </Type>
     <Type Name="System.Security.SecurityException">
       <Member Name="#ctor" />
@@ -10601,17 +10620,34 @@
       <Member MemberType="Field" Name="None" />
       <Member MemberType="Field" Name="value__" />
     </Type>
-    <Type Name="System.Security.SecurityCriticalAttribute">
-      <Member Name="#ctor" />
-    </Type>
     <Type Status="ImplRoot" Name="System.Security.SecurityRuntime">
       <Member Name="FrameDescHelper(System.Security.FrameSecurityDescriptor,System.Security.IPermission,System.Security.PermissionToken,System.RuntimeMethodHandleInternal)" /> <!-- EE -->
       <Member Name="FrameDescSetHelper(System.Security.FrameSecurityDescriptor,System.Security.PermissionSet,System.Security.PermissionSet@,System.RuntimeMethodHandleInternal)" /> <!-- EE -->
     </Type>
+    <Type Name="System.Security.SecurityRulesAttribute">
+      <Member Name="#ctor(System.Security.SecurityRuleSet)" />
+      <Member Name="get_RuleSet" />
+      <Member Name="get_SkipVerificationInFullTrust" />
+      <Member Name="set_SkipVerificationInFullTrust(System.Boolean)" />
+      <Member MemberType="Property" Name="RuleSet" />
+      <Member MemberType="Property" Name="SkipVerificationInFullTrust" />
+    </Type>
+    <Type Name="System.Security.SecurityRuleSet">
+      <Member MemberType="Field" Name="Level1" />
+      <Member MemberType="Field" Name="Level2" />
+      <Member MemberType="Field" Name="None" />
+      <Member MemberType="Field" Name="value__" />
+    </Type>
+    <Type Name="System.Security.SecuritySafeCriticalAttribute">
+      <Member Name="#ctor" />
+    </Type>
     <Type Name="System.Security.SecurityTransparentAttribute">
       <Member Name="#ctor" />
     </Type>
-    <Type Name="System.Security.SecuritySafeCriticalAttribute" >
+    <Type Name="System.Security.SecurityTreatAsSafeAttribute">
+      <Member Name="#ctor" />
+    </Type>
+    <Type Name="System.Security.SuppressUnmanagedCodeSecurityAttribute">
       <Member Name="#ctor" />
     </Type>
     <Type Name="System.Security.UnverifiableCodeAttribute">

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -11950,11 +11950,28 @@ namespace System.Security
     public sealed partial class AllowPartiallyTrustedCallersAttribute : System.Attribute
     {
         public AllowPartiallyTrustedCallersAttribute() { }
+        public System.Security.PartialTrustVisibilityLevel PartialTrustVisibilityLevel { get { throw null; } set { } }
+    }
+    public enum PartialTrustVisibilityLevel
+    {
+        NotVisibleByDefault = 1,
+        VisibleToAllHosts = 0,
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(5501), AllowMultiple=false, Inherited=false)]
     public sealed partial class SecurityCriticalAttribute : System.Attribute
     {
         public SecurityCriticalAttribute() { }
+#pragma warning disable 0618        
+        public SecurityCriticalAttribute(System.Security.SecurityCriticalScope scope) { }
+#pragma warning restore 0618
+        [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
+        public System.Security.SecurityCriticalScope Scope { get { throw null; } }
+    }
+    [System.ObsoleteAttribute("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
+    public enum SecurityCriticalScope
+    {
+        Everything = 1,
+        Explicit = 0,
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public partial class SecurityException : System.SystemException
@@ -11978,6 +11995,19 @@ namespace System.Security
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
     }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(1), AllowMultiple=false)]
+    public sealed partial class SecurityRulesAttribute : System.Attribute
+    {
+        public SecurityRulesAttribute(System.Security.SecurityRuleSet ruleSet) { }
+        public System.Security.SecurityRuleSet RuleSet { get { throw null; } }
+        public bool SkipVerificationInFullTrust { get { throw null; } set { } }
+    }
+    public enum SecurityRuleSet : byte
+    {
+        Level1 = (byte)1,
+        Level2 = (byte)2,
+        None = (byte)0,
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(5500), AllowMultiple=false, Inherited=false)]
     public sealed partial class SecuritySafeCriticalAttribute : System.Attribute
     {
@@ -11995,6 +12025,17 @@ namespace System.Security
     public sealed partial class SecurityTransparentAttribute : System.Attribute
     {
         public SecurityTransparentAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5501), AllowMultiple=false, Inherited=false)]
+    [System.ObsoleteAttribute("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility.  Please use the SecuritySafeCriticalAttribute instead.")]
+    public sealed partial class SecurityTreatAsSafeAttribute : System.Attribute
+    {
+        public SecurityTreatAsSafeAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(5188), AllowMultiple=true, Inherited=false)]
+    public sealed partial class SuppressUnmanagedCodeSecurityAttribute : System.Attribute
+    {
+        public SuppressUnmanagedCodeSecurityAttribute() { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(2), AllowMultiple=true, Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]

--- a/src/mscorlib/src/System/Security/Attributes.cs
+++ b/src/mscorlib/src/System/Security/Attributes.cs
@@ -57,14 +57,12 @@ namespace System.Security
         NotVisibleByDefault = 1
     }
 
-#if !FEATURE_CORECLR
     [Obsolete("SecurityCriticalScope is only used for .NET 2.0 transparency compatibility.")]
     public enum SecurityCriticalScope
     {
         Explicit = 0,
         Everything = 0x1
     }
-#endif // FEATURE_CORECLR
 
     // SecurityCriticalAttribute
     //  Indicates that the decorated code or assembly performs security critical operations (e.g. Assert, "unsafe", LinkDemand, etc.)
@@ -84,12 +82,10 @@ namespace System.Security
     {
 #pragma warning disable 618    // We still use SecurityCriticalScope for v2 compat
 
-#if !FEATURE_CORECLR        
-         private SecurityCriticalScope  _val;
-#endif // FEATURE_CORECLR
+        private SecurityCriticalScope  _val;
+
         public SecurityCriticalAttribute () {}
 
-#if !FEATURE_CORECLR
         public SecurityCriticalAttribute(SecurityCriticalScope scope)
         {
             _val = scope;
@@ -101,7 +97,6 @@ namespace System.Security
                 return _val;
             }
         }
-#endif // FEATURE_CORECLR
 
 #pragma warning restore 618
     }
@@ -167,7 +162,6 @@ namespace System.Security
         public SecurityTransparentAttribute () {}
     }
 
-#if !FEATURE_CORECLR
     public enum SecurityRuleSet : byte
     {
         None    = 0,
@@ -205,5 +199,4 @@ namespace System.Security
             get { return m_ruleSet; }
         }
     }
-#endif // !FEATURE_CORECLR
 }


### PR DESCRIPTION
I prepared a change with all of these in CoreFX but @jkotas recommended that they stay in CoreCLR because many of the attributes are adorning public types there.

Part of https://github.com/dotnet/corefx/issues/11115

@jkotas