### PR TITLE
Change JIT-EE interface GUID

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -231,11 +231,11 @@ TODO: Talk about initializing strutures before use
 #if COR_JIT_EE_VERSION > 460
 
 // Update this one
-SELECTANY const GUID JITEEVersionIdentifier = { /* 0b17dfeb-1ead-4e06-b025-d60d3a493b53 */
-    0x0b17dfeb,
-    0x1ead,
-    0x4e06,
-    { 0xb0, 0x25, 0xd6, 0x0d, 0x3a, 0x49, 0x3b, 0x53 }
+SELECTANY const GUID JITEEVersionIdentifier = { /* 8d588c98-4cef-4e6d-9792-08e1f5ab88c5 */
+    0x8d588c98,
+    0x4cef,
+    0x4e6d,
+    {0x97, 0x92, 0x08, 0xe1, 0xf5, 0xab, 0x88, 0xc5}
 };
 
 #else


### PR DESCRIPTION
This should have been changed with #7672. However, changing it now
will help prevent unexpected bad interactions with SuperPMI and other
tools that expect the old interface.