### PR TITLE
Fix assertion regarding byteable reg when ngen'ing desktop mscorlib

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1214,7 +1214,7 @@ public:
         return OperIsLocalRead(OperGet());
     }
 
-    bool OperIsCompare()
+    bool OperIsCompare() const
     {
         return (OperKind(gtOper) & GTK_RELOP) != 0;
     }

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -134,6 +134,8 @@ private:
 
     void TreeNodeInfoInit(GenTree* stmt);
 
+    void TreeNodeInfoInitCheckByteable(GenTree* tree);
+
 #if defined(_TARGET_XARCH_)
     void TreeNodeInfoInitSimple(GenTree* tree);
 


### PR DESCRIPTION
Fixes #7483

The issue is that TreeNodeInfoInitCmp() will, under certain circumstances,
perform a tree transformation of a child node into a TYP_UBYTE type. Since
the TreeNodeInfo walk is bottom-up, its children have already been processed,
and they don't get the "byteable" register processing that is as the end of
TreeNodeInfoInit().

I extracted that processing into a TreeNodeInfoInitCheckByteable() function that
can be called after the TreeNodeInfoInitCmp() transformation.

A better solution might be to extract this, and other, tree transformations into
the prior "lowering" pass, such that TreeNodeInfoInit() and friends will only
do register requirement annotation. But that would be considerably more complicated,
so I opted not to do that for now.

I also fixed up a bunch of comments.