### PR TITLE
Do not materialize CAS PseudoCustomAttribute

### DIFF
--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -2089,6 +2089,7 @@ namespace System.Reflection
         #endregion
 
         #region FCalls
+#if FEATURE_CAS_POLICY
         [System.Security.SecurityCritical]  // auto-generated
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         unsafe private static extern void _GetSecurityAttributes(RuntimeModule module, int token, bool assembly, out object[] securityAttributes);
@@ -2097,6 +2098,12 @@ namespace System.Reflection
         {
             _GetSecurityAttributes(module.GetNativeHandle(), token, assembly, out securityAttributes);
         }
+#else
+        internal static void GetSecurityAttributes(RuntimeModule module, int token, bool assembly, out object[] securityAttributes)
+        {
+            securityAttributes = null;
+        }
+#endif
         #endregion
 
         #region Static Constructor
@@ -2142,9 +2149,9 @@ namespace System.Reflection
             //AllowMultiple is true for TypeForwardedToAttribute
             //Contract.Assert(usage.AllowMultiple == false, "Pseudo CA Error");
         }
-        #endregion
+#endregion
 
-        #region Internal Static
+#region Internal Static
         internal static bool IsSecurityAttribute(RuntimeType type)
         {
 #pragma warning disable 618
@@ -2522,6 +2529,6 @@ namespace System.Reflection
         {
             return false;
         }
-        #endregion
+#endregion
     }
 }

--- a/src/vm/customattribute.cpp
+++ b/src/vm/customattribute.cpp
@@ -906,6 +906,7 @@ FCIMPL5(VOID, COMCustomAttribute::ParseAttributeUsageAttribute, PVOID pData, ULO
 }
 FCIMPLEND
 
