### PR TITLE
Implement DecomposeRotate

### DIFF
--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -52,6 +52,7 @@ private:
     GenTree* DecomposeNeg(LIR::Use& use);
     GenTree* DecomposeArith(LIR::Use& use);
     GenTree* DecomposeShift(LIR::Use& use);
+    GenTree* DecomposeRotate(LIR::Use& use);
     GenTree* DecomposeMul(LIR::Use& use);
     GenTree* DecomposeUMod(LIR::Use& use);
 

--- a/tests/src/JIT/CodeGenBringUpTests/Rotate.cs
+++ b/tests/src/JIT/CodeGenBringUpTests/Rotate.cs
@@ -102,9 +102,27 @@ public class Test
     [MethodImpl(MethodImplOptions.NoInlining)]
     static ulong rol64const()
     {
-        ulong value = flag() ? (ulong)0x123456789abcdef : (ulong)0x123456789abcdef;
+        ulong value = flag() ? (ulong)0x123456789abcdef : (ulong)0xabcdef123456789;
         int amount = 16;
         return (value >> (64 - amount)) | (value << amount);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong rol64_16(ulong value)
+    {
+        return (value >> (64 - 16)) | (value << 16);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong rol64_32(ulong value)
+    {
+        return (value >> (64 - 32)) | (value << 32);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong rol64_33(ulong value)
+    {
+        return (value >> (64 - 33)) | (value << 33);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -128,9 +146,27 @@ public class Test
     [MethodImpl(MethodImplOptions.NoInlining)]
     static ulong ror64const()
     {
-        ulong value = flag() ? (ulong)0x123456789abcdef : (ulong)0x123456789abcdef;
+        ulong value = flag() ? (ulong)0x123456789abcdef : (ulong)0xabcdef123456789;
         int amount = flag() ? 5 : 5;
         return (value << (64 - amount)) | (value >> amount);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong ror64_5(ulong value)
+    {
+        return (value << (64 - 5)) | (value >> 5);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong ror64_32(ulong value)
+    {
+        return (value << (64 - 32)) | (value >> 32);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong ror64_33(ulong value)
+    {
+        return (value << (64 - 33)) | (value >> 33);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -244,6 +280,21 @@ public class Test
             return Fail;
         }
 
+        if (rol64_16(0x123456789abcdef) != 0x456789abcdef0123)
+        {
+            return Fail;
+        }
+
+        if (rol64_32(0x123456789abcdef) != rol64(0x123456789abcdef, 32))
+        {
+            return Fail;
+        }
+
+        if (rol64_33(0x123456789abcdef) != rol64(0x123456789abcdef, 33))
+        {
+            return Fail;
+        }
+
         if (ror64(0x123456789abcdef, 0) != 0x123456789abcdef)
         {
             return Fail;
@@ -255,6 +306,21 @@ public class Test
         }
 
         if (ror64const() != 0x78091a2b3c4d5e6f)
+        {
+            return Fail;
+        }
+
+        if (ror64_5(0x123456789abcdef) != 0x78091a2b3c4d5e6f)
+        {
+            return Fail;
+        }
+
+        if (ror64_32(0x123456789abcdef) != ror64(0x123456789abcdef, 32))
+        {
+            return Fail;
+        }
+
+        if (ror64_33(0x123456789abcdef) != ror64(0x123456789abcdef, 33))
         {
             return Fail;
         }


### PR DESCRIPTION
fgRecognizeAndMorphBitwiseRotation can potentially morph a tree with a
TYP_LONG return type on x86 if the rotate amount is a GT_CNS_INT. This
change implements DecomposeRotate for those rotate instructions. There are
5 cases:

1) Rotate by 0: do nothing.
2) Rotate by 32: swap hi and lo.
3) Rotate by < 32: produce a shld/shld (for GT_ROL) or a shrd/shrd (for
GT_ROR).
4) Rotate by >= 32: swap hi and lo, subtract from the rotate amount 32, and
do option 3.
5) Rotate by >= 64: do rotateAmount % 64 to get the rotate amount between
0 and 63, then do one of options 1-4.