### PR TITLE
Revert "Delete mscorlib from CoreCLR targeting pack"

### DIFF
--- a/src/.nuget/Microsoft.TargetingPack.Private.CoreCLR/Microsoft.TargetingPack.Private.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.TargetingPack.Private.CoreCLR/Microsoft.TargetingPack.Private.CoreCLR.pkgproj
@@ -8,6 +8,9 @@
     <OutputPath>$(PackagesOutputPath)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <File Include="$(BinDir)/ref/mscorlib.dll">
+      <TargetPath>lib/netstandard1.0</TargetPath>
+    </File>
     <File Include="$(BinDir)/System.Private.CoreLib.dll">
       <TargetPath>lib/netstandard1.0</TargetPath>
     </File>


### PR DESCRIPTION
Reverts dotnet/coreclr#7494

CC @jkotas 

Corresponding issue - https://github.com/dotnet/coreclr/issues/7711