### PR TITLE
fix value numbering for frozen strings.

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -4805,8 +4805,16 @@ void Compiler::fgValueNumberTreeConst(GenTreePtr tree)
             tree->gtVNPair.SetBoth(vnStore->VNForDoubleCon(tree->gtDblCon.gtDconVal));
             break;
         case TYP_REF:
-            // Null is the only constant.  (Except maybe for String?)
-            tree->gtVNPair.SetBoth(ValueNumStore::VNForNull());
+            if (tree->gtIntConCommon.IconValue() == 0)
+            {
+                tree->gtVNPair.SetBoth(ValueNumStore::VNForNull());
+            }
+            else
+            {
+                assert(tree->gtFlags == GTF_ICON_STR_HDL); // Constant object can be only frozen string.
+                tree->gtVNPair.SetBoth(
+                    vnStore->VNForHandle(ssize_t(tree->gtIntConCommon.IconValue()), tree->GetIconHandleFlag()));
+            }
             break;
 
         case TYP_BYREF:


### PR DESCRIPTION
As Pat found it was value numbering issue.
Constant references were interpreted as NULL pointers. 
Case for frozen strings was added.  String assert allows to avoid unclear problems if new frozen types appear.
Fix dotnet/corert#1940.