### PR TITLE
Check PAL first, and then Windows Phone for crossgen

### DIFF
--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1705,16 +1705,16 @@ void ZapImage::OutputTables()
         SetSizeOfStackCommit(m_ModuleDecoder.GetSizeOfStackCommit());
     }
 
-#if defined(_TARGET_ARM_) && defined(FEATURE_CORECLR) && defined(FEATURE_CORESYSTEM)
+#if defined(FEATURE_PAL)
+    // PAL library requires native image sections to align to page bounaries.
+    SetFileAlignment(0x1000);
+#elif defined(_TARGET_ARM_) && defined(FEATURE_CORECLR) && defined(FEATURE_CORESYSTEM)
     if (!IsReadyToRunCompilation())
     {
         // On ARM CoreSys builds, crossgen will use 4k file alignment, as requested by Phone perf team
         // to improve perf on phones with compressed system partitions.
         SetFileAlignment(0x1000);
     }
-#elif defined(FEATURE_PAL)
-    // PAL library requires native image sections to align to page bounaries.
-    SetFileAlignment(0x1000);
 #endif
 }
 


### PR DESCRIPTION
It seems that ``crossgen`` uses the code for Windows Phone when running 'readytorun.genericsload.callgenericctor.callgenericctor' and 'readytorun.genericsload.usegenericfield.usegenericfield' even in ARM/Linux, which causes some unittest failure discussed in #6231.

This commit changes the order of '#fdef' to fix this issue.