### PR TITLE
Fix the condition to dump a basic block stats.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -9857,7 +9857,7 @@ void LinearScan::dumpLsraStats(FILE* file)
         unsigned resolutionMovCount = blockInfo[block->bbNum].resolutionMovCount;
         unsigned splitEdgeCount     = blockInfo[block->bbNum].splitEdgeCount;
 
-        if (spillCount != 0 || copyRegCount != 0 || resolutionMovCount != 0)
+        if (spillCount != 0 || copyRegCount != 0 || resolutionMovCount != 0 || splitEdgeCount != 0)
         {
             fprintf(file, "BB%02u [%8d]: ", block->bbNum, block->bbWeight);
             fprintf(file, "SpillCount = %d, ResolutionMovs = %d, SplitEdges = %d, CopyReg = %d\n", spillCount,


### PR DESCRIPTION
A minor fix to the condition under which an individual basic block stats are dumped is missing a check.