### PR TITLE
Unify alignment constants between the GC and the VM and assert that t…

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -293,8 +293,6 @@ typedef DPTR(uint8_t)   PTR_uint8_t;
 
 // -----------------------------------------------------------------------------------------------------------
 
-#define DATA_ALIGNMENT GC_DATA_ALIGNMENT
-
 #define RAW_KEYWORD(x) x
 
 #define DECLSPEC_ALIGN(x)   __declspec(align(x))

--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -293,7 +293,7 @@ typedef DPTR(uint8_t)   PTR_uint8_t;
 
 // -----------------------------------------------------------------------------------------------------------
 
-#define DATA_ALIGNMENT sizeof(uintptr_t)
+#define DATA_ALIGNMENT GC_DATA_ALIGNMENT
 
 #define RAW_KEYWORD(x) x
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -84,6 +84,14 @@ struct segment_info
 
 #define LARGE_OBJECT_SIZE ((size_t)(85000))
 
+// Alignment constants for allocation. The allocator APIs will automatically
+// align any allocation requests, but any allocations that are done directly
+// by the VM (i.e. in assembly helpers) will need to be aligned manually
+// using these constants.
+#define GC_DATA_ALIGNMENT sizeof(uintptr_t)
+#define GC_ALIGNCONST (GC_DATA_ALIGNMENT-1)
+
+
 // The minimum size of an object is three pointers wide: one for the syncblock,
 // one for the object header, and one for the first field in the object.
 #define min_obj_size ((sizeof(uint8_t*) + sizeof(uintptr_t) + sizeof(size_t)))

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -208,7 +208,7 @@ void GCLogConfig (const char *fmt, ... );
 #define REQD_ALIGN_DCL ,int requiredAlignment
 #define REQD_ALIGN_ARG ,requiredAlignment
 #define REQD_ALIGN_AND_OFFSET_DCL ,int requiredAlignment,size_t alignmentOffset
-#define REQD_ALIGN_AND_OFFSET_DEFAULT_DCL ,int requiredAlignment=DATA_ALIGNMENT,size_t alignmentOffset=0
+#define REQD_ALIGN_AND_OFFSET_DEFAULT_DCL ,int requiredAlignment=GC_DATA_ALIGNMENT,size_t alignmentOffset=0
 #define REQD_ALIGN_AND_OFFSET_ARG ,requiredAlignment,alignmentOffset
 #else // FEATURE_STRUCTALIGN
 #define REQD_ALIGN_DCL
@@ -870,11 +870,8 @@ struct seg_mapping
 };
 #endif //SEG_MAPPING_TABLE
 
-// alignment helpers
-#define ALIGNCONST GC_ALIGNCONST
-
 inline
-size_t Align (size_t nbytes, int alignment=ALIGNCONST)
+size_t Align (size_t nbytes, int alignment=GC_ALIGNCONST)
 {
     return (nbytes + alignment) & ~alignment;
 }
@@ -886,9 +883,9 @@ int get_alignment_constant (BOOL small_object_p)
 #ifdef FEATURE_STRUCTALIGN
     // If any objects on the large object heap require 8-byte alignment,
     // the compiler will tell us so.  Let's not guess an alignment here.
-    return ALIGNCONST;
+    return GC_ALIGNCONST;
 #else // FEATURE_STRUCTALIGN
-    return small_object_p ? ALIGNCONST : 7;
+    return small_object_p ? GC_ALIGNCONST : 7;
 #endif // FEATURE_STRUCTALIGN
 }
 

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -871,8 +871,7 @@ struct seg_mapping
 #endif //SEG_MAPPING_TABLE
 
 // alignment helpers
-//Alignment constant for allocation
-#define ALIGNCONST (DATA_ALIGNMENT-1)
+#define ALIGNCONST GC_ALIGNCONST
 
 inline
 size_t Align (size_t nbytes, int alignment=ALIGNCONST)

--- a/src/vm/amd64/JitHelpers_InlineGetThread.asm
+++ b/src/vm/amd64/JitHelpers_InlineGetThread.asm
@@ -175,8 +175,8 @@ LEAF_ENTRY AllocateStringFastMP_InlineGetThread, _TEXT
         ; Calculate the final size to allocate.
         ; We need to calculate baseSize + cnt*2, then round that up by adding 7 and anding ~7.
 
