### PR TITLE
Build tests against packages & produce Core_Root for arbitrary OS

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,12 @@
       "values": [],
       "defaultValue": ""
     },
+    "__Container": {
+      "description": "Container name for Azure upload.",
+      "valueType": "property",
+      "values": [],
+      "defaultValue": ""
+    },
     "MsBuildFileLogging": {
       "description": "MsBuild logging options.",
       "valueType": "passThrough",
@@ -240,6 +246,12 @@
       "values": [],
       "defaultValue": ""
     },
+    "CreateNonWindowsTestOverlay": {
+      "description": "Runs CreateNonWindowsTestOverlay target.",
+      "valueType": "target",
+      "values": [],
+      "defaultValue": ""
+    },
     "Verbosity": {
       "description": "Sets build verbosity.",
       "valueType": "passThrough",
@@ -260,6 +272,60 @@
     },
     "UpdateInvalidPackageVersions": {
       "description": "Runs the target to update package versions.",
+      "valueType": "target",
+      "values": [],
+      "defaultValue": ""
+    },
+    "GenerateRuntimeLayout": {
+      "description": "Generates Core_Root folder",
+      "valueType": "property",
+      "values": [ true, false ],
+      "defaultValue": true
+    },
+    "BuildTestsAgainstPackages": {
+      "description": "Sets the property specifying if we're building tests against packages",
+      "valueType": "property",
+      "values": [ true, false ],
+      "defaultValue": true
+    },
+    "PublishTestNativeBins": {
+      "description": "Publishes test native binaries to Azure on non-windows",
+      "valueType": "property",
+      "values": [ true, false ],
+      "defaultValue": true
+    },
+    "RuntimeId": {
+      "description": "Specifies the OS to build Core_Root for",
+      "valueType": "property",
+      "values": [ "debian.8-x64", "fedora.23-x64", "opensuse.13.2-x64", "opensuse.42.1-x64", "osx.10.10-x64", "rhel.7-x64", "ubuntu.14.04-x64", "ubuntu.16.04-x64", "ubuntu.16.10-x64" ],
+      "defaultValue": "${__RuntimeId}"
+    },
+    "UpdateDependencies": {
+      "description": "MsBuild target that updates project.json dependencies.",
+      "valueType": "target",
+      "values": [],
+      "defaultValue": ""
+    },
+    "BatchRestorePackages": {
+      "description": "MsBuild target that restores the packages.",
+      "valueType": "target",
+      "values": [],
+      "defaultValue": ""
+    },
+    "BinPlaceRef": {
+      "description": "Place mscorlib.dll in bin/Product ref folder for building tests against",
+      "valueType": "target",
+      "values": [],
+      "defaultValue": ""
+    },
+    "BinPlaceProduct": {
+      "description": "Place test dependencies in bin/Product folder for building tests against",
+      "valueType": "target",
+      "values": [],
+      "defaultValue": ""
+    },
+    "CopyCrossgenToProduct": {
+      "description": "Place crossgen.exe in bin/Product folder for building tests against",
       "valueType": "target",
       "values": [],
       "defaultValue": ""
@@ -380,6 +446,12 @@
             "CloudDropAccountName": "default"
           }
         },
+        "container": {
+          "description": "Container name to download from in Azure Blob storage.",
+          "settings": {
+            "__Container": "default"
+          }
+        },
         "verbose": {
           "description": "Passes /flp:v=diag to the msbuild command or the value passed by the user.",
           "settings": {
@@ -396,6 +468,12 @@
           "description": "To download a specific group of product packages, specify build number. The value for -BuildMajor required.",
           "settings": {
             "BuildNumberMinor": "default"
+          }
+        },
+        "PublishTestNativeBins": {
+          "description": "Downloads Published test native binaries.",
+          "settings": {
+            "PublishTestNativeBins": "default"
           }
         }
       },
@@ -420,6 +498,12 @@
             "CloudDropAccountName": "default"
           }
         },
+        "container": {
+          "description": "Container name to upload into in Azure Blob storage.",
+          "settings": {
+            "__Container": "default"
+          }
+        },
         "buildArch": {
           "description": "Specifies architecture to publish, can be x64, x86, arm or arm64",
           "settings": {
@@ -436,6 +520,18 @@
           "description": "Specifies the OS to publish packages.",
           "settings": {
             "__BuildOS": "default"
+          }
+        },
+        "distroRid": {
+          "description": "Specifies distro rid for Unix OS.",
+          "settings": {
+            "__DistroRid": "default"
+          }
+        },
+        "PublishTestNativeBins": {
+          "description": "Publishes test native binaries.",
+          "settings": {
+            "PublishTestNativeBins": "default"
           }
         }
       },

