### PR TITLE
Fix the codegen for by-value struct args on x86.

### DIFF
--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -40,7 +40,7 @@ void genCkfinite(GenTreePtr treeNode);
 
 void genIntrinsic(GenTreePtr treeNode);
 
-void genPutArgStk(GenTreePtr treeNode);
+void genPutArgStk(GenTreePutArgStk* treeNode);
 unsigned getBaseVarForPutArgStk(GenTreePtr treeNode);
 
 #if defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)
@@ -162,6 +162,10 @@ void genCodeForCpBlkRepMovs(GenTreeBlk* cpBlkNode);
 void genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode);
 
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
+#ifdef _TARGET_X86_
+bool genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk, bool isSrcInMemory);
+#endif // _TARGET_X86_
+
 void genPutStructArgStk(GenTreePutArgStk* treeNode);
 
 int genMove8IfNeeded(unsigned size, regNumber tmpReg, GenTree* srcAddr, unsigned offset);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -170,7 +170,7 @@ int genMove2IfNeeded(unsigned size, regNumber tmpReg, GenTree* srcAddr, unsigned
 int genMove1IfNeeded(unsigned size, regNumber tmpReg, GenTree* srcAddr, unsigned offset);
 void genStructPutArgRepMovs(GenTreePutArgStk* putArgStkNode);
 void genStructPutArgUnroll(GenTreePutArgStk* putArgStkNode);
-void genStoreRegToStackArg(var_types type, regNumber reg, unsigned offset);
+void genStoreRegToStackArg(var_types type, regNumber reg, int offset);
 #endif // FEATURE_PUT_STRUCT_ARG_STK
 
 void genCodeForLoadOffset(instruction ins, emitAttr size, regNumber dst, GenTree* base, unsigned offset);

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7357,7 +7357,7 @@ void CodeGen::genPutArgStk(GenTreePtr treeNode)
     {
         // If this is less than 16 bytes, and has no gc refs, then we will push the args.
         // Otherwise, we will decrement sp and do regular stores.
-        if ((treeNode->AsPutArgStk()->getArgSize() < 16) && (treeNode->AsPutArgStk()->gtNumberReferenceSlots == 0))
+        if ((treeNode->AsPutArgStk()->getArgSize() < 16) || (treeNode->AsPutArgStk()->gtNumberReferenceSlots != 0))
         {
             m_pushStkArg = true;
         }
@@ -7397,30 +7397,106 @@ void CodeGen::genPutArgStk(GenTreePtr treeNode)
     }
     else if (data->OperGet() == GT_FIELD_LIST)
     {
-        GenTreeFieldList* fieldList = data->AsFieldList();
-        // TODO-X86-CQ: If there are no gaps or padding in the layout, we can use a series of pushes.
-        // For now, always make space for the struct, and store each field at its offset.
+        GenTreePutArgStk* const putArgStk = treeNode->AsPutArgStk();
 
-        unsigned structSize = treeNode->AsPutArgStk()->getArgSize();
-        m_pushStkArg        = false;
-        inst_RV_IV(INS_sub, REG_SPBASE, structSize, EA_PTRSIZE);
-        genStackLevel += structSize;
-        for (; fieldList != nullptr; fieldList = fieldList->Rest())
+        GenTreeFieldList* const fieldList = data->AsFieldList();
+        assert(fieldList != nullptr);
+
+        m_pushStkArg      = false;
+        const int argSize = putArgStk->getArgSize();
+        assert((argSize % TARGET_POINTER_SIZE) == 0);
+
+        // Set the current field offset to the size of the struct arg (which must be a multiple of the target pointer
+        // size).
+        int currentOffset = argSize;
+
+        // If there are no GC references in this field list and the argument is either larger than 16 bytes or the
+        // argument contains padding, we will pre-adjust the stack pointer and use stores instead of pushes.
+        const bool preAdjustStack =
+            (putArgStk->gtNumberReferenceSlots == 0) &&
+            ((argSize > 16) || (putArgStk->gtPutArgStkKind != GenTreePutArgStk::PutArgStkKindRepInstr));
+        if (preAdjustStack)
         {
-            GenTree* fieldNode = fieldList->Current();
+            inst_RV_IV(INS_sub, REG_SPBASE, argSize, EA_PTRSIZE);
+            currentOffset = 0;
+            genStackLevel += argSize;
+        }
+
+        unsigned prevFieldOffset = argSize;
+        for (GenTreeFieldList* current = fieldList; current != nullptr; current = current->Rest())
+        {
+            GenTree* const fieldNode   = current->Current();
+            const unsigned fieldOffset = current->gtFieldOffset;
+            var_types      fieldType   = current->gtFieldType;
+
+            // Long-typed nodes should have been handled by the decomposition pass, and lowering should have sorted the
+            // field list in descending order by offset.
+            assert(!varTypeIsLong(fieldType));
+            assert(fieldOffset <= prevFieldOffset);
+
             // TODO-X86-CQ: If this is not a register candidate, or is not in a register,
             // make it contained.
             genConsumeReg(fieldNode);
+
+            // If the field is slot-like, we can store the entire register no matter the type.
+            const bool fieldIsSlot =
+                varTypeIsIntegralOrI(fieldType) && ((fieldOffset % 4) == 0) && ((prevFieldOffset - fieldOffset) >= 4);
+            if (fieldIsSlot)
+            {
+                fieldType = genActualType(fieldType);
+                assert(genTypeSize(fieldType) == 4);
+            }
+
+            // We can use a push instruction for any slot-like field.
+            //
+            // NOTE: if the field is of GC type, we must use a push instruction, since the emmitter is not otherwise
+            // able to detect stores into the outgoing argument area of the stack on x86.
+            const bool usePush = !preAdjustStack && fieldIsSlot;
+            assert(usePush || !varTypeIsGC(fieldType));
+
+            // Adjust the stack if necessary. If we are going to generate a `push` instruction, this moves the stack
+            // pointer to (fieldOffset + sizeof(fieldType)) to account for the `push`.
+            const int fieldSize     = genTypeSize(fieldType);
+            const int desiredOffset = current->gtFieldOffset + (usePush ? fieldSize : 0);
+            if (currentOffset > desiredOffset)
+            {
+                assert(!preAdjustStack);
+
+                // The GC encoder requires that the stack remain 4-byte aligned at all times. Round the adjustment up
+                // to the next multiple of 4. If we are going to generate a `push` instruction, the adjustment must
+                // not require rounding.
+                const int adjustment = roundUp(currentOffset - desiredOffset, 4);
+                assert(!usePush || (adjustment == (currentOffset - desiredOffset)));
+                inst_RV_IV(INS_sub, REG_SPBASE, adjustment, EA_PTRSIZE);
+                currentOffset -= adjustment;
+                genStackLevel += adjustment;
+            }
+
             // Note that the argReg may not be the lcl->gtRegNum, if it has been copied
             // or reloaded to a different register.
-            regNumber argReg    = fieldNode->gtRegNum;
-            unsigned  offset    = fieldList->gtFieldOffset;
-            var_types fieldType = fieldList->gtFieldType;
-            if (varTypeIsLong(fieldType))
+            const regNumber argReg = fieldNode->gtRegNum;
+            if (usePush)
             {
-                NYI_X86("Long field of promoted struct arg");
+                // Adjust the stack if necessary and push the field.
+                // Push the field.
+                inst_RV(INS_push, argReg, fieldType, emitTypeSize(fieldType));
+                currentOffset -= fieldSize;
+                genStackLevel += fieldSize;
             }
-            genStoreRegToStackArg(fieldType, argReg, offset);
+            else
+            {
+                assert(!m_pushStkArg);
+                genStoreRegToStackArg(fieldType, argReg, desiredOffset - currentOffset);
+            }
+
+            prevFieldOffset = fieldOffset;
+        }
+
+        // Adjust the stack if necessary.
+        if (currentOffset != 0)
+        {
+            inst_RV_IV(INS_sub, REG_SPBASE, currentOffset, EA_PTRSIZE);
+            genStackLevel += currentOffset;
         }
     }
     else if (data->isContained())
@@ -7510,7 +7586,7 @@ void CodeGen::genPutArgStk(GenTreePtr treeNode)
 //          type is EA_8BYTE. The movdqa/u are 16 byte instructions, so it works, but
 //          this probably needs to be changed.
 //
-void CodeGen::genStoreRegToStackArg(var_types type, regNumber srcReg, unsigned offset)
+void CodeGen::genStoreRegToStackArg(var_types type, regNumber srcReg, int offset)
 {
     assert(srcReg != REG_NA);
     instruction ins;
@@ -7619,16 +7695,74 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
     else
     {
         // No need to disable GC the way COPYOBJ does. Here the refs are copied in atomic operations always.
+        CLANG_FORMAT_COMMENT_ANCHOR;
+
+#ifdef _TARGET_X86_
+        assert(m_pushStkArg);
+
+        GenTree*       srcAddr  = putArgStk->gtGetOp1()->gtGetOp1();
+        BYTE*          gcPtrs   = putArgStk->gtGcPtrs;
+        const unsigned numSlots = putArgStk->gtNumSlots;
+
+        regNumber  srcRegNum    = srcAddr->gtRegNum;
+        const bool srcAddrInReg = srcRegNum != REG_NA;
+
+        unsigned srcLclNum    = 0;
+        unsigned srcLclOffset = 0;
+        if (srcAddrInReg)
+        {
+            genConsumeReg(srcAddr);
+        }
+        else
+        {
+            assert(srcAddr->OperIsLocalAddr());
+
+            srcLclNum = srcAddr->AsLclVarCommon()->gtLclNum;
+            if (srcAddr->OperGet() == GT_LCL_FLD_ADDR)
+            {
+                srcLclOffset = srcAddr->AsLclFld()->gtLclOffs;
+            }
+        }
+
+        for (int i = numSlots - 1; i >= 0; --i)
+        {
+            emitAttr slotAttr;
+            if (gcPtrs[i] == TYPE_GC_NONE)
+            {
+                slotAttr = EA_4BYTE;
+            }
+            else if (gcPtrs[i] == TYPE_GC_REF)
+            {
+                slotAttr = EA_GCREF;
+            }
+            else
+            {
+                assert(gcPtrs[i] == TYPE_GC_BYREF);
+                slotAttr = EA_BYREF;
+            }
+
+            const unsigned offset = i * 4;
+            if (srcAddrInReg)
+            {
+                getEmitter()->emitIns_AR_R(INS_push, slotAttr, REG_NA, srcRegNum, offset);
+            }
+            else
+            {
+                getEmitter()->emitIns_S(INS_push, slotAttr, srcLclNum, srcLclOffset + offset);
+            }
+            genStackLevel += 4;
+        }
+#else // !defined(_TARGET_X86_)
 
         // Consume these registers.
         // They may now contain gc pointers (depending on their type; gcMarkRegPtrVal will "do the right thing").
         genConsumePutStructArgStk(putArgStk, REG_RDI, REG_RSI, REG_NA);
 
-        const bool     srcIsLocal  = putArgStk->gtOp1->AsObj()->gtOp1->OperIsLocalAddr();
-        const emitAttr srcAddrAttr = srcIsLocal ? EA_PTRSIZE : EA_BYREF;
+        const bool     srcIsLocal       = putArgStk->gtOp1->AsObj()->gtOp1->OperIsLocalAddr();
+        const emitAttr srcAddrAttr      = srcIsLocal ? EA_PTRSIZE : EA_BYREF;
 
 #if DEBUG
-        unsigned numGCSlotsCopied = 0;
+        unsigned       numGCSlotsCopied = 0;
 #endif // DEBUG
 
         BYTE*          gcPtrs   = putArgStk->gtGcPtrs;
@@ -7695,6 +7829,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
         }
 
         assert(numGCSlotsCopied == putArgStk->gtNumberReferenceSlots);
+#endif // _TARGET_X86_
     }
 }
 #endif // defined(FEATURE_PUT_STRUCT_ARG_STK)

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4479,7 +4479,6 @@ struct GenTreePutArgStk : public GenTreeUnOp
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
         , gtPutArgStkKind(PutArgStkKindInvalid)
         , gtNumSlots(numSlots)
