### PR TITLE
DateTime.ToString(“o”) allocates 32 objects,

### DIFF
--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -958,7 +958,7 @@ namespace System {
 
             if (format.Length == 1) {
                 if (format[0] == 'o' || format[0] == 'O') {
-                        return FastFormatRoundTrip(dateTime);
+                        return FastFormatRoundtrip(dateTime);
                 }
 
                 format = ExpandPredefinedFormat(format, ref dateTime, ref dtfi, ref offset);
@@ -967,7 +967,7 @@ namespace System {
             return (FormatCustomized(dateTime, format, dtfi, offset));
         }
 
-        internal static string FastFormatRoundTrip(DateTime dateTime)
+        internal static string FastFormatRoundtrip(DateTime dateTime)
         {
             StringBuilder result = StringBuilderCache.Acquire();
             AppendNumber(result, dateTime.Year, 4);

--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -807,10 +807,6 @@ namespace System {
                 case 'M':       // Month/Day Date
                     realFormat = dtfi.MonthDayPattern;
                     break;
-                case 'o':
-                case 'O':
-                    realFormat = RoundtripFormat;
-                    break;
                 case 'r':
                 case 'R':       // RFC 1123 Standard                    
                     realFormat = dtfi.RFC1123Pattern;
@@ -848,10 +844,6 @@ namespace System {
         //
         private static String ExpandPredefinedFormat(String format, ref DateTime dateTime, ref DateTimeFormatInfo dtfi, ref TimeSpan offset) {
             switch (format[0]) {
-                case 'o':
-                case 'O':       // Round trip format
-                    dtfi = DateTimeFormatInfo.InvariantInfo;
-                    break;
                 case 'r':
                 case 'R':       // RFC 1123 Standard                    
                     if (offset != NullOffset) {

--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -1002,13 +1002,14 @@ namespace System {
             }
 
             int index = 1;
-
             while (val > 0 && index <= digits)
             {
                 builder[builder.Length - index] = (char)('0' + (val % 10));
                 val = val / 10;
                 index++;
             }
+
+            Contract.Assert(val == 0, "DateTimeFormat.AppendNumber(): digits less than size of val");
         }
 
         internal static String[] GetAllDateTimes(DateTime dateTime, char format, DateTimeFormatInfo dtfi)

--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -949,9 +949,9 @@ namespace System {
             }
 
             if (format.Length == 1) {
-                switch (format) {
-                    case "o":
-                    case "O":
+                switch (format[0]) {
+                    case 'o':
+                    case 'O':
                         // Fast track for round trip format without going through a format string.
                         return RoundTripFormat(ref dateTime);
                 }

--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -1034,7 +1034,6 @@ namespace System {
             }
         }
 
-
         internal static String[] GetAllDateTimes(DateTime dateTime, char format, DateTimeFormatInfo dtfi)
         {
             Contract.Requires(dtfi != null);


### PR DESCRIPTION
Fix for #7815 

I'm still working on running the corefx tests on this change and possibly adding some but wanted to start the CR process.

I'm seeing an ~90% reduction in allocation count and ~80% reduction in allocated bytes after this change.

@tarekgh @weshaggard @stephentoub 
