### PR TITLE
Recognize Vector<int>.Dot on AVX as a JIT intrinsic.

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -76,9 +76,7 @@ bool emitter::IsThreeOperandBinaryAVXInstruction(instruction ins)
             ins == INS_paddw || ins == INS_paddd || ins == INS_paddq || ins == INS_psubb || ins == INS_psubw ||
             ins == INS_psubd || ins == INS_psubq || ins == INS_pmuludq || ins == INS_pxor || ins == INS_pmaxub ||
             ins == INS_pminub || ins == INS_pmaxsw || ins == INS_pminsw || ins == INS_insertps ||
-            ins == INS_vinsertf128 || ins == INS_punpckldq
-
-            );
+            ins == INS_vinsertf128 || ins == INS_punpckldq || ins == INS_phaddd);
 }
 
 // Returns true if the AVX instruction is a move operator that requires 3 operands.
@@ -105,7 +103,7 @@ bool Is4ByteAVXInstruction(instruction ins)
     return (ins == INS_dpps || ins == INS_dppd || ins == INS_insertps || ins == INS_pcmpeqq || ins == INS_pcmpgtq ||
             ins == INS_vbroadcastss || ins == INS_vbroadcastsd || ins == INS_vpbroadcastb || ins == INS_vpbroadcastw ||
             ins == INS_vpbroadcastd || ins == INS_vpbroadcastq || ins == INS_vextractf128 || ins == INS_vinsertf128 ||
-            ins == INS_pmulld || ins == INS_ptest);
+            ins == INS_pmulld || ins == INS_ptest || ins == INS_phaddd);
 #else
     return false;
 #endif

--- a/src/jit/instrsxarch.h
+++ b/src/jit/instrsxarch.h
@@ -318,6 +318,7 @@ INST3( pcmpeqq,      "pcmpeqq"     , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SS
 INST3( pcmpgtq,      "pcmpgtq"     , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x37))   // Packed compare 64-bit integers for equality
 INST3( pmulld,       "pmulld"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x40))   // Packed multiply 32 bit unsigned integers and store lower 32 bits of each result
 INST3( ptest,        "ptest"       , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x17))   // Packed logical compare
+INST3( phaddd,       "phaddd"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x02))   // Packed horizontal add
 INST3(LAST_SSE4_INSTRUCTION, "LAST_SSE4_INSTRUCTION",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, BAD_CODE)
 
 INST3(FIRST_AVX_INSTRUCTION, "FIRST_AVX_INSTRUCTION",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, BAD_CODE)

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -2367,15 +2367,14 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
 
         case SIMDIntrinsicDotProduct:
         {
-#if defined(_TARGET_AMD64_) && defined(DEBUG)
-            // Right now dot product is supported only for float vectors.
-            // See SIMDIntrinsicList.h for supported base types for this intrinsic.
-            if (!varTypeIsFloating(baseType))
+#ifdef _TARGET_AMD64_
+            // Right now dot product is supported only for float/double vectors and
+            // int vectors on AVX.
+            if (!varTypeIsFloating(baseType) && !(baseType == TYP_INT && canUseAVX()))
             {
-                assert(!"Dot product on integer type vectors not supported");
                 return nullptr;
             }
-#endif //_TARGET_AMD64_ && DEBUG
+#endif // _TARGET_AMD64_
 
             // op1 is a SIMD variable that is the first source and also "this" arg.
             // op2 is a SIMD variable which is the second source.

--- a/src/jit/simdintrinsiclist.h
+++ b/src/jit/simdintrinsiclist.h
@@ -111,7 +111,8 @@ SIMD_INTRINSIC("op_BitwiseOr",              false,       BitwiseOr,             
 SIMD_INTRINSIC("op_ExclusiveOr",            false,       BitwiseXor,               "^",                      TYP_STRUCT,     2,      {TYP_STRUCT, TYP_STRUCT, TYP_UNDEF},   {TYP_INT, TYP_FLOAT, TYP_DOUBLE, TYP_LONG, TYP_CHAR, TYP_UBYTE, TYP_BYTE, TYP_SHORT, TYP_UINT, TYP_ULONG})
 
 // Dot Product
-SIMD_INTRINSIC("Dot",                       false,       DotProduct,               "Dot",                    TYP_UNKNOWN,    2,      {TYP_STRUCT, TYP_STRUCT, TYP_UNDEF},   {TYP_FLOAT, TYP_DOUBLE, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF})
+// Is supported only on Vector<int> on AVX.
+SIMD_INTRINSIC("Dot",                       false,       DotProduct,               "Dot",                    TYP_UNKNOWN,    2,      {TYP_STRUCT, TYP_STRUCT, TYP_UNDEF},   {TYP_INT, TYP_FLOAT, TYP_DOUBLE, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF})
 
 // Select
 SIMD_INTRINSIC("ConditionalSelect",         false,       Select,                   "Select",                 TYP_STRUCT,     3,      {TYP_STRUCT, TYP_STRUCT, TYP_STRUCT},  {TYP_INT, TYP_FLOAT, TYP_DOUBLE, TYP_LONG, TYP_CHAR, TYP_UBYTE, TYP_BYTE, TYP_SHORT, TYP_UINT, TYP_ULONG})

--- a/tests/src/JIT/SIMD/VectorDot.cs
+++ b/tests/src/JIT/SIMD/VectorDot.cs
@@ -113,12 +113,17 @@ internal partial class VectorTest
         if (VectorDotTest<ulong>.VectorDot(3ul, 2ul, 6ul * (ulong)Vector<ulong>.Count) != Pass) returnVal = Fail;
 
         JitLog jitLog = new JitLog();
-        // Dot is only recognized as an intrinsic for floating point element types.
+        // Dot is only recognized as an intrinsic for floating point element types
+        // and Vector<int> on AVX.
         if (!jitLog.Check("Dot", "Single")) returnVal = Fail;
         if (!jitLog.Check("Dot", "Double")) returnVal = Fail;
         if (!jitLog.Check("System.Numerics.Vector4:Dot")) returnVal = Fail;
         if (!jitLog.Check("System.Numerics.Vector3:Dot")) returnVal = Fail;
         if (!jitLog.Check("System.Numerics.Vector2:Dot")) returnVal = Fail;
+        if (Vector<int>.Count == 8)
+        {
+            if (!jitLog.Check("Dot", "Int32")) returnVal = Fail;
+        }
         jitLog.Dispose();
 
         return returnVal;


### PR DESCRIPTION
AVX supports pmulld and horizontal add instructions that could be taken advantage of to efficiently implement Dot Product on `Vector<int>`.

Fix #7572