### PR TITLE
[ARM/CI] Change the name of corefx project

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2091,7 +2091,7 @@ combinedScenarios.each { scenario ->
                                             latestSuccessful(true)
                                         }
                                     }
-                                    copyArtifacts("${corefxFolder}/linuxarmemulator_cross_${lowerConfiguration}") {
+                                    copyArtifacts("${corefxFolder}/linuxarmemulator_softfp_cross_${lowerConfiguration}") {
                                         includePatterns('bin/build.tar.gz')
                                         buildSelector {
                                             latestSuccessful(true)


### PR DESCRIPTION
The default project name of corefx has changed so we need this changes.

This will fix Linux ARM Emulator checks fails