--- a/publish-packages.cmd
+++ b/publish-packages.cmd
@@ -18,6 +18,8 @@ echo   -AzureAccount="account name"
 echo   -AzureToken="access token"
 echo   -BuildType="Configuration"
 echo   -BuildArch="Architecture"
+echo To specify the name of the container to publish into, use the following property:
+echo   -Container="container name"
 echo Architecture can be x64, x86, arm, or arm64
 echo Configuration can be Release, Debug, or Checked
 exit /b

--- a/publish-packages.sh
+++ b/publish-packages.sh
@@ -8,6 +8,8 @@ usage()
     echo "   -AzureToken=\"access token\""
     echo "   -BuildType=\"Configuration\""
     echo "   -BuildArch=\"Architecture\""
+    echo "To specify the name of the container to publish into, use the following property:"
+    echo "   -Container=\"container name\""
     echo "Configuration can be Release, Checked, or Debug"
     echo "Architecture can be x64, x86, arm, or arm64"
     exit 1
@@ -16,6 +18,7 @@ usage()
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 $working_tree_root/run.sh publish-packages -BuildOS $*
+$working_tree_root/run.sh publish-packages -BuildOS -distroRid -PublishTestNativeBins $*
 if [ $? -ne 0 ]
 then
     echo "ERROR: An error occurred while publishing packages; see $working_tree_root/publish-packages.log for more details. There may have been networking problems, so please try again in a few minutes."

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -13,21 +13,26 @@
     <!-- add relative blob path metadata -->
     <ItemGroup>
       <ForPublishing>
-        <RelativeBlobPath>$(__BuildType)/%(RecursiveDir)%(Filename)%(Extension)</RelativeBlobPath>  
+        <RelativeBlobPath Condition="'$(PublishTestNativeBins)' != 'true'">$(__BuildType)/%(RecursiveDir)%(Filename)%(Extension)</RelativeBlobPath>
+        <RelativeBlobPath Condition="'$(PublishTestNativeBins)' == 'true'">$(__DistroRid)-$(__BuildArch)/$(__BuildType)/%(RecursiveDir)%(Filename)%(Extension)</RelativeBlobPath>    
       </ForPublishing>
     </ItemGroup>
     <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />
   </Target>
 
   <PropertyGroup>
-    <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackagesBinDir)**\*.nupkg</PublishPattern>
+    <PublishPattern Condition="'$(PublishPattern)' == '' and '$(PublishTestNativeBins)' != 'true'">$(PackagesBinDir)**\*.nupkg</PublishPattern>
+    <PublishPattern Condition="'$(PublishPattern)' == '' and '$(PublishTestNativeBins)' == 'true'">$(OutputPath)\tests\src\**</PublishPattern>
   </PropertyGroup>
 
   <Target Name="CreateContainerName"
           DependsOnTargets="CreateVersionFileDuringBuild"
-          Condition="'$(ContainerName)' == ''">
+          Condition="'$(ContainerName)' == '' or '$(PublishTestNativeBins)' == 'true'">
     <PropertyGroup>
-      <ContainerName>coreclr-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
+      <ContainerName Condition="'$(__Container)' == '' and '$(PublishTestNativeBins)' != 'true'">coreclr-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
+      <ContainerName Condition="'$(__Container)' == '' and '$(PublishTestNativeBins)' == 'true'">coreclr-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-test-native-bins</ContainerName>
+      <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' != 'true'">$(__Container)</ContainerName>
+      <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' == 'true'">$(__Container)-test-native-bins</ContainerName>
     </PropertyGroup>
   </Target>
 

--- a/src/syncAzure.proj
+++ b/src/syncAzure.proj
@@ -4,8 +4,11 @@
 
   <PropertyGroup>
     <ContainerNamePrefix Condition="'$(ContainerNamePrefix)' == ''">coreclr-$(PreReleaseLabel)</ContainerNamePrefix>
