### PR TITLE
[Linux][GDB-JIT] Fix DWARF linetable info provided by GDBJIT

### DIFF
--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -141,9 +141,9 @@ private:
                                NewArrayHolder<LocalsDebugInfo>& localsDebug,
                                unsigned int localsDebugSize);
     static bool BuildDebugPub(MemBuf& buf, const char* name, uint32_t size, uint32_t dieOffset);
-    static bool BuildLineTable(MemBuf& buf, PCODE startAddr, SymbolsInfo* lines, unsigned nlines);
+    static bool BuildLineTable(MemBuf& buf, PCODE startAddr, TADDR codeSize, SymbolsInfo* lines, unsigned nlines);
     static bool BuildFileTable(MemBuf& buf, SymbolsInfo* lines, unsigned nlines);
-    static bool BuildLineProg(MemBuf& buf, PCODE startAddr, SymbolsInfo* lines, unsigned nlines);
+    static bool BuildLineProg(MemBuf& buf, PCODE startAddr, TADDR codeSize, SymbolsInfo* lines, unsigned nlines);
     static bool FitIntoSpecialOpcode(int8_t line_shift, uint8_t addr_shift);
     static void IssueSetAddress(char*& ptr, PCODE addr);
     static void IssueEndOfSequence(char*& ptr);


### PR DESCRIPTION
This PR fixes DWARF linetable info which is generated by GDBJIT for each function.
Previously address near the function end were not covered by DWARF info which caused the debugger to show machine assembly code instead of source code.

@mikem8361, @janvorli PTAL

\cc @Dmitri-Botcharnikov @chunseoklee @seanshpark