+#ifdef FEATURE_CAS_POLICY
 FCIMPL4(VOID, COMCustomAttribute::GetSecurityAttributes, ReflectModuleBaseObject *pModuleUNSAFE, DWORD tkToken, CLR_BOOL fAssembly, PTRARRAYREF* ppArray)
 {
     FCALL_CONTRACT;
@@ -991,6 +992,7 @@ FCIMPL4(VOID, COMCustomAttribute::GetSecurityAttributes, ReflectModuleBaseObject
     HELPER_METHOD_FRAME_END();
 }
 FCIMPLEND
+#endif // FEATURE_CAS_POLICY
 
 FCIMPL7(void, COMCustomAttribute::GetPropertyOrFieldData, ReflectModuleBaseObject *pModuleUNSAFE, BYTE** ppBlobStart, BYTE* pBlobEnd, STRINGREF* pName, CLR_BOOL* pbIsProperty, OBJECTREF* pType, OBJECTREF* value)
 {

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -650,9 +650,11 @@ FCFuncStart(gCustomAttributeEncodedArgument)
     FCFuncElement("ParseAttributeArguments", Attribute::ParseAttributeArguments)
 FCFuncEnd()
 
+#ifdef FEATURE_CAS_POLICY
 FCFuncStart(gPseudoCustomAttribute)
     FCFuncElement("_GetSecurityAttributes", COMCustomAttribute::GetSecurityAttributes)
 FCFuncEnd()
+#endif
 
 FCFuncStart(gCOMCustomAttributeFuncs)
     FCFuncElement("_ParseAttributeUsageAttribute", COMCustomAttribute::ParseAttributeUsageAttribute)
@@ -2325,7 +2327,9 @@ FCClassElement("PolicyManager", "System.Security", gPolicyManagerFuncs)
 FCClassElement("ProfileOptimization", "System.Runtime", gProfileOptimizationFuncs)
 #endif  // defined(FEATURE_MULTICOREJIT) && !defined(FEATURE_CORECLR)
 
+#ifdef FEATURE_CAS_POLICY
 FCClassElement("PseudoCustomAttribute", "System.Reflection", gPseudoCustomAttribute)
+#endif
 #ifdef FEATURE_CORECLR
 FCClassElement("PunkSafeHandle", "System.Reflection.Emit", gSymWrapperCodePunkSafeHandleFuncs)
 #endif

--- a/src/vm/securityattributes.cpp
+++ b/src/vm/securityattributes.cpp
@@ -304,9 +304,7 @@ void SecurityAttributes::EncodePermissionSet(IN OBJECTREF* pRef,
                                             ppbData,
                                             pcbData);
 }
-#endif // FEATURE_CAS_POLICY
 
-#ifdef FEATURE_CAS_POLICY
 static void SetupRestrictSecAttributes()
 {
     CONTRACTL {
@@ -334,7 +332,6 @@ static void SetupRestrictSecAttributes()
     }
     EX_END_CATCH(RethrowTerminalExceptions)
 }
-#endif // FEATURE_CAS_POLICY
 
 Assembly* SecurityAttributes::LoadAssemblyFromToken(IMetaDataAssemblyImport *pImport, mdAssemblyRef tkAssemblyRef)
 {
@@ -1182,7 +1179,6 @@ void SecurityAttributes::AttrSetBlobToPermissionSets(
         COMPlusThrowHR(hr);
 }
 
-#ifdef FEATURE_CAS_POLICY
 HRESULT SecurityAttributes::TranslateSecurityAttributesHelper(
                             CORSEC_ATTRSET    *pAttrSet,
                             BYTE          **ppbOutput,
@@ -1255,7 +1251,6 @@ HRESULT SecurityAttributes::TranslateSecurityAttributesHelper(
     EX_CATCH_HRESULT(hr);
     return hr;
 }
-#endif // FEATURE_CAS_POLICY
 
 // Call into managed code to group permissions into a PermissionSet and serialize it to XML
 void SecurityAttributes::AttrArrayToPermissionSet(OBJECTREF* attrArray,
@@ -1354,7 +1349,7 @@ void SecurityAttributes::AttrArrayToPermissionSet(OBJECTREF* attrArray,
 
     GCPROTECT_END();
 }
-
+#endif // FEATURE_CAS_POLICY
 
 //
 // This is a public exported method

--- a/src/vm/securitydeclarativecache.cpp
+++ b/src/vm/securitydeclarativecache.cpp
@@ -75,6 +75,7 @@ OBJECTREF PsetCacheEntry::CreateManagedPsetObject(DWORD dwAction, bool createEmp
         MODE_COOPERATIVE;
     } CONTRACTL_END;
 
+#ifdef FEATURE_CAS_POLICY
     OBJECTREF orRet;
 
     orRet = GetManagedPsetObject();
@@ -106,7 +107,6 @@ OBJECTREF PsetCacheEntry::CreateManagedPsetObject(DWORD dwAction, bool createEmp
         
     } else {
 
-#ifdef FEATURE_CAS_POLICY
         SecurityAttributes::XmlToPermissionSet(m_pKey->m_pbPset,
                                                m_pKey->m_cbPset,  
                                                &gc.pset, 
@@ -115,10 +115,6 @@ OBJECTREF PsetCacheEntry::CreateManagedPsetObject(DWORD dwAction, bool createEmp
                                                0, 
                                                &gc.orNonCasPset, 
                                                &gc.orNonCasEncoding);
-#else
-        // The v1.x serialized permission set format is not supported on CoreCLR
-        COMPlusThrowHR(CORSECATTR_E_BAD_ATTRIBUTE);
-#endif //FEATURE_CAS_POLICY
     }
 
     StoreFirstObjectInHandle(m_handle, gc.pset);
@@ -135,6 +131,9 @@ OBJECTREF PsetCacheEntry::CreateManagedPsetObject(DWORD dwAction, bool createEmp
 
     orRet = GetManagedPsetObject();
     return orRet;
+#else
+    return NULL;
+#endif
 }
 #endif // CROSSGEN_COMPILE
 


### PR DESCRIPTION
Do not materialize CAS permissionsets as custom attributes in reflection. We are just providing the CAS types in corefx to make things compile, but nothing else.

Fix https://github.com/dotnet/corefx/issues/12759