### PR TITLE
Fix P/Invoke call and method {pro,epi}logs in RyuJIT/x86.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2615,6 +2615,7 @@ void Lowering::InsertPInvokeMethodProlog()
     // --------------------------------------------------------
     // On 32-bit targets, CORINFO_HELP_INIT_PINVOKE_FRAME initializes the PInvoke frame and then pushes it onto
     // the current thread's Frame stack. On 64-bit targets, it only initializes the PInvoke frame.
+    CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef _TARGET_64BIT_
     if (comp->opts.eeFlags & CORJIT_FLG_IL_STUB)
@@ -2690,6 +2691,7 @@ void Lowering::InsertPInvokeMethodEpilog(BasicBlock* returnBB DEBUGARG(GenTreePt
 
     // Pop the frame if necessary. This always happens in the epilog on 32-bit targets. For 64-bit targets, we only do
     // this in the epilog for IL stubs; for non-IL stubs the frame is popped after every PInvoke call.
+    CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef _TARGET_64BIT_
     if (comp->opts.eeFlags & CORJIT_FLG_IL_STUB)
@@ -2831,6 +2833,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
 
     // Push the PInvoke frame if necessary. On 32-bit targets this only happens in the method prolog if a method
     // contains PInvokes; on 64-bit targets this is necessary in non-stubs.
+    CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef _TARGET_64BIT_
     if (!(comp->opts.eeFlags & CORJIT_FLG_IL_STUB))
@@ -2898,6 +2901,7 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
 
     // Pop the frame if necessary. On 32-bit targets this only happens in the method epilog; on 64-bit targets thi
     // happens after every PInvoke call in non-stubs.
+    CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef _TARGET_64BIT_
     if (!(comp->opts.eeFlags & CORJIT_FLG_IL_STUB))

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2613,7 +2613,10 @@ void Lowering::InsertPInvokeMethodProlog()
     DISPTREERANGE(firstBlockRange, storeFP);
 
     // --------------------------------------------------------
+    // On 32-bit targets, CORINFO_HELP_INIT_PINVOKE_FRAME initializes the PInvoke frame and then pushes it onto
+    // the current thread's Frame stack. On 64-bit targets, it only initializes the PInvoke frame.
 
+#ifdef _TARGET_64BIT_
     if (comp->opts.eeFlags & CORJIT_FLG_IL_STUB)
     {
         // Push a frame - if we are NOT in an IL stub, this is done right before the call
@@ -2622,6 +2625,7 @@ void Lowering::InsertPInvokeMethodProlog()
         firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, frameUpd));
         DISPTREERANGE(firstBlockRange, frameUpd);
     }
+#endif // _TARGET_64BIT_
 }
 
 //------------------------------------------------------------------------
@@ -2684,9 +2688,13 @@ void Lowering::InsertPInvokeMethodEpilog(BasicBlock* returnBB DEBUGARG(GenTreePt
     GenTree* storeGCState = SetGCState(1);
     returnBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, storeGCState));
 
+    // Pop the frame if necessary. This always happens in the epilog on 32-bit targets. For 64-bit targets, we only do
+    // this in the epilog for IL stubs; for non-IL stubs the frame is popped after every PInvoke call.
+
+#ifdef _TARGET_64BIT_
     if (comp->opts.eeFlags & CORJIT_FLG_IL_STUB)
+#endif // _TARGET_64BIT_
     {
-        // Pop the frame, in non-stubs we do this around each PInvoke call
         GenTree* frameUpd = CreateFrameLinkUpdate(PopFrame);
         returnBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, frameUpd));
     }
@@ -2743,7 +2751,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
     // InlinedCallFrame.m_pCallSiteSP = SP          // x86 only
     // InlinedCallFrame.m_pCallerReturnAddress = return address
     // Thread.gcState = 0
-    // (non-stub) - update top Frame on TCB
+    // (non-stub) - update top Frame on TCB         // 64-bit targets only
 
     // ----------------------------------------------------------------------------------
     // Setup InlinedCallFrame.callSiteTarget (which is how the JIT refers to it).
@@ -2821,6 +2829,10 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
 
     BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, storeLab));
 
+    // Push the PInvoke frame if necessary. On 32-bit targets this only happens in the method prolog if a method
+    // contains PInvokes; on 64-bit targets this is necessary in non-stubs.
+
+#ifdef _TARGET_64BIT_
     if (!(comp->opts.eeFlags & CORJIT_FLG_IL_STUB))
     {
         // Set the TCB's frame to be the one we just created.
@@ -2831,6 +2843,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
         GenTree* frameUpd = CreateFrameLinkUpdate(PushFrame);
         BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, frameUpd));
     }
+#endif // _TARGET_64BIT_
 
     // IMPORTANT **** This instruction must come last!!! ****
     // It changes the thread's state to Preemptive mode
@@ -2883,12 +2896,16 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
     tree = CreateReturnTrapSeq();
     BlockRange().InsertBefore(insertionPoint, LIR::SeqTree(comp, tree));
 
-    // Pop the frame if necessasry
+    // Pop the frame if necessary. On 32-bit targets this only happens in the method epilog; on 64-bit targets thi
+    // happens after every PInvoke call in non-stubs.
+
+#ifdef _TARGET_64BIT_
     if (!(comp->opts.eeFlags & CORJIT_FLG_IL_STUB))
     {
         tree = CreateFrameLinkUpdate(PopFrame);
         BlockRange().InsertBefore(insertionPoint, LIR::SeqTree(comp, tree));
     }
+#endif // _TARGET_64BIT_
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
The contract for methods that contain P/Invokes differs between 64- and
32-bit targets.

In the former case, the JIT must:
- In the method prolog, initialize the P/Invoke frame with a call to
  CORINFO_HELP_INIT_PINVOKE_FRAME and push the frame on to the current
  thread's frame list if the method is an IL stub.
- Before/after each call, if the method is *not* an IL stub, push/pop
  the frame (respectively).
- In the method epilog, if the method is an IL stub, pop the P/Invoke
  frame.

In the latter case, CORINFO_HELP_INIT_PINVOKE_FRAME pushes the P/Invoke
frame on to the current thread's frame list, and the frame need only
be popped in the method epilog.

This change adjusts P/Invoke lowering s.t. the 64-bit discipline is
only followed for 64-bit targets.