### PR TITLE
Optimize SIMD codegen for (in)equality check against zero that produces bool result.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5491,7 +5491,13 @@ void CodeGen::genConsumeRegs(GenTree* tree)
         }
         else
         {
+#ifdef FEATURE_SIMD
+            // (In)Equality operation that produces bool result, when compared
+            // against Vector zero, marks its Vector Zero operand as contained.
+            assert(tree->OperIsLeaf() || tree->IsIntegralConstVector(0));
+#else
             assert(tree->OperIsLeaf());
+#endif
         }
     }
     else

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -105,7 +105,7 @@ bool Is4ByteAVXInstruction(instruction ins)
     return (ins == INS_dpps || ins == INS_dppd || ins == INS_insertps || ins == INS_pcmpeqq || ins == INS_pcmpgtq ||
             ins == INS_vbroadcastss || ins == INS_vbroadcastsd || ins == INS_vpbroadcastb || ins == INS_vpbroadcastw ||
             ins == INS_vpbroadcastd || ins == INS_vpbroadcastq || ins == INS_vextractf128 || ins == INS_vinsertf128 ||
-            ins == INS_pmulld);
+            ins == INS_pmulld || ins == INS_ptest);
 #else
     return false;
 #endif

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1490,6 +1490,7 @@ public:
 
     inline bool IsFPZero();
     inline bool IsIntegralConst(ssize_t constVal);
+    inline bool IsIntegralConstVector(ssize_t constVal);
 
     inline bool IsBoxedValue();
 
@@ -4876,6 +4877,32 @@ inline bool GenTree::IsIntegralConst(ssize_t constVal)
     {
         return true;
     }
+
+    return false;
+}
+
+//-------------------------------------------------------------------
+// IsIntegralConstVector: returns true if this this is a SIMD vector
+// with all its elements equal to an integral constant.
+//
+// Arguments:
+//     constVal  -  const value of vector element
+//
+// Returns:
+//     True if this represents an integral const SIMD vector.
+//
+inline bool GenTree::IsIntegralConstVector(ssize_t constVal)
+{
+#ifdef FEATURE_SIMD
+    // SIMDIntrinsicInit intrinsic with a const value as initializer
+    // represents a const vector.
+    if ((gtOper == GT_SIMD) && (gtSIMD.gtSIMDIntrinsicID == SIMDIntrinsicInit) && gtGetOp1()->IsIntegralConst(constVal))
+    {
+        assert(varTypeIsIntegral(gtSIMD.gtSIMDBaseType));
+        assert(gtGetOp2() == nullptr);
+        return true;
+    }
+#endif
 
     return false;
 }

--- a/src/jit/instrsxarch.h
+++ b/src/jit/instrsxarch.h
@@ -317,6 +317,7 @@ INST3( insertps,     "insertps"    , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SS
 INST3( pcmpeqq,      "pcmpeqq"     , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x29))   // Packed compare 64-bit integers for equality
 INST3( pcmpgtq,      "pcmpgtq"     , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x37))   // Packed compare 64-bit integers for equality
 INST3( pmulld,       "pmulld"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x40))   // Packed multiply 32 bit unsigned integers and store lower 32 bits of each result
+INST3( ptest,        "ptest"       , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x17))   // Packed logical compare
 INST3(LAST_SSE4_INSTRUCTION, "LAST_SSE4_INSTRUCTION",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, BAD_CODE)
 
 INST3(FIRST_AVX_INSTRUCTION, "FIRST_AVX_INSTRUCTION",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, BAD_CODE)

--- a/tests/src/JIT/SIMD/VectorIntEquals.cs
+++ b/tests/src/JIT/SIMD/VectorIntEquals.cs
@@ -17,12 +17,27 @@ internal partial class VectorTest
         Vector<int> B = new Vector<int>(3);
         Vector<int> C = new Vector<int>(5);
 
-
         bool result = A.Equals(B);
-        if (!result) return Fail;
+        if (!result)
+        {
+            return Fail;
+        }
 
         result = A.Equals(C);
-        if (result) return Fail;
+        if (result)
+        {
+            return Fail;
+        }
+
+        if (A.Equals(Vector<int>.Zero))
+        {
+            return Fail;
+        }
+
+        if (!Vector<int>.Zero.Equals(Vector<int>.Zero))
+        {
+            return Fail;
+        }
 
         return Pass;
     }


### PR DESCRIPTION
As per Intel TechEmPower benchmark analysis, Kestrel.Internal.Infrastructure.MemoryPoolIterator.Seek() is one of the hot methods. This method uses equality against Vector.Zero

```
var data = new Vector<byte>(array, index);

// The below logic is repeated 3 times in the method
// against 3 different vectors.
var byte0Equals = Vector.Equals(data, byte0Vector);
if (!byte0Equals.Equals(Vector<byte>.Zero))
{
     byte0Index = FindFirstEqualByte(ref byte0Equals);
}
```

That is, SIMD API used is

`bool Vector<T>.Equals(Vector<T> v) `

Right now RyuJIT backend is generating the following

```
// Assume that byte0Equals in ymm0 reg
// Code generated for 
// byte0Equals.Equals(Vector<byte>.Zero)

vpxor ymm1, ymm1, ymm1
vmovaps ymm2, ymm0
vpcmpeqd ymm2, ymm2, ymm1
vextractf128 xmm3, ymm2, 0x1
vandps ymm2, ymm2, ymm3
vpshufd xmm3, xmm2, 0x4e
vandps ymm2, ymm2, ymm3
vpshufd xmm3, xmm2, 0x1
vpand ymm2, ymm2, ymm3
vmovd edi, xmm2
cmp edi, 0xffffffff
setz dil
movzx edi, dil
```


RyuJIT backend should be able to detect equality check against is Vector.Zero and generate the following optimal code

```
ptest ymm0, ymm0
setz dil
movzx edx, dil
```

Similarly for in-equality check against zero, we can generate

ptest ymm0, ymm0
setnz dil
movzx edx, dil

Fix #7358