-        , gtIsStruct(isStruct)
         , gtNumberReferenceSlots(0)
         , gtGcPtrs(nullptr)
 #endif // FEATURE_PUT_STRUCT_ARG_STK
@@ -4492,8 +4491,7 @@ struct GenTreePutArgStk : public GenTreeUnOp
     GenTreePutArgStk(genTreeOps oper,
                      var_types  type,
                      GenTreePtr op1,
-                     unsigned slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(unsigned numSlots)
-                         PUT_STRUCT_ARG_STK_ONLY_ARG(bool isStruct),
+                     unsigned slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(unsigned numSlots),
                      bool _putInIncomingArgArea = false DEBUGARG(GenTreePtr callNode = nullptr)
                          DEBUGARG(bool largeNode = false))
         : GenTreeUnOp(oper, type, op1 DEBUGARG(largeNode))
@@ -4502,7 +4500,6 @@ struct GenTreePutArgStk : public GenTreeUnOp
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
         , gtPutArgStkKind(PutArgStkKindInvalid)
         , gtNumSlots(numSlots)
-        , gtIsStruct(isStruct)
         , gtNumberReferenceSlots(0)
         , gtGcPtrs(nullptr)
 #endif // FEATURE_PUT_STRUCT_ARG_STK
@@ -4517,14 +4514,12 @@ struct GenTreePutArgStk : public GenTreeUnOp
     GenTreePutArgStk(genTreeOps oper,
                      var_types  type,
                      unsigned slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(unsigned numSlots)
-                         PUT_STRUCT_ARG_STK_ONLY_ARG(bool isStruct) DEBUGARG(GenTreePtr callNode = NULL)
-                             DEBUGARG(bool largeNode = false))
+                         DEBUGARG(GenTreePtr callNode = NULL) DEBUGARG(bool largeNode = false))
         : GenTreeUnOp(oper, type DEBUGARG(largeNode))
         , gtSlotNum(slotNum)
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
         , gtPutArgStkKind(PutArgStkKindInvalid)
         , gtNumSlots(numSlots)
