### PR TITLE
Remove AllowPartiallyTrustedCallers from a test

### DIFF
--- a/tests/src/JIT/jit64/verif/sniff/fg/ver_fg_13.il
+++ b/tests/src/JIT/jit64/verif/sniff/fg/ver_fg_13.il
@@ -11,12 +11,7 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
-.assembly test 
-{
-  .custom instance void [mscorlib]System.Security.AllowPartiallyTrustedCallersAttribute::.ctor() = ( 01 00 01 00 00 ) 
-
-}
-
+.assembly test { }
 
 .module ver_fg_13.exe
 


### PR DESCRIPTION
Partial trust is not part of .NET Core.