### PR TITLE
[Linux][GDB-JIT] Fix lldb stepping issues

### DIFF
--- a/src/ToolBox/SOS/NETCore/SymbolReader.cs
+++ b/src/ToolBox/SOS/NETCore/SymbolReader.cs
@@ -517,8 +517,6 @@ namespace SOS
 
                     foreach (SequencePoint point in sequencePoints)
                     {
-                        if (point.StartLine == 0 || point.StartLine == SequencePoint.HiddenLine)
-                            continue;
 
                         DebugInfo debugInfo = new DebugInfo();
                         debugInfo.lineNumber = point.StartLine;

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1217,7 +1217,13 @@ struct Elf_Symbol {
     int m_off;
     TADDR m_value;
     int m_section, m_size;
-    Elf_Symbol() : m_name(nullptr), m_off(0), m_value(0), m_section(0), m_size(0) {}
+    bool m_releaseName;
+    Elf_Symbol() : m_name(nullptr), m_off(0), m_value(0), m_section(0), m_size(0), m_releaseName(false) {}
+    ~Elf_Symbol()
+    {
+        if (m_releaseName)
+            delete [] m_name;
+    }
 };
 
 static int countFuncs(const SymbolsInfo *lines, int nlines)
@@ -2101,6 +2107,7 @@ bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods)
             LPCUTF8 methodName = pMD->GetName();
             int symbolNameLength = strlen(methodName) + sizeof("__thunk_");
             SymbolNames[i].m_name = new char[symbolNameLength];
+            SymbolNames[i].m_releaseName = true;
             sprintf((char*)SymbolNames[i].m_name, "__thunk_%s", methodName);
             SymbolNames[i].m_value = callAddr;
             ++i;

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1455,7 +1455,7 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
     /* Build .strtab section */
     SymbolNames[0].m_name = "";
     for (int i = 0; i < method_count; ++i) {
-        SymbolNames[1 + i].m_name = methodName;
+        SymbolNames[1 + i].m_name = method[i]->m_member_name;
         SymbolNames[1 + i].m_value = method[i]->m_sub_low_pc;
         SymbolNames[1 + i].m_section = 1;
         SymbolNames[1 + i].m_size = method[i]->m_sub_high_pc;
@@ -2154,10 +2154,9 @@ bool NotifyGdb::BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize)
         sym[i].st_name = SymbolNames[i].m_off;
         sym[i].setBindingAndType(STB_GLOBAL, STT_FUNC);
         sym[i].st_other = 0;
+        sym[i].st_value = SymbolNames[i].m_value - addr;
 #ifdef _TARGET_ARM_
-        sym[i].st_value = 1; // for THUMB code
-#else    
-        sym[i].st_value = 0;
+        sym[i].st_value |= 1; // for THUMB code
 #endif    
         sym[i].st_shndx = 1; // .text section index
         sym[i].st_size = SymbolNames[i].m_size;

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1372,7 +1372,12 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
 
     unsigned int firstLineIndex = 0;
     for (;firstLineIndex < symInfoLen; firstLineIndex++) {
-        if (symInfo[firstLineIndex].lineNumber != 0 && symInfo[firstLineIndex].lineNumber != HiddenLine && symInfo[firstLineIndex].fileName[0] != 0) break;
+        if (symInfo[firstLineIndex].lineNumber != 0 && symInfo[firstLineIndex].lineNumber != HiddenLine) break;
+    }
+
+    if (firstLineIndex >= symInfoLen)
+    {
+        return;
     }
 
     method = new (nothrow) FunctionMember*[method_count];

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1797,6 +1797,7 @@ bool NotifyGdb::BuildLineProg(MemBuf& buf, PCODE startAddr, TADDR codeSize, Symb
                 + 6                              /* set file command */
                 + nlines * 6                     /* advance line commands */
                 + nlines * (3 + ADDRESS_SIZE)    /* set address commands */
+                + nlines * 1                     /* set prologue end or epilogue begin commands */
                 + nlines * 1                     /* copy commands */
                 + 6                              /* advance PC command */
                 + 3;                             /* end of sequence command */
@@ -1827,6 +1828,11 @@ bool NotifyGdb::BuildLineProg(MemBuf& buf, PCODE startAddr, TADDR codeSize, Symb
             IssueParamCommand(ptr, DW_LNS_advance_line, cnv_buf, len);
             prevLine = lines[i].lineNumber;
         }
+
+        if (lines[i].ilOffset == ICorDebugInfo::EPILOG)
+            IssueSimpleCommand(ptr, DW_LNS_set_epilogue_begin);
+        else if (i > 0 && lines[i - 1].ilOffset == ICorDebugInfo::PROLOG)
+            IssueSimpleCommand(ptr, DW_LNS_set_prologue_end);
 
         IssueParamCommand(ptr, DW_LNS_copy, NULL, 0);
     }

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -2267,6 +2267,10 @@ bool NotifyGdb::BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf)
     Elf_Shdr* pSh = sectionHeaders;
     uint32_t sectNameOffset = 0;
 
