### PR TITLE
Vector<T>.ctor(T val) is not recognized for ubyte/byte/short/ushort when the arg is a local of small int type (e.g. method args).

### DIFF
--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -525,7 +525,8 @@ const SIMDIntrinsicInfo* Compiler::getSIMDIntrinsicInfo(CORINFO_CLASS_HANDLE* in
                 // We don't check anything in that case.
                 if (!isThisPtr || !isNewObj)
                 {
-                    GenTreePtr arg = impStackTop(stackIndex).val;
+                    GenTreePtr arg     = impStackTop(stackIndex).val;
+                    var_types  argType = arg->TypeGet();
 
                     var_types expectedArgType;
                     if (argIndex < fixedArgCnt)
@@ -540,6 +541,7 @@ const SIMDIntrinsicInfo* Compiler::getSIMDIntrinsicInfo(CORINFO_CLASS_HANDLE* in
                         {
                             // The type of the argument will be genActualType(*baseType).
                             expectedArgType = genActualType(*baseType);
+                            argType         = genActualType(argType);
                         }
                     }
                     else
@@ -547,7 +549,6 @@ const SIMDIntrinsicInfo* Compiler::getSIMDIntrinsicInfo(CORINFO_CLASS_HANDLE* in
                         expectedArgType = *baseType;
                     }
 
-                    var_types argType = arg->TypeGet();
                     if (!isThisPtr && argType == TYP_I_IMPL)
                     {
                         // The reference implementation has a constructor that takes a pointer.


### PR DESCRIPTION
Kesteral server constructs `Vector<byte>` vectors and reported this issue(#7459).

Here is a reduced repro case:
```
        [MethodImpl(MethodImplOptions.NoInlining)]
        public static Vector<byte> GetVector(byte vectorByte)
        {
            return new Vector<byte>(vectorByte);
        }
```

IR:
```
In Compiler::impImportCall: opcode is newobj, kind=0, callRetType is void, structSize is 0
  Known type SIMD Vector<ubyte>
Method .ctor is NOT a SIMD intrinsic
INLINER: during 'impMarkInlineCandidate' result 'failed this callee' reason 'too many il bytes' for 'VectorTest:GetByteVector(ubyte):struct' calling 'System.Numerics.Vector`1[Byte][System.Byte]:.ctor(ubyte):this'

INLINER: Marking System.Numerics.Vector`1[Byte][System.Byte]:.ctor(ubyte):this as NOINLINE because of too many il bytes
INLINER: during 'impMarkInlineCandidate' result 'failed this callee' reason 'too many il bytes'


               [000010] ------------             *  stmtExpr  void  (IL   ???...  ???)
               [000008] --C-G-------             \--*  call      void   System.Numerics.Vector`1[Byte][System.Byte]..ctor
               [000007] L----------- this in rcx    +--*  addr      byref 
               [000006] ------------                |  \--*  lclVar    simd16 V02 loc0         
               [000001] ------------ arg1           \--*  lclVar    ubyte  V01 arg0
```

Here argType is TYP_UBYTE and expectedArgType is TYP_INT and as a result, .ctor is not recognized as an intrinsic.  The fix is that when expected type is given by baseType, use genActualType of argType for comparing against expectedArgType.

Asm diffs across all SIMD tests indicate, even similar issue exists for other small type vectors.
On SSE2 there is 1555 bytes of code size win over 60 methods that got impacted (3.95%).

Fix #7459
