### PR TITLE
[Linux][GDB-JIT] Initial support of local variables and arguments 

### DIFF
--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -258,9 +258,10 @@ int coreclr_initialize(
         if (!SUCCEEDED(hr))
         {
             fprintf(stderr,
-                    "Can't create delegate for 'System.Diagnostics.Debug.SymbolReader.SymbolReader.GetInfoForMethod' "
+                    "Can't create delegate for 'SOS.SymbolReader.GetInfoForMethod' "
                     "method - status: 0x%08x\n", hr);
         }
+
         hr = S_OK; // We don't need to fail if we can't create delegate
 #endif
     }

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 #include "method.hpp"
+#include "dbginterface.h"
 #include "../inc/llvm/ELF.h"
 #include "../inc/llvm/Dwarf.h"
 
@@ -69,7 +70,45 @@ struct SymbolsInfo
     int lineNumber, ilOffset, nativeOffset, fileIndex;
     char fileName[2*MAX_PATH_FNAME];
 };
+struct LocalsInfo
+{
+    int size;
+    char** localsName;
+    ULONG32 countVars;
+    ICorDebugInfo::NativeVarInfo *pVars;
+};
 
+struct ArgsDebugInfo
+{
+    int m_type_index;
+    const char* m_type_name;
+    int  m_type_name_offset;
+    int m_type_encoding;
+    int m_type_size;
+    int m_type_abbrev;
+    int m_type_offset;
+    int m_il_index;
+    const char* m_arg_name;
+    int m_arg_name_offset;
+    int m_arg_abbrev;
+    int m_native_offset;
+};
+
+struct LocalsDebugInfo
+{
+    int m_type_index;
+    const char* m_type_name;
+    int  m_type_name_offset;
+    int m_type_encoding;
+    int m_type_size;
+    int m_type_abbrev;
+    int m_type_offset;
+    int m_il_index;
+    char* m_var_name;
+    int m_var_name_offset;
+    int m_var_abbrev;
+    int m_native_offset;
+};
 
 class NotifyGdb
 {
@@ -90,9 +129,17 @@ private:
     static bool BuildSectionTable(MemBuf& buf);
     static bool BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize);
     static bool BuildStringTableSection(MemBuf& strTab);
-    static bool BuildDebugStrings(MemBuf& buf);
-    static bool BuildDebugAbbrev(MemBuf& buf);    
-    static bool BuildDebugInfo(MemBuf& buf);
+    static bool BuildDebugStrings(MemBuf& buf,
+                                  NewArrayHolder<ArgsDebugInfo>& argsDebug,
+                                  unsigned int argsDebugSize,
+                                  NewArrayHolder<LocalsDebugInfo>& localsDebug,
+                                  unsigned int localsDebugSize, const char *retTypeStr);
+    static bool BuildDebugAbbrev(MemBuf& buf);
+    static bool BuildDebugInfo(MemBuf& buf,
+                               NewArrayHolder<ArgsDebugInfo>& argsDebug,
+                               unsigned int argsDebugSize,
+                               NewArrayHolder<LocalsDebugInfo>& localsDebug,
+                               unsigned int localsDebugSize);
     static bool BuildDebugPub(MemBuf& buf, const char* name, uint32_t size, uint32_t dieOffset);
     static bool BuildLineTable(MemBuf& buf, PCODE startAddr, SymbolsInfo* lines, unsigned nlines);
     static bool BuildFileTable(MemBuf& buf, SymbolsInfo* lines, unsigned nlines);

--- a/src/vm/gdbjithelpers.h
+++ b/src/vm/gdbjithelpers.h
@@ -23,6 +23,8 @@ struct MethodDebugInfo
 {
     SequencePointInfo* points;
     int size;
+    char16_t** locals;
+    int localsSize;
 };
 
 typedef BOOL (*GetInfoForMethodDelegate)(const char*, unsigned int, MethodDebugInfo& methodDebugInfo);

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -228,7 +228,7 @@ void DACNotifyCompilationFinished(MethodDesc *methodDesc)
         // Are we listed?
         USHORT jnt = jn.Requested((TADDR) modulePtr, t);
         if (jnt & CLRDATA_METHNOTIFY_GENERATED)
-        {            
+        {
             // If so, throw an exception!
 #endif
             DACNotify::DoJITNotification(methodDesc);


### PR DESCRIPTION
This PR implements initial support of showing local variables and arguments in lldb using gdb jit interface. At this moment only basic types are supported. 

```
(lldb) breakpoint set -m false -f helloworld5.cs -l  10
Breakpoint 1: no locations (pending).
WARNING:  Unable to resolve breakpoint to any actual locations.
(lldb) c
1 location added to breakpoint 1
Process 27799 resuming
Process 27799 stopped
* thread #1: tid = 27799, 0x00007fff7d54cc60 JIT(0x71f4e0)`show_message(this=0x00007fff6001f8e8, a=5) + 64 at helloworld5.cs:10, name = 'corerun', stop reason = breakpoint 1.1
    frame #0: 0x00007fff7d54cc60 JIT(0x71f4e0)`show_message(this=0x00007fff6001f8e8, a=5) + 64 at helloworld5.cs:10
   7   	        public int show_message(int a)
   8   	        {
   9   	            int i = 0;
-> 10  	            i+=a;
   11  	            if (i > 0)
   12  	                return 1;
   13  	            else

(lldb) frame variable
(void *) this = 0x00007fff6001f8e8
(int) a = 5
(int) i = 0
(lldb) 
```
@mikem8361, @janvorli PTAL

\cc @Dmitri-Botcharnikov @chunseoklee @seanshpark 