-        , gtIsStruct(isStruct)
         , gtNumberReferenceSlots(0)
         , gtGcPtrs(nullptr)
 #endif // FEATURE_PUT_STRUCT_ARG_STK
@@ -4538,14 +4533,12 @@ struct GenTreePutArgStk : public GenTreeUnOp
                      var_types  type,
                      GenTreePtr op1,
                      unsigned slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(unsigned numSlots)
-                         PUT_STRUCT_ARG_STK_ONLY_ARG(bool isStruct) DEBUGARG(GenTreePtr callNode = NULL)
-                             DEBUGARG(bool largeNode = false))
+                         DEBUGARG(GenTreePtr callNode = NULL) DEBUGARG(bool largeNode = false))
         : GenTreeUnOp(oper, type, op1 DEBUGARG(largeNode))
         , gtSlotNum(slotNum)
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
         , gtPutArgStkKind(PutArgStkKindInvalid)
         , gtNumSlots(numSlots)
-        , gtIsStruct(isStruct)
         , gtNumberReferenceSlots(0)
         , gtGcPtrs(nullptr)
 #endif // FEATURE_PUT_STRUCT_ARG_STK
@@ -4602,14 +4595,11 @@ struct GenTreePutArgStk : public GenTreeUnOp
     // TODO-Throughput: The following information should be obtained from the child
     // block node.
 
