### PR TITLE
GCInfoDecoder cleanup

### DIFF
--- a/src/gcdump/gcdumpnonx86.cpp
+++ b/src/gcdump/gcdumpnonx86.cpp
@@ -520,7 +520,7 @@ void    GCDump::DumpPtrsInFrame(PTR_CBYTE   gcInfoBlock,
 #define LOG(x) ((void)0)
 #endif
 
-#define GCINFODECODER_CONTRACT(contract)
+#define GCINFODECODER_CONTRACT ((void)0)
 #define GET_CALLER_SP(pREGDISPLAY) ((size_t)GetSP(pREGDISPLAY->pCallerContext))
 #define VALIDATE_OBJECTREF(objref, fDeep) ((void)0)
 #define VALIDATE_ROOT(isInterior, hCallBack, pObjRef) ((void)0)

--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -112,7 +112,7 @@ inline BOOL IS_ALIGNED( void* val, size_t alignment )
 #ifndef _EETWAIN_H
 
 typedef void (*GCEnumCallback)(
-    LPVOID          hCallback,      // callback data
+    void *          hCallback,      // callback data
     OBJECTREF*      pObject,        // address of obect-reference we are reporting
     uint32_t        flags           // is this a pinned and/or interior pointer
 );
@@ -442,16 +442,16 @@ public:
     // This is used for gccoverage
     bool IsSafePoint(UINT32 codeOffset);
 
-    typedef void EnumerateSafePointsCallback (UINT32 offset, LPVOID hCallback);
-    void EnumerateSafePoints(EnumerateSafePointsCallback *pCallback, LPVOID hCallback);
+    typedef void EnumerateSafePointsCallback (UINT32 offset, void * hCallback);
+    void EnumerateSafePoints(EnumerateSafePointsCallback * pCallback, void * hCallback);
 
 #endif
     // Returns true to stop enumerating.
-    typedef bool EnumerateInterruptibleRangesCallback (UINT32 startOffset, UINT32 stopOffset, LPVOID hCallback);
+    typedef bool EnumerateInterruptibleRangesCallback (UINT32 startOffset, UINT32 stopOffset, void * hCallback);
 
     void EnumerateInterruptibleRanges (
                 EnumerateInterruptibleRangesCallback *pCallback,
-                LPVOID                                hCallback);
+                void *                                hCallback);
 
     //------------------------------------------------------------------------
     // GC lifetime information
@@ -462,7 +462,7 @@ public:
                 bool                reportScratchSlots,
                 unsigned            flags,
                 GCEnumCallback      pCallBack,
-                LPVOID              hCallBack
+                void *              hCallBack
                 );
 
     // Public for the gc info dumper
@@ -470,7 +470,7 @@ public:
                 PREGDISPLAY         pRD,
                 unsigned            flags,
                 GCEnumCallback      pCallBack,
-                LPVOID              hCallBack
+                void *              hCallBack
                 );
 
     //------------------------------------------------------------------------
@@ -539,7 +539,7 @@ private:
 #endif
     UINT32 m_Version;
 
-    static bool SetIsInterruptibleCB (UINT32 startOffset, UINT32 stopOffset, LPVOID hCallback);
+    static bool SetIsInterruptibleCB (UINT32 startOffset, UINT32 stopOffset, void * hCallback);
 
     OBJECTREF* GetRegisterSlot(
                         int             regNum,
@@ -571,7 +571,7 @@ private:
                 PREGDISPLAY         pRD,
                 unsigned            flags,
                 GCEnumCallback      pCallBack,
-                LPVOID              hCallBack
+                void *              hCallBack
                 );
 
     void ReportRegisterToGC(
@@ -580,7 +580,7 @@ private:
                                 PREGDISPLAY     pRD,
                                 unsigned        flags,
                                 GCEnumCallback  pCallBack,
-                                LPVOID          hCallBack
+                                void *          hCallBack
                                 );
 
     void ReportStackSlotToGC(
@@ -590,7 +590,7 @@ private:
                                 PREGDISPLAY     pRD,
                                 unsigned        flags,
                                 GCEnumCallback  pCallBack,
-                                LPVOID          hCallBack
+                                void *          hCallBack
                                 );
 
 
@@ -601,7 +601,7 @@ private:
                     bool                reportScratchSlots,
                     unsigned            inputFlags,
                     GCEnumCallback      pCallBack,
