### PR TITLE
GC for large object allocation when fail to get new segment

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -14785,6 +14785,9 @@ int gc_heap::generation_to_condemn (int n_initial,
         dprintf (GTC_LOG, ("h%d: alloc full - BLOCK", heap_number));
         n = max_generation;
         *blocking_collection_p = TRUE;
+        if ((local_settings->reason == reason_oos_loh) ||
+            (local_settings->reason == reason_alloc_loh))
+            evaluate_elevation = FALSE;
 
         local_condemn_reasons->set_condition (gen_before_oom);
     }
@@ -16499,7 +16502,7 @@ int gc_heap::garbage_collect (int n)
         if ((settings.condemned_generation == max_generation) &&
             (recursive_gc_sync::background_running_p()))
         {
-            //TODO BACKGROUND_GC If we just wait for the end of gc, it won't woork
+            //TODO BACKGROUND_GC If we just wait for the end of gc, it won't work
             // because we have to collect 0 and 1 properly
             // in particular, the allocation contexts are gone.
             // For now, it is simpler to collect max_generation-1


### PR DESCRIPTION
Related issue: #7649 

- Scenario

1) try to allocate large object
2) new_allocation of generation 3 > 0  (not try to GC)
3) fail to allocate
4) try to get new segment
5) fail to get new segment
6) try to GC for generation 3

In this scenario, we need to GC for generation 3 area at 6), not elevation of generation 1.

- Fix to resume new_allocation value when fail to get new segment.

- Fix typo.