### PR TITLE
Permanently fix benchview package version, and add code to produce perf-*-summary.xml on Linux

### DIFF
--- a/tests/scripts/perf-prep.sh
+++ b/tests/scripts/perf-prep.sh
@@ -47,14 +47,14 @@ echo "configuration = $perfConfig"
 # Install nuget to download benchview package, which includes the script machinedata.py for machine data collection
 wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 chmod u+x ./nuget.exe
-./nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory ./tests/scripts -Prerelease
+./nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory ./tests/scripts -Prerelease -ExcludeVersion
 
 # Install python 3.5.2 to run machinedata.py for machine data collection
 sudo add-apt-repository ppa:fkrull/deadsnakes
 sudo apt-get update
 sudo apt-get --assume-yes install python3.5
 python3.5 --version
-python3.5 ./tests/scripts/Microsoft.BenchView.JSONFormat.0.1.0-pre010/tools/machinedata.py
+python3.5 ./tests/scripts/Microsoft.BenchView.JSONFormat/tools/machinedata.py
 
 # Set up the copies
 # Coreclr build containing the tests and mscorlib

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -388,12 +388,15 @@ DO_SETUP=TRUE
 
 if [ ${DO_SETUP} == "TRUE" ]; then
 cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.runner.cli/1.0.0-alpha-build0040/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.runner.cli.dll .
+cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.analysis.cli/1.0.0-alpha-build0040/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.analysis.cli.dll .
 cp  $testNativeBinDir/../../../../../packages/Microsoft.DotNet.xunit.performance.run.core/1.0.0-alpha-build0040/lib/dotnet/*.dll .
 fi
 
 # Run coreclr performance tests
 echo "Test root dir is: $testRootDir"
 tests=($(find $testRootDir/JIT/Performance/CodeQuality -name '*.exe'))
+
+echo "current dir is $PWD"
 
 for testcase in ${tests[@]}; do
 
@@ -404,7 +407,10 @@ echo "....Running $testname"
 cp $testcase .
 
 chmod u+x ./corerun
+echo "./corerun Microsoft.DotNet.xunit.performance.runner.cli.dll $test -runner xunit.console.netcore.exe -runnerhost ./corerun -verbose -runid perf-$testname"
 ./corerun Microsoft.DotNet.xunit.performance.runner.cli.dll $test -runner xunit.console.netcore.exe -runnerhost ./corerun -verbose -runid perf-$testname
+echo "./corerun Microsoft.DotNet.xunit.performance.analysis.cli.dll perf-$testname.xml -xml perf-$testname-summary.xml"
+./corerun Microsoft.DotNet.xunit.performance.analysis.cli.dll perf-$testname.xml -xml perf-$testname-summary.xml
 done
 
 mkdir ../../../../../sandbox


### PR DESCRIPTION
1. Make benchview package dir versionless, so the run won't be broken by its version updates.
2.  Add code to produce perf-*-summary.xml on Linux. Note fixes need to be made on Microsoft.DotNet.xunit.performance.analysis.cli.dll to enable the generation of perf-*-summary.xml on Linux, currently it doesn't successfully generate them on Linux.