### PR TITLE
Disable a test that is not compatible with GC stress.

### DIFF
--- a/tests/src/Loader/classloader/methodoverriding/regressions/549411/exploit.csproj
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/549411/exploit.csproj
@@ -15,6 +15,7 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This test fails under GCStress=0xC for all of RyuJIT/x86, legacy backend
x86, and JIT32.