### PR TITLE
Fixing PAL_TRY use in BOTR

### DIFF
--- a/Documentation/botr/exceptions.md
+++ b/Documentation/botr/exceptions.md
@@ -278,10 +278,16 @@ To use the callout filter, instead of this:
 write this:
 
     BOOL OneShot = TRUE;
+    struct Param {
+        BSTR*  pBSTR;
+        int length;
+    };
+    struct Param param;
+    param.pBSTR = pBSTR;
 
-    PAL_TRY
+    PAL_TRY(Param*, pParam, &param)
     {
-      length = SysStringLen(pBSTR);
+      pParam->length = SysStringLen(pParam->pBSTR);
     }
     PAL_EXCEPT_FILTER(CallOutFilter, &OneShot)
     {


### PR DESCRIPTION
In the Exceptions Section it gives an example use of `PAL_TRY`,
but the parameters to the `PAL_TRY` need to be passed as an argument,
and cannot be implicit.  This commit brings the change inline with
the programming model.