-        lea     edx, [edx + ecx*2 + 7]
-        and     edx, -8
+        lea     edx, [edx + ecx*2 + DATA_ALIGNMENT_CONSTANT]
+        and     edx, NOT_DATA_ALIGNMENT_CONSTANT
 
         PATCHABLE_INLINE_GETTHREAD r11, AllocateStringFastMP_InlineGetThread__PatchTLSOffset
         mov     r10, [r11 + OFFSET__Thread__m_alloc_context__alloc_limit]
@@ -237,8 +237,8 @@ LEAF_ENTRY JIT_NewArr1VC_MP_InlineGetThread, _TEXT
 
         ; round the size to a multiple of 8
 
-        add     r8d, 7
-        and     r8d, -8
+        add     r8d, DATA_ALIGNMENT_CONSTANT
+        and     r8d, NOT_DATA_ALIGNMENT_CONSTANT
 
 
         PATCHABLE_INLINE_GETTHREAD r11, JIT_NewArr1VC_MP_InlineGetThread__PatchTLSOffset

--- a/src/vm/amd64/JitHelpers_Slow.asm
+++ b/src/vm/amd64/JitHelpers_Slow.asm
@@ -292,8 +292,8 @@ NESTED_ENTRY AllocateStringFastMP, _TEXT
         ; Calculate the final size to allocate.
         ; We need to calculate baseSize + cnt*2, then round that up by adding 7 and anding ~7.
 
-        lea     r8d, [r8d + ecx*2 + 7]
-        and     r8d, -8
+        lea     r8d, [r8d + ecx*2 + DATA_ALIGNMENT_CONSTANT]
+        and     r8d, NOT_DATA_ALIGNMENT_CONSTANT
 
         mov     r10, [r11 + OFFSET__Thread__m_alloc_context__alloc_limit]
         mov     rax, [r11 + OFFSET__Thread__m_alloc_context__alloc_ptr]
@@ -370,8 +370,8 @@ NESTED_ENTRY JIT_NewArr1VC_MP, _TEXT
 
         ; round the size to a multiple of 8
 
-        add     r8d, 7
-        and     r8d, -8
+        add     r8d, DATA_ALIGNMENT_CONSTANT
+        and     r8d, NOT_DATA_ALIGNMENT_CONSTANT
 
         mov     r10, [r11 + OFFSET__Thread__m_alloc_context__alloc_limit]
         mov     rax, [r11 + OFFSET__Thread__m_alloc_context__alloc_ptr]

--- a/src/vm/amd64/asmconstants.h
+++ b/src/vm/amd64/asmconstants.h
@@ -73,7 +73,9 @@ ASMCONSTANTS_C_ASSERT(ASM_CLRTASKHOSTED   == CLRTASKHOSTED);
 #define SIZEOF_MAX_FP_ARG_SPILL             0x40
 #endif
 
-
+// Constants use for data alignment on this platform.
+#define DATA_ALIGNMENT_CONSTANT 7
+#define NOT_DATA_ALIGNMENT_CONSTANT -8
 
 #ifndef UNIX_AMD64_ABI
 #define SIZEOF_CalleeSavedRegisters         0x40

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -16,12 +16,21 @@
 #include "gcenv.h"
 
 #include "threadsuspend.h"
+#include "asmconstants.h"
 
 #ifdef FEATURE_COMINTEROP
 #include "runtimecallablewrapper.h"
 #include "rcwwalker.h"
 #include "comcallablewrapper.h"
 #endif // FEATURE_COMINTEROP
+
+static_assert_no_msg(DATA_ALIGNMENT == GC_DATA_ALIGNMENT);
+
+#ifdef DATA_ALIGNMENT_CONSTANT
+// not every platform defines this constant, since not every platform
+// needs to align sizes from JIT helpers.
+static_assert_no_msg(DATA_ALIGNMENT_CONSTANT == GC_ALIGNCONST);
+#endif
 
 void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)
 {


### PR DESCRIPTION
…hey are equivalent. This is the second set of changes discussed in #7501. The `DATA_ALIGNMENT` macro is defined in `src/vm/<arch>/cgencpu.h`, so in `gcenv.ee.cpp` it is asserted that this macro and the one exported by the GC are the same.

For `amd64`, where we can allocate in assembly helpers, constants are introduced for the alignment constants (`7` and `~7`) and those are asserted against what the GC uses as well. In all but two cases, the requested allocation size is already aligned - for those two cases I used the introduced constants instead of immediate values.
