### PR TITLE
set ready to run flag for protojit

### DIFF
--- a/src/jit/protojit/CMakeLists.txt
+++ b/src/jit/protojit/CMakeLists.txt
@@ -3,6 +3,7 @@ project(protojit)
 add_definitions(-DALT_JIT)
 add_definitions(-DFEATURE_NO_HOST)
 add_definitions(-DSELF_NO_HOST)
+add_definitions(-DFEATURE_READYTORUN_COMPILER)
 remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
 add_library_clr(protojit


### PR DESCRIPTION
Define READY_TO_RUN for protojit. It hides #7547, because jit goes to another case there.
This commit can affect other issues, so PTL @dotnet/jit-contrib .