### PR TITLE
Flag does_not_return early

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4355,7 +4355,7 @@ protected:
 
     void fgLinkBasicBlocks();
 
-    void fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, BYTE* jumpTarget);
+    unsigned fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, BYTE* jumpTarget);
 
     void fgCheckBasicBlockControlFlow();
 

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -70,7 +70,7 @@ namespace System {
             if ((object)elementType == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.elementType);
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
             Contract.Ensures(Contract.Result<Array>() != null);
             Contract.Ensures(Contract.Result<Array>().Length == length);
             Contract.Ensures(Contract.Result<Array>().Rank == 1);
@@ -904,7 +904,7 @@ namespace System {
             if (index < lb)
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
             if (array.Length - (index - lb) < length)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             if (array.Rank != 1)
@@ -1002,7 +1002,7 @@ namespace System {
             if (index < 0)
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
 
             if (array.Length - index < length)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
@@ -1136,11 +1136,11 @@ namespace System {
             }
 
             if( startIndex < 0 || startIndex > array.Length ) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             }
 
             if (count < 0 || startIndex > array.Length - count) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+                ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             }
 
             if( match == null) {
@@ -1205,19 +1205,19 @@ namespace System {
             if(array.Length == 0) {
                 // Special case for 0 length List
                 if( startIndex != -1) {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                    ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
                 }
             }
             else {
                 // Make sure we're not out of range            
                 if ( startIndex < 0 || startIndex >= array.Length) {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                    ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
                 }
             }
             
             // 2nd have of this also catches when startIndex == MAXINT, so MAXINT - 0 + 1 == -1, which is < 0.
             if (count < 0 || startIndex - count + 1 < 0) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+                ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             }
 
             int endIndex = startIndex - count;
@@ -1305,9 +1305,9 @@ namespace System {
 
             int lb = array.GetLowerBound(0);
             if (startIndex < lb || startIndex > array.Length + lb)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             if (count < 0 || count > array.Length - startIndex + lb)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+                ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
 
             // Try calling a quick native method to handle primitive types.
             int retVal;
@@ -1376,11 +1376,11 @@ namespace System {
             }
 
             if (startIndex < 0 || startIndex > array.Length ) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             }
 
             if (count < 0 || count > array.Length - startIndex) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+                ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             }
             Contract.Ensures(Contract.Result<int>() < array.Length);
             Contract.EndContractBlock();
@@ -1442,9 +1442,9 @@ namespace System {
             }
 
             if (startIndex < lb || startIndex >= array.Length + lb)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             if (count < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+                ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             if (count > startIndex - lb + 1)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.endIndex, ExceptionResource.ArgumentOutOfRange_EndIndexStartIndex);
             if (array.Rank != 1)
@@ -1518,24 +1518,24 @@ namespace System {
                 // accept -1 and 0 as valid startIndex for compablility reason.
                 //
                 if( startIndex != -1 && startIndex != 0) {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                    ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
                 }
 
                 // only 0 is a valid value for count if array is empty
                 if( count != 0) {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+                    ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
                 }
                 return -1;
             }
 
             // Make sure we're not out of range            
             if ( startIndex < 0 || startIndex >= array.Length) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             }
             
             // 2nd have of this also catches when startIndex == MAXINT, so MAXINT - 0 + 1 == -1, which is < 0.
             if (count < 0 || startIndex - count + 1 < 0) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+                ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             }
 
             return EqualityComparer<T>.Default.LastIndexOf(array, value, startIndex, count);            