-                    LPVOID              hCallBack
+                    void *              hCallBack
                     )
     {
         _ASSERTE(slotIndex < slotDecoder.GetNumSlots());

--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -153,10 +153,6 @@ enum ICodeManagerFlags
     #define MAX_PREDECODED_SLOTS 64
 #endif
 
-#if defined(FEATURE_PAL) && !defined(STATIC_CONTRACT_SUPPORTS_DAC_HOST_ONLY)
-#define STATIC_CONTRACT_SUPPORTS_DAC_HOST_ONLY
-#endif
-
 
 
 enum GcInfoDecoderFlags
@@ -286,8 +282,6 @@ public:
     
     __forceinline void SetCurrentPos( size_t pos )
     {
-        STATIC_CONTRACT_SUPPORTS_DAC_HOST_ONLY; // note: this will set only the host instance, not the target instance
-
         size_t adjPos = pos + m_InitialRelPos;
         m_pCurrent = m_pBuffer + adjPos / BITS_PER_SIZE_T;
         m_RelPos = (int)(adjPos % BITS_PER_SIZE_T);

--- a/src/inc/gcinfoencoder.h
+++ b/src/inc/gcinfoencoder.h
@@ -110,7 +110,6 @@ struct GcInfoSize
     size_t NumRanges;
     size_t NumRegs;
     size_t NumStack;
-    size_t NumEh;
     size_t NumTransitions;
     size_t SizeOfCode;
 
@@ -134,7 +133,6 @@ struct GcInfoSize
     size_t RegSlotSize;
     size_t StackSlotSize;
     size_t CallSiteStateSize;
-    size_t NumEhSize;
     size_t EhPosSize;
     size_t EhStateSize;
     size_t ChunkPtrSize;

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -8,32 +8,6 @@
 
 #include "gcinfo.h"
 
-// This file is included when building an "alt jit".  In that case, we are doing a cross-compile:
-// we may be building the ARM jit on x86, for example.  We generally make that work by conditionalizing on
-// a _TARGET_XXX_ variable that we explicitly set in the build, rather than the _XXX_ variable implicitly
-// set by the compiler.  But this file is *also* included by the runtime, and needs in that case to be
-// conditionalized by the actual platform we're compiling for.  We solve this by:
-//    1) conditionalizing on _TARGET_XXX_ in this file,
-//    2) having a _TARGET_SET_ variable so we know whether we're in a compilation for JIT in which some
-//       _TARGET_XXX_ has already been set, and
-//    3) if _TARGET_SET_ is not set, set the _TARGET_XXX_ variable appropriate for the current _XXX_.
-// 
-#ifndef _TARGET_SET_
-
-//#ifdef _X86_
-//#define _TARGET_X86_
-//#endif
-
-//#ifdef _AMD64_
-//#define _TARGET_AMD64_
-//#endif
-
-//#ifdef _ARM_
-//#define _TARGET_ARM_
-//#endif
-
-#endif // _TARGET_SET_
-
 #if defined(_TARGET_AMD64_) || defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
 #define PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
 #endif

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -8,21 +8,10 @@
 
 #include "gcinfo.h"
 
-#if defined(_TARGET_AMD64_) || defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
 #define PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-#endif
 
-#ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-//
-// The EH vector mechanism is not completely worked out, 
-//   so it's temporarily disabled. We rely on fully-interruptible instead.
-//
-#define DISABLE_EH_VECTORS
-#endif
-
-#if defined(_TARGET_AMD64_) || defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
 #define FIXED_STACK_PARAMETER_SCRATCH_AREA
-#endif
+
 
 #define BITS_PER_SIZE_T ((int)sizeof(size_t)*8)
 

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -6,11 +6,6 @@
 #ifndef _TARGET_H_
 #define _TARGET_H_
 
-// Inform includers that we're in a context in which a target has been set.
-#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_) || defined(_TARGET_ARM_)
-#define _TARGET_SET_
-#endif
-
 // If the UNIX_AMD64_ABI is defined make sure that _TARGET_AMD64_ is also defined.
 #if defined(UNIX_AMD64_ABI)
 #if !defined(_TARGET_AMD64_)

--- a/src/vm/gcinfodecoder.cpp
+++ b/src/vm/gcinfodecoder.cpp
@@ -17,7 +17,7 @@
 #endif
 
 #ifndef GCINFODECODER_CONTRACT
-#define GCINFODECODER_CONTRACT(contract) contract
+#define GCINFODECODER_CONTRACT LIMITED_METHOD_CONTRACT
 #endif // !GCINFODECODER_CONTRACT
 
 
@@ -1430,10 +1430,7 @@ void GcInfoDecoder::ReportRegisterToGC(  // AMD64
                                 GCEnumCallback  pCallBack,
                                 LPVOID          hCallBack)
 {
-    GCINFODECODER_CONTRACT(CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-    } CONTRACTL_END);
+    GCINFODECODER_CONTRACT;
 
     _ASSERTE(regNum >= 0 && regNum <= 16);
     _ASSERTE(regNum != 4);  // rsp
@@ -1567,10 +1564,7 @@ void GcInfoDecoder::ReportRegisterToGC(  // ARM
                                 GCEnumCallback  pCallBack,
                                 LPVOID          hCallBack)
 {
-    GCINFODECODER_CONTRACT(CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-    } CONTRACTL_END);
+    GCINFODECODER_CONTRACT;
 
     _ASSERTE(regNum >= 0 && regNum <= 14);
     _ASSERTE(regNum != 13);  // sp
@@ -1661,10 +1655,7 @@ void GcInfoDecoder::ReportRegisterToGC( // ARM64
                                 GCEnumCallback  pCallBack,
                                 LPVOID          hCallBack)
 {
-    GCINFODECODER_CONTRACT(CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-    } CONTRACTL_END);
+    GCINFODECODER_CONTRACT;
 
     _ASSERTE(regNum >= 0 && regNum <= 30);
     _ASSERTE(regNum != 18);
@@ -1821,10 +1812,7 @@ void GcInfoDecoder::ReportStackSlotToGC(
                                 GCEnumCallback  pCallBack,
                                 LPVOID          hCallBack)
 {
-    GCINFODECODER_CONTRACT(CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-    } CONTRACTL_END);
+    GCINFODECODER_CONTRACT;
 
     OBJECTREF* pObjRef = GetStackSlot(spOffset, spBase, pRD);
     _ASSERTE( IS_ALIGNED( pObjRef, sizeof( Object* ) ) );

--- a/src/vm/gcinfodecoder.cpp
+++ b/src/vm/gcinfodecoder.cpp
@@ -68,7 +68,7 @@
     }
 #endif // !LOG_PIPTR
 
-bool GcInfoDecoder::SetIsInterruptibleCB (UINT32 startOffset, UINT32 stopOffset, LPVOID hCallback)
+bool GcInfoDecoder::SetIsInterruptibleCB (UINT32 startOffset, UINT32 stopOffset, void * hCallback)
 {
     GcInfoDecoder *pThis = (GcInfoDecoder*)hCallback;
 
@@ -426,14 +426,14 @@ UINT32 GcInfoDecoder::FindSafePoint(UINT32 breakOffset)
     return result;
 }
 
-void GcInfoDecoder::EnumerateSafePoints(EnumerateSafePointsCallback *pCallback, LPVOID hCallback)
+void GcInfoDecoder::EnumerateSafePoints(EnumerateSafePointsCallback *pCallback, void * hCallback)
 {
     if(m_NumSafePoints == 0)
         return;
 
     const UINT32 numBitsPerOffset = CeilOfLog2(NORMALIZE_CODE_OFFSET(m_CodeLength));
 
-    for(UINT i = 0; i < m_NumSafePoints; i++)
+    for(UINT32 i = 0; i < m_NumSafePoints; i++)
     {
         UINT32 normOffset = (UINT32)m_Reader.Read(numBitsPerOffset);
         UINT32 offset = DENORMALIZE_CODE_OFFSET(normOffset) + 2;
@@ -450,7 +450,7 @@ void GcInfoDecoder::EnumerateSafePoints(EnumerateSafePointsCallback *pCallback, 
 
 void GcInfoDecoder::EnumerateInterruptibleRanges (
             EnumerateInterruptibleRangesCallback *pCallback,
-            LPVOID                                hCallback)
+            void *                                hCallback)
 {
     // If no info is found for the call site, we default to fully-interruptbile
     LOG((LF_GCROOTS, LL_INFO1000000, "No GC info found for call site at offset %x. Defaulting to fully-interruptible information.\n", (int) m_InstructionOffset));
@@ -581,7 +581,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
                 bool                reportScratchSlots,
                 unsigned            inputFlags,
                 GCEnumCallback      pCallBack,
-                LPVOID              hCallBack
+                void *              hCallBack
                 )
 {
 
@@ -983,7 +983,7 @@ void GcInfoDecoder::EnumerateUntrackedSlots(
                 PREGDISPLAY         pRD,
                 unsigned            inputFlags,
                 GCEnumCallback      pCallBack,
-                LPVOID              hCallBack
+                void *              hCallBack
                 )
 {
     _ASSERTE(GC_SLOT_INTERIOR == GC_CALL_INTERIOR);
@@ -1017,7 +1017,7 @@ void GcInfoDecoder::ReportUntrackedSlots(
                 PREGDISPLAY         pRD,
                 unsigned            inputFlags,
                 GCEnumCallback      pCallBack,
-                LPVOID              hCallBack
+                void *              hCallBack
                 )
 {
     for(UINT32 slotIndex = slotDecoder.GetNumTracked(); slotIndex < slotDecoder.GetNumSlots(); slotIndex++)
@@ -1428,7 +1428,7 @@ void GcInfoDecoder::ReportRegisterToGC(  // AMD64
                                 PREGDISPLAY     pRD,
                                 unsigned        flags,
                                 GCEnumCallback  pCallBack,
-                                LPVOID          hCallBack)
+                                void *          hCallBack)
 {
     GCINFODECODER_CONTRACT;
 
@@ -1562,7 +1562,7 @@ void GcInfoDecoder::ReportRegisterToGC(  // ARM
                                 PREGDISPLAY     pRD,
                                 unsigned        flags,
                                 GCEnumCallback  pCallBack,
-                                LPVOID          hCallBack)
+                                void *          hCallBack)
 {
     GCINFODECODER_CONTRACT;
 
@@ -1653,7 +1653,7 @@ void GcInfoDecoder::ReportRegisterToGC( // ARM64
                                 PREGDISPLAY     pRD,
                                 unsigned        flags,
                                 GCEnumCallback  pCallBack,
-                                LPVOID          hCallBack)
+                                void *          hCallBack)
 {
     GCINFODECODER_CONTRACT;
 
@@ -1731,7 +1731,7 @@ void GcInfoDecoder::ReportRegisterToGC(
                                 PREGDISPLAY     pRD,
                                 unsigned        flags,
                                 GCEnumCallback  pCallBack,
-                                LPVOID          hCallBack)
+                                void *          hCallBack)
 {
     _ASSERTE( !"NYI" );
 }
@@ -1810,7 +1810,7 @@ void GcInfoDecoder::ReportStackSlotToGC(
                                 PREGDISPLAY     pRD,
                                 unsigned        flags,
                                 GCEnumCallback  pCallBack,
-                                LPVOID          hCallBack)
+                                void *          hCallBack)
 {
     GCINFODECODER_CONTRACT;
 

--- a/src/vm/gcinfodecoder.cpp
+++ b/src/vm/gcinfodecoder.cpp
@@ -645,48 +645,6 @@ bool GcInfoDecoder::EnumerateLiveSlots(
 
 
 #ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-#ifndef DISABLE_EH_VECTORS
-    if(m_SafePointIndex < m_NumSafePoints || executionAborted)
-    {
-        // Skip interruptibility information
-        for(UINT32 i=0; i<m_NumInterruptibleRanges; i++)
-        {
-            m_Reader.DecodeVarLengthUnsigned( INTERRUPTIBLE_RANGE_DELTA1_ENCBASE );
-            m_Reader.DecodeVarLengthUnsigned( INTERRUPTIBLE_RANGE_DELTA2_ENCBASE );
-        }
-    }
-    else
-    {
-        //
-        // We didn't find the break offset in the list of call sites
-        //    and are not in an executionAborted frame
-        // So we must have fully-interruptible information
-        //
-        _ASSERTE(m_NumInterruptibleRanges);
-
-#ifdef _DEBUG
-        int dbgCountIntersections = 0;
-#endif
-        UINT32 lastNormStop = 0;
-        for(UINT32 i=0; i<m_NumInterruptibleRanges; i++)
-        {
-            UINT32 normStartDelta = (UINT32) m_Reader.DecodeVarLengthUnsigned( INTERRUPTIBLE_RANGE_DELTA1_ENCBASE );
-            UINT32 normStopDelta = (UINT32) m_Reader.DecodeVarLengthUnsigned( INTERRUPTIBLE_RANGE_DELTA2_ENCBASE ) + 1;
-
-            UINT32 normStart = lastNormStop + normStartDelta;
-            UINT32 normStop = normStart + normStopDelta;
-            if(normBreakOffset >= normStart && normBreakOffset < normStop)
-            {
-                _ASSERTE(pseudoBreakOffset == 0);
-                _ASSERTE(dbgCountIntersections++ == 0);
-                pseudoBreakOffset = numInterruptibleLength + normBreakOffset - normStart;
-            }
-            numInterruptibleLength += normStopDelta;
-            lastNormStop = normStop;
-        }        
-        _ASSERTE(dbgCountIntersections == 1);
-    }        
-#else // DISABLE_EH_VECTORS
     if(m_SafePointIndex < m_NumSafePoints && !executionAborted)
     {
         // Skip interruptibility information
@@ -736,7 +694,6 @@ bool GcInfoDecoder::EnumerateLiveSlots(
             goto ExitSuccess;
         }
     }        
-#endif // DISABLE_EH_VECTORS
 #else   // !PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
 
     // Skip interruptibility information
@@ -778,52 +735,8 @@ bool GcInfoDecoder::EnumerateLiveSlots(
 
         if(executionAborted)
         {
-#ifndef DISABLE_EH_VECTORS
-            m_Reader.Skip(m_NumSafePoints * numSlots);
-
-            UINT32 numClauses = (UINT32) m_Reader.DecodeVarLengthUnsigned(NUM_EH_CLAUSES_ENCBASE);
-
-            if(numClauses)
-            {
-                UINT32 numBitsPerOffset = CeilOfLog2(NORMALIZE_CODE_OFFSET(m_CodeLength));
-                
-                for(UINT32 i = 0; i < numClauses; i++)
-                {
-                    UINT32 startOffset = (UINT32) DENORMALIZE_CODE_OFFSET(m_Reader.Read(numBitsPerOffset));
-                    UINT32 stopOffset = (UINT32) DENORMALIZE_CODE_OFFSET(m_Reader.Read(numBitsPerOffset) + 1);
-                    
-                    if(m_InstructionOffset >= startOffset 
-                        && m_InstructionOffset < stopOffset)
-                    {
-                        for(UINT32 slotIndex = 0; slotIndex < numSlots; slotIndex++)
-                        {
-                            if(m_Reader.ReadOneFast())
-                            {
-                                ReportSlotToGC(
-                                        slotDecoder,
-                                        slotIndex,
-                                        pRD,
-                                        reportScratchSlots,
-                                        inputFlags,
-                                        pCallBack,
-                                        hCallBack
-                                        );
-                            }
-                        }
-                    }
-                    else
-                    {
-                        m_Reader.Skip(numSlots);
-                    }
-                }
-            }
-            goto ReportUntracked;
-#else //DISABLE_EH_VECTORS
-
             _ASSERTE(m_NumSafePoints == 0);
             m_Reader.Skip(m_NumSafePoints * numSlots);
-
-#endif //DISABLE_EH_VECTORS
         }
         else if( m_SafePointIndex != m_NumSafePoints )
         {
@@ -891,15 +804,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
         else
         {
             m_Reader.Skip(m_NumSafePoints * numSlots);
-
-#ifndef DISABLE_EH_VECTORS
-            UINT32 numClauses = (UINT32) m_Reader.DecodeVarLengthUnsigned(NUM_EH_CLAUSES_ENCBASE);
-            UINT32 numBitsPerOffset = CeilOfLog2(NORMALIZE_CODE_OFFSET(m_CodeLength));
-
-            m_Reader.Skip((numBitsPerOffset * 2 + numSlots) * numClauses);
-#endif //DISABLE_EH_VECTORS
-        } 
-    
+        }
 #endif // PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
         
         _ASSERTE(m_NumInterruptibleRanges);
@@ -1069,9 +974,7 @@ ReportUntracked:
         ReportUntrackedSlots(slotDecoder, pRD, inputFlags, pCallBack, hCallBack);
     }
 
-#ifdef DISABLE_EH_VECTORS
 ExitSuccess:
-#endif
 
     return true;
 }


### PR DESCRIPTION
Remove stale ifdefs and a few portability tweaks to make the decoder easier to reuse in CoreRT