### PR TITLE
Check index before access

### DIFF
--- a/src/ToolBox/SOS/Strike/sildasm.cpp
+++ b/src/ToolBox/SOS/Strike/sildasm.cpp
@@ -789,7 +789,7 @@ PCCOR_SIGNATURE PrettyPrintType(
                         {   
                             //if (sizes[i] != 0 || lowerBounds[i] != 0)   
                             {   
-                                if (lowerBounds[i] == 0 && i < numSizes)    
+                                if (i < numSizes && lowerBounds[i] == 0)
                                     appendStrNum(out, sizes[i]);    
                                 else    
                                 {   


### PR DESCRIPTION
This was found with Cppcheck. Original code first accesses the array, then checks the index, it should check the index first.