### PR TITLE
Copy CoreFX FileStream to CoreLib

### DIFF
--- a/clr.coreclr.props
+++ b/clr.coreclr.props
@@ -77,6 +77,9 @@
      -->
     <FeatureImplicitTls Condition="'$(TargetArch)' == 'arm64'">true</FeatureImplicitTls>
     <FeatureSvrGc Condition="'$(TargetArch)' != 'arm'">true</FeatureSvrGc>
+    <FeatureCoreFxFileStream>true</FeatureCoreFxFileStream>
+    <FeatureCoreFxShim>true</FeatureCoreFxShim>
+    <FeatureCoreFxOverlapped>true</FeatureCoreFxOverlapped>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">
@@ -101,5 +104,11 @@
   <PropertyGroup Condition="'$(TargetsUnix)' != 'true'">
     <FeatureUseLcid>true</FeatureUseLcid>
     <FeatureImplicitLongPath>true</FeatureImplicitLongPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsUnix)' != 'true' and '$(ClrProduct)' == 'core_clr'">
+    <FeatureCoreFxWindowsInterop>true</FeatureCoreFxWindowsInterop>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsUnix)' == 'true' and '$(ClrProduct)' == 'core_clr'">
+    <FeatureCoreFxUnixInterop>true</FeatureCoreFxUnixInterop>
   </PropertyGroup>
 </Project>

--- a/src/inc/dacvars.h
+++ b/src/inc/dacvars.h
@@ -231,7 +231,9 @@ DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pValueTypeClass, ::g_pValueTyp
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pEnumClass, ::g_pEnumClass)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pThreadClass, ::g_pThreadClass)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pCriticalFinalizerObjectClass, ::g_pCriticalFinalizerObjectClass)
+#ifndef FEATURE_CORECLR
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pAsyncFileStream_AsyncResultClass, ::g_pAsyncFileStream_AsyncResultClass)
+#endif // !FEATURE_CORECLR
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pPredefinedArrayTypes, ::g_pPredefinedArrayTypes)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_TypedReferenceMT, ::g_TypedReferenceMT)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pByteArrayMT, ::g_pByteArrayMT)

