### PR TITLE
Fix broken range check

### DIFF
--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -1725,7 +1725,7 @@ void Assembler::EmitInstrBrOffset(Instr* instr, int offset)
     unsigned opc=instr->opcode;
     if(m_fOptimize)
     {
-        if((-128 >= offset)&&(offset <= 127))
+        if((-128 <= offset)&&(offset <= 127))
         {
             opc = instr->opcode = ShortOf(opc);
         }


### PR DESCRIPTION
This was found with Cppcheck. The check looks broken - if `-128 >= offset` is true this means `offset <= -128` and then surely `offset < 127` is also true. Code depending on this check looks like using values in byte range only. Therefore this is a broken range check which should be fixed.