### PR TITLE
Introduce trimming of unused bits into BitArray.CopyTo

### DIFF
--- a/src/mscorlib/src/System/Collections/BitArray.cs
+++ b/src/mscorlib/src/System/Collections/BitArray.cs
@@ -365,17 +365,49 @@ namespace System.Collections {
 
             if (array is int[])
             {
-                Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32));
+                int last = GetArrayLength(m_length, BitsPerInt32) - 1;
+                int bits = m_length % BitsPerInt32;
+
+                if (bits == 0)
+                {
+                    // we have perfect bit alignment, no need to sanitize, just copy
+                    Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32));
+                }
+                else
+                {
+                    // do not copy the last int, as it is not completely used
+                    Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32) - 1);
+
+                    // the last int needs to be masked
+                    ((int[])array)[last] = m_array[last] & (1 << bits) - 1;
+                }
             }
             else if (array is byte[])
             {
+                int bits = m_length % BitsPerByte;
+
                 int arrayLength = GetArrayLength(m_length, BitsPerByte);
                 if ((array.Length - index) < arrayLength)
-                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
+                    throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
+
+                if (bits > 0)
+                {
+                    // last byte is not aligned, we will directly copy one less byte
+                    arrayLength -= 1;
+                }
 
                 byte [] b = (byte[])array;
+
+                // copy all the perfectly-aligned bytes
                 for (int i = 0; i < arrayLength; i++)
                     b[index + i] = (byte)((m_array[i/4] >> ((i%4)*8)) & 0x000000FF); // Shift to bring the required byte to LSB, then mask
+
+                if (bits > 0)
+                {
+                    // mask the final byte
+                    int i = arrayLength;
+                    b[index + i] = (byte)((m_array[i/4] >> ((i%4)*8)) & 0x000000FF & ((1 << bits) - 1));
+                }
             }
             else if (array is bool[])
             {

--- a/src/mscorlib/src/System/Collections/BitArray.cs
+++ b/src/mscorlib/src/System/Collections/BitArray.cs
@@ -406,7 +406,7 @@ namespace System.Collections {
                 {
                     // mask the final byte
                     int i = arrayLength;
-                    b[index + i] = (byte)((m_array[i/4] >> ((i%4)*8)) & 0x000000FF & ((1 << bits) - 1));
+                    b[index + i] = (byte)((m_array[i/4] >> ((i%4)*8)) & ((1 << bits) - 1));
                 }
             }
             else if (array is bool[])


### PR DESCRIPTION
An issue has been identified in `BitArray` that causes the `CopyTo` method to "leak" unused bits from the underlying internal array.

The issue was originally discovered in _corefx_ and I decided to submit a PR there, but since some tests use the _mscorlib_ implementation of `BitArray`, fixing the issue in _corefx_ only causes test failure. I was instructed to prepare the same fix for _coreclr_ to bring the two implementation in line.

The _corefx_ issue discussion: [link](https://github.com/dotnet/corefx/issues/9838)
The _corefx_ PR discussion: [link](https://github.com/dotnet/corefx/pull/12597)

According to the discussion, this might be a Bucket 3 breaking change.