### PR TITLE
Inliner: avoid inlining callees with GC structs on cold paths

### DIFF
--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -156,6 +156,7 @@ INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",        
 
 // ------ Call Site Performance ------- 
 
+INLINE_OBSERVATION(RARE_GC_STRUCT,            bool,   "rarely called, has gc struct",  FATAL,       CALLSITE)
 
 // ------ Call Site Information ------- 
 

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
@@ -11,6 +11,8 @@
 // on a cold path and the other which has similar structure but
 // does not call String.Format. Expectation is that they will have
 // similar performance.
+//
+// See https://github.com/dotnet/coreclr/issues/7569 for context.
 
 using Microsoft.Xunit.Performance;
 using System;

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
@@ -2,6 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// In CoreCLR String.Format(ref, ref) is small and readily inlined.
+// The inline introduces a System.Parms GC struct local which is
+// untracked and must be zero initialized in the prolog. When the
+// inlined callsite is in a cold path, the inline hurts performance.
+//
+// There are two test methods below, one of which calls String.Format
+// on a cold path and the other which has similar structure but
+// does not call String.Format. Expectation is that they will have
+// similar performance.
+
 using Microsoft.Xunit.Performance;
 using System;
 using System.Runtime.CompilerServices;
@@ -12,110 +22,122 @@ using Xunit;
 
 public class InlineGCStruct
 {
-
 #if DEBUG
     public const int Iterations = 1;
 #else
     public const int Iterations = 2500000;
 #endif
 
-[MethodImpl(MethodImplOptions.NoInlining)]
-public static int FastFunctionNotCallingStringFormat(int param)
-{
-    if (param < 0) {
-        throw new Exception(String.Format("We do not like the value {0:N0}.", param));
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int FastFunctionNotCallingStringFormat(int param)
+    {
+        if (param < 0)
+        {
+            throw new Exception(String.Format("We do not like the value {0:N0}.", param));
+        }
+
+        if (param == int.MaxValue)
+        {
+            throw new Exception(String.Format("{0:N0} is maxed out.", param));
+        }
+
+        if (param > int.MaxValue / 2)
+        {
+            throw new Exception(String.Format("We do not like the value {0:N0} either.", param));
+        }
+
+        return param * 2;
     }
 
-    if (param == int.MaxValue) {
-        throw new Exception(String.Format("{0:N0} is maxed out.", param));
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int FastFunctionNotHavingStringFormat(int param)
+    {
+        if (param < 0)
+        {
+            throw new ArgumentOutOfRangeException("param", "We do not like this value.");
+        }
+
+        if (param == int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException("param", "Maxed out.");
+        }
+
+        if (param > int.MaxValue / 2)
+        {
+            throw new ArgumentOutOfRangeException("param", "We do not like this value either.");
+        }
+
+        return param * 2;
     }
 
-    if (param > int.MaxValue / 2) {
-        throw new Exception(String.Format("We do not like the value {0:N0} either.", param));
-    }
+    [Benchmark]
+    public static bool WithFormat()
+    {
+        int result = 0;
 
-    return param * 2;
-}
-
-[MethodImpl(MethodImplOptions.NoInlining)]
-public static int FastFunctionNotHavingStringFormat(int param)
-{
-    if (param < 0) {
-        throw new ArgumentOutOfRangeException("param", "We do not like this value.");
-    }
-
-    if (param == int.MaxValue) {
-        throw new ArgumentOutOfRangeException("param", "Maxed out.");
-    }
-
-    if (param > int.MaxValue / 2) {
-        throw new ArgumentOutOfRangeException("param", "We do not like this value either.");
-    }
-
-    return param * 2;
-}
-
-[Benchmark]
-public static bool WithFormat()
-{
-    int result = 0;
-
-    foreach (var iteration in Benchmark.Iterations) {
-        using (iteration.StartMeasurement()) {
-            for (int i = 0; i < Iterations; i++) {
-                result |= FastFunctionNotCallingStringFormat(11);
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for (int i = 0; i < Iterations; i++)
+                {
+                    result |= FastFunctionNotCallingStringFormat(11);
+                }
             }
         }
+
+        return (result == 22);
     }
 
-    return (result == 22);
-}
+    [Benchmark]
+    public static bool WithoutFormat()
+    {
+        int result = 0;
 
-[Benchmark]
-public static bool WithoutFormat()
-{
-    int result = 0;
-
-    foreach (var iteration in Benchmark.Iterations) {
-        using (iteration.StartMeasurement()) {
-            for (int i = 0; i < Iterations; i++) {
-                result |= FastFunctionNotHavingStringFormat(11);
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for (int i = 0; i < Iterations; i++)
+                {
+                    result |= FastFunctionNotHavingStringFormat(11);
+                }
             }
         }
+
+        return (result == 22);
     }
 
-    return (result == 22);
-}
+    public static bool WithoutFormatBase()
+    {
+        int result = 0;
 
-public static bool WithoutFormatBase()
-{
-    int result = 0;
+        for (int i = 0; i < Iterations; i++)
+        {
+            result |= FastFunctionNotHavingStringFormat(11);
+        }
 
-    for (int i = 0; i < Iterations; i++) {
-        result |= FastFunctionNotHavingStringFormat(11);
+        return (result == 22);
     }
 
-    return (result == 22);
-}
+    public static bool WithFormatBase()
+    {
+        int result = 0;
 
-public static bool WithFormatBase()
-{
-    int result = 0;
+        for (int i = 0; i < Iterations; i++)
+        {
+            result |= FastFunctionNotCallingStringFormat(11);
+        }
 
-    for (int i = 0; i < Iterations; i++) {
-        result |= FastFunctionNotCallingStringFormat(11);
+        return (result == 22);
     }
 
-    return (result == 22);
-}
+    public static int Main()
+    {
+        bool withFormat = WithFormatBase();
+        bool withoutFormat = WithoutFormatBase();
 
-public static int Main()
-{
-    bool withFormat = WithFormatBase();
-    bool withoutFormat = WithoutFormatBase();
-
-    return (withFormat && withoutFormat ? 100 : -1);
-}
-
+        return (withFormat && withoutFormat ? 100 : -1);
+    }
 }
 

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+[assembly: OptimizeForBenchmarks]
+[assembly: MeasureInstructionsRetired]
+
+public class InlineGCStruct
+{
+
+#if DEBUG
+    public const int Iterations = 1;
+#else
+    public const int Iterations = 2500000;
+#endif
+
+[MethodImpl(MethodImplOptions.NoInlining)]
+public static int FastFunctionNotCallingStringFormat(int param)
+{
+    if (param < 0) {
+        throw new Exception(String.Format("We do not like the value {0:N0}.", param));
+    }
+
+    if (param == int.MaxValue) {
+        throw new Exception(String.Format("{0:N0} is maxed out.", param));
+    }
+
+    if (param > int.MaxValue / 2) {
+        throw new Exception(String.Format("We do not like the value {0:N0} either.", param));
+    }
+
+    return param * 2;
+}
+
+[MethodImpl(MethodImplOptions.NoInlining)]
+public static int FastFunctionNotHavingStringFormat(int param)
+{
+    if (param < 0) {
+        throw new ArgumentOutOfRangeException("param", "We do not like this value.");
+    }
+
+    if (param == int.MaxValue) {
+        throw new ArgumentOutOfRangeException("param", "Maxed out.");
+    }
+
+    if (param > int.MaxValue / 2) {
+        throw new ArgumentOutOfRangeException("param", "We do not like this value either.");
+    }
+
+    return param * 2;
+}
+
+[Benchmark]
+public static bool WithFormat()
+{
+    int result = 0;
+
+    foreach (var iteration in Benchmark.Iterations) {
+        using (iteration.StartMeasurement()) {
+            for (int i = 0; i < Iterations; i++) {
+                result |= FastFunctionNotCallingStringFormat(11);
+            }
+        }
+    }
+
+    return (result == 22);
+}
+
+[Benchmark]
+public static bool WithoutFormat()
+{
+    int result = 0;
+
+    foreach (var iteration in Benchmark.Iterations) {
+        using (iteration.StartMeasurement()) {
+            for (int i = 0; i < Iterations; i++) {
+                result |= FastFunctionNotHavingStringFormat(11);
+            }
+        }
+    }
+
+    return (result == 22);
+}
+
+public static bool WithoutFormatBase()
+{
+    int result = 0;
+
+    for (int i = 0; i < Iterations; i++) {
+        result |= FastFunctionNotHavingStringFormat(11);
+    }
+
+    return (result == 22);
+}
+
+public static bool WithFormatBase()
+{
+    int result = 0;
+
+    for (int i = 0; i < Iterations; i++) {
+        result |= FastFunctionNotCallingStringFormat(11);
+    }
+
+    return (result == 22);
+}
+
+public static int Main()
+{
+    bool withFormat = WithFormatBase();
+    bool withoutFormat = WithoutFormatBase();
+
+    return (withFormat && withoutFormat ? 100 : -1);
+}
+
+}
+

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.csproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="InlineGCStruct.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)benchmark\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)benchmark\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
If an inline introduces a local or temp GC struct, the initialization
of that struct is done in the root method prolog. This can hurt
performance if the inline call site is cold. Detect this during
importation and update the inline policy to back out of the inline if
the inline is an always or discretionary candidate.

Jit diffs shows size wins in the core library with no regressions.
```
Total bytes of diff: -8789 (-0.29 % of base)
    diff is an improvement.
Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes
Top file improvements by size (bytes):
       -8789 : System.Private.CoreLib.dasm (-0.29 % of base)
1 total files with size differences.
Top method improvements by size (bytes):
        -320 : System.Private.CoreLib.dasm - FrameSecurityDescriptor:CheckDemand2(ref,ref,long,bool):bool:this
        -224 : System.Private.CoreLib.dasm - RuntimeConstructorInfo:CheckCanCreateInstance(ref,bool)
        -214 : System.Private.CoreLib.dasm - RuntimeType:GetMethodBase(ref,long):ref
        -150 : System.Private.CoreLib.dasm - CultureInfo:GetCultureInfoByIetfLanguageTag(ref):ref
        -146 : System.Private.CoreLib.dasm - GC:RegisterForFullGCNotification(int,int)
103 total methods with size differences.
```
Desktop testing shows similar wins in a number of places and only
a few sparse small regressions.

Added a perf test. Thanks to @hypersw for noticing this.

Closes #7569.