### PR TITLE
Exclude DevDiv_255294.cmd for jit32 due to timeout

### DIFF
--- a/tests/x86_jit32_issues.targets
+++ b/tests/x86_jit32_issues.targets
@@ -515,5 +515,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b409748\b409748\b409748.cmd">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_255294\DevDiv_255294\DevDiv_255294.cmd">
+            <Issue>times out</Issue>
+        </ExcludeList>
+ 
     </ItemGroup>
 </Project>


### PR DESCRIPTION
@RussKeldorph @adiaaida ptal
/cc @dotnet/jit-contrib 