### PR TITLE
Add missing System.IO APIs

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3507,6 +3507,8 @@
       <Member Name="#ctor(System.String,System.String,System.Int32)" /> <!-- Used by EE, do not remove -->
       <Member Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
       <Member Name="get_FileName" />
+      <Member Name="get_FusionLog" />
+      <Member MemberType="Property" Name="FusionLog" />
     </Type>
     <Type Name="System.IObservable&lt;T&gt;">
       <Member Name="Subscribe(System.IObserver&lt;T&gt;)"/>
@@ -9051,8 +9053,10 @@
       <Member Name="#ctor(System.String,System.String)" />
       <Member Name="#ctor(System.String,System.String,System.Exception)" />
       <Member Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
-      <Member Name="get_FileName" />
+      <Member Name="get_FileName" />      
+      <Member Name="get_FusionLog" />
       <Member MemberType="Property" Name="FileName" />
+      <Member MemberType="Property" Name="FusionLog" />
       <Member Status="ImplRoot" Name="#ctor(System.String,System.String,System.Int32)" />
     </Type>
     <Type Name="System.IO.IOException">
@@ -9153,6 +9157,7 @@
       <Member Name="CopyToAsync(System.IO.Stream,System.Int32)"  />
       <Member Name="CopyToAsync(System.IO.Stream,System.Int32,System.Threading.CancellationToken)"  />
       <Member Name="Close" />
+      <Member Name="CreateWaitHandle" />
       <Member Name="Dispose" />
       <Member Name="Dispose(System.Boolean)" />
       <Member Name="EndRead(System.IAsyncResult)" />
@@ -9168,6 +9173,7 @@
       <Member Name="get_Position" />
       <Member Name="get_ReadTimeout" />
       <Member Name="get_WriteTimeout" />
+      <Member Name="ObjectInvariant" />
       <Member Name="Read(System.Byte[],System.Int32,System.Int32)" />
       <Member Name="ReadByte" />
       <Member Name="ReadAsync(System.Byte[],System.Int32,System.Int32)"  />
@@ -9177,6 +9183,7 @@
       <Member Name="set_ReadTimeout(System.Int32)" />
       <Member Name="set_WriteTimeout(System.Int32)" />
       <Member Name="SetLength(System.Int64)" />
+      <Member Name="Synchronized(System.IO.Stream)" />
       <Member Name="Write(System.Byte[],System.Int32,System.Int32)" />
       <Member Name="WriteAsync(System.Byte[],System.Int32,System.Int32)"  />
       <Member Name="WriteAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)"  />
@@ -9307,6 +9314,7 @@
       <Member Name="ReadLineAsync"  />
       <Member Name="ReadToEnd" />
       <Member Name="ReadToEndAsync"  />
+      <Member Name="Synchronized(System.IO.TextReader)" />
     </Type>
     <Type Name="System.IO.TextWriter">
       <Member MemberType="Field" Name="CoreNewLine" />
@@ -9321,6 +9329,7 @@
       <Member Name="get_FormatProvider" />
       <Member Name="get_NewLine" />
       <Member Name="set_NewLine(System.String)" />
+      <Member Name="Synchronized(System.IO.TextWriter)" />
       <Member Name="Write(System.Boolean)" />
       <Member Name="Write(System.Char)" />
       <Member Name="Write(System.Char[])" />
@@ -9380,6 +9389,8 @@
       <Member Name="get_Capacity" />
       <Member Name="get_IsOpen" />
       <Member Name="Initialize(System.Runtime.InteropServices.SafeBuffer,System.Int64,System.Int64,System.IO.FileAccess)" />
+      <Member Name="Read&lt;T&gt;(System.Int64,T@)" />
+      <Member Name="ReadArray&lt;T&gt;(System.Int64,T[],System.Int32,System.Int32)" />
       <Member Name="ReadBoolean(System.Int64)" />
       <Member Name="ReadByte(System.Int64)" />
       <Member Name="ReadChar(System.Int64)" />
@@ -9406,6 +9417,8 @@
       <Member Name="Write(System.Int64,System.UInt16)" />
       <Member Name="Write(System.Int64,System.UInt32)" />
       <Member Name="Write(System.Int64,System.UInt64)" />
