### PR TITLE
x86: adjust stack level at throw blocks

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -250,6 +250,8 @@ protected:
 
     void genAdjustSP(ssize_t delta);
 
+    void genAdjustStackLevel(BasicBlock* block);
+
     void genExitCode(BasicBlock* block);
 
     //-------------------------------------------------------------------------

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -12762,27 +12762,7 @@ void CodeGen::genCodeForBBlist()
         genResetFPstkLevel();
 #endif // FEATURE_STACK_FP_X87
 
-#if !FEATURE_FIXED_OUT_ARGS
-        /* Check for inserted throw blocks and adjust genStackLevel */
-
-        if (!isFramePointerUsed() && compiler->fgIsThrowHlpBlk(block))
-        {
-            noway_assert(block->bbFlags & BBF_JMP_TARGET);
-
-            genStackLevel = compiler->fgThrowHlpBlkStkLevel(block) * sizeof(int);
-
-            if (genStackLevel)
-            {
-#ifdef _TARGET_X86_
-                getEmitter()->emitMarkStackLvl(genStackLevel);
-                inst_RV_IV(INS_add, REG_SPBASE, genStackLevel, EA_PTRSIZE);
-                genStackLevel = 0;
-#else  // _TARGET_X86_
-                NYI("Need emitMarkStackLvl()");
-#endif // _TARGET_X86_
-            }
-        }
-#endif // !FEATURE_FIXED_OUT_ARGS
+        genAdjustStackLevel(block);
 
         savedStkLvl = genStackLevel;
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -296,7 +296,7 @@ void CodeGen::genCodeForBBlist()
         /* Both stacks are always empty on entry to a basic block */
 
         genStackLevel = 0;
-
+        genAdjustStackLevel(block);
         savedStkLvl = genStackLevel;
 
         /* Tell everyone which basic block we're working on */

--- a/src/jit/sideeffects.h
+++ b/src/jit/sideeffects.h
@@ -136,6 +136,12 @@ public:
 // SideEffectSet:
 //    Represents a set of side effects for the purposes of analyzing code
 //    motion.
+//    Note that for non-fixed-size frames without a frame pointer (currently
+//    x86-only), we don't track the modification of the stack level that occurs
+//    with a GT_PUTARG_STK as a side-effect. If we ever support general code
+//    reordering, that would have to be taken into account. As it happens,
+//    we currently do not reorder any other side-effecting nodes relative to
+//    these.
 //
 class SideEffectSet final
 {


### PR DESCRIPTION
When we don't have a frame pointer, we need to adjust the frame pointer before calling the throw helper.
I initially had some concern that we had some exposure from instruction reordering in the backend, but we don't do any reordering of the `GT_PUTARG_STK` nodes. I have added a note to sideeffects.h to call attention to the fact that we need to consider stack depth changes to be side effects, for future consideration should we start doing more general code motion.
For the more general issue, I have extracted the code from codegenlegacy.cpp that does the stack adjustment, and am now unconditionally calling it from both codegenlegacy.cpp and codegenlinear.cpp.

Fix #5699