-    <ContainerName Condition="'$(ContainerNamePrefix)' != '' and '$(BuildNumberMajor)' != '' and '$(BuildNumberMinor)' != ''">$(ContainerNamePrefix)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
-    <DownloadDirectory>$(PackagesDir)AzureTransfer</DownloadDirectory>
+    <ContainerName Condition="'$(__Container)' == '' and '$(ContainerNamePrefix)' != '' and '$(BuildNumberMajor)' != '' and '$(BuildNumberMinor)' != ''">$(ContainerNamePrefix)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
+    <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' != 'true'">$(__Container)</ContainerName>
+    <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' == 'true'">$(__Container)-test-native-bins</ContainerName>
+    <DownloadDirectory Condition="'$(PublishTestNativeBins)' != 'true'">$(PackagesDir)AzureTransfer</DownloadDirectory>
+    <DownloadDirectory Condition="'$(PublishTestNativeBins)' == 'true'">$(PackagesDir)TestNativeBins</DownloadDirectory>
   </PropertyGroup>
 
   <Import Project="$(ToolsDir)SyncCloudContent.targets" />

--- a/sync.cmd
+++ b/sync.cmd
@@ -7,6 +7,7 @@ if /I [%1] == [-help] goto Usage
 @if [%1]==[] set __args=-p
 
  @call %~dp0run.cmd sync %__args% %*
+ @call %~dp0run.cmd sync -PublishTestNativeBins %__args% %*
 @exit /b %ERRORLEVEL%
 
 :Usage
@@ -24,6 +25,8 @@ echo                 -AzureToken="Access token"
 echo              To download a specific group of product packages, specify:
 echo                 -BuildMajor
 echo                 -BuildMinor
+echo              To download from a specific container, specify:
+echo                 -Container="container name"
 echo.
 echo.
 echo If no option is specified then sync.cmd -p is implied.

--- a/tests/publishdependency.targets
+++ b/tests/publishdependency.targets
@@ -8,13 +8,45 @@
     </TestTargetFramework>
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- defined in buildtools packaging.targets, but we need this before targets are imported -->
+    <PackagePlatform Condition="'$(PackagePlatform)' == ''">$(__BuildArch)</PackagePlatform>
+    <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
+    <MinOSForArch>win7</MinOSForArch>
+    <MinOSForArch Condition="'$(PackagePlatform)' == 'arm'">win8</MinOSForArch>
+    <MinOSForArch Condition="'$(PackagePlatform)' == 'arm64'">win10</MinOSForArch>
+  </PropertyGroup>
+
   <ItemGroup>
-    <ProjectLockJsonFiles Include="$(SourceDir)Common\test_runtime\project.lock.json"/>
-    <ProjectLockJsonFiles Include="$(SourceDir)Common\test_dependencies\project.lock.json"/>
+    <CoreRootProjectLockJsonFiles Include="$(SourceDir)Common\test_runtime\project.lock.json"/>
+    <CoreRootProjectLockJsonFiles Include="$(SourceDir)Common\test_dependencies\project.lock.json"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <NonWindowsProjectLockJsonFiles Include="@(CoreRootProjectLockJsonFiles)"/>
+    <NonWindowsProjectLockJsonFiles Include="$(SourceDir)Common\build_against_pkg_dependencies\project.lock.json"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <RefProjectLockJsonFiles Include="$(SourceDir)Common\targeting_pack_ref\project.lock.json"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProductProjectLockJsonFiles Include="$(SourceDir)Common\build_against_pkg_dependencies\project.lock.json"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <CrossGenFiles Include="..\packages\runtime.$(MinOSForArch)-$(PackagePlatform).Microsoft.NETCore.Runtime.CoreCLR\$(CoreClrPackageVersion)\tools\crossgen.exe"/>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <ProductDestination>$(ProjectDir)\..\bin\Product\$(BuildOS).$(BuildArch).$(BuildType)</ProductDestination>
+    <RefDestination>$(ProductDestination)\ref</RefDestination>
+    <CoreOverlay>$(CORE_ROOT)\..\coreoverlay</CoreOverlay>
+  </PropertyGroup>
+
   <Target Name="CopyDependecyToCoreRoot"
-    Inputs="@(ProjectLockJsonFiles)"
+    Inputs="@(CoreRootProjectLockJsonFiles)"
     Outputs="$(CORE_ROOT)\*.*">
 
     <MSBuild Projects="$(SourceDir)Common\test_runtime\test_runtime.csproj"/>
@@ -28,7 +60,7 @@
                                          NuGetPackagesDirectory="$(PackagesDir)"
                                          RuntimeIdentifier="$(TestNugetRuntimeId)"
                                          ProjectLanguage="$(Language)"
