### PR TITLE
Fix a calling convention in SimpleStructNative.

### DIFF
--- a/tests/src/Interop/SimpleStruct/SimpleStructNative.cpp
+++ b/tests/src/Interop/SimpleStruct/SimpleStructNative.cpp
@@ -81,7 +81,7 @@ DLL_EXPORT ExplStruct* _cdecl CdeclSimpleExplStruct(ExplStruct p,BOOL *result)
 }
 
 extern "C"
-DLL_EXPORT voidPtr _cdecl GetFptr(int i)
+DLL_EXPORT voidPtr __stdcall GetFptr(int i)
 {
 	switch(i)
 	{


### PR DESCRIPTION
The managed code expects `GetFptr` to have the `stdcall` calling
convention. Because of the mismatch, the JIT-generated code was not
cleaning up the stack after P/Invoking to this function on x86, which
was causing a failure during GC stress.