### PR TITLE
Fix Binder based PInvoke resolution for dynamic assembly

### DIFF
--- a/src/vm/assembly.cpp
+++ b/src/vm/assembly.cpp
@@ -762,7 +762,7 @@ Assembly *Assembly::CreateDynamic(AppDomain *pDomain, CreateDynamicAssemblyArgs 
         // using an actual binder. As a result, we will assume the same binding/loadcontext information for the dynamic assembly as its
         // caller/creator to ensure that any assembly loads triggered by the dynamic assembly are resolved using the intended load context.
         //
-        // If the creator assembly has a HostAssembly associated with it, then use it for binding. Otherwise, ithe creator is dynamic
+        // If the creator assembly has a HostAssembly associated with it, then use it for binding. Otherwise, the creator is dynamic
         // and will have a fallback load context binder associated with it.
         ICLRPrivBinder *pFallbackLoadContextBinder = nullptr;
         

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -6832,15 +6832,29 @@ HMODULE NDirect::LoadLibraryModuleViaHost(NDirectMethodDesc * pMD, AppDomain* pD
     CLRPrivBinderCoreCLR *pTPABinder = pDomain->GetTPABinderContext();
     Assembly* pAssembly = pMD->GetMethodTable()->GetAssembly();
    
-    PTR_ICLRPrivBinder pBindingContext = pAssembly->GetManifestFile()->GetBindingContext();
+    PEFile *pManifestFile = pAssembly->GetManifestFile();
+    PTR_ICLRPrivBinder pBindingContext = pManifestFile->GetBindingContext();
 
     //Step 0: Check if  the assembly was bound using TPA. 
     //        The Binding Context can be null or an overridden TPA context
     if (pBindingContext == NULL)
     {
-        return NULL;
+        pBindingContext = nullptr;
+
+        // If the assembly does not have a binder associated with it explicitly, then check if it is
+        // a dynamic assembly, or not, since they can have a fallback load context associated with them.
+        if (pManifestFile->IsDynamic())
+        {
+            pBindingContext = pManifestFile->GetFallbackLoadContextBinder();
+        } 
     }
-    
+
+    // If we do not have any binder associated, then return to the default resolution mechanism.
+    if (pBindingContext == nullptr)
+    {
+        return NULL;
+    }    
+
     UINT_PTR assemblyBinderID = 0;
     IfFailThrow(pBindingContext->GetBinderID(&assemblyBinderID));
         


### PR DESCRIPTION
When performing PInvoke resolution to go via the Binder, we need to account for the fact that the PInvoke could be from within a Dynamic assembly and if so, leverage the fallback load context to perform the resolution.

Also, fixed a typo.

@jkotas PTAL.