### PR TITLE
Add an option to crossgen S.P.CoreLib using the alt jit.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -104,6 +104,7 @@ if /i "%1" == "skipbuildpackages"   (set __BuildPackages=0&set processedArgs=!pr
 if /i "%1" == "usenmakemakefiles"   (set __NMakeMakefiles=1&set __ConfigureOnly=1&set __BuildNative=1&set __BuildNativeCoreLib=0&set __BuildCoreLib=0&set __BuildTests=0&set __BuildPackages=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "buildjit32"          (set __BuildJit32="-DBUILD_JIT32=1"&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "toolset_dir"         (set __ToolsetDir=%2&set __PassThroughArgs=%__PassThroughArgs% %2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
+if /i "%1" == "altjitcrossgen"      (set __AltJitCrossgen=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if [!processedArgs!]==[] (
   call set __UnprocessedBuildArgs=!__args!
@@ -373,8 +374,21 @@ if %__BuildNativeCoreLib% EQU 1 (
 
     set "__CrossGenCoreLibLog=%__LogsDir%\CrossgenMSCoreLib_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
     set "__CrossgenExe=%__CrossComponentBinDir%\crossgen.exe"
+
+    if "%__AltJitCrossgen%"=="1" (
+        set COMPlus_AltJitNgen=*
+        set COMPlus_AltJitName=protojit.dll
+    )
+
     "!__CrossgenExe!" /Platform_Assemblies_Paths "%__BinDir%" /out "%__BinDir%\mscorlib.ni.dll" "%__BinDir%\mscorlib.dll" > "!__CrossGenCoreLibLog!" 2>&1
-    if NOT !errorlevel! == 0 (
+    set err=!errorlevel!
+
+    if "%__AltJitCrossgen%"=="1" (
+        set COMPlus_AltJitNgen=
+        set COMPlus_AltJitName=
+    )
+
+    if NOT !err! == 0 (
         echo %__MsgPrefix%Error: CrossGen mscorlib facade build failed. Refer to the build log file for details:
         echo     !__CrossGenCoreLibLog!
         exit /b 1

--- a/netci.groovy
+++ b/netci.groovy
@@ -1711,7 +1711,12 @@ combinedScenarios.each { scenario ->
                                 case 'x86ryujit':
                                 case 'x86lb':
                                     def arch = architecture
-                                    if (architecture == 'x86ryujit' || architecture == 'x86lb') {
+                                    def buildOpts = ''
+                                    if (architecture == 'x86ryujit') {
+                                        arch = 'x86'
+                                        buildOpts = 'altjitcrossgen'
+                                    }
+                                    else if (architecture == 'x86lb') {
                                         arch = 'x86'
                                     }
                                     
@@ -1719,7 +1724,7 @@ combinedScenarios.each { scenario ->
                                             scenario == 'default' ||
                                             scenario == 'r2r' ||
                                             Constants.r2rJitStressScenarios.indexOf(scenario) != -1) {
-                                        buildOpts = enableCorefxTesting ? 'skiptests' : ''
+                                        buildOpts += enableCorefxTesting ? ' skiptests' : ''
                                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts}"
                                     }
 
@@ -1730,15 +1735,15 @@ combinedScenarios.each { scenario ->
                                     // 35 characters long.
 
                                     else if (scenario == 'pri1' || scenario == 'pri1r2r' || scenario == 'gcstress15_pri1r2r'|| scenario == 'coverage') {
-                                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} -priority=1"
+                                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts} -priority=1"
                                     }
                                     else if (scenario == 'ilrt') {
                                         // First do the build with skiptests and then build the tests with ilasm roundtrip
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} skiptests"
+                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
                                         buildCommands += "set __TestIntermediateDir=int&&build-test.cmd ${lowerConfiguration} ${arch} -ilasmroundtrip"
                                     }
                                     else if (isLongGc(scenario)) {
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} skiptests"
+                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
                                         buildCommands += "set __TestIntermediateDir=int&&build-test.cmd ${lowerConfiguration} ${arch}"
                                     }
                                     else if (scenario == 'formatting') {


### PR DESCRIPTION
This also changes the x86/RyuJIT CI job to pass this option to
build.cmd. This leg will now use RyuJIT when crossgen'ing S.P.CoreLib
and when running tests.