### PR TITLE
Adding back isVolatile to mscorlib facade as C# compiler uses it

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6300,6 +6300,7 @@
       <Member Name="IsInstanceOfInterface(System.Runtime.CompilerServices.ICastable,System.RuntimeType,System.Exception@)" /> <!-- EE -->
       <Member Name="GetImplType(System.Runtime.CompilerServices.ICastable,System.RuntimeType)" /> <!-- EE -->
     </Type>
+    <Type Name="System.Runtime.CompilerServices.IsVolatile" />  <!-- for All Compilers, [ C# and MC++ uses it] -->
     <Type Name="System.Runtime.CompilerServices.MethodCodeType">
       <Member MemberType="Field" Name="IL" />
       <Member MemberType="Field" Name="Native" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -9992,6 +9992,10 @@ namespace System.Runtime.CompilerServices
         public bool AllInternalsVisible { get { throw null; } set { } }
         public string AssemblyName { get { throw null; } }
     }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public static partial class IsVolatile 
+    {
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false, AllowMultiple=false)]
     public sealed partial class IteratorStateMachineAttribute : System.Runtime.CompilerServices.StateMachineAttribute
     {


### PR DESCRIPTION
@tarekms @weshaggard  @jkotas PTAL