### PR TITLE
Fix pre-release versioning for WinArm and JIT packages.

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -15,16 +15,14 @@
     <!-- Declare a runtime dependency on the win8-arm CoreCLR built using the TFS builds -->
     <RuntimeDependency Include="runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR">
       <TargetRuntime>win8-arm</TargetRuntime>
-      <Version>1.0.5</Version>
+      <Version>1.0.5-$(ExternalExpectedPrerelease)</Version>
     </RuntimeDependency>
     <!-- ApiSets are only applicable for Windows. 
          Despite the unconditioned package dependency it is constrained by runtime IDs within it's own package -->
     <Dependency Include="Microsoft.NETCore.Windows.ApiSets">
       <Version>1.0.1</Version>
     </Dependency>
-    <Dependency Include="Microsoft.NETCore.Jit">
-      <Version>1.0.5</Version>
-    </Dependency>
+    <ProjectReference Include="..\Microsoft.NETCore.Jit\Microsoft.NETCore.Jit.pkgproj" />
     <ProjectReference Include="win\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>


### PR DESCRIPTION
@ericstj PTAL. This is based upon the discussion we had in the morning.

I also fixed the dependency of Arm package.

CC @leecow We will need to take this for LTS.