### PR TITLE
Prevent Tools folder being deleted in normal build (#7763)

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -27,8 +27,6 @@ if exist "%BUILD_TOOLS_SEMAPHORE%" (
   goto :DONE
 )
 
-if exist "%TOOLRUNTIME_DIR%" rmdir /S /Q "%TOOLRUNTIME_DIR%"
-
 :: Download Nuget.exe
 if NOT exist "%PACKAGES_DIR%NuGet.exe" (
   if NOT exist "%PACKAGES_DIR%" mkdir "%PACKAGES_DIR%"


### PR DESCRIPTION
The normal .\build will delete the Tools folder, which significantlly slow
down the build process as we have to re-download tools via internet.

Just remove a line of code to prevent this.

Fix #7763