### PR TITLE
Fix change to GenericEqualityComparer.Equals from #5804

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -177,11 +177,13 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself.
+        // If in the future this type is made sealed, change the is check to GetType() == obj.GetType().
         public override bool Equals(Object obj) =>
-            obj != null && GetType() == obj.GetType();
+            obj != null && obj is GenericEqualityComparer<T>;
 
+        // If in the future this type is made sealed, change typeof(...) to GetType().
         public override int GetHashCode() =>
-            GetType().GetHashCode();
+            typeof(GenericEqualityComparer<T>).GetHashCode();
     }
 
     [Serializable]

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -179,7 +179,7 @@ namespace System.Collections.Generic
         // Equals method for the comparer itself.
         // If in the future this type is made sealed, change the is check to GetType() == obj.GetType().
         public override bool Equals(Object obj) =>
-            obj != null && obj is GenericEqualityComparer<T>;
+            obj is GenericEqualityComparer<T>;
 
         // If in the future this type is made sealed, change typeof(...) to GetType().
         public override int GetHashCode() =>

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -177,7 +177,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself.
-        // If in the future this type is made sealed, change the is check to GetType() == obj.GetType().
+        // If in the future this type is made sealed, change the is check to obj != null && GetType() == obj.GetType().
         public override bool Equals(Object obj) =>
             obj is GenericEqualityComparer<T>;
 


### PR DESCRIPTION
[`NonRandomizedStringEqualityComparer`](https://github.com/jamesqo/coreclr/blob/316c72b9c809e452edc768d826c572ecdc1b98ee/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs#L303) subclasses `GenericEqualityComparer<string>`, so if someone creates a new Dictionary with `string` as the key and then checks `d.Comparer` for equality to `EqualityComparer<string>.Default`, it will now return false where previously it had returned true. This fixes that by replacing `GetType()` calls with is-checks / typeof.

Apologies for the mess-up.

(Luckily this can't happen with `EnumEqualityComparer` even though it's not sealed; for a given enum T there is only one possible subclass of `EnumEqualityComparer` that its comparer can be.)

cc @jkotas 