-    enum PutArgStkKind : __int8{
-        PutArgStkKindInvalid, PutArgStkKindRepInstr, PutArgStkKindUnroll,
-    };
+    enum PutArgStkKind : __int8{PutArgStkKindInvalid, PutArgStkKindRepInstr, PutArgStkKindUnroll};
 
     PutArgStkKind gtPutArgStkKind;
 
     unsigned gtNumSlots;             // Number of slots for the argument to be passed on stack
-    bool     gtIsStruct;             // This stack arg is a struct.
     unsigned gtNumberReferenceSlots; // Number of reference slots.
     BYTE*    gtGcPtrs;               // gcPointers
 #endif                               // FEATURE_PUT_STRUCT_ARG_STK

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4477,7 +4477,7 @@ struct GenTreePutArgStk : public GenTreeUnOp
         , gtSlotNum(slotNum)
         , putInIncomingArgArea(_putInIncomingArgArea)
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
-        , gtPutArgStkKind(PutArgStkKindInvalid)
+        , gtPutArgStkKind(Kind::Invalid)
         , gtNumSlots(numSlots)
         , gtNumberReferenceSlots(0)
         , gtGcPtrs(nullptr)
@@ -4498,7 +4498,7 @@ struct GenTreePutArgStk : public GenTreeUnOp
         , gtSlotNum(slotNum)
         , putInIncomingArgArea(_putInIncomingArgArea)
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
-        , gtPutArgStkKind(PutArgStkKindInvalid)
+        , gtPutArgStkKind(Kind::Invalid)
         , gtNumSlots(numSlots)
         , gtNumberReferenceSlots(0)
         , gtGcPtrs(nullptr)