+    // Additional memory for remaining section names,
+    // grows twice on each reallocation.
+    int addSize = SECT_NAME_LENGTH;
+
     // Fill section headers and names
     for (int i = 0; i < SectionNamesCount + thunks_count; ++i, ++pSh)
     {
@@ -2290,8 +2294,10 @@ bool NotifyGdb::BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf)
         sectNameOffset += strlen(sectName) + 1;
         if (sectNameOffset > strBuf.MemSize)
         {
-            if (!strBuf.Resize(sectNameOffset))
+            // Allocate more memory for remaining section names
+            if (!strBuf.Resize(sectNameOffset + addSize))
                 return false;
+            addSize *= 2;
         }
 
         strcpy(strBuf.MemPtr + pSh->sh_name, sectName);

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -2097,11 +2097,11 @@ bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods)
         TADDR callAddr = (TADDR)pList->GetCallAddr();
         if (!codeAddrs.Contains(callAddr))
         {
-            char buf[256];
             MethodDesc* pMD = pList->GetMethodDesc();
-            sprintf(buf, "__thunk_%s", pMD->GetName());
-            SymbolNames[i].m_name = new char[strlen(buf) + 1];
-            strcpy((char*)SymbolNames[i].m_name, buf);
+            LPCUTF8 methodName = pMD->GetName();
+            int symbolNameLength = strlen(methodName) + sizeof("__thunk_");
+            SymbolNames[i].m_name = new char[symbolNameLength];
+            sprintf((char*)SymbolNames[i].m_name, "__thunk_%s", methodName);
             SymbolNames[i].m_value = callAddr;
             ++i;
             codeAddrs.Add(callAddr);

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -366,11 +366,27 @@ private:
         unsigned MemSize;
         MemBuf() : MemPtr(0), MemSize(0)
         {}
+        bool Resize(unsigned newSize)
+        {
+            if (newSize == 0)
+            {
+                MemPtr = nullptr;
+                MemSize = 0;
+                return true;
+            }
+            char *tmp = new (nothrow) char [newSize];
+            if (tmp == nullptr)
+                return false;
+            memmove(tmp, MemPtr.GetValue(), newSize < MemSize ? newSize : MemSize);
+            MemPtr = tmp;
+            MemSize = newSize;
+            return true;
+        }
     };
 
+    static int GetSectionIndex(const char *sectName);
     static bool BuildELFHeader(MemBuf& buf);
-    static bool BuildSectionNameTable(MemBuf& buf);
-    static bool BuildSectionTable(MemBuf& buf);
+    static bool BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf);
     static bool BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize);
     static bool BuildStringTableSection(MemBuf& strTab);
     static bool BuildDebugStrings(MemBuf& buf, PTK_TypeInfoMap pTypeMap);

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -377,12 +377,10 @@ private:
     static bool BuildLineTable(MemBuf& buf, PCODE startAddr, TADDR codeSize, SymbolsInfo* lines, unsigned nlines);
     static bool BuildFileTable(MemBuf& buf, SymbolsInfo* lines, unsigned nlines);
     static bool BuildLineProg(MemBuf& buf, PCODE startAddr, TADDR codeSize, SymbolsInfo* lines, unsigned nlines);
-    static bool FitIntoSpecialOpcode(int8_t line_shift, uint8_t addr_shift);
     static void IssueSetAddress(char*& ptr, PCODE addr);
     static void IssueEndOfSequence(char*& ptr);
     static void IssueSimpleCommand(char*& ptr, uint8_t command);
     static void IssueParamCommand(char*& ptr, uint8_t command, char* param, int param_len);
-    static void IssueSpecialCommand(char*& ptr, int8_t line_shift, uint8_t addr_shift);
     static void SplitPathname(const char* path, const char*& pathName, const char*& fileName);
     static bool CollectCalledMethods(CalledMethod* pCM);
 #ifdef _DEBUG

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -354,7 +354,10 @@ public:
 
     typedef MapSHash<TypeKey*, TypeInfoBase*, DeleteValuesOnDestructSHashTraits<TypeKeyHashTraits<TypeInfoBase*>>> TK_TypeInfoMap;
     typedef TK_TypeInfoMap* PTK_TypeInfoMap;
-
+    typedef SetSHash< TADDR,
+                      NoRemoveSHashTraits <
+                      NonDacAwareSHashTraits< SetSHashTraits <TADDR> >
+                    > > AddrSet;
 private:
 
     struct MemBuf

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -105,10 +105,13 @@ struct __attribute__((packed)) DwarfLineNumHeader
     uint8_t m_std_num_arg[DW_LNS_MAX];
 };
 
+const ULONG32 HiddenLine = 0x00feefee;
+
 struct SymbolsInfo
 {
     int lineNumber, ilOffset, nativeOffset, fileIndex;
     char fileName[2*MAX_PATH_FNAME];
+    ICorDebugInfo::SourceTypes source;
 };
 
 class DwarfDumpable


### PR DESCRIPTION
This PR fixes various issues in GDB/JIT that prevented the lldb from stepping in/through managed code.

Highlights:
- More info about SequencePoints is passed from SymbolReader into gdbjit. This allows to generate more accurate DWARF line info and handle multiple prologues/epilogues and negative line changes;
- Fixed overlapping .thunk sections from different methods by mapping each __thunk symbol as a separate section. This was preventing the debugger from correctly resolving __thunk_\* symbols in those sections.

@mikem8361, @janvorli PTAL

cc @Dmitri-Botcharnikov @chunseoklee @seanshpark @lucenticus
