### PR TITLE
[ARM/CI] Add runtest option for using dumpling service

### DIFF
--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -270,7 +270,8 @@ function copy_to_emulator {
 function run_tests {
     sudo chroot $__ARMRootfsMountPath /bin/bash -x <<EOF
         cd "$__ARMEmulCoreclr"
-        ./tests/runtest.sh --testRootDir=$__testRootDirBase \
+        ./tests/runtest.sh --limitedDumpGeneration \
+		                   --testRootDir=$__testRootDirBase \
                            --mscorlibDir=$__mscorlibDirBase \
                            --coreFxNativeBinDir=$__coreFxNativeBinDirBase \
                            --coreFxBinDir="$__coreFxBinDirBase" \


### PR DESCRIPTION
To make sure the reason of test failure ramdomly( #6298 ),
the runtest option of '--limitedDumpGeneration' is added.
