### PR TITLE
cross/build-rootfs.sh: fix default UbuntuPackages for default BuildArch

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -17,10 +17,10 @@ __BuildArch=arm
 __UbuntuArch=armhf
 __UbuntuRepo="http://ports.ubuntu.com/"
 __UbuntuPackagesBase="build-essential libunwind8-dev gettext symlinks liblttng-ust-dev libicu-dev"
-__UbuntuPackages="$__UbuntuPackagesBase"
 if [ -z "$LLVM_ARM_HOME" ]; then
     __LLDB_Package="lldb-3.6-dev"
 fi
+__UbuntuPackages="$__UbuntuPackagesBase $__LLDB_Package"
 __MachineTriple=arm-linux-gnueabihf
 __UnprocessedBuildArgs=
 for i in "$@"

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -34,7 +34,6 @@ for i in "$@"
         arm)
         __BuildArch=arm
         __UbuntuArch=armhf
-        __UbuntuPackages="$__UbuntuPackagesBase $__LLDB_Package"
         __MachineTriple=arm-linux-gnueabihf
         ;;
         arm64)
@@ -47,7 +46,6 @@ for i in "$@"
         __BuildArch=arm-softfp
         __UbuntuArch=armel
         __UbuntuRepo="http://ftp.debian.org/debian/"
-        __UbuntuPackages="$__UbuntuPackagesBase $__LLDB_Package"
         __MachineTriple=arm-linux-gnueabi
         __UbuntuCodeName=jessie
         ;;


### PR DESCRIPTION
Installs lldb-3.6-dev if no BuildArch arg is specified, since the default BuildArch (ARM) requires lldb-3.6-dev.

Fixes #7643.