### PR TITLE
Fix runtest.cmd return code

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -185,7 +185,7 @@ call :PrecompileFX
 :SkipPrecompileFX
 
 if  defined __GenerateLayoutOnly (
-    exit /b 1
+    exit /b 0
 )
 
 if not exist %CORE_ROOT%\coreclr.dll (


### PR DESCRIPTION
When running the GenerateLayoutOnly command of runtest.cmd the script
should return zero instead of one.