### PR TITLE
Cleanup arm32

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -9,7 +9,6 @@
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
     <CoreFxExpectedPrerelease>beta-24615-03</CoreFxExpectedPrerelease>
-    <ExternalExpectedPrerelease>beta-24616-00</ExternalExpectedPrerelease>
   </PropertyGroup>
 
   <!-- Full package version strings that are used in other parts of the build. -->
@@ -52,11 +51,6 @@
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>CoreClrPackageVersion</ElementName>
       <PackageId>Microsoft.NETCore.Runtime.CoreCLR</PackageId>
-    </XmlUpdateStep>
-    <XmlUpdateStep Include="External">
-      <Path>$(MSBuildThisFileFullPath)</Path>
-      <ElementName>ExternalExpectedPrerelease</ElementName>
-      <BuildInfoName>External</BuildInfoName>
     </XmlUpdateStep>
   </ItemGroup>
 

--- a/dependencies.props
+++ b/dependencies.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <CoreFxCurrentRef>53be2f8d2004d5c803341288480f2162c04b42a2</CoreFxCurrentRef>
     <CoreClrCurrentRef>64466edd856832814d52754759fb852aae82b6f3</CoreClrCurrentRef>
-    <ExternalCurrentRef>64466edd856832814d52754759fb852aae82b6f3</ExternalCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
@@ -33,11 +32,7 @@
       <BuildInfoPath>$(BaseDotNetBuildInfo)coreclr/$(DependencyBranch)</BuildInfoPath>
       <CurrentRef>$(CoreClrCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
-    <RemoteDependencyBuildInfo Include="External">
-      <BuildInfoPath>$(BaseDotNetBuildInfo)projectk-tfs/$(DependencyBranch)</BuildInfoPath>
-      <CurrentRef>$(ExternalCurrentRef)</CurrentRef>
-    </RemoteDependencyBuildInfo>
-
+    
     <DependencyBuildInfo Include="@(RemoteDependencyBuildInfo)">
       <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
     </DependencyBuildInfo>

--- a/dir.props
+++ b/dir.props
@@ -155,13 +155,11 @@
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">1.2.0</PackageVersion>
     <WindowsAPISetPackageVersion>1.0.1</WindowsAPISetPackageVersion>
-    <Win8ArmPackageVersion>$(PackageVersion)-$(ExternalExpectedPrerelease)</Win8ArmPackageVersion>
-
+    
     <!-- Set the boolean below to true to generate packages with stabilized versions -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
-    <Win8ArmPackageVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(StableVersion)</Win8ArmPackageVersion>
-
+    
     <!-- On Windows, MSbuild still runs against Desktop FX while it runs on .NET Core on non-Windows. this requires
          pulling in different packaging dependencies.
      -->

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -9,13 +9,6 @@
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
   </PropertyGroup>
   <ItemGroup>
-    <!-- ARM32_TODO: Clean this up.
-      Declare a runtime dependency on the win8-arm CoreCLR built using the TFS builds 
-    -->
-    <RuntimeDependency Include="runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR">
-      <TargetRuntime>win8-arm</TargetRuntime>
-      <Version>$(Win8ArmPackageVersion)</Version>
-    </RuntimeDependency>
     <!-- ApiSets are only applicable for Windows. 
          Despite the unconditioned package dependency it is constrained by runtime IDs within it's own package -->
     <Dependency Include="Microsoft.NETCore.Windows.ApiSets">

--- a/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.pkgproj
@@ -9,11 +9,6 @@
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Declare a runtime dependency on the win8-arm CoreCLR built using the TFS builds -->
-    <RuntimeDependency Include="runtime.win7-arm.Microsoft.NETCore.TestHost">
-      <TargetRuntime>win7-arm</TargetRuntime>
-      <Version>1.0.1-$(ExternalExpectedPrerelease)</Version>
-    </RuntimeDependency>
     <ProjectReference Include="win\Microsoft.NETCore.TestHost.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>


### PR DESCRIPTION
Now that the open build produces the packages, we do not need to depend upon this external dependency.

@weshaggard @dagood PTAL

@dagood Once this PR is merged, we will need to update Maestro to no longer update the ExternalDependency for CoreCLR master branch.

FYI - @RussKeldorph 