### PR TITLE
Fix flag check when morphing into rotate

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -14339,7 +14339,15 @@ GenTreePtr Compiler::fgRecognizeAndMorphBitwiseRotation(GenTreePtr tree)
                 tree->gtOp.gtOp1 = rotatedValue;
                 tree->gtOp.gtOp2 = rotateIndex;
                 tree->ChangeOper(rotateOp);
-                noway_assert(inputTreeEffects == ((rotatedValue->gtFlags | rotateIndex->gtFlags) & GTF_ALL_EFFECT));
+
+                unsigned childFlags = 0;
+                for (GenTree* op : tree->Operands())
+                {
+                    childFlags |= (op->gtFlags & GTF_ALL_EFFECT);
+                }
+
+                // The parent's flags should be a superset of its operands' flags
+                noway_assert((inputTreeEffects & childFlags) == childFlags);
             }
             else
             {


### PR DESCRIPTION
When we morphed a tree into a rotate, we assumed that the parent's flags
would be the same as its operands' flags, when in actuality, the parent's
flags should be a superset of its operands' flags. This change fixes the
flag check.

Fixes VSO 278374.