### PR TITLE
Only build TargetingPack when building on Windows

### DIFF
--- a/src/.nuget/packages.builds
+++ b/src/.nuget/packages.builds
@@ -9,6 +9,9 @@
 
   <ItemGroup Condition="'$(__SkipCoreLibBuild)'==''">
     <Project Include="Microsoft.NETCore.Runtime.CoreCLR\Microsoft.NETCore.Runtime.CoreCLR.builds" /> 
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Project Include="Microsoft.TargetingPack.Private.CoreCLR\Microsoft.TargetingPack.Private.CoreCLR.pkgproj" /> 
   </ItemGroup>
 


### PR DESCRIPTION
@joperezr this should solve the issues you were encountering (Tested on Windows & non-Windows, this works as expected).