### PR TITLE
Fix format.py to look for .bat on Windows

### DIFF
--- a/tests/scripts/format.py
+++ b/tests/scripts/format.py
@@ -185,7 +185,7 @@ def main(argv):
     if platform == 'Linux' or platform == 'OSX':
         jitformat = os.path.join(jitformat, "jit-format")
     elif platform == 'Windows_NT':
-        jitformat = os.path.join(jitformat,"jit-format.cmd")
+        jitformat = os.path.join(jitformat,"jit-format.bat")
     errorMessage = ""
 
     builds = ["Checked", "Debug", "Release"]


### PR DESCRIPTION
dotnet/jitutils#56 changed the file extension for
the script files on Windows to be .bat, so the format.py script needs to
be updated.