### PR TITLE
Fix and-cmp to test recognition

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -6066,10 +6066,9 @@ void CodeGen::genCompareInt(GenTreePtr treeNode)
             // op1 can be a contained memory op
             // or the special contained GT_AND that we created in Lowering::TreeNodeInfoInitCmp()
             //
-            if ((op1->OperGet() == GT_AND))
+            if ((op1->OperGet() == GT_AND) && op1->gtGetOp2()->isContainedIntOrIImmed() &&
+                ((tree->OperGet() == GT_EQ) || (tree->OperGet() == GT_NE)))
             {
-                noway_assert(op1->gtOp.gtOp2->isContainedIntOrIImmed());
-
                 ins = INS_test;        // we will generate "test andOp1, andOp2CnsVal"
                 op2 = op1->gtOp.gtOp2; // must assign op2 before we overwrite op1
                 op1 = op1->gtOp.gtOp1; // overwrite op1


### PR DESCRIPTION
Containment is used by `TreeNodeInfoInitCmp` to tell `genCompareInt` that a "and-cmp to test" pattern has been recognized.

Before LSRA added "reg optional" the result of `isContained` was solely determined by `TreeNodeInfoInit`. Now LSRA can make operands contained and then that happens `genCompareInt` wrongly believes that `TreeNodeInfoInitCmp` recognized the pattern.

To fix this `genCompareInt` needs to recognize `(x and c) == 0` in addition to checking `isContained`.

Fixes #7480
