### PR TITLE
Fixed #7519 - Dotnet crashes while saturating multiple CPU groups on Windows

### DIFF
--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -2232,7 +2232,7 @@ Thread::Thread()
     
     m_fGCSpecial = FALSE;
 
-#if !defined(FEATURE_CORECLR)
+#if !defined(FEATURE_PAL)
     m_wCPUGroup = 0;
     m_pAffinityMask = 0;
 #endif


### PR DESCRIPTION
Fix addresses issue #7519 for dotnet crashes while saturating a Broadwell server across multiple CPU groups while running Windows Server 2012 R2 with HT enabled.

Issue surfaces in the CPUGroupInfo::ClearCPUGroupAffinity function in util.cpp:1142  

    m_CPUGroupInfoArray[group].activeThreadWeight -= m_CPUGroupInfoArray[group].groupWeight;

The ‘group’ index to m_CPUGroupInfoArray had un-initialized data. This was supposed to be set from m_wCPUGroup in threads.cpp:671, which itself was un-initialized. 

m_wCPUGroup was to be set in one of two ways:
1) When m_pAffinityMask == 0, set value in the Thread::ChooseThreadCPUGroupAffinity function in threads.cpp:637. m_pAffinityMask was un-initialized, causing  this check to always fail. 
2) When m_pAffinityMask != 0, use its default value. A default value for m_wCPUGroup was not set.

The fix is to zero-initialize both m_wCPUGroup & pAffinityMask in the constructor in threads.cpp:2235 (already in code, had to use the FEATURE_PAL macro instead). 