### PR TITLE
Lower helper call inside PInvoke 

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2742,6 +2742,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
 
         comp->fgMorphTree(helperCall);
         BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, helperCall));
+        LowerNode(helperCall); // helper call is inserted before current node and should be lowered here.
         return;
     }
 #endif


### PR DESCRIPTION
Lowering can create a helper call. The helper call is inserted to the
part of the block, that was lowered. So the helper call should be
lowered independently. fix dotnet/corert#1982 