### PR TITLE
Return null on allocation failure due to OOM instead of throwing a exception from within the GC

### DIFF
--- a/src/gc/env/gcenv.object.h
+++ b/src/gc/env/gcenv.object.h
@@ -31,6 +31,8 @@ public:
     void ClrGCBit() { m_uSyncBlockValue &= ~BIT_SBLK_GC_RESERVE; }
 };
 
+static_assert(sizeof(ObjHeader) == sizeof(uintptr_t), "this assumption is made by the VM!");
+
 #define MTFlag_ContainsPointers 1
 #define MTFlag_HasFinalizer 2
 #define MTFlag_IsArray 4

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -30484,6 +30484,9 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, int64_t& alloc_byte
 #endif //BACKGROUND_GC
 #endif // MARK_ARRAY
 
+    // these next few lines are not strictly necessary anymore - they are here
+    // to sanity check that we didn't get asked to create an object
+    // that's too large.
     size_t maxObjectSize = (INT32_MAX - 7 - Align(min_obj_size));
 
 #ifdef BIT64
@@ -30493,15 +30496,9 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, int64_t& alloc_byte
     }
 #endif
 
-    if (jsize >= maxObjectSize)
-    {
-        if (g_pConfig->IsGCBreakOnOOMEnabled())
-        {
-            GCToOSInterface::DebugBreak();
-        }
-
-        return 0;
-    }
+    // The VM should have thrown instead of passing us an allocation
+    // request that's too large.
+    assert(jsize < maxObjectSize);
 
     size_t size = AlignQword (jsize);
     int align_const = get_alignment_constant (FALSE);

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -30500,11 +30500,7 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, int64_t& alloc_byte
             GCToOSInterface::DebugBreak();
         }
 
-#ifndef FEATURE_REDHAWK
-        ThrowOutOfMemoryDimensionsExceeded();
-#else
         return 0;
-#endif
     }
 
     size_t size = AlignQword (jsize);
@@ -34129,7 +34125,6 @@ BOOL GCHeap::StressHeap(gc_alloc_context * context)
 #define REGISTER_FOR_FINALIZATION(_object, _size) true
 #endif // FEATURE_PREMORTEM_FINALIZATION
 
-#ifdef FEATURE_REDHAWK
 #define CHECK_ALLOC_AND_POSSIBLY_REGISTER_FOR_FINALIZATION(_object, _size, _register) do {  \
     if ((_object) == NULL || ((_register) && !REGISTER_FOR_FINALIZATION(_object, _size)))   \
     {                                                                                       \
@@ -34137,19 +34132,6 @@ BOOL GCHeap::StressHeap(gc_alloc_context * context)
         return NULL;                                                                        \
     }                                                                                       \
 } while (false)
-#else // FEATURE_REDHAWK
-#define CHECK_ALLOC_AND_POSSIBLY_REGISTER_FOR_FINALIZATION(_object, _size, _register) do {  \
-    if ((_object) == NULL)                                                                  \
-    {                                                                                       \
-        STRESS_LOG_OOM_STACK(_size);                                                        \
-        ThrowOutOfMemory();                                                                 \
-    }                                                                                       \
-    if (_register)                                                                          \
-    {                                                                                       \
-        REGISTER_FOR_FINALIZATION(_object, _size);                                          \
-    }                                                                                       \
-} while (false)
-#endif // FEATURE_REDHAWK
 
 //
 // Small Object Allocator