@@ -4518,7 +4518,7 @@ struct GenTreePutArgStk : public GenTreeUnOp
         : GenTreeUnOp(oper, type DEBUGARG(largeNode))
         , gtSlotNum(slotNum)
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
-        , gtPutArgStkKind(PutArgStkKindInvalid)
+        , gtPutArgStkKind(Kind::Invalid)
         , gtNumSlots(numSlots)
         , gtNumberReferenceSlots(0)
         , gtGcPtrs(nullptr)
@@ -4537,7 +4537,7 @@ struct GenTreePutArgStk : public GenTreeUnOp
         : GenTreeUnOp(oper, type, op1 DEBUGARG(largeNode))
         , gtSlotNum(slotNum)
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
-        , gtPutArgStkKind(PutArgStkKindInvalid)
+        , gtPutArgStkKind(Kind::Invalid)
         , gtNumSlots(numSlots)
         , gtNumberReferenceSlots(0)
         , gtGcPtrs(nullptr)
@@ -4595,9 +4595,11 @@ struct GenTreePutArgStk : public GenTreeUnOp
     // TODO-Throughput: The following information should be obtained from the child
     // block node.
 
-    enum PutArgStkKind : __int8{PutArgStkKindInvalid, PutArgStkKindRepInstr, PutArgStkKindUnroll};
+    enum class Kind : __int8{
+        Invalid, RepInstr, Unroll, AllSlots,
+    };
 
-    PutArgStkKind gtPutArgStkKind;
+    Kind gtPutArgStkKind;
 
     unsigned gtNumSlots;             // Number of slots for the argument to be passed on stack
     unsigned gtNumberReferenceSlots; // Number of reference slots.

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -928,13 +928,12 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
 
 #if FEATURE_FASTTAILCALL
         putArg = new (comp, GT_PUTARG_STK)
-            GenTreePutArgStk(GT_PUTARG_STK, type, arg, info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots)
-                                                           PUT_STRUCT_ARG_STK_ONLY_ARG(info->isStruct),
+            GenTreePutArgStk(GT_PUTARG_STK, type, arg, info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots),
                              call->IsFastTailCall() DEBUGARG(call));
 #else
         putArg = new (comp, GT_PUTARG_STK)
-            GenTreePutArgStk(GT_PUTARG_STK, type, arg, info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots)
-                                                           PUT_STRUCT_ARG_STK_ONLY_ARG(info->isStruct) DEBUGARG(call));
+            GenTreePutArgStk(GT_PUTARG_STK, type, arg,
+                             info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots) DEBUGARG(call));
 #endif
 
 #ifdef FEATURE_PUT_STRUCT_ARG_STK

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -202,10 +202,10 @@ private:
 #endif // FEATURE_SIMD
     void TreeNodeInfoInitCast(GenTree* tree);
 #ifdef _TARGET_ARM64_
-    void TreeNodeInfoInitPutArgStk(GenTree* argNode, fgArgTabEntryPtr info);
+    void TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, fgArgTabEntryPtr info);
 #endif // _TARGET_ARM64_
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
-    void TreeNodeInfoInitPutArgStk(GenTree* tree);
+    void TreeNodeInfoInitPutArgStk(GenTreePutArgStk* tree);
 #endif // FEATURE_PUT_STRUCT_ARG_STK
     void TreeNodeInfoInitLclHeap(GenTree* tree);
 

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -990,7 +990,7 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
             // late arg that is not passed in a register
             assert(argNode->gtOper == GT_PUTARG_STK);
 