+      <Member Name="Write&lt;T&gt;(System.Int64,T@)" />
+      <Member Name="WriteArray&lt;T&gt;(System.Int64,T[],System.Int32,System.Int32)" />
       <Member MemberType="Property" Name="CanRead" />
       <Member MemberType="Property" Name="CanWrite" />
       <Member MemberType="Property" Name="Capacity" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -6627,6 +6627,7 @@ namespace System.IO
         public FileLoadException(string message, string fileName, System.Exception inner) { }
         protected FileLoadException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public string FileName { get { throw null; } }
+        public string FusionLog { [System.Security.SecuritySafeCriticalAttribute]get { throw null; } }
         public override string Message { get { throw null; } }
         public override string ToString() { throw null; }
     }
@@ -6640,6 +6641,7 @@ namespace System.IO
         public FileNotFoundException(string message, string fileName, System.Exception innerException) { }
         protected FileNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         public string FileName { get { throw null; } }
+        public string FusionLog { [System.Security.SecuritySafeCriticalAttribute]get { throw null; } }
         public override string Message { get { throw null; } }
         public override string ToString() { throw null; }
     }
@@ -6759,6 +6761,8 @@ namespace System.IO
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize) { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ObsoleteAttribute("CreateWaitHandle will be removed eventually.  Please use \"new ManualResetEvent(false)\" instead.")]
+        protected virtual System.Threading.WaitHandle CreateWaitHandle() { return default(System.Threading.WaitHandle); }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public virtual int EndRead(System.IAsyncResult asyncResult) { throw null; }
@@ -6768,6 +6772,8 @@ namespace System.IO
         public System.Threading.Tasks.Task FlushAsync() { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public virtual System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ObsoleteAttribute("Do not call or override this method.")]
+        protected virtual void ObjectInvariant() { }
         public abstract int Read(byte[] buffer, int offset, int count);
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count) { throw null; }
@@ -6776,6 +6782,7 @@ namespace System.IO
         public virtual int ReadByte() { throw null; }
         public abstract long Seek(long offset, System.IO.SeekOrigin origin);
         public abstract void SetLength(long value);
+        public static System.IO.Stream Synchronized(System.IO.Stream stream) { throw null; }
         public abstract void Write(byte[] buffer, int offset, int count);
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count) { throw null; }
@@ -6819,6 +6826,7 @@ namespace System.IO
         public override string ReadToEnd() { throw null; }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public override System.Threading.Tasks.Task<string> ReadToEndAsync() { throw null; }
+        public static System.IO.TextReader Synchronized(System.IO.TextReader reader) { throw null; }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public partial class StreamWriter : System.IO.TextWriter
@@ -6950,6 +6958,7 @@ namespace System.IO
         public virtual void Flush() { }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public virtual System.Threading.Tasks.Task FlushAsync() { throw null; }
+        public static System.IO.TextWriter Synchronized(System.IO.TextWriter writer) { throw null; }
         public virtual void Write(bool value) { }
         public virtual void Write(char value) { }
         public virtual void Write(char[] buffer) { }
@@ -7024,6 +7033,10 @@ namespace System.IO
         [System.Security.SecuritySafeCriticalAttribute]
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, Flags=(System.Security.Permissions.SecurityPermissionFlag)(2))]
         protected void Initialize(System.Runtime.InteropServices.SafeBuffer buffer, long offset, long capacity, System.IO.FileAccess access) { }
+        [System.Security.SecurityCriticalAttribute]
+        public void Read<T>(long position, out T structure) where T : struct { structure = default(T); throw null; }
+        [System.Security.SecurityCriticalAttribute]
+        public int ReadArray<T>(long position, T[] array, int offset, int count) where T : struct { throw null; }
         public bool ReadBoolean(long position) { throw null; }
         public byte ReadByte(long position) { throw null; }
         [System.Security.SecuritySafeCriticalAttribute]
@@ -7080,6 +7093,10 @@ namespace System.IO
         [System.CLSCompliantAttribute(false)]
         [System.Security.SecuritySafeCriticalAttribute]
         public void Write(long position, ulong value) { }
