### PR TITLE
Properly initialize lvaTrackedVarSet.

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2689,6 +2689,10 @@ void Compiler::lvaSortByRefCount()
     lvaTrackedCount             = 0;
     lvaTrackedCountInSizeTUnits = 0;
 
+#ifdef DEBUG
+    VarSetOps::AssignNoCopy(this, lvaTrackedVars, VarSetOps::MakeEmpty(this));
+#endif
+
     if (lvaCount == 0)
     {
         return;


### PR DESCRIPTION
The lack of initialization when `lvaCount == 0` was causing failures
under JITStressRegs=0x80. When this initialization is not performed,
it is initialized s.t. every bit is set, including bits that represent
non-existent lclVars. This caused LSRA to AV when attempting to access
the lclVar table using a lclNum derived from an iteration over
`lvaTrackedVarSet`.

Fixes #7090.