### PR TITLE
Remove coreclr checks from AppDomain apis

### DIFF
--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -2240,13 +2240,6 @@ namespace System {
 
         [System.Security.SecurityCritical]  // auto-generated_required
         public void SetData (string name, object data) {
-#if FEATURE_CORECLR        
-            if (!name.Equals("LOCATION_URI"))
-            {
-                // Only LOCATION_URI can be set using AppDomain.SetData
-                throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_SetData_OnlyLocationURI", name));
-            }
-#endif // FEATURE_CORECLR            
             SetDataHelper(name, data, null);
         }
 

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -12913,15 +12913,6 @@ void ExceptionNotifications::DeliverNotificationInternal(ExceptionNotificationHa
     AppDomain *pCurDomain = GetAppDomain();
     _ASSERTE(pCurDomain != NULL);
 
-#ifdef FEATURE_CORECLR
-    if (true)
-    {
-        // On CoreCLR, we dont support enhanced exception notifications
-        _ASSERTE(!"CoreCLR does not support enhanced exception notifications!");
-        return;
-    }
-#endif // FEATURE_CORECLR
-
     struct
     {
         OBJECTREF oNotificationDelegate;


### PR DESCRIPTION
SetData() & FirstChanceException() are now supported on coreclr. Remove the checks blocking its usage.