### PR TITLE
Initialize long return type descs in `gtNewCallNode`.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2785,8 +2785,6 @@ protected:
 
     GenTreePtr impFixupCallStructReturn(GenTreePtr call, CORINFO_CLASS_HANDLE retClsHnd);
 
-    GenTreePtr impInitCallLongReturn(GenTreePtr call);
-
     GenTreePtr impFixupStructReturnType(GenTreePtr op, CORINFO_CLASS_HANDLE retClsHnd);
 
 #ifdef DEBUG

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7447,10 +7447,6 @@ DONE_CALL:
             {
                 call = impFixupCallStructReturn(call, sig->retTypeClass);
             }
-            else if (varTypeIsLong(callRetTyp))
-            {
-                call = impInitCallLongReturn(call);
-            }
 
             if ((call->gtFlags & GTF_CALL_INLINE_CANDIDATE) != 0)
             {
@@ -7729,42 +7725,6 @@ GenTreePtr Compiler::impFixupCallStructReturn(GenTreePtr call, CORINFO_CLASS_HAN
     }
 
 #endif // not FEATURE_UNIX_AMD64_STRUCT_PASSING
-
-    return call;
-}
-
-//-------------------------------------------------------------------------------------
-//  impInitCallLongReturn:
-//     Initialize the ReturnTypDesc for a call that returns a TYP_LONG
-//
-//  Arguments:
-//    call       -  GT_CALL GenTree node
-//
-//  Return Value:
-//    Returns new GenTree node after initializing the ReturnTypeDesc of call node
-//
-GenTreePtr Compiler::impInitCallLongReturn(GenTreePtr call)
-{
-    assert(call->gtOper == GT_CALL);
-
-#if defined(_TARGET_X86_) && !defined(LEGACY_BACKEND)
-    // LEGACY_BACKEND does not use multi reg returns for calls with long return types
-
-    if (varTypeIsLong(call))
-    {
-        GenTreeCall* callNode = call->AsCall();
-
-        // The return type will remain as the incoming long type
-        callNode->gtReturnType = call->gtType;
-
-        // Initialize Return type descriptor of call node
-        ReturnTypeDesc* retTypeDesc = callNode->GetReturnTypeDesc();
-        retTypeDesc->InitializeLongReturnType(this);
-
-        // must be a long returned in two registers
-        assert(retTypeDesc->GetReturnRegCount() == 2);
-    }
-#endif // _TARGET_X86_ && !LEGACY_BACKEND
 
     return call;
 }


### PR DESCRIPTION
All long-returning calls (including helper calls) must have a properly
initialized ReturnTypeDesc. Previously, this ReturnTypeDesc was only
initialized by the importer for a subset of long-returning calls
(essentially user calls), which caused asserts whenother long-returning
calls were created by the compiler (e.g. for field accessors). This
change moves the necessary ReturnTypeDesc initialization into
`gtNewCallNode`.