-                                         ProjectLockFile="%(ProjectLockJsonFiles.Identity)"
+                                         ProjectLockFile="%(CoreRootProjectLockJsonFiles.Identity)"
                                          TargetMonikers="@(TestTargetFramework)">
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
       <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
@@ -56,6 +88,149 @@
       UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
+  </Target>
+
+  <Target Name="CopyNonWindowsDependecyToCoreRoot"
+    Inputs="@(NonWindowsProjectLockJsonFiles)"
+    Outputs="$(CoreOverlay)\*.*">
+
+    <MSBuild Projects="$(SourceDir)Common\test_runtime\test_runtime.csproj"/>
+
+    <MSBuild Projects="$(SourceDir)Common\test_dependencies\test_dependencies.csproj"/>
+
+    <MSBuild Projects="$(SourceDir)Common\build_against_pkg_dependencies\build_against_pkg_dependencies.csproj"/>
+
+    <!-- This will use the overridden PrereleaseResolveNuGetPackageAssets, which outputs copy local items
+         for the xunit wrapper projects -->
+    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
+                                         IncludeFrameworkReferences="false"
+                                         NuGetPackagesDirectory="$(PackagesDir)"
+                                         RuntimeIdentifier="$(RuntimeId)"
+                                         ProjectLanguage="$(Language)"
+                                         ProjectLockFile="%(NonWindowsProjectLockJsonFiles.Identity)"
+                                         TargetMonikers="@(TestTargetFramework)">
+      <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
+      <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
+      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="RunTimeCopyLocal" />
+    </PrereleaseResolveNuGetPackageAssets>
+    <ItemGroup>
+      <RunTimeDependecyExclude Include="$(CoreOverlay)\**\*.*"  />
+      <RunTimeDependecyExcludeFiles Include="@(RunTimeDependecyExclude -> '%(FileName)%(Extension)')" />
+      <RunTimeDependecyExcludeFiles Include="@(RunTimeDependecyExclude -> '%(FileName).ni%(Extension)')" />
+      <RunTimeDependecyExcludeFiles Include="@(RunTimeDependecyExclude -> '%(FileName).pdb')" />
+      <AllResolvedRuntimeDependencies Include="@(RunTimeCopyLocal -> '%(FileName)%(Extension)')">
+        <File>%(Identity)</File>
+      </AllResolvedRuntimeDependencies>
+      <RunTimeDependecyCopyLocalFile Include="@(AllResolvedRuntimeDependencies)"  Exclude="@(RunTimeDependecyExcludeFiles)"/>
+      <RunTimeDependecyCopyLocal Include="@(RunTimeDependecyCopyLocalFile -> '%(File)')"  />
+    </ItemGroup>
+    
+    <Copy
+      SourceFiles="@(RunTimeDependecyCopyLocal)"
+      DestinationFolder="$(CoreOverlay)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+
+    <ItemGroup>
+      <NonWindowsCrossGenFiles Include="..\packages\runtime.$(RuntimeID).Microsoft.NETCore.Runtime.CoreCLR\$(CoreClrPackageVersion)\tools\crossgen"/>
+    </ItemGroup>
+
+    <Copy
+      SourceFiles="@(NonWindowsCrossGenFiles)"
+      DestinationFolder="$(CoreOverlay)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+
+  </Target>
+
+  <Target Name="CopyDependencyToRef"
+    Inputs="@(RefProjectLockJsonFiles)"
+    Outputs="$(RefDestination)\*.*">
+
+    <MSBuild Projects="$(SourceDir)Common\targeting_pack_ref\targeting_pack_ref.csproj"/>
+
+    <!-- This will use the overridden PrereleaseResolveNuGetPackageAssets, which outputs copy local items
+         for the xunit wrapper projects -->
+    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
+                                         IncludeFrameworkReferences="false"
+                                         NuGetPackagesDirectory="$(PackagesDir)"
+                                         RuntimeIdentifier="$(TestNugetRuntimeId)"
+                                         ProjectLanguage="$(Language)"
+                                         ProjectLockFile="%(RefProjectLockJsonFiles.Identity)"
+                                         TargetMonikers="@(TestTargetFramework)">
+      <Output TaskParameter="ResolvedAnalyzers" ItemName="RefAnalyzer" />
+      <Output TaskParameter="ResolvedReferences" ItemName="RefReference" />
+      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="RefRunTimeCopyLocal" />
+    </PrereleaseResolveNuGetPackageAssets>
+    
+    <Copy
+      SourceFiles="@(RefRunTimeCopyLocal)"
+      DestinationFolder="$(RefDestination)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+  </Target>
+
+  <Target Name="CopyDependencyToProduct"
+    Inputs="@(ProductProjectLockJsonFiles)"
+    Outputs="$(ProductDestination)\*.*">
+
+    <MSBuild Projects="$(SourceDir)Common\build_against_pkg_dependencies\build_against_pkg_dependencies.csproj"/>
+
+    <!-- This will use the overridden PrereleaseResolveNuGetPackageAssets, which outputs copy local items
+         for the xunit wrapper projects -->
+    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
+                                         IncludeFrameworkReferences="false"
+                                         NuGetPackagesDirectory="$(PackagesDir)"
+                                         RuntimeIdentifier="$(TestNugetRuntimeId)"
+                                         ProjectLanguage="$(Language)"
+                                         ProjectLockFile="%(ProductProjectLockJsonFiles.Identity)"
+                                         TargetMonikers="@(TestTargetFramework)">
+      <Output TaskParameter="ResolvedAnalyzers" ItemName="RefAnalyzer" />
+      <Output TaskParameter="ResolvedReferences" ItemName="RefReference" />
+      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="RefRunTimeCopyLocal" />
+    </PrereleaseResolveNuGetPackageAssets>
+    
+    <Copy
+      SourceFiles="@(RefRunTimeCopyLocal)"
+      DestinationFolder="$(ProductDestination)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+  </Target>
+
+  <Target Name="CopyCrossgenToProduct"
+    Outputs="$(ProductDestination)\crossgen.exe;$(CoreOverlay)\crossgen.exe">
+
+    <Copy
+      SourceFiles="@(CrossGenFiles)"
+      DestinationFolder="$(ProductDestination)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+
   </Target>
 
 </Project>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -31,6 +31,7 @@ set __Sequential=
 set __msbuildExtraArgs=
 set __LongGCTests=
 set __GCSimulatorTests=
