### PR TITLE
Call JIT compiler's shutdown logic from crossgen.

### DIFF
--- a/crossgen.cmake
+++ b/crossgen.cmake
@@ -4,7 +4,6 @@ add_definitions(
     -DCROSSGEN_COMPILE
     -DCROSS_COMPILE
     -DFEATURE_NATIVE_IMAGE_GENERATION
-    -DFEATURE_JIT_METHOD_PERF
     -DSELF_NO_HOST)
 
 remove_definitions(

--- a/crossgen.cmake
+++ b/crossgen.cmake
@@ -4,6 +4,7 @@ add_definitions(
     -DCROSSGEN_COMPILE
     -DCROSS_COMPILE
     -DFEATURE_NATIVE_IMAGE_GENERATION
+    -DFEATURE_JIT_METHOD_PERF
     -DSELF_NO_HOST)
 
 remove_definitions(

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -1017,6 +1017,15 @@ void Zapper::DestroyDomain()
     CleanupAssembly();
 
     //
+    // Shut down JIT compiler.
+    //
+
+    if (m_pJitCompiler != NULL)
+    {
+        m_pJitCompiler->ProcessShutdownWork(NULL);
+    }
+
+    //
     // Get rid of domain.
     //
 


### PR DESCRIPTION
Without this the JIT's logic that does "end-of-life" is never invoked, so e.g. the phase timing log is never written out etc.

Co rikas, @jkotas ?