-            TreeNodeInfoInitPutArgStk(argNode, curArgTabEntry);
+            TreeNodeInfoInitPutArgStk(argNode->AsPutArgStk(), curArgTabEntry);
             continue;
         }
 
@@ -1116,7 +1116,7 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
 
                 assert(curArgTabEntry->regNum == REG_STK);
 
-                TreeNodeInfoInitPutArgStk(arg, curArgTabEntry);
+                TreeNodeInfoInitPutArgStk(arg->AsPutArgStk(), curArgTabEntry);
             }
             else
             {
@@ -1155,7 +1155,7 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
 // Notes:
 //    Set the child node(s) to be contained when we have a multireg arg
 //
-void Lowering::TreeNodeInfoInitPutArgStk(GenTree* argNode, fgArgTabEntryPtr info)
+void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* argNode, fgArgTabEntryPtr info)
 {
     assert(argNode->gtOper == GT_PUTARG_STK);
 

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1994,18 +1994,116 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTree* tree)
 #ifdef _TARGET_X86_
     if (tree->gtOp.gtOp1->gtOper == GT_FIELD_LIST)
     {
-        GenTreeFieldList* fieldListPtr = tree->gtOp.gtOp1->AsFieldList();
-        for (; fieldListPtr; fieldListPtr = fieldListPtr->Rest())
+        GenTreePutArgStk* putArgStk       = tree->AsPutArgStk();
+        putArgStk->gtNumberReferenceSlots = 0;
+        putArgStk->gtPutArgStkKind        = GenTreePutArgStk::PutArgStkKindInvalid;
+
+        GenTreeFieldList* fieldList = putArgStk->gtOp1->AsFieldList();
+
+        // The code generator will push these fields in reverse order by offset. Reorder the list here s.t. the order
+        // of uses is visible to LSRA.
+        unsigned          fieldCount = 0;
+        GenTreeFieldList* head       = nullptr;
+        for (GenTreeFieldList *current = fieldList, *next; current != nullptr; current = next)
         {
-            GenTree* fieldNode = fieldListPtr->Current();
-            assert(fieldNode->TypeGet() != TYP_LONG);
-            if (varTypeIsByte(fieldNode))
+            next = current->Rest();
+
+            // First, insert the field node into the sorted list.
+            GenTreeFieldList* prev = nullptr;
+            for (GenTreeFieldList* cursor = head;; cursor = cursor->Rest())
             {
-                fieldNode->gtLsraInfo.setSrcCandidates(l, l->allRegs(TYP_INT) & ~RBM_NON_BYTE_REGS);
+                // If the offset of the current list node is greater than the offset of the cursor or if we have
+                // reached the end of the list, insert the current node before the cursor and terminate.
+                if ((cursor == nullptr) || (current->gtFieldOffset > cursor->gtFieldOffset))
+                {
+                    if (prev == nullptr)
+                    {
+                        assert(cursor == head);
+                        head = current;
+                    }
+                    else
+                    {
+                        prev->Rest() = current;
+                    }
+
+                    current->Rest() = cursor;
+                    break;
+                }
             }
-            info->srcCount++;
+
+            fieldCount++;
         }
+
+        info->srcCount = fieldCount;
         info->dstCount = 0;
+
+        // In theory, the upper bound for the size of a field list is 8: these constructs only appear when passing the
+        // collection of lclVars that represent the fields of a promoted struct lclVar, and we do not promote struct
+        // lclVars with more than 4 fields. If each of these lclVars is of type long, decomposition will split the
+        // corresponding field list nodes in two, giving an upper bound of 8.
+        //
+        // The reason that this is important is that the algorithm we use above to sort the field list is O(N^2): if
+        // the maximum size of a field list grows significantly, we will need to reevaluate it.
+        assert(fieldCount <= 8);
+
+        // The sort above may have changed which node is at the head of the list. Update the PUTARG_STK node if
+        // necessary.
+        if (head != fieldList)
+        {
+            head->gtFlags |= GTF_FIELD_LIST_HEAD;
+            fieldList->gtFlags &= ~GTF_FIELD_LIST_HEAD;
+
+#ifdef DEBUG
+            head->gtSeqNum = fieldList->gtSeqNum;
+#endif // DEBUG
+
+            head->gtLsraInfo = fieldList->gtLsraInfo;
+            head->gtClearReg(comp);
+
+            BlockRange().InsertAfter(fieldList, head);
+            BlockRange().Remove(fieldList);
+
+            fieldList        = head;
+            putArgStk->gtOp1 = fieldList;
+        }
+
+        // Now that the fields have been sorted, initialize the LSRA info.
+        bool     allFieldsAreSlots = true;
+        unsigned prevOffset        = putArgStk->getArgSize();
+        for (GenTreeFieldList* current = fieldList; current != nullptr; current = current->Rest())
+        {
+            GenTree* const  fieldNode   = current->Current();
+            const var_types fieldType   = fieldNode->TypeGet();
+            const unsigned  fieldOffset = current->gtFieldOffset;
+            assert(fieldType != TYP_LONG);
+
+            const bool fieldIsSlot =
+                varTypeIsIntegralOrI(fieldType) && ((fieldOffset % 4) == 0) && ((prevOffset - fieldOffset) >= 4);
+            if (!fieldIsSlot)
+            {
+                allFieldsAreSlots = false;
+                if (varTypeIsByte(fieldType))
+                {
+                    // If this field is a slot--i.e. it is an integer field that is 4-byte aligned and takes up 4 bytes
+                    // (including padding)--we can store the whole value rather than just the byte. Otherwise, we will
+                    // need a byte-addressable register for the store.
+                    fieldNode->gtLsraInfo.setSrcCandidates(l, l->allRegs(TYP_INT) & ~RBM_NON_BYTE_REGS);
+                }
+            }
+
+            if (varTypeIsGC(fieldType))
+            {
+                putArgStk->gtNumberReferenceSlots++;
+            }
+
+            prevOffset = fieldOffset;
+        }
+
+        // If all fields of this list are slots, set the copy kind.
+        if (allFieldsAreSlots)
+        {
+            putArgStk->gtPutArgStkKind = GenTreePutArgStk::PutArgStkKindRepInstr;
+        }
         return;
     }
 #endif // _TARGET_X86_
