### PR TITLE
Support double-aligned frames for RyuJIT/x86

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3505,6 +3505,7 @@ public:
 
     bool fgMorphBlockStmt(BasicBlock* block, GenTreePtr stmt DEBUGARG(const char* msg));
 
+    void fgCheckArgCnt();
     void fgSetOptions();
 
 #ifdef DEBUG
@@ -6625,8 +6626,14 @@ public:
     {
         return codeGen->doDoubleAlign();
     }
-    DWORD getCanDoubleAlign(); // Defined & used only by RegAlloc
-#endif                         // DOUBLE_ALIGN
+    DWORD getCanDoubleAlign();
+    bool shouldDoubleAlign(unsigned refCntStk,
+                           unsigned refCntReg,
+                           unsigned refCntWtdReg,
+                           unsigned refCntStkParam,
+                           unsigned refCntWtdStkDbl);
+#endif // DOUBLE_ALIGN
+
     __declspec(property(get = getFullPtrRegMap, put = setFullPtrRegMap)) bool genFullPtrRegMap;
     bool getFullPtrRegMap()
     {

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1073,6 +1073,10 @@ private:
         return BlockSetOps::IsMember(compiler, bbVisitedSet, block->bbNum);
     }
 
+#if DOUBLE_ALIGN
+    bool doDoubleAlign;
+#endif
+
     // A map from bbNum to the block information used during register allocation.
     LsraBlockInfo* blockInfo;
     BasicBlock* findPredBlockForLiveIn(BasicBlock* block, BasicBlock* prevBlock DEBUGARG(bool* pPredBlockIsAllocated));

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -157,6 +157,9 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
     // Create the call node
     GenTreeCall* call = comp->gtNewCallNode(CT_USER_FUNC, callHnd, tree->gtType, args);
     call              = comp->fgMorphArgs(call);
+    // Determine if this call has changed any codegen requirements.
+    comp->fgCheckArgCnt();
+
 #ifdef FEATURE_READYTORUN_COMPILER
     call->gtCall.setEntryPoint(entryPoint);
 #endif

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -53,8 +53,6 @@ regMaskTP Compiler::raConfigRestrictMaskFP()
     return result;
 }
 
-#ifdef LEGACY_BACKEND // We don't use any of the old register allocator functions when LSRA is used instead.
-
 #if DOUBLE_ALIGN
 DWORD Compiler::getCanDoubleAlign()
 {
@@ -67,7 +65,83 @@ DWORD Compiler::getCanDoubleAlign()
     return DEFAULT_DOUBLE_ALIGN;
 #endif
 }