--- a/src/mscorlib/corefx/Debug.cs
+++ b/src/mscorlib/corefx/Debug.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System
+{
+    internal static class Debug
+    {
+        [Conditional("_DEBUG")]
+        static public void Assert(bool condition)
+        {
+            BCLDebug.Assert(condition);
+        }
+
+        [Conditional("_DEBUG")]
+        static public void Assert(bool condition, string message)
+        {
+            BCLDebug.Assert(condition, message);
+        }
+
+        [Conditional("_DEBUG")]
+        static public void Fail(string message)
+        {
+            BCLDebug.Assert(false, message);
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/Interop.Errors.cs
+++ b/src/mscorlib/corefx/Interop/Unix/Interop.Errors.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    /// <summary>Common Unix errno error codes.</summary>
+    internal enum Error
+    {
+        // These values were defined in src/Native/System.Native/fxerrno.h
+        //
+        // They compare against values obtained via Interop.Sys.GetLastError() not Marshal.GetLastWin32Error()
+        // which obtains the raw errno that varies between unixes. The strong typing as an enum is meant to
+        // prevent confusing the two. Casting to or from int is suspect. Use GetLastErrorInfo() if you need to
+        // correlate these to the underlying platform values or obtain the corresponding error message.
+        // 
+
+        SUCCESS          = 0,
+
+        E2BIG            = 0x10001,           // Argument list too long.
+        EACCES           = 0x10002,           // Permission denied.
+        EADDRINUSE       = 0x10003,           // Address in use.
+        EADDRNOTAVAIL    = 0x10004,           // Address not available.
+        EAFNOSUPPORT     = 0x10005,           // Address family not supported.
+        EAGAIN           = 0x10006,           // Resource unavailable, try again (same value as EWOULDBLOCK),
+        EALREADY         = 0x10007,           // Connection already in progress.
+        EBADF            = 0x10008,           // Bad file descriptor.
+        EBADMSG          = 0x10009,           // Bad message.
+        EBUSY            = 0x1000A,           // Device or resource busy.
+        ECANCELED        = 0x1000B,           // Operation canceled.
+        ECHILD           = 0x1000C,           // No child processes.
+        ECONNABORTED     = 0x1000D,           // Connection aborted.
+        ECONNREFUSED     = 0x1000E,           // Connection refused.
+        ECONNRESET       = 0x1000F,           // Connection reset.
+        EDEADLK          = 0x10010,           // Resource deadlock would occur.
+        EDESTADDRREQ     = 0x10011,           // Destination address required.
+        EDOM             = 0x10012,           // Mathematics argument out of domain of function.
+        EDQUOT           = 0x10013,           // Reserved.
+        EEXIST           = 0x10014,           // File exists.
+        EFAULT           = 0x10015,           // Bad address.
+        EFBIG            = 0x10016,           // File too large.
+        EHOSTUNREACH     = 0x10017,           // Host is unreachable.
+        EIDRM            = 0x10018,           // Identifier removed.
+        EILSEQ           = 0x10019,           // Illegal byte sequence.
+        EINPROGRESS      = 0x1001A,           // Operation in progress.
+        EINTR            = 0x1001B,           // Interrupted function.
+        EINVAL           = 0x1001C,           // Invalid argument.
+        EIO              = 0x1001D,           // I/O error.
+        EISCONN          = 0x1001E,           // Socket is connected.
+        EISDIR           = 0x1001F,           // Is a directory.
+        ELOOP            = 0x10020,           // Too many levels of symbolic links.
+        EMFILE           = 0x10021,           // File descriptor value too large.
+        EMLINK           = 0x10022,           // Too many links.
+        EMSGSIZE         = 0x10023,           // Message too large.
+        EMULTIHOP        = 0x10024,           // Reserved.
+        ENAMETOOLONG     = 0x10025,           // Filename too long.
+        ENETDOWN         = 0x10026,           // Network is down.
+        ENETRESET        = 0x10027,           // Connection aborted by network.
+        ENETUNREACH      = 0x10028,           // Network unreachable.
+        ENFILE           = 0x10029,           // Too many files open in system.
+        ENOBUFS          = 0x1002A,           // No buffer space available.
+        ENODEV           = 0x1002C,           // No such device.
+        ENOENT           = 0x1002D,           // No such file or directory.
+        ENOEXEC          = 0x1002E,           // Executable file format error.
+        ENOLCK           = 0x1002F,           // No locks available.
+        ENOLINK          = 0x10030,           // Reserved.
+        ENOMEM           = 0x10031,           // Not enough space.
+        ENOMSG           = 0x10032,           // No message of the desired type.
+        ENOPROTOOPT      = 0x10033,           // Protocol not available.
+        ENOSPC           = 0x10034,           // No space left on device.
+        ENOSYS           = 0x10037,           // Function not supported.
+        ENOTCONN         = 0x10038,           // The socket is not connected.
+        ENOTDIR          = 0x10039,           // Not a directory or a symbolic link to a directory.
+        ENOTEMPTY        = 0x1003A,           // Directory not empty.
+        ENOTSOCK         = 0x1003C,           // Not a socket.
+        ENOTSUP          = 0x1003D,           // Not supported (same value as EOPNOTSUP).
+        ENOTTY           = 0x1003E,           // Inappropriate I/O control operation.
+        ENXIO            = 0x1003F,           // No such device or address.
+        EOVERFLOW        = 0x10040,           // Value too large to be stored in data type.
+        EPERM            = 0x10042,           // Operation not permitted.
+        EPIPE            = 0x10043,           // Broken pipe.
+        EPROTO           = 0x10044,           // Protocol error.
+        EPROTONOSUPPORT  = 0x10045,           // Protocol not supported.
+        EPROTOTYPE       = 0x10046,           // Protocol wrong type for socket.
+        ERANGE           = 0x10047,           // Result too large.
+        EROFS            = 0x10048,           // Read-only file system.
+        ESPIPE           = 0x10049,           // Invalid seek.
+        ESRCH            = 0x1004A,           // No such process.
+        ESTALE           = 0x1004B,           // Reserved.
+        ETIMEDOUT        = 0x1004D,           // Connection timed out.
+        ETXTBSY          = 0x1004E,           // Text file busy.
+        EXDEV            = 0x1004F,           // Cross-device link.
+        ESOCKTNOSUPPORT  = 0x1005E,           // Socket type not supported.
+        EPFNOSUPPORT     = 0x10060,           // Protocol family not supported.
+        ESHUTDOWN        = 0x1006C,           // Socket shutdown.
+        EHOSTDOWN        = 0x10070,           // Host is down.
+        ENODATA          = 0x10071,           // No data available.
+
+        // POSIX permits these to have the same value and we make them always equal so
+        // that CoreFX cannot introduce a dependency on distinguishing between them that
+        // would not work on all platforms.
+        EOPNOTSUPP      = ENOTSUP,            // Operation not supported on socket.
+        EWOULDBLOCK     = EAGAIN,             // Operation would block.
+    }
+
+
+    // Represents a platform-agnostic Error and underlying platform-specific errno
+    internal struct ErrorInfo
+    {
+        private Error _error;
+        private int _rawErrno;
+
+        internal ErrorInfo(int errno)
+        {
+            _error = Interop.Sys.ConvertErrorPlatformToPal(errno);
+            _rawErrno = errno;
+        }
+
+        internal ErrorInfo(Error error)
+        {
+            _error = error;
+            _rawErrno = -1;
+        }
+
+        internal Error Error
+        {
+            get { return _error; }
+        }
+
+        internal int RawErrno
+        {
+            get { return _rawErrno == -1 ? (_rawErrno = Interop.Sys.ConvertErrorPalToPlatform(_error)) : _rawErrno; }
+        }
+
+        internal string GetErrorMessage()
+        {
+            return Interop.Sys.StrError(RawErrno);
+        }
+
+        public override string ToString()
+        {
+            return string.Format(
+                "RawErrno: {0} Error: {1} GetErrorMessage: {2}", // No localization required; text is member names used for debugging purposes
+                RawErrno, Error, GetErrorMessage());
+        }
+    }
+
+    internal partial class Sys
+    {
+        internal static Error GetLastError()
+        {
+            return ConvertErrorPlatformToPal(Marshal.GetLastWin32Error());
+        }
+
+        internal static ErrorInfo GetLastErrorInfo()
+        {
+            return new ErrorInfo(Marshal.GetLastWin32Error());
+        }
+
+        internal static unsafe string StrError(int platformErrno)
+        {
+            int maxBufferLength = 1024; // should be long enough for most any UNIX error
+            byte* buffer = stackalloc byte[maxBufferLength];
+            byte* message = StrErrorR(platformErrno, buffer, maxBufferLength);
+
+            if (message == null)
+            {
+                // This means the buffer was not large enough, but still contains
+                // as much of the error message as possible and is guaranteed to
+                // be null-terminated. We're not currently resizing/retrying because
+                // maxBufferLength is large enough in practice, but we could do
+                // so here in the future if necessary.
+                message = buffer;
+            }
+
+            return Marshal.PtrToStringAnsi((IntPtr)message);
+        }
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConvertErrorPlatformToPal")]
+        internal static extern Error ConvertErrorPlatformToPal(int platformErrno);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConvertErrorPalToPlatform")]
+        internal static extern int ConvertErrorPalToPlatform(Error error);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_StrErrorR")]
+        private static unsafe extern byte* StrErrorR(int platformErrno, byte* buffer, int bufferSize);
+    }
+}
+
+// NOTE: extension method can't be nested inside Interop class.
+internal static class InteropErrorExtensions
+{
+    // Intended usage is e.g. Interop.Error.EFAIL.Info() for brevity
+    // vs. new Interop.ErrorInfo(Interop.Error.EFAIL) for synthesizing
+    // errors. Errors originated from the system should be obtained
+    // via GetLastErrorInfo(), not GetLastError().Info() as that will
+    // convert twice, which is not only inefficient but also lossy if
+    // we ever encounter a raw errno that no equivalent in the Error
+    // enum.
+    public static Interop.ErrorInfo Info(this Interop.Error error)
+    {
+        return new Interop.ErrorInfo(error);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/Interop.IOErrors.cs
+++ b/src/mscorlib/corefx/Interop/Unix/Interop.IOErrors.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    private static void ThrowExceptionForIoErrno(ErrorInfo errorInfo, string path, bool isDirectory, Func<ErrorInfo, ErrorInfo> errorRewriter)
+    {
+        Debug.Assert(errorInfo.Error != Error.SUCCESS);
+        Debug.Assert(errorInfo.Error != Error.EINTR, "EINTR errors should be handled by the native shim and never bubble up to managed code");
+
+        if (errorRewriter != null)
+        {
+            errorInfo = errorRewriter(errorInfo);
+        }
+
+        throw Interop.GetExceptionForIoErrno(errorInfo, path, isDirectory);
+    }
+
+    internal static void CheckIo(Error error, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+    {
+        if (error != Interop.Error.SUCCESS)
+        {
+            ThrowExceptionForIoErrno(error.Info(), path, isDirectory, errorRewriter);
+        }
+    }
+
+    /// <summary>
+    /// Validates the result of system call that returns greater than or equal to 0 on success
+    /// and less than 0 on failure, with errno set to the error code.
+    /// If the system call failed for any reason, an exception is thrown. Otherwise, the system call succeeded.
+    /// </summary>
+    /// <param name="result">The result of the system call.</param>
+    /// <param name="path">The path with which this error is associated.  This may be null.</param>
+    /// <param name="isDirectory">true if the <paramref name="path"/> is known to be a directory; otherwise, false.</param>
+    /// <param name="errorRewriter">Optional function to change an error code prior to processing it.</param>
+    /// <returns>
+    /// On success, returns the non-negative result long that was validated.
+    /// </returns>
+    internal static long CheckIo(long result, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+    {
+        if (result < 0)
+        {
+            ThrowExceptionForIoErrno(Sys.GetLastErrorInfo(), path, isDirectory, errorRewriter);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Validates the result of system call that returns greater than or equal to 0 on success
+    /// and less than 0 on failure, with errno set to the error code.
+    /// If the system call failed for any reason, an exception is thrown. Otherwise, the system call succeeded.
+    /// </summary>
+    /// <returns>
+    /// On success, returns the non-negative result int that was validated.
+    /// </returns>
+    internal static int CheckIo(int result, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+    {
+        CheckIo((long)result, path, isDirectory, errorRewriter);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Validates the result of system call that returns greater than or equal to 0 on success
+    /// and less than 0 on failure, with errno set to the error code.
+    /// If the system call failed for any reason, an exception is thrown. Otherwise, the system call succeeded.
+    /// </summary>
+    /// <returns>
+    /// On success, returns the non-negative result IntPtr that was validated.
+    /// </returns>
+    internal static IntPtr CheckIo(IntPtr result, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+    {
+        CheckIo((long)result, path, isDirectory, errorRewriter);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Validates the result of system call that returns greater than or equal to 0 on success
+    /// and less than 0 on failure, with errno set to the error code.
+    /// If the system call failed for any reason, an exception is thrown. Otherwise, the system call succeeded.
+    /// </summary>
+    /// <returns>
+    /// On success, returns the valid SafeFileHandle that was validated.
+    /// </returns>
+    internal static TSafeHandle CheckIo<TSafeHandle>(TSafeHandle handle, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+        where TSafeHandle : SafeHandle
+    {
+        if (handle.IsInvalid)
+        {
+            ThrowExceptionForIoErrno(Sys.GetLastErrorInfo(), path, isDirectory, errorRewriter);
+        }
+
+        return handle;
+    }
+
+    /// <summary>
+    /// Gets an Exception to represent the supplied error info.
+    /// </summary>
+    /// <param name="error">The error info</param>
+    /// <param name="path">The path with which this error is associated.  This may be null.</param>
+    /// <param name="isDirectory">true if the <paramref name="path"/> is known to be a directory; otherwise, false.</param>
+    /// <returns></returns>
+    internal static Exception GetExceptionForIoErrno(ErrorInfo errorInfo, string path = null, bool isDirectory = false)
+    {
+        // Translate the errno into a known set of exception types.  For cases where multiple errnos map
+        // to the same exception type, include an inner exception with the details.
+        switch (errorInfo.Error)
+        {
+            case Error.ENOENT:
+                if (isDirectory)
+                {
+                    return !string.IsNullOrEmpty(path) ?
+                        new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, path)) :
+                        new DirectoryNotFoundException(SR.IO_PathNotFound_NoPathName);
+                }
+                else
+                {
+                    return !string.IsNullOrEmpty(path) ?
+                        new FileNotFoundException(SR.Format(SR.IO_FileNotFound_FileName, path), path) :
+                        new FileNotFoundException(SR.IO_FileNotFound);
+                }
+
+            case Error.EACCES:
+            case Error.EBADF:
+            case Error.EPERM:
+                Exception inner = GetIOException(errorInfo);
+                return !string.IsNullOrEmpty(path) ?
+                    new UnauthorizedAccessException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, path), inner) :
+                    new UnauthorizedAccessException(SR.UnauthorizedAccess_IODenied_NoPathName, inner);
+
+            case Error.ENAMETOOLONG:
+                return new PathTooLongException(SR.IO_PathTooLong);
+
+            case Error.EWOULDBLOCK:
+                return !string.IsNullOrEmpty(path) ?
+                    new IOException(SR.Format(SR.IO_SharingViolation_File, path), errorInfo.RawErrno) :
+                    new IOException(SR.IO_SharingViolation_NoFileName, errorInfo.RawErrno);
+
+            case Error.ECANCELED:
+                return new OperationCanceledException();
+
+            case Error.EFBIG:
+                return new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_FileLengthTooBig);
+
+            case Error.EEXIST:
+                if (!string.IsNullOrEmpty(path))
+                {
+                    return new IOException(SR.Format(SR.IO_FileExists_Name, path), errorInfo.RawErrno);
+                }
+                goto default;
+
+            default:
+                return GetIOException(errorInfo);
+        }
+    }
+
+    internal static Exception GetIOException(Interop.ErrorInfo errorInfo)
+    {
+        return new IOException(errorInfo.GetErrorMessage(), errorInfo.RawErrno);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/Interop.Libraries.cs
+++ b/src/mscorlib/corefx/Interop/Unix/Interop.Libraries.cs
@@ -7,5 +7,12 @@ internal static partial class Interop
     private static partial class Libraries
     {
         internal const string GlobalizationInterop = "System.Globalization.Native"; // CoreFX wrappers for ICU
+        // Shims
+        internal const string SystemNative = "System.Native";
+        internal const string HttpNative = "System.Net.Http.Native";
+        internal const string NetSecurityNative = "System.Net.Security.Native";
+        internal const string CryptoNative = "System.Security.Cryptography.Native.OpenSsl";
+        internal const string GlobalizationNative = "System.Globalization.Native";
+        internal const string CompressionNative = "System.IO.Compression.Native";
     }
 }

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Close.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Close.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Close", SetLastError = true)]
+        internal static extern int Close(IntPtr fd);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.FLock.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.FLock.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal enum LockOperations : int
+        {
+            LOCK_SH = 1,    /* shared lock */
+            LOCK_EX = 2,    /* exclusive lock */
+            LOCK_NB = 4,    /* don't block when locking*/
+            LOCK_UN = 8,    /* unlock */
+        }
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FLock", SetLastError = true)]
+        internal static extern int FLock(SafeFileHandle fd, LockOperations operation);
+
+        /// <summary>
+        /// Exposing this for SafeFileHandle.ReleaseHandle() to call.
+        /// Normal callers should use FLock(SafeFileHandle fd).
+        /// </summary>
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FLock", SetLastError = true)]
+        internal static extern int FLock(IntPtr fd, LockOperations operation);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.FSync.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.FSync.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FSync", SetLastError = true)]
+        internal static extern int FSync(SafeFileHandle fd);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.FTruncate.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.FTruncate.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FTruncate", SetLastError = true)]
+        internal static extern int FTruncate(SafeFileHandle fd, long length);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.LSeek.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.LSeek.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal enum SeekWhence
+        {
+            SEEK_SET = 0,
+            SEEK_CUR = 1,
+            SEEK_END = 2
+        }
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LSeek", SetLastError = true)]
+        internal static extern long LSeek(SafeFileHandle fd, long offset, SeekWhence whence);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Open.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Open.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Open", SetLastError = true)]
+        internal static extern SafeFileHandle Open(string filename, OpenFlags flags, int mode);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.OpenFlags.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.OpenFlags.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [Flags]
+        internal enum OpenFlags
+        {
+            // Access modes (mutually exclusive)
+            O_RDONLY = 0x0000,
+            O_WRONLY = 0x0001,
+            O_RDWR   = 0x0002,
+
+            // Flags (combinable)
+            O_CLOEXEC = 0x0010,
+            O_CREAT   = 0x0020,
+            O_EXCL    = 0x0040,
+            O_TRUNC   = 0x0080,
+            O_SYNC    = 0x0100,
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Permissions.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Permissions.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [Flags]
+        internal enum Permissions
+        {
+            Mask = S_IRWXU | S_IRWXG | S_IRWXO,
+
+            S_IRWXU = S_IRUSR | S_IWUSR | S_IXUSR,
+            S_IRUSR = 0x100,
+            S_IWUSR = 0x80,
+            S_IXUSR = 0x40,
+
+            S_IRWXG = S_IRGRP | S_IWGRP | S_IXGRP,
+            S_IRGRP = 0x20,
+            S_IWGRP = 0x10,
+            S_IXGRP = 0x8,
+
+            S_IRWXO = S_IROTH | S_IWOTH | S_IXOTH,
+            S_IROTH = 0x4,
+            S_IWOTH = 0x2,
+            S_IXOTH = 0x1,
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.PosixFAdvise.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.PosixFAdvise.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal enum FileAdvice : int
+        {
+            POSIX_FADV_NORMAL       = 0,    /* no special advice, the default value */
+            POSIX_FADV_RANDOM       = 1,    /* random I/O access */
+            POSIX_FADV_SEQUENTIAL   = 2,    /* sequential I/O access */
+            POSIX_FADV_WILLNEED     = 3,    /* will need specified pages */
+            POSIX_FADV_DONTNEED     = 4,    /* don't need the specified pages */
+            POSIX_FADV_NOREUSE      = 5,    /* data will only be acessed once */
+        }
+
+        /// <summary>
+        /// Notifies the OS kernel that the specified file will be accessed in a particular way soon; this allows the kernel to
+        /// potentially optimize the access pattern of the file.
+        /// </summary>
+        /// <param name="fd">The file descriptor of the file</param>
+        /// <param name="offset">The start of the region to advise about</param>
+        /// <param name="length">The number of bytes of the region (until the end of the file if 0)</param>
+        /// <param name="advice">The type of advice to give the kernel about the specified region</param>
+        /// <returns>
+        /// Returns 0 on success; otherwise, the error code is returned
+        /// </returns>
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PosixFAdvise", SetLastError = false /* this is explicitly called out in the man page */)]
+        internal static extern int PosixFAdvise(SafeFileHandle fd, long offset, long length, FileAdvice advice);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Read.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Read.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        /// <summary>
+        /// Reads a number of bytes from an open file descriptor into a specified buffer.
+        /// </summary>
+        /// <param name="fd">The open file descriptor to try to read from</param>
+        /// <param name="buffer">The buffer to read info into</param>
+        /// <param name="count">The size of the buffer</param>
+        /// <returns>
+        /// Returns the number of bytes read on success; otherwise, -1 is returned
+        /// Note - on fail. the position of the stream may change depending on the platform; consult man 2 read for more info
+        /// </returns>
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Read", SetLastError = true)]
+        internal static unsafe extern int Read(SafeFileHandle fd, byte* buffer, int count);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Stat.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Stat.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        // Even though csc will by default use a sequential layout, a CS0649 warning as error
+        // is produced for un-assigned fields when no StructLayout is specified.
+        //
+        // Explicitly saying Sequential disables that warning/error for consumers which only
+        // use Stat in debug builds.
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct FileStatus
+        {
+            internal FileStatusFlags Flags;
+            internal int Mode;
+            internal uint Uid;
+            internal uint Gid;
+            internal long Size;
+            internal long ATime;
+            internal long MTime;
+            internal long CTime;
+            internal long BirthTime;
+        }
+
+        internal static class FileTypes
+        {
+            internal const int S_IFMT = 0xF000;
+            internal const int S_IFIFO = 0x1000;
+            internal const int S_IFCHR = 0x2000;
+            internal const int S_IFDIR = 0x4000;
+            internal const int S_IFREG = 0x8000;
+            internal const int S_IFLNK = 0xA000;
+            internal const int S_IFSOCK = 0xC000;
+        }
+
+        [Flags]
+        internal enum FileStatusFlags
+        {
+            None = 0,
+            HasBirthTime = 1,
+        }
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat", SetLastError = true)]
+        internal static extern int FStat(SafeFileHandle fd, out FileStatus output);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat", SetLastError = true)]
+        internal static extern int Stat(string path, out FileStatus output);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat", SetLastError = true)]
+        internal static extern int LStat(string path, out FileStatus output);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Unlink.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Unlink.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Unlink", SetLastError = true)]
+        internal static extern int Unlink(string pathname);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Write.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Write.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        /// <summary>
+        /// Writes the specified buffer to the provided open file descriptor
+        /// </summary>
+        /// <param name="fd">The file descriptor to try and write to</param>
+        /// <param name="buffer">The data to attempt to write</param>
+        /// <param name="bufferSize">The amount of data to write, in bytes</param>
+        /// <returns>
+        /// Returns the number of bytes written on success; otherwise, returns -1 and sets errno
+        /// </returns>
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
+        internal static unsafe extern int Write(SafeFileHandle fd, byte* buffer, int bufferSize);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
+        internal static unsafe extern int Write(int fd, byte* buffer, int bufferSize);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/Interop.BOOL.cs
+++ b/src/mscorlib/corefx/Interop/Windows/Interop.BOOL.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    /// <summary>
+    /// Blittable version of Windows BOOL type. It is convenient in situations where
+    /// manual marshalling is required, or to avoid overhead of regular bool marshalling.
+    /// </summary>
+    /// <remarks>
+    /// Some Windows APIs return arbitrary integer values although the return type is defined
+    /// as BOOL. It is best to never compare BOOL to TRUE. Always use bResult != BOOL.FALSE
+    /// or bResult == BOOL.FALSE .
+    /// </remarks>
+    internal enum BOOL : int
+    {
+        FALSE = 0,
+        TRUE = 1,
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/Interop.Libraries.cs
+++ b/src/mscorlib/corefx/Interop/Windows/Interop.Libraries.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static class Libraries
+    {
+        internal const string Advapi32 = "advapi32.dll";
+        internal const string BCrypt = "BCrypt.dll";
+        internal const string Combase = "combase.dll";
+        internal const string Console_L1 = "api-ms-win-core-console-l1-1-0.dll";
+        internal const string Console_L2 = "api-ms-win-core-console-l2-1-0.dll";
+        internal const string CoreFile_L1 = "api-ms-win-core-file-l1-1-0.dll";
+        internal const string CoreFile_L1_2 = "api-ms-win-core-file-l1-2-0.dll";
+        internal const string CoreFile_L2 = "api-ms-win-core-file-l2-1-0.dll";
+        internal const string Crypt32 = "crypt32.dll";
+        internal const string Debug = "api-ms-win-core-debug-l1-1-0.dll";
+        internal const string Error_L1 = "api-ms-win-core-winrt-error-l1-1-0.dll";
+        internal const string ErrorHandling = "api-ms-win-core-errorhandling-l1-1-0.dll";
+        internal const string Eventing = "api-ms-win-eventing-provider-l1-1-0.dll";
+        internal const string Handle = "api-ms-win-core-handle-l1-1-0.dll";
+        internal const string Heap = "api-ms-win-core-heap-obsolete-l1-1-0.dll";
+        internal const string Heap_L1 = "api-ms-win-core-heap-l1-1-0.dll";
+        internal const string IO = "api-ms-win-core-io-l1-1-0.dll";
+        internal const string IpHlpApi = "iphlpapi.dll";
+        internal const string Kernel32 = "kernel32.dll";
+        internal const string Kernel32_L1 = "api-ms-win-core-kernel32-legacy-l1-1-1.dll";
+        internal const string Kernel32_L2 = "api-ms-win-core-kernel32-legacy-l1-1-0.dll";
+        internal const string Keyboard = "ext-ms-win-ntuser-keyboard-l1-2-1.dll";
+        internal const string LibraryLoader = "api-ms-win-core-libraryloader-l1-1-0.dll";
+        internal const string Localization = "api-ms-win-core-localization-l1-2-0.dll";
+        internal const string Memory_L1_0 = "api-ms-win-core-memory-l1-1-0.dll";
+        internal const string Memory_L1_1 = "api-ms-win-core-memory-l1-1-1.dll";
+        internal const string Memory_L1_2 = "api-ms-win-core-memory-l1-1-2.dll";
+        internal const string Memory_L1_3 = "api-ms-win-core-memory-l1-1-3.dll";
+        internal const string NCrypt = "ncrypt.dll";
+        internal const string NtDll = "ntdll.dll";
+        internal const string OleAut32 = "oleaut32.dll";
+        internal const string Pipe = "api-ms-win-core-namedpipe-l1-1-0.dll";
+        internal const string Pipe_L2 = "api-ms-win-core-namedpipe-l1-2-1.dll";
+        internal const string ProcessEnvironment = "api-ms-win-core-processenvironment-l1-1-0.dll";
+        internal const string ProcessThread_L1 = "api-ms-win-core-processthreads-l1-1-0.dll";
+        internal const string ProcessThread_L1_1 = "api-ms-win-core-processthreads-l1-1-1.dll";
+        internal const string ProcessThread_L1_2 = "api-ms-win-core-processthreads-l1-1-2.dll";
+        internal const string ProcessTopology = "api-ms-win-core-processtopology-obsolete-l1-1-0.dll";
+        internal const string Profile = "api-ms-win-core-profile-l1-1-0.dll";
+        internal const string Psapi = "api-ms-win-core-psapi-l1-1-0.dll";
+        internal const string Psapi_Obsolete = "api-ms-win-core-psapi-obsolete-l1-1-0.dll";
+        internal const string Registry_L1 = "api-ms-win-core-registry-l1-1-0.dll";
+        internal const string Registry_L2 = "api-ms-win-core-registry-l2-1-0.dll";
+        internal const string RoBuffer = "api-ms-win-core-winrt-robuffer-l1-1-0.dll";
+        internal const string SecurityBase = "api-ms-win-security-base-l1-1-0.dll";
+        internal const string SecurityCpwl = "api-ms-win-security-cpwl-l1-1-0.dll";
+        internal const string SecurityCryptoApi = "api-ms-win-security-cryptoapi-l1-1-0.dll";
+        internal const string SecurityLsa = "api-ms-win-security-lsalookup-l2-1-0.dll";
+        internal const string SecurityLsaPolicy = "api-ms-win-security-lsapolicy-l1-1-0.dll";
+        internal const string SecurityProvider = "api-ms-win-security-provider-l1-1-0.dll";
+        internal const string SecuritySddl = "api-ms-win-security-sddl-l1-1-0.dll";
+        internal const string ServiceCore = "api-ms-win-service-core-l1-1-1.dll";
+        internal const string ServiceMgmt_L1 = "api-ms-win-service-management-l1-1-0.dll";
+        internal const string ServiceMgmt_L2 = "api-ms-win-service-management-l2-1-0.dll";
+        internal const string ServiceWinSvc = "api-ms-win-service-winsvc-l1-1-0.dll";
+        internal const string Shell = "shell32.dll";
+        internal const string ShellFolders = "ext-ms-win-shell32-shellfolders-l1-1-0.dll";
+        internal const string Sspi = "sspicli.dll";
+        internal const string String_L1 = "api-ms-win-core-string-l1-1-0.dll";
+        internal const string Synch = "api-ms-win-core-synch-l1-1-0.dll";
+        internal const string SystemInfo_L1_1 = "api-ms-win-core-sysinfo-l1-1-0.dll";
+        internal const string SystemInfo_L1_2 = "api-ms-win-core-sysinfo-l1-2-0.dll";
+        internal const string SystemInfo_L2_1 = "api-ms-win-core-sysinfo-l2-1-0.dll";
+        internal const string ThreadPool = "api-ms-win-core-threadpool-l1-2-0.dll";
+        internal const string User32 = "user32.dll";
+        internal const string Util = "api-ms-win-core-util-l1-1-0.dll";
+        internal const string Version = "api-ms-win-core-version-l1-1-0.dll";
+        internal const string WinHttp = "winhttp.dll";
+        internal const string Winsock = "Ws2_32.dll";
+        internal const string Wow64 = "api-ms-win-core-wow64-l1-1-0.dll";
+        internal const string Ws2_32 = "ws2_32.dll";
+        internal const string Zlib = "clrcompression.dll";
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.CancelIoEx.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.CancelIoEx.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.IO, SetLastError = true)]
+        internal static unsafe extern bool CancelIoEx(SafeHandle handle, NativeOverlapped* lpOverlapped);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.CloseHandle.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.CloseHandle.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.Handle, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool CloseHandle(IntPtr handle);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.CreateFile.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.CreateFile.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use CreateFile.
+        /// </summary>
+        [DllImport(Libraries.CoreFile_L1, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        private static extern SafeFileHandle CreateFilePrivate(
+            string lpFileName,
+            int dwDesiredAccess,
+            System.IO.FileShare dwShareMode,
+            [In] ref SECURITY_ATTRIBUTES securityAttrs,
+            System.IO.FileMode dwCreationDisposition,
+            int dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        internal static SafeFileHandle CreateFile(
+            string lpFileName,
+            int dwDesiredAccess,
+            System.IO.FileShare dwShareMode,
+            [In] ref SECURITY_ATTRIBUTES securityAttrs,
+            System.IO.FileMode dwCreationDisposition,
+            int dwFlagsAndAttributes,
+            IntPtr hTemplateFile)
+        {
+            lpFileName = PathInternal.EnsureExtendedPrefixOverMaxPath(lpFileName);
+            return CreateFilePrivate(lpFileName, dwDesiredAccess, dwShareMode, ref securityAttrs, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.Errors.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.Errors.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        internal partial class Errors
+        {
+            internal const int ERROR_SUCCESS = 0x0;
+            internal const int ERROR_INVALID_FUNCTION = 0x1;
+            internal const int ERROR_FILE_NOT_FOUND = 0x2;
+            internal const int ERROR_PATH_NOT_FOUND = 0x3;
+            internal const int ERROR_ACCESS_DENIED = 0x5;
+            internal const int ERROR_INVALID_HANDLE = 0x6;
+            internal const int ERROR_NOT_ENOUGH_MEMORY = 0x8;
+            internal const int ERROR_INVALID_DATA = 0xD;
+            internal const int ERROR_INVALID_DRIVE = 0xF;
+            internal const int ERROR_NO_MORE_FILES = 0x12;
+            internal const int ERROR_NOT_READY = 0x15;
+            internal const int ERROR_BAD_LENGTH = 0x18;
+            internal const int ERROR_SHARING_VIOLATION = 0x20;
+            internal const int ERROR_LOCK_VIOLATION = 0x21;
+            internal const int ERROR_HANDLE_EOF = 0x26;
+            internal const int ERROR_FILE_EXISTS = 0x50;
+            internal const int ERROR_INVALID_PARAMETER = 0x57;
+            internal const int ERROR_BROKEN_PIPE = 0x6D;
+            internal const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
+            internal const int ERROR_INVALID_NAME = 0x7B;
+            internal const int ERROR_NEGATIVE_SEEK = 0x83;
+            internal const int ERROR_DIR_NOT_EMPTY = 0x91;
+            internal const int ERROR_BAD_PATHNAME = 0xA1;
+            internal const int ERROR_LOCK_FAILED = 0xA7;
+            internal const int ERROR_BUSY = 0xAA;
+            internal const int ERROR_ALREADY_EXISTS = 0xB7;
+            internal const int ERROR_BAD_EXE_FORMAT = 0xC1;
+            internal const int ERROR_ENVVAR_NOT_FOUND = 0xCB;
+            internal const int ERROR_FILENAME_EXCED_RANGE = 0xCE;
+            internal const int ERROR_EXE_MACHINE_TYPE_MISMATCH = 0xD8;
+            internal const int ERROR_PIPE_BUSY = 0xE7;
+            internal const int ERROR_NO_DATA = 0xE8;
+            internal const int ERROR_PIPE_NOT_CONNECTED = 0xE9;
+            internal const int ERROR_MORE_DATA = 0xEA;
+            internal const int ERROR_NO_MORE_ITEMS = 0x103;
+            internal const int ERROR_PARTIAL_COPY = 0x12B;
+            internal const int ERROR_ARITHMETIC_OVERFLOW = 0x216;
+            internal const int ERROR_PIPE_CONNECTED = 0x217;
+            internal const int ERROR_PIPE_LISTENING = 0x218;
+            internal const int ERROR_OPERATION_ABORTED = 0x3E3;
+            internal const int ERROR_IO_PENDING = 0x3E5;
+            internal const int ERROR_NO_TOKEN = 0x3f0;
+            internal const int ERROR_DLL_INIT_FAILED = 0x45A;
+            internal const int ERROR_NOT_FOUND = 0x490;
+            internal const int ERROR_NON_ACCOUNT_SID = 0x4E9;
+            internal const int ERROR_NOT_ALL_ASSIGNED = 0x514;
+            internal const int ERROR_UNKNOWN_REVISION = 0x519;
+            internal const int ERROR_INVALID_OWNER = 0x51B;
+            internal const int ERROR_INVALID_PRIMARY_GROUP = 0x51C;
+            internal const int ERROR_NO_SUCH_PRIVILEGE = 0x521;
+            internal const int ERROR_PRIVILEGE_NOT_HELD = 0x522;
+            internal const int ERROR_INVALID_ACL = 0x538;
+            internal const int ERROR_INVALID_SECURITY_DESCR = 0x53A;
+            internal const int ERROR_INVALID_SID = 0x539;
+            internal const int ERROR_BAD_IMPERSONATION_LEVEL = 0x542;
+            internal const int ERROR_CANT_OPEN_ANONYMOUS = 0x543;
+            internal const int ERROR_NO_SECURITY_ON_OBJECT = 0x546;
+            internal const int ERROR_TRUSTED_RELATIONSHIP_FAILURE = 0x6FD;
+            internal const int ERROR_RESOURCE_LANG_NOT_FOUND = 0x717;
+            internal const int EFail = unchecked((int)0x80004005);
+            internal const int E_FILENOTFOUND = unchecked((int)0x80070002);
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.FileOperations.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.FileOperations.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        internal partial class IOReparseOptions
+        {
+            internal const uint IO_REPARSE_TAG_FILE_PLACEHOLDER = 0x80000015;
+            internal const uint IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003;
+        }
+
+        internal partial class FileOperations
+        {
+            internal const int OPEN_EXISTING = 3;
+            internal const int COPY_FILE_FAIL_IF_EXISTS = 0x00000001;
+
+            internal const int FILE_ACTION_ADDED = 1;
+            internal const int FILE_ACTION_REMOVED = 2;
+            internal const int FILE_ACTION_MODIFIED = 3;
+            internal const int FILE_ACTION_RENAMED_OLD_NAME = 4;
+            internal const int FILE_ACTION_RENAMED_NEW_NAME = 5;
+
+            internal const int FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+            internal const int FILE_FLAG_FIRST_PIPE_INSTANCE = 0x00080000;
+            internal const int FILE_FLAG_OVERLAPPED = 0x40000000;
+
+            internal const int FILE_LIST_DIRECTORY = 0x0001;
+        }
+
+        internal const uint SEM_FAILCRITICALERRORS = 1;
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.FileTypes.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.FileTypes.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        internal partial class FileTypes
+        {
+            internal const int FILE_TYPE_DISK = 0x0001;
+            internal const int FILE_TYPE_CHAR = 0x0002;
+            internal const int FILE_TYPE_PIPE = 0x0003;
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.FlushFileBuffers.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.FlushFileBuffers.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool FlushFileBuffers(SafeHandle hHandle);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.FormatMessage.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.FormatMessage.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        private const int FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
+        private const int FORMAT_MESSAGE_FROM_HMODULE = 0x00000800;
+        private const int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
+        private const int FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000;
+
+
+        private const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
+
+        [DllImport(Libraries.Localization, CharSet = CharSet.Unicode, EntryPoint = "FormatMessageW", SetLastError = true, BestFitMapping = true)]
+        private static extern int FormatMessage(
+            int dwFlags,
+            IntPtr lpSource,
+            uint dwMessageId,
+            int dwLanguageId,
+            [Out] StringBuilder lpBuffer,
+            int nSize,
+            IntPtr[] arguments);
+
+        /// <summary>
+        ///     Returns a string message for the specified Win32 error code.
+        /// </summary>
+        internal static string GetMessage(int errorCode)
+        {
+            return GetMessage(IntPtr.Zero, errorCode);
+        }
+
+        internal static string GetMessage(IntPtr moduleHandle, int errorCode)
+        {
+            var sb = new StringBuilder(InitialBufferSize);
+            do
+            {
+                string errorMsg;
+                if (TryGetErrorMessage(moduleHandle, errorCode, sb, out errorMsg))
+                {
+                    return errorMsg;
+                }
+                else
+                {
+                    // increase the capacity of the StringBuilder.
+                    sb.Capacity *= BufferSizeIncreaseFactor;
+                }
+            }
+            while (sb.Capacity < MaxAllowedBufferSize);
+
+            // If you come here then a size as large as 65K is also not sufficient and so we give the generic errorMsg.
+            return string.Format("Unknown error (0x{0:x})", errorCode);
+        }
+
+        private static bool TryGetErrorMessage(IntPtr moduleHandle, int errorCode, StringBuilder sb, out string errorMsg)
+        {
+            errorMsg = "";
+
+            int flags = FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ARGUMENT_ARRAY;
+            if (moduleHandle != IntPtr.Zero)
+            {
+                flags |= FORMAT_MESSAGE_FROM_HMODULE;
+            }
+
+            int result = FormatMessage(flags, moduleHandle, (uint)errorCode, 0, sb, sb.Capacity, null);
+            if (result != 0)
+            {
+                int i = sb.Length;
+                while (i > 0)
+                {
+                    char ch = sb[i - 1];
+                    if (ch > 32 && ch != '.') break;
+                    i--;
+                }
+                errorMsg = sb.ToString(0, i);
+            }
+            else if (Marshal.GetLastWin32Error() == ERROR_INSUFFICIENT_BUFFER)
+            {
+                return false;
+            }
+            else
+            {
+                errorMsg = string.Format("Unknown error (0x{0:x})", errorCode);
+            }
+
+            return true;
+        }
+
+        // Windows API FormatMessage lets you format a message string given an errorcode.
+        // Unlike other APIs this API does not support a way to query it for the total message size.
+        //
+        // So the API can only be used in one of these two ways.
+        // a. You pass a buffer of appropriate size and get the resource.
+        // b. Windows creates a buffer and passes the address back and the onus of releasing the buffer lies on the caller.
+        //
+        // Since the error code is coming from the user, it is not possible to know the size in advance.
+        // Unfortunately we can't use option b. since the buffer can only be freed using LocalFree and it is a private API on onecore.
+        // Also, using option b is ugly for the managed code and could cause memory leak in situations where freeing is unsuccessful.
+        // 
+        // As a result we use the following approach.
+        // We initially call the API with a buffer size of 256 and then gradually increase the size in case of failure until we reach the maximum allowed limit of 65K.
+        private const int InitialBufferSize = 256;
+        private const int BufferSizeIncreaseFactor = 4;
+        private const int MaxAllowedBufferSize = 65 * 1024;
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.GetFileInformationByHandleEx.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.GetFileInformationByHandleEx.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L2, SetLastError = true)]
+        internal static extern bool GetFileInformationByHandleEx(SafeFileHandle hFile, FILE_INFO_BY_HANDLE_CLASS FileInformationClass, out FILE_STANDARD_INFO lpFileInformation, uint dwBufferSize);
+
+        internal partial struct FILE_STANDARD_INFO
+        {
+            internal long AllocationSize;
+            internal long EndOfFile;
+            internal uint NumberOfLinks;
+            internal BOOL DeletePending;
+            internal BOOL Directory;
+        }
+
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.GetFileType_SafeHandle.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.GetFileType_SafeHandle.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal extern static int GetFileType(SafeHandle hFile);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.LockFile.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.LockFile.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal static extern bool LockFile(SafeFileHandle handle, int offsetLow, int offsetHigh, int countLow, int countHigh);
+
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal static extern bool UnlockFile(SafeFileHandle handle, int offsetLow, int offsetHigh, int countLow, int countHigh);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.ReadFile_SafeHandle_IntPtr.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.ReadFile_SafeHandle_IntPtr.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        unsafe internal static extern int ReadFile(
+            SafeHandle handle,
+            byte* bytes,
+            int numBytesToRead,
+            out int numBytesRead,
+            IntPtr mustBeZero);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.ReadFile_SafeHandle_NativeOverlapped.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.ReadFile_SafeHandle_NativeOverlapped.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        unsafe internal static extern int ReadFile(
+            SafeHandle handle,
+            byte* bytes,
+            int numBytesToRead,
+            IntPtr numBytesRead_mustBeZero,
+            NativeOverlapped* overlapped);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SECURITY_ATTRIBUTES.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SECURITY_ATTRIBUTES.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SECURITY_ATTRIBUTES
+        {
+            internal uint nLength;
+            internal IntPtr lpSecurityDescriptor;
+            internal BOOL bInheritHandle;
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SafeCreateFile.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SafeCreateFile.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        internal static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);  // WinBase.h
+
+        /// <summary>
+        /// Does not allow access to non-file devices. This disallows DOS devices like "con:", "com1:",
+        /// "lpt1:", etc.  Use this to avoid security problems, like allowing a web client asking a server
+        /// for "http://server/com1.aspx" and then causing a worker process to hang.
+        /// </summary>
+        [System.Security.SecurityCritical]  // auto-generated
+        internal static SafeFileHandle SafeCreateFile(
+            String lpFileName,
+            int dwDesiredAccess,
+            System.IO.FileShare dwShareMode,
+            ref Interop.mincore.SECURITY_ATTRIBUTES securityAttrs,
+            FileMode dwCreationDisposition,
+            int dwFlagsAndAttributes,
+            IntPtr hTemplateFile)
+        {
+            SafeFileHandle handle = UnsafeCreateFile(lpFileName, dwDesiredAccess, dwShareMode, ref securityAttrs, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+
+            if (!handle.IsInvalid)
+            {
+                int fileType = Interop.mincore.GetFileType(handle);
+                if (fileType != Interop.mincore.FileTypes.FILE_TYPE_DISK)
+                {
+                    handle.Dispose();
+                    throw new NotSupportedException(SR.NotSupported_FileStreamOnNonFiles);
+                }
+            }
+
+            return handle;
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SecurityOptions.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SecurityOptions.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        internal partial class SecurityOptions
+        {
+            internal const int SECURITY_SQOS_PRESENT = 0x00100000;
+            internal const int SECURITY_ANONYMOUS = 0 << 16;
+            internal const int SECURITY_IDENTIFICATION = 1 << 16;
+            internal const int SECURITY_IMPERSONATION = 2 << 16;
+            internal const int SECURITY_DELEGATION = 3 << 16;
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SetEndOfFile.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SetEndOfFile.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal static extern bool SetEndOfFile(SafeFileHandle hFile);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SetErrorMode.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SetErrorMode.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.ErrorHandling, SetLastError = false, EntryPoint = "SetErrorMode", ExactSpelling = true)]
+        internal static extern uint SetErrorMode(uint newMode);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SetFileInformationByHandle.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SetFileInformationByHandle.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal static extern bool SetFileInformationByHandle(SafeFileHandle hFile, FILE_INFO_BY_HANDLE_CLASS FileInformationClass, ref FILE_BASIC_INFO lpFileInformation, uint dwBufferSize);
+
+        // Default values indicate "no change".  Use defaults so that we don't force callsites to be aware of the default values
+        internal unsafe static bool SetFileTime(
+            SafeFileHandle hFile,
+            long creationTime = -1,
+            long lastAccessTime = -1,
+            long lastWriteTime = -1,
+            long changeTime = -1,
+            uint fileAttributes = 0)
+        {
+            FILE_BASIC_INFO basicInfo = new FILE_BASIC_INFO()
+            {
+                CreationTime = creationTime,
+                LastAccessTime = lastAccessTime,
+                LastWriteTime = lastWriteTime,
+                ChangeTime = changeTime,
+                FileAttributes = fileAttributes
+            };
+
+            return SetFileInformationByHandle(hFile, FILE_INFO_BY_HANDLE_CLASS.FileBasicInfo, ref basicInfo, (uint)Marshal.SizeOf<FILE_BASIC_INFO>());
+        }
+
+        internal struct FILE_BASIC_INFO
+        {
+            internal long CreationTime;
+            internal long LastAccessTime;
+            internal long LastWriteTime;
+            internal long ChangeTime;
+            internal uint FileAttributes;
+        }
+
+        internal enum FILE_INFO_BY_HANDLE_CLASS : uint
+        {
+            FileBasicInfo = 0x0u,
+            FileStandardInfo = 0x1u,
+            FileNameInfo = 0x2u,
+            FileRenameInfo = 0x3u,
+            FileDispositionInfo = 0x4u,
+            FileAllocationInfo = 0x5u,
+            FileEndOfFileInfo = 0x6u,
+            FileStreamInfo = 0x7u,
+            FileCompressionInfo = 0x8u,
+            FileAttributeTagInfo = 0x9u,
+            FileIdBothDirectoryInfo = 0xAu,
+            FileIdBothDirectoryRestartInfo = 0xBu,
+            FileIoPriorityHintInfo = 0xCu,
+            FileRemoteProtocolInfo = 0xDu,
+            FileFullDirectoryInfo = 0xEu,
+            FileFullDirectoryRestartInfo = 0xFu,
+            FileStorageInfo = 0x10u,
+            FileAlignmentInfo = 0x11u,
+            FileIdInfo = 0x12u,
+            FileIdExtdDirectoryInfo = 0x13u,
+            FileIdExtdDirectoryRestartInfo = 0x14u,
+            MaximumFileInfoByHandleClass = 0x15u,
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SetFilePointerEx.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.SetFilePointerEx.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal static extern bool SetFilePointerEx(SafeFileHandle hFile, long liDistanceToMove, out long lpNewFilePointer, uint dwMoveMethod);
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.ThreadPoolIO.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.ThreadPoolIO.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class mincore
+    {
+        [DllImport(Libraries.ThreadPool, SetLastError = true)]
+        internal static unsafe extern SafeThreadPoolIOHandle CreateThreadpoolIo(SafeHandle fl, [MarshalAs(UnmanagedType.FunctionPtr)] NativeIoCompletionCallback pfnio, IntPtr context, IntPtr pcbe);
+
+        [DllImport(Libraries.ThreadPool)]
+        internal static unsafe extern void CloseThreadpoolIo(IntPtr pio);
+
+        [DllImport(Libraries.ThreadPool)]
+        internal static unsafe extern void StartThreadpoolIo(SafeThreadPoolIOHandle pio);
+
+        [DllImport(Libraries.ThreadPool)]
+        internal static unsafe extern void CancelThreadpoolIo(SafeThreadPoolIOHandle pio);
+    }
+
+    internal delegate void NativeIoCompletionCallback(IntPtr instance, IntPtr context, IntPtr overlapped, uint ioResult, UIntPtr numberOfBytesTransferred, IntPtr io);
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.UnsafeCreateFile.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.UnsafeCreateFile.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.Win32.SafeHandles;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        [System.Security.SecurityCritical]  // auto-generated
+        internal static SafeFileHandle UnsafeCreateFile(
+            string lpFileName,
+            int dwDesiredAccess,
+            FileShare dwShareMode,
+            ref Interop.mincore.SECURITY_ATTRIBUTES securityAttrs,
+            FileMode dwCreationDisposition,
+            int dwFlagsAndAttributes,
+            IntPtr hTemplateFile)
+        {
+            return CreateFile(lpFileName, dwDesiredAccess, dwShareMode, ref securityAttrs, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.WriteFile_SafeHandle_IntPtr.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.WriteFile_SafeHandle_IntPtr.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        // Note there are two different WriteFile prototypes - this is to use 
+        // the type system to force you to not trip across a "feature" in 
+        // Win32's async IO support.  You can't do the following three things
+        // simultaneously: overlapped IO, free the memory for the overlapped 
+        // struct in a callback (or an EndWrite method called by that callback),
+        // and pass in an address for the numBytesRead parameter.
+
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal static unsafe extern int WriteFile(SafeHandle handle, byte* bytes, int numBytesToWrite, out int numBytesWritten, IntPtr mustBeZero);
+
+    }
+}

--- a/src/mscorlib/corefx/Interop/Windows/mincore/Interop.WriteFile_SafeHandle_NativeOverlapped.cs
+++ b/src/mscorlib/corefx/Interop/Windows/mincore/Interop.WriteFile_SafeHandle_NativeOverlapped.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        // Note there are two different WriteFile prototypes - this is to use 
+        // the type system to force you to not trip across a "feature" in 
+        // Win32's async IO support.  You can't do the following three things
+        // simultaneously: overlapped IO, free the memory for the overlapped 
+        // struct in a callback (or an EndWrite method called by that callback),
+        // and pass in an address for the numBytesRead parameter.
+        [DllImport(Libraries.CoreFile_L1, SetLastError = true)]
+        internal static unsafe extern int WriteFile(SafeHandle handle, byte* bytes, int numBytesToWrite, IntPtr numBytesWritten_mustBeZero, NativeOverlapped* lpOverlapped);
+    }
+}

--- a/src/mscorlib/corefx/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/mscorlib/corefx/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    [System.Security.SecurityCritical]
+    public sealed class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        /// <summary>A handle value of -1.</summary>
+        private static readonly IntPtr s_invalidHandle = new IntPtr(-1);
+
+        private SafeFileHandle() : this(ownsHandle: true)
+        {
+        }
+
+        private SafeFileHandle(bool ownsHandle)
+            : base(ownsHandle)
+        {
+            SetHandle(s_invalidHandle);
+        }
+
+        public SafeFileHandle(IntPtr preexistingHandle, bool ownsHandle) : this(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
+        internal bool? IsAsync { get; set; }
+
+        /// <summary>Opens the specified file with the requested flags and mode.</summary>
+        /// <param name="path">The path to the file.</param>
+        /// <param name="flags">The flags with which to open the file.</param>
+        /// <param name="mode">The mode for opening the file.</param>
+        /// <returns>A SafeFileHandle for the opened file.</returns>
+        internal static SafeFileHandle Open(string path, Interop.Sys.OpenFlags flags, int mode)
+        {
+            Debug.Assert(path != null);
+
+            // If we fail to open the file due to a path not existing, we need to know whether to blame
+            // the file itself or its directory.  If we're creating the file, then we blame the directory,
+            // otherwise we blame the file.
+            bool enoentDueToDirectory = (flags & Interop.Sys.OpenFlags.O_CREAT) != 0;
+
+            // Open the file. 
+            SafeFileHandle handle = Interop.CheckIo(
+                Interop.Sys.Open(path, flags, mode),
+                path, 
+                isDirectory: enoentDueToDirectory,
+                errorRewriter: e => (e.Error == Interop.Error.EISDIR) ? Interop.Error.EACCES.Info() : e);
+
+            // Make sure it's not a directory; we do this after opening it once we have a file descriptor 
+            // to avoid race conditions.
+            Interop.Sys.FileStatus status;
+            if (Interop.Sys.FStat(handle, out status) != 0)
+            {
+                handle.Dispose();
+                throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo(), path);
+            }
+            if ((status.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR)
+            {
+                handle.Dispose();
+                throw Interop.GetExceptionForIoErrno(Interop.Error.EACCES.Info(), path, isDirectory: true);
+            }
+
+            return handle;
+        }
+
+        /// <summary>Opens a SafeFileHandle for a file descriptor created by a provided delegate.</summary>
+        /// <param name="fdFunc">
+        /// The function that creates the file descriptor. Returns the file descriptor on success, or an invalid
+        /// file descriptor on error with Marshal.GetLastWin32Error() set to the error code.
+        /// </param>
+        /// <returns>The created SafeFileHandle.</returns>
+        internal static SafeFileHandle Open(Func<SafeFileHandle> fdFunc)
+        {
+            SafeFileHandle handle = Interop.CheckIo(fdFunc());
+
+            Debug.Assert(!handle.IsInvalid, "File descriptor is invalid");
+            return handle;
+        }
+
+        [System.Security.SecurityCritical]
+        protected override bool ReleaseHandle()
+        {
+            // When the SafeFileHandle was opened, we likely issued an flock on the created descriptor in order to add 
+            // an advisory lock.  This lock should be removed via closing the file descriptor, but close can be
+            // interrupted, and we don't retry closes.  As such, we could end up leaving the file locked,
+            // which could prevent subsequent usage of the file until this process dies.  To avoid that, we proactively
+            // try to release the lock before we close the handle. (If it's not locked, there's no behavioral
+            // problem trying to unlock it.)
+            Interop.Sys.FLock(handle, Interop.Sys.LockOperations.LOCK_UN); // ignore any errors
+
+            // Close the descriptor. Although close is documented to potentially fail with EINTR, we never want
+            // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
+            // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
+            int result = Interop.Sys.Close(handle);
+#if DEBUG
+            if (result != 0)
+            {
+                Debug.Fail(string.Format(
+                    "Close failed with result {0} and error {1}", 
+                    result, Interop.Sys.GetLastErrorInfo()));
+            }
+#endif
+            return result == 0;
+        }
+
+        public override bool IsInvalid
+        {
+            [System.Security.SecurityCritical]
+            get
+            {
+                long h = (long)handle;
+                return h < 0 || h > int.MaxValue;
+            }
+        }
+    }
+}

--- a/src/mscorlib/corefx/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/mscorlib/corefx/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.Win32;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    [System.Security.SecurityCritical]  // auto-generated_required
+    public sealed class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        private bool? _isAsync;
+
+        private SafeFileHandle() : base(true)
+        {
+            _isAsync = null;
+        }
+
+        public SafeFileHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+
+            _isAsync = null;
+        }
+
+        internal bool? IsAsync
+        {
+            get
+            {
+                return _isAsync;
+            }
+
+            set
+            {
+                _isAsync = value;
+            }
+        }
+
+        internal ThreadPoolBoundHandle ThreadPoolBinding { get; set; }
+
+        [System.Security.SecurityCritical]
+        override protected bool ReleaseHandle()
+        {
+            return Interop.mincore.CloseHandle(handle);
+        }
+    }
+}
+

--- a/src/mscorlib/corefx/Microsoft/Win32/SafeHandles/SafeThreadPoolIOHandle.cs
+++ b/src/mscorlib/corefx/Microsoft/Win32/SafeHandles/SafeThreadPoolIOHandle.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal class SafeThreadPoolIOHandle : SafeHandle
+    {
+        private SafeThreadPoolIOHandle() 
+            : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid
+        {
+            get { return handle == IntPtr.Zero; }
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.mincore.CloseThreadpoolIo(handle);
+            return true;
+        }
+    }
+}

--- a/src/mscorlib/corefx/SR.cs
+++ b/src/mscorlib/corefx/SR.cs
@@ -1,6 +1,7 @@
 using System;
+using System.Globalization;
 
-namespace System.Globalization
+namespace System
 {
     internal static class SR
     {
@@ -287,6 +288,211 @@ namespace System.Globalization
         public static string Serialization_MemberOutOfRange
         {
             get { return Environment.GetResourceString("Serialization_MemberOutOfRange"); }
+        }
+
+        public static string Arg_InvalidHandle
+        {
+            get { return Environment.GetResourceString("Arg_InvalidHandle"); }
+        }
+
+        public static string ObjectDisposed_FileClosed
+        {
+            get { return Environment.GetResourceString("ObjectDisposed_FileClosed"); }
+        }
+
+        public static string Arg_HandleNotAsync
+        {
+            get { return Environment.GetResourceString("Arg_HandleNotAsync"); }
+        }
+
+        public static string ArgumentNull_Path
+        {
+            get { return Environment.GetResourceString("ArgumentNull_Path"); }
+        }
+
+        public static string Argument_EmptyPath
+        {
+            get { return Environment.GetResourceString("Argument_EmptyPath"); }
+        }
+
+        public static string Argument_InvalidFileModeAndAccessCombo
+        {
+            get { return Environment.GetResourceString("Argument_InvalidFileMode&AccessCombo"); }
+        }
+
+        public static string Argument_InvalidAppendMode
+        {
+            get { return Environment.GetResourceString("Argument_InvalidAppendMode"); }
+        }
+
+        public static string ArgumentNull_Buffer
+        {
+            get { return Environment.GetResourceString("ArgumentNull_Buffer"); }
+        }
+
+        public static string Argument_InvalidOffLen
+        {
+            get { return Environment.GetResourceString("Argument_InvalidOffLen"); }
+        }
+
+        public static string IO_UnknownFileName
+        {
+            get { return Environment.GetResourceString("IO_UnknownFileName"); }
+        }
+
+        public static string IO_FileStreamHandlePosition
+        {
+            get { return Environment.GetResourceString("IO.IO_FileStreamHandlePosition"); }
+        }
+
+        public static string NotSupported_FileStreamOnNonFiles
+        {
+            get { return Environment.GetResourceString("NotSupported_FileStreamOnNonFiles"); }
+        }
+
+        public static string IO_BindHandleFailed
+        {
+            get { return Environment.GetResourceString("IO.IO_BindHandleFailed"); }
+        }
+
+        public static string Arg_HandleNotSync
+        {
+            get { return Environment.GetResourceString("Arg_HandleNotSync"); }
+        }
+
+        public static string IO_SetLengthAppendTruncate
+        {
+            get { return Environment.GetResourceString("IO.IO_SetLengthAppendTruncate"); }
+        }
+
+        public static string ArgumentOutOfRange_FileLengthTooBig
+        {
+            get { return Environment.GetResourceString("ArgumentOutOfRange_FileLengthTooBig"); }
+        }
+
+        public static string Argument_InvalidSeekOrigin
+        {
+            get { return Environment.GetResourceString("Argument_InvalidSeekOrigin"); }
+        }
+
+        public static string IO_SeekAppendOverwrite
+        {
+            get { return Environment.GetResourceString("IO.IO_SeekAppendOverwrite"); }
+        }
+
+        public static string IO_FileTooLongOrHandleNotSync
+        {
+            get { return Environment.GetResourceString("IO_FileTooLongOrHandleNotSync"); }
+        }
+
+        public static string IndexOutOfRange_IORaceCondition
+        {
+            get { return Environment.GetResourceString("IndexOutOfRange_IORaceCondition"); }
+        }
+
+        public static string IO_FileNotFound
+        {
+            get { return Environment.GetResourceString("IO.FileNotFound"); }
+        }
+
+        public static string IO_FileNotFound_FileName
+        {
+            get { return Environment.GetResourceString("IO.FileNotFound_FileName"); }
+        }
+
+        public static string IO_PathNotFound_NoPathName
+        {
+            get { return Environment.GetResourceString("IO.PathNotFound_NoPathName"); }
+        }
+
+        public static string IO_PathNotFound_Path
+        {
+            get { return Environment.GetResourceString("IO.PathNotFound_Path"); }
+        }
+
+        public static string UnauthorizedAccess_IODenied_NoPathName
+        {
+            get { return Environment.GetResourceString("UnauthorizedAccess_IODenied_NoPathName"); }
+        }
+
+        public static string UnauthorizedAccess_IODenied_Path
+        {
+            get { return Environment.GetResourceString("UnauthorizedAccess_IODenied_Path"); }
+        }
+
+        public static string IO_AlreadyExists_Name
+        {
+            get { return Environment.GetResourceString("IO.IO_AlreadyExists_Name"); }
+        }
+
+        public static string IO_PathTooLong
+        {
+            get { return Environment.GetResourceString("IO.PathTooLong"); }
+        }
+
+        public static string IO_SharingViolation_NoFileName
+        {
+            get { return Environment.GetResourceString("IO.IO_SharingViolation_NoFileName"); }
+        }
+
+        public static string IO_SharingViolation_File
+        {
+            get { return Environment.GetResourceString("IO.IO_SharingViolation_File"); }
+        }
+
+        public static string IO_FileExists_Name
+        {
+            get { return Environment.GetResourceString("IO.IO_FileExists_Name"); }
+        }
+
+        public static string NotSupported_UnwritableStream
+        {
+            get { return Environment.GetResourceString("NotSupported_UnwritableStream"); }
+        }
+
+        public static string NotSupported_UnreadableStream
+        {
+            get { return Environment.GetResourceString("NotSupported_UnreadableStream"); }
+        }
+
+        public static string NotSupported_UnseekableStream
+        {
+            get { return Environment.GetResourceString("NotSupported_UnseekableStream"); }
+        }
+
+        public static string IO_EOF_ReadBeyondEOF
+        {
+            get { return Environment.GetResourceString("IO.EOF_ReadBeyondEOF"); }
+        }
+
+        public static string Argument_InvalidHandle
+        {
+            get { return Environment.GetResourceString("Argument_InvalidHandle"); }
+        }
+
+        public static string Argument_AlreadyBoundOrSyncHandle
+        {
+            get { return Environment.GetResourceString("Argument_AlreadyBoundOrSyncHandle"); }
+        }
+
+        public static string Argument_PreAllocatedAlreadyAllocated
+        {
+            get { return Environment.GetResourceString("Argument_PreAllocatedAlreadyAllocated"); }
+        }
+
+        public static string Argument_NativeOverlappedAlreadyFree
+        {
+            get { return Environment.GetResourceString("Argument_NativeOverlappedAlreadyFree"); }
+        }
+
+        public static string Argument_NativeOverlappedWrongBoundHandle
+        {
+            get { return Environment.GetResourceString("Argument_NativeOverlappedWrongBoundHandle"); }
+        }
+
+        public static string InvalidOperation_NativeOverlappedReused
+        {
+            get { return Environment.GetResourceString("InvalidOperation_NativeOverlappedReused"); }
         }
 
         public static string Format(string formatString, params object[] args)

--- a/src/mscorlib/corefx/System/HResults.cs
+++ b/src/mscorlib/corefx/System/HResults.cs
@@ -1,0 +1,236 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//=============================================================================
+//
+//
+// Purpose: Define HResult constants. Every exception has one of these.
+//
+//
+//===========================================================================*/
+
+using System;
+
+namespace System
+{
+    // Note: FACILITY_URT is defined as 0x13 (0x8013xxxx).  Within that
+    // range, 0x1yyy is for Runtime errors (used for Security, Metadata, etc).
+    // In that subrange, 0x15zz and 0x16zz have been allocated for classlib-type 
+    // HResults. Also note that some of our HResults have to map to certain 
+    // COM HR's, etc.
+
+    // Another arbitrary decision...  Feel free to change this, as long as you
+    // renumber the HResults yourself (and update rexcep.h).
+    // Reflection will use 0x1600 -> 0x161f.  IO will use 0x1620 -> 0x163f.
+    // Security will use 0x1640 -> 0x165f
+
+    // There are HResults files in the IO, Remoting, Reflection & 
+    // Security/Util directories as well, so choose your HResults carefully.
+    internal static class HResults
+    {
+        internal const int APPMODEL_ERROR_NO_PACKAGE = unchecked((int)0x80073D54);
+        internal const int CLDB_E_FILE_CORRUPT = unchecked((int)0x8013110e);
+        internal const int CLDB_E_FILE_OLDVER = unchecked((int)0x80131107);
+        internal const int CLDB_E_INDEX_NOTFOUND = unchecked((int)0x80131124);
+        internal const int CLR_E_BIND_ASSEMBLY_NOT_FOUND = unchecked((int)0x80132004);
+        internal const int CLR_E_BIND_ASSEMBLY_PUBLIC_KEY_MISMATCH = unchecked((int)0x80132001);
+        internal const int CLR_E_BIND_ASSEMBLY_VERSION_TOO_LOW = unchecked((int)0x80132000);
+        internal const int CLR_E_BIND_TYPE_NOT_FOUND = unchecked((int)0x80132005);
+        internal const int CLR_E_BIND_UNRECOGNIZED_IDENTITY_FORMAT = unchecked((int)0x80132003);
+        internal const int COR_E_ABANDONEDMUTEX = unchecked((int)0x8013152D);
+        internal const int COR_E_AMBIGUOUSMATCH = unchecked((int)0x8000211D);
+        internal const int COR_E_APPDOMAINUNLOADED = unchecked((int)0x80131014);
+        internal const int COR_E_APPLICATION = unchecked((int)0x80131600);
+        internal const int COR_E_ARGUMENT = unchecked((int)0x80070057);
+        internal const int COR_E_ARGUMENTOUTOFRANGE = unchecked((int)0x80131502);
+        internal const int COR_E_ARITHMETIC = unchecked((int)0x80070216);
+        internal const int COR_E_ARRAYTYPEMISMATCH = unchecked((int)0x80131503);
+        internal const int COR_E_ASSEMBLYEXPECTED = unchecked((int)0x80131018);
+        internal const int COR_E_BADIMAGEFORMAT = unchecked((int)0x8007000B);
+        internal const int COR_E_CANNOTUNLOADAPPDOMAIN = unchecked((int)0x80131015);
+        internal const int COR_E_CODECONTRACTFAILED = unchecked((int)0x80131542);
+        internal const int COR_E_CONTEXTMARSHAL = unchecked((int)0x80131504);
+        internal const int COR_E_CUSTOMATTRIBUTEFORMAT = unchecked((int)0x80131605);
+        internal const int COR_E_DATAMISALIGNED = unchecked((int)0x80131541);
+        internal const int COR_E_DIVIDEBYZERO = unchecked((int)0x80020012); // DISP_E_DIVBYZERO
+        internal const int COR_E_DLLNOTFOUND = unchecked((int)0x80131524);
+        internal const int COR_E_DUPLICATEWAITOBJECT = unchecked((int)0x80131529);
+        internal const int COR_E_ENTRYPOINTNOTFOUND = unchecked((int)0x80131523);
+        internal const int COR_E_EXCEPTION = unchecked((int)0x80131500);
+        internal const int COR_E_EXECUTIONENGINE = unchecked((int)0x80131506);
+        internal const int COR_E_FIELDACCESS = unchecked((int)0x80131507);
+        internal const int COR_E_FIXUPSINEXE = unchecked((int)0x80131019);
+        internal const int COR_E_FORMAT = unchecked((int)0x80131537);
+        internal const int COR_E_INDEXOUTOFRANGE = unchecked((int)0x80131508);
+        internal const int COR_E_INSUFFICIENTEXECUTIONSTACK = unchecked((int)0x80131578);
+        internal const int COR_E_INVALIDCAST = unchecked((int)0x80004002);
+        internal const int COR_E_INVALIDCOMOBJECT = unchecked((int)0x80131527);
+        internal const int COR_E_INVALIDFILTERCRITERIA = unchecked((int)0x80131601);
+        internal const int COR_E_INVALIDOLEVARIANTTYPE = unchecked((int)0x80131531);
+        internal const int COR_E_INVALIDOPERATION = unchecked((int)0x80131509);
+        internal const int COR_E_INVALIDPROGRAM = unchecked((int)0x8013153a);
+        internal const int COR_E_KEYNOTFOUND = unchecked((int)0x80131577);
+        internal const int COR_E_LOADING_REFERENCE_ASSEMBLY = unchecked((int)0x80131058);
+        internal const int COR_E_MARSHALDIRECTIVE = unchecked((int)0x80131535);
+        internal const int COR_E_MEMBERACCESS = unchecked((int)0x8013151A);
+        internal const int COR_E_METHODACCESS = unchecked((int)0x80131510);
+        internal const int COR_E_MISSINGFIELD = unchecked((int)0x80131511);
+        internal const int COR_E_MISSINGMANIFESTRESOURCE = unchecked((int)0x80131532);
+        internal const int COR_E_MISSINGMEMBER = unchecked((int)0x80131512);
+        internal const int COR_E_MISSINGMETHOD = unchecked((int)0x80131513);
+        internal const int COR_E_MISSINGSATELLITEASSEMBLY = unchecked((int)0x80131536);
+        internal const int COR_E_MODULE_HASH_CHECK_FAILED = unchecked((int)0x80131039);
+        internal const int COR_E_MULTICASTNOTSUPPORTED = unchecked((int)0x80131514);
+        internal const int COR_E_NEWER_RUNTIME = unchecked((int)0x8013101b);
+        internal const int COR_E_NOTFINITENUMBER = unchecked((int)0x80131528);
+        internal const int COR_E_NOTSUPPORTED = unchecked((int)0x80131515);
+        internal const int COR_E_NULLREFERENCE = unchecked((int)0x80004003);
+        internal const int COR_E_OBJECTDISPOSED = unchecked((int)0x80131622);
+        internal const int COR_E_OPERATIONCANCELED = unchecked((int)0x8013153B);
+        internal const int COR_E_OUTOFMEMORY = unchecked((int)0x8007000E);
+        internal const int COR_E_OVERFLOW = unchecked((int)0x80131516);
+        internal const int COR_E_PLATFORMNOTSUPPORTED = unchecked((int)0x80131539);
+        internal const int COR_E_RANK = unchecked((int)0x80131517);
+        internal const int COR_E_REFLECTIONTYPELOAD = unchecked((int)0x80131602);
+        internal const int COR_E_REMOTING = unchecked((int)0x8013150b);
+        internal const int COR_E_RUNTIMEWRAPPED = unchecked((int)0x8013153e);
+        internal const int COR_E_SAFEARRAYRANKMISMATCH = unchecked((int)0x80131538);
+        internal const int COR_E_SAFEARRAYTYPEMISMATCH = unchecked((int)0x80131533);
+        internal const int COR_E_SECURITY = unchecked((int)0x8013150A);
+        internal const int COR_E_SERIALIZATION = unchecked((int)0x8013150C);
+        internal const int COR_E_SERVER = unchecked((int)0x8013150e);
+        internal const int COR_E_STACKOVERFLOW = unchecked((int)0x800703E9);
+        internal const int COR_E_SYNCHRONIZATIONLOCK = unchecked((int)0x80131518);
+        internal const int COR_E_SYSTEM = unchecked((int)0x80131501);
+        internal const int COR_E_TARGET = unchecked((int)0x80131603);
+        internal const int COR_E_TARGETINVOCATION = unchecked((int)0x80131604);
+        internal const int COR_E_TARGETPARAMCOUNT = unchecked((int)0x8002000e);
+        internal const int COR_E_THREADABORTED = unchecked((int)0x80131530);
+        internal const int COR_E_THREADINTERRUPTED = unchecked((int)0x80131519);
+        internal const int COR_E_THREADSTART = unchecked((int)0x80131525);
+        internal const int COR_E_THREADSTATE = unchecked((int)0x80131520);
+        internal const int COR_E_TIMEOUT = unchecked((int)0x80131505);
+        internal const int COR_E_TYPEACCESS = unchecked((int)0x80131543);
+        internal const int COR_E_TYPEINITIALIZATION = unchecked((int)0x80131534);
+        internal const int COR_E_TYPELOAD = unchecked((int)0x80131522);
+        internal const int COR_E_TYPEUNLOADED = unchecked((int)0x80131013);
+        internal const int COR_E_UNAUTHORIZEDACCESS = unchecked((int)0x80070005);
+        internal const int COR_E_VERIFICATION = unchecked((int)0x8013150D);
+        internal const int COR_E_WAITHANDLECANNOTBEOPENED = unchecked((int)0x8013152C);
+        internal const int CORSEC_E_CRYPTO = unchecked((int)0x80131430);
+        internal const int CORSEC_E_CRYPTO_UNEX_OPER = unchecked((int)0x80131431);
+        internal const int CORSEC_E_INVALID_IMAGE_FORMAT = unchecked((int)0x8013141d);
+        internal const int CORSEC_E_INVALID_PUBLICKEY = unchecked((int)0x8013141e);
+        internal const int CORSEC_E_INVALID_STRONGNAME = unchecked((int)0x8013141a);
+        internal const int CORSEC_E_MIN_GRANT_FAIL = unchecked((int)0x80131417);
+        internal const int CORSEC_E_MISSING_STRONGNAME = unchecked((int)0x8013141b);
+        internal const int CORSEC_E_NO_EXEC_PERM = unchecked((int)0x80131418);
+        internal const int CORSEC_E_POLICY_EXCEPTION = unchecked((int)0x80131416);
+        internal const int CORSEC_E_SIGNATURE_MISMATCH = unchecked((int)0x80131420);
+        internal const int CORSEC_E_XMLSYNTAX = unchecked((int)0x80131419);
+        internal const int CTL_E_DEVICEIOERROR = unchecked((int)0x800A0039);
+        internal const int CTL_E_DIVISIONBYZERO = unchecked((int)0x800A000B);
+        internal const int CTL_E_FILENOTFOUND = unchecked((int)0x800A0035);
+        internal const int CTL_E_OUTOFMEMORY = unchecked((int)0x800A0007);
+        internal const int CTL_E_OUTOFSTACKSPACE = unchecked((int)0x800A001C);
+        internal const int CTL_E_OVERFLOW = unchecked((int)0x800A0006);
+        internal const int CTL_E_PATHFILEACCESSERROR = unchecked((int)0x800A004B);
+        internal const int CTL_E_PATHNOTFOUND = unchecked((int)0x800A004C);
+        internal const int CTL_E_PERMISSIONDENIED = unchecked((int)0x800A0046);
+        internal const int E_ELEMENTNOTAVAILABLE = unchecked((int)0x802B001F);
+        internal const int E_ELEMENTNOTENABLED = unchecked((int)0x802B001E);
+        internal const int E_FAIL = unchecked((int)0x80004005);
+        internal const int E_HANDLE = unchecked((int)0x80070006);
+        internal const int E_ILLEGAL_DELEGATE_ASSIGNMENT = unchecked((int)0x80000018);
+        internal const int E_ILLEGAL_METHOD_CALL = unchecked((int)0x8000000E);
+        internal const int E_ILLEGAL_STATE_CHANGE = unchecked((int)0x8000000D);
+        internal const int E_INVALIDARG = unchecked((int)0x80070057);
+        internal const int E_LAYOUTCYCLE = unchecked((int)0x802B0014);
+        internal const int E_NOTIMPL = unchecked((int)0x80004001);
+        internal const int E_OUTOFMEMORY = unchecked((int)0x8007000E);
+        internal const int E_POINTER = unchecked((int)0x80004003L);
+        internal const int E_XAMLPARSEFAILED = unchecked((int)0x802B000A);
+        internal const int ERROR_BAD_EXE_FORMAT = unchecked((int)0x800700C1);
+        internal const int ERROR_BAD_NET_NAME = unchecked((int)0x80070043);
+        internal const int ERROR_BAD_NETPATH = unchecked((int)0x80070035);
+        internal const int ERROR_DISK_CORRUPT = unchecked((int)0x80070571);
+        internal const int ERROR_DLL_INIT_FAILED = unchecked((int)0x8007045A);
+        internal const int ERROR_DLL_NOT_FOUND = unchecked((int)0x80070485);
+        internal const int ERROR_EXE_MARKED_INVALID = unchecked((int)0x800700C0);
+        internal const int ERROR_FILE_CORRUPT = unchecked((int)0x80070570);
+        internal const int ERROR_FILE_INVALID = unchecked((int)0x800703EE);
+        internal const int ERROR_FILE_NOT_FOUND = unchecked((int)0x80070002);
+        internal const int ERROR_INVALID_DLL = unchecked((int)0x80070482);
+        internal const int ERROR_INVALID_NAME = unchecked((int)0x8007007B);
+        internal const int ERROR_INVALID_ORDINAL = unchecked((int)0x800700B6);
+        internal const int ERROR_INVALID_PARAMETER = unchecked((int)0x80070057);
+        internal const int ERROR_LOCK_VIOLATION = unchecked((int)0x80070021);
+        internal const int ERROR_MOD_NOT_FOUND = unchecked((int)0x8007007E);
+        internal const int ERROR_NO_UNICODE_TRANSLATION = unchecked((int)0x80070459);
+        internal const int ERROR_NOACCESS = unchecked((int)0x800703E6);
+        internal const int ERROR_NOT_READY = unchecked((int)0x80070015);
+        internal const int ERROR_OPEN_FAILED = unchecked((int)0x8007006E);
+        internal const int ERROR_PATH_NOT_FOUND = unchecked((int)0x80070003);
+        internal const int ERROR_SHARING_VIOLATION = unchecked((int)0x80070020);
+        internal const int ERROR_TOO_MANY_OPEN_FILES = unchecked((int)0x80070004);
+        internal const int ERROR_UNRECOGNIZED_VOLUME = unchecked((int)0x800703ED);
+        internal const int ERROR_WRONG_TARGET_NAME = unchecked((int)0x80070574);
+        internal const int FUSION_E_ASM_MODULE_MISSING = unchecked((int)0x80131042);
+        internal const int FUSION_E_CACHEFILE_FAILED = unchecked((int)0x80131052);
+        internal const int FUSION_E_CODE_DOWNLOAD_DISABLED = unchecked((int)0x80131048);
+        internal const int FUSION_E_HOST_GAC_ASM_MISMATCH = unchecked((int)0x80131050);
+        internal const int FUSION_E_INVALID_NAME = unchecked((int)0x80131047);
+        internal const int FUSION_E_INVALID_PRIVATE_ASM_LOCATION = unchecked((int)0x80131041);
+        internal const int FUSION_E_LOADFROM_BLOCKED = unchecked((int)0x80131051);
+        internal const int FUSION_E_PRIVATE_ASM_DISALLOWED = unchecked((int)0x80131044);
+        internal const int FUSION_E_REF_DEF_MISMATCH = unchecked((int)0x80131040);
+        internal const int FUSION_E_SIGNATURE_CHECK_FAILED = unchecked((int)0x80131045);
+        internal const int INET_E_CANNOT_CONNECT = unchecked((int)0x800C0004);
+        internal const int INET_E_CONNECTION_TIMEOUT = unchecked((int)0x800C000B);
+        internal const int INET_E_DATA_NOT_AVAILABLE = unchecked((int)0x800C0007);
+        internal const int INET_E_DOWNLOAD_FAILURE = unchecked((int)0x800C0008);
+        internal const int INET_E_OBJECT_NOT_FOUND = unchecked((int)0x800C0006);
+        internal const int INET_E_RESOURCE_NOT_FOUND = unchecked((int)0x800C0005);
+        internal const int INET_E_UNKNOWN_PROTOCOL = unchecked((int)0x800C000D);
+        internal const int ISS_E_ALLOC_TOO_LARGE = unchecked((int)0x80131484);
+        internal const int ISS_E_BLOCK_SIZE_TOO_SMALL = unchecked((int)0x80131483);
+        internal const int ISS_E_CALLER = unchecked((int)0x801314A1);
+        internal const int ISS_E_CORRUPTED_STORE_FILE = unchecked((int)0x80131480);
+        internal const int ISS_E_CREATE_DIR = unchecked((int)0x80131468);
+        internal const int ISS_E_CREATE_MUTEX = unchecked((int)0x80131464);
+        internal const int ISS_E_DEPRECATE = unchecked((int)0x801314A0);
+        internal const int ISS_E_FILE_NOT_MAPPED = unchecked((int)0x80131482);
+        internal const int ISS_E_FILE_WRITE = unchecked((int)0x80131466);
+        internal const int ISS_E_GET_FILE_SIZE = unchecked((int)0x80131463);
+        internal const int ISS_E_ISOSTORE = unchecked((int)0x80131450);
+        internal const int ISS_E_LOCK_FAILED = unchecked((int)0x80131465);
+        internal const int ISS_E_MACHINE = unchecked((int)0x801314A3);
+        internal const int ISS_E_MACHINE_DACL = unchecked((int)0x801314A4);
+        internal const int ISS_E_MAP_VIEW_OF_FILE = unchecked((int)0x80131462);
+        internal const int ISS_E_OPEN_FILE_MAPPING = unchecked((int)0x80131461);
+        internal const int ISS_E_OPEN_STORE_FILE = unchecked((int)0x80131460);
+        internal const int ISS_E_PATH_LENGTH = unchecked((int)0x801314A2);
+        internal const int ISS_E_SET_FILE_POINTER = unchecked((int)0x80131467);
+        internal const int ISS_E_STORE_NOT_OPEN = unchecked((int)0x80131469);
+        internal const int ISS_E_STORE_VERSION = unchecked((int)0x80131481);
+        internal const int ISS_E_TABLE_ROW_NOT_FOUND = unchecked((int)0x80131486);
+        internal const int ISS_E_USAGE_WILL_EXCEED_QUOTA = unchecked((int)0x80131485);
+        internal const int META_E_BAD_SIGNATURE = unchecked((int)0x80131192);
+        internal const int META_E_CA_FRIENDS_SN_REQUIRED = unchecked((int)0x801311e6);
+        internal const int MSEE_E_ASSEMBLYLOADINPROGRESS = unchecked((int)0x80131016);
+        internal const int RO_E_CLOSED = unchecked((int)0x80000013);
+        internal const int E_BOUNDS = unchecked((int)0x8000000B);
+        internal const int RO_E_METADATA_NAME_NOT_FOUND = unchecked((int)0x8000000F);
+        internal const int SECURITY_E_INCOMPATIBLE_EVIDENCE = unchecked((int)0x80131403);
+        internal const int SECURITY_E_INCOMPATIBLE_SHARE = unchecked((int)0x80131401);
+        internal const int SECURITY_E_UNVERIFIABLE = unchecked((int)0x80131402);
+        internal const int STG_E_PATHNOTFOUND = unchecked((int)0x80030003);
+        public const int COR_E_DIRECTORYNOTFOUND = unchecked((int)0x80070003);
+        public const int COR_E_ENDOFSTREAM = unchecked((int)0x80070026);  // OS defined
+        public const int COR_E_FILELOAD = unchecked((int)0x80131621);
+        public const int COR_E_FILENOTFOUND = unchecked((int)0x80070002);
+        public const int COR_E_IO = unchecked((int)0x80131620);
+        public const int COR_E_PATHTOOLONG = unchecked((int)0x800700CE);
+    }
+}

--- a/src/mscorlib/corefx/System/IO/Error.cs
+++ b/src/mscorlib/corefx/System/IO/Error.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Globalization;
+using System.Diagnostics.Contracts;
+
+namespace System.IO
+{
+    /// <summary>
+    ///     Provides centralized methods for creating exceptions for System.IO.FileSystem.
+    /// </summary>
+    [Pure]
+    internal static class Error
+    {
+        internal static Exception GetEndOfFile()
+        {
+            return new EndOfStreamException(SR.IO_EOF_ReadBeyondEOF);
+        }
+
+        internal static Exception GetFileNotOpen()
+        {
+            return new ObjectDisposedException(null, SR.ObjectDisposed_FileClosed);
+        }
+
+        internal static Exception GetReadNotSupported()
+        {
+            return new NotSupportedException(SR.NotSupported_UnreadableStream);
+        }
+
+        internal static Exception GetSeekNotSupported()
+        {
+            return new NotSupportedException(SR.NotSupported_UnseekableStream);
+        }
+
+        internal static Exception GetWriteNotSupported()
+        {
+            return new NotSupportedException(SR.NotSupported_UnwritableStream);
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/IO/FileStream.NetStandard17.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.NetStandard17.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Threading;
+
+namespace System.IO
+{
+    public partial class FileStream : Stream
+    {
+        public override IAsyncResult BeginRead(byte[] array, int offset, int numBytes, AsyncCallback callback, object state)
+        {
+            if (array == null)
+                throw new ArgumentNullException(nameof(array));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (numBytes < 0)
+                throw new ArgumentOutOfRangeException(nameof(numBytes), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (array.Length - offset < numBytes)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+
+            if (IsClosed) throw new ObjectDisposedException(SR.ObjectDisposed_FileClosed);
+            if (!CanRead) throw new NotSupportedException(SR.NotSupported_UnreadableStream);
+
+            if (!IsAsync)
+                return base.BeginRead(array, offset, numBytes, callback, state);
+            else
+                return TaskToApm.Begin(ReadAsyncInternal(array, offset, numBytes, CancellationToken.None), callback, state);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] array, int offset, int numBytes, AsyncCallback callback, object state)
+        {
+            if (array == null)
+                throw new ArgumentNullException(nameof(array));
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (numBytes < 0)
+                throw new ArgumentOutOfRangeException(nameof(numBytes), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (array.Length - offset < numBytes)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+
+            if (IsClosed) throw new ObjectDisposedException(SR.ObjectDisposed_FileClosed);
+            if (!CanWrite) throw new NotSupportedException(SR.NotSupported_UnwritableStream);
+
+            if (!IsAsync)
+                return base.BeginWrite(array, offset, numBytes, callback, state);
+            else
+                return TaskToApm.Begin(WriteAsyncInternal(array, offset, numBytes, CancellationToken.None), callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            if (asyncResult == null)
+                throw new ArgumentNullException(nameof(asyncResult));
+
+            if (!IsAsync)
+                return base.EndRead(asyncResult);
+            else
+                return TaskToApm.End<int>(asyncResult);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            if (asyncResult == null)
+                throw new ArgumentNullException(nameof(asyncResult));
+
+            if (!IsAsync)
+                base.EndWrite(asyncResult);
+            else
+                TaskToApm.End(asyncResult);
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/IO/FileStream.Unix.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.Unix.cs
@@ -1,0 +1,948 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    /// <summary>Provides an implementation of a file stream for Unix files.</summary>
+    public partial class FileStream : Stream
+    {
+        /// <summary>File mode.</summary>
+        private FileMode _mode;
+
+        /// <summary>Advanced options requested when opening the file.</summary>
+        private FileOptions _options;
+
+        /// <summary>If the file was opened with FileMode.Append, the length of the file when opened; otherwise, -1.</summary>
+        private long _appendStart = -1;
+
+        /// <summary>
+        /// Extra state used by the file stream when _useAsyncIO is true.  This includes
+        /// the semaphore used to serialize all operation, the buffer/offset/count provided by the
+        /// caller for ReadAsync/WriteAsync operations, and the last successful task returned
+        /// synchronously from ReadAsync which can be reused if the count matches the next request.
+        /// Only initialized when <see cref="_useAsyncIO"/> is true.
+        /// </summary>
+        private AsyncState _asyncState;
+
+        /// <summary>Lazily-initialized value for whether the file supports seeking.</summary>
+        private bool? _canSeek;
+
+        private SafeFileHandle OpenHandle(FileMode mode, FileShare share, FileOptions options)
+        {
+            // FileStream performs most of the general argument validation.  We can assume here that the arguments
+            // are all checked and consistent (e.g. non-null-or-empty path; valid enums in mode, access, share, and options; etc.)
+            // Store the arguments
+            _mode = mode;
+            _options = options;
+
+            if (_useAsyncIO)
+                _asyncState = new AsyncState();
+
+            // Translate the arguments into arguments for an open call.
+            Interop.Sys.OpenFlags openFlags = PreOpenConfigurationFromOptions(mode, _access, options); // FileShare currently ignored
+
+            // If the file gets created a new, we'll select the permissions for it.  Most utilities by default use 666 (read and 
+            // write for all). However, on Windows it's possible to write out a file and then execute it.  To maintain that similarity, 
+            // we use 766, so that in addition the user has execute privileges. No matter what we choose, it'll be subject to the umask 
+            // applied by the system, such that the actual permissions will typically be less than what we select here.
+            const Interop.Sys.Permissions openPermissions =
+                Interop.Sys.Permissions.S_IRWXU |
+                Interop.Sys.Permissions.S_IRGRP | Interop.Sys.Permissions.S_IWGRP |
+                Interop.Sys.Permissions.S_IROTH | Interop.Sys.Permissions.S_IWOTH;
+
+            // Open the file and store the safe handle.
+            return SafeFileHandle.Open(_path, openFlags, (int)openPermissions);
+        }
+
+        /// <summary>Initializes a stream for reading or writing a Unix file.</summary>
+        /// <param name="mode">How the file should be opened.</param>
+        /// <param name="share">What other access to the file should be allowed.  This is currently ignored.</param>
+        private void Init(FileMode mode, FileShare share)
+        {
+            _fileHandle.IsAsync = _useAsyncIO;
+
+            // Lock the file if requested via FileShare.  This is only advisory locking. FileShare.None implies an exclusive 
+            // lock on the file and all other modes use a shared lock.  While this is not as granular as Windows, not mandatory, 
+            // and not atomic with file opening, it's better than nothing.
+            Interop.Sys.LockOperations lockOperation = (share == FileShare.None) ? Interop.Sys.LockOperations.LOCK_EX : Interop.Sys.LockOperations.LOCK_SH;
+            if (Interop.Sys.FLock(_fileHandle, lockOperation | Interop.Sys.LockOperations.LOCK_NB) < 0)
+            {
+                // The only error we care about is EWOULDBLOCK, which indicates that the file is currently locked by someone
+                // else and we would block trying to access it.  Other errors, such as ENOTSUP (locking isn't supported) or
+                // EACCES (the file system doesn't allow us to lock), will only hamper FileStream's usage without providing value,
+                // given again that this is only advisory / best-effort.
+                Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
+                if (errorInfo.Error == Interop.Error.EWOULDBLOCK)
+                {
+                    throw Interop.GetExceptionForIoErrno(errorInfo, _path, isDirectory: false);
+                }
+            }
+
+            // These provide hints around how the file will be accessed.  Specifying both RandomAccess
+            // and Sequential together doesn't make sense as they are two competing options on the same spectrum,
+            // so if both are specified, we prefer RandomAccess (behavior on Windows is unspecified if both are provided).
+            Interop.Sys.FileAdvice fadv =
+                (_options & FileOptions.RandomAccess) != 0 ? Interop.Sys.FileAdvice.POSIX_FADV_RANDOM :
+                (_options & FileOptions.SequentialScan) != 0 ? Interop.Sys.FileAdvice.POSIX_FADV_SEQUENTIAL :
+                0;
+            if (fadv != 0)
+            {
+                CheckFileCall(Interop.Sys.PosixFAdvise(_fileHandle, 0, 0, fadv),
+                    ignoreNotSupported: true); // just a hint.
+            }
+
+            // Jump to the end of the file if opened as Append.
+            if (_mode == FileMode.Append)
+            {
+                _appendStart = SeekCore(0, SeekOrigin.End);
+            }
+        }
+
+        /// <summary>Initializes a stream from an already open file handle (file descriptor).</summary>
+        /// <param name="handle">The handle to the file.</param>
+        /// <param name="bufferSize">The size of the buffer to use when buffering.</param>
+        /// <param name="useAsyncIO">Whether access to the stream is performed asynchronously.</param>
+        private void InitFromHandle(SafeFileHandle handle)
+        {
+            if (_useAsyncIO)
+                _asyncState = new AsyncState();
+
+            if (CanSeekCore) // use non-virtual CanSeekCore rather than CanSeek to avoid making virtual call during ctor
+                SeekCore(0, SeekOrigin.Current);
+        }
+
+        /// <summary>Translates the FileMode, FileAccess, and FileOptions values into flags to be passed when opening the file.</summary>
+        /// <param name="mode">The FileMode provided to the stream's constructor.</param>
+        /// <param name="access">The FileAccess provided to the stream's constructor</param>
+        /// <param name="options">The FileOptions provided to the stream's constructor</param>
+        /// <returns>The flags value to be passed to the open system call.</returns>
+        private static Interop.Sys.OpenFlags PreOpenConfigurationFromOptions(FileMode mode, FileAccess access, FileOptions options)
+        {
+            // Translate FileMode.  Most of the values map cleanly to one or more options for open.
+            Interop.Sys.OpenFlags flags = default(Interop.Sys.OpenFlags);
+            switch (mode)
+            {
+                default:
+                case FileMode.Open: // Open maps to the default behavior for open(...).  No flags needed.
+                    break;
+
+                case FileMode.Append: // Append is the same as OpenOrCreate, except that we'll also separately jump to the end later
+                case FileMode.OpenOrCreate:
+                    flags |= Interop.Sys.OpenFlags.O_CREAT;
+                    break;
+
+                case FileMode.Create:
+                    flags |= (Interop.Sys.OpenFlags.O_CREAT | Interop.Sys.OpenFlags.O_TRUNC);
+                    break;
+
+                case FileMode.CreateNew:
+                    flags |= (Interop.Sys.OpenFlags.O_CREAT | Interop.Sys.OpenFlags.O_EXCL);
+                    break;
+
+                case FileMode.Truncate:
+                    flags |= Interop.Sys.OpenFlags.O_TRUNC;
+                    break;
+            }
+
+            // Translate FileAccess.  All possible values map cleanly to corresponding values for open.
+            switch (access)
+            {
+                case FileAccess.Read:
+                    flags |= Interop.Sys.OpenFlags.O_RDONLY;
+                    break;
+
+                case FileAccess.ReadWrite:
+                    flags |= Interop.Sys.OpenFlags.O_RDWR;
+                    break;
+
+                case FileAccess.Write:
+                    flags |= Interop.Sys.OpenFlags.O_WRONLY;
+                    break;
+            }
+
+            // Translate some FileOptions; some just aren't supported, and others will be handled after calling open.
+            // - Asynchronous: Handled in ctor, setting _useAsync and SafeFileHandle.IsAsync to true
+            // - DeleteOnClose: Doesn't have a Unix equivalent, but we approximate it in Dispose
+            // - Encrypted: No equivalent on Unix and is ignored
+            // - RandomAccess: Implemented after open if posix_fadvise is available
+            // - SequentialScan: Implemented after open if posix_fadvise is available
+            // - WriteThrough: Handled here
+            if ((options & FileOptions.WriteThrough) != 0)
+            {
+                flags |= Interop.Sys.OpenFlags.O_SYNC;
+            }
+
+            return flags;
+        }
+
+        /// <summary>Gets a value indicating whether the current stream supports seeking.</summary>
+        public override bool CanSeek => CanSeekCore;
+
+        /// <summary>Gets a value indicating whether the current stream supports seeking.</summary>
+        /// <remarks>Separated out of CanSeek to enable making non-virtual call to this logic.</remarks>
+        private bool CanSeekCore
+        {
+            get
+            {
+                if (_fileHandle.IsClosed)
+                {
+                    return false;
+                }
+
+                if (!_canSeek.HasValue)
+                {
+                    // Lazily-initialize whether we're able to seek, tested by seeking to our current location.
+                    _canSeek = Interop.Sys.LSeek(_fileHandle, 0, Interop.Sys.SeekWhence.SEEK_CUR) >= 0;
+                }
+                return _canSeek.Value;
+            }
+        }
+
+        private long GetLengthInternal()
+        {
+            // Get the length of the file as reported by the OS
+            Interop.Sys.FileStatus status;
+            CheckFileCall(Interop.Sys.FStat(_fileHandle, out status));
+            long length = status.Size;
+
+            // But we may have buffered some data to be written that puts our length
+            // beyond what the OS is aware of.  Update accordingly.
+            if (_writePos > 0 && _filePosition + _writePos > length)
+            {
+                length = _writePos + _filePosition;
+            }
+
+            return length;
+        }
+
+        /// <summary>Releases the unmanaged resources used by the stream.</summary>
+        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (_fileHandle != null && !_fileHandle.IsClosed)
+                {
+                    // Flush any remaining data in the file
+                    FlushWriteBuffer();
+
+                    // If DeleteOnClose was requested when constructed, delete the file now.
+                    // (Unix doesn't directly support DeleteOnClose, so we mimic it here.)
+                    if (_path != null && (_options & FileOptions.DeleteOnClose) != 0)
+                    {
+                        // Since we still have the file open, this will end up deleting
+                        // it (assuming we're the only link to it) once it's closed, but the
+                        // name will be removed immediately.
+                        Interop.Sys.Unlink(_path); // ignore errors; it's valid that the path may no longer exist
+                    }
+                }
+            }
+            finally
+            {
+                if (_fileHandle != null && !_fileHandle.IsClosed)
+                {
+                    _fileHandle.Dispose();
+                }
+                base.Dispose(disposing);
+            }
+        }
+
+        /// <summary>Flushes the OS buffer.  This does not flush the internal read/write buffer.</summary>
+        private void FlushOSBuffer()
+        {
+            if (Interop.Sys.FSync(_fileHandle) < 0)
+            {
+                Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
+                switch (errorInfo.Error)
+                {
+                    case Interop.Error.EROFS:
+                    case Interop.Error.EINVAL:
+                    case Interop.Error.ENOTSUP:
+                        // Ignore failures due to the FileStream being bound to a special file that
+                        // doesn't support synchronization.  In such cases there's nothing to flush.
+                        break;
+                    default:
+                        throw Interop.GetExceptionForIoErrno(errorInfo, _path, isDirectory: false);
+                }
+            }
+        }
+
+        /// <summary>Writes any data in the write buffer to the underlying stream and resets the buffer.</summary>
+        private void FlushWriteBuffer()
+        {
+            AssertBufferInvariants();
+            if (_writePos > 0)
+            {
+                WriteNative(GetBuffer(), 0, _writePos);
+                _writePos = 0;
+            }
+        }
+
+        /// <summary>Asynchronously clears all buffers for this stream, causing any buffered data to be written to the underlying device.</summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous flush operation.</returns>
+        private Task FlushAsyncInternal(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+            if (_fileHandle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+
+            // As with Win32FileStream, flush the buffers synchronously to avoid race conditions.
+            try
+            {
+                FlushInternalBuffer();
+            }
+            catch (Exception e)
+            {
+                return Task.FromException(e);
+            }
+
+            // We then separately flush to disk asynchronously.  This is only 
+            // necessary if we support writing; otherwise, we're done.
+            if (CanWrite)
+            {
+                return Task.Factory.StartNew(
+                    state => ((FileStream)state).FlushOSBuffer(),
+                    this,
+                    cancellationToken,
+                    TaskCreationOptions.DenyChildAttach,
+                    TaskScheduler.Default);
+            }
+            else
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>Sets the length of this stream to the given value.</summary>
+        /// <param name="value">The new length of the stream.</param>
+        private void SetLengthInternal(long value)
+        {
+            FlushInternalBuffer();
+
+            if (_appendStart != -1 && value < _appendStart)
+            {
+                throw new IOException(SR.IO_SetLengthAppendTruncate);
+            }
+
+            long origPos = _filePosition;
+
+            VerifyOSHandlePosition();
+
+            if (_filePosition != value)
+            {
+                SeekCore(value, SeekOrigin.Begin);
+            }
+
+            CheckFileCall(Interop.Sys.FTruncate(_fileHandle, value));
+
+            // Return file pointer to where it was before setting length
+            if (origPos != value)
+            {
+                if (origPos < value)
+                {
+                    SeekCore(origPos, SeekOrigin.Begin);
+                }
+                else
+                {
+                    SeekCore(0, SeekOrigin.End);
+                }
+            }
+        }
+
+        /// <summary>Reads a block of bytes from the stream and writes the data in a given buffer.</summary>
+        /// <param name="array">
+        /// When this method returns, contains the specified byte array with the values between offset and 
+        /// (offset + count - 1) replaced by the bytes read from the current source.
+        /// </param>
+        /// <param name="offset">The byte offset in array at which the read bytes will be placed.</param>
+        /// <param name="count">The maximum number of bytes to read. </param>
+        /// <returns>
+        /// The total number of bytes read into the buffer. This might be less than the number of bytes requested 
+        /// if that number of bytes are not currently available, or zero if the end of the stream is reached.
+        /// </returns>
+        public override int Read(byte[] array, int offset, int count)
+        {
+            ValidateReadWriteArgs(array, offset, count);
+
+            if (_useAsyncIO)
+            {
+                _asyncState.Wait();
+                try { return ReadCore(array, offset, count); }
+                finally { _asyncState.Release(); }
+            }
+            else
+            {
+                return ReadCore(array, offset, count);
+            }
+        }
+
+        /// <summary>Reads a block of bytes from the stream and writes the data in a given buffer.</summary>
+        /// <param name="array">
+        /// When this method returns, contains the specified byte array with the values between offset and 
+        /// (offset + count - 1) replaced by the bytes read from the current source.
+        /// </param>
+        /// <param name="offset">The byte offset in array at which the read bytes will be placed.</param>
+        /// <param name="count">The maximum number of bytes to read. </param>
+        /// <returns>
+        /// The total number of bytes read into the buffer. This might be less than the number of bytes requested 
+        /// if that number of bytes are not currently available, or zero if the end of the stream is reached.
+        /// </returns>
+        private int ReadCore(byte[] array, int offset, int count)
+        {
+            PrepareForReading();
+
+            // Are there any bytes available in the read buffer? If yes,
+            // we can just return from the buffer.  If the buffer is empty
+            // or has no more available data in it, we can either refill it
+            // (and then read from the buffer into the user's buffer) or
+            // we can just go directly into the user's buffer, if they asked
+            // for more data than we'd otherwise buffer.
+            int numBytesAvailable = _readLength - _readPos;
+            bool readFromOS = false;
+            if (numBytesAvailable == 0)
+            {
+                // If we're not able to seek, then we're not able to rewind the stream (i.e. flushing
+                // a read buffer), in which case we don't want to use a read buffer.  Similarly, if
+                // the user has asked for more data than we can buffer, we also want to skip the buffer.
+                if (!CanSeek || (count >= _bufferLength))
+                {
+                    // Read directly into the user's buffer
+                    _readPos = _readLength = 0;
+                    return ReadNative(array, offset, count);
+                }
+                else
+                {
+                    // Read into our buffer.
+                    _readLength = numBytesAvailable = ReadNative(GetBuffer(), 0, _bufferLength);
+                    _readPos = 0;
+                    if (numBytesAvailable == 0)
+                    {
+                        return 0;
+                    }
+
+                    // Note that we did an OS read as part of this Read, so that later
+                    // we don't try to do one again if what's in the buffer doesn't
+                    // meet the user's request.
+                    readFromOS = true;
+                }
+            }
+
+            // Now that we know there's data in the buffer, read from it into the user's buffer.
+            Debug.Assert(numBytesAvailable > 0, "Data must be in the buffer to be here");
+            int bytesRead = Math.Min(numBytesAvailable, count);
+            Buffer.BlockCopy(GetBuffer(), _readPos, array, offset, bytesRead);
+            _readPos += bytesRead;
+
+            // We may not have had enough data in the buffer to completely satisfy the user's request.
+            // While Read doesn't require that we return as much data as the user requested (any amount
+            // up to the requested count is fine), FileStream on Windows tries to do so by doing a 
+            // subsequent read from the file if we tried to satisfy the request with what was in the 
+            // buffer but the buffer contained less than the requested count. To be consistent with that 
+            // behavior, we do the same thing here on Unix.  Note that we may still get less the requested 
+            // amount, as the OS may give us back fewer than we request, either due to reaching the end of 
+            // file, or due to its own whims.
+            if (!readFromOS && bytesRead < count)
+            {
+                Debug.Assert(_readPos == _readLength, "bytesToRead should only be < count if numBytesAvailable < count");
+                _readPos = _readLength = 0; // no data left in the read buffer
+                bytesRead += ReadNative(array, offset + bytesRead, count - bytesRead);
+            }
+
+            return bytesRead;
+        }
+
+        /// <summary>Unbuffered, reads a block of bytes from the stream and writes the data in a given buffer.</summary>
+        /// <param name="array">
+        /// When this method returns, contains the specified byte array with the values between offset and 
+        /// (offset + count - 1) replaced by the bytes read from the current source.
+        /// </param>
+        /// <param name="offset">The byte offset in array at which the read bytes will be placed.</param>
+        /// <param name="count">The maximum number of bytes to read. </param>
+        /// <returns>
+        /// The total number of bytes read into the buffer. This might be less than the number of bytes requested 
+        /// if that number of bytes are not currently available, or zero if the end of the stream is reached.
+        /// </returns>
+        private unsafe int ReadNative(byte[] array, int offset, int count)
+        {
+            FlushWriteBuffer(); // we're about to read; dump the write buffer
+
+            VerifyOSHandlePosition();
+
+            int bytesRead;
+            fixed (byte* bufPtr = array)
+            {
+                bytesRead = CheckFileCall(Interop.Sys.Read(_fileHandle, bufPtr + offset, count));
+                Debug.Assert(bytesRead <= count);
+            }
+            _filePosition += bytesRead;
+            return bytesRead;
+        }
+
+        /// <summary>
+        /// Asynchronously reads a sequence of bytes from the current stream and advances
+        /// the position within the stream by the number of bytes read.
+        /// </summary>
+        /// <param name="buffer">The buffer to write the data into.</param>
+        /// <param name="offset">The byte offset in buffer at which to begin writing data from the stream.</param>
+        /// <param name="count">The maximum number of bytes to read.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous read operation.</returns>
+        private Task<int> ReadAsyncInternal(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (_useAsyncIO)
+            {
+                if (!CanRead) // match Windows behavior; this gets thrown synchronously
+                {
+                    throw Error.GetReadNotSupported();
+                }
+
+                // Serialize operations using the semaphore.
+                Task waitTask = _asyncState.WaitAsync();
+
+                // If we got ownership immediately, and if there's enough data in our buffer
+                // to satisfy the full request of the caller, hand back the buffered data.
+                // While it would be a legal implementation of the Read contract, we don't
+                // hand back here less than the amount requested so as to match the behavior
+                // in ReadCore that will make a native call to try to fulfill the remainder
+                // of the request.
+                if (waitTask.Status == TaskStatus.RanToCompletion)
+                {
+                    int numBytesAvailable = _readLength - _readPos;
+                    if (numBytesAvailable >= count)
+                    {
+                        try
+                        {
+                            PrepareForReading();
+
+                            Buffer.BlockCopy(GetBuffer(), _readPos, buffer, offset, count);
+                            _readPos += count;
+
+                            return _asyncState._lastSuccessfulReadTask != null && _asyncState._lastSuccessfulReadTask.Result == count ?
+                                _asyncState._lastSuccessfulReadTask :
+                                (_asyncState._lastSuccessfulReadTask = Task.FromResult(count));
+                        }
+                        catch (Exception exc)
+                        {
+                            return Task.FromException<int>(exc);
+                        }
+                        finally
+                        {
+                            _asyncState.Release();
+                        }
+                    }
+                }
+
+                // Otherwise, issue the whole request asynchronously.
+                _asyncState.Update(buffer, offset, count);
+                return waitTask.ContinueWith((t, s) =>
+                {
+                    // The options available on Unix for writing asynchronously to an arbitrary file 
+                    // handle typically amount to just using another thread to do the synchronous write, 
+                    // which is exactly  what this implementation does. This does mean there are subtle
+                    // differences in certain FileStream behaviors between Windows and Unix when multiple 
+                    // asynchronous operations are issued against the stream to execute concurrently; on 
+                    // Unix the operations will be serialized due to the usage of a semaphore, but the 
+                    // position /length information won't be updated until after the write has completed, 
+                    // whereas on Windows it may happen before the write has completed.
+
+                    Debug.Assert(t.Status == TaskStatus.RanToCompletion);
+                    var thisRef = (FileStream)s;
+                    try
+                    {
+                        byte[] b = thisRef._asyncState._buffer;
+                        thisRef._asyncState._buffer = null; // remove reference to user's buffer
+                        return thisRef.ReadCore(b, thisRef._asyncState._offset, thisRef._asyncState._count);
+                    }
+                    finally { thisRef._asyncState.Release(); }
+                }, this, CancellationToken.None, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
+            }
+            else
+            {
+                return base.ReadAsync(buffer, offset, count, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Reads a byte from the stream and advances the position within the stream
+        /// by one byte, or returns -1 if at the end of the stream.
+        /// </summary>
+        /// <returns>The unsigned byte cast to an Int32, or -1 if at the end of the stream.</returns>
+        public override int ReadByte()
+        {
+            if (_useAsyncIO)
+            {
+                _asyncState.Wait();
+                try { return ReadByteCore(); }
+                finally { _asyncState.Release(); }
+            }
+            else
+            {
+                return ReadByteCore();
+            }
+        }
+
+        /// <summary>Writes a block of bytes to the file stream.</summary>
+        /// <param name="array">The buffer containing data to write to the stream.</param>
+        /// <param name="offset">The zero-based byte offset in array from which to begin copying bytes to the stream.</param>
+        /// <param name="count">The maximum number of bytes to write.</param>
+        public override void Write(byte[] array, int offset, int count)
+        {
+            ValidateReadWriteArgs(array, offset, count);
+
+            if (_useAsyncIO)
+            {
+                _asyncState.Wait();
+                try { WriteCore(array, offset, count); }
+                finally { _asyncState.Release(); }
+            }
+            else
+            {
+                WriteCore(array, offset, count);
+            }
+        }
+
+        /// <summary>Writes a block of bytes to the file stream.</summary>
+        /// <param name="array">The buffer containing data to write to the stream.</param>
+        /// <param name="offset">The zero-based byte offset in array from which to begin copying bytes to the stream.</param>
+        /// <param name="count">The maximum number of bytes to write.</param>
+        private void WriteCore(byte[] array, int offset, int count)
+        {
+            PrepareForWriting();
+
+            // If no data is being written, nothing more to do.
+            if (count == 0)
+            {
+                return;
+            }
+
+            // If there's already data in our write buffer, then we need to go through
+            // our buffer to ensure data isn't corrupted.
+            if (_writePos > 0)
+            {
+                // If there's space remaining in the buffer, then copy as much as
+                // we can from the user's buffer into ours.
+                int spaceRemaining = _bufferLength - _writePos;
+                if (spaceRemaining > 0)
+                {
+                    int bytesToCopy = Math.Min(spaceRemaining, count);
+                    Buffer.BlockCopy(array, offset, GetBuffer(), _writePos, bytesToCopy);
+                    _writePos += bytesToCopy;
+
+                    // If we've successfully copied all of the user's data, we're done.
+                    if (count == bytesToCopy)
+                    {
+                        return;
+                    }
+
+                    // Otherwise, keep track of how much more data needs to be handled.
+                    offset += bytesToCopy;
+                    count -= bytesToCopy;
+                }
+
+                // At this point, the buffer is full, so flush it out.
+                FlushWriteBuffer();
+            }
+
+            // Our buffer is now empty.  If using the buffer would slow things down (because
+            // the user's looking to write more data than we can store in the buffer),
+            // skip the buffer.  Otherwise, put the remaining data into the buffer.
+            Debug.Assert(_writePos == 0);
+            if (count >= _bufferLength)
+            {
+                WriteNative(array, offset, count);
+            }
+            else
+            {
+                Buffer.BlockCopy(array, offset, GetBuffer(), _writePos, count);
+                _writePos = count;
+            }
+        }
+
+        /// <summary>Unbuffered, writes a block of bytes to the file stream.</summary>
+        /// <param name="array">The buffer containing data to write to the stream.</param>
+        /// <param name="offset">The zero-based byte offset in array from which to begin copying bytes to the stream.</param>
+        /// <param name="count">The maximum number of bytes to write.</param>
+        private unsafe void WriteNative(byte[] array, int offset, int count)
+        {
+            VerifyOSHandlePosition();
+
+            fixed (byte* bufPtr = array)
+            {
+                while (count > 0)
+                {
+                    int bytesWritten = CheckFileCall(Interop.Sys.Write(_fileHandle, bufPtr + offset, count));
+                    Debug.Assert(bytesWritten <= count);
+
+                    _filePosition += bytesWritten;
+                    count -= bytesWritten;
+                    offset += bytesWritten;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes a sequence of bytes to the current stream, advances
+        /// the current position within this stream by the number of bytes written, and
+        /// monitors cancellation requests.
+        /// </summary>
+        /// <param name="buffer">The buffer to write data from.</param>
+        /// <param name="offset">The zero-based byte offset in buffer from which to begin copying bytes to the stream.</param>
+        /// <param name="count">The maximum number of bytes to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private Task WriteAsyncInternal(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+
+            if (_fileHandle.IsClosed)
+                throw Error.GetFileNotOpen();
+
+            if (_useAsyncIO)
+            {
+                if (!CanWrite) // match Windows behavior; this gets thrown synchronously
+                {
+                    throw Error.GetWriteNotSupported();
+                }
+
+                // Serialize operations using the semaphore.
+                Task waitTask = _asyncState.WaitAsync();
+
+                // If we got ownership immediately, and if there's enough space in our buffer
+                // to buffer the entire write request, then do so and we're done.
+                if (waitTask.Status == TaskStatus.RanToCompletion)
+                {
+                    int spaceRemaining = _bufferLength - _writePos;
+                    if (spaceRemaining >= count)
+                    {
+                        try
+                        {
+                            PrepareForWriting();
+
+                            Buffer.BlockCopy(buffer, offset, GetBuffer(), _writePos, count);
+                            _writePos += count;
+
+                            return Task.CompletedTask;
+                        }
+                        catch (Exception exc)
+                        {
+                            return Task.FromException(exc);
+                        }
+                        finally
+                        {
+                            _asyncState.Release();
+                        }
+                    }
+                }
+
+                // Otherwise, issue the whole request asynchronously.
+                _asyncState.Update(buffer, offset, count);
+                return waitTask.ContinueWith((t, s) =>
+                {
+                    // The options available on Unix for writing asynchronously to an arbitrary file 
+                    // handle typically amount to just using another thread to do the synchronous write, 
+                    // which is exactly  what this implementation does. This does mean there are subtle
+                    // differences in certain FileStream behaviors between Windows and Unix when multiple 
+                    // asynchronous operations are issued against the stream to execute concurrently; on 
+                    // Unix the operations will be serialized due to the usage of a semaphore, but the 
+                    // position /length information won't be updated until after the write has completed, 
+                    // whereas on Windows it may happen before the write has completed.
+
+                    Debug.Assert(t.Status == TaskStatus.RanToCompletion);
+                    var thisRef = (FileStream)s;
+                    try
+                    {
+                        byte[] b = thisRef._asyncState._buffer;
+                        thisRef._asyncState._buffer = null; // remove reference to user's buffer
+                        thisRef.WriteCore(b, thisRef._asyncState._offset, thisRef._asyncState._count);
+                    }
+                    finally { thisRef._asyncState.Release(); }
+                }, this, CancellationToken.None, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
+            }
+            else
+            {
+                return base.WriteAsync(buffer, offset, count, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Writes a byte to the current position in the stream and advances the position
+        /// within the stream by one byte.
+        /// </summary>
+        /// <param name="value">The byte to write to the stream.</param>
+        public override void WriteByte(byte value) // avoids an array allocation in the base implementation
+        {
+            if (_useAsyncIO)
+            {
+                _asyncState.Wait();
+                try { WriteByteCore(value); }
+                finally { _asyncState.Release(); }
+            }
+            else
+            {
+                WriteByteCore(value);
+            }
+        }
+
+        /// <summary>Prevents other processes from reading from or writing to the FileStream.</summary>
+        /// <param name="position">The beginning of the range to lock.</param>
+        /// <param name="length">The range to be locked.</param>
+        private void LockInternal(long position, long length)
+        {
+            // TODO #5964: Implement this with fcntl and F_SETLK in System.Native
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>Allows access by other processes to all or part of a file that was previously locked.</summary>
+        /// <param name="position">The beginning of the range to unlock.</param>
+        /// <param name="length">The range to be unlocked.</param>
+        private void UnlockInternal(long position, long length)
+        {
+            // TODO #5964: Implement this with fcntl and F_SETLK in System.Native
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>
+        /// Asynchronously reads the bytes from the current stream and writes them to another
+        /// stream, using a specified buffer size.
+        /// </summary>
+        /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
+        /// <param name="bufferSize">The size, in bytes, of the buffer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return StreamHelpers.ArrayPoolCopyToAsync(this, destination, bufferSize, cancellationToken);
+        }
+
+        /// <summary>Sets the current position of this stream to the given value.</summary>
+        /// <param name="offset">The point relative to origin from which to begin seeking. </param>
+        /// <param name="origin">
+        /// Specifies the beginning, the end, or the current position as a reference 
+        /// point for offset, using a value of type SeekOrigin.
+        /// </param>
+        /// <returns>The new position in the stream.</returns>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (origin < SeekOrigin.Begin || origin > SeekOrigin.End)
+            {
+                throw new ArgumentException(SR.Argument_InvalidSeekOrigin, nameof(origin));
+            }
+            if (_fileHandle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+            if (!CanSeek)
+            {
+                throw Error.GetSeekNotSupported();
+            }
+
+            VerifyOSHandlePosition();
+
+            // Flush our write/read buffer.  FlushWrite will output any write buffer we have and reset _bufferWritePos.
+            // We don't call FlushRead, as that will do an unnecessary seek to rewind the read buffer, and since we're 
+            // about to seek and update our position, we can simply update the offset as necessary and reset our read 
+            // position and length to 0. (In the future, for some simple cases we could potentially add an optimization 
+            // here to just move data around in the buffer for short jumps, to avoid re-reading the data from disk.)
+            FlushWriteBuffer();
+            if (origin == SeekOrigin.Current)
+            {
+                offset -= (_readLength - _readPos);
+            }
+            _readPos = _readLength = 0;
+
+            // Keep track of where we were, in case we're in append mode and need to verify
+            long oldPos = 0;
+            if (_appendStart >= 0)
+            {
+                oldPos = SeekCore(0, SeekOrigin.Current);
+            }
+
+            // Jump to the new location
+            long pos = SeekCore(offset, origin);
+
+            // Prevent users from overwriting data in a file that was opened in append mode.
+            if (_appendStart != -1 && pos < _appendStart)
+            {
+                SeekCore(oldPos, SeekOrigin.Begin);
+                throw new IOException(SR.IO_SeekAppendOverwrite);
+            }
+
+            // Return the new position
+            return pos;
+        }
+
+        /// <summary>Sets the current position of this stream to the given value.</summary>
+        /// <param name="offset">The point relative to origin from which to begin seeking. </param>
+        /// <param name="origin">
+        /// Specifies the beginning, the end, or the current position as a reference 
+        /// point for offset, using a value of type SeekOrigin.
+        /// </param>
+        /// <returns>The new position in the stream.</returns>
+        private long SeekCore(long offset, SeekOrigin origin)
+        {
+            Debug.Assert(!_fileHandle.IsClosed && (GetType() != typeof(FileStream) || CanSeek)); // verify that we can seek, but only if CanSeek won't be a virtual call (which could happen in the ctor)
+            Debug.Assert(origin >= SeekOrigin.Begin && origin <= SeekOrigin.End);
+
+            long pos = CheckFileCall(Interop.Sys.LSeek(_fileHandle, offset, (Interop.Sys.SeekWhence)(int)origin)); // SeekOrigin values are the same as Interop.libc.SeekWhence values
+            _filePosition = pos;
+            return pos;
+        }
+
+        private long CheckFileCall(long result, bool ignoreNotSupported = false)
+        {
+            if (result < 0)
+            {
+                Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
+                if (!(ignoreNotSupported && errorInfo.Error == Interop.Error.ENOTSUP))
+                {
+                    throw Interop.GetExceptionForIoErrno(errorInfo, _path, isDirectory: false);
+                }
+            }
+
+            return result;
+        }
+
+        private int CheckFileCall(int result, bool ignoreNotSupported = false)
+        {
+            CheckFileCall((long)result, ignoreNotSupported);
+
+            return result;
+        }
+
+        /// <summary>State used when the stream is in async mode.</summary>
+        private sealed class AsyncState : SemaphoreSlim
+        {
+            /// <summary>The caller's buffer currently being used by the active async operation.</summary>
+            internal byte[] _buffer;
+            /// <summary>The caller's offset currently being used by the active async operation.</summary>
+            internal int _offset;
+            /// <summary>The caller's count currently being used by the active async operation.</summary>
+            internal int _count;
+            /// <summary>The last task successfully, synchronously returned task from ReadAsync.</summary>
+            internal Task<int> _lastSuccessfulReadTask;
+
+            /// <summary>Initialize the AsyncState.</summary>
+            internal AsyncState() : base(initialCount: 1, maxCount: 1) { }
+
+            /// <summary>Sets the active buffer, offset, and count.</summary>
+            internal void Update(byte[] buffer, int offset, int count)
+            {
+                _buffer = buffer;
+                _offset = offset;
+                _count = count;
+            }
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/IO/FileStream.Win32.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.Win32.cs
@@ -1,0 +1,1770 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.CompilerServices;
+
+/*
+ * Win32FileStream supports different modes of accessing the disk - async mode
+ * and sync mode.  They are two completely different codepaths in the
+ * sync & async methods (i.e. Read/Write vs. ReadAsync/WriteAsync).  File
+ * handles in NT can be opened in only sync or overlapped (async) mode,
+ * and we have to deal with this pain.  Stream has implementations of
+ * the sync methods in terms of the async ones, so we'll
+ * call through to our base class to get those methods when necessary.
+ *
+ * Also buffering is added into Win32FileStream as well. Folded in the
+ * code from BufferedStream, so all the comments about it being mostly
+ * aggressive (and the possible perf improvement) apply to Win32FileStream as 
+ * well.  Also added some buffering to the async code paths.
+ *
+ * Class Invariants:
+ * The class has one buffer, shared for reading & writing.  It can only be
+ * used for one or the other at any point in time - not both.  The following
+ * should be true:
+ *   0 <= _readPos <= _readLen < _bufferSize
+ *   0 <= _writePos < _bufferSize
+ *   _readPos == _readLen && _readPos > 0 implies the read buffer is valid, 
+ *     but we're at the end of the buffer.
+ *   _readPos == _readLen == 0 means the read buffer contains garbage.
+ *   Either _writePos can be greater than 0, or _readLen & _readPos can be
+ *     greater than zero, but neither can be greater than zero at the same time.
+ *
+ */
+
+namespace System.IO
+{
+    public partial class FileStream : Stream
+    {
+        private bool _canSeek;
+        private bool _isPipe;      // Whether to disable async buffering code.
+        private long _appendStart; // When appending, prevent overwriting file.
+
+        private static unsafe IOCompletionCallback s_ioCallback = FileStreamCompletionSource.IOCallback;
+
+        private Task<int> _lastSynchronouslyCompletedTask = null;   // cached task for read ops that complete synchronously
+        private Task _activeBufferOperation = null;                 // tracks in-progress async ops using the buffer
+        private PreAllocatedOverlapped _preallocatedOverlapped;     // optimization for async ops to avoid per-op allocations
+        private FileStreamCompletionSource _currentOverlappedOwner; // async op currently using the preallocated overlapped
+
+        private SafeFileHandle OpenHandle(FileMode mode, FileShare share, FileOptions options)
+        {
+            Interop.mincore.SECURITY_ATTRIBUTES secAttrs = GetSecAttrs(share);
+
+            int fAccess =
+                ((_access & FileAccess.Read) == FileAccess.Read ? GENERIC_READ : 0) |
+                ((_access & FileAccess.Write) == FileAccess.Write ? GENERIC_WRITE : 0);
+
+            // Our Inheritable bit was stolen from Windows, but should be set in
+            // the security attributes class.  Don't leave this bit set.
+            share &= ~FileShare.Inheritable;
+
+            // Must use a valid Win32 constant here...
+            if (mode == FileMode.Append)
+                mode = FileMode.OpenOrCreate;
+
+            int flagsAndAttributes = (int)options;
+
+            // For mitigating local elevation of privilege attack through named pipes
+            // make sure we always call CreateFile with SECURITY_ANONYMOUS so that the
+            // named pipe server can't impersonate a high privileged client security context
+            flagsAndAttributes |= (Interop.mincore.SecurityOptions.SECURITY_SQOS_PRESENT | Interop.mincore.SecurityOptions.SECURITY_ANONYMOUS);
+
+            // Don't pop up a dialog for reading from an empty floppy drive
+            uint oldMode = Interop.mincore.SetErrorMode(Interop.mincore.SEM_FAILCRITICALERRORS);
+            try
+            {
+                SafeFileHandle fileHandle = Interop.mincore.SafeCreateFile(_path, fAccess, share, ref secAttrs, mode, flagsAndAttributes, IntPtr.Zero);
+                fileHandle.IsAsync = _useAsyncIO;
+
+                if (fileHandle.IsInvalid)
+                {
+                    // Return a meaningful exception with the full path.
+
+                    // NT5 oddity - when trying to open "C:\" as a Win32FileStream,
+                    // we usually get ERROR_PATH_NOT_FOUND from the OS.  We should
+                    // probably be consistent w/ every other directory.
+                    int errorCode = Marshal.GetLastWin32Error();
+
+                    if (errorCode == Interop.mincore.Errors.ERROR_PATH_NOT_FOUND && _path.Equals(Directory.InternalGetDirectoryRoot(_path)))
+                        errorCode = Interop.mincore.Errors.ERROR_ACCESS_DENIED;
+
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                }
+
+                return fileHandle;
+            }
+            finally
+            {
+                Interop.mincore.SetErrorMode(oldMode);
+            }
+        }
+
+        private void Init(FileMode mode, FileShare share)
+        {
+            // Disallow access to all non-file devices from the Win32FileStream
+            // constructors that take a String.  Everyone else can call 
+            // CreateFile themselves then use the constructor that takes an 
+            // IntPtr.  Disallows "con:", "com1:", "lpt1:", etc.
+            int fileType = Interop.mincore.GetFileType(_fileHandle);
+            if (fileType != Interop.mincore.FileTypes.FILE_TYPE_DISK)
+            {
+                _fileHandle.Dispose();
+                throw new NotSupportedException(SR.NotSupported_FileStreamOnNonFiles);
+            }
+
+            // This is necessary for async IO using IO Completion ports via our 
+            // managed Threadpool API's.  This (theoretically) calls the OS's 
+            // BindIoCompletionCallback method, and passes in a stub for the 
+            // LPOVERLAPPED_COMPLETION_ROUTINE.  This stub looks at the Overlapped
+            // struct for this request and gets a delegate to a managed callback 
+            // from there, which it then calls on a threadpool thread.  (We allocate
+            // our native OVERLAPPED structs 2 pointers too large and store EE state
+            // & GC handles there, one to an IAsyncResult, the other to a delegate.)
+            if (_useAsyncIO)
+            {
+                try
+                {
+                    _fileHandle.ThreadPoolBinding = ThreadPoolBoundHandle.BindHandle(_fileHandle);
+                }
+                catch (ArgumentException ex)
+                {
+                    throw new IOException(SR.IO_BindHandleFailed, ex);
+                }
+                finally
+                {
+                    if (_fileHandle.ThreadPoolBinding == null)
+                    {
+                        // We should close the handle so that the handle is not open until SafeFileHandle GC
+                        Debug.Assert(!_exposedHandle, "Are we closing handle that we exposed/not own, how?");
+                        _fileHandle.Dispose();
+                    }
+                }
+            }
+
+            _canSeek = true;
+
+            // For Append mode...
+            if (mode == FileMode.Append)
+            {
+                _appendStart = SeekCore(0, SeekOrigin.End);
+            }
+            else
+            {
+                _appendStart = -1;
+            }
+        }
+
+        private void InitFromHandle(SafeFileHandle handle)
+        {
+            int handleType = Interop.mincore.GetFileType(_fileHandle);
+            Debug.Assert(handleType == Interop.mincore.FileTypes.FILE_TYPE_DISK || handleType == Interop.mincore.FileTypes.FILE_TYPE_PIPE || handleType == Interop.mincore.FileTypes.FILE_TYPE_CHAR, "FileStream was passed an unknown file type!");
+
+            _canSeek = handleType == Interop.mincore.FileTypes.FILE_TYPE_DISK;
+            _isPipe = handleType == Interop.mincore.FileTypes.FILE_TYPE_PIPE;
+
+            // This is necessary for async IO using IO Completion ports via our 
+            // managed Threadpool API's.  This calls the OS's 
+            // BindIoCompletionCallback method, and passes in a stub for the 
+            // LPOVERLAPPED_COMPLETION_ROUTINE.  This stub looks at the Overlapped
+            // struct for this request and gets a delegate to a managed callback 
+            // from there, which it then calls on a threadpool thread.  (We allocate
+            // our native OVERLAPPED structs 2 pointers too large and store EE 
+            // state & a handle to a delegate there.)
+            // 
+            // If, however, we've already bound this file handle to our completion port,
+            // don't try to bind it again because it will fail.  A handle can only be
+            // bound to a single completion port at a time.
+            if (_useAsyncIO && !GetSuppressBindHandle(handle))
+            {
+                try
+                {
+                    _fileHandle.ThreadPoolBinding = ThreadPoolBoundHandle.BindHandle(_fileHandle);
+                }
+                catch (Exception ex)
+                {
+                    // If you passed in a synchronous handle and told us to use
+                    // it asynchronously, throw here.
+                    throw new ArgumentException(SR.Arg_HandleNotAsync, nameof(handle), ex);
+                }
+            }
+            else if (!_useAsyncIO)
+            {
+                if (handleType != Interop.mincore.FileTypes.FILE_TYPE_PIPE)
+                    VerifyHandleIsSync();
+            }
+
+            if (_canSeek)
+                SeekCore(0, SeekOrigin.Current);
+            else
+                _filePosition = 0;
+        }
+
+        private static bool GetSuppressBindHandle(SafeFileHandle handle)
+        {
+            return handle.IsAsync.HasValue ? handle.IsAsync.Value : false;
+        }
+
+        private unsafe static Interop.mincore.SECURITY_ATTRIBUTES GetSecAttrs(FileShare share)
+        {
+            Interop.mincore.SECURITY_ATTRIBUTES secAttrs = default(Interop.mincore.SECURITY_ATTRIBUTES);
+            if ((share & FileShare.Inheritable) != 0)
+            {
+                secAttrs = new Interop.mincore.SECURITY_ATTRIBUTES();
+                secAttrs.nLength = (uint)sizeof(Interop.mincore.SECURITY_ATTRIBUTES);
+
+                secAttrs.bInheritHandle = Interop.BOOL.TRUE;
+            }
+            return secAttrs;
+        }
+
+        // Verifies that this handle supports synchronous IO operations (unless you
+        // didn't open it for either reading or writing).
+        private unsafe void VerifyHandleIsSync()
+        {
+            Debug.Assert(!_useAsyncIO);
+
+            // Do NOT use this method on pipes.  Reading or writing to a pipe may
+            // cause an app to block incorrectly, introducing a deadlock (depending
+            // on whether a write will wake up an already-blocked thread or this
+            // Win32FileStream's thread).
+            Debug.Assert(Interop.mincore.GetFileType(_fileHandle) != Interop.mincore.FileTypes.FILE_TYPE_PIPE);
+
+            byte* bytes = stackalloc byte[1];
+            int numBytesReadWritten;
+            int r = -1;
+
+            // If the handle is a pipe, ReadFile will block until there
+            // has been a write on the other end.  We'll just have to deal with it,
+            // For the read end of a pipe, you can mess up and 
+            // accidentally read synchronously from an async pipe.
+            if ((_access & FileAccess.Read) != 0) // don't use the virtual CanRead or CanWrite, as this may be used in the ctor
+            {
+                r = Interop.mincore.ReadFile(_fileHandle, bytes, 0, out numBytesReadWritten, IntPtr.Zero);
+            }
+            else if ((_access & FileAccess.Write) != 0) // don't use the virtual CanRead or CanWrite, as this may be used in the ctor
+            {
+                r = Interop.mincore.WriteFile(_fileHandle, bytes, 0, out numBytesReadWritten, IntPtr.Zero);
+            }
+
+            if (r == 0)
+            {
+                int errorCode = GetLastWin32ErrorAndDisposeHandleIfInvalid(throwIfInvalidHandle: true);
+                if (errorCode == ERROR_INVALID_PARAMETER)
+                    throw new ArgumentException(SR.Arg_HandleNotSync, "handle");
+            }
+        }
+
+        private bool HasActiveBufferOperation
+        {
+            get { return _activeBufferOperation != null && !_activeBufferOperation.IsCompleted; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return _canSeek; }
+        }
+
+        private long GetLengthInternal()
+        {
+            Interop.mincore.FILE_STANDARD_INFO info = new Interop.mincore.FILE_STANDARD_INFO();
+
+            if (!Interop.mincore.GetFileInformationByHandleEx(_fileHandle, Interop.mincore.FILE_INFO_BY_HANDLE_CLASS.FileStandardInfo, out info, (uint)Marshal.SizeOf<Interop.mincore.FILE_STANDARD_INFO>()))
+                throw Win32Marshal.GetExceptionForLastWin32Error();
+            long len = info.EndOfFile;
+            // If we're writing near the end of the file, we must include our
+            // internal buffer in our Length calculation.  Don't flush because
+            // we use the length of the file in our async write method.
+            if (_writePos > 0 && _filePosition + _writePos > len)
+                len = _writePos + _filePosition;
+            return len;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // Nothing will be done differently based on whether we are 
+            // disposing vs. finalizing.  This is taking advantage of the
+            // weak ordering between normal finalizable objects & critical
+            // finalizable objects, which I included in the SafeHandle 
+            // design for Win32FileStream, which would often "just work" when 
+            // finalized.
+            try
+            {
+                if (_fileHandle != null && !_fileHandle.IsClosed)
+                {
+                    // Flush data to disk iff we were writing.  After 
+                    // thinking about this, we also don't need to flush
+                    // our read position, regardless of whether the handle
+                    // was exposed to the user.  They probably would NOT 
+                    // want us to do this.
+                    if (_writePos > 0)
+                    {
+                        FlushWriteBuffer(!disposing);
+                    }
+                }
+            }
+            finally
+            {
+                if (_fileHandle != null && !_fileHandle.IsClosed)
+                {
+                    if (_fileHandle.ThreadPoolBinding != null)
+                        _fileHandle.ThreadPoolBinding.Dispose();
+
+                    _fileHandle.Dispose();
+                }
+
+                if (_preallocatedOverlapped != null)
+                    _preallocatedOverlapped.Dispose();
+
+                _canSeek = false;
+
+                // Don't set the buffer to null, to avoid a NullReferenceException
+                // when users have a race condition in their code (i.e. they call
+                // Close when calling another method on Stream like Read).
+                //_buffer = null;
+                base.Dispose(disposing);
+            }
+        }
+
+        private void FlushOSBuffer()
+        {
+            if (!Interop.mincore.FlushFileBuffers(_fileHandle))
+            {
+                throw Win32Marshal.GetExceptionForLastWin32Error();
+            }
+        }
+
+        // Returns a task that flushes the internal write buffer
+        private Task FlushWriteAsync(CancellationToken cancellationToken)
+        {
+            Debug.Assert(_useAsyncIO);
+            Debug.Assert(_readPos == 0 && _readLength == 0, "FileStream: Read buffer must be empty in FlushWriteAsync!");
+
+            // If the buffer is already flushed, don't spin up the OS write
+            if (_writePos == 0) return Task.CompletedTask;
+
+            Task flushTask = WriteInternalCoreAsync(GetBuffer(), 0, _writePos, cancellationToken);
+            _writePos = 0;
+
+            // Update the active buffer operation
+            _activeBufferOperation = HasActiveBufferOperation ? 
+                Task.WhenAll(_activeBufferOperation, flushTask) : 
+                flushTask;
+
+            return flushTask;
+        }
+
+        // Writes are buffered.  Anytime the buffer fills up 
+        // (_writePos + delta > _bufferSize) or the buffer switches to reading
+        // and there is left over data (_writePos > 0), this function must be called.
+        private void FlushWriteBuffer(bool calledFromFinalizer = false)
+        {
+            if (_writePos == 0) return;
+            Debug.Assert(_readPos == 0 && _readLength == 0, "FileStream: Read buffer must be empty in FlushWrite!");
+
+            if (_useAsyncIO)
+            {
+                Task writeTask = FlushWriteAsync(CancellationToken.None);
+                // With our Whidbey async IO & overlapped support for AD unloads,
+                // we don't strictly need to block here to release resources
+                // since that support takes care of the pinning & freeing the 
+                // overlapped struct.  We need to do this when called from
+                // Close so that the handle is closed when Close returns, but
+                // we don't need to call EndWrite from the finalizer.  
+                // Additionally, if we do call EndWrite, we block forever 
+                // because AD unloads prevent us from running the managed 
+                // callback from the IO completion port.  Blocking here when 
+                // called from the finalizer during AD unload is clearly wrong, 
+                // but we can't use any sort of test for whether the AD is 
+                // unloading because if we weren't unloading, an AD unload 
+                // could happen on a separate thread before we call EndWrite.
+                if (!calledFromFinalizer)
+                {
+                    writeTask.GetAwaiter().GetResult();
+                }
+            }
+            else
+            {
+                WriteCore(GetBuffer(), 0, _writePos);
+            }
+
+            _writePos = 0;
+        }
+
+        private void SetLengthInternal(long value)
+        {
+            // Handle buffering updates.
+            if (_writePos > 0)
+            {
+                FlushWriteBuffer();
+            }
+            else if (_readPos < _readLength)
+            {
+                FlushReadBuffer();
+            }
+            _readPos = 0;
+            _readLength = 0;
+
+            if (_appendStart != -1 && value < _appendStart)
+                throw new IOException(SR.IO_SetLengthAppendTruncate);
+            SetLengthCore(value);
+        }
+
+        // We absolutely need this method broken out so that WriteInternalCoreAsync can call
+        // a method without having to go through buffering code that might call FlushWrite.
+        private void SetLengthCore(long value)
+        {
+            Debug.Assert(value >= 0, "value >= 0");
+            long origPos = _filePosition;
+
+            VerifyOSHandlePosition();
+            if (_filePosition != value)
+                SeekCore(value, SeekOrigin.Begin);
+            if (!Interop.mincore.SetEndOfFile(_fileHandle))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+                if (errorCode == Interop.mincore.Errors.ERROR_INVALID_PARAMETER)
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_FileLengthTooBig);
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+            }
+            // Return file pointer to where it was before setting length
+            if (origPos != value)
+            {
+                if (origPos < value)
+                    SeekCore(origPos, SeekOrigin.Begin);
+                else
+                    SeekCore(0, SeekOrigin.End);
+            }
+        }
+
+        // Instance method to help code external to this MarshalByRefObject avoid
+        // accessing its fields by ref.  This avoids a compiler warning.
+        private FileStreamCompletionSource CompareExchangeCurrentOverlappedOwner(FileStreamCompletionSource newSource, FileStreamCompletionSource existingSource) => Interlocked.CompareExchange(ref _currentOverlappedOwner, newSource, existingSource);
+
+        public override int Read(byte[] array, int offset, int count)
+        {
+            ValidateReadWriteArgs(array, offset, count);
+            return ReadCore(array, offset, count);
+        }
+
+        private int ReadCore(byte[] array, int offset, int count)
+        {
+            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength),
+                "We're either reading or writing, but not both.");
+
+            bool isBlocked = false;
+            int n = _readLength - _readPos;
+            // if the read buffer is empty, read into either user's array or our
+            // buffer, depending on number of bytes user asked for and buffer size.
+            if (n == 0)
+            {
+                if (!CanRead) throw Error.GetReadNotSupported();
+                if (_writePos > 0) FlushWriteBuffer();
+                if (!CanSeek || (count >= _bufferLength))
+                {
+                    n = ReadNative(array, offset, count);
+                    // Throw away read buffer.
+                    _readPos = 0;
+                    _readLength = 0;
+                    return n;
+                }
+                n = ReadNative(GetBuffer(), 0, _bufferLength);
+                if (n == 0) return 0;
+                isBlocked = n < _bufferLength;
+                _readPos = 0;
+                _readLength = n;
+            }
+            // Now copy min of count or numBytesAvailable (i.e. near EOF) to array.
+            if (n > count) n = count;
+            Buffer.BlockCopy(GetBuffer(), _readPos, array, offset, n);
+            _readPos += n;
+
+            // We may have read less than the number of bytes the user asked 
+            // for, but that is part of the Stream contract.  Reading again for
+            // more data may cause us to block if we're using a device with 
+            // no clear end of file, such as a serial port or pipe.  If we
+            // blocked here & this code was used with redirected pipes for a
+            // process's standard output, this can lead to deadlocks involving
+            // two processes. But leave this here for files to avoid what would
+            // probably be a breaking change.         -- 
+
+            // If we are reading from a device with no clear EOF like a 
+            // serial port or a pipe, this will cause us to block incorrectly.
+            if (!_isPipe)
+            {
+                // If we hit the end of the buffer and didn't have enough bytes, we must
+                // read some more from the underlying stream.  However, if we got
+                // fewer bytes from the underlying stream than we asked for (i.e. we're 
+                // probably blocked), don't ask for more bytes.
+                if (n < count && !isBlocked)
+                {
+                    Debug.Assert(_readPos == _readLength, "Read buffer should be empty!");
+                    int moreBytesRead = ReadNative(array, offset + n, count - n);
+                    n += moreBytesRead;
+                    // We've just made our buffer inconsistent with our position 
+                    // pointer.  We must throw away the read buffer.
+                    _readPos = 0;
+                    _readLength = 0;
+                }
+            }
+
+            return n;
+        }
+
+        [Conditional("DEBUG")]
+        private void AssertCanRead(byte[] buffer, int offset, int count)
+        {
+            Debug.Assert(!_fileHandle.IsClosed, "!_fileHandle.IsClosed");
+            Debug.Assert(CanRead, "CanRead");
+            Debug.Assert(buffer != null, "buffer != null");
+            Debug.Assert(_writePos == 0, "_writePos == 0");
+            Debug.Assert(offset >= 0, "offset is negative");
+            Debug.Assert(count >= 0, "count is negative");
+        }
+
+        private unsafe int ReadNative(byte[] buffer, int offset, int count)
+        {
+            AssertCanRead(buffer, offset, count);
+
+            if (_useAsyncIO)
+                return ReadNativeAsync(buffer, offset, count, 0, CancellationToken.None).GetAwaiter().GetResult();
+
+            // Make sure we are reading from the right spot
+            VerifyOSHandlePosition();
+
+            int errorCode = 0;
+            int r = ReadFileNative(_fileHandle, buffer, offset, count, null, out errorCode);
+
+            if (r == -1)
+            {
+                // For pipes, ERROR_BROKEN_PIPE is the normal end of the pipe.
+                if (errorCode == ERROR_BROKEN_PIPE)
+                {
+                    r = 0;
+                }
+                else
+                {
+                    if (errorCode == ERROR_INVALID_PARAMETER)
+                        throw new ArgumentException(SR.Arg_HandleNotSync, "_fileHandle");
+
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                }
+            }
+            Debug.Assert(r >= 0, "FileStream's ReadNative is likely broken.");
+            _filePosition += r;
+
+            return r;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (origin < SeekOrigin.Begin || origin > SeekOrigin.End)
+                throw new ArgumentException(SR.Argument_InvalidSeekOrigin, nameof(origin));
+            if (_fileHandle.IsClosed) throw Error.GetFileNotOpen();
+            if (!CanSeek) throw Error.GetSeekNotSupported();
+
+            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength), "We're either reading or writing, but not both.");
+
+            // If we've got bytes in our buffer to write, write them out.
+            // If we've read in and consumed some bytes, we'll have to adjust
+            // our seek positions ONLY IF we're seeking relative to the current
+            // position in the stream.  This simulates doing a seek to the new
+            // position, then a read for the number of bytes we have in our buffer.
+            if (_writePos > 0)
+            {
+                FlushWriteBuffer();
+            }
+            else if (origin == SeekOrigin.Current)
+            {
+                // Don't call FlushRead here, which would have caused an infinite
+                // loop.  Simply adjust the seek origin.  This isn't necessary
+                // if we're seeking relative to the beginning or end of the stream.
+                offset -= (_readLength - _readPos);
+            }
+            _readPos = _readLength = 0;
+
+            // Verify that internal position is in sync with the handle
+            VerifyOSHandlePosition();
+
+            long oldPos = _filePosition + (_readPos - _readLength);
+            long pos = SeekCore(offset, origin);
+
+            // Prevent users from overwriting data in a file that was opened in
+            // append mode.
+            if (_appendStart != -1 && pos < _appendStart)
+            {
+                SeekCore(oldPos, SeekOrigin.Begin);
+                throw new IOException(SR.IO_SeekAppendOverwrite);
+            }
+
+            // We now must update the read buffer.  We can in some cases simply
+            // update _readPos within the buffer, copy around the buffer so our 
+            // Position property is still correct, and avoid having to do more 
+            // reads from the disk.  Otherwise, discard the buffer's contents.
+            if (_readLength > 0)
+            {
+                // We can optimize the following condition:
+                // oldPos - _readPos <= pos < oldPos + _readLen - _readPos
+                if (oldPos == pos)
+                {
+                    if (_readPos > 0)
+                    {
+                        //Console.WriteLine("Seek: seeked for 0, adjusting buffer back by: "+_readPos+"  _readLen: "+_readLen);
+                        Buffer.BlockCopy(GetBuffer(), _readPos, GetBuffer(), 0, _readLength - _readPos);
+                        _readLength -= _readPos;
+                        _readPos = 0;
+                    }
+                    // If we still have buffered data, we must update the stream's 
+                    // position so our Position property is correct.
+                    if (_readLength > 0)
+                        SeekCore(_readLength, SeekOrigin.Current);
+                }
+                else if (oldPos - _readPos < pos && pos < oldPos + _readLength - _readPos)
+                {
+                    int diff = (int)(pos - oldPos);
+                    //Console.WriteLine("Seek: diff was "+diff+", readpos was "+_readPos+"  adjusting buffer - shrinking by "+ (_readPos + diff));
+                    Buffer.BlockCopy(GetBuffer(), _readPos + diff, GetBuffer(), 0, _readLength - (_readPos + diff));
+                    _readLength -= (_readPos + diff);
+                    _readPos = 0;
+                    if (_readLength > 0)
+                        SeekCore(_readLength, SeekOrigin.Current);
+                }
+                else
+                {
+                    // Lose the read buffer.
+                    _readPos = 0;
+                    _readLength = 0;
+                }
+                Debug.Assert(_readLength >= 0 && _readPos <= _readLength, "_readLen should be nonnegative, and _readPos should be less than or equal _readLen");
+                Debug.Assert(pos == Position, "Seek optimization: pos != Position!  Buffer math was mangled.");
+            }
+            return pos;
+        }
+
+        // This doesn't do argument checking.  Necessary for SetLength, which must
+        // set the file pointer beyond the end of the file. This will update the 
+        // internal position
+        // This is called during construction so it should avoid any virtual
+        // calls
+        private long SeekCore(long offset, SeekOrigin origin)
+        {
+            Debug.Assert(!_fileHandle.IsClosed && _canSeek, "!_handle.IsClosed && _parent.CanSeek");
+            Debug.Assert(origin >= SeekOrigin.Begin && origin <= SeekOrigin.End, "origin>=SeekOrigin.Begin && origin<=SeekOrigin.End");
+            long ret = 0;
+
+            if (!Interop.mincore.SetFilePointerEx(_fileHandle, offset, out ret, (uint)origin))
+            {
+                int errorCode = GetLastWin32ErrorAndDisposeHandleIfInvalid();
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+            }
+
+            _filePosition = ret;
+            return ret;
+        }
+
+        partial void OnBufferAllocated()
+        {
+            Debug.Assert(_buffer != null);
+            Debug.Assert(_preallocatedOverlapped == null);
+
+            if (_useAsyncIO)
+                _preallocatedOverlapped = new PreAllocatedOverlapped(s_ioCallback, this, _buffer);
+        }
+
+        public override void Write(byte[] array, int offset, int count)
+        {
+            ValidateReadWriteArgs(array, offset, count);
+
+            if (_writePos == 0)
+            {
+                // Ensure we can write to the stream, and ready buffer for writing.
+                if (!CanWrite) throw Error.GetWriteNotSupported();
+                if (_readPos < _readLength) FlushReadBuffer();
+                _readPos = 0;
+                _readLength = 0;
+            }
+
+            // If our buffer has data in it, copy data from the user's array into
+            // the buffer, and if we can fit it all there, return.  Otherwise, write
+            // the buffer to disk and copy any remaining data into our buffer.
+            // The assumption here is memcpy is cheaper than disk (or net) IO.
+            // (10 milliseconds to disk vs. ~20-30 microseconds for a 4K memcpy)
+            // So the extra copying will reduce the total number of writes, in 
+            // non-pathological cases (i.e. write 1 byte, then write for the buffer 
+            // size repeatedly)
+            if (_writePos > 0)
+            {
+                int numBytes = _bufferLength - _writePos;   // space left in buffer
+                if (numBytes > 0)
+                {
+                    if (numBytes > count)
+                        numBytes = count;
+                    Buffer.BlockCopy(array, offset, GetBuffer(), _writePos, numBytes);
+                    _writePos += numBytes;
+                    if (count == numBytes) return;
+                    offset += numBytes;
+                    count -= numBytes;
+                }
+                // Reset our buffer.  We essentially want to call FlushWrite
+                // without calling Flush on the underlying Stream.
+
+                if (_useAsyncIO)
+                {
+                    WriteInternalCoreAsync(GetBuffer(), 0, _writePos, CancellationToken.None).GetAwaiter().GetResult();
+                }
+                else
+                {
+                    WriteCore(GetBuffer(), 0, _writePos);
+                }
+                _writePos = 0;
+            }
+            // If the buffer would slow writes down, avoid buffer completely.
+            if (count >= _bufferLength)
+            {
+                Debug.Assert(_writePos == 0, "FileStream cannot have buffered data to write here!  Your stream will be corrupted.");
+                WriteCore(array, offset, count);
+                return;
+            }
+            else if (count == 0)
+            {
+                return;  // Don't allocate a buffer then call memcpy for 0 bytes.
+            }
+
+            // Copy remaining bytes into buffer, to write at a later date.
+            Buffer.BlockCopy(array, offset, GetBuffer(), _writePos, count);
+            _writePos = count;
+            return;
+        }
+
+        private unsafe void WriteCore(byte[] buffer, int offset, int count)
+        {
+            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
+            Debug.Assert(CanWrite, "_parent.CanWrite");
+
+            Debug.Assert(buffer != null, "buffer != null");
+            Debug.Assert(_readPos == _readLength, "_readPos == _readLen");
+            Debug.Assert(offset >= 0, "offset is negative");
+            Debug.Assert(count >= 0, "count is negative");
+            if (_useAsyncIO)
+            {
+                WriteInternalCoreAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
+                return;
+            }
+
+            // Make sure we are writing to the position that we think we are
+            VerifyOSHandlePosition();
+
+            int errorCode = 0;
+            int r = WriteFileNative(_fileHandle, buffer, offset, count, null, out errorCode);
+
+            if (r == -1)
+            {
+                // For pipes, ERROR_NO_DATA is not an error, but the pipe is closing.
+                if (errorCode == ERROR_NO_DATA)
+                {
+                    r = 0;
+                }
+                else
+                {
+                    // ERROR_INVALID_PARAMETER may be returned for writes
+                    // where the position is too large (i.e. writing at Int64.MaxValue 
+                    // on Win9x) OR for synchronous writes to a handle opened 
+                    // asynchronously.
+                    if (errorCode == ERROR_INVALID_PARAMETER)
+                        throw new IOException(SR.IO_FileTooLongOrHandleNotSync);
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                }
+            }
+            Debug.Assert(r >= 0, "FileStream's WriteCore is likely broken.");
+            _filePosition += r;
+            return;
+        }
+
+        private Task<int> ReadAsyncInternal(byte[] array, int offset, int numBytes, CancellationToken cancellationToken)
+        {
+            // If async IO is not supported on this platform or 
+            // if this Win32FileStream was not opened with FileOptions.Asynchronous.
+            if (!_useAsyncIO)
+            {
+                return base.ReadAsync(array, offset, numBytes, cancellationToken);
+            }
+
+            if (!CanRead) throw Error.GetReadNotSupported();
+
+            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength), "We're either reading or writing, but not both.");
+
+            if (_isPipe)
+            {
+                // Pipes are tricky, at least when you have 2 different pipes
+                // that you want to use simultaneously.  When redirecting stdout
+                // & stderr with the Process class, it's easy to deadlock your
+                // parent & child processes when doing writes 4K at a time.  The
+                // OS appears to use a 4K buffer internally.  If you write to a
+                // pipe that is full, you will block until someone read from 
+                // that pipe.  If you try reading from an empty pipe and 
+                // Win32FileStream's ReadAsync blocks waiting for data to fill it's 
+                // internal buffer, you will be blocked.  In a case where a child
+                // process writes to stdout & stderr while a parent process tries
+                // reading from both, you can easily get into a deadlock here.
+                // To avoid this deadlock, don't buffer when doing async IO on
+                // pipes.  But don't completely ignore buffered data either.  
+                if (_readPos < _readLength)
+                {
+                    int n = _readLength - _readPos;
+                    if (n > numBytes) n = numBytes;
+                    Buffer.BlockCopy(GetBuffer(), _readPos, array, offset, n);
+                    _readPos += n;
+
+                    // Return a completed task
+                    return TaskFromResultOrCache(n);
+                }
+                else
+                {
+                    Debug.Assert(_writePos == 0, "Win32FileStream must not have buffered write data here!  Pipes should be unidirectional.");
+                    return ReadNativeAsync(array, offset, numBytes, 0, cancellationToken);
+                }
+            }
+
+            Debug.Assert(!_isPipe, "Should not be a pipe.");
+
+            // Handle buffering.
+            if (_writePos > 0) FlushWriteBuffer();
+            if (_readPos == _readLength)
+            {
+                // I can't see how to handle buffering of async requests when 
+                // filling the buffer asynchronously, without a lot of complexity.
+                // The problems I see are issuing an async read, we do an async 
+                // read to fill the buffer, then someone issues another read 
+                // (either synchronously or asynchronously) before the first one 
+                // returns.  This would involve some sort of complex buffer locking
+                // that we probably don't want to get into, at least not in V1.
+                // If we did a sync read to fill the buffer, we could avoid the
+                // problem, and any async read less than 64K gets turned into a
+                // synchronous read by NT anyways...       -- 
+
+                if (numBytes < _bufferLength)
+                {
+                    Task<int> readTask = ReadNativeAsync(GetBuffer(), 0, _bufferLength, 0, cancellationToken);
+                    _readLength = readTask.GetAwaiter().GetResult();
+                    int n = _readLength;
+                    if (n > numBytes) n = numBytes;
+                    Buffer.BlockCopy(GetBuffer(), 0, array, offset, n);
+                    _readPos = n;
+
+                    // Return a completed task (recycling the one above if possible)
+                    return (_readLength == n ? readTask : TaskFromResultOrCache(n));
+                }
+                else
+                {
+                    // Here we're making our position pointer inconsistent
+                    // with our read buffer.  Throw away the read buffer's contents.
+                    _readPos = 0;
+                    _readLength = 0;
+                    return ReadNativeAsync(array, offset, numBytes, 0, cancellationToken);
+                }
+            }
+            else
+            {
+                int n = _readLength - _readPos;
+                if (n > numBytes) n = numBytes;
+                Buffer.BlockCopy(GetBuffer(), _readPos, array, offset, n);
+                _readPos += n;
+
+                if (n >= numBytes)
+                {
+                    // Return a completed task
+                    return TaskFromResultOrCache(n);
+                }
+                else
+                {
+                    // For streams with no clear EOF like serial ports or pipes
+                    // we cannot read more data without causing an app to block
+                    // incorrectly.  Pipes don't go down this path 
+                    // though.  This code needs to be fixed.
+                    // Throw away read buffer.
+                    _readPos = 0;
+                    _readLength = 0;
+                    return ReadNativeAsync(array, offset + n, numBytes - n, n, cancellationToken);
+                }
+            }
+        }
+
+        unsafe private Task<int> ReadNativeAsync(byte[] bytes, int offset, int numBytes, int numBufferedBytesRead, CancellationToken cancellationToken)
+        {
+            AssertCanRead(bytes, offset, numBytes);
+            Debug.Assert(_useAsyncIO, "ReadNativeAsync doesn't work on synchronous file streams!");
+
+            // Create and store async stream class library specific data in the async result
+
+            FileStreamCompletionSource completionSource = new FileStreamCompletionSource(this, numBufferedBytesRead, bytes, cancellationToken);
+            NativeOverlapped* intOverlapped = completionSource.Overlapped;
+
+            // Calculate position in the file we should be at after the read is done
+            if (CanSeek)
+            {
+                long len = Length;
+
+                // Make sure we are reading from the position that we think we are
+                VerifyOSHandlePosition();
+
+                if (_filePosition + numBytes > len)
+                {
+                    if (_filePosition <= len)
+                        numBytes = (int)(len - _filePosition);
+                    else
+                        numBytes = 0;
+                }
+
+                // Now set the position to read from in the NativeOverlapped struct
+                // For pipes, we should leave the offset fields set to 0.
+                intOverlapped->OffsetLow = unchecked((int)_filePosition);
+                intOverlapped->OffsetHigh = (int)(_filePosition >> 32);
+
+                // When using overlapped IO, the OS is not supposed to 
+                // touch the file pointer location at all.  We will adjust it 
+                // ourselves. This isn't threadsafe.
+
+                // WriteFile should not update the file pointer when writing
+                // in overlapped mode, according to MSDN.  But it does update 
+                // the file pointer when writing to a UNC path!   
+                // So changed the code below to seek to an absolute 
+                // location, not a relative one.  ReadFile seems consistent though.
+                SeekCore(numBytes, SeekOrigin.Current);
+            }
+
+            // queue an async ReadFile operation and pass in a packed overlapped
+            int errorCode = 0;
+            int r = ReadFileNative(_fileHandle, bytes, offset, numBytes, intOverlapped, out errorCode);
+            // ReadFile, the OS version, will return 0 on failure.  But
+            // my ReadFileNative wrapper returns -1.  My wrapper will return
+            // the following:
+            // On error, r==-1.
+            // On async requests that are still pending, r==-1 w/ errorCode==ERROR_IO_PENDING
+            // on async requests that completed sequentially, r==0
+            // You will NEVER RELIABLY be able to get the number of bytes
+            // read back from this call when using overlapped structures!  You must
+            // not pass in a non-null lpNumBytesRead to ReadFile when using 
+            // overlapped structures!  This is by design NT behavior.
+            if (r == -1 && numBytes != -1)
+            {
+                // For pipes, when they hit EOF, they will come here.
+                if (errorCode == ERROR_BROKEN_PIPE)
+                {
+                    // Not an error, but EOF.  AsyncFSCallback will NOT be 
+                    // called.  Call the user callback here.
+
+                    // We clear the overlapped status bit for this special case.
+                    // Failure to do so looks like we are freeing a pending overlapped later.
+                    intOverlapped->InternalLow = IntPtr.Zero;
+                    completionSource.SetCompletedSynchronously(0);
+                }
+                else if (errorCode != ERROR_IO_PENDING)
+                {
+                    if (!_fileHandle.IsClosed && CanSeek)  // Update Position - It could be anywhere.
+                    {
+                        SeekCore(0, SeekOrigin.Current);
+                    }
+
+                    completionSource.ReleaseNativeResource();
+
+                    if (errorCode == ERROR_HANDLE_EOF)
+                    {
+                        throw Error.GetEndOfFile();
+                    }
+                    else
+                    {
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                    }
+                }
+                else
+                {
+                    // Only once the IO is pending do we register for cancellation
+                    completionSource.RegisterForCancellation();
+                }
+            }
+            else
+            {
+                // Due to a workaround for a race condition in NT's ReadFile & 
+                // WriteFile routines, we will always be returning 0 from ReadFileNative
+                // when we do async IO instead of the number of bytes read, 
+                // irregardless of whether the operation completed 
+                // synchronously or asynchronously.  We absolutely must not
+                // set asyncResult._numBytes here, since will never have correct
+                // results.  
+                //Console.WriteLine("ReadFile returned: "+r+" (0x"+Int32.Format(r, "x")+")  The IO completed synchronously, but the user callback was called on a separate thread");
+            }
+
+            return completionSource.Task;
+        }
+
+        // Reads a byte from the file stream.  Returns the byte cast to an int
+        // or -1 if reading from the end of the stream.
+        public override int ReadByte()
+        {
+            return ReadByteCore();
+        }
+
+        private Task WriteAsyncInternal(byte[] array, int offset, int numBytes, CancellationToken cancellationToken)
+        {
+            // If async IO is not supported on this platform or 
+            // if this Win32FileStream was not opened with FileOptions.Asynchronous.
+            if (!_useAsyncIO)
+            {
+                return base.WriteAsync(array, offset, numBytes, cancellationToken);
+            }
+
+            if (!CanWrite) throw Error.GetWriteNotSupported();
+
+            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength), "We're either reading or writing, but not both.");
+            Debug.Assert(!_isPipe || (_readPos == 0 && _readLength == 0), "Win32FileStream must not have buffered data here!  Pipes should be unidirectional.");
+
+            bool writeDataStoredInBuffer = false;
+            if (!_isPipe) // avoid async buffering with pipes, as doing so can lead to deadlocks (see comments in ReadInternalAsyncCore)
+            {
+                // Ensure the buffer is clear for writing
+                if (_writePos == 0)
+                {
+                    if (_readPos < _readLength)
+                    {
+                        FlushReadBuffer();
+                    }
+                    _readPos = 0;
+                    _readLength = 0;
+                }
+
+                // Determine how much space remains in the buffer
+                int remainingBuffer = _bufferLength - _writePos;
+                Debug.Assert(remainingBuffer >= 0);
+
+                // Simple/common case:
+                // - The write is smaller than our buffer, such that it's worth considering buffering it.
+                // - There's no active flush operation, such that we don't have to worry about the existing buffer being in use.
+                // - And the data we're trying to write fits in the buffer, meaning it wasn't already filled by previous writes.
+                // In that case, just store it in the buffer.
+                if (numBytes < _bufferLength && !HasActiveBufferOperation && numBytes <= remainingBuffer)
+                {
+                    Buffer.BlockCopy(array, offset, GetBuffer(), _writePos, numBytes);
+                    _writePos += numBytes;
+                    writeDataStoredInBuffer = true;
+
+                    // There is one special-but-common case, common because devs often use
+                    // byte[] sizes that are powers of 2 and thus fit nicely into our buffer, which is
+                    // also a power of 2. If after our write the buffer still has remaining space,
+                    // then we're done and can return a completed task now.  But if we filled the buffer
+                    // completely, we want to do the asynchronous flush/write as part of this operation 
+                    // rather than waiting until the next write that fills the buffer.
+                    if (numBytes != remainingBuffer)
+                        return Task.CompletedTask;
+
+                    Debug.Assert(_writePos == _bufferLength);
+                }
+            }
+
+            // At this point, at least one of the following is true:
+            // 1. There was an active flush operation (it could have completed by now, though).
+            // 2. The data doesn't fit in the remaining buffer (or it's a pipe and we chose not to try).
+            // 3. We wrote all of the data to the buffer, filling it.
+            //
+            // If there's an active operation, we can't touch the current buffer because it's in use.
+            // That gives us a choice: we can either allocate a new buffer, or we can skip the buffer
+            // entirely (even if the data would otherwise fit in it).  For now, for simplicity, we do
+            // the latter; it could also have performance wins due to OS-level optimizations, and we could
+            // potentially add support for PreAllocatedOverlapped due to having a single buffer. (We can
+            // switch to allocating a new buffer, potentially experimenting with buffer pooling, should
+            // performance data suggest it's appropriate.)
+            //
+            // If the data doesn't fit in the remaining buffer, it could be because it's so large
+            // it's greater than the entire buffer size, in which case we'd always skip the buffer,
+            // or it could be because there's more data than just the space remaining.  For the latter
+            // case, we need to issue an asynchronous write to flush that data, which then turns this into
+            // the first case above with an active operation.
+            //
+            // If we already stored the data, then we have nothing additional to write beyond what
+            // we need to flush.
+            //
+            // In any of these cases, we have the same outcome:
+            // - If there's data in the buffer, flush it by writing it out asynchronously.
+            // - Then, if there's any data to be written, issue a write for it concurrently.
+            // We return a Task that represents one or both.
+
+            // Flush the buffer asynchronously if there's anything to flush
+            Task flushTask = null;
+            if (_writePos > 0)
+            {
+                flushTask = FlushWriteAsync(cancellationToken);
+
+                // If we already copied all of the data into the buffer,
+                // simply return the flush task here.  Same goes for if the task has 
+                // already completed and was unsuccessful.
+                if (writeDataStoredInBuffer ||
+                    flushTask.IsFaulted ||
+                    flushTask.IsCanceled)
+                {
+                    return flushTask;
+                }
+            }
+
+            Debug.Assert(!writeDataStoredInBuffer);
+            Debug.Assert(_writePos == 0);
+
+            // Finally, issue the write asynchronously, and return a Task that logically
+            // represents the write operation, including any flushing done.
+            Task writeTask = WriteInternalCoreAsync(array, offset, numBytes, cancellationToken);
+            return
+                (flushTask == null || flushTask.Status == TaskStatus.RanToCompletion) ? writeTask :
+                (writeTask.Status == TaskStatus.RanToCompletion) ? flushTask :
+                Task.WhenAll(flushTask, writeTask);
+        }
+
+        private unsafe Task WriteInternalCoreAsync(byte[] bytes, int offset, int numBytes, CancellationToken cancellationToken)
+        {
+            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
+            Debug.Assert(CanWrite, "_parent.CanWrite");
+            Debug.Assert(bytes != null, "bytes != null");
+            Debug.Assert(_readPos == _readLength, "_readPos == _readLen");
+            Debug.Assert(_useAsyncIO, "WriteInternalCoreAsync doesn't work on synchronous file streams!");
+            Debug.Assert(offset >= 0, "offset is negative");
+            Debug.Assert(numBytes >= 0, "numBytes is negative");
+
+            // Create and store async stream class library specific data in the async result
+            FileStreamCompletionSource completionSource = new FileStreamCompletionSource(this, 0, bytes, cancellationToken);
+            NativeOverlapped* intOverlapped = completionSource.Overlapped;
+
+            if (CanSeek)
+            {
+                // Make sure we set the length of the file appropriately.
+                long len = Length;
+                //Console.WriteLine("WriteInternalCoreAsync - Calculating end pos.  pos: "+pos+"  len: "+len+"  numBytes: "+numBytes);
+
+                // Make sure we are writing to the position that we think we are
+                VerifyOSHandlePosition();
+
+                if (_filePosition + numBytes > len)
+                {
+                    //Console.WriteLine("WriteInternalCoreAsync - Setting length to: "+(pos + numBytes));
+                    SetLengthCore(_filePosition + numBytes);
+                }
+
+                // Now set the position to read from in the NativeOverlapped struct
+                // For pipes, we should leave the offset fields set to 0.
+                intOverlapped->OffsetLow = (int)_filePosition;
+                intOverlapped->OffsetHigh = (int)(_filePosition >> 32);
+
+                // When using overlapped IO, the OS is not supposed to 
+                // touch the file pointer location at all.  We will adjust it 
+                // ourselves.  This isn't threadsafe.
+                SeekCore(numBytes, SeekOrigin.Current);
+            }
+
+            //Console.WriteLine("WriteInternalCoreAsync finishing.  pos: "+pos+"  numBytes: "+numBytes+"  _pos: "+_pos+"  Position: "+Position);
+
+            int errorCode = 0;
+            // queue an async WriteFile operation and pass in a packed overlapped
+            int r = WriteFileNative(_fileHandle, bytes, offset, numBytes, intOverlapped, out errorCode);
+
+            // WriteFile, the OS version, will return 0 on failure.  But
+            // my WriteFileNative wrapper returns -1.  My wrapper will return
+            // the following:
+            // On error, r==-1.
+            // On async requests that are still pending, r==-1 w/ errorCode==ERROR_IO_PENDING
+            // On async requests that completed sequentially, r==0
+            // You will NEVER RELIABLY be able to get the number of bytes
+            // written back from this call when using overlapped IO!  You must
+            // not pass in a non-null lpNumBytesWritten to WriteFile when using 
+            // overlapped structures!  This is ByDesign NT behavior.
+            if (r == -1 && numBytes != -1)
+            {
+                //Console.WriteLine("WriteFile returned 0;  Write will complete asynchronously (if errorCode==3e5)  errorCode: 0x{0:x}", errorCode);
+
+                // For pipes, when they are closed on the other side, they will come here.
+                if (errorCode == ERROR_NO_DATA)
+                {
+                    // Not an error, but EOF. AsyncFSCallback will NOT be called.
+                    // Completing TCS and return cached task allowing the GC to collect TCS.
+                    completionSource.SetCompletedSynchronously(0);
+                    return Task.CompletedTask;
+                }
+                else if (errorCode != ERROR_IO_PENDING)
+                {
+                    if (!_fileHandle.IsClosed && CanSeek)  // Update Position - It could be anywhere.
+                    {
+                        SeekCore(0, SeekOrigin.Current);
+                    }
+
+                    completionSource.ReleaseNativeResource();
+
+                    if (errorCode == ERROR_HANDLE_EOF)
+                    {
+                        throw Error.GetEndOfFile();
+                    }
+                    else
+                    {
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                    }
+                }
+                else // ERROR_IO_PENDING
+                {
+                    // Only once the IO is pending do we register for cancellation
+                    completionSource.RegisterForCancellation();
+                }
+            }
+            else
+            {
+                // Due to a workaround for a race condition in NT's ReadFile & 
+                // WriteFile routines, we will always be returning 0 from WriteFileNative
+                // when we do async IO instead of the number of bytes written, 
+                // irregardless of whether the operation completed 
+                // synchronously or asynchronously.  We absolutely must not
+                // set asyncResult._numBytes here, since will never have correct
+                // results.  
+                //Console.WriteLine("WriteFile returned: "+r+" (0x"+Int32.Format(r, "x")+")  The IO completed synchronously, but the user callback was called on another thread.");
+            }
+
+            return completionSource.Task;
+        }
+
+        public override void WriteByte(byte value)
+        {
+            WriteByteCore(value);
+        }
+
+        // Windows API definitions, from winbase.h and others
+
+        private const int FILE_ATTRIBUTE_NORMAL = 0x00000080;
+        private const int FILE_ATTRIBUTE_ENCRYPTED = 0x00004000;
+        private const int FILE_FLAG_OVERLAPPED = 0x40000000;
+        internal const int GENERIC_READ = unchecked((int)0x80000000);
+        private const int GENERIC_WRITE = 0x40000000;
+
+        private const int FILE_BEGIN = 0;
+        private const int FILE_CURRENT = 1;
+        private const int FILE_END = 2;
+
+        // Error codes (not HRESULTS), from winerror.h
+        internal const int ERROR_BROKEN_PIPE = 109;
+        internal const int ERROR_NO_DATA = 232;
+        private const int ERROR_HANDLE_EOF = 38;
+        private const int ERROR_INVALID_PARAMETER = 87;
+        private const int ERROR_IO_PENDING = 997;
+
+        // __ConsoleStream also uses this code. 
+        private unsafe int ReadFileNative(SafeFileHandle handle, byte[] bytes, int offset, int count, NativeOverlapped* overlapped, out int errorCode)
+        {
+            Debug.Assert(handle != null, "handle != null");
+            Debug.Assert(offset >= 0, "offset >= 0");
+            Debug.Assert(count >= 0, "count >= 0");
+            Debug.Assert(bytes != null, "bytes != null");
+            // Don't corrupt memory when multiple threads are erroneously writing
+            // to this stream simultaneously.
+            if (bytes.Length - offset < count)
+                throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
+
+            Debug.Assert((_useAsyncIO && overlapped != null) || (!_useAsyncIO && overlapped == null), "Async IO and overlapped parameters inconsistent in call to ReadFileNative.");
+
+            // You can't use the fixed statement on an array of length 0.
+            if (bytes.Length == 0)
+            {
+                errorCode = 0;
+                return 0;
+            }
+
+            int r = 0;
+            int numBytesRead = 0;
+
+            fixed (byte* p = bytes)
+            {
+                if (_useAsyncIO)
+                    r = Interop.mincore.ReadFile(handle, p + offset, count, IntPtr.Zero, overlapped);
+                else
+                    r = Interop.mincore.ReadFile(handle, p + offset, count, out numBytesRead, IntPtr.Zero);
+            }
+
+            if (r == 0)
+            {
+                errorCode = GetLastWin32ErrorAndDisposeHandleIfInvalid();
+                return -1;
+            }
+            else
+            {
+                errorCode = 0;
+                return numBytesRead;
+            }
+        }
+
+        private unsafe int WriteFileNative(SafeFileHandle handle, byte[] bytes, int offset, int count, NativeOverlapped* overlapped, out int errorCode)
+        {
+            Debug.Assert(handle != null, "handle != null");
+            Debug.Assert(offset >= 0, "offset >= 0");
+            Debug.Assert(count >= 0, "count >= 0");
+            Debug.Assert(bytes != null, "bytes != null");
+            // Don't corrupt memory when multiple threads are erroneously writing
+            // to this stream simultaneously.  (the OS is reading from
+            // the array we pass to WriteFile, but if we read beyond the end and
+            // that memory isn't allocated, we could get an AV.)
+            if (bytes.Length - offset < count)
+                throw new IndexOutOfRangeException(SR.IndexOutOfRange_IORaceCondition);
+
+            Debug.Assert((_useAsyncIO && overlapped != null) || (!_useAsyncIO && overlapped == null), "Async IO and overlapped parameters inconsistent in call to WriteFileNative.");
+
+            // You can't use the fixed statement on an array of length 0.
+            if (bytes.Length == 0)
+            {
+                errorCode = 0;
+                return 0;
+            }
+
+            int numBytesWritten = 0;
+            int r = 0;
+
+            fixed (byte* p = bytes)
+            {
+                if (_useAsyncIO)
+                    r = Interop.mincore.WriteFile(handle, p + offset, count, IntPtr.Zero, overlapped);
+                else
+                    r = Interop.mincore.WriteFile(handle, p + offset, count, out numBytesWritten, IntPtr.Zero);
+            }
+
+            if (r == 0)
+            {
+                errorCode = GetLastWin32ErrorAndDisposeHandleIfInvalid();
+                return -1;
+            }
+            else
+            {
+                errorCode = 0;
+                return numBytesWritten;
+            }
+        }
+
+        private int GetLastWin32ErrorAndDisposeHandleIfInvalid(bool throwIfInvalidHandle = false)
+        {
+            int errorCode = Marshal.GetLastWin32Error();
+
+            // If ERROR_INVALID_HANDLE is returned, it doesn't suffice to set
+            // the handle as invalid; the handle must also be closed.
+            //
+            // Marking the handle as invalid but not closing the handle
+            // resulted in exceptions during finalization and locked column
+            // values (due to invalid but unclosed handle) in SQL Win32FileStream
+            // scenarios.
+            //
+            // A more mainstream scenario involves accessing a file on a
+            // network share. ERROR_INVALID_HANDLE may occur because the network
+            // connection was dropped and the server closed the handle. However,
+            // the client side handle is still open and even valid for certain
+            // operations.
+            //
+            // Note that _parent.Dispose doesn't throw so we don't need to special case.
+            // SetHandleAsInvalid only sets _closed field to true (without
+            // actually closing handle) so we don't need to call that as well.
+            if (errorCode == Interop.mincore.Errors.ERROR_INVALID_HANDLE)
+            {
+                _fileHandle.Dispose();
+
+                if (throwIfInvalidHandle)
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+            }
+
+            return errorCode;
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            // If we're in sync mode, just use the shared CopyToAsync implementation that does
+            // typical read/write looping.  We also need to take this path if this is a derived
+            // instance from FileStream, as a derived type could have overridden ReadAsync, in which
+            // case our custom CopyToAsync implementation isn't necessarily correct.
+            if (!_useAsyncIO || GetType() != typeof(FileStream))
+            {
+                return StreamHelpers.ArrayPoolCopyToAsync(this, destination, bufferSize, cancellationToken);
+            }
+
+            StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
+
+            // Bail early for cancellation if cancellation has been requested
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<int>(cancellationToken);
+            }
+
+            // Fail if the file was closed
+            if (_fileHandle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+
+            // Do the async copy, with differing implementations based on whether the FileStream was opened as async or sync
+            Debug.Assert((_readPos == 0 && _readLength == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLength), "We're either reading or writing, but not both.");
+            return AsyncModeCopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        private async Task AsyncModeCopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            Debug.Assert(_useAsyncIO, "This implementation is for async mode only");
+            Debug.Assert(!_fileHandle.IsClosed, "!_handle.IsClosed");
+            Debug.Assert(CanRead, "_parent.CanRead");
+
+            // Make sure any pending writes have been flushed before we do a read.
+            if (_writePos > 0)
+            {
+                await FlushWriteAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            // Typically CopyToAsync would be invoked as the only "read" on the stream, but it's possible some reading is
+            // done and then the CopyToAsync is issued.  For that case, see if we have any data available in the buffer.
+            if (GetBuffer() != null)
+            {
+                int bufferedBytes = _readLength - _readPos;
+                if (bufferedBytes > 0)
+                {
+                    await destination.WriteAsync(GetBuffer(), _readPos, bufferedBytes, cancellationToken).ConfigureAwait(false);
+                    _readPos = _readLength = 0;
+                }
+            }
+
+            // For efficiency, we avoid creating a new task and associated state for each asynchronous read.
+            // Instead, we create a single reusable awaitable object that will be triggered when an await completes
+            // and reset before going again.
+            var readAwaitable = new AsyncCopyToAwaitable(this);
+
+            // Make sure we are reading from the position that we think we are.
+            // Only set the position in the awaitable if we can seek (e.g. not for pipes).
+            bool canSeek = CanSeek;
+            if (canSeek)
+            {
+                VerifyOSHandlePosition();
+                readAwaitable._position = _filePosition;
+            }
+
+            // Get the buffer to use for the copy operation, as the base CopyToAsync does. We don't try to use
+            // _buffer here, even if it's not null, as concurrent operations are allowed, and another operation may
+            // actually be using the buffer already. Plus, it'll be rare for _buffer to be non-null, as typically
+            // CopyToAsync is used as the only operation performed on the stream, and the buffer is lazily initialized.
+            // Further, typically the CopyToAsync buffer size will be larger than that used by the FileStream, such that
+            // we'd likely be unable to use it anyway.  Instead, we rent the buffer from a pool.
+            byte[] copyBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+            bufferSize = 0; // repurpose bufferSize to be the high water mark for the buffer, to avoid an extra field in the state machine
+
+            // Allocate an Overlapped we can use repeatedly for all operations
+            var awaitableOverlapped = new PreAllocatedOverlapped(AsyncCopyToAwaitable.s_callback, readAwaitable, copyBuffer);
+            var cancellationReg = default(CancellationTokenRegistration);
+            try
+            {
+                // Register for cancellation.  We do this once for the whole copy operation, and just try to cancel
+                // whatever read operation may currently be in progress, if there is one.  It's possible the cancellation
+                // request could come in between operations, in which case we flag that with explicit calls to ThrowIfCancellationRequested
+                // in the read/write copy loop.
+                if (cancellationToken.CanBeCanceled)
+                {
+                    cancellationReg = cancellationToken.Register(s =>
+                    {
+                        var innerAwaitable = (AsyncCopyToAwaitable)s;
+                        unsafe
+                        {
+                            lock (innerAwaitable.CancellationLock) // synchronize with cleanup of the overlapped
+                            {
+                                if (innerAwaitable._nativeOverlapped != null)
+                                {
+                                    // Try to cancel the I/O.  We ignore the return value, as cancellation is opportunistic and we
+                                    // don't want to fail the operation because we couldn't cancel it.
+                                    Interop.mincore.CancelIoEx(innerAwaitable._fileStream._fileHandle, innerAwaitable._nativeOverlapped);
+                                }
+                            }
+                        }
+                    }, readAwaitable);
+                }
+
+                // Repeatedly read from this FileStream and write the results to the destination stream.
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    readAwaitable.ResetForNextOperation();
+
+                    try
+                    {
+                        bool synchronousSuccess;
+                        int errorCode;
+                        unsafe
+                        {
+                            // Allocate a native overlapped for our reusable overlapped, and set position to read based on the next
+                            // desired address stored in the awaitable.  (This position may be 0, if either we're at the beginning or
+                            // if the stream isn't seekable.)
+                            readAwaitable._nativeOverlapped = _fileHandle.ThreadPoolBinding.AllocateNativeOverlapped(awaitableOverlapped);
+                            if (canSeek)
+                            {
+                                readAwaitable._nativeOverlapped->OffsetLow = unchecked((int)readAwaitable._position);
+                                readAwaitable._nativeOverlapped->OffsetHigh = (int)(readAwaitable._position >> 32);
+                            }
+
+                            // Kick off the read.
+                            synchronousSuccess = ReadFileNative(_fileHandle, copyBuffer, 0, copyBuffer.Length, readAwaitable._nativeOverlapped, out errorCode) >= 0;
+                        }
+
+                        // If the operation did not synchronously succeed, it either failed or initiated the asynchronous operation.
+                        if (!synchronousSuccess)
+                        {
+                            switch (errorCode)
+                            {
+                                case ERROR_IO_PENDING:
+                                    // Async operation in progress.
+                                    break;
+                                case ERROR_BROKEN_PIPE:
+                                case ERROR_HANDLE_EOF:
+                                    // We're at or past the end of the file, and the overlapped callback
+                                    // won't be raised in these cases. Mark it as completed so that the await
+                                    // below will see it as such.
+                                    readAwaitable.MarkCompleted();
+                                    break;
+                                default:
+                                    // Everything else is an error (and there won't be a callback).
+                                    throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                            }
+                        }
+
+                        // Wait for the async operation (which may or may not have already completed), then throw if it failed.
+                        await readAwaitable;
+                        switch (readAwaitable._errorCode)
+                        {
+                            case 0: // success
+                                Debug.Assert(readAwaitable._numBytes >= 0, $"Expected non-negative numBytes, got {readAwaitable._numBytes}");
+                                break;
+                            case ERROR_BROKEN_PIPE: // logically success with 0 bytes read (write end of pipe closed)
+                            case ERROR_HANDLE_EOF:  // logically success with 0 bytes read (read at end of file)
+                                Debug.Assert(readAwaitable._numBytes == 0, $"Expected 0 bytes read, got {readAwaitable._numBytes}");
+                                break;
+                            case Interop.mincore.Errors.ERROR_OPERATION_ABORTED: // canceled
+                                throw new OperationCanceledException(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
+                            default: // error
+                                throw Win32Marshal.GetExceptionForWin32Error((int)readAwaitable._errorCode);
+                        }
+
+                        // Successful operation.  If we got zero bytes, we're done: exit the read/write loop.
+                        int numBytesRead = (int)readAwaitable._numBytes;
+                        if (numBytesRead == 0)
+                        {
+                            break;
+                        }
+
+                        // Otherwise, update the read position for next time accordingly.
+                        if (canSeek)
+                        {
+                            readAwaitable._position += numBytesRead;
+                        }
+
+                        // (and keep track of the maximum number of bytes in the buffer we used, to avoid excessive and unnecessary
+                        // clearing of the buffer before we return it to the pool)
+                        if (numBytesRead > bufferSize)
+                        {
+                            bufferSize = numBytesRead;
+                        }
+                    }
+                    finally
+                    {
+                        // Free the resources for this read operation
+                        unsafe
+                        {
+                            NativeOverlapped* overlapped;
+                            lock (readAwaitable.CancellationLock) // just an Exchange, but we need this to be synchronized with cancellation, so using the same lock
+                            {
+                                overlapped = readAwaitable._nativeOverlapped;
+                                readAwaitable._nativeOverlapped = null;
+                            }
+                            if (overlapped != null)
+                            {
+                                _fileHandle.ThreadPoolBinding.FreeNativeOverlapped(overlapped);
+                            }
+                        }
+                    }
+
+                    // Write out the read data.
+                    await destination.WriteAsync(copyBuffer, 0, (int)readAwaitable._numBytes, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                // Cleanup from the whole copy operation
+                cancellationReg.Dispose();
+                awaitableOverlapped.Dispose();
+
+                Array.Clear(copyBuffer, 0, bufferSize);
+                ArrayPool<byte>.Shared.Return(copyBuffer, clearArray: false);
+
+                // Make sure the stream's current position reflects where we ended up
+                if (!_fileHandle.IsClosed && CanSeek)
+                {
+                    SeekCore(0, SeekOrigin.End);
+                }
+            }
+        }
+
+        /// <summary>Used by CopyToAsync to enable awaiting the result of an overlapped I/O operation with minimal overhead.</summary>
+        private sealed unsafe class AsyncCopyToAwaitable : ICriticalNotifyCompletion
+        {
+            /// <summary>Sentinel object used to indicate that the I/O operation has completed before being awaited.</summary>
+            private readonly static Action s_sentinel = () => { };
+            /// <summary>Cached delegate to IOCallback.</summary>
+            internal static readonly IOCompletionCallback s_callback = IOCallback;
+
+            /// <summary>The FileStream that owns this instance.</summary>
+            internal readonly FileStream _fileStream;
+
+            /// <summary>Tracked position representing the next location from which to read.</summary>
+            internal long _position;
+            /// <summary>The current native overlapped pointer.  This changes for each operation.</summary>
+            internal NativeOverlapped* _nativeOverlapped;
+            /// <summary>
+            /// null if the operation is still in progress,
+            /// s_sentinel if the I/O operation completed before the await,
+            /// s_callback if it completed after the await yielded.
+            /// </summary>
+            internal Action _continuation;
+            /// <summary>Last error code from completed operation.</summary>
+            internal uint _errorCode;
+            /// <summary>Last number of read bytes from completed operation.</summary>
+            internal uint _numBytes;
+
+            /// <summary>Lock object used to protect cancellation-related access to _nativeOverlapped.</summary>
+            internal object CancellationLock => this;
+
+            /// <summary>Initialize the awaitable.</summary>
+            internal unsafe AsyncCopyToAwaitable(FileStream fileStream)
+            {
+                _fileStream = fileStream;
+            }
+
+            /// <summary>Reset state to prepare for the next read operation.</summary>
+            internal void ResetForNextOperation()
+            {
+                Debug.Assert(_position >= 0, $"Expected non-negative position, got {_position}");
+                _continuation = null;
+                _errorCode = 0;
+                _numBytes = 0;
+            }
+
+            /// <summary>Overlapped callback: store the results, then invoke the continuation delegate.</summary>
+            internal unsafe static void IOCallback(uint errorCode, uint numBytes, NativeOverlapped* pOVERLAP)
+            {
+                var awaitable = (AsyncCopyToAwaitable)ThreadPoolBoundHandle.GetNativeOverlappedState(pOVERLAP);
+
+                Debug.Assert(awaitable._continuation != s_sentinel, "Sentinel must not have already been set as the continuation");
+                awaitable._errorCode = errorCode;
+                awaitable._numBytes = numBytes;
+
+                (awaitable._continuation ?? Interlocked.CompareExchange(ref awaitable._continuation, s_sentinel, null))?.Invoke();
+            }
+
+            /// <summary>
+            /// Called when it's known that the I/O callback for an operation will not be invoked but we'll
+            /// still be awaiting the awaitable.
+            /// </summary>
+            internal void MarkCompleted()
+            {
+                Debug.Assert(_continuation == null, "Expected null continuation");
+                _continuation = s_sentinel;
+            }
+
+            public AsyncCopyToAwaitable GetAwaiter() => this;
+            public bool IsCompleted => _continuation == s_sentinel;
+            public void GetResult() { }
+            public void OnCompleted(Action continuation) => UnsafeOnCompleted(continuation);
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                if (_continuation == s_sentinel ||
+                    Interlocked.CompareExchange(ref _continuation, continuation, null) != null)
+                {
+                    Debug.Assert(_continuation == s_sentinel, $"Expected continuation set to s_sentinel, got ${_continuation}");
+                    Task.Run(continuation);
+                }
+            }
+        }
+
+        // Unlike Flush(), FlushAsync() always flushes to disk. This is intentional.
+        // Legend is that we chose not to flush the OS file buffers in Flush() in fear of 
+        // perf problems with frequent, long running FlushFileBuffers() calls. But we don't 
+        // have that problem with FlushAsync() because we will call FlushFileBuffers() in the background.
+        private Task FlushAsyncInternal(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+
+            if (_fileHandle.IsClosed)
+                throw Error.GetFileNotOpen();
+
+            // The always synchronous data transfer between the OS and the internal buffer is intentional 
+            // because this is needed to allow concurrent async IO requests. Concurrent data transfer
+            // between the OS and the internal buffer will result in race conditions. Since FlushWrite and
+            // FlushRead modify internal state of the stream and transfer data between the OS and the 
+            // internal buffer, they cannot be truly async. We will, however, flush the OS file buffers
+            // asynchronously because it doesn't modify any internal state of the stream and is potentially 
+            // a long running process.
+            try
+            {
+                FlushInternalBuffer();
+            }
+            catch (Exception e)
+            {
+                return Task.FromException(e);
+            }
+
+            if (CanWrite)
+            {
+                return Task.Factory.StartNew(
+                    state => FlushOSBuffer(),
+                    this,
+                    cancellationToken,
+                    TaskCreationOptions.DenyChildAttach,
+                    TaskScheduler.Default);
+            }
+            else
+            {
+                return Task.CompletedTask;
+            }
+        }
+        
+        private Task<int> TaskFromResultOrCache(int result)
+        {
+            Task<int> completedTask = _lastSynchronouslyCompletedTask;
+            Debug.Assert(completedTask == null || completedTask.Status == TaskStatus.RanToCompletion, "Cached task should have completed successfully");
+
+            if ((completedTask == null) || (completedTask.Result != result))
+            {
+                completedTask = Task.FromResult(result);
+                _lastSynchronouslyCompletedTask = completedTask;
+            }
+
+            return completedTask;
+        }
+
+        private void LockInternal(long position, long length)
+        {
+            int positionLow = unchecked((int)(position));
+            int positionHigh = unchecked((int)(position >> 32));
+            int lengthLow = unchecked((int)(length));
+            int lengthHigh = unchecked((int)(length >> 32));
+
+            if (!Interop.mincore.LockFile(_fileHandle, positionLow, positionHigh, lengthLow, lengthHigh))
+            {
+                throw Win32Marshal.GetExceptionForLastWin32Error();
+            }
+        }
+
+        private void UnlockInternal(long position, long length)
+        {
+            int positionLow = unchecked((int)(position));
+            int positionHigh = unchecked((int)(position >> 32));
+            int lengthLow = unchecked((int)(length));
+            int lengthHigh = unchecked((int)(length >> 32));
+
+            if (!Interop.mincore.UnlockFile(_fileHandle, positionLow, positionHigh, lengthLow, lengthHigh))
+            {
+                throw Win32Marshal.GetExceptionForLastWin32Error();
+            }
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/IO/FileStream.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.cs
@@ -1,0 +1,630 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+
+namespace System.IO
+{
+    public partial class FileStream : Stream
+    {
+        private const FileShare DefaultShare = FileShare.Read;
+        private const bool DefaultIsAsync = false;
+        internal const int DefaultBufferSize = 4096;
+
+        private byte[] _buffer;
+        private int _bufferLength;
+        private readonly SafeFileHandle _fileHandle;
+
+        /// <summary>Whether the file is opened for reading, writing, or both.</summary>
+        private readonly FileAccess _access;
+
+        /// <summary>The path to the opened file.</summary>
+        private readonly string _path;
+
+        /// <summary>The next available byte to be read from the _buffer.</summary>
+        private int _readPos;
+
+        /// <summary>The number of valid bytes in _buffer.</summary>
+        private int _readLength;
+
+        /// <summary>The next location in which a write should occur to the buffer.</summary>
+        private int _writePos;
+
+        /// <summary>
+        /// Whether asynchronous read/write/flush operations should be performed using async I/O.
+        /// On Windows FileOptions.Asynchronous controls how the file handle is configured, 
+        /// and then as a result how operations are issued against that file handle.  On Unix, 
+        /// there isn't any distinction around how file descriptors are created for async vs 
+        /// sync, but we still differentiate how the operations are issued in order to provide
+        /// similar behavioral semantics and performance characteristics as on Windows.  On
+        /// Windows, if non-async, async read/write requests just delegate to the base stream,
+        /// and no attempt is made to synchronize between sync and async operations on the stream;
+        /// if async, then async read/write requests are implemented specially, and sync read/write
+        /// requests are coordinated with async ones by implementing the sync ones over the async
+        /// ones.  On Unix, we do something similar.  If non-async, async read/write requests just
+        /// delegate to the base stream, and no attempt is made to synchronize.  If async, we use
+        /// a semaphore to coordinate both sync and async operations.
+        /// </summary>
+        private readonly bool _useAsyncIO;
+
+        /// <summary>
+        /// Currently cached position in the stream.  This should always mirror the underlying file's actual position,
+        /// and should only ever be out of sync if another stream with access to this same file manipulates it, at which
+        /// point we attempt to error out.
+        /// </summary>
+        private long _filePosition;
+
+        /// <summary>Whether the file stream's handle has been exposed.</summary>
+        private bool _exposedHandle;
+
+        public FileStream(SafeFileHandle handle, FileAccess access)
+            : this(handle, access, DefaultBufferSize)
+        {
+        }
+
+        public FileStream(SafeFileHandle handle, FileAccess access, int bufferSize)
+            : this(handle, access, bufferSize, GetDefaultIsAsync(handle))
+        {
+        }
+
+        public FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
+        {
+            if (handle.IsInvalid)
+                throw new ArgumentException(SR.Arg_InvalidHandle, nameof(handle));
+
+            if (access < FileAccess.Read || access > FileAccess.ReadWrite)
+                throw new ArgumentOutOfRangeException(nameof(access), SR.ArgumentOutOfRange_Enum);
+            if (bufferSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+
+            if (handle.IsClosed)
+                throw new ObjectDisposedException(SR.ObjectDisposed_FileClosed);
+            if (handle.IsAsync.HasValue && isAsync != handle.IsAsync.Value)
+                throw new ArgumentException(SR.Arg_HandleNotAsync, nameof(handle));
+
+            _access = access;
+            _useAsyncIO = isAsync;
+            _exposedHandle = true;
+            _bufferLength = bufferSize;
+            _fileHandle = handle;
+
+            InitFromHandle(handle);
+        }
+
+        public FileStream(string path, FileMode mode) :
+            this(path, mode, (mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite), DefaultShare, DefaultBufferSize, DefaultIsAsync)
+        { }
+
+        public FileStream(string path, FileMode mode, FileAccess access) :
+            this(path, mode, access, DefaultShare, DefaultBufferSize, DefaultIsAsync)
+        { }
+
+        public FileStream(string path, FileMode mode, FileAccess access, FileShare share) :
+            this(path, mode, access, share, DefaultBufferSize, DefaultIsAsync)
+        { }
+
+        public FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize) :
+            this(path, mode, access, share, bufferSize, DefaultIsAsync)
+        { }
+
+        public FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, bool useAsync) :
+            this(path, mode, access, share, bufferSize, useAsync ? FileOptions.Asynchronous : FileOptions.None)
+        { }
+
+        internal FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options, string msgPath, bool bFromProxy)
+            : this(path, mode, access, share, bufferSize, options, msgPath, bFromProxy, useLongPath: false, checkHost: false)
+        {
+        }
+
+        internal FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options, string msgPath, bool bFromProxy, bool useLongPath, bool checkHost)
+            : this(path, mode, access, share, bufferSize, options)
+        {
+            // msgPath is the path that is handed back to untrusted code, CoreCLR is always full trust
+            // bFromProxy is also related to asserting rights for limited trust and also can be ignored
+            // useLongPath was used to get around the legacy MaxPath check, this is no longer applicable as everything supports long paths
+            // checkHost is also related to limited trust scenarios
+        }
+
+        public FileStream(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
+        {
+            if (path == null)
+                throw new ArgumentNullException(nameof(path), SR.ArgumentNull_Path);
+            if (path.Length == 0)
+                throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
+
+            // don't include inheritable in our bounds check for share
+            FileShare tempshare = share & ~FileShare.Inheritable;
+            string badArg = null;
+
+            if (mode < FileMode.CreateNew || mode > FileMode.Append)
+                badArg = "mode";
+            else if (access < FileAccess.Read || access > FileAccess.ReadWrite)
+                badArg = "access";
+            else if (tempshare < FileShare.None || tempshare > (FileShare.ReadWrite | FileShare.Delete))
+                badArg = "share";
+
+            if (badArg != null)
+                throw new ArgumentOutOfRangeException(badArg, SR.ArgumentOutOfRange_Enum);
+
+            // NOTE: any change to FileOptions enum needs to be matched here in the error validation
+            if (options != FileOptions.None && (options & ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose | FileOptions.SequentialScan | FileOptions.Encrypted | (FileOptions)0x20000000 /* NoBuffering */)) != 0)
+                throw new ArgumentOutOfRangeException(nameof(options), SR.ArgumentOutOfRange_Enum);
+
+            if (bufferSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+
+            // Write access validation
+            if ((access & FileAccess.Write) == 0)
+            {
+                if (mode == FileMode.Truncate || mode == FileMode.CreateNew || mode == FileMode.Create || mode == FileMode.Append)
+                {
+                    // No write access, mode and access disagree but flag access since mode comes first
+                    throw new ArgumentException(SR.Format(SR.Argument_InvalidFileModeAndAccessCombo, mode, access), nameof(access));
+                }
+            }
+
+            if ((access & FileAccess.Read) != 0 && mode == FileMode.Append)
+                throw new ArgumentException(SR.Argument_InvalidAppendMode, nameof(access));
+
+            string fullPath = Path.GetFullPath(path);
+
+            _path = fullPath;
+            _access = access;
+            _bufferLength = bufferSize;
+
+            if ((options & FileOptions.Asynchronous) != 0)
+                _useAsyncIO = true;
+
+            _fileHandle = OpenHandle(mode, share, options);
+
+            try
+            {
+                Init(mode, share);
+            }
+            catch
+            {
+                // If anything goes wrong while setting up the stream, make sure we deterministically dispose
+                // of the opened handle.
+                _fileHandle.Dispose();
+                _fileHandle = null;
+                throw;
+            }
+        }
+
+        private static bool GetDefaultIsAsync(SafeFileHandle handle)
+        {
+            // This will eventually get more complicated as we can actually check the underlying handle type on Windows
+            return handle.IsAsync.HasValue ? handle.IsAsync.Value : false;
+        }
+
+        // InternalOpen, InternalCreate, and InternalAppend:
+        // Factory methods for FileStream used by File, FileInfo, and ReadLinesIterator
+        // Specifies default access and sharing options for FileStreams created by those classes
+        internal static FileStream InternalOpen(string path, int bufferSize = DefaultBufferSize, bool useAsync = DefaultIsAsync)
+        {
+            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, useAsync);
+        }
+
+        internal static FileStream InternalCreate(string path, int bufferSize = DefaultBufferSize, bool useAsync = DefaultIsAsync)
+        {
+            return new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read, bufferSize, useAsync);
+        }
+
+        internal static FileStream InternalAppend(string path, int bufferSize = DefaultBufferSize, bool useAsync = DefaultIsAsync)
+        {
+            return new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read, bufferSize, useAsync);
+        }
+
+        [Obsolete("This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  http://go.microsoft.com/fwlink/?linkid=14202")]
+        public virtual IntPtr Handle { get { return SafeFileHandle.DangerousGetHandle(); } }
+
+        public virtual void Lock(long position, long length)
+        {
+            if (position < 0 || length < 0)
+            {
+                throw new ArgumentOutOfRangeException(position < 0 ? nameof(position) : nameof(length), SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (_fileHandle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+
+            LockInternal(position, length);
+        }
+
+        public virtual void Unlock(long position, long length)
+        {
+            if (position < 0 || length < 0)
+            {
+                throw new ArgumentOutOfRangeException(position < 0 ? nameof(position) : nameof(length), SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (_fileHandle.IsClosed)
+            {
+                throw Error.GetFileNotOpen();
+            }
+
+            UnlockInternal(position, length);
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            // If we have been inherited into a subclass, the following implementation could be incorrect
+            // since it does not call through to Flush() which a subclass might have overridden.  To be safe 
+            // we will only use this implementation in cases where we know it is safe to do so,
+            // and delegate to our base class (which will call into Flush) when we are not sure.
+            if (GetType() != typeof(FileStream))
+                return base.FlushAsync(cancellationToken);
+
+            return FlushAsyncInternal(cancellationToken);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException(nameof(buffer), SR.ArgumentNull_Buffer);
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (buffer.Length - offset < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen /*, no good single parameter name to pass*/);
+
+            // If we have been inherited into a subclass, the following implementation could be incorrect
+            // since it does not call through to Read() or ReadAsync() which a subclass might have overridden.  
+            // To be safe we will only use this implementation in cases where we know it is safe to do so,
+            // and delegate to our base class (which will call into Read/ReadAsync) when we are not sure.
+            if (GetType() != typeof(FileStream))
+                return base.ReadAsync(buffer, offset, count, cancellationToken);
+
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<int>(cancellationToken);
+
+            if (IsClosed)
+                throw Error.GetFileNotOpen();
+
+            return ReadAsyncInternal(buffer, offset, count, cancellationToken);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException(nameof(buffer), SR.ArgumentNull_Buffer);
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (buffer.Length - offset < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen /*, no good single parameter name to pass*/);
+
+            // If we have been inherited into a subclass, the following implementation could be incorrect
+            // since it does not call through to Write() or WriteAsync() which a subclass might have overridden.  
+            // To be safe we will only use this implementation in cases where we know it is safe to do so,
+            // and delegate to our base class (which will call into Write/WriteAsync) when we are not sure.
+            if (GetType() != typeof(FileStream))
+                return base.WriteAsync(buffer, offset, count, cancellationToken);
+
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+
+            if (IsClosed)
+                throw Error.GetFileNotOpen();
+
+            return WriteAsyncInternal(buffer, offset, count, cancellationToken);
+        }
+
+        /// <summary>
+        /// Clears buffers for this stream and causes any buffered data to be written to the file.
+        /// </summary>
+        public override void Flush()
+        {
+            // Make sure that we call through the public virtual API
+            Flush(flushToDisk: false);
+        }
+
+        /// <summary>
+        /// Clears buffers for this stream, and if <param name="flushToDisk"/> is true, 
+        /// causes any buffered data to be written to the file.
+        /// </summary>
+        public virtual void Flush(bool flushToDisk)
+        {
+            if (IsClosed) throw Error.GetFileNotOpen();
+
+            FlushInternalBuffer();
+
+            if (flushToDisk && CanWrite)
+            {
+                FlushOSBuffer();
+            }
+        }
+
+        /// <summary>Gets a value indicating whether the current stream supports reading.</summary>
+        public override bool CanRead
+        {
+            get { return !_fileHandle.IsClosed && (_access & FileAccess.Read) != 0; }
+        }
+
+        /// <summary>Gets a value indicating whether the current stream supports writing.</summary>
+        public override bool CanWrite
+        {
+            get { return !_fileHandle.IsClosed && (_access & FileAccess.Write) != 0; }
+        }
+
+        /// <summary>Validates arguments to Read and Write and throws resulting exceptions.</summary>
+        /// <param name="array">The buffer to read from or write to.</param>
+        /// <param name="offset">The zero-based offset into the array.</param>
+        /// <param name="count">The maximum number of bytes to read or write.</param>
+        private void ValidateReadWriteArgs(byte[] array, int offset, int count)
+        {
+            if (array == null)
+                throw new ArgumentNullException(nameof(array), SR.ArgumentNull_Buffer);
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (array.Length - offset < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen /*, no good single parameter name to pass*/);
+            if (_fileHandle.IsClosed)
+                throw Error.GetFileNotOpen();
+        }
+
+        /// <summary>Sets the length of this stream to the given value.</summary>
+        /// <param name="value">The new length of the stream.</param>
+        public override void SetLength(long value)
+        {
+            if (value < 0)
+                throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (_fileHandle.IsClosed)
+                throw Error.GetFileNotOpen();
+            if (!CanSeek)
+                throw Error.GetSeekNotSupported();
+            if (!CanWrite)
+                throw Error.GetWriteNotSupported();
+
+            SetLengthInternal(value);
+        }
+
+        public virtual SafeFileHandle SafeFileHandle
+        {
+            get
+            {
+                Flush();
+                _exposedHandle = true;
+                return _fileHandle;
+            }
+        }
+
+        /// <summary>Gets the path that was passed to the constructor.</summary>
+        public virtual string Name { get { return _path ?? SR.IO_UnknownFileName; } }
+
+        /// <summary>Gets a value indicating whether the stream was opened for I/O to be performed synchronously or asynchronously.</summary>
+        public virtual bool IsAsync
+        {
+            get { return _useAsyncIO; }
+        }
+
+        /// <summary>Gets the length of the stream in bytes.</summary>
+        public override long Length
+        {
+            get
+            {
+                if (_fileHandle.IsClosed) throw Error.GetFileNotOpen();
+                if (!CanSeek) throw Error.GetSeekNotSupported();
+                return GetLengthInternal();
+            }
+        }
+
+        /// <summary>
+        /// Verify that the actual position of the OS's handle equals what we expect it to.
+        /// This will fail if someone else moved the UnixFileStream's handle or if
+        /// our position updating code is incorrect.
+        /// </summary>
+        private void VerifyOSHandlePosition()
+        {
+            bool verifyPosition = _exposedHandle; // in release, only verify if we've given out the handle such that someone else could be manipulating it
+#if DEBUG
+            verifyPosition = true; // in debug, always make sure our position matches what the OS says it should be
+#endif
+            if (verifyPosition && CanSeek)
+            {
+                long oldPos = _filePosition; // SeekCore will override the current _position, so save it now
+                long curPos = SeekCore(0, SeekOrigin.Current);
+                if (oldPos != curPos)
+                {
+                    // For reads, this is non-fatal but we still could have returned corrupted 
+                    // data in some cases, so discard the internal buffer. For writes, 
+                    // this is a problem; discard the buffer and error out.
+                    _readPos = _readLength = 0;
+                    if (_writePos > 0)
+                    {
+                        _writePos = 0;
+                        throw new IOException(SR.IO_FileStreamHandlePosition);
+                    }
+                }
+            }
+        }
+
+        /// <summary>Verifies that state relating to the read/write buffer is consistent.</summary>
+        [Conditional("DEBUG")]
+        private void AssertBufferInvariants()
+        {
+            // Read buffer values must be in range: 0 <= _bufferReadPos <= _bufferReadLength <= _bufferLength
+            Debug.Assert(0 <= _readPos && _readPos <= _readLength && _readLength <= _bufferLength);
+
+            // Write buffer values must be in range: 0 <= _bufferWritePos <= _bufferLength
+            Debug.Assert(0 <= _writePos && _writePos <= _bufferLength);
+
+            // Read buffering and write buffering can't both be active
+            Debug.Assert((_readPos == 0 && _readLength == 0) || _writePos == 0);
+        }
+
+        /// <summary>Validates that we're ready to read from the stream.</summary>
+        private void PrepareForReading()
+        {
+            if (_fileHandle.IsClosed)
+                throw Error.GetFileNotOpen();
+            if (_readLength == 0 && !CanRead)
+                throw Error.GetReadNotSupported();
+
+            AssertBufferInvariants();
+        }
+
+        /// <summary>Gets or sets the position within the current stream</summary>
+        public override long Position
+        {
+            get
+            {
+                if (_fileHandle.IsClosed)
+                    throw Error.GetFileNotOpen();
+
+                if (!CanSeek)
+                    throw Error.GetSeekNotSupported();
+
+                AssertBufferInvariants();
+                VerifyOSHandlePosition();
+
+                // We may have read data into our buffer from the handle, such that the handle position
+                // is artificially further along than the consumer's view of the stream's position.
+                // Thus, when reading, our position is really starting from the handle position negatively
+                // offset by the number of bytes in the buffer and positively offset by the number of
+                // bytes into that buffer we've read.  When writing, both the read length and position
+                // must be zero, and our position is just the handle position offset positive by how many
+                // bytes we've written into the buffer.
+                return (_filePosition - _readLength) + _readPos + _writePos;
+            }
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_NeedNonNegNum);
+
+                Seek(value, SeekOrigin.Begin);
+            }
+        }
+
+        internal virtual bool IsClosed => _fileHandle.IsClosed;
+
+        /// <summary>
+        /// Gets the array used for buffering reading and writing.  
+        /// If the array hasn't been allocated, this will lazily allocate it.
+        /// </summary>
+        /// <returns>The buffer.</returns>
+        private byte[] GetBuffer()
+        {
+            Debug.Assert(_buffer == null || _buffer.Length == _bufferLength);
+            if (_buffer == null)
+            {
+                _buffer = new byte[_bufferLength];
+                OnBufferAllocated();
+            }
+
+            return _buffer;
+        }
+
+        partial void OnBufferAllocated();
+
+        /// <summary>
+        /// Flushes the internal read/write buffer for this stream.  If write data has been buffered,
+        /// that data is written out to the underlying file.  Or if data has been buffered for 
+        /// reading from the stream, the data is dumped and our position in the underlying file 
+        /// is rewound as necessary.  This does not flush the OS buffer.
+        /// </summary>
+        private void FlushInternalBuffer()
+        {
+            AssertBufferInvariants();
+            if (_writePos > 0)
+            {
+                FlushWriteBuffer();
+            }
+            else if (_readPos < _readLength && CanSeek)
+            {
+                FlushReadBuffer();
+            }
+        }
+
+        /// <summary>Dumps any read data in the buffer and rewinds our position in the stream, accordingly, as necessary.</summary>
+        private void FlushReadBuffer()
+        {
+            // Reading is done by blocks from the file, but someone could read
+            // 1 byte from the buffer then write.  At that point, the OS's file
+            // pointer is out of sync with the stream's position.  All write 
+            // functions should call this function to preserve the position in the file.
+
+            AssertBufferInvariants();
+            Debug.Assert(_writePos == 0, "FileStream: Write buffer must be empty in FlushReadBuffer!");
+
+            int rewind = _readPos - _readLength;
+            if (rewind != 0)
+            {
+                Debug.Assert(CanSeek, "FileStream will lose buffered read data now.");
+                SeekCore(rewind, SeekOrigin.Current);
+            }
+            _readPos = _readLength = 0;
+        }
+
+        private int ReadByteCore()
+        {
+            PrepareForReading();
+
+            byte[] buffer = GetBuffer();
+            if (_readPos == _readLength)
+            {
+                FlushWriteBuffer();
+                Debug.Assert(_bufferLength > 0, "_bufferSize > 0");
+
+                _readLength = ReadNative(buffer, 0, _bufferLength);
+                _readPos = 0;
+                if (_readLength == 0)
+                {
+                    return -1;
+                }
+            }
+
+            return buffer[_readPos++];
+        }
+
+        private void WriteByteCore(byte value)
+        {
+            PrepareForWriting();
+
+            // Flush the write buffer if it's full
+            if (_writePos == _bufferLength)
+                FlushWriteBuffer();
+
+            // We now have space in the buffer. Store the byte.
+            GetBuffer()[_writePos++] = value;
+        }
+
+        /// <summary>
+        /// Validates that we're ready to write to the stream,
+        /// including flushing a read buffer if necessary.
+        /// </summary>
+        private void PrepareForWriting()
+        {
+            if (_fileHandle.IsClosed)
+                throw Error.GetFileNotOpen();
+
+            // Make sure we're good to write.  We only need to do this if there's nothing already
+            // in our write buffer, since if there is something in the buffer, we've already done 
+            // this checking and flushing.
+            if (_writePos == 0)
+            {
+                if (!CanWrite) throw Error.GetWriteNotSupported();
+                FlushReadBuffer();
+                Debug.Assert(_bufferLength > 0, "_bufferSize > 0");
+            }
+        }
+
+        ~FileStream()
+        {
+            // Preserved for compatibility since FileStream has defined a 
+            // finalizer in past releases and derived classes may depend
+            // on Dispose(false) call.
+            Dispose(false);
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/IO/FileStreamCompletionSource.Win32.cs
+++ b/src/mscorlib/corefx/System/IO/FileStreamCompletionSource.Win32.cs
@@ -1,0 +1,221 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+
+namespace System.IO
+{
+    public partial class FileStream : Stream
+    {
+        // This is an internal object extending TaskCompletionSource with fields
+        // for all of the relevant data necessary to complete the IO operation.
+        // This is used by IOCallback and all of the async methods.
+        unsafe private sealed class FileStreamCompletionSource : TaskCompletionSource<int>
+        {
+            private const long NoResult = 0;
+            private const long ResultSuccess = (long)1 << 32;
+            private const long ResultError = (long)2 << 32;
+            private const long RegisteringCancellation = (long)4 << 32;
+            private const long CompletedCallback = (long)8 << 32;
+            private const ulong ResultMask = ((ulong)uint.MaxValue) << 32;
+
+            private static Action<object> s_cancelCallback;
+
+            private readonly FileStream _stream;
+            private readonly int _numBufferedBytes;
+            private readonly CancellationToken _cancellationToken;
+            private CancellationTokenRegistration _cancellationRegistration;
+#if DEBUG
+            private bool _cancellationHasBeenRegistered;
+#endif
+            private NativeOverlapped* _overlapped; // Overlapped class responsible for operations in progress when an appdomain unload occurs
+            private long _result; // Using long since this needs to be used in Interlocked APIs
+
+            // Using RunContinuationsAsynchronously for compat reasons (old API used Task.Factory.StartNew for continuations)
+            internal FileStreamCompletionSource(FileStream stream, int numBufferedBytes, byte[] bytes, CancellationToken cancellationToken)
+                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            {
+                _numBufferedBytes = numBufferedBytes;
+                _stream = stream;
+                _result = NoResult;
+                _cancellationToken = cancellationToken;
+
+                // Create the native overlapped. We try to use the preallocated overlapped if possible: 
+                // it's possible if the byte buffer is the same one that's associated with the preallocated overlapped 
+                // and if no one else is currently using the preallocated overlapped.  This is the fast-path for cases 
+                // where the user-provided buffer is smaller than the FileStream's buffer (such that the FileStream's 
+                // buffer is used) and where operations on the FileStream are not being performed concurrently.
+                _overlapped = ReferenceEquals(bytes, _stream._buffer) && _stream.CompareExchangeCurrentOverlappedOwner(this, null) == null ?
+                    _stream._fileHandle.ThreadPoolBinding.AllocateNativeOverlapped(_stream._preallocatedOverlapped) :
+                    _stream._fileHandle.ThreadPoolBinding.AllocateNativeOverlapped(s_ioCallback, this, bytes);
+                Debug.Assert(_overlapped != null, "AllocateNativeOverlapped returned null");
+            }
+
+            internal NativeOverlapped* Overlapped
+            {
+                [SecurityCritical]get { return _overlapped; }
+            }
+
+            public void SetCompletedSynchronously(int numBytes)
+            {
+                ReleaseNativeResource();
+                TrySetResult(numBytes + _numBufferedBytes);
+            }
+
+            public void RegisterForCancellation()
+            {
+#if DEBUG
+                Debug.Assert(!_cancellationHasBeenRegistered, "Cannot register for cancellation twice");
+                _cancellationHasBeenRegistered = true;
+#endif
+
+                // Quick check to make sure that the cancellation token supports cancellation, and that the IO hasn't completed
+                if ((_cancellationToken.CanBeCanceled) && (_overlapped != null))
+                {
+                    var cancelCallback = s_cancelCallback;
+                    if (cancelCallback == null) s_cancelCallback = cancelCallback = Cancel;
+
+                    // Register the cancellation only if the IO hasn't completed
+                    long packedResult = Interlocked.CompareExchange(ref _result, RegisteringCancellation, NoResult);
+                    if (packedResult == NoResult)
+                    {
+                        _cancellationRegistration = _cancellationToken.Register(cancelCallback, this);
+
+                        // Switch the result, just in case IO completed while we were setting the registration
+                        packedResult = Interlocked.Exchange(ref _result, NoResult);
+                    }
+                    else if (packedResult != CompletedCallback)
+                    {
+                        // Failed to set the result, IO is in the process of completing
+                        // Attempt to take the packed result
+                        packedResult = Interlocked.Exchange(ref _result, NoResult);
+                    }
+
+                    // If we have a callback that needs to be completed
+                    if ((packedResult != NoResult) && (packedResult != CompletedCallback) && (packedResult != RegisteringCancellation))
+                    {
+                        CompleteCallback((ulong)packedResult);
+                    }
+                }
+            }
+
+            internal void ReleaseNativeResource()
+            {
+                // Ensure that cancellation has been completed and cleaned up.
+                _cancellationRegistration.Dispose();
+
+                // Free the overlapped.
+                // NOTE: The cancellation must *NOT* be running at this point, or it may observe freed memory
+                // (this is why we disposed the registration above).
+                if (_overlapped != null)
+                {
+                    _stream._fileHandle.ThreadPoolBinding.FreeNativeOverlapped(_overlapped);
+                    _overlapped = null;
+                }
+
+                // Ensure we're no longer set as the current completion source (we may not have been to begin with).
+                // Only one operation at a time is eligible to use the preallocated overlapped, 
+                _stream.CompareExchangeCurrentOverlappedOwner(null, this);
+            }
+
+            // When doing IO asynchronously (i.e. _isAsync==true), this callback is 
+            // called by a free thread in the threadpool when the IO operation 
+            // completes.  
+            internal static unsafe void IOCallback(uint errorCode, uint numBytes, NativeOverlapped* pOverlapped)
+            {
+                // Extract the completion source from the overlapped.  The state in the overlapped
+                // will either be a Win32FileStream (in the case where the preallocated overlapped was used),
+                // in which case the operation being completed is its _currentOverlappedOwner, or it'll
+                // be directly the FileStreamCompletion that's completing (in the case where the preallocated
+                // overlapped was already in use by another operation).
+                object state = ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped);
+                FileStream fs = state as FileStream;
+                FileStreamCompletionSource completionSource = fs != null ? 
+                    fs._currentOverlappedOwner : 
+                    (FileStreamCompletionSource)state;
+                Debug.Assert(completionSource._overlapped == pOverlapped, "Overlaps don't match");
+
+                // Handle reading from & writing to closed pipes.  While I'm not sure
+                // this is entirely necessary anymore, maybe it's possible for 
+                // an async read on a pipe to be issued and then the pipe is closed, 
+                // returning this error.  This may very well be necessary.
+                ulong packedResult;
+                if (errorCode != 0 && errorCode != ERROR_BROKEN_PIPE && errorCode != ERROR_NO_DATA)
+                {
+                    packedResult = ((ulong)ResultError | errorCode);
+                }
+                else
+                {
+                    packedResult = ((ulong)ResultSuccess | numBytes);
+                }
+
+                // Stow the result so that other threads can observe it
+                // And, if no other thread is registering cancellation, continue
+                if (NoResult == Interlocked.Exchange(ref completionSource._result, (long)packedResult))
+                {
+                    // Successfully set the state, attempt to take back the callback
+                    if (Interlocked.Exchange(ref completionSource._result, CompletedCallback) != NoResult)
+                    {
+                        // Successfully got the callback, finish the callback
+                        completionSource.CompleteCallback(packedResult);
+                    }
+                    // else: Some other thread stole the result, so now it is responsible to finish the callback
+                }
+                // else: Some other thread is registering a cancellation, so it *must* finish the callback
+            }
+
+            private void CompleteCallback(ulong packedResult) {
+                // Free up the native resource and cancellation registration
+                ReleaseNativeResource();
+
+                // Unpack the result and send it to the user
+                long result = (long)(packedResult & ResultMask);
+                if (result == ResultError)
+                {
+                    int errorCode = unchecked((int)(packedResult & uint.MaxValue));
+                    if (errorCode == Interop.mincore.Errors.ERROR_OPERATION_ABORTED)
+                    {
+                        TrySetCanceled(_cancellationToken.IsCancellationRequested ? _cancellationToken : new CancellationToken(true));
+                    }
+                    else
+                    {
+                        TrySetException(Win32Marshal.GetExceptionForWin32Error(errorCode));
+                    }
+                }
+                else
+                {
+                    Debug.Assert(result == ResultSuccess, "Unknown result");
+                    TrySetResult((int)(packedResult & uint.MaxValue) + _numBufferedBytes);
+                }
+            }
+
+            private static void Cancel(object state)
+            {
+                // WARNING: This may potentially be called under a lock (during cancellation registration)
+
+                FileStreamCompletionSource completionSource = state as FileStreamCompletionSource;
+                Debug.Assert(completionSource != null, "Unknown state passed to cancellation");
+                Debug.Assert(completionSource._overlapped != null && !completionSource.Task.IsCompleted, "IO should not have completed yet");
+
+                // If the handle is still valid, attempt to cancel the IO
+                if (!completionSource._stream._fileHandle.IsInvalid && 
+                    !Interop.mincore.CancelIoEx(completionSource._stream._fileHandle, completionSource._overlapped))
+                {
+                    int errorCode = Marshal.GetLastWin32Error();
+
+                    // ERROR_NOT_FOUND is returned if CancelIoEx cannot find the request to cancel.
+                    // This probably means that the IO operation has completed.
+                    if (errorCode != Interop.mincore.Errors.ERROR_NOT_FOUND)
+                    {
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode);
+                    }
+                }
+            }
+        } 
+    }
+}

--- a/src/mscorlib/corefx/System/IO/StreamHelpers.ArrayPoolCopy.cs
+++ b/src/mscorlib/corefx/System/IO/StreamHelpers.ArrayPoolCopy.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    /// <summary>Provides methods to help in the implementation of Stream-derived types.</summary>
+    internal static partial class StreamHelpers
+    {
+        /// <summary>
+        /// Provides an implementation usable as an override of Stream.CopyToAsync but that uses the shared
+        /// ArrayPool for the intermediate buffer rather than allocating a new buffer each time.
+        /// </summary>
+        /// <param name="source">The source stream from which to read.</param>
+        /// <param name="destination">The destination stream to which to write.</param>
+        /// <param name="bufferSize">The buffer size to use.</param>
+        /// <param name="cancellationToken">The cancellation token to use to cancel the operation.</param>
+        /// <remarks>
+        /// If/when the base CopyToAsync implementation is changed to use a pooled buffer, 
+        /// this will no longer be necessary.
+        /// </remarks>
+        public static Task ArrayPoolCopyToAsync(Stream source, Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            Debug.Assert(source != null);
+            ValidateCopyToArgs(source, destination, bufferSize);
+            return ArrayPoolCopyToAsyncCore(source, destination, bufferSize, cancellationToken);
+        }
+
+        /// <summary>Standard read/write loop using ReadAsync on the source and WriteAsync on the destination.</summary>
+        private static async Task ArrayPoolCopyToAsyncCore(Stream source, Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+            bufferSize = 0; // reuse same field for high water mark to avoid needing another field in the state machine
+            try
+            {
+                while (true)
+                {
+                    int bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+                    if (bytesRead > bufferSize)
+                    {
+                        bufferSize = bytesRead;
+                    }
+                    await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                Array.Clear(buffer, 0, bufferSize); // clear only the most we used
+                ArrayPool<byte>.Shared.Return(buffer, clearArray: false);
+            }
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/IO/Win32Marshal.cs
+++ b/src/mscorlib/corefx/System/IO/Win32Marshal.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace System.IO
+{
+    /// <summary>
+    ///     Provides static methods for converting from Win32 errors codes to exceptions, HRESULTS and error messages.
+    /// </summary>
+    internal static class Win32Marshal
+    {
+        /// <summary>
+        ///     Converts, resetting it, the last Win32 error into a corresponding <see cref="Exception"/> object.
+        /// </summary>
+        internal static Exception GetExceptionForLastWin32Error()
+        {
+            int errorCode = Marshal.GetLastWin32Error();
+            return GetExceptionForWin32Error(errorCode, string.Empty);
+        }
+
+        /// <summary>
+        ///     Converts, resetting it, the last Win32 error into a corresponding <see cref="Exception"/> object, optionally 
+        ///     including the specified path in the error message.
+        /// </summary>
+        internal static Exception GetExceptionForLastWin32Error(string path)
+        {
+            int errorCode = Marshal.GetLastWin32Error();
+            return GetExceptionForWin32Error(errorCode, path);
+        }
+
+        /// <summary>
+        ///     Converts the specified Win32 error into a corresponding <see cref="Exception"/> object.
+        /// </summary>
+        internal static Exception GetExceptionForWin32Error(int errorCode)
+        {
+            return GetExceptionForWin32Error(errorCode, string.Empty);
+        }
+
+        /// <summary>
+        ///     Converts the specified Win32 error into a corresponding <see cref="Exception"/> object, optionally 
+        ///     including the specified path in the error message.
+        /// </summary>
+        internal static Exception GetExceptionForWin32Error(int errorCode, string path)
+        {
+            switch (errorCode)
+            {
+                case Interop.mincore.Errors.ERROR_FILE_NOT_FOUND:
+                    if (path.Length == 0)
+                        return new FileNotFoundException(SR.IO_FileNotFound);
+                    else
+                        return new FileNotFoundException(SR.Format(SR.IO_FileNotFound_FileName, path), path);
+
+                case Interop.mincore.Errors.ERROR_PATH_NOT_FOUND:
+                    if (path.Length == 0)
+                        return new DirectoryNotFoundException(SR.IO_PathNotFound_NoPathName);
+                    else
+                        return new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, path));
+
+                case Interop.mincore.Errors.ERROR_ACCESS_DENIED:
+                    if (path.Length == 0)
+                        return new UnauthorizedAccessException(SR.UnauthorizedAccess_IODenied_NoPathName);
+                    else
+                        return new UnauthorizedAccessException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, path));
+
+                case Interop.mincore.Errors.ERROR_ALREADY_EXISTS:
+                    if (path.Length == 0)
+                        goto default;
+
+                    return new IOException(SR.Format(SR.IO_AlreadyExists_Name, path), MakeHRFromErrorCode(errorCode));
+
+                case Interop.mincore.Errors.ERROR_FILENAME_EXCED_RANGE:
+                    return new PathTooLongException(SR.IO_PathTooLong);
+
+                case Interop.mincore.Errors.ERROR_INVALID_PARAMETER:
+                    return new IOException(GetMessage(errorCode), MakeHRFromErrorCode(errorCode));
+
+                case Interop.mincore.Errors.ERROR_SHARING_VIOLATION:
+                    if (path.Length == 0)
+                        return new IOException(SR.IO_SharingViolation_NoFileName, MakeHRFromErrorCode(errorCode));
+                    else
+                        return new IOException(SR.Format(SR.IO_SharingViolation_File, path), MakeHRFromErrorCode(errorCode));
+
+                case Interop.mincore.Errors.ERROR_FILE_EXISTS:
+                    if (path.Length == 0)
+                        goto default;
+
+                    return new IOException(SR.Format(SR.IO_FileExists_Name, path), MakeHRFromErrorCode(errorCode));
+
+                case Interop.mincore.Errors.ERROR_OPERATION_ABORTED:
+                    return new OperationCanceledException();
+
+                default:
+                    return new IOException(GetMessage(errorCode), MakeHRFromErrorCode(errorCode));
+            }
+        }
+
+        /// <summary>
+        ///     Returns a HRESULT for the specified Win32 error code.
+        /// </summary>
+        internal static int MakeHRFromErrorCode(int errorCode)
+        {
+            Debug.Assert((0xFFFF0000 & errorCode) == 0, "This is an HRESULT, not an error code!");
+
+            return unchecked(((int)0x80070000) | errorCode);
+        }
+
+        /// <summary>
+        ///     Returns a Win32 error code for the specified HRESULT if it came from FACILITY_WIN32
+        ///     If not, returns the HRESULT unchanged
+        /// </summary>
+        internal static int TryMakeWin32ErrorCodeFromHR(int hr)
+        {
+            if ((0xFFFF0000 & hr) == 0x80070000)
+            {
+                // Win32 error, Win32Marshal.GetExceptionForWin32Error expects the Win32 format
+                hr &= 0x0000FFFF;
+            }
+
+            return hr;
+        }
+
+        /// <summary>
+        ///     Returns a string message for the specified Win32 error code.
+        /// </summary>
+        internal static string GetMessage(int errorCode)
+        {
+            return Interop.mincore.GetMessage(errorCode);
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/Threading/ClrThreadPoolBoundHandle.cs
+++ b/src/mscorlib/corefx/System/Threading/ClrThreadPoolBoundHandle.cs
@@ -1,0 +1,319 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace System.Threading
+{
+    //
+    // Implementation of ThreadPoolBoundHandle that sits on top of the CLR's ThreadPool and Overlapped infrastructure
+    //
+
+    /// <summary>
+    ///     Represents an I/O handle that is bound to the system thread pool and enables low-level
+    ///     components to receive notifications for asynchronous I/O operations.
+    /// </summary>
+    public sealed partial class ThreadPoolBoundHandle : IDisposable
+    {
+        private readonly SafeHandle _handle;
+        private bool _isDisposed;
+
+        private ThreadPoolBoundHandle(SafeHandle handle)
+        {
+            _handle = handle;
+        }
+
+        /// <summary>
+        ///     Gets the bound operating system handle.
+        /// </summary>
+        /// <value>
+        ///     A <see cref="SafeHandle"/> object that holds the bound operating system handle.
+        /// </value>
+        public SafeHandle Handle
+        {
+            get { return _handle; }
+        }
+
+        /// <summary>
+        ///     Returns a <see cref="ThreadPoolBoundHandle"/> for the specific handle, 
+        ///     which is bound to the system thread pool.
+        /// </summary>
+        /// <param name="handle">
+        ///     A <see cref="SafeHandle"/> object that holds the operating system handle. The 
+        ///     handle must have been opened for overlapped I/O on the unmanaged side.
+        /// </param>
+        /// <returns>
+        ///     <see cref="ThreadPoolBoundHandle"/> for <paramref name="handle"/>, which 
+        ///     is bound to the system thread pool.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="handle"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="handle"/> has been disposed.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="handle"/> does not refer to a valid I/O handle.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="handle"/> refers to a handle that has not been opened 
+        ///     for overlapped I/O.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="handle"/> refers to a handle that has already been bound.
+        /// </exception>
+        /// <remarks>
+        ///     This method should be called once per handle.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <see cref="ThreadPoolBoundHandle"/> does not take ownership of <paramref name="handle"/>, 
+        ///     it remains the responsibility of the caller to call <see cref="SafeHandle.Dispose"/>.
+        /// </remarks>
+        public static ThreadPoolBoundHandle BindHandle(SafeHandle handle)
+        {
+            if (handle == null)
+                throw new ArgumentNullException(nameof(handle));
+
+            if (handle.IsClosed || handle.IsInvalid)
+                throw new ArgumentException(SR.Argument_InvalidHandle, nameof(handle));
+
+            try
+            {
+                // ThreadPool.BindHandle will always return true, otherwise, it throws. See the underlying FCall
+                // implementation in ThreadPoolNative::CorBindIoCompletionCallback to see the implementation.
+                bool succeeded = ThreadPool.BindHandle(handle);
+                Debug.Assert(succeeded);
+            }
+            catch (Exception ex)
+            {   // BindHandle throws ApplicationException on full CLR and Exception on CoreCLR.
+                // We do not let either of these leak and convert them to ArgumentException to 
+                // indicate that the specified handles are invalid.
+
+                if (ex.HResult == System.HResults.E_HANDLE)         // Bad handle
+                    throw new ArgumentException(SR.Argument_InvalidHandle, nameof(handle));
+
+                if (ex.HResult == System.HResults.E_INVALIDARG)     // Handle already bound or sync handle
+                    throw new ArgumentException(SR.Argument_AlreadyBoundOrSyncHandle, nameof(handle));
+
+                throw;
+            }
+
+            return new ThreadPoolBoundHandle(handle);
+        }
+
+        /// <summary>
+        ///     Returns an unmanaged pointer to a <see cref="NativeOverlapped"/> structure, specifying 
+        ///     a delegate that is invoked when the asynchronous I/O operation is complete, a user-provided 
+        ///     object providing context, and managed objects that serve as buffers.
+        /// </summary>
+        /// <param name="callback">
+        ///     An <see cref="IOCompletionCallback"/> delegate that represents the callback method 
+        ///     invoked when the asynchronous I/O operation completes.
+        /// </param>
+        /// <param name="state">
+        ///     A user-provided object that distinguishes this <see cref="NativeOverlapped"/> from other 
+        ///     <see cref="NativeOverlapped"/> instances. Can be <see langword="null"/>.
+        /// </param>
+        /// <param name="pinData">
+        ///     An object or array of objects representing the input or output buffer for the operation. Each 
+        ///     object represents a buffer, for example an array of bytes.  Can be <see langword="null"/>.
+        /// </param>
+        /// <returns>
+        ///     An unmanaged pointer to a <see cref="NativeOverlapped"/> structure.
+        /// </returns>
+        /// <remarks>
+        ///     <para>
+        ///         The unmanaged pointer returned by this method can be passed to the operating system in 
+        ///         overlapped I/O operations. The <see cref="NativeOverlapped"/> structure is fixed in 
+        ///         physical memory until <see cref="FreeNativeOverlapped(NativeOverlapped*)"/> is called.
+        ///     </para>
+        ///     <para>
+        ///         The buffer or buffers specified in <paramref name="pinData"/> must be the same as those passed 
+        ///         to the unmanaged operating system function that performs the asynchronous I/O.
+        ///     </para>
+        ///     <note>
+        ///         The buffers specified in <paramref name="pinData"/> are pinned for the duration of 
+        ///         the I/O operation.
+        ///     </note>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="callback"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///     This method was called after the <see cref="ThreadPoolBoundHandle"/> was disposed.
+        /// </exception>
+        [CLSCompliant(false)]
+        public unsafe NativeOverlapped* AllocateNativeOverlapped(IOCompletionCallback callback, object state, object pinData)
+        {
+            if (callback == null)
+                throw new ArgumentNullException(nameof(callback));
+
+            EnsureNotDisposed();
+
+            ThreadPoolBoundHandleOverlapped overlapped = new ThreadPoolBoundHandleOverlapped(callback, state, pinData, preAllocated: null);
+            overlapped._boundHandle = this;
+            return overlapped._nativeOverlapped;
+        }
+
+        /// <summary>
+        ///     Returns an unmanaged pointer to a <see cref="NativeOverlapped"/> structure, using the callback,
+        ///     state, and buffers associated with the specified <see cref="PreAllocatedOverlapped"/> object.
+        /// </summary>
+        /// <param name="preAllocated">
+        ///     A <see cref="PreAllocatedOverlapped"/> object from which to create the NativeOverlapped pointer.
+        /// </param>
+        /// <returns>
+        ///     An unmanaged pointer to a <see cref="NativeOverlapped"/> structure.
+        /// </returns>
+        /// <remarks>
+        ///     <para>
+        ///         The unmanaged pointer returned by this method can be passed to the operating system in 
+        ///         overlapped I/O operations. The <see cref="NativeOverlapped"/> structure is fixed in 
+        ///         physical memory until <see cref="FreeNativeOverlapped(NativeOverlapped*)"/> is called.
+        ///     </para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="preAllocated"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="preAllocated"/> is currently in use for another I/O operation.  
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///     This method was called after the <see cref="ThreadPoolBoundHandle"/> was disposed, or 
+        ///     this method was called after <paramref name="preAllocated"/> was disposed.
+        /// </exception>
+        /// <seealso cref="PreAllocatedOverlapped"/>
+        [CLSCompliant(false)]
+        public unsafe NativeOverlapped* AllocateNativeOverlapped(PreAllocatedOverlapped preAllocated)
+        {
+            if (preAllocated == null)
+                throw new ArgumentNullException(nameof(preAllocated));
+
+            EnsureNotDisposed();
+
+            preAllocated.AddRef();
+            try
+            {
+                ThreadPoolBoundHandleOverlapped overlapped = preAllocated._overlapped;
+
+                if (overlapped._boundHandle != null)
+                    throw new ArgumentException(SR.Argument_PreAllocatedAlreadyAllocated, nameof(preAllocated));
+
+                overlapped._boundHandle = this;
+
+                return overlapped._nativeOverlapped;
+            }
+            catch
+            {
+                preAllocated.Release();
+                throw;
+            }
+        }
+
+        /// <summary>
+        ///     Frees the unmanaged memory associated with a <see cref="NativeOverlapped"/> structure 
+        ///     allocated by the <see cref="AllocateNativeOverlapped"/> method.
+        /// </summary>
+        /// <param name="overlapped">
+        ///     An unmanaged pointer to the <see cref="NativeOverlapped"/> structure to be freed.
+        /// </param>
+        /// <remarks>
+        ///     <note type="caution">
+        ///         You must call the <see cref="FreeNativeOverlapped(NativeOverlapped*)"/> method exactly once 
+        ///         on every <see cref="NativeOverlapped"/> unmanaged pointer allocated using the 
+        ///         <see cref="AllocateNativeOverlapped"/> method. 
+        ///         If you do not call the <see cref="FreeNativeOverlapped(NativeOverlapped*)"/> method, you will 
+        ///         leak memory. If you call the <see cref="FreeNativeOverlapped(NativeOverlapped*)"/> method more 
+        ///         than once on the same <see cref="NativeOverlapped"/> unmanaged pointer, memory will be corrupted.
+        ///     </note>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="overlapped"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///     This method was called after the <see cref="ThreadPoolBoundHandle"/> was disposed.
+        /// </exception>
+        [CLSCompliant(false)]
+        public unsafe void FreeNativeOverlapped(NativeOverlapped* overlapped)
+        {
+            if (overlapped == null)
+                throw new ArgumentNullException(nameof(overlapped));
+
+            // Note: we explicitly allow FreeNativeOverlapped calls after the ThreadPoolBoundHandle has been Disposed.
+
+            ThreadPoolBoundHandleOverlapped wrapper = GetOverlappedWrapper(overlapped, this);
+
+            if (wrapper._boundHandle != this)
+                throw new ArgumentException(SR.Argument_NativeOverlappedWrongBoundHandle, nameof(overlapped));
+
+            if (wrapper._preAllocated != null)
+                wrapper._preAllocated.Release();
+            else
+                Overlapped.Free(overlapped);
+        }
+
+        /// <summary>
+        ///     Returns the user-provided object specified when the <see cref="NativeOverlapped"/> instance was
+        ///     allocated using the <see cref="AllocateNativeOverlapped(IOCompletionCallback, object, byte[])"/>.
+        /// </summary>
+        /// <param name="overlapped">
+        ///     An unmanaged pointer to the <see cref="NativeOverlapped"/> structure from which to return the 
+        ///     asscociated user-provided object.
+        /// </param>
+        /// <returns>
+        ///     A user-provided object that distinguishes this <see cref="NativeOverlapped"/> 
+        ///     from other <see cref="NativeOverlapped"/> instances, otherwise, <see langword="null"/> if one was 
+        ///     not specified when the instance was allocated using <see cref="AllocateNativeOverlapped"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="overlapped"/> is <see langword="null"/>.
+        /// </exception>
+        [CLSCompliant(false)]
+        public unsafe static object GetNativeOverlappedState(NativeOverlapped* overlapped)
+        {
+            if (overlapped == null)
+                throw new ArgumentNullException(nameof(overlapped));
+
+            ThreadPoolBoundHandleOverlapped wrapper = GetOverlappedWrapper(overlapped, null);
+            Debug.Assert(wrapper._boundHandle != null);
+            return wrapper._userState;
+        }
+
+        private static unsafe ThreadPoolBoundHandleOverlapped GetOverlappedWrapper(NativeOverlapped* overlapped, ThreadPoolBoundHandle expectedBoundHandle)
+        {
+            ThreadPoolBoundHandleOverlapped wrapper;
+            try
+            {
+                wrapper = (ThreadPoolBoundHandleOverlapped)Overlapped.Unpack(overlapped);
+            }
+            catch (NullReferenceException ex)
+            {
+                throw new ArgumentException(SR.Argument_NativeOverlappedAlreadyFree, nameof(overlapped), ex);
+            }
+
+            return wrapper;
+        }
+
+        public void Dispose()
+        {
+            // .NET Native's version of ThreadPoolBoundHandle that wraps the Win32 ThreadPool holds onto
+            // native resources so it needs to be disposable. To match the contract, we are also disposable.
+            // We also implement a disposable state to mimic behavior between this implementation and 
+            // .NET Native's version (code written against us, will also work against .NET Native's version).
+            _isDisposed = true;
+        }
+
+
+        private void EnsureNotDisposed()
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException(GetType().ToString());
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/Threading/ClrThreadPoolBoundHandleOverlapped.cs
+++ b/src/mscorlib/corefx/System/Threading/ClrThreadPoolBoundHandleOverlapped.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Threading
+{
+    /// <summary>
+    /// Overlapped subclass adding data needed by ThreadPoolBoundHandle.
+    /// </summary>
+    internal sealed class ThreadPoolBoundHandleOverlapped : Overlapped
+    {
+        private readonly IOCompletionCallback _userCallback;
+        internal readonly object _userState;
+        internal PreAllocatedOverlapped _preAllocated;
+        internal unsafe NativeOverlapped* _nativeOverlapped;
+        internal ThreadPoolBoundHandle _boundHandle;
+        internal bool _completed;
+
+        public unsafe ThreadPoolBoundHandleOverlapped(IOCompletionCallback callback, object state, object pinData, PreAllocatedOverlapped preAllocated)
+        {
+            _userCallback = callback;
+            _userState = state;
+            _preAllocated = preAllocated;
+
+            _nativeOverlapped = Pack(CompletionCallback, pinData);
+            _nativeOverlapped->OffsetLow = 0;        // CLR reuses NativeOverlapped instances and does not reset these
+            _nativeOverlapped->OffsetHigh = 0;
+        }
+
+        private unsafe static void CompletionCallback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
+        {
+            ThreadPoolBoundHandleOverlapped overlapped = (ThreadPoolBoundHandleOverlapped)Overlapped.Unpack(nativeOverlapped);
+
+            //
+            // The Win32 thread pool implementation of ThreadPoolBoundHandle does not permit reuse of NativeOverlapped
+            // pointers without freeing them and allocating new a new one.  We need to ensure that code using the CLR
+            // ThreadPool implementation follows those rules.
+            //
+            if (overlapped._completed)
+                throw new InvalidOperationException(SR.InvalidOperation_NativeOverlappedReused);
+
+            overlapped._completed = true;
+
+            if (overlapped._boundHandle == null)
+                throw new InvalidOperationException(SR.Argument_NativeOverlappedAlreadyFree);
+
+            overlapped._userCallback(errorCode, numBytes, nativeOverlapped);
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/Threading/ClrThreadPoolPreAllocatedOverlapped.cs
+++ b/src/mscorlib/corefx/System/Threading/ClrThreadPoolPreAllocatedOverlapped.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Threading
+{
+    /// <summary>
+    /// Represents pre-allocated state for native overlapped I/O operations.
+    /// </summary>
+    /// <seealso cref="ThreadPoolBoundHandle.AllocateNativeOverlapped(PreAllocatedOverlapped)"/>
+    public sealed class PreAllocatedOverlapped : IDisposable, IDeferredDisposable
+    {
+        internal readonly ThreadPoolBoundHandleOverlapped _overlapped;
+        private DeferredDisposableLifetime<PreAllocatedOverlapped> _lifetime;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="PreAllocatedOverlapped"/> class, specifying 
+        ///     a delegate that is invoked when each asynchronous I/O operation is complete, a user-provided 
+        ///     object providing context, and managed objects that serve as buffers.
+        /// </summary>
+        /// <param name="callback">
+        ///     An <see cref="IOCompletionCallback"/> delegate that represents the callback method 
+        ///     invoked when each asynchronous I/O operation completes.
+        /// </param>
+        /// <param name="state">
+        ///     A user-provided object that distinguishes <see cref="NativeOverlapped"/> instance produced from this
+        ///     object from other <see cref="NativeOverlapped"/> instances. Can be <see langword="null"/>.
+        /// </param>
+        /// <param name="pinData">
+        ///     An object or array of objects representing the input or output buffer for the operations. Each 
+        ///     object represents a buffer, for example an array of bytes.  Can be <see langword="null"/>.
+        /// </param>
+        /// <remarks>
+        ///     The new <see cref="PreAllocatedOverlapped"/> instance can be passed to 
+        ///     <see cref="ThreadPoolBoundHandle.AllocateNativeOverlapped(PreAllocatedOverlapped)"/>, to produce
+        ///     a <see cref="NativeOverlapped"/> instance that can be passed to the operating system in overlapped
+        ///     I/O operations.  A single <see cref="PreAllocatedOverlapped"/> instance can only be used for 
+        ///     a single native I/O operation at a time.  However, the state stored in the <see cref="PreAllocatedOverlapped"/>
+        ///     instance can be reused for subsequent native operations.
+        ///     <note>
+        ///         The buffers specified in <paramref name="pinData"/> are pinned until <see cref="Dispose"/> is called.
+        ///     </note>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="callback"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///     This method was called after the <see cref="ThreadPoolBoundHandle"/> was disposed.
+        /// </exception>
+        [CLSCompliant(false)]
+        public unsafe PreAllocatedOverlapped(IOCompletionCallback callback, object state, object pinData)
+        {
+            if (callback == null)
+                throw new ArgumentNullException(nameof(callback));
+
+            _overlapped = new ThreadPoolBoundHandleOverlapped(callback, state, pinData, this);
+        }
+
+        internal bool AddRef()
+        {
+            return _lifetime.AddRef(this);
+        }
+
+        internal void Release()
+        {
+            _lifetime.Release(this);
+        }
+
+        /// <summary>
+        /// Frees the resources associated with this <see cref="PreAllocatedOverlapped"/> instance. 
+        /// </summary>
+        public unsafe void Dispose()
+        {
+            _lifetime.Dispose(this);
+            GC.SuppressFinalize(this);
+        }
+
+        ~PreAllocatedOverlapped()
+        {
+            //
+            // During shutdown, don't automatically clean up, because this instance may still be
+            // reachable/usable by other code.
+            //
+            if (!Environment.HasShutdownStarted)
+                Dispose();
+        }
+
+        unsafe void IDeferredDisposable.OnFinalRelease(bool disposed)
+        {
+            if (_overlapped != null)
+            {
+                if (disposed)
+                {
+                    Overlapped.Free(_overlapped._nativeOverlapped);
+                }
+                else
+                {
+                    _overlapped._boundHandle = null;
+                    _overlapped._completed = false;
+                    *_overlapped._nativeOverlapped = default(NativeOverlapped);
+                }
+            }
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/Threading/DeferredDisposableLifetime.cs
+++ b/src/mscorlib/corefx/System/Threading/DeferredDisposableLifetime.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Threading
+{
+    /// <summary>
+    /// Provides callbacks to objects whose lifetime is managed by <see cref="DeferredDisposableLifetime{T}"/>.
+    /// </summary>
+    internal interface IDeferredDisposable
+    {
+        /// <summary>
+        /// Called when the object's refcount reaches zero.
+        /// </summary>
+        /// <param name="disposed">
+        /// Indicates whether the object has been disposed.
+        /// </param>
+        /// <remarks>
+        /// If the refount reaches zero before the object is disposed, this method will be called with
+        /// <paramref name="disposed"/> set to false.  If the object is then disposed, this method will be
+        /// called again, with <paramref name="disposed"/> set to true.  If the refcount reaches zero
+        /// after the object has already been disposed, this will be called a single time, with 
+        /// <paramref name="disposed"/> set to true.
+        /// </remarks>
+        void OnFinalRelease(bool disposed);
+    }
+
+    /// <summary>
+    /// Manages the lifetime of an object which implements IDisposable, but which must defer the actual
+    /// cleanup of state until all existing uses of the object are complete.
+    /// </summary>
+    /// <typeparam name="T">The type of object whose lifetime will be managed.</typeparam>
+    /// <remarks>
+    /// This type maintains a reference count, and tracks whether the object has been disposed.  When
+    /// Callbacks are made to <see cref="IDeferredDisposable.OnFinalRelease(bool)"/> when the refcount
+    /// reaches zero.  Objects that need to defer cleanup until they have been disposed *and* they have
+    /// no more references can do so in <see cref="IDeferredDisposable.OnFinalRelease(bool)"/> when
+    /// 'disposed' is true.
+    /// </remarks>
+    internal struct DeferredDisposableLifetime<T> where T : class, IDeferredDisposable
+    {
+        //
+        // _count is positive until Dispose is called, after which it's (-1 - refcount).
+        //
+        private int _count;
+
+        public bool AddRef(T obj)
+        {
+            while (true)
+            {
+                int oldCount = Volatile.Read(ref _count);
+
+                // Have we been disposed?
+                if (oldCount < 0)
+                    throw new ObjectDisposedException(typeof(T).ToString());
+
+                int newCount = checked(oldCount + 1);
+
+                if (Interlocked.CompareExchange(ref _count, newCount, oldCount) == oldCount)
+                    return true;
+            }
+        }
+
+        public void Release(T obj)
+        {
+            while (true)
+            {
+                int oldCount = Volatile.Read(ref _count);
+                if (oldCount > 0)
+                {
+                    // We haven't been disposed.  Decrement _count.
+                    int newCount = oldCount - 1;
+                    if (Interlocked.CompareExchange(ref _count, newCount, oldCount) == oldCount)
+                    {
+                        if (newCount == 0)
+                            obj.OnFinalRelease(disposed: false);
+                        return;
+                    }
+                }
+                else
+                {
+                    Debug.Assert(oldCount != 0 && oldCount != -1);
+
+                    // We've been disposed.  Increment _count.
+                    int newCount = oldCount + 1;
+                    if (Interlocked.CompareExchange(ref _count, newCount, oldCount) == oldCount)
+                    {
+                        if (newCount == -1)
+                            obj.OnFinalRelease(disposed: true);
+                        return;
+                    }
+                }
+            }
+        }
+
+        public void Dispose(T obj)
+        {
+            while (true)
+            {
+                int oldCount = Volatile.Read(ref _count);
+                if (oldCount < 0)
+                    return; // already disposed
+
+                int newCount = -1 - oldCount;
+                if (Interlocked.CompareExchange(ref _count, newCount, oldCount) == oldCount)
+                {
+                    if (newCount == -1)
+                        obj.OnFinalRelease(disposed: true);
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6994,9 +6994,9 @@
     <Type Name="System.Runtime.InteropServices.PrimaryInteropAssemblyAttribute">
       <Member Name="#ctor(System.Int32,System.Int32)" />
       <Member Name="get_MajorVersion" />
-      <Member MemberType="Property" Name="MajorVersion" />      
+      <Member MemberType="Property" Name="MajorVersion" />
       <Member Name="get_MinorVersion" />
-      <Member MemberType="Property" Name="MinorVersion" />      
+      <Member MemberType="Property" Name="MinorVersion" />
     </Type>    
     <Type Name="System.Runtime.InteropServices.ProgIdAttribute">
       <Member Name="#ctor(System.String)" />
@@ -7030,9 +7030,9 @@
     <Type Name="System.Runtime.InteropServices.TypeLibVersionAttribute">
       <Member Name="#ctor(System.Int32,System.Int32)" />
       <Member Name="get_MajorVersion" />
-      <Member MemberType="Property" Name="MajorVersion" />      
+      <Member MemberType="Property" Name="MajorVersion" />
       <Member Name="get_MinorVersion" />
-      <Member MemberType="Property" Name="MinorVersion" />      
+      <Member MemberType="Property" Name="MinorVersion" />
     </Type>       
     <Type Name="System.Runtime.InteropServices.CriticalHandle">
       <Member MemberType="Field" Name="handle" />
@@ -7066,6 +7066,9 @@
     <Type Name="Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid">
       <Member Name="#ctor(System.Boolean)" />
       <Member Name="get_IsInvalid" />
+    </Type>
+    <Type Name="Microsoft.Win32.SafeHandles.SafeFileHandle">
+      <Member Name="#ctor(System.IntPtr,System.Boolean)" />
     </Type>
     <Type Name="Microsoft.Win32.SafeHandles.SafeWaitHandle">
       <Member Name="#ctor(System.IntPtr,System.Boolean)" />
@@ -9267,11 +9270,61 @@
       <Member Name="#ctor(System.String,System.String)" />
       <Member Name="#ctor(System.String,System.String,System.Exception)" />
       <Member Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
-      <Member Name="get_FileName" />      
+      <Member Name="get_FileName" />
       <Member Name="get_FusionLog" />
       <Member MemberType="Property" Name="FileName" />
       <Member MemberType="Property" Name="FusionLog" />
       <Member Status="ImplRoot" Name="#ctor(System.String,System.String,System.Int32)" />
+    </Type>
+    <Type Name="System.IO.FileStream">
+      <Member Name="#ctor(Microsoft.Win32.SafeHandles.SafeFileHandle,System.IO.FileAccess)" />
+      <Member Name="#ctor(Microsoft.Win32.SafeHandles.SafeFileHandle,System.IO.FileAccess,System.Int32)" />
+      <Member Name="#ctor(Microsoft.Win32.SafeHandles.SafeFileHandle,System.IO.FileAccess,System.Int32,System.Boolean)" />
+      <Member Name="#ctor(System.String,System.IO.FileMode)" />
+      <Member Name="#ctor(System.String,System.IO.FileMode,System.IO.FileAccess)" />
+      <Member Name="#ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare)" />
+      <Member Name="#ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.Int32)" />
+      <Member Name="#ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.Int32,System.Boolean)" />
+      <Member Name="#ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.Int32,System.IO.FileOptions)" />
+      <Member Name="BeginRead(System.Byte[],System.Int32,System.Int32,System.AsyncCallback,System.Object)" />
+      <Member Name="BeginWrite(System.Byte[],System.Int32,System.Int32,System.AsyncCallback,System.Object)" />
+      <Member Name="CopyToAsync(System.IO.Stream,System.Int32,System.Threading.CancellationToken)" />
+      <Member Name="Dispose(System.Boolean)" />
+      <Member Name="EndRead(System.IAsyncResult)" />
+      <Member Name="EndWrite(System.IAsyncResult)" />
+      <Member Name="Finalize" />
+      <Member Name="Flush" />
+      <Member Name="Flush(System.Boolean)" />
+      <Member Name="FlushAsync(System.Threading.CancellationToken)" />
+      <Member Name="get_CanRead" />
+      <Member Name="get_CanSeek" />
+      <Member Name="get_CanWrite" />
+      <Member Name="get_Handle" />
+      <Member Name="get_IsAsync" />
+      <Member Name="get_Length" />
+      <Member Name="get_Name" />
+      <Member Name="get_Position" />
+      <Member Name="get_SafeFileHandle" />
+      <Member Name="Lock(System.Int64,System.Int64)" />
+      <Member Name="Read(System.Byte[],System.Int32,System.Int32)" />
+      <Member Name="ReadAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)" />
+      <Member Name="ReadByte" />
+      <Member Name="Seek(System.Int64,System.IO.SeekOrigin)" />
+      <Member Name="set_Position(System.Int64)" />
+      <Member Name="SetLength(System.Int64)" />
+      <Member Name="Unlock(System.Int64,System.Int64)" />
+      <Member Name="Write(System.Byte[],System.Int32,System.Int32)" />
+      <Member Name="WriteAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)" />
+      <Member Name="WriteByte(System.Byte)" />
+      <Member MemberType="Property" Name="CanRead" />
+      <Member MemberType="Property" Name="CanSeek" />
+      <Member MemberType="Property" Name="CanWrite" />
+      <Member MemberType="Property" Name="Handle" />
+      <Member MemberType="Property" Name="IsAsync" />
+      <Member MemberType="Property" Name="Length" />
+      <Member MemberType="Property" Name="Name" />
+      <Member MemberType="Property" Name="Position" />
+      <Member MemberType="Property" Name="SafeFileHandle" />
     </Type>
     <Type Name="System.IO.IOException">
       <Member Name="#ctor" />

--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -613,8 +613,10 @@
     <GlobalizationSources Condition="'$(FeatureOnlyCoreCalendars)'==''" Include="$(BclSourcesRoot)\System\Globalization\KoreanLunisolarCalendar.cs" />
     <GlobalizationSources Condition="'$(FeatureOnlyCoreCalendars)'==''" Include="$(BclSourcesRoot)\System\Globalization\TaiwanLunisolarCalendar.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(FeatureCoreFxGlobalization)' == 'true'">
+  <ItemGroup Condition="'$(FeatureCoreFxGlobalization)' == 'true' or '$(FeatureCoreFxFileStream)' == 'true'">
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\SR.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCoreFxGlobalization)' == 'true'">
     <GlobalizationSources Condition="'$(FeatureCoreClr)'=='true'" Include="$(CoreFxSourcesRoot)\System\Globalization\STUBS.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\Calendar.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\CalendarAlgorithmType.cs" />
@@ -664,7 +666,6 @@
     <GlobalizationSources Include="$(BclSourcesRoot)\System\Globalization\EncodingDataItem.Unix.cs" />
     <GlobalizationSources Include="$(BclSourcesRoot)\System\Text\Normalization.Unix.cs" />
 
-    <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\Interop.Libraries.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Calendar.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Casing.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Collation.cs" />
@@ -680,7 +681,7 @@
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\DigitShapes.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\HijriCalendar.Unix.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\JapaneseCalendar.Unix.cs" />
-    <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\LocaleData.Unix.cs" />    
+    <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\LocaleData.Unix.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\TextInfo.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -754,6 +755,32 @@
     <ThreadingSources Include="$(BclSourcesRoot)\System\Threading\Tasks\TaskToApm.cs" />
     <ThreadingSources Condition="'$(FeatureCominterop)' == 'true'" Include="$(BclSourcesRoot)\System\Threading\Tasks\IAsyncCausalityTracerStatics.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCoreFxFileStream)' != 'true'">
+    <FileStreamSources Include="$(BclSourcesRoot)\System\IO\FileStream.cs" />
+    <SafehandleSources Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeFileHandle.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCoreFxFileStream)' == 'true'">
+    <FileStreamSources Include="$(CoreFxSourcesRoot)\System\IO\FileStream.cs" />
+    <FileStreamSources Include="$(CoreFxSourcesRoot)\System\IO\FileStream.NetStandard17.cs" />
+    <FileStreamSources Include="$(CoreFxSourcesRoot)\System\IO\Error.cs" />
+    <FileStreamSources Include="$(CoreFxSourcesRoot)\System\IO\StreamHelpers.ArrayPoolCopy.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCoreFxFileStream)' == 'true' and '$(TargetsUnix)' == 'true'">
+    <SafehandleSources Include="$(CoreFxSourcesRoot)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs" />
+    <FileStreamSources Include="$(CoreFxSourcesRoot)\System\IO\FileStream.Unix.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCoreFxFileStream)' == 'true' and '$(TargetsUnix)' != 'true'">
+    <SafehandleSources Include="$(CoreFxSourcesRoot)\Microsoft\Win32\SafeHandles\SafeFileHandle.Windows.cs" />
+    <FileStreamSources Include="$(CoreFxSourcesRoot)\System\IO\FileStream.Win32.cs" />
+    <FileStreamSources Include="$(CoreFxSourcesRoot)\System\IO\FileStreamCompletionSource.Win32.cs" />
+    <FileStreamSources Include="$(CoreFxSourcesRoot)\System\IO\Win32Marshal.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCoreFxOverlapped)' == 'true'" >
+    <ThreadingSources Include="$(CoreFxSourcesRoot)\System\Threading\DeferredDisposableLifetime.cs" />
+    <ThreadingSources Include="$(CoreFxSourcesRoot)\System\Threading\ClrThreadPoolBoundHandle.cs" />
+    <ThreadingSources Include="$(CoreFxSourcesRoot)\System\Threading\ClrThreadPoolBoundHandleOverlapped.cs" />
+    <ThreadingSources Include="$(CoreFxSourcesRoot)\System\Threading\ClrThreadPoolPreAllocatedOverlapped.cs" />
+  </ItemGroup>
   <ItemGroup>
     <IoSources Include="$(BclSourcesRoot)\System\IO\__Error.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\__HResults.cs" />
@@ -774,7 +801,6 @@
     <IoSources Include="$(BclSourcesRoot)\System\IO\FileNotFoundException.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\FileOptions.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\FileShare.cs" />
-    <IoSources Include="$(BclSourcesRoot)\System\IO\FileStream.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\FileSystemEnumerable.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\FileSystemInfo.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\FileAttributes.cs" />
@@ -1120,7 +1146,6 @@
     <GenericsSources Include="$(BclSourcesRoot)\System\Collections\Concurrent\PartitionerStatic.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SafehandleSources Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeFileHandle.cs" />
     <SafehandleSources Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeFileMappingHandle.cs" />
     <SafehandleSources Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeFindHandle.cs" />
     <SafehandleSources Include="$(BclSourcesRoot)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs" />
@@ -1139,6 +1164,56 @@
     <BuffersSources Condition="'$(FeatureCoreClr)'=='true'" Include="$(BclSourcesRoot)\System\Buffers\DefaultArrayPool.cs" />
     <BuffersSources Condition="'$(FeatureCoreClr)'=='true'" Include="$(BclSourcesRoot)\System\Buffers\DefaultArrayPoolBucket.cs" />
     <BuffersSources Condition="'$(FeatureCoreClr)'=='true'" Include="$(BclSourcesRoot)\System\Buffers\Utilities.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCoreFxWindowsInterop)' == 'true'">
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\System\HResults.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\Interop.BOOL.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\Interop.Libraries.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.CancelIoEx.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.CloseHandle.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.CreateFile.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.Errors.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.FileTypes.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.FileOperations.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.FlushFileBuffers.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.FormatMessage.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.GetFileInformationByHandleEx.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.GetFileType_SafeHandle.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.LockFile.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.ReadFile_SafeHandle_IntPtr.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.ReadFile_SafeHandle_NativeOverlapped.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.SafeCreateFile.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.SECURITY_ATTRIBUTES.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.SecurityOptions.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.SetEndOfFile.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.SetErrorMode.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.SetFileInformationByHandle.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.SetFilePointerEx.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.UnsafeCreateFile.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.WriteFile_SafeHandle_IntPtr.cs" />
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Interop\Windows\mincore\Interop.WriteFile_SafeHandle_NativeOverlapped.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCoreFxUnixInterop)' == 'true'">
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\System\HResults.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\Interop.Errors.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\Interop.IOErrors.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\Interop.Libraries.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.Close.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.FLock.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.FSync.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.FTruncate.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.LSeek.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.Open.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.OpenFlags.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.Permissions.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.PosixFAdvise.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.Read.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.Stat.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.Unlink.cs" />
+    <UnixInteropSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Native\Interop.Write.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(FeatureCoreFxShim)' == 'true'">
+    <WindowsInteropSources Include="$(CoreFxSourcesRoot)\Debug.cs" />
   </ItemGroup>
   <ItemGroup>
     <MscorlibSources Include="@(SystemSources)"/>
@@ -1170,6 +1245,7 @@
     <MscorlibSources Include="@(WinRTTSources)"/>
     <MscorlibSources Include="@(WinRTCollectionSources)"/>
     <MscorlibSources Include="@(IoSources)"/>
+    <MscorlibSources Include="@(FileStreamSources)"/>
     <MscorlibSources Include="@(CompilerServicesSources)"/>
     <MscorlibSources Include="@(RuntimeSources)"/>
     <MscorlibSources Include="@(XmlSources)"/>
@@ -1193,5 +1269,7 @@
     <MscorlibSources Include="@(NumericsSources)"/>
     <MscorlibSources Include="$(BclSourcesRoot)\GlobalSuppressions.cs"/>
     <MscorlibSources Include="@(BuffersSources)"/>
+    <MscorlibSources Include="@(WindowsInteropSources)"/>
+    <MscorlibSources Include="@(UnixInteropSources)"/>
   </ItemGroup>
 </Project>

--- a/src/mscorlib/src/Microsoft/Win32/SafeHandles/Win32SafeHandles.cs
+++ b/src/mscorlib/src/Microsoft/Win32/SafeHandles/Win32SafeHandles.cs
@@ -108,5 +108,4 @@ namespace Microsoft.Win32.SafeHandles
             get { return handle == new IntPtr(-1); }
         }
     }
-
 }

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -910,6 +910,7 @@ namespace Microsoft.Win32 {
         [DllImport(KERNEL32, SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern uint GetLongPathNameW(string lpszShortPath, SafeHandle lpszLongPath, uint cchBuffer);
 
+#if !FEATURE_CORECLR
         // Disallow access to all non-file devices from methods that take
         // a String.  This disallows DOS devices like "con:", "com1:", 
         // "lpt1:", etc.  Use this to avoid security problems, like allowing
@@ -935,7 +936,7 @@ namespace Microsoft.Win32 {
             }
 
             return handle;
-        }            
+        }
 
         [System.Security.SecurityCritical]  // auto-generated
         internal static SafeFileHandle UnsafeCreateFile(String lpFileName,
@@ -948,8 +949,8 @@ namespace Microsoft.Win32 {
                                 dwFlagsAndAttributes, hTemplateFile );
 
             return handle;
-        }            
-    
+        }
+
         // Do not use these directly, use the safe or unsafe versions above.
         // The safe version does not support devices (aka if will only open
         // files on disk), while the unsafe version give you the full semantic
@@ -959,6 +960,7 @@ namespace Microsoft.Win32 {
                     int dwDesiredAccess, System.IO.FileShare dwShareMode,
                     SECURITY_ATTRIBUTES securityAttrs, System.IO.FileMode dwCreationDisposition,
                     int dwFlagsAndAttributes, IntPtr hTemplateFile);
+#endif
 
         [DllImport(KERNEL32, SetLastError=true, CharSet=CharSet.Auto, BestFitMapping=false)]
         internal static extern SafeFileMappingHandle CreateFileMapping(SafeFileHandle hFile, IntPtr lpAttributes, uint fProtect, uint dwMaximumSizeHigh, uint dwMaximumSizeLow, String lpName);

--- a/src/mscorlib/src/System.Private.CoreLib.txt
+++ b/src/mscorlib/src/System.Private.CoreLib.txt
@@ -630,6 +630,10 @@ Argument_UnmanagedMemAccessorWrapAround = The UnmanagedMemoryAccessor capacity a
 Argument_UnrecognizedLoaderOptimization = Unrecognized LOADER_OPTIMIZATION property value.  Supported values may include "SingleDomain", "MultiDomain", "MultiDomainHost", and "NotSpecified".
 ArgumentException_NotAllCustomSortingFuncsDefined = Implementations of all the NLS functions must be provided.
 ArgumentException_MinSortingVersion = The runtime does not support a version of "{0}" less than {1}.
+Argument_PreAllocatedAlreadyAllocated = 'preAllocated' is already in use.
+Argument_NativeOverlappedWrongBoundHandle = 'overlapped' was not allocated by this ThreadPoolBoundHandle instance.
+Argument_NativeOverlappedAlreadyFree = 'overlapped' has already been freed.
+Argument_AlreadyBoundOrSyncHandle = 'handle' has already been bound to the thread pool, or was not opened for asynchronous I/O.
 
 ;
 ; =====================================================
@@ -1157,6 +1161,7 @@ InvalidOperation_MethodBaked = Type definition of the method is complete.
 InvalidOperation_MethodHasBody = Method already has a body.
 InvalidOperation_ModificationOfNonCanonicalAcl = This access control list is not in canonical form and therefore cannot be modified.
 InvalidOperation_Method = This method is not supported by the current object.
+InvalidOperation_NativeOverlappedReused = NativeOverlapped cannot be reused for multiple operations.
 InvalidOperation_NotADebugModule = Not a debug ModuleBuilder.
 InvalidOperation_NoMultiModuleAssembly = You cannot have more than one dynamic module in each dynamic assembly in this version of the runtime.
 InvalidOperation_OpenLocalVariableScope = Local variable scope was not properly closed.
@@ -1874,7 +1879,7 @@ IO.PathNotFound_Path = Could not find a part of the path '{0}'.
 IO.PathNotFound_NoPathName = Could not find a part of the path.
 
 ; PathTooLongException
-IO.PathTooLong = The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters.
+IO.PathTooLong = The specified file name or path is too long, or a component of the specified path is too long.
 
 #if FEATURE_CORECLR
 ; SecurityException

--- a/src/mscorlib/src/System/IO/Directory.cs
+++ b/src/mscorlib/src/System/IO/Directory.cs
@@ -404,6 +404,7 @@ namespace System.IO {
                     && ((data.fileAttributes & Win32Native.FILE_ATTRIBUTE_DIRECTORY) != 0);
         }
 
+#if !FEATURE_CORECLR
         public static void SetCreationTime(String path,DateTime creationTime)
         {
             SetCreationTimeUtc(path, creationTime.ToUniversalTime());
@@ -422,6 +423,7 @@ namespace System.IO {
                 }
             }
         }
+#endif // !FEATURE_CORECLR
 
         public static DateTime GetCreationTime(String path)
         {
@@ -433,6 +435,7 @@ namespace System.IO {
             return File.GetCreationTimeUtc(path);
         }
 
+#if !FEATURE_CORECLR
         public static void SetLastWriteTime(String path,DateTime lastWriteTime)
         {
             SetLastWriteTimeUtc(path, lastWriteTime.ToUniversalTime());
@@ -451,6 +454,7 @@ namespace System.IO {
                 }
             }
         }
+#endif // !FEATURE_CORECLR
 
         public static DateTime GetLastWriteTime(String path)
         {
@@ -462,6 +466,7 @@ namespace System.IO {
             return File.GetLastWriteTimeUtc(path);
         }
 
+#if !FEATURE_CORECLR
         public static void SetLastAccessTime(String path,DateTime lastAccessTime)
         {
             SetLastAccessTimeUtc(path, lastAccessTime.ToUniversalTime());
@@ -480,6 +485,7 @@ namespace System.IO {
                 }
             }
         }
+#endif // !FEATURE_CORECLR
 
         public static DateTime GetLastAccessTime(String path)
         {
@@ -1040,11 +1046,11 @@ namespace System.IO {
             }
         }
 
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] // auto-generated
-        #else
+#else
         [System.Security.SecuritySafeCritical]
-        #endif
+#endif
         public static void SetCurrentDirectory(String path)
         {
             if (path==null)
@@ -1347,6 +1353,7 @@ namespace System.IO {
             }
         }
 
+#if !FEATURE_CORECLR
         // WinNT only. Win9x this code will not work.
         [System.Security.SecurityCritical]  // auto-generated
         private static SafeFileHandle OpenHandle(String path)
@@ -1376,6 +1383,7 @@ namespace System.IO {
             }
             return handle;
         }
+#endif // !FEATURE_CORECLR
 
         private const int FILE_ATTRIBUTE_DIRECTORY = 0x00000010;    
         private const int GENERIC_WRITE = unchecked((int)0x40000000);
@@ -1384,6 +1392,5 @@ namespace System.IO {
         private const int OPEN_EXISTING = 0x00000003;
         private const int FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
     }
-
 }
 

--- a/src/mscorlib/src/System/IO/File.cs
+++ b/src/mscorlib/src/System/IO/File.cs
@@ -36,6 +36,11 @@ namespace System.IO {
     [ComVisible(true)]
     public static class File
     {
+        internal const int GENERIC_READ = unchecked((int)0x80000000);
+        private const int GENERIC_WRITE = unchecked((int)0x40000000);
+        private const int FILE_SHARE_WRITE = 0x00000002;
+        private const int FILE_SHARE_DELETE = 0x00000004;
+
         private const int GetFileExInfoStandard = 0;
 
         public static StreamReader OpenText(String path)
@@ -156,13 +161,15 @@ namespace System.IO {
                 String fileName = destFileName;
 
                 if (errorCode != Win32Native.ERROR_FILE_EXISTS) {
+#if !FEATURE_CORECLR
                     // For a number of error codes (sharing violation, path 
                     // not found, etc) we don't know if the problem was with
                     // the source or dest file.  Try reading the source file.
-                    using(SafeFileHandle handle = Win32Native.UnsafeCreateFile(fullSourceFileName, FileStream.GENERIC_READ, FileShare.Read, null, FileMode.Open, 0, IntPtr.Zero)) {
+                    using(SafeFileHandle handle = Win32Native.UnsafeCreateFile(fullSourceFileName, GENERIC_READ, FileShare.Read, null, FileMode.Open, 0, IntPtr.Zero)) {
                         if (handle.IsInvalid)
                             fileName = sourceFileName;
                     }
+#endif // !FEATURE_CORECLR
 
                     if (errorCode == Win32Native.ERROR_ACCESS_DENIED) {
                         if (Directory.InternalExists(fullDestFileName))
@@ -397,6 +404,7 @@ namespace System.IO {
             return new FileStream(path, mode, access, share);
         }
 
+#if !FEATURE_CORECLR
         public static void SetCreationTime(String path, DateTime creationTime)
         {
             SetCreationTimeUtc(path, creationTime.ToUniversalTime());
@@ -416,6 +424,7 @@ namespace System.IO {
                 }
             }
         }
+#endif // !FEATURE_CORECLR
 
         [System.Security.SecuritySafeCritical]
         public static DateTime GetCreationTime(String path)
@@ -452,6 +461,7 @@ namespace System.IO {
             return DateTime.FromFileTimeUtc(dt);
         }
 
+#if !FEATURE_CORECLR
         public static void SetLastAccessTime(String path, DateTime lastAccessTime)
         {
             SetLastAccessTimeUtc(path, lastAccessTime.ToUniversalTime());
@@ -471,6 +481,7 @@ namespace System.IO {
                 }
             }
         }
+#endif // FEATURE_CORECLR
 
         [System.Security.SecuritySafeCritical]
         public static DateTime GetLastAccessTime(String path)
@@ -507,6 +518,7 @@ namespace System.IO {
             return DateTime.FromFileTimeUtc(dt);
         }
 
+#if !FEATURE_CORECLR
         public static void SetLastWriteTime(String path, DateTime lastWriteTime)
         {
             SetLastWriteTimeUtc(path, lastWriteTime.ToUniversalTime());
@@ -526,6 +538,7 @@ namespace System.IO {
                 }
             }
         }
+#endif // !FEATURE_CORECLR
 
         [System.Security.SecuritySafeCritical]
         public static DateTime GetLastWriteTime(String path)
@@ -581,11 +594,11 @@ namespace System.IO {
             return (FileAttributes) data.fileAttributes;
         }
 
-        #if FEATURE_CORECLR
+#if FEATURE_CORECLR
         [System.Security.SecurityCritical] 
-        #else
+#else
         [System.Security.SecuritySafeCritical]
-        #endif
+#endif
         public static void SetAttributes(String path, FileAttributes fileAttributes) 
         {
             String fullPath = Path.GetFullPathInternal(path);
@@ -1223,6 +1236,7 @@ namespace System.IO {
             return dataInitialised;
         }
 
+#if !FEATURE_CORECLR
         [System.Security.SecurityCritical]  // auto-generated
         private static FileStream OpenFile(String path, FileAccess access, out SafeFileHandle handle)
         {
@@ -1246,6 +1260,7 @@ namespace System.IO {
             }
             return fs;
         }
+#endif // !FEATURE_CORECLR
 
 
          // Defined in WinError.h

--- a/src/mscorlib/src/System/IO/FileSystemInfo.cs
+++ b/src/mscorlib/src/System/IO/FileSystemInfo.cs
@@ -156,13 +156,15 @@ namespace System.IO {
                     // depends on the security check in get_CreationTimeUtc
                     return CreationTimeUtc.ToLocalTime();
             }
-
-            set {
+#if !FEATURE_CORECLR
+            set
+            {
                 CreationTimeUtc = value.ToUniversalTime();
             }
+#endif // !FEATURE_CORECLR
         }
 
-       [ComVisible(false)]
+        [ComVisible(false)]
        public DateTime CreationTimeUtc {
            [System.Security.SecuritySafeCritical]
             get {
@@ -183,7 +185,7 @@ namespace System.IO {
                 return DateTime.FromFileTimeUtc(fileTime);
                 
             }
-        
+#if !FEATURE_CORECLR
             set {
                 if (this is DirectoryInfo)
                     Directory.SetCreationTimeUtc(FullPath,value);
@@ -191,11 +193,12 @@ namespace System.IO {
                     File.SetCreationTimeUtc(FullPath,value);
                 _dataInitialised = -1;
             }
+#endif // !FEATURE_CORECLR
         }
 
 
         public DateTime LastAccessTime
-       {
+        {
            get {
                 // depends on the security check in get_LastAccessTimeUtc
                 return LastAccessTimeUtc.ToLocalTime();
@@ -228,11 +231,13 @@ namespace System.IO {
             }
 
             set {
+#if !FEATURE_CORECLR
                 if (this is DirectoryInfo)
                     Directory.SetLastAccessTimeUtc(FullPath,value);
                 else
                     File.SetLastAccessTimeUtc(FullPath,value);
                 _dataInitialised = -1;
+#endif // !FEATURE_CORECLR
             }
         }
 
@@ -271,11 +276,13 @@ namespace System.IO {
             }
 
             set {
+#if !FEATURE_CORECLR
                 if (this is DirectoryInfo)
                     Directory.SetLastWriteTimeUtc(FullPath,value);
                 else
                     File.SetLastWriteTimeUtc(FullPath,value);
                 _dataInitialised = -1;
+#endif // !FEATURE_CORECLR
             }
         }
 

--- a/src/mscorlib/src/System/IO/PathInternal.cs
+++ b/src/mscorlib/src/System/IO/PathInternal.cs
@@ -201,6 +201,22 @@ namespace System.IO
         }
 
         /// <summary>
+        /// Adds the extended path prefix (\\?\) if not already a device path, IF the path is not relative,
+        /// AND the path is more than 259 characters. (> MAX_PATH + null)
+        /// </summary>
+        internal static string EnsureExtendedPrefixOverMaxPath(string path)
+        {
+            if (path != null && path.Length >= MaxShortPath)
+            {
+                return EnsureExtendedPrefix(path);
+            }
+            else
+            {
+                return path;
+            }
+        }
+
+        /// <summary>
         /// Removes the extended path prefix (\\?\) if present.
         /// </summary>
         internal static string RemoveExtendedPrefix(string path)

--- a/src/vm/microsoft.comservices_i.c
+++ b/src/vm/microsoft.comservices_i.c
@@ -151,7 +151,7 @@ typedef IID CLSID;
 #define MIDL_DEFINE_GUID(type,name,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8) \
         const type name = {l,w1,w2,{b1,b2,b3,b4,b5,b6,b7,b8}}
 
-#endif !_MIDL_USE_GUIDDEF_
+#endif // !_MIDL_USE_GUIDDEF_
 
 MIDL_DEFINE_GUID(IID, LIBID_Microsoft_ComServices,0xD7F68C66,0x3833,0x3832,0xB6,0xD0,0xB7,0x96,0xBB,0x7D,0x2D,0xFF);
 

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -773,6 +773,7 @@ DEFINE_CLASS(I_RT_FIELD_INFO,       System,                 IRuntimeFieldInfo)
 
 DEFINE_CLASS(FIELD_INFO,            Reflection,             FieldInfo)
 
+#ifndef FEATURE_CORECLR
 DEFINE_CLASS_U(IO,               FileStreamAsyncResult, AsyncResultBase)
 DEFINE_FIELD_U(_userCallback,          AsyncResultBase,    _userCallback)
 DEFINE_FIELD_U(_userStateObject,       AsyncResultBase,    _userStateObject)
@@ -787,6 +788,7 @@ DEFINE_FIELD_U(_isWrite,               AsyncResultBase,    _isWrite)
 DEFINE_FIELD_U(_isComplete,            AsyncResultBase,    _isComplete)
 DEFINE_FIELD_U(_completedSynchronously, AsyncResultBase, _completedSynchronously)
 DEFINE_CLASS(FILESTREAM_ASYNCRESULT, IO,               FileStreamAsyncResult)
+#endif // !FEATURE_CORECLR
 
 DEFINE_CLASS_U(Security,           FrameSecurityDescriptor, FrameSecurityDescriptorBaseObject)
 DEFINE_FIELD_U(m_assertions,       FrameSecurityDescriptorBaseObject,  m_assertions)

--- a/src/vm/nativeoverlapped.h
+++ b/src/vm/nativeoverlapped.h
@@ -22,6 +22,7 @@ class OverlappedDataObject : public Object
 {
 public:
     ASYNCRESULTREF m_asyncResult;
+
     OBJECTREF m_iocb;
     OBJECTREF m_iocbHelper;
     OBJECTREF m_overlapped;

--- a/src/vm/vars.cpp
+++ b/src/vm/vars.cpp
@@ -80,7 +80,9 @@ GPTR_IMPL(MethodTable,      g_pValueTypeClass);
 GPTR_IMPL(MethodTable,      g_pEnumClass);
 GPTR_IMPL(MethodTable,      g_pThreadClass);
 GPTR_IMPL(MethodTable,      g_pCriticalFinalizerObjectClass);
+#ifndef FEATURE_CORECLR
 GPTR_IMPL(MethodTable,      g_pAsyncFileStream_AsyncResultClass);
+#endif // !FEATURE_CORECLR
 GPTR_IMPL(MethodTable,      g_pFreeObjectMethodTable);
 GPTR_IMPL(MethodTable,      g_pOverlappedDataClass);
 

--- a/src/vm/vars.hpp
+++ b/src/vm/vars.hpp
@@ -415,7 +415,9 @@ GPTR_DECL(MethodTable,      g_pValueTypeClass);
 GPTR_DECL(MethodTable,      g_pEnumClass);
 GPTR_DECL(MethodTable,      g_pThreadClass);
 GPTR_DECL(MethodTable,      g_pCriticalFinalizerObjectClass);
+#ifndef FEATURE_CORECLR
 GPTR_DECL(MethodTable,      g_pAsyncFileStream_AsyncResultClass);
+#endif // !FEATURE_CORECLR
 GPTR_DECL(MethodTable,      g_pOverlappedDataClass);
 
 GPTR_DECL(MethodTable,      g_TypedReferenceMT);


### PR DESCRIPTION
This copies FileStream to CoreLib and uses it in place of the legacy
FileStream. Code is mostly a direct copy with the addition of a few
internal constructor overloads.

Adds a simple Debug wrapper for BCLDebug to allow keeping the code
the same. Also follows the same pattern for SR wrapping.

Needed to bring down PreAllocatedOverlapped.

This change gets the Win32 version compiling. I'm still working on the Unix sources, but wanted to get feedback on the approach for integrating the code and the Windows sources while I continue.

@weshaggard, @ianhays, @jkotas, @stephentoub, @ericeil, @ericstj 