@@ -1575,7 +1575,7 @@ namespace System {
             if (index < lowerBound)
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
 
             if (array.Length - (index - lowerBound) < length)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
@@ -1632,7 +1632,7 @@ namespace System {
             if (index < 0)
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
             if (array.Length - index < length)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             Contract.EndContractBlock();
@@ -1757,7 +1757,7 @@ namespace System {
             if (index < keysLowerBound)
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
 
             if (keys.Length - (index - keysLowerBound) < length || (items != null && (index - keysLowerBound) > items.Length - length))
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
@@ -1841,7 +1841,7 @@ namespace System {
             if (index < 0)
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
             if (array.Length - index < length)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             Contract.EndContractBlock();
@@ -1865,7 +1865,7 @@ namespace System {
             if (index < 0)
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             if (length < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum();
             if (keys.Length - index < length || (items != null && index > items.Length - length))
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2589,8 +2589,8 @@ namespace System {
     
             public Object Current {
                 get {
-                    if (_index < 0) ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
-                    if (_index >= _endIndex) ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
+                    if (_index < 0) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
+                    if (_index >= _endIndex) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
                     return _array.GetValue(_index);
                 }
             }
@@ -2667,8 +2667,8 @@ namespace System {
     
             public Object Current {
                 get {
-                    if (index < startIndex) ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
-                    if (_complete) ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
+                    if (index < startIndex) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
+                    if (_complete) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
                     return array.GetValue(_indices);
                 }
             }
@@ -2866,8 +2866,8 @@ namespace System {
     
             public T Current {
                 get {
-                    if (_index < 0) ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
-                    if (_index >= _endIndex) ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
+                    if (_index < 0) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
+                    if (_index >= _endIndex) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
                     return _array[_index];
                 }
             }

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -315,8 +315,8 @@ namespace System
             {
                 get
                 {
-                    if (_current < _start) ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
-                    if (_current >= _end) ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
+                    if (_current < _start) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
+                    if (_current >= _end) ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
                     return _array[_current];
                 }
             }

--- a/src/mscorlib/src/System/BitConverter.cs
+++ b/src/mscorlib/src/System/BitConverter.cs
@@ -156,7 +156,7 @@ namespace System {
             }
 
             if ((uint)startIndex >= value.Length) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             }
 
             if (startIndex > value.Length - 2) {
@@ -175,7 +175,7 @@ namespace System {
             }
             
             if ((uint) startIndex >= value.Length) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             }
         
             if (startIndex > value.Length -2) {
@@ -207,7 +207,7 @@ namespace System {
             }
         
             if ((uint) startIndex >= value.Length) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             }
         
             if (startIndex > value.Length -4) {
@@ -238,7 +238,7 @@ namespace System {
             }
         
             if ((uint) startIndex >= value.Length) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             }
         
             if (startIndex > value.Length -8) {
@@ -274,7 +274,7 @@ namespace System {
             if (value == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
             if ((uint)startIndex >= value.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             if (startIndex > value.Length - 2)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
             Contract.EndContractBlock();
@@ -290,7 +290,7 @@ namespace System {
             if (value == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
             if ((uint)startIndex >= value.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             if (startIndex > value.Length - 4)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
             Contract.EndContractBlock();
@@ -306,7 +306,7 @@ namespace System {
             if (value == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
             if ((uint)startIndex >= value.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             if (startIndex > value.Length - 8)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
             Contract.EndContractBlock();
@@ -321,7 +321,7 @@ namespace System {
             if (value == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
             if ((uint)startIndex >= value.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             if (startIndex > value.Length - 4)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
             Contract.EndContractBlock();
@@ -337,7 +337,7 @@ namespace System {
             if (value == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
             if ((uint)startIndex >= value.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             if (startIndex > value.Length - 8)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -263,7 +263,7 @@ namespace System.Collections.Generic {
             }
             
             if (index < 0 || index > array.Length ) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if (array.Length - index < Count) {
@@ -557,7 +557,7 @@ namespace System.Collections.Generic {
             }
             
             if (index < 0 || index > array.Length) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if (array.Length - index < Count) {
@@ -837,7 +837,7 @@ namespace System.Collections.Generic {
                 }
 
                 if (index < 0 || index > array.Length) {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                    ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
                 }
 
                 if (array.Length - index < dictionary.Count) {
@@ -898,7 +898,7 @@ namespace System.Collections.Generic {
                 }
 
                 if (index < 0 || index > array.Length) {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                    ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
                 }
 
                 if (array.Length - index < dictionary.Count) {
@@ -1024,7 +1024,7 @@ namespace System.Collections.Generic {
                 }
 
                 if (index < 0 || index > array.Length) {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                    ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
                 }
 
                 if (array.Length - index < dictionary.Count) {
@@ -1085,7 +1085,7 @@ namespace System.Collections.Generic {
                 }
 
                 if (index < 0 || index > array.Length) { 
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                    ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
                 }
 
                 if (array.Length - index < dictionary.Count)

--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -580,7 +580,7 @@ namespace System.Collections.Generic {
             else {
                 object[] objects = array as object[];
                 if (objects == null) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
 
                 try {
@@ -593,7 +593,7 @@ namespace System.Collections.Generic {
                     }
                 }
                 catch(ArrayTypeMismatchException) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
             }
         }
@@ -912,7 +912,7 @@ namespace System.Collections.Generic {
                 else {
                     object[] objects = array as object[];
                     if (objects == null) {
-                        ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                     }
                                          
                     int count = dictionary.count;
@@ -923,7 +923,7 @@ namespace System.Collections.Generic {
                         }
                     }                    
                     catch(ArrayTypeMismatchException) {
-                        ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                     }
                 }
             }
@@ -1098,7 +1098,7 @@ namespace System.Collections.Generic {
                 else {
                     object[] objects = array as object[];
                     if (objects == null) {
-                        ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                     }
 
                     int count = dictionary.count;
@@ -1109,7 +1109,7 @@ namespace System.Collections.Generic {
                         }
                     }
                     catch(ArrayTypeMismatchException) {
-                        ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                     }
                 }
             }

--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -733,7 +733,7 @@ namespace System.Collections.Generic {
 
             public bool MoveNext() {
                 if (version != dictionary.version) {
-                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                 }
 
                 // Use unsigned comparison since we set index to dictionary.count+1 when the enumeration ends.
@@ -762,7 +762,7 @@ namespace System.Collections.Generic {
             object IEnumerator.Current {
                 get { 
                     if( index == 0 || (index == dictionary.count + 1)) {
-                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);                        
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();                        
                     }      
 
                     if (getEnumeratorRetType == DictEntry) {
@@ -775,7 +775,7 @@ namespace System.Collections.Generic {
 
             void IEnumerator.Reset() {
                 if (version != dictionary.version) {
-                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                 }
 
                 index = 0;
@@ -785,7 +785,7 @@ namespace System.Collections.Generic {
             DictionaryEntry IDictionaryEnumerator.Entry {
                 get { 
                     if( index == 0 || (index == dictionary.count + 1)) {
-                         ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);                        
+                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();                        
                     }                        
                     
                     return new DictionaryEntry(current.Key, current.Value); 
@@ -795,7 +795,7 @@ namespace System.Collections.Generic {
             object IDictionaryEnumerator.Key {
                 get { 
                     if( index == 0 || (index == dictionary.count + 1)) {
-                         ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);                        
+                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();                        
                     }                        
                     
                     return current.Key; 
@@ -805,7 +805,7 @@ namespace System.Collections.Generic {
             object IDictionaryEnumerator.Value {
                 get { 
                     if( index == 0 || (index == dictionary.count + 1)) {
-                         ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);                        
+                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();                        
                     }                        
                     
                     return current.Value; 
@@ -956,7 +956,7 @@ namespace System.Collections.Generic {
 
                 public bool MoveNext() {
                     if (version != dictionary.version) {
-                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                     }
 
                     while ((uint)index < (uint)dictionary.count) {
@@ -982,7 +982,7 @@ namespace System.Collections.Generic {
                 Object System.Collections.IEnumerator.Current {
                     get {                      
                         if( index == 0 || (index == dictionary.count + 1)) {
-                             ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);                        
+                             ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();                        
                         }                        
                         
                         return currentKey;
@@ -991,7 +991,7 @@ namespace System.Collections.Generic {
                 
                 void System.Collections.IEnumerator.Reset() {
                     if (version != dictionary.version) {
-                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);                        
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();                        
                     }
 
                     index = 0;                    
@@ -1142,7 +1142,7 @@ namespace System.Collections.Generic {
 
                 public bool MoveNext() {                    
                     if (version != dictionary.version) {
-                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                     }
                     
                     while ((uint)index < (uint)dictionary.count) {
@@ -1167,7 +1167,7 @@ namespace System.Collections.Generic {
                 Object System.Collections.IEnumerator.Current {
                     get {                      
                         if( index == 0 || (index == dictionary.count + 1)) {
-                             ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);                        
+                             ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();                        
                         }                        
                         
                         return currentValue;
@@ -1176,7 +1176,7 @@ namespace System.Collections.Generic {
                 
                 void System.Collections.IEnumerator.Reset() {
                     if (version != dictionary.version) {
-                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                     }
                     index = 0;                    
                     currentValue = default(TValue);

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -369,7 +369,7 @@ namespace System.Collections.Generic {
                 Array.Copy(_items, 0, array, arrayIndex, _size);
             }
             catch(ArrayTypeMismatchException){
-                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
             }
         }
     

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -454,11 +454,11 @@ namespace System.Collections.Generic {
  
         public int FindIndex(int startIndex, int count, Predicate<T> match) {
             if( (uint)startIndex > (uint)_size ) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);                
+                ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();                
             }
 
             if (count < 0 || startIndex > _size - count) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+                ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             }
 
             if( match == null) {
@@ -512,19 +512,19 @@ namespace System.Collections.Generic {
             if(_size == 0) {
                 // Special case for 0 length List
                 if( startIndex != -1) {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                    ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
                 }
             }
             else {
                 // Make sure we're not out of range            
                 if ( (uint)startIndex >= (uint)_size) {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+                    ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
                 }
             }
             
             // 2nd have of this also catches when startIndex == MAXINT, so MAXINT - 0 + 1 == -1, which is < 0.
             if (count < 0 || startIndex - count + 1 < 0) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+                ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             }
                         
             int endIndex = startIndex - count;
@@ -648,7 +648,7 @@ namespace System.Collections.Generic {
             if (index > _size)
                 ThrowHelper.ThrowArgumentOutOfRange_IndexException();
 
-            if (count <0 || index > _size - count) ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+            if (count <0 || index > _size - count) ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             Contract.Ensures(Contract.Result<int>() >= -1);
             Contract.Ensures(Contract.Result<int>() < Count);
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -552,7 +552,7 @@ namespace System.Collections.Generic {
             }
 
             if (version != _version && BinaryCompatibility.TargetsAtLeast_Desktop_V4_5)
-                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+                ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
         }
 
         // Returns an enumerator for this list with the given
@@ -1065,7 +1065,7 @@ namespace System.Collections.Generic {
             private bool MoveNextRare()
             {                
                 if (version != list._version) {
-                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                 }
 
                 index = list._size + 1;
@@ -1082,7 +1082,7 @@ namespace System.Collections.Generic {
             Object System.Collections.IEnumerator.Current {
                 get {
                     if( index == 0 || index == list._size + 1) {
-                         ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);
+                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
                     }
                     return Current;
                 }
@@ -1090,7 +1090,7 @@ namespace System.Collections.Generic {
     
             void System.Collections.IEnumerator.Reset() {
                 if (version != list._version) {
-                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                 }
                 
                 index = 0;

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -274,7 +274,7 @@ namespace System.Collections.Generic {
         // 
         public int BinarySearch(int index, int count, T item, IComparer<T> comparer) {
             if (index < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             if (count < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
             if (_size - index < count)
@@ -575,7 +575,7 @@ namespace System.Collections.Generic {
 
         public List<T> GetRange(int index, int count) {
             if (index < 0) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if (count < 0) {
@@ -628,7 +628,7 @@ namespace System.Collections.Generic {
         // 
         public int IndexOf(T item, int index) {
             if (index > _size)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             Contract.Ensures(Contract.Result<int>() >= -1);
             Contract.Ensures(Contract.Result<int>() < Count);
             Contract.EndContractBlock();
@@ -646,7 +646,7 @@ namespace System.Collections.Generic {
         // 
         public int IndexOf(T item, int index, int count) {
             if (index > _size)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
 
             if (count <0 || index > _size - count) ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
             Contract.Ensures(Contract.Result<int>() >= -1);
@@ -698,7 +698,7 @@ namespace System.Collections.Generic {
             }
             
             if ((uint)index > (uint)_size) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             }
             Contract.EndContractBlock();
 
@@ -766,7 +766,7 @@ namespace System.Collections.Generic {
         public int LastIndexOf(T item, int index)
         {
             if (index >= _size)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             Contract.Ensures(Contract.Result<int>() >= -1);
             Contract.Ensures(((Count == 0) && (Contract.Result<int>() == -1)) || ((Count > 0) && (Contract.Result<int>() <= index)));
             Contract.EndContractBlock();
@@ -784,7 +784,7 @@ namespace System.Collections.Generic {
         // 
         public int LastIndexOf(T item, int index, int count) {
             if ((Count != 0) && (index < 0)) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if ((Count !=0) && (count < 0)) {
@@ -883,7 +883,7 @@ namespace System.Collections.Generic {
         // 
         public void RemoveRange(int index, int count) {
             if (index < 0) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if (count < 0) {
@@ -917,7 +917,7 @@ namespace System.Collections.Generic {
         // 
         public void Reverse(int index, int count) {
             if (index < 0) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
                 
             if (count < 0) {
@@ -956,7 +956,7 @@ namespace System.Collections.Generic {
         // 
         public void Sort(int index, int count, IComparer<T> comparer) {
             if (index < 0) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
             
             if (count < 0) {

--- a/src/mscorlib/src/System/Collections/ObjectModel/Collection.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/Collection.cs
@@ -183,7 +183,7 @@ namespace System.Collections.ObjectModel
             }
             
             if (index < 0 ) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if (array.Length - index < Count) {

--- a/src/mscorlib/src/System/Collections/ObjectModel/Collection.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/Collection.cs
@@ -204,7 +204,7 @@ namespace System.Collections.ObjectModel
                 Type targetType = array.GetType().GetElementType(); 
                 Type sourceType = typeof(T);
                 if(!(targetType.IsAssignableFrom(sourceType) || sourceType.IsAssignableFrom(targetType))) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
 
                 //
@@ -213,7 +213,7 @@ namespace System.Collections.ObjectModel
                 //
                 object[] objects = array as object[];
                 if( objects == null) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
 
                 int count = items.Count;
@@ -223,7 +223,7 @@ namespace System.Collections.ObjectModel
                     }
                 }
                 catch(ArrayTypeMismatchException) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
             }            
         }

--- a/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -128,7 +128,7 @@ namespace System.Collections.ObjectModel
             }
             
             if (index < 0) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.arrayIndex, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if (array.Length - index < Count) {

--- a/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -149,7 +149,7 @@ namespace System.Collections.ObjectModel
                 Type targetType = array.GetType().GetElementType(); 
                 Type sourceType = typeof(T);
                 if(!(targetType.IsAssignableFrom(sourceType) || sourceType.IsAssignableFrom(targetType))) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
 
                 //
@@ -158,7 +158,7 @@ namespace System.Collections.ObjectModel
                 //
                 object[] objects = array as object[];
                 if( objects == null) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
 
                 int count = list.Count;
@@ -168,7 +168,7 @@ namespace System.Collections.ObjectModel
                     }
                 }
                 catch(ArrayTypeMismatchException) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
             }
         }

--- a/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -240,7 +240,7 @@ namespace System.Collections.ObjectModel
             }
 
             if (index < 0 || index > array.Length) {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+                ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if (array.Length - index < Count) {

--- a/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -261,7 +261,7 @@ namespace System.Collections.ObjectModel
                 else {
                     object[] objects = array as object[];
                     if (objects == null) {
-                        ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                     }
 
                     try {
@@ -270,7 +270,7 @@ namespace System.Collections.ObjectModel
                         }
                     }
                     catch (ArrayTypeMismatchException) {
-                        ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                        ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                     }
                 }
             }
@@ -596,7 +596,7 @@ namespace System.Collections.ObjectModel
                 Type targetType = array.GetType().GetElementType();
                 Type sourceType = typeof(T);
                 if (!(targetType.IsAssignableFrom(sourceType) || sourceType.IsAssignableFrom(targetType))) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
 
                 //
@@ -605,7 +605,7 @@ namespace System.Collections.ObjectModel
                 //
                 object[] objects = array as object[];
                 if (objects == null) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
 
                 try {
@@ -614,7 +614,7 @@ namespace System.Collections.ObjectModel
                     }
                 }
                 catch (ArrayTypeMismatchException) {
-                    ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArrayType);
+                    ThrowHelper.ThrowArgumentException_Argument_InvalidArrayType();
                 }
             }
         }

--- a/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IteratorToEnumeratorAdapter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/WindowsRuntime/IteratorToEnumeratorAdapter.cs
@@ -123,10 +123,10 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             {
                 // The enumerator has not been advanced to the first element yet.
                 if (!m_isInitialized)
-                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
                 // The enumerator has reached the end of the collection
                 if (!m_hadCurrent)
-                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
                 return m_current;
             }
         }
@@ -137,10 +137,10 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             {
                 // The enumerator has not been advanced to the first element yet.
                 if (!m_isInitialized)
-                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
                 // The enumerator has reached the end of the collection
                 if (!m_hadCurrent)
-                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
                 return m_current;
             }
         }
@@ -187,7 +187,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 // Translate E_CHANGED_STATE into an InvalidOperationException for an updated enumeration
                 if (Marshal.GetHRForException(e) == __HResults.E_CHANGED_STATE)
                 {
-                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                 }
                 else
                 {

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -44,27 +44,31 @@ namespace System {
     [Pure]
     internal static class ThrowHelper {    
         internal static void ThrowArgumentOutOfRange_IndexException() {
-            throw new ArgumentOutOfRangeException(GetArgumentName(ExceptionArgument.index),
-                                                    Environment.GetResourceString(GetResourceName(ExceptionResource.ArgumentOutOfRange_Index)));
+            throw GetArgumentOutOfRangeException(ExceptionArgument.index, 
+                                                    ExceptionResource.ArgumentOutOfRange_Index);
         }
 
         internal static void ThrowIndexArgumentOutOfRange_NeedNonNegNumException() {
-            throw new ArgumentOutOfRangeException(
-                        GetArgumentName(ExceptionArgument.index),
-                        Environment.GetResourceString(GetResourceName(ExceptionResource.ArgumentOutOfRange_NeedNonNegNum)));
+            throw GetArgumentOutOfRangeException(ExceptionArgument.index, 
+                                                    ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
         }
 
         internal static void ThrowWrongKeyTypeArgumentException(object key, Type targetType) {
-            throw new ArgumentException(Environment.GetResourceString("Arg_WrongType", key, targetType), "key");
+            throw GetWrongKeyTypeArgumentException(key, targetType);
         }
 
         internal static void ThrowWrongValueTypeArgumentException(object value, Type targetType) {
-            throw new ArgumentException(Environment.GetResourceString("Arg_WrongType", value, targetType), "value");
+            throw GetWrongValueTypeArgumentException(value, targetType);
         }
 
+
 #if FEATURE_CORECLR
+        private static ArgumentException GetAddingDuplicateWithKeyArgumentException(object key) {
+            return new ArgumentException(Environment.GetResourceString("Argument_AddingDuplicateWithKey", key));
+        }
+
         internal static void ThrowAddingDuplicateWithKeyArgumentException(object key) {
-            throw new ArgumentException(Environment.GetResourceString("Argument_AddingDuplicateWithKey", key));
+            throw GetAddingDuplicateWithKeyArgumentException(key);
         }
 #endif
 
@@ -73,11 +77,11 @@ namespace System {
         }
         
         internal static void ThrowArgumentException(ExceptionResource resource) {
-            throw new ArgumentException(Environment.GetResourceString(GetResourceName(resource)));
+            throw new ArgumentException(GetResourceString(resource));
         }
 
         internal static void ThrowArgumentException(ExceptionResource resource, ExceptionArgument argument) {
-            throw new ArgumentException(Environment.GetResourceString(GetResourceName(resource)), GetArgumentName(argument));
+            throw GetArgumentException(resource, argument);
         }
 
         internal static void ThrowArgumentNullException(ExceptionArgument argument) {
@@ -86,7 +90,7 @@ namespace System {
 
         internal static void ThrowArgumentNullException(ExceptionResource resource)
         {
-            throw new ArgumentNullException(Environment.GetResourceString(GetResourceName(resource)));
+            throw new ArgumentNullException(GetResourceString(resource));
         }
 
         internal static void ThrowArgumentOutOfRangeException(ExceptionArgument argument) {
@@ -94,60 +98,76 @@ namespace System {
         }
 
         internal static void ThrowArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
-            throw new ArgumentOutOfRangeException(GetArgumentName(argument),
-                                                    Environment.GetResourceString(GetResourceName(resource)));
+            throw GetArgumentOutOfRangeException(argument, resource);
         }
 
         internal static void ThrowArgumentOutOfRangeException(ExceptionArgument argument, int paramNumber, ExceptionResource resource) {
-            throw new ArgumentOutOfRangeException(GetArgumentName(argument) + "[" + paramNumber.ToString() + "]",
-                                                    Environment.GetResourceString(GetResourceName(resource)));
+            throw GetArgumentOutOfRangeException(argument, paramNumber, resource);
         }
 
         internal static void ThrowInvalidOperationException(ExceptionResource resource) {
-            throw new InvalidOperationException(Environment.GetResourceString(GetResourceName(resource)));
+            throw new InvalidOperationException(GetResourceString(resource));
         }
 
         internal static void ThrowInvalidOperationException(ExceptionResource resource, Exception e) {
-            throw new InvalidOperationException(Environment.GetResourceString(GetResourceName(resource)), e);
+            throw new InvalidOperationException(GetResourceString(resource), e);
         }
 
         internal static void ThrowSerializationException(ExceptionResource resource) {
-            throw new SerializationException(Environment.GetResourceString(GetResourceName(resource)));
+            throw new SerializationException(GetResourceString(resource));
         }
 
         internal static void  ThrowSecurityException(ExceptionResource resource) {
-            throw new System.Security.SecurityException(Environment.GetResourceString(GetResourceName(resource)));
+            throw new System.Security.SecurityException(GetResourceString(resource));
         }
 
         internal static void ThrowRankException(ExceptionResource resource) {
-            throw new RankException(Environment.GetResourceString(GetResourceName(resource)));
+            throw new RankException(GetResourceString(resource));
         }
 
         internal static void ThrowNotSupportedException(ExceptionResource resource) {
-            throw new NotSupportedException(Environment.GetResourceString(GetResourceName(resource)));
+            throw new NotSupportedException(GetResourceString(resource));
         }
 
         internal static void ThrowUnauthorizedAccessException(ExceptionResource resource) {
-            throw new UnauthorizedAccessException(Environment.GetResourceString(GetResourceName(resource)));
+            throw new UnauthorizedAccessException(GetResourceString(resource));
         }
 
         internal static void ThrowObjectDisposedException(string objectName, ExceptionResource resource) {
-            throw new ObjectDisposedException(objectName, Environment.GetResourceString(GetResourceName(resource)));
+            throw new ObjectDisposedException(objectName, GetResourceString(resource));
         }
 
-        internal static void ThrowObjectDisposedException(ExceptionResource resource)
-        {
-            throw new ObjectDisposedException(null, Environment.GetResourceString(GetResourceName(resource)));
+        internal static void ThrowObjectDisposedException(ExceptionResource resource) {
+            throw new ObjectDisposedException(null, GetResourceString(resource));
         }
 
-        internal static void ThrowNotSupportedException()
-        {
+        internal static void ThrowNotSupportedException() {
             throw new NotSupportedException();
         }
 
-        internal static void ThrowAggregateException(List<Exception> exceptions)
-        {
+        internal static void ThrowAggregateException(List<Exception> exceptions) {
             throw new AggregateException(exceptions);
+        }
+
+
+        private static ArgumentException GetWrongKeyTypeArgumentException(object key, Type targetType) {
+            return new ArgumentException(Environment.GetResourceString("Arg_WrongType", key, targetType), "key");
+        }
+
+        private static ArgumentException GetWrongValueTypeArgumentException(object value, Type targetType) {
+            return new ArgumentException(Environment.GetResourceString("Arg_WrongType", value, targetType), "value");
+        }
+
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
+            return new ArgumentOutOfRangeException(GetArgumentName(argument), GetResourceString(resource));
+        }
+
+        private static ArgumentException GetArgumentException(ExceptionResource resource, ExceptionArgument argument) {
+            return new ArgumentException(GetResourceString(resource), GetArgumentName(argument));
+        }
+
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, int paramNumber, ExceptionResource resource) {
+            return new ArgumentOutOfRangeException(GetArgumentName(argument) + "[" + paramNumber.ToString() + "]", GetResourceString(resource));
         }
 
         // Allow nulls for reference types and Nullable<U>, but not for value types.
@@ -160,26 +180,43 @@ namespace System {
                 ThrowHelper.ThrowArgumentNullException(argName);
         }
 
-        //
         // This function will convert an ExceptionArgument enum value to the argument name string.
-        //
-        internal static string GetArgumentName(ExceptionArgument argument) {
+        private static string GetArgumentName(ExceptionArgument argument) {
+            // This is indirected through a second NoInlining function it has a special meaning
+            // in System.Private.CoreLib of indicatating it takes a StackMark which cause 
+            // the caller to also be not inlined; so we can't mark it directly.
+            // So is the effect of marking this function as non-inlining in a regular situation.
+            return GetArgumentNameInner(argument);
+        }
+
+        // This function will convert an ExceptionArgument enum value to the argument name string.
+        // Second function in chain so as to not propergate the non-inlining to outside caller
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static string GetArgumentNameInner(ExceptionArgument argument) {
             Contract.Assert(Enum.IsDefined(typeof(ExceptionArgument), argument),
                 "The enum value is not defined, please check the ExceptionArgument Enum.");
 
             return argument.ToString();
         }
 
-        //
         // This function will convert an ExceptionResource enum value to the resource string.
-        //
-        internal static string GetResourceName(ExceptionResource resource) {
+        private static string GetResourceString(ExceptionResource resource) {
+            // This is indirected through a second NoInlining function it has a special meaning
+            // in System.Private.CoreLib of indicatating it takes a StackMark which cause 
+            // the caller to also be not inlined; so we can't mark it directly.
+            // So is the effect of marking this function as non-inlining in a regular situation.
+            return GetResourceStringInner(resource);
+        }
+
+        // This function will convert an ExceptionResource enum value to the resource string.
+        // Second function in chain so as to not propergate the non-inlining to outside caller
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static string GetResourceStringInner(ExceptionResource resource) {
             Contract.Assert(Enum.IsDefined(typeof(ExceptionResource), resource),
                 "The enum value is not defined, please check the ExceptionResource Enum.");
 
-            return resource.ToString();
+            return Environment.GetResourceString(resource.ToString());
         }
-
     }
 
     //

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -77,7 +77,7 @@ namespace System {
         }
         
         internal static void ThrowArgumentException(ExceptionResource resource) {
-            throw new ArgumentException(GetResourceString(resource));
+            throw GetArgumentException(resource);
         }
 
         internal static void ThrowArgumentException(ExceptionResource resource, ExceptionArgument argument) {
@@ -88,8 +88,7 @@ namespace System {
             throw new ArgumentNullException(GetArgumentName(argument));
         }
 
-        internal static void ThrowArgumentNullException(ExceptionResource resource)
-        {
+        internal static void ThrowArgumentNullException(ExceptionResource resource) {
             throw new ArgumentNullException(GetResourceString(resource));
         }
 
@@ -149,6 +148,9 @@ namespace System {
             throw new AggregateException(exceptions);
         }
 
+        internal static void ThrowArgumentException_Argument_InvalidArrayType() {
+            throw GetArgumentException(ExceptionResource.Argument_InvalidArrayType);
+        }
 
         internal static void ThrowInvalidOperationException_InvalidOperation_EnumNotStarted() {
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
@@ -166,6 +168,9 @@ namespace System {
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);
         }
 
+        private static ArgumentException GetArgumentException(ExceptionResource resource) {
+            return new ArgumentException(GetResourceString(resource));
+        }
 
         private static InvalidOperationException GetInvalidOperationException(ExceptionResource resource) {
             return new InvalidOperationException(GetResourceString(resource));

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -106,7 +106,7 @@ namespace System {
         }
 
         internal static void ThrowInvalidOperationException(ExceptionResource resource) {
-            throw new InvalidOperationException(GetResourceString(resource));
+            throw GetInvalidOperationException(resource);
         }
 
         internal static void ThrowInvalidOperationException(ExceptionResource resource, Exception e) {
@@ -149,6 +149,27 @@ namespace System {
             throw new AggregateException(exceptions);
         }
 
+
+        internal static void ThrowInvalidOperationException_InvalidOperation_EnumNotStarted() {
+            throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
+        }
+
+        internal static void ThrowInvalidOperationException_InvalidOperation_EnumEnded() {
+            throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
+        }
+
+        internal static void ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion() {
+            throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
+        }
+
+        internal static void ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen() {
+            throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);
+        }
+
+
+        private static InvalidOperationException GetInvalidOperationException(ExceptionResource resource) {
+            return new InvalidOperationException(GetResourceString(resource));
+        }
 
         private static ArgumentException GetWrongKeyTypeArgumentException(object key, Type targetType) {
             return new ArgumentException(Environment.GetResourceString("Arg_WrongType", key, targetType), "key");

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -53,6 +53,21 @@ namespace System {
                                                     ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
         }
 
+        internal static void ThrowLengthArgumentOutOfRange_ArgumentOutOfRange_NeedNonNegNum() {
+            throw GetArgumentOutOfRangeException(ExceptionArgument.length,
+                                                    ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+        }
+
+        internal static void ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index() {
+            throw GetArgumentOutOfRangeException(ExceptionArgument.startIndex,
+                                                    ExceptionResource.ArgumentOutOfRange_Index);
+        }
+
+        internal static void ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count() {
+            throw GetArgumentOutOfRangeException(ExceptionArgument.count,
+                                                    ExceptionResource.ArgumentOutOfRange_Count);
+        }
+
         internal static void ThrowWrongKeyTypeArgumentException(object key, Type targetType) {
             throw GetWrongKeyTypeArgumentException(key, targetType);
         }


### PR DESCRIPTION
All ThrowHelper calls are now recognised as cold code.

Adds gtCallMoreFlags |= GTF_CALL_M_DOES_NOT_RETURN to fgFindJumpTargets which happens in early in pipeline (which may mark the method as uninlinable, so prevent the later setting in fgFindBasicBlocks).

Count the BBJ_RETURNs in fgMakeBasicBlocks rather than recounting afterwards (perf)

Reduced the immediate throw path in `ThrowHelper` to help with recognition of the only throws condition.

There were some regressions with so much more recognised as cold code and moved out of the main execution path; so I added some common exception arguments as extra functions for the generics to call in ThrowHelper which resolved this. (Kept as individual commits)

With current branch -0.37 % diff improvement

Resolves https://github.com/dotnet/coreclr/issues/6744
Replacement for https://github.com/dotnet/coreclr/pull/6742

/cc @mikedn @AndyAyersMS @pgavlin