+
+//------------------------------------------------------------------------
+// shouldDoubleAlign: Determine whether to double-align the frame
+//
+// Arguments:
+//    refCntStk       - sum of     ref counts for all stack based variables
+//    refCntEBP       - sum of     ref counts for EBP enregistered variables
+//    refCntWtdEBP    - sum of wtd ref counts for EBP enregistered variables
+//    refCntStkParam  - sum of     ref counts for all stack based parameters
+//    refCntWtdStkDbl - sum of wtd ref counts for stack based doubles (including structs
+//                      with double fields).
+//
+// Return Value:
+//    Returns true if this method estimates that a double-aligned frame would be beneficial
+//
+// Notes:
+//    The impact of a double-aligned frame is computed as follows:
+//    - We save a byte of code for each parameter reference (they are frame-pointer relative)
+//    - We pay a byte of code for each non-parameter stack reference.
+//    - We save the misalignment penalty and possible cache-line crossing penalty.
+//      This is estimated as 0 for SMALL_CODE, 16 for FAST_CODE and 4 otherwise.
+//    - We pay 7 extra bytes for:
+//        MOV EBP,ESP,
+//        LEA ESP,[EBP-offset]
+//        AND ESP,-8 to double align ESP
+//    - We pay one extra memory reference for each variable that could have been enregistered in EBP (refCntWtdEBP).
+//
+//    If the misalignment penalty is estimated to be less than the bytes used, we don't double align.
+//    Otherwise, we compare the weighted ref count of ebp-enregistered variables aginst double the
+//    ref count for double-aligned values.
+//
+bool Compiler::shouldDoubleAlign(
+    unsigned refCntStk, unsigned refCntEBP, unsigned refCntWtdEBP, unsigned refCntStkParam, unsigned refCntWtdStkDbl)
+{
+    bool           doDoubleAlign        = false;
+    const unsigned DBL_ALIGN_SETUP_SIZE = 7;
+
+    unsigned bytesUsed         = refCntStk + refCntEBP - refCntStkParam + DBL_ALIGN_SETUP_SIZE;
+    unsigned misaligned_weight = 4;
+
+    if (compCodeOpt() == Compiler::SMALL_CODE)
+        misaligned_weight = 0;
+
+    if (compCodeOpt() == Compiler::FAST_CODE)
+        misaligned_weight *= 4;
+
+    JITDUMP("\nDouble alignment:\n");
+    JITDUMP("  Bytes that could be saved by not using EBP frame: %i\n", bytesUsed);
+    JITDUMP("  Sum of weighted ref counts for EBP enregistered variables: %i\n", refCntWtdEBP);
+    JITDUMP("  Sum of weighted ref counts for weighted stack based doubles: %i\n", refCntWtdStkDbl);
+
+    if (bytesUsed > ((refCntWtdStkDbl * misaligned_weight) / BB_UNITY_WEIGHT))
+    {
+        JITDUMP("    Predicting not to double-align ESP to save %d bytes of code.\n", bytesUsed);
+    }
+    else if (refCntWtdEBP > refCntWtdStkDbl * 2)
+    {
+        // TODO-CQ: On P4 2 Proc XEON's, SciMark.FFT degrades if SciMark.FFT.transform_internal is
+        // not double aligned.
+        // Here are the numbers that make this not double-aligned.
+        //     refCntWtdStkDbl = 0x164
+        //     refCntWtdEBP    = 0x1a4
+        // We think we do need to change the heuristic to be in favor of double-align.
+
+        JITDUMP("    Predicting not to double-align ESP to allow EBP to be used to enregister variables.\n");
+    }
+    else
+    {
+        // OK we passed all of the benefit tests, so we'll predict a double aligned frame.
+        JITDUMP("    Predicting to create a double-aligned frame\n");
+        doDoubleAlign = true;
+    }
+    return doDoubleAlign;
+}
 #endif // DOUBLE_ALIGN
