### PR TITLE
Correct preprocessor conditional termination in case BACKGROUND_GC is…

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -9972,8 +9972,8 @@ gc_heap::init_semi_shared()
         {
             goto cleanup;
         }
-#endif //BACKGROUND_GC
     }
+#endif //BACKGROUND_GC
 
     memset (&current_no_gc_region_info, 0, sizeof (current_no_gc_region_info));
 


### PR DESCRIPTION
… not defined.

This patch ensures that the code remains valid even when BACKGROUND_GC is not defined.
Before this patch, the endif that terminates the conditional compilation block
misses the terminating curly brace. That means there will be an extra, erroneous
closing brace the moment BACKGROUND_GC isn't defined.