### PR TITLE
Allow GT_FIELD_LIST as legal arg for RyuJIT/x86

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4972,13 +4972,13 @@ inline bool GenTree::IsValidCallArgument()
     }
     if (OperIsFieldList())
     {
-#if defined(LEGACY_BACKEND) || !FEATURE_MULTIREG_ARGS
+#if defined(LEGACY_BACKEND) || (!FEATURE_MULTIREG_ARGS && !FEATURE_PUT_STRUCT_ARG_STK)
         // Not allowed to have a GT_FIELD_LIST for an argument
-        // unless we have a RyuJIT backend and FEATURE_MULTIREG_ARGS
+        // unless we have a RyuJIT backend and FEATURE_MULTIREG_ARGS or FEATURE_PUT_STRUCT_ARG_STK
 
         return false;
 
-#else // we have RyuJIT backend and FEATURE_MULTIREG_ARGS
+#else // we have RyuJIT backend and FEATURE_MULTIREG_ARGS or FEATURE_PUT_STRUCT_ARG_STK
 
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
         // For UNIX ABI we currently only allow a GT_FIELD_LIST of GT_LCL_FLDs nodes


### PR DESCRIPTION
The condition in GenTree::IsValidCallArgument() was not correct for
GT_FIELD_LIST, which is used for passing a struct on the stack in
RyuJIT/x86.

Fix #7460