### PR TITLE
Fixing the reference declarations for System.MathF.

### DIFF
--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -2630,54 +2630,53 @@ namespace System
     {
         public const float E =  2.71828183f;
         public const float PI = 3.14159265f;
+        public static float Abs(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Abs(float x) { return default(float); }
+        public static float Acos(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Acos(float x) { return default(float); }
+        public static float Asin(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Asin(float x) { return default(float); }
+        public static float Atan(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Atan(float x) { return default(float); }
+        public static float Atan2(float y, float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Atan2(float y, float x) { return default(float); }
+        public static float Ceiling(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Ceiling(float x) { return default(float); }
+        public static float Cos(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Cos(float x) { return default(float); }
+        public static float Cosh(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Cosh(float x) { return default(float); }
+        public static float Exp(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Exp(float x) { return default(float); }
+        public static float Floor(float x) { throw null; }
+        public static float IEEERemainder(float x, float y) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Floor(float x) { return default(float); }
-        public static float IEEERemainder(float x, float y) { return default(float); }
+        public static float Log(float x) { throw null; }
+        public static float Log(float x, float y) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Log(float x) { return default(float); }
-        public static float Log(float x, float y) { return default(float); }
+        public static float Log10(float x) { throw null; }        
+        public static float Max(float x, float y) { throw null; }
+        public static float Min(float x, float y) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Log10(float x) { return default(float); }        
-        public static float Max(float x, float y) { return default(float); }
-        public static float Min(float x, float y) { return default(float); }
+        public static float Pow(float x, float y) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Pow(float x, float y) { return default(float); }
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Round(float x) { return default(float); }
-        public static float Round(float x, int digits) { return default(float); }
-        public static float Round(float x, int digits, System.MidpointRounding mode) { return default(float); }
-        public static float Round(float x, System.MidpointRounding mode) { return default(float); }
+        public static float Round(float x) { throw null; }
+        public static float Round(float x, int digits) { throw null; }
+        public static float Round(float x, int digits, System.MidpointRounding mode) { throw null; }
+        public static float Round(float x, System.MidpointRounding mode) { throw null; }
         public static int Sign(float x) { return default(int); }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Sin(float x) { return default(float); }
+        public static float Sin(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Sinh(float x) { return default(float); }
+        public static float Sinh(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)]
         [System.Security.SecuritySafeCriticalAttribute]
-        public static float Sqrt(float x) { return default(float); }
+        public static float Sqrt(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Tan(float x) { return default(float); }
+        public static float Tan(float x) { throw null; }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
-        public static float Tanh(float x) { return default(float); }
-        public static float Truncate(float x) { return default(float); }
+        public static float Tanh(float x) { throw null; }
+        public static float Truncate(float x) { throw null; }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public partial class MemberAccessException : System.SystemException

--- a/src/mscorlib/src/System/MathF.cs
+++ b/src/mscorlib/src/System/MathF.cs
@@ -32,7 +32,6 @@ namespace System {
 
         public const float E = 2.71828183f;
 
-        [System.Security.SecuritySafeCritical]  // auto-generated
         public static float Abs(float x) => Math.Abs(x);
 
         [System.Security.SecuritySafeCritical]  // auto-generated
@@ -112,7 +111,7 @@ namespace System {
                 }
             }
 
-            if (Math.Abs(alternativeResult) < Math.Abs(regularMod))
+            if (Abs(alternativeResult) < Abs(regularMod))
             {
                 return alternativeResult;
             }


### PR DESCRIPTION
@janvorli. The mscorlib reference declarations should have been updated alongside: https://github.com/dotnet/coreclr/pull/7721

It also looks like the reference declarations should have used `throw null;` instead of `return default(float);`

Finally, it looks like I should have removed the `System.Security.SecuritySafeCritical` attribute from `System.MathF.Abs` since it is no longer an FCALL.

This fixes all three of those issues.