@@ -2022,27 +2120,19 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTree* tree)
     GenTreePtr src     = tree->gtOp.gtOp1;
     GenTreePtr srcAddr = nullptr;
 
+    bool haveLocalAddr = false;
     if ((src->OperGet() == GT_OBJ) || (src->OperGet() == GT_IND))
     {
         srcAddr = src->gtOp.gtOp1;
+        assert(srcAddr != nullptr);
+        haveLocalAddr = srcAddr->OperIsLocalAddr();
     }
     else
     {
         assert(varTypeIsSIMD(tree));
     }
+
     info->srcCount = src->gtLsraInfo.dstCount;
-
-    // If this is a stack variable address,
-    // make the op1 contained, so this way
-    // there is no unnecessary copying between registers.
-    // To avoid assertion, increment the parent's source.
-    // It is recovered below.
-    bool haveLocalAddr = ((srcAddr != nullptr) && (srcAddr->OperIsLocalAddr()));
-    if (haveLocalAddr)
-    {
-        info->srcCount += 1;
-    }
-
     info->dstCount = 0;
 
     // In case of a CpBlk we could use a helper call. In case of putarg_stk we
@@ -2096,23 +2186,20 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTree* tree)
             info->addInternalCandidates(l, l->internalFloatRegCandidates());
         }
 
-        if (haveLocalAddr)
-        {
-            MakeSrcContained(putArgStkTree, srcAddr);
-        }
-
         // If src or dst are on stack, we don't have to generate the address into a register
         // because it's just some constant+SP
         putArgStkTree->gtPutArgStkKind = GenTreePutArgStk::PutArgStkKindUnroll;
     }
+#ifdef _TARGET_X86_
+    else if (putArgStkTree->gtNumberReferenceSlots != 0)
+    {
+        putArgStkTree->gtPutArgStkKind = GenTreePutArgStk::PutArgStkKindRepInstr;
+    }
+#endif // _TARGET_X86_
     else
     {
         info->internalIntCount += 3;
         info->setInternalCandidates(l, (RBM_RDI | RBM_RCX | RBM_RSI));
-        if (haveLocalAddr)
-        {
-            MakeSrcContained(putArgStkTree, srcAddr);
-        }
 
         putArgStkTree->gtPutArgStkKind = GenTreePutArgStk::PutArgStkKindRepInstr;
     }