+
+#ifdef LEGACY_BACKEND // We don't use any of the old register allocator functions when LSRA is used instead.
 
 void Compiler::raInit()
 {
@@ -5840,114 +5914,14 @@ regMaskTP Compiler::rpPredictAssignRegVars(regMaskTP regAvail)
 
         if (getCanDoubleAlign() == CAN_DOUBLE_ALIGN && (refCntWtdStkDbl > 0))
         {
-            /* OK, there may be some benefit to double-aligning the frame */
-            /* But let us compare the benefits vs. the costs of this      */
-
-            /*
-               One cost to consider is the benefit of smaller code
-               when using EBP as a frame pointer register
-
-               Each stack variable reference is an extra byte of code
-               if we use a double-aligned frame, parameters are
-               accessed via EBP for a double-aligned frame so they
-               don't use an extra byte of code.
-
-               We pay one byte of code for each refCntStk and we pay
-               one byte or more for each refCntEBP but we save one
-               byte for each refCntStkParam.
-
-               Our savings are the elimination of a possible misaligned
-               access and a possible DCU spilt when an access crossed
-               a cache-line boundry.
-
-               We use the loop weighted value of
-                  refCntWtdStkDbl * misaligned_weight (0, 4, 16)
-               to represent this savings.
-            */
-
-            // We also pay 7 extra bytes for the MOV EBP,ESP,
-            // LEA ESP,[EBP-0x10] and the AND ESP,-8 to double align ESP
-            const unsigned DBL_ALIGN_SETUP_SIZE = 7;
-
-            unsigned bytesUsed         = refCntStk + refCntEBP - refCntStkParam + DBL_ALIGN_SETUP_SIZE;
-            unsigned misaligned_weight = 4;
-
-            if (compCodeOpt() == SMALL_CODE)
-                misaligned_weight = 0;
-
-            if (compCodeOpt() == FAST_CODE)
-                misaligned_weight *= 4;
-
-#ifdef DEBUG
-            if (verbose)
+            if (shouldDoubleAlign(refCntStk, refCntEBP, refCntWtdEBP, refCntStkParam, refCntWtdStkDbl))
             {
-                printf("; Double alignment:\n");
-                printf("; Bytes that could be save by not using EBP frame: %i\n", bytesUsed);
-                printf("; Sum of weighted ref counts for EBP enregistered variables: %i\n", refCntWtdEBP);
-                printf("; Sum of weighted ref counts for weighted stack based doubles: %i\n", refCntWtdStkDbl);
+                rpFrameType = FT_DOUBLE_ALIGN_FRAME;
+                goto REVERSE_EBP_ENREG;
             }
-#endif
-
-            if (bytesUsed > ((refCntWtdStkDbl * misaligned_weight) / BB_UNITY_WEIGHT))
-            {
-                /* It's probably better to use EBP as a frame pointer */
-                CLANG_FORMAT_COMMENT_ANCHOR;
-
-#ifdef DEBUG
-                if (verbose)
-                    printf("; Predicting not to double-align ESP to save %d bytes of code.\n", bytesUsed);
-#endif
-                goto NO_DOUBLE_ALIGN;
-            }
-
-            /*
-               Another cost to consider is the benefit of using EBP to enregister
-               one or more integer variables
-
-               We pay one extra memory reference for each refCntWtdEBP
-
-               Our savings are the elimination of a possible misaligned
-               access and a possible DCU spilt when an access crossed
-               a cache-line boundry.
-
-            */
-
-            // <BUGNUM>
-            // VSW 346717: On P4 2 Proc XEON's, SciMark.FFT degrades if SciMark.FFT.transform_internal is
-            // not double aligned.
-            // Here are the numbers that make this not double-aligned.
-            //     refCntWtdStkDbl = 0x164
-            //     refCntWtdEBP    = 0x1a4
-            // We think we do need to change the heuristic to be in favor of double-align.
-            // </BUGNUM>
-
-            if (refCntWtdEBP > refCntWtdStkDbl * 2)
-            {
-                /* It's probably better to use EBP to enregister integer variables */
-                CLANG_FORMAT_COMMENT_ANCHOR;
-
-#ifdef DEBUG
-                if (verbose)
-                    printf("; Predicting not to double-align ESP to allow EBP to be used to enregister variables\n");
-#endif
-                goto NO_DOUBLE_ALIGN;
-            }
-
-#ifdef DEBUG
-            if (verbose)
-                printf("; Predicting to create a double-aligned frame\n");
-#endif
-            /*
-               OK we passed all of the benefit tests
-               so we'll predict a double aligned frame
-            */
-
-            rpFrameType = FT_DOUBLE_ALIGN_FRAME;
-            goto REVERSE_EBP_ENREG;
         }
     }
 
-NO_DOUBLE_ALIGN:
 #endif // DOUBLE_ALIGN
 
     if (!codeGen->isFramePointerRequired() && !codeGen->isFrameRequired())

--- a/src/jit/regalloc.h
+++ b/src/jit/regalloc.h
@@ -17,6 +17,18 @@ enum FrameType
 #endif
 };
 
+#if DOUBLE_ALIGN
+enum CanDoubleAlign
+{
+    CANT_DOUBLE_ALIGN,
+    CAN_DOUBLE_ALIGN,
+    MUST_DOUBLE_ALIGN,
+    COUNT_DOUBLE_ALIGN,
+
+    DEFAULT_DOUBLE_ALIGN = CAN_DOUBLE_ALIGN
+};
+#endif
+
 #ifdef LEGACY_BACKEND
 
 #include "varset.h"
@@ -94,18 +106,6 @@ enum rpPredictReg
 #endif // _TARGET_
 
 };
-#if DOUBLE_ALIGN
-enum CanDoubleAlign
-{
-    CANT_DOUBLE_ALIGN,
-    CAN_DOUBLE_ALIGN,
-    MUST_DOUBLE_ALIGN,
-    COUNT_DOUBLE_ALIGN,
-
-    DEFAULT_DOUBLE_ALIGN = CAN_DOUBLE_ALIGN
-};
-#endif
-
 #endif // LEGACY_BACKEND
 
 #endif // REGALLOC_H_

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -245,9 +245,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlstack\*">
             <Issue>6553</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b103058\b103058\b103058.cmd">
-            <Issue>7008</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->


### PR DESCRIPTION
This factors out the analysis for when to use a double-aligned frame from the legacy backend.
Doing so exposed an assert for a case where we turn an intrinsic into a call in the Rationalizer, but don't update the frame requirements.
There may be some remaining tuning opportunities, given that the (pre-existing) algorithm doesn't attempt to create a double-aligned frame if we need an EBP-based frame for other reasons.

Fix #7008