### PR TITLE
Optimize 'test' instruction in case of op1 == 0 or op1 != 0 where op1 is known to set Zero flag.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -8603,14 +8603,13 @@ bool GenTree::gtSetFlags() const
     //
     // Precondition we have a GTK_SMPOP
     //
-    assert(OperIsSimple());
-
     if (!varTypeIsIntegralOrI(TypeGet()))
     {
         return false;
     }
 
 #if FEATURE_SET_FLAGS
+    assert(OperIsSimple());
 
     if ((gtFlags & GTF_SET_FLAGS) && gtOper != GT_IND)
     {
@@ -8624,6 +8623,7 @@ bool GenTree::gtSetFlags() const
 
 #else // !FEATURE_SET_FLAGS
 
+#ifdef LEGACY_BACKEND
 #ifdef _TARGET_XARCH_
     // Return true if/when the codegen for this node will set the flags
     //
@@ -8644,6 +8644,22 @@ bool GenTree::gtSetFlags() const
     // Otherwise for other architectures we should return false
     return false;
 #endif
+
+#else // !LEGACY_BACKEND
+#ifdef _TARGET_XARCH_
+    if (((gtFlags & GTF_SET_FLAGS) != 0) && (gtOper != GT_IND))
+    {
+        // GTF_SET_FLAGS is not valid on GT_IND and is overlaid with GTF_NONFAULTING_IND
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+#else
+    unreached();
+#endif
+#endif // !LEGACY_BACKEND
 
 #endif // !FEATURE_SET_FLAGS
 }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -768,15 +768,15 @@ public:
 #ifdef LEGACY_BACKEND
 #define GTF_SPILLED_OPER 0x00000100 // op1 has been spilled
 #define GTF_SPILLED_OP2 0x00000200  // op2 has been spilled
-#else
+#else                               // !LEGACY_BACKEND
 #define GTF_NOREG_AT_USE 0x00000100 // tree node is in memory at the point of use
-#endif                              // LEGACY_BACKEND
+#endif                              // !LEGACY_BACKEND
 
 #define GTF_ZSF_SET 0x00000400 // the zero(ZF) and sign(SF) flags set to the operand
-#if FEATURE_SET_FLAGS
+
 #define GTF_SET_FLAGS 0x00000800 // Requires that codegen for this node set the flags
                                  // Use gtSetFlags() to check this flags
-#endif
+
 #define GTF_IND_NONFAULTING 0x00000800 // An indir that cannot fault.  GTF_SET_FLAGS is not used on indirs
 
 #define GTF_MAKE_CSE 0x00002000   // Hoisted Expression: try hard to make this into CSE  (see optPerformHoistExpr)
@@ -1844,6 +1844,14 @@ public:
     bool gtOverflowEx() const;
     bool gtSetFlags() const;
     bool gtRequestSetFlags();
+
+    // Returns true if the codegen of this tree node
+    // sets ZF and SF flags.
+    bool gtSetZSFlags() const
+    {
+        return (gtFlags & GTF_ZSF_SET) != 0;
+    }
+
 #ifdef DEBUG
     bool       gtIsValid64RsltMul();
     static int gtDispFlags(unsigned flags, unsigned debugFlags);

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -342,7 +342,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             //   integerCompareResult = GT_EQ/NE(simdCompareResult, true/false)
             //   GT_JTRUE(integerCompareResult)
             //
-            // In this case we don't need to generate code fo GT_EQ_/NE, since SIMD (In)Equality
+            // In this case we don't need to generate code for GT_EQ_/NE, since SIMD (In)Equality
             // intrinsic would set or clear Zero flag.
 
             genTreeOps cmpOper = cmp->OperGet();
@@ -568,6 +568,11 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             {
                 info->internalFloatCount = 1;
                 info->setInternalCandidates(l, l->internalFloatRegCandidates());
+            }
+            else
+            {
+                // Codegen of this tree node sets ZF and SF flags.
+                tree->gtFlags |= GTF_ZSF_SET;
             }
             break;
 
@@ -1164,6 +1169,9 @@ void Lowering::TreeNodeInfoInitShiftRotate(GenTree* tree)
     {
         MakeSrcContained(tree, shiftBy);
     }
+
+    // Codegen of this tree node sets ZF and SF flags.
+    tree->gtFlags |= GTF_ZSF_SET;
 }
 
 //------------------------------------------------------------------------
@@ -2399,6 +2407,9 @@ void Lowering::TreeNodeInfoInitLogicalOp(GenTree* tree)
         // as reg optional.
         SetRegOptionalForBinOp(tree);
     }
+
+    // Codegen of this tree node sets ZF and SF flags.
+    tree->gtFlags |= GTF_ZSF_SET;
 }
 
 //------------------------------------------------------------------------
@@ -3603,6 +3614,41 @@ void Lowering::TreeNodeInfoInitCmp(GenTreePtr tree)
                 if (!op1IsMadeContained)
                 {
                     SetRegOptional(op1);
+
+                    // If op1 codegen sets ZF and SF flags and ==/!= against
+                    // zero, we don't need to generate test instruction,
+                    // provided we don't have another GenTree node between op1
+                    // and tree that could potentially modify flags.
+                    //
+                    // TODO-CQ: right now the below peep is inexpensive and
+                    // gets the benefit in most of cases because in majority
+                    // of cases op1, op2 and tree would be in that order in
+                    // execution.  In general we should be able to check that all
+                    // the nodes that come after op1 in execution order do not
+                    // modify the flags so that it is safe to avoid generating a
+                    // test instruction.  Such a check requires that on each
+                    // GenTree node we need to set the info whether its codegen
+                    // will modify flags.
+                    //
+                    // TODO-CQ: We can optimize compare against zero in the
+                    // following cases by generating the branch as indicated
+                    // against each case.
+                    //  1) unsigned compare
+                    //        < 0  - always FALSE
+                    //       <= 0  - ZF=1 and jne
+                    //        > 0  - ZF=0 and je
+                    //       >= 0  - always TRUE
+                    //
+                    // 2) signed compare
+                    //        < 0  - SF=1 and js
+                    //       >= 0  - SF=0 and jns
+                    if (isEqualityCompare && op1->gtSetZSFlags() && op2->IsIntegralConst(0) && (op1->gtNext == op2) &&
+                        (op2->gtNext == tree))
+                    {
+                        // Require codegen of op1 to set the flags.
+                        assert(!op1->gtSetFlags());
+                        op1->gtFlags |= GTF_SET_FLAGS;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Summary of code changes:

gentree.h/gentree.cpp:
Legacy backend already uses GTF_ZSF_SET and GTF_SET_FLAGS.  These flags are now used by RyuJIT backend.

GTF_ZSF_SET  - codegen of the tree node sets/modifies ZF and SF flags
GTF_SET_FLAGS - codegen of the tree node is required to set the flags.  This would mean codegen cannot optimize GT_ADD by generating 'lea'.

Lowerxarch.cpp: 
Compare lowering logic checks to see whether op1 sets ZF flag and if so sets GTF_SET_FLAGS on op1 to indicate to codegen not to perform any optimizations while generating code that would prevent it from setting flags.

Codegenxarch.cpp - If GTF_SET_FLAGS is set on op1, 'test' instruction is not generated.

Asm Diffs:
This gives 1703 bytes of code size win across all CQ Perf benchmarks
1056 bytes of code size win against desktop mscorlib

Execution Perf:
This changes gives 1.29% improvement in execution perf of Crafty
(Before: 49665,  Ater : 49020)


