### PR TITLE
Implements UMThunkStub Handler for ARM/Linux

### DIFF
--- a/src/pal/inc/pal_unwind.h
+++ b/src/pal/inc/pal_unwind.h
@@ -19,6 +19,142 @@ extern "C"
 {
 #endif // __cplusplus
 
+#ifdef _ARM_
+    //
+    // Exception Handling ABI Level I: Base ABI
+    //
+    typedef enum
+    {
+        /* Operation completed successfully */
+        _URC_OK                         = 0,
+        _URC_FOREIGN_EXCEPTION_CAUGHT   = 1,
+        _URC_HANDLER_FOUND              = 6,
+        _URC_INSTALL_CONTEXT            = 7,
+        _URC_CONTINUE_UNWIND            = 8,
+        /* Unspecified failure of some kind */
+        _URC_FAILURE                    = 9
+    } _Unwind_Reason_Code;
+
+    typedef enum
+    {
+        _US_VIRTUAL_UNWIND_FRAME   = 0,
+        _US_UNWIND_FRAME_STARTING  = 1,
+        _US_UNWIND_FRAME_RESUME    = 2
+    } _Unwind_State;
+
+    typedef struct _Unwind_Context _Unwind_Context;
+
+    typedef unsigned int _Unwind_EHT_Header;
+
+    struct _Unwind_Control_Block
+    {
+        char exception_class[8];
+
+        /* Unwinder cache - Private fields for the unwinder's use */
+        void (*exception_cleanup)(_Unwind_Reason_Code, _Unwind_Control_Block *);
+
+        /* Propagation barrier cache (valid after phase 1): */
+        struct
+        {
+            /* init reserved1 to 0, then don't touch */
+            unsigned int reserved1;
+            unsigned int reserved2;
+            unsigned int reserved3;
+            unsigned int reserved4;
+            unsigned int reserved5;
+        } unwinder_cache;
+
+        /* Cleanup cache (preserved over cleanup): */
+        struct
+        {
+            unsigned int sp;
+            unsigned int bitpattern[5];
+        } barrier_cache;
+
+        /* PR cache (for pr's benefit): */
+        struct
+        {
+            unsigned int bitpattern[4];
+        } cleanup_cache;
+
+        struct
+        {
+            /* function start address */
+            unsigned int fnstart;
+            /* pointer to EHT entry header word */
+            _Unwind_EHT_Header *ehtp;
+            /* additional data */
+            unsigned int additional;
+            unsigned int reserved1;
+        } pr_cache;
+
+        /* Force alignment of next item to 8-byte boundary */
+        long long int :0;
+    };
+
+    typedef enum
+    {
+        /* integer register */
+        _UVRSC_CORE  = 0,
+        /* vfp */
+        _UVRSC_VFP   = 1,
+        /* Intel WMMX data register */
+        _UVRSC_WMMXD = 3,
+        /* Intel WMMX control register */
+        _UVRSC_WMMXC = 4
+    } _Unwind_VRS_RegClass;
+
+    typedef enum
+    {
+        _UVRSD_UINT32 = 0,
+        _UVRSD_VFPX   = 1,
+        _UVRSD_UINT64 = 3,
+        _UVRSD_FLOAT  = 4,
+        _UVRSD_DOUBLE = 5
+    } _Unwind_VRS_DataRepresentation;
+
+    typedef enum
+    {
+        _UVRSR_OK              = 0,
+        _UVRSR_NOT_IMPLEMENTED = 1,
+        _UVRSR_FAILED          = 2
+    } _Unwind_VRS_Result;
+
+    _Unwind_VRS_Result _Unwind_VRS_Get(_Unwind_Context *context,
+                                       _Unwind_VRS_RegClass regclass,
+                                       unsigned int regno,
+                                       _Unwind_VRS_DataRepresentation representation,
+                                       void *valuep);
+
+    _Unwind_VRS_Result _Unwind_VRS_Set(_Unwind_Context *context,
+                                       _Unwind_VRS_RegClass regclass,
+                                       unsigned int regno,
+                                       _Unwind_VRS_DataRepresentation representation,
+                                       void *valuep);
+
+    _Unwind_VRS_Result _Unwind_VRS_Pop(_Unwind_Context *context,
+                                       _Unwind_VRS_RegClass regclass,
+                                       unsigned int discriminator,
+                                       _Unwind_VRS_DataRepresentation representation);
+    //
+    // Exception Handling ABI Level II: C++ ABI
+    //
+    void *__cxa_begin_catch(_Unwind_Control_Block *ucbp);
+    void  __cxa_end_catch(void);
+
+    typedef enum
+    {
+        ctm_failed                      = 0,
+        ctm_succeeded                   = 1,
+        ctm_succeeded_with_ptr_to_base  = 2
+    } __cxa_type_match_result;
+
+
+    __cxa_type_match_result __cxa_type_match(_Unwind_Control_Block *ucbp,
+                                             void *rttip, // const std::type_info *
+                                             bool is_reference_type,
+                                             void **matched_object);
+#else // ARM
     //
     // Exception Handling ABI Level I: Base ABI
     //
@@ -81,6 +217,7 @@ extern "C"
 
     void *__cxa_begin_catch(void *exceptionObject);
     void __cxa_end_catch();
+#endif
 
 #ifdef __cplusplus
 };

