### PR TITLE
Inliner: fix RARE_GC_STRUCT observation impact

### DIFF
--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -156,7 +156,7 @@ INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",        
 
 // ------ Call Site Performance ------- 
 
-INLINE_OBSERVATION(RARE_GC_STRUCT,            bool,   "rarely called, has gc struct",  FATAL,       CALLSITE)
+INLINE_OBSERVATION(RARE_GC_STRUCT,            bool,   "rarely called, has gc struct",  INFORMATION, CALLSITE)
 
 // ------ Call Site Information ------- 
 

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -106,7 +106,7 @@ InlinePolicy* InlinePolicy::GetPolicy(Compiler* compiler, bool isPrejitRoot)
 void LegalPolicy::NoteFatal(InlineObservation obs)
 {
     // As a safeguard, all fatal impact must be
-    // reported via noteFatal.
+    // reported via NoteFatal.
     assert(InlGetImpact(obs) == InlineImpact::FATAL);
     NoteInternal(obs);
     assert(InlDecisionIsFailure(m_Decision));
@@ -243,7 +243,7 @@ void LegacyPolicy::NoteBool(InlineObservation obs, bool value)
     InlineImpact impact = InlGetImpact(obs);
 
     // As a safeguard, all fatal impact must be
-    // reported via noteFatal.
+    // reported via NoteFatal.
     assert(impact != InlineImpact::FATAL);
 
     // Handle most information here
@@ -847,6 +847,16 @@ int LegacyPolicy::CodeSizeEstimate()
 
 void EnhancedLegacyPolicy::NoteBool(InlineObservation obs, bool value)
 {
+
+#ifdef DEBUG
+    // Check the impact
+    InlineImpact impact = InlGetImpact(obs);
+
+    // As a safeguard, all fatal impact must be
+    // reported via NoteFatal.
+    assert(impact != InlineImpact::FATAL);
+#endif // DEBUG
+
     switch (obs)
     {
         case InlineObservation::CALLEE_DOES_NOT_RETURN:
@@ -1001,7 +1011,7 @@ void RandomPolicy::NoteBool(InlineObservation obs, bool value)
     InlineImpact impact = InlGetImpact(obs);
 
     // As a safeguard, all fatal impact must be
-    // reported via noteFatal.
+    // reported via NoteFatal.
     assert(impact != InlineImpact::FATAL);
 
     // Handle most information here


### PR DESCRIPTION
Closes #7792.

Since this observation isn't always fatal, change its impact to INFORMATION.
Also, refresh the assertion checking around fatal observations so that the
EnhancedLegacyPolicy (which is the current default) will catch this kind of
error going forward.