### PR TITLE
RyuJIT/x86: fix VSO 278365

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -204,6 +204,9 @@ GenTreePtr Compiler::fgMorphCast(GenTreePtr tree)
                 {
                     case TYP_INT:
 #ifdef _TARGET_X86_ // there is no rounding convert to integer instruction on ARM or x64 so skip this
+#ifdef LEGACY_BACKEND
+                        // the RyuJIT backend does not use the x87 FPU and therefore
+                        // does not support folding the cast conv.i4(round.d(d))
                         if ((oper->gtOper == GT_INTRINSIC) &&
                             (oper->gtIntrinsic.gtIntrinsicId == CORINFO_INTRINSIC_Round))
                         {
@@ -212,7 +215,9 @@ GenTreePtr Compiler::fgMorphCast(GenTreePtr tree)
                             return fgMorphTree(oper);
                         }
                         // if SSE2 is not enabled, we need the helper
-                        else if (!opts.compCanUseSSE2)
+                        else
+#endif // LEGACY_BACKEND
+                            if (!opts.compCanUseSSE2)
                         {
                             return fgMorphCastIntoHelper(tree, CORINFO_HELP_DBL2INT, oper);
                         }

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -156,7 +156,14 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
 
     // Create the call node
     GenTreeCall* call = comp->gtNewCallNode(CT_USER_FUNC, callHnd, tree->gtType, args);
-    call              = comp->fgMorphArgs(call);
+
+#if DEBUG
+    CORINFO_SIG_INFO sig;
+    comp->eeGetMethodSig(callHnd, &sig);
+    assert(JITtype2varType(sig.retType) == tree->gtType);
+#endif // DEBUG
+
+    call = comp->fgMorphArgs(call);
     // Determine if this call has changed any codegen requirements.
     comp->fgCheckArgCnt();
 

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278365/DevDiv_278365.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278365/DevDiv_278365.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Runtime.CompilerServices;
+
+// This test is a reduced repro case for DevDiv VSO bug 278365.
+// The failure mode is that the RyuJIT/x86 backend changed call to ROUND intrinsic
+// with double return type to ROUND intrinsic with int return type, that is not supported.
+
+internal class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Bar()
+    {
+        int sum = 0;
+        for (int i = 0; i < 100; ++i)
+        {
+            int v = (int)Math.Round(4.4 + i);
+            sum += v;
+        }
+        sum -= 4 * 100;
+        if (sum != 100 * 99 / 2)
+        {
+            return 0;
+        }
+        else
+        {
+            return 100;
+        }        
+    }
+	
+    private static int Main(string[] args)
+    {
+        try
+        {
+            if (Bar() != 100)
+                return 0;
+        }
+        catch (Exception)
+        {
+        }
+
+        Console.WriteLine("Pass");
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278365/DevDiv_278365.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278365/DevDiv_278365.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_278365.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
don't convert conv.i4(round.d(d)) to round.i(d) on RyuJit/x86.