### PR TITLE
[Linux][GDB-JIT] Fix incorrect frame location when we have a lot of locals

### DIFF
--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -154,7 +154,7 @@ private:
     static bool CollectCalledMethods(CalledMethod* pCM);
     static int Leb128Encode(uint32_t num, char* buf, int size);
     static int Leb128Encode(int32_t num, char* buf, int size);
-    static int GetFrameLocation(int native_offset, char*& var_loc);
+    static int GetFrameLocation(int nativeOffset, char* varLoc);
     static int GetArgsAndLocalsLen(NewArrayHolder<ArgsDebugInfo>& argsDebug,
                                    unsigned int argsDebugSize,
                                    NewArrayHolder<LocalsDebugInfo>& localsDebug,

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -154,6 +154,11 @@ private:
     static bool CollectCalledMethods(CalledMethod* pCM);
     static int Leb128Encode(uint32_t num, char* buf, int size);
     static int Leb128Encode(int32_t num, char* buf, int size);
+    static int GetFrameLocation(int native_offset, char*& var_loc);
+    static int GetArgsAndLocalsLen(NewArrayHolder<ArgsDebugInfo>& argsDebug,
+                                   unsigned int argsDebugSize,
+                                   NewArrayHolder<LocalsDebugInfo>& localsDebug,
+                                   unsigned int localsDebugSize);
 #ifdef _DEBUG
     static void DumpElf(const char* methodName, const MemBuf& buf);
 #endif


### PR DESCRIPTION
This PR fixed incorrect writing of frame location to DWARF for locals and arguments.
As a result of  the issue  `frame variable` command works incorrectly when we have more than 10 locals and/or arguments.  
@mikem8361, @janvorli, please take a look.

\cc: @Dmitri-Botcharnikov @chunseoklee @seanshpark 
