### PR TITLE
Arm64 StoreBlk Lowering Fix

### DIFF
--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1370,7 +1370,6 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
             // CopyBlk
             unsigned   size                  = blkNode->gtBlkSize;
             GenTreePtr dstAddr               = blkNode->Addr();
-            GenTreePtr srcAddr               = blkNode->Data();
             short      internalIntCount      = 0;
             regMaskTP  internalIntCandidates = RBM_NONE;
 


### PR DESCRIPTION
With the block assignment changes, the Arm64 version of
Lowering::TreeNodeInfoInitBlockStore was not using the correct node
for the source address.

Fix #7197