### PR TITLE
Fail fast on a couple flaky tests to get crash dumps

### DIFF
--- a/tests/src/GC/API/GCHandleCollector/Usage.cs
+++ b/tests/src/GC/API/GCHandleCollector/Usage.cs
@@ -146,7 +146,8 @@ public class Usage
             // ensure threshold is increasing
             if (!CheckPercentageIncrease(handleCount, prevHandleCount))
             {
-                Console.WriteLine("Case 3 failed: threshold not increasing!");
+                // see github#4093 for the rationale for fail-fast in this test.
+                Environment.FailFast(string.Empty);
                 return false;
             }
             prevHandleCount = handleCount;

--- a/tests/src/GC/Scenarios/DoublinkList/dlcollect.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/dlcollect.cs
@@ -77,6 +77,12 @@ namespace DoubLink {
 
             GC.WaitForPendingFinalizers();
 
+            if (DLinkNode.FinalCount != iRep * iObj * 10)
+            {
+                // see github#4093 for the rationale for fail-fast in this test.
+                Environment.FailFast(string.Empty);
+            }
+
             Console.WriteLine("{0} DLinkNodes finalized", DLinkNode.FinalCount);
             return (DLinkNode.FinalCount==iRep*iObj*10);
         }

--- a/tests/src/GC/Scenarios/DoublinkList/dlstack.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/dlstack.cs
@@ -85,6 +85,12 @@ namespace DoubLink {
 				curTotalMemory = GC.GetTotalMemory(false);
 			}
 
+            if (DLinkNode.FinalCount != iRep * iObj * 10)
+            {
+                // see github#4093 for the rationale for fail-fast in this test.
+                Environment.FailFast(string.Empty);
+            }
+
             Console.WriteLine("{0} DLinkNodes finalized", DLinkNode.FinalCount);
             return (DLinkNode.FinalCount==iRep*iObj*10);
 

--- a/tests/src/GC/Scenarios/DoublinkList/doublinkgen.cs
+++ b/tests/src/GC/Scenarios/DoublinkList/doublinkgen.cs
@@ -71,6 +71,12 @@ namespace DoubLink {
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
+            if (DLinkNode.FinalCount != iRep * iObj)
+            {
+                // see github#4093 for the rationale for fail-fast in this test.
+                Environment.FailFast(string.Empty);
+            }
+
             Console.Write(DLinkNode.FinalCount);
             Console.WriteLine(" DLinkNodes finalized");
             return (DLinkNode.FinalCount==iRep*iObj);


### PR DESCRIPTION
See #4093 and the other sub-issues linked to this issue for more information. The idea is to fail fast on test failure to get a crash dump from the CI since I've been unable to reproduce the failures locally since April.