### PR TITLE
Set missed default value for coreclr runtest.cmd #7488.

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -5,6 +5,7 @@ setlocal EnableDelayedExpansion
 set __BuildArch=x64
 set __BuildType=Debug
 set __BuildOS=Windows_NT
+set __MSBuildBuildArch=x64
 
 :: Default to highest Visual Studio version available
 set __VSVersion=vs2015


### PR DESCRIPTION
__MSBuildBuildArch is set to x64 by default like __BuildArch. Fixes #7488.