--- a/src/vm/arm/asmhelpers.S
+++ b/src/vm/arm/asmhelpers.S
@@ -309,7 +309,7 @@ LOCAL_LABEL(LNullThis):
 //
 // r12 = UMEntryThunk*
 //
-        NESTED_ENTRY UMThunkStub,_TEXT,UnhandledExceptionHandlerUnix
+        NESTED_ENTRY UMThunkStub,_TEXT,UMThunkStubHandler
         PROLOG_PUSH         "{r4,r5,r7,r11,lr}"
         PROLOG_STACK_SAVE_OFFSET   r7, #8
 

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -5714,6 +5714,83 @@ void CleanUpForSecondPass(Thread* pThread, bool fIsSO, LPVOID MemoryStackFpForFr
 }
 
 #ifdef FEATURE_PAL
+#ifdef _ARM_
+namespace std
+{
+    struct type_info;
+}
+
+static void UMThunkStubCatch(_Unwind_Control_Block *ucbp)
+{
+    PAL_SEHException ex;
+
+    PAL_SEHException *exp = (PAL_SEHException *) __cxa_begin_catch(ucbp);
+    ex = std::move(*exp);
+    __cxa_end_catch();
+
+    DispatchManagedException(ex, false);
+}
+
+EXTERN_C _Unwind_Reason_Code
+UMThunkStubHandler(IN _Unwind_State state,
+                   IN _Unwind_Control_Block *ucbp,
+                   IN _Unwind_Context *ucp
+                  )
+{
+    _Unwind_Reason_Code res = _URC_FAILURE;
+
+    if ( strncmp(ucbp->exception_class + 4, "C++", 4) != 0 )
+    {
+        return res;
+    }
+
+    if ( state == _US_VIRTUAL_UNWIND_FRAME )
+    {
+        void *exp = nullptr;
+
+        if ( ctm_failed != __cxa_type_match(ucbp, (void *) &typeid(PAL_SEHException), false, &exp) )
+        {
+            ucbp->barrier_cache.bitpattern[0] = (unsigned int) exp;
+
+            res = _URC_HANDLER_FOUND;
+        }
+        else
+        {
+            ucbp->barrier_cache.bitpattern[0] = 0;
+        }
+    }
+    else if ( state == _US_UNWIND_FRAME_STARTING )
+    {
+        if ( ucbp->barrier_cache.bitpattern[0] != 0 )
+        {
+            unsigned int arg0 = (unsigned int) ucbp;
+            unsigned int code = (unsigned int) UMThunkStubCatch;
+
+            _Unwind_VRS_Set(ucp, _UVRSC_CORE, 0,  _UVRSD_UINT32, &arg0);
+            _Unwind_VRS_Set(ucp, _UVRSC_CORE, 15, _UVRSD_UINT32, &code);
+
+            res = _URC_INSTALL_CONTEXT;
+        }
+    }
+
+    return res;
+}
+
+EXTERN_C _Unwind_Reason_Code
+UnhandledExceptionHandlerUnix(IN _Unwind_State state,
+                              IN _Unwind_Control_Block *ucbp,
+                              IN _Unwind_Context *ucp
+                             )
+{
+    // Unhandled exception happened, so dump the managed stack trace and terminate the process
+
+    DefaultCatchHandler(NULL /*pExceptionInfo*/, NULL /*Throwable*/, TRUE /*useLastThrownObject*/,
+        TRUE /*isTerminating*/, FALSE /*isThreadBaseFIlter*/, FALSE /*sendAppDomainEvents*/);
+
+    EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+    return _URC_FAILURE;
+}
+#else // __ARM__
 
 // This is a personality routine for TheUMEntryPrestub and UMThunkStub Unix asm stubs.
 // An exception propagating through these stubs is an unhandled exception.
@@ -5735,6 +5812,7 @@ UnhandledExceptionHandlerUnix(
     EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
     return _URC_FATAL_PHASE1_ERROR;
 }
+#endif
 
 #else // FEATURE_PAL
 


### PR DESCRIPTION
This commit implements `UMThunkStubHandler` for `UMThunkStub` in order to propagate exception through unmaned-managed boundary

This commit fixes #7651.
