### PR TITLE
Initialize member variable

### DIFF
--- a/src/debug/di/breakpoint.cpp
+++ b/src/debug/di/breakpoint.cpp
@@ -15,7 +15,7 @@
 
 CordbBreakpoint::CordbBreakpoint(CordbProcess * pProcess, CordbBreakpointType bpType)
   : CordbBase(pProcess, 0, enumCordbBreakpoint), 
-  m_active(false), m_type(bpType)
+  m_active(false), m_pAppDomain(NULL), m_type(bpType)
 {
 }
 


### PR DESCRIPTION
This was found with Cppcheck. One of member variables having built-in types was not being initialized.