@@ -2120,10 +2207,16 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTree* tree)
     // Always mark the OBJ and ADDR as contained trees by the putarg_stk. The codegen will deal with this tree.
     MakeSrcContained(putArgStkTree, src);
 
-    // Balance up the inc above.
     if (haveLocalAddr)
     {
-        info->srcCount -= 1;
+        // If the source address is the address of a lclVar, make the source address contained to avoid unnecessary
+        // copies.
+        //
+        // To avoid an assertion in MakeSrcContained, increment the parent's source count beforehand and decrement it
+        // afterwards.
+        info->srcCount++;
+        MakeSrcContained(putArgStkTree, srcAddr);
+        info->srcCount--;
     }
 }
 #endif // FEATURE_PUT_STRUCT_ARG_STK


### PR DESCRIPTION
Fix the codegen for by-value struct args on x86.
Although the existing code generation for by-value struct args containing
GC references on x86 was correct with respect to the layout of the data
being passed, it was not correct with respect to the invariants necessary
for the GC info encoder.

The existing codegen for by-value struct args--whether represented by
`GT_OBJ` or `GT_FIELD_LIST` nodes--takes what is essentially the
following approach:

    sub esp, argument_size
    mov [esp + offset_0], field_0
    mov [esp + offset_1], field_1
    ...
    mov [esp + offset_n], field_n

Although this puts the correct data in the correct locations, the
emitter is unable to recognize that a GC info update is requires if any
of the `mov` instructions write a GC reference to the stack: instead,
on x86, `push` instructions must be used to write GC references on the
stack. Furthermore, the stack must be kept 4-byte aligned.

This change modifies the code generator to use `push` instructions to
write outgoing GC references to the stack while obeying the alignment
invariant required by the GC encoding. For outgoing by-value struct
args represented by `GT_OBJ`, this results in very straightforward code:

    push [val_addr]
    push [val_addr + 4]
    ...
    push [val_addr + n]

For args represented by `GT_FIELD_LIST`, the picture is a bit more
complicated as the stack must be kept 4-byte aligned. Handling of these
args is split into two cases: if a field list contains no GC references
and is larger than 16 bytes or contains any fields that cannot be
treated as a 4-byte-aligned, int32-sized value, the argument is passed
using the `sub esp, arg_size; mov [esp + offset], field` approach.
Otherwise--if the struct contains any GC references or is smaller than
16 bytes and only contains fields that can be treated as slots--the
argument is passed using the following approach:
- If a field is a GC reference or can be treated as a 4-byte slot, the
  field is stored to the stack using a `push` instruction.
- Otherwise, the stack pointer is first adjusted to the next 4-byte
  aligned address after the offset of the field and the field is
  stored to the appropriate address using a `mov`.

For example, given the following IR:

     t55 =    lclVar    bool   V06 tmp4         u:6 esi REG esi RV $40

    t138 =    dconst    float  0.00000000000000000 REG mm0 $80

           /--*  t138   float
           +--*  t55    bool
    t139 = *  <fldList> void   float at offset 4 REG NA $180

           /--*  t139   void
    t152 = *  putarg_stk [+0x00] void   REG NA

The backend will generate the following code:

    sub      esp, 8
    movss    dword ptr [esp+04H], xmm0
    mov      dword ptr [esp], esi

And given the following IR:

    t13 =    lclVar    ref    V04 tmp1         u:2 esi (last use) REG esi RV $1c0

    t45 =    lclVar    int    V05 tmp2         u:2 eax (last use) REG eax RV $200

          /--*  t45    int
          +--*  t13    ref
    t46 = *  <fldList> void   int at offset 4 REG NA $240

The backend will instead generate the following:

    push     eax
    push     esi

These changes also produce beneficial diffs: for example, the native image
for System.Private.CoreLib.dll has diffs in ~1000 methods for an overall
size improvement of 1%.

Fixes #7088.