### PR TITLE
Mark tests GCStress-incompatible for x86.

### DIFF
--- a/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
+++ b/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
@@ -14,6 +14,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
+++ b/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
@@ -14,6 +14,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
+++ b/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
@@ -14,6 +14,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
+++ b/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
@@ -14,6 +14,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-Beta2/b311420/b311420.csproj
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-Beta2/b311420/b311420.csproj
@@ -14,6 +14,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-Beta2/b311420/b311420.csproj
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-Beta2/b311420/b311420.csproj
@@ -14,6 +14,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/jit64/opt/cse/HugeArray.csproj
+++ b/tests/src/JIT/jit64/opt/cse/HugeArray.csproj
@@ -14,6 +14,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/jit64/opt/cse/HugeArray.csproj
+++ b/tests/src/JIT/jit64/opt/cse/HugeArray.csproj
@@ -14,6 +14,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_d.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_d.csproj
@@ -14,6 +14,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_d.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_d.csproj
@@ -14,6 +14,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_r.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_r.csproj
@@ -14,6 +14,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_r.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_r.csproj
@@ -14,6 +14,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
These tests time out when GC stress is enabled on x86.

Fixes #7692 and #7695.