### PR TITLE
Port fix passing struct with four floats in registers via reflection to 1.1.0

### DIFF
--- a/src/vm/argdestination.h
+++ b/src/vm/argdestination.h
@@ -136,7 +136,7 @@ public:
                     _ASSERTE(eightByteSize == 4);
                     *(UINT32*)floatRegDest = *(UINT32*)src;
                 }
-                floatRegDest += 8;
+                floatRegDest += 16;
             }
             else
             {

--- a/tests/src/Regressions/coreclr/GitHub_7685/Test7685.csproj
+++ b/tests/src/Regressions/coreclr/GitHub_7685/Test7685.csproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{E55A6F8B-B9E3-45CE-88F4-22AE70F606CB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="test7685.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/Regressions/coreclr/GitHub_7685/test7685.cs
+++ b/tests/src/Regressions/coreclr/GitHub_7685/test7685.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Reflection;
+
+public class Test7685
+{
+    static RectangleF argumentInDStuff;
+    
+    public static int Main()
+    {
+        int iRetVal = 100;
+        
+        var r = new RectangleF(1.2f, 3.4f, 5.6f, 7.8f);
+        typeof(Test7685).GetTypeInfo().GetDeclaredMethod("DoStuff").Invoke(null, new object[] { r });
+
+        if (!RectangleF.Equals(ref argumentInDStuff, ref r))
+        {
+            TestLibrary.Logging.WriteLine($"Error: passing struct with floats via reflection. Callee received {argumentInDStuff} instead of {r}");
+            iRetVal = 0;
+        }
+        
+        return iRetVal;
+    }
+
+    public static void DoStuff(RectangleF r)
+    {
+        argumentInDStuff = r;
+    }
+}
+
+public struct RectangleF
+{
+    private float _x, _y, _width, _height;
+
+    public RectangleF(float x, float y, float width, float height)
+    {
+        _x = x; _y = y; _width = width; _height = height;
+    }
+    
+    public static bool Equals(ref RectangleF r1, ref RectangleF r2)
+    {
+        return (r2._x == r1._x) && (r2._y == r1._y) && (r2._width == r1._width) && (r2._height == r1._height);
+    }
+
+    public override string ToString() => $"[{_x}, {_y}, {_width}, {_height}]";
+}


### PR DESCRIPTION
This change fixes a bug in the code that copies a struct into the transition
frame. When it contains four floats, the first two are put to the right place,
but the following two are placed to an address that's offset by 8 instead of
by 16.

It also adds regression test for this problem as Pri 1 test.