### PR TITLE
Fix broken #elif

### DIFF
--- a/src/ToolBox/SOS/Strike/datatarget.cpp
+++ b/src/ToolBox/SOS/Strike/datatarget.cpp
@@ -85,7 +85,7 @@ DataTarget::GetPointerSize(
     *size = 8;
 #elif defined(SOS_TARGET_ARM)
     *size = 4;
-#elif
+#else
   #error Unsupported architecture
 #endif
 


### PR DESCRIPTION
This was found with Cppcheck. You cannot have an `elif` without a token after it.