### PR TITLE
[Linux] [SOS.NETCore] Quick fix for Path.GetFileName

### DIFF
--- a/src/ToolBox/SOS/NETCore/SymbolReader.cs
+++ b/src/ToolBox/SOS/NETCore/SymbolReader.cs
@@ -126,6 +126,27 @@ namespace SOS
         }
 
         /// <summary>
+        /// Quick fix for Path.GetFileName which incorrectly handles Windows-style paths on Linux
+        /// </summary>
+        /// <param name="pathName"> File path to be processed </param>
+        /// <returns>Last component of path</returns>
+        private static string GetFileName(string pathName)
+        {
+            int pos = -1;
+            for (int i = pathName.Length - 1; i >= 0; --i)
+            {
+                if (pathName[i] == '/' || pathName[i] == '\\')
+                {
+                    pos = i;
+                    break;
+                }
+            }
+            if (pos < 0)
+                return pathName;
+            return pathName.Substring(pos + 1);
+        }
+
+        /// <summary>
         /// Checks availability of debugging information for given assembly.
         /// </summary>
         /// <param name="assemblyPath">
@@ -207,7 +228,7 @@ namespace SOS
 
             try
             {
-                string fileName = Path.GetFileName(filePath);
+                string fileName = GetFileName(filePath);
                 foreach (MethodDebugInformationHandle methodDebugInformationHandle in reader.MethodDebugInformation)
                 {
                     MethodDebugInformation methodDebugInfo = reader.GetMethodDebugInformation(methodDebugInformationHandle);
@@ -215,7 +236,7 @@ namespace SOS
                     foreach (SequencePoint point in sequencePoints)
                     {
                         string sourceName = reader.GetString(reader.GetDocument(point.Document).Name);
-                        if (point.StartLine == lineNumber && Path.GetFileName(sourceName) == fileName)
+                        if (point.StartLine == lineNumber && GetFileName(sourceName) == fileName)
                         {
                             methodToken = MetadataTokens.GetToken(methodDebugInformationHandle.ToDefinitionHandle());
                             ilOffset = point.Offset;
@@ -451,7 +472,7 @@ namespace SOS
 
                         DebugInfo debugInfo = new DebugInfo();
                         debugInfo.lineNumber = point.StartLine;
-                        debugInfo.fileName = openedReader.Reader.GetString(openedReader.Reader.GetDocument(point.Document).Name);
+                        debugInfo.fileName = GetFileName(openedReader.Reader.GetString(openedReader.Reader.GetDocument(point.Document).Name));
                         debugInfo.ilOffset = point.Offset;
                         points.Add(debugInfo);
                     }
@@ -609,7 +630,7 @@ namespace SOS
                 {
                     try
                     {
-                        pdbPath = Path.Combine(Path.GetDirectoryName(assemblyPath), Path.GetFileName(pdbPath));
+                        pdbPath = Path.Combine(Path.GetDirectoryName(assemblyPath), GetFileName(pdbPath));
                     }
                     catch
                     {

--- a/src/ToolBox/SOS/NETCore/SymbolReader.cs
+++ b/src/ToolBox/SOS/NETCore/SymbolReader.cs
@@ -132,15 +132,7 @@ namespace SOS
         /// <returns>Last component of path</returns>
         private static string GetFileName(string pathName)
         {
-            int pos = -1;
-            for (int i = pathName.Length - 1; i >= 0; --i)
-            {
-                if (pathName[i] == '/' || pathName[i] == '\\')
-                {
-                    pos = i;
-                    break;
-                }
-            }
+            int pos = pathName.LastIndexOfAny(new char[] { '/', '\\'});
             if (pos < 0)
                 return pathName;
             return pathName.Substring(pos + 1);


### PR DESCRIPTION
This patch is a quick fix for issue #7184 that enables `SOS.NETCore` on Linux to read debugging information generated on Windows.
@mikem8361 @seanshpark @chunseoklee @lucenticus @kvochko @ayuckhulk 
