### PR TITLE
Explicitly specify the Windows SDK version for CMake.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -222,7 +222,13 @@ if %__BuildNative% EQU 1 (
     :: Set the environment for the native build
     set __VCBuildArch=x86_amd64
     if /i "%__BuildArch%" == "x86" ( set __VCBuildArch=x86 )
-    if /i "%__BuildArch%" == "arm" (set __VCBuildArch=x86_arm)
+    if /i "%__BuildArch%" == "arm" (
+        set __VCBuildArch=x86_arm
+        
+        REM Make CMake pick the highest installed version in the 10.0.* range
+        set __ExtraCmakeArgs="-DCMAKE_SYSTEM_VERSION=10.0"
+    )
+
     echo %__MsgPrefix%Using environment: "%__VSToolsRoot%\..\..\VC\vcvarsall.bat" !__VCBuildArch!
     call                                 "%__VSToolsRoot%\..\..\VC\vcvarsall.bat" !__VCBuildArch!
 	@if defined _echo @echo on
@@ -232,13 +238,14 @@ if %__BuildNative% EQU 1 (
         exit /b 1
     )
     if not exist "!VSINSTALLDIR!DIA SDK" goto NoDIA
+
 :GenVSSolution
     if defined __SkipConfigure goto SkipConfigure
 
     echo %__MsgPrefix%Regenerating the Visual Studio solution
 
     pushd "%__IntermediatesDir%"
-    set __ExtraCmakeArgs="-DCLR_CMAKE_TARGET_OS=%__BuildOs%" "-DCLR_CMAKE_PACKAGES_DIR=%__PackagesDir%" "-DCLR_CMAKE_PGO_INSTRUMENT=%__PgoInstrument%"
+    set __ExtraCmakeArgs=%__ExtraCmakeArgs% "-DCLR_CMAKE_TARGET_OS=%__BuildOs%" "-DCLR_CMAKE_PACKAGES_DIR=%__PackagesDir%" "-DCLR_CMAKE_PGO_INSTRUMENT=%__PgoInstrument%"
     call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectDir%" %__VSVersion% %__BuildArch% %__BuildJit32% !__ExtraCmakeArgs!
 	@if defined _echo @echo on
     popd


### PR DESCRIPTION
On CI machines, WinArm32 builds failed due to inability of locating the appropriate Windows SDK. @BruceForstall also ran into this on his machine.

Looking closer into this, it seems that the most reliable way to CMake pickup Windows SDK is to set the version of CMAKE_SYSTEM_VERSION. It uses this to then enumerate the SDK versions and pick the highest one available as described at https://cmake.org/Bug/view.php?id=15831#c40161.

I have confirmed that, with this change, CI machine can successfully build WinArm32 binaries.

@jkotas PTAL

CC @mmitche