### PR TITLE
Dump LSRA stats.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6275,7 +6275,7 @@ public:
 
     BOOL eeIsValueClass(CORINFO_CLASS_HANDLE clsHnd);
 
-#if defined(DEBUG) || defined(FEATURE_JIT_METHOD_PERF) || defined(FEATURE_SIMD)
+#if defined(DEBUG) || defined(FEATURE_JIT_METHOD_PERF) || defined(FEATURE_SIMD) || defined(TRACK_LSRA_STATS)
 
     bool IsSuperPMIException(unsigned code)
     {

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -483,9 +483,11 @@ typedef ptrdiff_t ssize_t;
 #ifdef DEBUG
 #define MEASURE_MEM_ALLOC 1 // Collect memory allocation stats.
 #define LOOP_HOIST_STATS 1  // Collect loop hoisting stats.
+#define TRACK_LSRA_STATS 1  // Collect LSRA stats
 #else
 #define MEASURE_MEM_ALLOC 0 // You can set this to 1 to get memory stats in retail, as well
 #define LOOP_HOIST_STATS 0  // You can set this to 1 to get loop hoist stats in retail, as well
+#define TRACK_LSRA_STATS 0  // You can set this to 1 to get LSRA stats in retail, as well
 #endif
 
 // Timing calls to clr.dll is only available under certain conditions.

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -17,9 +17,10 @@ CONFIG_INTEGER(DebugBreakOnVerificationFailure, W("DebugBreakOnVerificationFailu
                                                                                          // verification failure
 CONFIG_INTEGER(DiffableDasm, W("JitDiffableDasm"), 0)            // Make the disassembly diff-able
 CONFIG_INTEGER(DisplayLoopHoistStats, W("JitLoopHoistStats"), 0) // Display JIT loop hoisting statistics
-CONFIG_INTEGER(DumpJittedMethods, W("DumpJittedMethods"), 0)     // Prints all jitted methods to the console
-CONFIG_INTEGER(EnablePCRelAddr, W("JitEnablePCRelAddr"), 1)      // Whether absolute addr be encoded as PC-rel offset by
-                                                                 // RyuJIT where possible
+CONFIG_INTEGER(DisplayLsraStats, W("JitLsraStats"), 0)       // Display JIT Linear Scan Register Allocator statistics
+CONFIG_INTEGER(DumpJittedMethods, W("DumpJittedMethods"), 0) // Prints all jitted methods to the console
+CONFIG_INTEGER(EnablePCRelAddr, W("JitEnablePCRelAddr"), 1)  // Whether absolute addr be encoded as PC-rel offset by
+                                                             // RyuJIT where possible
 CONFIG_INTEGER(InterpreterFallback, W("InterpreterFallback"), 0) // Fallback to the interpreter when the JIT compiler
                                                                  // fails
 CONFIG_INTEGER(JitAssertOnMaxRAPasses, W("JitAssertOnMaxRAPasses"), 0)

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -73,6 +73,25 @@ struct LsraBlockInfo
     unsigned int         predBBNum;
     bool                 hasCriticalInEdge;
     bool                 hasCriticalOutEdge;
+
+#if TRACK_LSRA_STATS
+    // Per block maintained LSRA statistics.
+
+    // Number of spills of local vars or tree temps in this basic block.
+    unsigned spillCount;
+
+    // Number of GT_COPY nodes inserted in this basic block while allocating regs.
+    // Note that GT_COPY nodes are also inserted as part of basic block boundary
+    // resolution, which are accounted against resolutionMovCount but not
+    // against copyRegCount.
+    unsigned copyRegCount;
+
+    // Number of resolution moves inserted in this basic block.
+    unsigned resolutionMovCount;
+
+    // Number of critical edges from this block that are split.
+    unsigned splitEdgeCount;
+#endif // TRACK_LSRA_STATS
 };
 
 // This is sort of a bit mask
@@ -1026,6 +1045,20 @@ private:
 
     void validateIntervals();
 #endif // DEBUG
+
+#if TRACK_LSRA_STATS
+    enum LsraStat{
+        LSRA_STAT_SPILL, LSRA_STAT_COPY_REG, LSRA_STAT_RESOLUTION_MOV, LSRA_STAT_SPLIT_EDGE,
+    };
+
+    void updateLsraStat(LsraStat stat, unsigned currentBBNum);
+
+    void dumpLsraStats(FILE* file);
+
+#define INTRACK_STATS(x) x
+#else // !TRACK_LSRA_STATS
+#define INTRACK_STATS(x)
+#endif // !TRACK_LSRA_STATS
 
     Compiler* compiler;
 


### PR DESCRIPTION
These changes are meant to dump the following LSRA stats:
1) spill count 
2) Number of GT_COPY nodes inserted
3) resolution mov count
4) Weighted counts of (1) to (3) above
5) Number of split edges.
6) Total number of spill temps created

These stats get dumped as part of jitdump of a method.
One can get a print of stats of all the methods jitted by setting complus_JitLsraStats=1.
To obtain a dump of these stats in retail, one needs to set TRACK_LSRA_STATS to 1 in jit.h and use the retail binary thus obtained in combination with complus_JitLsraStats=1 setting.

Here is a sample dump for TryMe method in 8queens:

```
----------
LSRA Stats : Midori.CompilerPerf.Eightqueens:TryMe(int,byref,ref,ref):this
----------
BB07 [     200]: SpillCount = 0, CopyReg = 0, ResolutionMovs = 1
BB08 [     200]: SpillCount = 1, CopyReg = 0, ResolutionMovs = 2
BB09 [     200]: SpillCount = 7, CopyReg = 0, ResolutionMovs = 1
BB10 [     200]: SpillCount = 0, CopyReg = 0, ResolutionMovs = 1
BB11 [     200]: SpillCount = 0, CopyReg = 0, ResolutionMovs = 4
BB12 [     200]: SpillCount = 0, CopyReg = 0, ResolutionMovs = 1
Total Spill Count: 8    Weighted: 1600
Total CopyReg Count: 0   Weighted: 0
Total ResolutionMov Count: 10    Weighted: 2000
Total number of split edges: 0
Total Number of spill temps created: 0

```