### PR TITLE
Add support for Alpine Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,16 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
         clr_unknown_arch()
     endif()
     set(CLR_CMAKE_PLATFORM_LINUX 1)
+
+    # Detect Alpine Linux
+    SET(OS_RELEASE_FILENAME "/etc/os-release")
+    if (EXISTS ${OS_RELEASE_FILENAME})
+        file(READ ${OS_RELEASE_FILENAME} OS_RELEASE)
+        string(FIND "${OS_RELEASE}" "ID=alpine" CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+        if(CLR_CMAKE_PLATFORM_ALPINE_LINUX EQUAL -1)
+            unset(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+        endif(CLR_CMAKE_PLATFORM_ALPINE_LINUX EQUAL -1)
+    endif(EXISTS ${OS_RELEASE_FILENAME})
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)

--- a/clrdefinitions.cmake
+++ b/clrdefinitions.cmake
@@ -61,6 +61,12 @@ if (CLR_CMAKE_PLATFORM_UNIX)
 
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
+if(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+  # Alpine Linux doesn't have fixed stack limit, this define disables some stack pointer
+  # sanity checks in debug / checked build that rely on a fixed stack limit
+  add_definitions(-DNO_FIXED_STACK_LIMIT)
+endif(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+
 add_definitions(-D_BLD_CLR)
 add_definitions(-DDEBUGGING_SUPPORTED)
 add_definitions(-DPROFILING_SUPPORTED)

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -2,13 +2,6 @@ cmake_minimum_required(VERSION 2.8.12.2)
 
 include_directories(SYSTEM /usr/local/include)
 
-# set kernel version to detect Alpine
-EXEC_PROGRAM(uname ARGS -v OUTPUT_VARIABLE CMAKE_SYSTEM_KERNEL_VERSION)
-string(FIND "${CMAKE_SYSTEM_KERNEL_VERSION}" "Alpine" PAL_SYSTEM_ALPINE)
-if(PAL_SYSTEM_ALPINE EQUAL -1)
-    unset(PAL_SYSTEM_ALPINE)
-endif()
-
 include(configure.cmake)
 
 project(coreclrpal)
@@ -69,6 +62,16 @@ elseif(PAL_CMAKE_PLATFORM_ARCH_ARM64)
   add_definitions(-DBIT64=1)
   add_definitions(-D_WIN64=1)
 endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+  # Currently the _xstate is not available on Alpine Linux
+  add_definitions(-DXSTATE_SUPPORTED)
+endif(CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+
+if(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+  # Setting RLIMIT_NOFILE breaks debugging of coreclr on Alpine Linux for some reason
+  add_definitions(-DDONT_SET_RLIMIT_NOFILE)
+endif(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
 
 # turn off capability to remove unused functions (which was enabled in debug build with sanitizers)
 set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -Wl,--no-gc-sections")
@@ -252,7 +255,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     find_library(UNWIND_ARCH NAMES unwind-x86_64)
   endif()
 
-  if(PAL_SYSTEM_ALPINE)
+  if(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
     find_library(INTL intl)
   endif()
 

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -88,6 +88,10 @@ PHARDWARE_EXCEPTION_SAFETY_CHECK_FUNCTION g_safeExceptionCheckFunction = NULL;
 
 PGET_GCMARKER_EXCEPTION_CODE g_getGcMarkerExceptionCode = NULL;
 
+// Return address of the SEHProcessException, which is used to enable walking over 
+// the signal handler trampoline on some Unixes where the libunwind cannot do that.
+void* g_SEHProcessExceptionReturnAddress = NULL;
+
 /* Internal function definitions **********************************************/
 
 /*++
@@ -245,6 +249,8 @@ Return value:
 BOOL
 SEHProcessException(PAL_SEHException* exception)
 {
+    g_SEHProcessExceptionReturnAddress = __builtin_return_address(0);
+
     CONTEXT* contextRecord = exception->GetContextRecord();
     EXCEPTION_RECORD* exceptionRecord = exception->GetExceptionRecord();
 

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -100,6 +100,10 @@ static bool registered_sigterm_handler = false;
 struct sigaction g_previous_activation;
 #endif
 
+// Offset of the local variable containing native context in the common_signal_handler function.
+// This offset is relative to the frame pointer.
+int g_common_signal_handler_context_locvar_offset = 0;
+
 /* public function definitions ************************************************/
 
 /*++
@@ -582,6 +586,7 @@ Note:
     the "pointers" parameter should contain a valid exception record pointer,
     but the ContextRecord pointer will be overwritten.
 --*/
+__attribute__((noinline))
 static bool common_signal_handler(int code, siginfo_t *siginfo, void *sigcontext, int numParams, ...)
 {
     sigset_t signal_set;
@@ -590,6 +595,7 @@ static bool common_signal_handler(int code, siginfo_t *siginfo, void *sigcontext
     native_context_t *ucontext;
 
     ucontext = (native_context_t *)sigcontext;
+    g_common_signal_handler_context_locvar_offset = (int)((char*)&ucontext - (char*)__builtin_frame_address(0));
 
     AllocateExceptionRecords(&exceptionRecord, &contextRecord);
 

--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -139,6 +139,8 @@ typedef ucontext_t native_context_t;
 /////////////////////
 // Extended state
 
+#ifdef XSTATE_SUPPORTED
+
 inline _fpx_sw_bytes *FPREG_FpxSwBytes(const ucontext_t *uc)
 {
     // Bytes 464..511 in the FXSAVE format are available for software to use for any purpose. In this case, they are used to
@@ -184,6 +186,8 @@ inline void *FPREG_Xstate_Ymmh(const ucontext_t *uc)
 
     return reinterpret_cast<_xstate *>(FPREG_Fpstate(uc))->ymmh.ymmh_space;
 }
+
+#endif // XSTATE_SUPPORTED
 
 /////////////////////
 
@@ -465,6 +469,19 @@ inline static void CONTEXTSetPC(LPCONTEXT pContext, DWORD64 pc)
     pContext->Pc = pc;
 #else
 #error don't know how to set the program counter for this architecture
+#endif
+}
+
+inline static DWORD64 CONTEXTGetFP(LPCONTEXT pContext)
+{
+#if defined(_AMD64_)
+    return pContext->Rbp;
+#elif defined(_ARM_)
+    return pContext->R7;
+#elif defined(_ARM64_)
+    return pContext->X29;    
+#else
+#error don't know how to get the frame pointer for this architecture
 #endif
 }
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -992,6 +992,7 @@ Return value:
 --*/
 static BOOL INIT_IncreaseDescriptorLimit(void)
 {
+#ifndef DONT_SET_RLIMIT_NOFILE
     struct rlimit rlp;
     int result;
     
@@ -1008,7 +1009,7 @@ static BOOL INIT_IncreaseDescriptorLimit(void)
     {
         return FALSE;
     }
-
+#endif // !DONT_SET_RLIMIT_NOFILE
     return TRUE;
 }
 

--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -467,13 +467,13 @@ void CONTEXTToNativeContext(CONST CONTEXT *lpContext, native_context_t *native)
     }
 
     // TODO: Enable for all Unix systems
-#if defined(_AMD64_) && defined(__linux__)
+#if defined(_AMD64_) && defined(XSTATE_SUPPORTED)
     if ((lpContext->ContextFlags & CONTEXT_XSTATE) == CONTEXT_XSTATE)
     {
         _ASSERTE(FPREG_HasExtendedState(native));
         memcpy_s(FPREG_Xstate_Ymmh(native), sizeof(M128A) * 16, lpContext->VectorRegister, sizeof(M128A) * 16);
     }
-#endif // _AMD64_
+#endif //_AMD64_ && XSTATE_SUPPORTED
 }
 
 /*++
@@ -564,22 +564,24 @@ void CONTEXTFromNativeContext(const native_context_t *native, LPCONTEXT lpContex
 #endif
     }
 
-    // TODO: Enable for all Unix systems
-#if defined(_AMD64_) && defined(__linux__)
+#ifdef _AMD64_
     if ((contextFlags & CONTEXT_XSTATE) == CONTEXT_XSTATE)
     {
+    // TODO: Enable for all Unix systems
+#if XSTATE_SUPPORTED
         if (FPREG_HasExtendedState(native))
         {
             memcpy_s(lpContext->VectorRegister, sizeof(M128A) * 16, FPREG_Xstate_Ymmh(native), sizeof(M128A) * 16);
         }
         else
+#endif // XSTATE_SUPPORTED
         {
             // Reset the CONTEXT_XSTATE bit(s) so it's clear that the extended state data in
             // the CONTEXT is not valid.
             const ULONG xstateFlags = CONTEXT_XSTATE & ~(CONTEXT_CONTROL & CONTEXT_INTEGER);
             lpContext->ContextFlags &= ~xstateFlags;
         }
-    } 
+    }
 #endif // _AMD64_
 }
 

--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -2560,7 +2560,9 @@ StackWalkAction StackFrameIterator::NextRaw(void)
         // to recover from AVs during profiler stackwalk.)
 
         PTR_VOID newSP = PTR_VOID((TADDR)GetRegdisplaySP(m_crawl.pRD));
+#ifndef NO_FIXED_STACK_LIMIT
         FAIL_IF_SPECULATIVE_WALK(newSP >= m_crawl.pThread->GetCachedStackLimit());
+#endif // !NO_FIXED_STACK_LIMIT
         FAIL_IF_SPECULATIVE_WALK(newSP < m_crawl.pThread->GetCachedStackBase());
 
 #undef FAIL_IF_SPECULATIVE_WALK

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -8245,7 +8245,9 @@ void CheckRegDisplaySP (REGDISPLAY *pRD)
 {
     if (pRD->SP && pRD->_pThread)
     {
+#ifndef NO_FIXED_STACK_LIMIT
         _ASSERTE(PTR_VOID(pRD->SP) >= pRD->_pThread->GetCachedStackLimit());
+#endif // NO_FIXED_STACK_LIMIT
         _ASSERTE(PTR_VOID(pRD->SP) <  pRD->_pThread->GetCachedStackBase());
     }
 }


### PR DESCRIPTION
This change enables build of CoreCLR on Alpine Linux. Here is the list
of changes:
- Disable asserts checking RSP in arbitrary threads against cached stack limit
  for the respective thread. The stack on Alpine obviously grows over the limit
  reported by the pthread functions.
- Disable using XSTATE on Alpine. This should be re-enabled after MUSL gets the _xstate,
  _fpx_sw_bytes and related data structures added to the signal.h header.
- Disable setting rlimit of RLIMIT_NOFILE to the max value, since it breaks
  debugging for some reason.
- Add skipping over the hardware signal trampoline in the PAL_VirtualUnwind.
  While we were not trying to walk over it in a simple case, in a case where
  an exception was thrown from a catch handler of a hardware exception, we
  still attempted to walk over it and it fails on Alpine.
- Fix detection of Alpine Linux in the PAL's CMakeLists.txt so that it works
  in Docker containers too.
- Modified PAL_VirtualUnwind to make the check for unwinding past the bottom
  of the stack unconditional. We had a long list of platforms where we were
  doing this check and it doesn't hurt to do it on platforms where it is not
  needed. I have done that rather than adding a check for Alpine Linux as
  another platform that needs it.