### PR TITLE
Allow non-constant size for rep stos InitBlk on x86

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2745,14 +2745,24 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* storeBlkNode)
 #endif // !defined(JIT32_GCENCODER)
 }
 
-// Generate code for InitBlk using rep stos.
+//
+//------------------------------------------------------------------------
+// genCodeForInitBlkRepStos: Generate code for InitBlk using rep stos.
+//
+// Arguments:
+//    initBlkNode - The Block store for which we are generating code.
+//
 // Preconditions:
-//  The size of the buffers must be a constant and also less than INITBLK_STOS_LIMIT bytes.
-//  Any value larger than that, we'll use the helper even if both the
-//  fill byte and the size are integer constants.
+//    On x64:
+//      The size of the buffers must be a constant and also less than INITBLK_STOS_LIMIT bytes.
+//      Any value larger than that, we'll use the helper even if both the fill byte and the
+//      size are integer constants.
+//  On x86:
+//      The size must either be a non-constant or less than INITBLK_STOS_LIMIT bytes.
+//
 void CodeGen::genCodeForInitBlkRepStos(GenTreeBlk* initBlkNode)
 {
-    // Make sure we got the arguments of the initblk/initobj operation in the right registers
+    // Make sure we got the arguments of the initblk/initobj operation in the right registers.
     unsigned   size    = initBlkNode->Size();
     GenTreePtr dstAddr = initBlkNode->Addr();
     GenTreePtr initVal = initBlkNode->Data();
@@ -2768,7 +2778,8 @@ void CodeGen::genCodeForInitBlkRepStos(GenTreeBlk* initBlkNode)
 #ifdef _TARGET_AMD64_
         assert(size > CPBLK_UNROLL_LIMIT && size < CPBLK_MOVS_LIMIT);
 #else
-        assert(size > CPBLK_UNROLL_LIMIT);
+        // Note that a size of zero means a non-constant size.
+        assert((size == 0) || (size > CPBLK_UNROLL_LIMIT));
 #endif
     }
 

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278371/DevDiv_278371.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278371/DevDiv_278371.il
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Test for a bug involving an initblk with a non-constant size,
+// which uses rep movs on x86 (x64 uses a helper call).
+
+.assembly extern legacy library mscorlib {}
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly DevDiv_278371 {}
+
+.class public sequential ansi sealed beforefieldinit S
+       extends [mscorlib]System.ValueType
+{
+  .field public uint32 val
+} // end of class S
+
+.class private auto ansi beforefieldinit Program
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig static void  Init(valuetype S& s,
+                                             int32 size) cil managed noinlining
+  {
+          nop
+          ldarg.0
+          ldc.i4     0xaa
+          ldarg.1
+          initblk
+          ret
+  } // end of method Program::Init
+
+  .method private hidebysig static int32 
+          Main() cil managed
+  {
+    .entrypoint
+    .locals init (valuetype S V_0,
+             bool V_1,
+             int32 V_2)
+              ldloca.s   V_0
+              initobj    S
+              ldloca.s   V_0
+              ldc.i4     4
+              call       void Program::Init(valuetype S&, int32)
+              ldloc.0
+              ldfld      uint32 S::val
+              ldc.i4     0xaaaaaaaa
+              ceq
+              ldc.i4.0
+              ceq
+              stloc.1
+              ldloc.1
+              brfalse.s  L1
+
+              ldstr      "Fail"
+              call       void [mscorlib]System.Console::WriteLine(string)
+              nop
+              ldc.i4.m1
+              stloc.2
+              br.s       L2
+
+    L1:       ldstr      "Pass"
+              call       void [mscorlib]System.Console::WriteLine(string)
+              nop
+              ldc.i4.s   100
+              stloc.2
+
+    L2:       ldloc.2
+              ret
+  } // end of method Program::Main
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+              ldarg.0
+              call       instance void [mscorlib]System.Object::.ctor()
+              nop
+              ret
+  } // end of method Program::.ctor
+
+} // end of class Program
+

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278371/DevDiv_278371.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278371/DevDiv_278371.ilproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_278371.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Fixes DevDiv VSO bug 278371, and adds a test case.