@@ -34159,22 +34141,9 @@ Object *
 GCHeap::Alloc( size_t size, uint32_t flags REQD_ALIGN_DCL)
 {
     CONTRACTL {
-#ifdef FEATURE_REDHAWK
-        // Under Redhawk NULL is returned on failure.
         NOTHROW;
-#else
-        THROWS;
-#endif
         GC_TRIGGERS;
     } CONTRACTL_END;
-
-#if defined(_DEBUG) && !defined(FEATURE_REDHAWK)
-    if (g_pConfig->ShouldInjectFault(INJECTFAULT_GCHEAP))
-    {
-        char *a = new char;
-        delete a;
-    }
-#endif //_DEBUG && !FEATURE_REDHAWK
 
     TRIGGERSGC();
 
@@ -34255,12 +34224,7 @@ GCHeap::AllocAlign8( size_t size, uint32_t flags)
 {
 #ifdef FEATURE_64BIT_ALIGNMENT
     CONTRACTL {
-#ifdef FEATURE_REDHAWK
-        // Under Redhawk NULL is returned on failure.
         NOTHROW;
-#else
-        THROWS;
-#endif
         GC_TRIGGERS;
     } CONTRACTL_END;
 
@@ -34294,12 +34258,7 @@ GCHeap::AllocAlign8(gc_alloc_context* ctx, size_t size, uint32_t flags )
 {
 #ifdef FEATURE_64BIT_ALIGNMENT
     CONTRACTL {
-#ifdef FEATURE_REDHAWK
-        // Under Redhawk NULL is returned on failure.
         NOTHROW;
-#else
-        THROWS;
-#endif
         GC_TRIGGERS;
     } CONTRACTL_END;
 
@@ -34333,24 +34292,11 @@ GCHeap::AllocAlign8Common(void* _hp, alloc_context* acontext, size_t size, uint3
 {
 #ifdef FEATURE_64BIT_ALIGNMENT
     CONTRACTL {
-#ifdef FEATURE_REDHAWK
-        // Under Redhawk NULL is returned on failure.
         NOTHROW;
-#else
-        THROWS;
-#endif
         GC_TRIGGERS;
     } CONTRACTL_END;
 
     gc_heap* hp = (gc_heap*)_hp;
-
-#if defined(_DEBUG) && !defined(FEATURE_REDHAWK)
-    if (g_pConfig->ShouldInjectFault(INJECTFAULT_GCHEAP))
-    {
-        char *a = new char;
-        delete a;
-    }
-#endif //_DEBUG && !FEATURE_REDHAWK
 
     TRIGGERSGC();
 
@@ -34465,22 +34411,9 @@ Object *
 GCHeap::AllocLHeap( size_t size, uint32_t flags REQD_ALIGN_DCL)
 {
     CONTRACTL {
-#ifdef FEATURE_REDHAWK
-        // Under Redhawk NULL is returned on failure.
         NOTHROW;
-#else
-        THROWS;
-#endif
         GC_TRIGGERS;
     } CONTRACTL_END;
-
-#if defined(_DEBUG) && !defined(FEATURE_REDHAWK)
-    if (g_pConfig->ShouldInjectFault(INJECTFAULT_GCHEAP))
-    {
-        char *a = new char;
-        delete a;
-    }
-#endif //_DEBUG && !FEATURE_REDHAWK
 
     TRIGGERSGC();
 
@@ -34536,22 +34469,9 @@ Object*
 GCHeap::Alloc(gc_alloc_context* context, size_t size, uint32_t flags REQD_ALIGN_DCL)
 {
     CONTRACTL {
-#ifdef FEATURE_REDHAWK
-        // Under Redhawk NULL is returned on failure.
         NOTHROW;
-#else
-        THROWS;
-#endif
         GC_TRIGGERS;
     } CONTRACTL_END;
-
-#if defined(_DEBUG) && !defined(FEATURE_REDHAWK)
-    if (g_pConfig->ShouldInjectFault(INJECTFAULT_GCHEAP))
-    {
-        char *a = new char;
-        delete a;
-    }
-#endif //_DEBUG && !FEATURE_REDHAWK
 
     TRIGGERSGC();
 
@@ -36038,12 +35958,7 @@ bool
 CFinalize::RegisterForFinalization (int gen, Object* obj, size_t size)
 {
     CONTRACTL {
-#ifdef FEATURE_REDHAWK
-        // Under Redhawk false is returned on failure.
         NOTHROW;
-#else
-        THROWS;
-#endif
         GC_NOTRIGGER;
     } CONTRACTL_END;
 
@@ -36081,11 +35996,7 @@ CFinalize::RegisterForFinalization (int gen, Object* obj, size_t size)
             {
                 GCToOSInterface::DebugBreak();
             }
-#ifdef FEATURE_REDHAWK
             return false;
-#else
-            ThrowOutOfMemory();
-#endif
         }
     }
     Object*** end_si = &SegQueueLimit (dest);

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -30487,14 +30487,11 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, int64_t& alloc_byte
     // these next few lines are not strictly necessary anymore - they are here
     // to sanity check that we didn't get asked to create an object
     // that's too large.
-    size_t maxObjectSize = (INT32_MAX - 7 - Align(min_obj_size));
-
-#ifdef BIT64
-    if (g_pConfig->GetGCAllowVeryLargeObjects())
-    {
-        maxObjectSize = (INT64_MAX - 7 - Align(min_obj_size));
-    }
-#endif
+    #if BIT64
+    size_t maxObjectSize = (INT64_MAX - 7 - Align(min_obj_size)); 
+    #else
+    size_t maxObjectSize = (INT32_MAX - 7 - Align(min_obj_size)); 
+    #endif
 
     // The VM should have thrown instead of passing us an allocation
     // request that's too large.

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -53,6 +53,10 @@ struct segment_info
 
 #define LARGE_OBJECT_SIZE ((size_t)(85000))
 
+// The minimum size of an object is three pointers wide: one for the syncblock,
+// one for the object header, and one for the first field in the object.
+#define min_obj_size ((sizeof(uint8_t*) + sizeof(uintptr_t) + sizeof(size_t)))
+
 class Object;
 class IGCHeap;
 class IGCToCLR;
@@ -362,9 +366,8 @@ public:
 
     These allocation routines should not be called with allocation requests
     larger than:
-       32-bit                                 -> 0x7FFFFFE0
-       64-bit, GCAllowVeryLargeObjects: false -> 0x000000007FFFFFE0
-       64-bit, GCAllocVeryLargeObjects: true  -> 0x7FFFFFFFFFFFFFE0
+       32-bit  -> 0x7FFFFFE0
+       64-bit  -> 0x7FFFFFFFFFFFFFE0
 
     It is up to the caller of the API to raise appropriate errors if the amount
     of requested memory is too large.

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -359,6 +359,15 @@ public:
     Allocation routines. These all call into the GC's allocator and may trigger a garbage
     collection. All allocation routines return NULL when the allocation request
     couldn't be serviced due to being out of memory.
+
+    These allocation routines should not be called with allocation requests
+    larger than:
+       32-bit                                 -> 0x7FFFFFE0
+       64-bit, GCAllowVeryLargeObjects: false -> 0x000000007FFFFFE0
+       64-bit, GCAllocVeryLargeObjects: true  -> 0x7FFFFFFFFFFFFFE0
+
+    It is up to the caller of the API to raise appropriate errors if the amount
+    of requested memory is too large.
     ===========================================================================
     */
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -357,7 +357,8 @@ public:
     /*
     ===========================================================================
     Allocation routines. These all call into the GC's allocator and may trigger a garbage
-    collection.
+    collection. All allocation routines return NULL when the allocation request
+    couldn't be serviced due to being out of memory.
     ===========================================================================
     */
 

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -4073,8 +4073,6 @@ size_t generation_unusable_fragmentation (generation* inst)
 }
 
 #define plug_skew           sizeof(ObjHeader)
-#define min_obj_size        (sizeof(uint8_t*)+plug_skew+sizeof(size_t))//syncblock + vtable+ first field
-//Note that this encodes the fact that plug_skew is a multiple of uint8_t*.
 // We always use USE_PADDING_TAIL when fitting so items on the free list should be
 // twice the min_obj_size.
 #define min_free_list       (2*min_obj_size)

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -72,10 +72,6 @@ inline void CheckObjectSize(size_t alloc_size)
         GC_TRIGGERS;
     } CONTRACTL_END;
 
-    size_t min_obj_size = sizeof(uint8_t*)   // sync block
-                        + sizeof(uintptr_t)  // objheader
-                        + sizeof(size_t)     // first field
-                        + sizeof(uintptr_t); // alignment
     size_t max_object_size;
 #ifdef BIT64
     if (g_pConfig->GetGCAllowVeryLargeObjects())

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -106,6 +106,12 @@ inline Object* Alloc(size_t size, BOOL bFinalize, BOOL bContainsPointers )
         retVal = GCHeapUtilities::GetGCHeap()->Alloc(GetThreadAllocContext(), size, flags);
     else
         retVal = GCHeapUtilities::GetGCHeap()->Alloc(size, flags);
+
+    if (!retVal)
+    {
+        ThrowOutOfMemory();
+    }
+
     END_INTERIOR_STACK_PROBE;
     return retVal;
 }
@@ -134,6 +140,11 @@ inline Object* AllocAlign8(size_t size, BOOL bFinalize, BOOL bContainsPointers, 
         retVal = GCHeapUtilities::GetGCHeap()->AllocAlign8(GetThreadAllocContext(), size, flags);
     else
         retVal = GCHeapUtilities::GetGCHeap()->AllocAlign8(size, flags);
+
+    if (!retVal)
+    {
+        ThrowOutOfMemory();
+    }
 
     END_INTERIOR_STACK_PROBE;
     return retVal;
@@ -174,6 +185,12 @@ inline Object* AllocLHeap(size_t size, BOOL bFinalize, BOOL bContainsPointers )
     // of stack before calling in.
     INTERIOR_STACK_PROBE_FOR(GetThread(), static_cast<unsigned>(DEFAULT_ENTRY_PROBE_AMOUNT * 1.5));
     retVal = GCHeapUtilities::GetGCHeap()->AllocLHeap(size, flags);
+
+    if (!retVal)
+    {
+        ThrowOutOfMemory();
+    }
+
     END_INTERIOR_STACK_PROBE;
     return retVal;
 }

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -65,11 +65,16 @@ inline gc_alloc_context* GetThreadAllocContext()
 // an OutOfMemoryException with a message indicating that
 // the OOM was not from memory pressure but from an object
 // being too large.
-inline void CheckObjectSizeOrThrow(size_t alloc_size)
+inline void CheckObjectSize(size_t alloc_size)
 {
+    CONTRACTL {
+        THROWS;
+        GC_TRIGGERS;
+    } CONTRACTL_END;
+
     size_t min_obj_size = sizeof(uint8_t*)   // sync block
                         + sizeof(uintptr_t)  // objheader
-                        + sizeof(size_t);    // first field
+                        + sizeof(size_t)     // first field
                         + sizeof(uintptr_t); // alignment
     size_t max_object_size;
 #ifdef BIT64
@@ -132,7 +137,7 @@ inline Object* Alloc(size_t size, BOOL bFinalize, BOOL bContainsPointers )
                    (bFinalize ? GC_ALLOC_FINALIZE : 0));
 
     Object *retVal = NULL;
-    CheckObjectSizeOrThrow(size);
+    CheckObjectSize(size);
 
     // We don't want to throw an SO during the GC, so make sure we have plenty
     // of stack before calling in.
@@ -167,7 +172,7 @@ inline Object* AllocAlign8(size_t size, BOOL bFinalize, BOOL bContainsPointers, 
                    (bAlignBias ? GC_ALLOC_ALIGN8_BIAS : 0));
 
     Object *retVal = NULL;
-    CheckObjectSizeOrThrow(size);
+    CheckObjectSize(size);
 
     // We don't want to throw an SO during the GC, so make sure we have plenty
     // of stack before calling in.
@@ -216,7 +221,7 @@ inline Object* AllocLHeap(size_t size, BOOL bFinalize, BOOL bContainsPointers )
                    (bFinalize ? GC_ALLOC_FINALIZE : 0));
 
     Object *retVal = NULL;
-    CheckObjectSizeOrThrow(size);
+    CheckObjectSize(size);
 
     // We don't want to throw an SO during the GC, so make sure we have plenty
     // of stack before calling in.


### PR DESCRIPTION
The idea of throwing an `OutOfMemoryException` on allocation failure is a VM-specific idea that shouldn't be within the GC - the function `ThrowOutOfMemory` is itself defined in `src/vm/gchelpers.cpp` and shouldn't be called from the GC side of the GC-EE interface.

This PR aligns the CoreCLR GC to the Redhawk strategy of returning `null` on allocation failure and letting the VM decide what to do when an allocation fails. In this case, the VM does exactly what the GC is doing today - it throws an out of memory exception if any of the allocation routines return `null`. This has the benefit of removing some `#ifdef FEATURE_REDHAWK`s in the GC, aligning CoreRT and CoreCLR's allocation strategy, and removing the interface violation.

The only difference in behavior that this will cause is that allocating an object that is too large will not call `ThrowOutOfMemoryDimensionsExceeded` like it does today - I am not sure how CoreRT deals with this and what it affects. Currently, that function calls `ThrowOutOfMemory` unless `_WIN64` is defined, otherwise it throws an `OutOfMemoryException` with a specific error message.

cc @jkotas, who suggested this.