### PR TITLE
Set default x86 test run to assert on nyi

### DIFF
--- a/tests/x86/ryujit_x86_testenv.cmd
+++ b/tests/x86/ryujit_x86_testenv.cmd
@@ -7,11 +7,7 @@
 set COMPLUS_AltJit=*
 set COMPLUS_AltJitName=protojit.dll
 set COMPLUS_NoGuiOnAssert=1
-
-@REM By default, do not set COMPLUS_AltJitAssertOnNYI=1. This allows us to compile
-@REM as much as possible with RyuJIT, and not just stop at the first NYI. It means
-@REM we will fall back to x86 legacy JIT for many functions.
-@REM set COMPLUS_AltJitAssertOnNYI=1
+set COMPLUS_AltJitAssertOnNYI=1
 
 @REM -------------------------------------------------------------------------
 @REM A JitFuncInfoLogFile is a per-function record of which functions were


### PR DESCRIPTION
Now that we have eliminated all of the NYIs from the base test run, set
the default to be to assert on NYI, incase we expose new NYIs.