### PR TITLE
Properly initialize the varargs base lclVar.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -8997,7 +8997,7 @@ void CodeGen::genFnProlog()
         // LEA EAX, &<VARARGS HANDLE> + EAX
         getEmitter()->emitIns_R_ARR(INS_lea, EA_PTRSIZE, REG_EAX, genFramePointerReg(), REG_EAX, offset);
 
-        if (varDsc->lvRegister)
+        if (varDsc->lvIsInReg())
         {
             if (varDsc->lvRegNum != REG_EAX)
             {


### PR DESCRIPTION
The code that initializes this lclVar was not using the correct helper
to determine whether or not a lclVar was enregistered at the beginning
of a method.