### PR TITLE
Disable emit{Enable,Disable}GC for x86.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1227,9 +1227,11 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 
     switch (treeNode->gtOper)
     {
+#ifndef JIT32_GCENCODER
         case GT_START_NONGC:
             getEmitter()->emitDisableGC();
             break;
+#endif // !defined(JIT32_GCENCODER)
 
         case GT_PROF_HOOK:
 #ifdef PROFILING_SUPPORTED
@@ -2686,10 +2688,15 @@ BAILOUT:
 
 void CodeGen::genCodeForStoreBlk(GenTreeBlk* storeBlkNode)
 {
+#ifdef JIT32_GCENCODER
+    assert(!storeBlkNode->gtBlkOpGcUnsafe);
+#else
     if (storeBlkNode->gtBlkOpGcUnsafe)
     {
         getEmitter()->emitDisableGC();
     }
+#endif // JIT32_GCENCODER
+
     bool isCopyBlk = storeBlkNode->OperIsCopyBlkOp();
 
     switch (storeBlkNode->gtBlkOpKind)
@@ -2729,10 +2736,13 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* storeBlkNode)
         default:
             unreached();
     }
+
+#ifndef JIT32_GCENCODER
     if (storeBlkNode->gtBlkOpGcUnsafe)
     {
         getEmitter()->emitEnableGC();
     }
+#endif // !defined(JIT32_GCENCODER)
 }
 
 // Generate code for InitBlk using rep stos.

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1822,8 +1822,12 @@ private:
     void emitInsertIGAfter(insGroup* insertAfterIG, insGroup* ig);
 
     void emitNewIG();
+
+#if !defined(JIT32_GCENCODER)
     void emitDisableGC();
     void emitEnableGC();
+#endif // !defined(JIT32_GCENCODER)
+
     void emitGenIG(insGroup* ig);
     insGroup* emitSavIG(bool emitAdd = false);
     void emitNxtIG(bool emitAdd = false);
@@ -2707,6 +2711,7 @@ inline void emitter::emitNewIG()
     emitGenIG(ig);
 }
 
+#if !defined(JIT32_GCENCODER)
 // Start a new instruction group that is not interruptable
 inline void emitter::emitDisableGC()
 {
@@ -2736,6 +2741,7 @@ inline void emitter::emitEnableGC()
     // instruction groups.
     emitForceNewIG = true;
 }
+#endif // !defined(JIT32_GCENCODER)
 
 /*****************************************************************************/
 #endif // _EMIT_H_


### PR DESCRIPTION
The GC info encoding for this platform does not permit marking
arbitrary regions of generated code as non-interruptible.

Fixes #7548.