### PR TITLE
Add test to validate ByRef type unification

### DIFF
--- a/tests/src/reflection/ldtoken/byrefs.il
+++ b/tests/src/reflection/ldtoken/byrefs.il
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// This test makes sure that ByRef types are properly unified by the reflection stack
+// and that a type constructed by reflection is equivalent to a type constructed through
+// the LDTOKEN instruction.
+//
+
+.assembly extern mscorlib { }
+.assembly extern System.Console
+{
+    .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+    .ver 4:0:0:0
+}
+.assembly byrefs
+{
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+}
+
+.class private auto ansi beforefieldinit Test
+       extends [mscorlib]System.Object
+{
+    .method private hidebysig static int32  Main() cil managed
+    {
+        .entrypoint
+        .maxstack  2
+	
+        call       bool Test::LdTokenEqualsMakeByRef()
+        brfalse    Failed
+        
+        call       bool Test::MakeByRefEqualsLdToken()
+        brfalse    Failed
+	
+        ldc.i4     100
+        ldstr      "ByRefs look good"
+        br.s       Done
+    Failed:
+        ldc.i4     666
+        ldstr      "ByRefs are broken"
+    Done:
+        call       void class [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+  
+    .method private hidebysig static bool LdTokenEqualsMakeByRef() cil managed
+    {
+        .maxstack  2
+  
+        ldtoken    valuetype MyType1&
+        call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+	
+        ldtoken    valuetype MyType1
+        call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        callvirt   instance class [mscorlib]System.Type [mscorlib]System.Type::MakeByRefType()
+	
+        ceq
+	
+        ret
+    }
+  
+    .method private hidebysig static bool MakeByRefEqualsLdToken() cil managed
+    {
+        .maxstack  2
+  	
+        ldtoken    valuetype MyType2
+        call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        callvirt   instance class [mscorlib]System.Type [mscorlib]System.Type::MakeByRefType()
+        
+        ldtoken    valuetype MyType2&
+        call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+	
+        ceq
+	
+        ret
+    }
+}
+
+.class private auto ansi beforefieldinit MyType1
+       extends [mscorlib]System.ValueType
+{
+}
+
+.class private auto ansi beforefieldinit MyType2
+       extends [mscorlib]System.ValueType
+{
+}

--- a/tests/src/reflection/ldtoken/byrefs.ilproj
+++ b/tests/src/reflection/ldtoken/byrefs.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>byrefs</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="byrefs.il" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Make sure that `ldtoken SomeType&` leads to the same type as `ldtoken
SomeType` followed by `MakeByRefType`.

This test is most interesting for runtimes where reflection type system and runtime type system are disjoint (CoreRT...).