### PR TITLE
String.SplitInternal: Remove unnecessary stackalloc

### DIFF
--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -1001,9 +1001,7 @@ namespace System
         [System.Security.SecuritySafeCritical]
         private unsafe String[] SplitInternal(char separator, int count, StringSplitOptions options)
         {
-            char* pSeparators = stackalloc char[1];
-            pSeparators[0] = separator;
-            return SplitInternal(pSeparators, /*separatorsLength*/ 1, count, options);
+            return SplitInternal(&separator, 1, count, options);
         }
 
         [System.Security.SecuritySafeCritical]


### PR DESCRIPTION
Simply take the address of the `char` instead of stackallocating a `char[1]`.

cc: @jkotas