+set __AgainstPackages=
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -56,6 +57,7 @@ if /i "%1" == "SkipWrapperGeneration" (set __SkipWrapperGeneration=true&shift&go
 if /i "%1" == "Exclude"               (set __Exclude=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "Exclude0"              (set __Exclude0=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "TestEnv"               (set __TestEnv=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "AgainstPackages"       (set __AgainstPackages=1&shift&goto Arg_Loop)
 if /i "%1" == "sequential"            (set __Sequential=1&shift&goto Arg_Loop)
 if /i "%1" == "crossgen"              (set __DoCrossgen=1&shift&goto Arg_Loop)
 if /i "%1" == "longgc"                (set __LongGCTests=1&shift&goto Arg_Loop)
@@ -68,7 +70,7 @@ if /i "%1" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&set __SkipWrap
 if /i "%1" == "PerfTests"             (set __PerfTests=true&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"      (set RunCrossGen=true&shift&goto Arg_Loop)
 REM change it to COMPlus_GCStress when we stop using xunit harness
-if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop) 
+if /i "%1" == "gcstresslevel"         (set __GCSTRESSLEVEL=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop)
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.
@@ -141,6 +143,10 @@ if not defined __Sequential (
     set __msbuildCommonArgs=%__msbuildCommonArgs% /maxcpucount
 ) else (
     set __msbuildCommonArgs=%__msbuildCommonArgs% /p:ParallelRun=false
+)
+
+if defined __AgainstPackages (
+    set __msbuildCommonArgs=%__msbuildCommonArgs% /p:BuildTestsAgainstPackages=true
 )
 
 REM Prepare the Test Drop
@@ -361,6 +367,7 @@ echo                                Set to "" to disable default exclusion file.
 echo Exclude-  Optional parameter - this will exclude individual tests from running, specified by ExcludeList ItemGroup in an .targets file.
 echo TestEnv- Optional parameter - this will run a custom script to set custom test environment settings.
 echo VSVersion- Optional parameter - VS2013 or VS2015 ^(default: VS2015^)
+echo AgainstPackages - Optional parameter - this indicates that we are running tests that were built against packages
 echo GenerateLayoutOnly - If specified will not run the tests and will only create the Runtime Dependency Layout
 echo RunCrossgenTests   - Runs ReadytoRun tests
 echo jitstress n        - Runs the tests with COMPlus_JitStress=n

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -323,6 +323,28 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
              Properties="Language=C#" />
   </Target>
 
+  <Target Name="CreateNonWindowsTestOverlay">
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="CopyNonWindowsDependecyToCoreRoot"
+             Properties="Language=C#;NonWindowsRuntimeId=$(NonWindowsRuntimeId)" />
+  </Target>
+
+  <Target Name="BinPlaceRef">
+    <!-- Copy mscorlib.dll from TargetingPack to bin/Product/ref, if we're building against packages -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="CopyDependencyToRef"
+             Properties="Language=C#"
+             Condition=" '$(BuildTestsAgainstPackages)'=='true' " />
+  </Target>
+
+  <Target Name="BinPlaceProduct">
+    <!-- Copy test dependencies to bin/Product, if we're building against packages -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="CopyDependencyToProduct"
+             Properties="Language=C#"
+             Condition=" '$(BuildTestsAgainstPackages)'=='true' " />
+  </Target>
+
   <!-- All the test projects need to add dependency to currently built runtime as they require that to run. 
        In addition the version number of built runtime can change so all project.json needs to be dynamically generated.
        Instead the following task creates a project.json with dependencies like  Microsoft.netcore.runtime.coreclr ..etc.

--- a/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
+++ b/tests/src/Common/build_against_pkg_dependencies/build_against_pkg_dependencies.csproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+     <DnuSourceList Include="$(CORE_ROOT)\.nuget\pkg" /> 
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Target Name="Build"
+     DependsOnTargets="ResolveReferences" /> 
+</Project>

--- a/tests/src/Common/build_against_pkg_dependencies/project.json
+++ b/tests/src/Common/build_against_pkg_dependencies/project.json
@@ -1,0 +1,32 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.ILAsm": "1.2.0-beta-24616-02",
+    "Microsoft.NETCore.ILDAsm": "1.2.0-beta-24616-02",
+    "Microsoft.NETCore.Jit": "1.2.0-beta-24616-02",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.2.0-beta-24616-02",
+    "Microsoft.NETCore.TestHost": "1.2.0-beta-24616-02"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "win10-arm64": {},
+    "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {},
+  }
+}

--- a/tests/src/Common/targeting_pack_ref/project.json
+++ b/tests/src/Common/targeting_pack_ref/project.json
@@ -1,0 +1,22 @@
+{
+  "dependencies": {
+    "Microsoft.TargetingPack.Private.CoreCLR": "1.2.0-beta-24616-02"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8-x64": {}
+  }
+}

--- a/tests/src/Common/targeting_pack_ref/targeting_pack_ref.csproj
+++ b/tests/src/Common/targeting_pack_ref/targeting_pack_ref.csproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Target Name="Build"
+     DependsOnTargets="ResolveReferences" /> 
+</Project>


### PR DESCRIPTION
This is a pretty substantial change, which will allow us to build tests against packages in CoreCLR, as well as to build a useable Coreoverlay for any OS we support (this is the test overlay directory containing all the binaries that tests need to run against). Currently, an end-to-end non-Windows test run looks like the following:

- Build Product on Windows
- Build Tests on Windows
- Copy Product & Tests to non-Windows
- Build CoreCLR Product on non-Windows
- Build CoreFX Product non non-Windows
- Call runtest.sh, which will gather binaries from both builds of CoreCLR & the build of CoreFX, then run tests against those binaries

After this change, the same test run will look like the following:

- Build tests on Windows
- Copy tests & Coreoverlay to non-Windows
- Run tests

This change does not remove the ability to run tests the old way (though that may be coming later), it just adds the option of doing it in the new way. Such a test run would involve the following commands:

**Windows test run**

`./build-tests.cmd buildagainstpackages`
`./tests/runtest.cmd AgainstPackages`

**Non-Windows test run**

`./build-tests.cmd buildagainstpackages runtimed <Insert target Runtime ID here>`
`(Copy tests & coreoverlay to non-windows)`
`./tests/runtest.sh --coreoverlaydir="coreoverlay dir" --testRootDir="test root dir"`

This change will also require some minor changes to pipebuild once it goes in (in publish-packages.sh/cmd, we will need to change "/p:ContainerName" to "-Container="

CC @gkhanna79 @dotnet/coreclr-contrib 