### PR TITLE
Expose apis in System.Reflection.Assembly

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3960,7 +3960,10 @@
       <Member Name="GetReferencedAssemblies" />
       <Member Name="get_EntryPoint" />
       <Member Name="get_FullName" />
+      <Member Name="get_GlobalAssemblyCache" />
+      <Member Name="get_HostContext" />
       <Member Name="get_ImageRuntimeVersion" />
+      <Member Name="get_IsFullyTrusted" />
       <Member Name="get_IsDynamic" />
       <Member Name="get_CodeBase" />
       <Member Name="get_Location" />
@@ -3968,6 +3971,7 @@
       <Member Name="get_CustomAttributes" />
       <Member Name="get_Modules" />
       <Member Name="get_ReflectionOnly" />
+      <Member Name="get_SecurityRuleSet" />
       <Member Name="GetAssembly(System.Type)" />
       <Member Name="op_Equality(System.Reflection.Assembly,System.Reflection.Assembly)" />
       <Member Name="op_Inequality(System.Reflection.Assembly,System.Reflection.Assembly)" />
@@ -4003,20 +4007,31 @@
       <Member Name="Load(System.String)" />
       <Member Name="Load(System.Byte[])" />
       <Member Name="Load(System.Byte[],System.Byte[])" />
+      <Member Name="LoadFile(System.String)" />
+      <Member Name="LoadFrom(System.String)" />
+      <Member Name="LoadFrom(System.String,System.Byte[],System.Configuration.Assemblies.AssemblyHashAlgorithm)" />
+      <Member Name="LoadModule(System.String,System.Byte[])" />
+      <Member Name="LoadModule(System.String,System.Byte[],System.Byte[])" />
+      <Member Name="LoadWithPartialName(System.String)" />
       <Member Name="ReflectionOnlyLoad(System.String)" />
       <Member Name="ReflectionOnlyLoad(System.Byte[])" />
       <Member Name="ReflectionOnlyLoadFrom(System.String)" />
       <Member Name="ToString" />
+      <Member Name="UnsafeLoadFrom(System.String)" />
       <Member MemberType="Property" Name="DefinedTypes" />
       <Member MemberType="Property" Name="CustomAttributes" />
       <Member MemberType="Property" Name="Modules" />
       <Member MemberType="Property" Name="ExportedTypes" />
       <Member MemberType="Property" Name="EntryPoint" />
       <Member MemberType="Property" Name="FullName" />
+      <Member MemberType="Property" Name="GlobalAssemblyCache" />
+      <Member MemberType="Property" Name="HostContext" />
       <Member MemberType="Property" Name="CodeBase" />
       <Member MemberType="Property" Name="ImageRuntimeVersion" />
+      <Member MemberType="Property" Name="IsFullyTrusted" />
       <Member MemberType="Property" Name="Location" />
       <Member MemberType="Property" Name="ManifestModule" />
+      <Member MemberType="Property" Name="SecurityRuleSet" />
       <Member Status="ImplRoot" MemberType="Event" Name="ModuleResolve" />
     </Type>
     <Type Name="System.Reflection.IntrospectionExtensions">

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -7254,9 +7254,12 @@ namespace System.Reflection
         public virtual System.Reflection.MethodInfo EntryPoint { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Type> ExportedTypes { get { throw null; } }
         public virtual string FullName { get { throw null; } }
+        public virtual bool GlobalAssemblyCache { get { throw null; } }
+        public virtual Int64 HostContext { get { throw null; } }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public virtual string ImageRuntimeVersion { get { throw null; } }
         public virtual bool IsDynamic { get { throw null; } }
+        public bool IsFullyTrusted { get { throw null; } }
         public virtual string Location { [System.Security.SecurityCriticalAttribute]get { throw null; } }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public virtual System.Reflection.Module ManifestModule { get { throw null; } }
@@ -7264,6 +7267,7 @@ namespace System.Reflection
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.Module> Modules { get { throw null; } }
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         public virtual bool ReflectionOnly { get { throw null; } }
+        public virtual System.Security.SecurityRuleSet SecurityRuleSet { get { throw null; } }
         public object CreateInstance(string typeName) { throw null; }
         public object CreateInstance(string typeName, bool ignoreCase) { throw null; }
         public virtual object CreateInstance(String typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, System.Globalization.CultureInfo culture, Object[] activationAttributes) { throw null; }
@@ -7314,6 +7318,13 @@ namespace System.Reflection
         public static System.Reflection.Assembly Load(System.Reflection.AssemblyName assemblyRef) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)][System.Security.SecuritySafeCriticalAttribute]
         public static System.Reflection.Assembly Load(string assemblyString) { throw null; }
+        public static System.Reflection.Assembly LoadFile(String path) { throw null; }
+        public static System.Reflection.Assembly LoadFrom(String path) { throw null; }
+        public static Assembly LoadFrom(string assemblyFile, byte[] hashValue, System.Configuration.Assemblies.AssemblyHashAlgorithm hashAlgorithm) { throw null; }
+        public System.Reflection.Module LoadModule(String moduleName, byte[] rawModule) { throw null; }
+        public System.Reflection.Module LoadModule(String moduleName, byte[] rawModule, byte[] rawSymbolStore) { throw null; }
+        [ObsoleteAttribute("This method has been deprecated. Please use Assembly.Load() instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public static Assembly LoadWithPartialName(string partialName) { throw null; }
         [System.Security.SecuritySafeCriticalAttribute][System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         public static Assembly ReflectionOnlyLoad(byte[] rawAssembly) { throw null; }
         [System.Security.SecuritySafeCriticalAttribute][System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
@@ -7321,6 +7332,7 @@ namespace System.Reflection
         [System.Security.SecuritySafeCriticalAttribute][System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         public static Assembly ReflectionOnlyLoadFrom(string assemblyFile) { throw null; }
         public override string ToString() { throw null; }
+        public static Assembly UnsafeLoadFrom(string assemblyFile) { throw null; }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]

--- a/src/mscorlib/src/System.Private.CoreLib.txt
+++ b/src/mscorlib/src/System.Private.CoreLib.txt
@@ -1477,6 +1477,7 @@ NotSupported_PIAInAppxProcess = A Primary Interop Assembly is not supported in A
 ; Not referring to "Windows Phone" in the messages, as FEATURE_WINDOWSPHONE is defined for .NET Core as well.
 NotSupported_WindowsPhone = {0} is not supported.
 NotSupported_AssemblyLoadCodeBase = Assembly.Load with a Codebase is not supported.
+NotSupported_AssemblyLoadFromHash = Assembly.LoadFrom with hashValue is not supported.
 #endif
 
 ; TypeLoadException

--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -476,6 +476,20 @@ namespace System.Runtime.Loader
             return null;
         }
     }
+
+    [System.Security.SecuritySafeCritical]
+    internal class FileLoadAssemblyLoadContext : AssemblyLoadContext
+    {
+        internal FileLoadAssemblyLoadContext() : base(false)
+        {
+        }
+
+        [System.Security.SecuritySafeCritical]  
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            return null;
+        }
+    }
 }
 
 #endif // FEATURE_HOST_ASSEMBLY_RESOLVER


### PR DESCRIPTION
Following are still remaining:
P:System.Reflection.Assembly.EscapedCodeBase - depends on win32 apis so requires platform independent implementation. Uri.EscapeUriString has similar looking code.
Below ones return FileStream type which is present in corefx so blocked on bringing that back to corelib
M:System.Reflection.Assembly.GetFile(System.String)
M:System.Reflection.Assembly.GetFiles
M:System.Reflection.Assembly.GetFiles(System.Boolean)