### PR TITLE
Force byteable registers for indir op source

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -4087,6 +4087,20 @@ bool Lowering::SetStoreIndOpCountsIfRMWMemOp(GenTreePtr storeInd)
     }
     m_lsra->clearOperandCounts(indirCandidateChild);
 
+#ifdef _TARGET_X86_
+    if (varTypeIsByte(storeInd))
+    {
+        // If storeInd is of TYP_BYTE, set indirOpSources to byteable registers.
+        bool containedNode = indirOpSource->gtLsraInfo.dstCount == 0;
+        if (!containedNode)
+        {
+            regMaskTP regMask = indirOpSource->gtLsraInfo.getSrcCandidates(m_lsra);
+            assert(regMask != RBM_NONE);
+            indirOpSource->gtLsraInfo.setSrcCandidates(m_lsra, regMask & ~RBM_NON_BYTE_REGS);
+        }
+    }
+#endif
+
     return true;
 }
 


### PR DESCRIPTION
When we have a GT_STOREIND, we need to not only make sure that the
source and dest of the storeind are marked as requiring byteable
registers, but also the indirect op's source. For example:

```
GT_STOREIND(GT_ADD(TYP_INT, mem of TYP_BYTE, reg of TYP_INT or TYP_BYTE))
```

We need to make sure that the source reg of the GT_ADD is byteable.

This change fixes #7224.