### PR TITLE
Force byteable register for CMP if op2 is CNS_INT

### DIFF
--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -128,6 +128,10 @@ private:
     // return true if this call target is within range of a pc-rel call on the machine
     bool IsCallTargetInRange(void* addr);
 
+#ifdef _TARGET_X86_
+    bool ExcludeNonByteableRegisters(GenTree* tree);
+#endif
+
     void TreeNodeInfoInit(GenTree* stmt);
 
 #if defined(_TARGET_XARCH_)


### PR DESCRIPTION
On x86 we need to force byteable registers for compares not only when both
ops are typ_byte, but also when the first is of typ_byte and the second is
a constant int. The original condition for cmp only considered the first
case. This change adds the second condition.

Fixes #7478.