### PR TITLE
Fix memcpy undef

### DIFF
--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -348,9 +348,7 @@ function_name() to call the system's implementation
 #undef atexit
 #undef div
 #undef div_t
-#if !defined(_DEBUG)
 #undef memcpy
-#endif //!defined(_DEBUG)
 #undef memcmp
 #undef memset
 #undef memmove


### PR DESCRIPTION
This change fixes a memcpy #undef in the palinternal.h. It was undefed only for
non-debug builds, but it needs to be undefed for debug build as well. The non-debug
undef covers the case where memcpy is defined as DUMMY_memcpy, but doesn't cover
the debug case where memcpy is defined as PAL_memcpy.