### PR TITLE
Exclude GC\Scenarios\DoublinkList\dlstack across all platforms

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -40,6 +40,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\muldimjagary\muldimjagary\*">
             <Issue>3392</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlstack\*">
+            <Issue>6574</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\bleref_il_d\bleref_il_d.cmd">
             <Issue>2414</Issue>
         </ExcludeList>
@@ -242,9 +245,6 @@
     <!-- The following x86 failures only occur with RyuJIT/x86 -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x86'">
-        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlstack\*">
-            <Issue>6553</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b103058\b103058\b103058.cmd">
             <Issue>7008</Issue>
         </ExcludeList>


### PR DESCRIPTION
See https://github.com/dotnet/coreclr/issues/6553 for details on this. I am still investigating this issue but I don't believe it to be ryujit/x86 specific at this time (in particular since issues like https://github.com/dotnet/coreclr/issues/6574 occur).

cc @BruceForstall 