### PR TITLE
Always treat incoming on-stack parameters as GC-untracked.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -361,7 +361,7 @@ void CodeGen::genPrepForCompiler()
             {
                 VarSetOps::AddElemD(compiler, compiler->raRegVarsMask, varDsc->lvVarIndex);
             }
-            else if (compiler->lvaIsGCTracked(varDsc) && (!varDsc->lvIsParam || varDsc->lvIsRegArg))
+            else if (compiler->lvaIsGCTracked(varDsc))
             {
                 VarSetOps::AddElemD(compiler, gcInfo.gcTrkStkPtrLcls, varDsc->lvVarIndex);
             }

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4371,10 +4371,12 @@ inline bool Compiler::lvaIsGCTracked(const LclVarDsc* varDsc)
 {
     if (varDsc->lvTracked && (varDsc->lvType == TYP_REF || varDsc->lvType == TYP_BYREF))
     {
+        // Stack parameters are always untracked w.r.t. GC reportings
+        const bool isStackParam = varDsc->lvIsParam && !varDsc->lvIsRegArg;
 #ifdef _TARGET_AMD64_
-        return !lvaIsFieldOfDependentlyPromotedStruct(varDsc);
+        return !isStackParam && !lvaIsFieldOfDependentlyPromotedStruct(varDsc);
 #else  // !_TARGET_AMD64_
-        return true;
+        return !isStackParam;
 #endif // !_TARGET_AMD64_
     }
     else


### PR DESCRIPTION
Incoming parameters that are passed on the stack are never reported as
tracked to the GC, but `lvaIsGCTracked` (which is used to determine
whether or not to report liveness for a lclVar's stack slot) still
returned true if the corresponding lclVar was tracked. This caused
problems on x86 when dealing with incoming GC stack parameters in ESP
frames: in this case, writes to a GC stack parameter could incorrectly
change the liveness for a lclVar at the same offset from ESP as the
parameter's offset from EBP.

Fixes #7696.