### PR TITLE
Use the existing operands for long decomposition #6925 

### DIFF
--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -57,6 +57,7 @@ private:
 
     // Helper functions
     GenTree* FinalizeDecomposition(LIR::Use& use, GenTree* loResult, GenTree* hiResult, GenTree* insertResultAfter);
+    GenTree* RepresentOpAsLocalVar(GenTree* op, GenTree* user, GenTree** edge);
 
     GenTree* StoreNodeToVar(LIR::Use& use);
     static genTreeOps GetHiOper(genTreeOps oper);


### PR DESCRIPTION
Use the existing operands for long decomposition where is it possible.
Temporary local variables were deleted in NEG and some parts of SHIFT.
Commits will be squashed before the push.