+        [System.Security.SecurityCriticalAttribute]
+        public void Write<T>(long position, ref T structure) where T : struct { }
+        [System.Security.SecurityCriticalAttribute]
+        public void WriteArray<T>(long position, T[] array, int offset, int count) where T : struct { }
     }
     public partial class UnmanagedMemoryStream : System.IO.Stream
     {

--- a/src/mscorlib/src/System/IO/FileLoadException.cs
+++ b/src/mscorlib/src/System/IO/FileLoadException.cs
@@ -91,7 +91,6 @@ namespace System.IO {
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;
 
-#if FEATURE_FUSION
             try
             {
                 if(FusionLog!=null)
@@ -107,7 +106,6 @@ namespace System.IO {
             {
             
             }
-#endif // FEATURE_FUSION
 
             return s;
         }
@@ -117,7 +115,6 @@ namespace System.IO {
 
             _fileName = info.GetString("FileLoad_FileName");
 
-#if FEATURE_FUSION
             try
             {
                 _fusionLog = info.GetString("FileLoad_FusionLog");
@@ -126,7 +123,6 @@ namespace System.IO {
             {
                 _fusionLog = null;
             }
-#endif 
         }
 
         private FileLoadException(String fileName, String fusionLog,int hResult)
@@ -138,13 +134,10 @@ namespace System.IO {
             SetMessageField();
         }
 
-#if FEATURE_FUSION
         public String FusionLog {
             [System.Security.SecuritySafeCritical]  // auto-generated
-            [SecurityPermissionAttribute( SecurityAction.Demand, Flags = SecurityPermissionFlag.ControlEvidence | SecurityPermissionFlag.ControlPolicy)]
             get { return _fusionLog; }
         }
-#endif // FEATURE_FUSION
 
         [System.Security.SecurityCritical]  // auto-generated_required
         public override void GetObjectData(SerializationInfo info, StreamingContext context) {
@@ -154,7 +147,6 @@ namespace System.IO {
             // Serialize data for this class
             info.AddValue("FileLoad_FileName", _fileName, typeof(String));
 
-#if FEATURE_FUSION
             try
             {
                 info.AddValue("FileLoad_FusionLog", FusionLog, typeof(String));
@@ -162,7 +154,6 @@ namespace System.IO {
             catch (SecurityException)
             {
             }
-#endif
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/mscorlib/src/System/IO/FileNotFoundException.cs
+++ b/src/mscorlib/src/System/IO/FileNotFoundException.cs
@@ -93,7 +93,6 @@ namespace System.IO {
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;
 
-#if FEATURE_FUSION            
             try
             {
                 if(FusionLog!=null)
@@ -109,7 +108,6 @@ namespace System.IO {
             {
             
             }
-#endif            
             return s;
             
         }
@@ -118,7 +116,6 @@ namespace System.IO {
             // Base class constructor will check info != null.
 
             _fileName = info.GetString("FileNotFound_FileName");
-#if FEATURE_FUSION
             try
             {
                 _fusionLog = info.GetString("FileNotFound_FusionLog");
@@ -127,7 +124,6 @@ namespace System.IO {
             {
                 _fusionLog = null;
             }
-#endif
         }
 
         private FileNotFoundException(String fileName, String fusionLog,int hResult)
@@ -139,13 +135,10 @@ namespace System.IO {
             SetMessageField();
         }
 
-#if FEATURE_FUSION
         public String FusionLog {
             [System.Security.SecuritySafeCritical]  // auto-generated
-            [SecurityPermissionAttribute( SecurityAction.Demand, Flags = SecurityPermissionFlag.ControlEvidence | SecurityPermissionFlag.ControlPolicy)]
             get { return _fusionLog; }
         }
-#endif
 
         [System.Security.SecurityCritical]  // auto-generated_required
         public override void GetObjectData(SerializationInfo info, StreamingContext context) {
@@ -155,7 +148,6 @@ namespace System.IO {
             // Serialize data for this class
             info.AddValue("FileNotFound_FileName", _fileName, typeof(String));
 
-#if FEATURE_FUSION
             try
             {
                 info.AddValue("FileNotFound_FusionLog", FusionLog, typeof(String));
@@ -163,7 +155,6 @@ namespace System.IO {
             catch (SecurityException)
             {
             }
-#endif
         }
     }
 }


### PR DESCRIPTION
This is the last chunk of APIs missing from System.IO that will be included in netstandard20 and that live in mscorlib.

progress towards https://github.com/dotnet/corefx/issues/9465

@danmosemsft I included the fusionlog property since it's listed in https://github.com/dotnet/standard/blob/master/netstandard/ref/mscorlib.cs still.

@joperezr 