### PR TITLE
Introduce new CORJIT_FLAGS type

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/icorjitcompilerimpl.h
+++ b/src/ToolBox/superpmi/superpmi-shared/icorjitcompilerimpl.h
@@ -57,7 +57,11 @@ public:
     // When the EE loads the System.Numerics.Vectors assembly, it asks the JIT what length (in bytes) of
     // SIMD vector it supports as an intrinsic type.  Zero means that the JIT does not support SIMD
     // intrinsics, so the EE should use the default size (i.e. the size of the IL implementation).
+#if COR_JIT_EE_VERSION > 460
+    unsigned getMaxIntrinsicSIMDVectorLength(CORJIT_FLAGS cpuCompileFlags); /* { return 0; } */
+#else
     unsigned getMaxIntrinsicSIMDVectorLength(DWORD cpuCompileFlags); /* { return 0; } */
+#endif
 
     // IL obfuscators sometimes interpose on the EE-JIT interface. This function allows the VM to
     // tell the JIT to use a particular ICorJitCompiler to implement the methods of this interface,

--- a/src/ToolBox/superpmi/superpmi-shared/icorjitinfoimpl.h
+++ b/src/ToolBox/superpmi/superpmi-shared/icorjitinfoimpl.h
@@ -653,7 +653,7 @@ public:
     // in the code are.  The native compiler will ensure that these places
     // have a corresponding break point in native code.
     //
-    // Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+    // Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
     // be used only as a hint and the native compiler should not change its
     // code generation.
     void getBoundaries(
@@ -683,7 +683,7 @@ public:
     // under debugging, the JIT needs to keep them live over their
     // entire scope so that they can be inspected.
     //
-    // Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+    // Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
     // be used only as a hint and the native compiler should not change its
     // code generation.
     void getVars(

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -744,7 +744,7 @@ void MethodContext::recCompileMethod(CORINFO_METHOD_INFO *info, unsigned flags)
 void MethodContext::dmpCompileMethod(DWORD key, const Agnostic_CompileMethod& value)
 {
     printf("CompiledMethod key %u, value ftn-%016llX scp-%016llX ilo-%u ils-%u ms-%u ehc-%u opt-%u rk-%u "
-             "args{cc-%u rc-%016llX rts-%016llX rt-%u(%s) flg-%08X nA-%u cc-%u ci-%u mc-%u mi-%u arg-%016llX cb-%u pSig-%u scp-%016llX tok-%08X} "
+           "args{cc-%u rc-%016llX rts-%016llX rt-%u(%s) flg-%08X nA-%u cc-%u ci-%u mc-%u mi-%u arg-%016llX cb-%u pSig-%u scp-%016llX tok-%08X} "
            "locals{cc-%u rc-%016llX rts-%016llX rt-%u(%s) flg-%08X nA-%u cc-%u ci-%u mc-%u mi-%u arg-%016llX cb-%u pSig-%u scp-%016llX tok-%08X} "
            "flg-%08X",
         key,
@@ -1098,8 +1098,8 @@ void MethodContext::recGetJitFlags(CORJIT_FLAGS *jitFlags, DWORD sizeInBytes, DW
 }
 void MethodContext::dmpGetJitFlags(DWORD key, DD value)
 {
-    CORJIT_FLAGS *flags = (CORJIT_FLAGS*)GetJitFlags->GetBuffer(value.A);
-    printf("GetJitFlags key %u sizeInBytes-%u corJitFlags-%08X corJitFlags2-%08X", key, value.B, flags->corJitFlags, flags->corJitFlags2);
+    CORJIT_FLAGS *jitflags = (CORJIT_FLAGS*)GetJitFlags->GetBuffer(value.A);
+    printf("GetJitFlags key %u sizeInBytes-%u jitFlags-%016llX", key, value.B, jitflags->GetFlagsRaw());
     GetJitFlags->Unlock();
 }
 DWORD MethodContext::repGetJitFlags(CORJIT_FLAGS *jitFlags, DWORD sizeInBytes)

--- a/src/ToolBox/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/icorjitcompiler.cpp
@@ -109,7 +109,7 @@ void interceptor_ICJC::getVersionIdentifier(GUID* versionIdentifier /* OUT */)
     original_ICorJitCompiler->getVersionIdentifier(versionIdentifier);
 }
 
-unsigned interceptor_ICJC::getMaxIntrinsicSIMDVectorLength(DWORD cpuCompileFlags)
+unsigned interceptor_ICJC::getMaxIntrinsicSIMDVectorLength(CORJIT_FLAGS cpuCompileFlags)
 {
     return original_ICorJitCompiler->getMaxIntrinsicSIMDVectorLength(cpuCompileFlags);
 }

--- a/src/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -1173,7 +1173,7 @@ bool interceptor_ICJI::isFieldStatic(CORINFO_FIELD_HANDLE fldHnd)
 // in the code are.  The native compiler will ensure that these places
 // have a corresponding break point in native code.
 //
-// Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+// Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
 // be used only as a hint and the native compiler should not change its
 // code generation.
 void interceptor_ICJI::getBoundaries(
@@ -1214,7 +1214,7 @@ void interceptor_ICJI::setBoundaries(
 // under debugging, the JIT needs to keep them live over their
 // entire scope so that they can be inspected.
 //
-// Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+// Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
 // be used only as a hint and the native compiler should not change its
 // code generation.
 void interceptor_ICJI::getVars(

--- a/src/ToolBox/superpmi/superpmi-shim-counter/icorjitcompiler.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/icorjitcompiler.cpp
@@ -55,7 +55,7 @@ void interceptor_ICJC::getVersionIdentifier(GUID* versionIdentifier /* OUT */)
     original_ICorJitCompiler->getVersionIdentifier(versionIdentifier);
 }
 
-unsigned interceptor_ICJC::getMaxIntrinsicSIMDVectorLength(DWORD cpuCompileFlags)
+unsigned interceptor_ICJC::getMaxIntrinsicSIMDVectorLength(CORJIT_FLAGS cpuCompileFlags)
 {
     mcs->AddCall("getMaxIntrinsicSIMDVectorLength");
     return original_ICorJitCompiler->getMaxIntrinsicSIMDVectorLength(cpuCompileFlags);

--- a/src/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/icorjitinfo.cpp
@@ -961,7 +961,7 @@ bool interceptor_ICJI::isFieldStatic(CORINFO_FIELD_HANDLE fldHnd)
 // in the code are.  The native compiler will ensure that these places
 // have a corresponding break point in native code.
 //
-// Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+// Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
 // be used only as a hint and the native compiler should not change its
 // code generation.
 void interceptor_ICJI::getBoundaries(
@@ -999,7 +999,7 @@ void interceptor_ICJI::setBoundaries(
 // under debugging, the JIT needs to keep them live over their
 // entire scope so that they can be inspected.
 //
-// Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+// Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
 // be used only as a hint and the native compiler should not change its
 // code generation.
 void interceptor_ICJI::getVars(

--- a/src/ToolBox/superpmi/superpmi-shim-simple/icorjitcompiler.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/icorjitcompiler.cpp
@@ -48,7 +48,7 @@ void interceptor_ICJC::getVersionIdentifier(GUID* versionIdentifier /* OUT */)
     original_ICorJitCompiler->getVersionIdentifier(versionIdentifier);
 }
 
-unsigned interceptor_ICJC::getMaxIntrinsicSIMDVectorLength(DWORD cpuCompileFlags)
+unsigned interceptor_ICJC::getMaxIntrinsicSIMDVectorLength(CORJIT_FLAGS cpuCompileFlags)
 {
     return original_ICorJitCompiler->getMaxIntrinsicSIMDVectorLength(cpuCompileFlags);
 }

--- a/src/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/icorjitinfo.cpp
@@ -876,7 +876,7 @@ bool interceptor_ICJI::isFieldStatic(CORINFO_FIELD_HANDLE fldHnd)
 // in the code are.  The native compiler will ensure that these places
 // have a corresponding break point in native code.
 //
-// Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+// Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
 // be used only as a hint and the native compiler should not change its
 // code generation.
 void interceptor_ICJI::getBoundaries(
@@ -912,7 +912,7 @@ void interceptor_ICJI::setBoundaries(
 // under debugging, the JIT needs to keep them live over their
 // entire scope so that they can be inspected.
 //
-// Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+// Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
 // be used only as a hint and the native compiler should not change its
 // code generation.
 void interceptor_ICJI::getVars(

--- a/src/ToolBox/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi/icorjitinfo.cpp
@@ -1018,7 +1018,7 @@ bool MyICJI::isFieldStatic(CORINFO_FIELD_HANDLE fldHnd)
 // in the code are.  The native compiler will ensure that these places
 // have a corresponding break point in native code.
 //
-// Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+// Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
 // be used only as a hint and the native compiler should not change its
 // code generation.
 void MyICJI::getBoundaries(
@@ -1068,7 +1068,7 @@ void MyICJI::setBoundaries(
 // under debugging, the JIT needs to keep them live over their
 // entire scope so that they can be inspected.
 //
-// Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+// Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
 // be used only as a hint and the native compiler should not change its
 // code generation.
 void MyICJI::getVars(

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1164,7 +1164,7 @@ enum CorCompileILRegion
 class ICorCompilePreloader
 {
  public:
-    typedef void (__stdcall *CORCOMPILE_CompileStubCallback)(LPVOID pContext, CORINFO_METHOD_HANDLE hStub, DWORD dwJitFlags);
+    typedef void (__stdcall *CORCOMPILE_CompileStubCallback)(LPVOID pContext, CORINFO_METHOD_HANDLE hStub, CORJIT_FLAGS jitFlags);
 
     //
     // Map methods are available after Serialize() is called
@@ -1849,7 +1849,7 @@ class ICorCompileInfo
     // Get the compilation flags that are shared between JIT and NGen
     virtual HRESULT GetBaseJitFlags(
             IN  CORINFO_METHOD_HANDLE   hMethod,
-            OUT DWORD                  *pFlags) = 0;
+            OUT CORJIT_FLAGS           *pFlags) = 0;
 
     // needed for stubs to obtain the number of bytes to copy into the native image
     // return the beginning of the stub and the size to copy (in bytes)
@@ -1887,16 +1887,16 @@ class ICorCompileInfo
 /*****************************************************************************/
 // This function determines the compile flags to use for a generic intatiation
 // since only the open instantiation can be verified.
-// See the comment associated with CORJIT_FLG_SKIP_VERIFICATION for details.
+// See the comment associated with CORJIT_FLAG_SKIP_VERIFICATION for details.
 //
 // On return:
 // if *raiseVerificationException=TRUE, the caller should raise a VerificationException.
 // if *unverifiableGenericCode=TRUE, the method is a generic instantiation with
 // unverifiable code
 
-CorJitFlag GetCompileFlagsIfGenericInstantiation(
+CORJIT_FLAGS GetCompileFlagsIfGenericInstantiation(
         CORINFO_METHOD_HANDLE method,
-        CorJitFlag compileFlags,
+        CORJIT_FLAGS compileFlags,
         ICorJitInfo * pCorJitInfo,
         BOOL * raiseVerificationException,
         BOOL * unverifiableGenericCode);

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -231,11 +231,11 @@ TODO: Talk about initializing strutures before use
 #if COR_JIT_EE_VERSION > 460
 
 // Update this one
-SELECTANY const GUID JITEEVersionIdentifier = { /* 8d588c98-4cef-4e6d-9792-08e1f5ab88c5 */
-    0x8d588c98,
-    0x4cef,
-    0x4e6d,
-    {0x97, 0x92, 0x08, 0xe1, 0xf5, 0xab, 0x88, 0xc5}
+SELECTANY const GUID JITEEVersionIdentifier = { /* 4bd06266-8ef7-4172-bec6-d3149fde7859 */
+    0x4bd06266,
+    0x8ef7,
+    0x4172,
+    {0xbe, 0xc6, 0xd3, 0x14, 0x9f, 0xde, 0x78, 0x59}
 };
 
 #else
@@ -2635,7 +2635,7 @@ public:
     // in the code are.  The native compiler will ensure that these places
     // have a corresponding break point in native code.
     //
-    // Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+    // Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
     // be used only as a hint and the native compiler should not change its
     // code generation.
     virtual void getBoundaries(
@@ -2665,7 +2665,7 @@ public:
     // under debugging, the JIT needs to keep them live over their
     // entire scope so that they can be inspected.
     //
-    // Note that unless CORJIT_FLG_DEBUG_CODE is specified, this function will
+    // Note that unless CORJIT_FLAG_DEBUG_CODE is specified, this function will
     // be used only as a hint and the native compiler should not change its
     // code generation.
     virtual void getVars(

--- a/src/inc/zapper.h
+++ b/src/inc/zapper.h
@@ -540,7 +540,7 @@ class ZapperOptions
 
     bool        m_fNGenLastRetry;       // This is retry of the compilation
 
-    unsigned    m_compilerFlags;
+    CORJIT_FLAGS m_compilerFlags;
 
     bool       m_legacyMode;          // true if the zapper was invoked using legacy mode
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -3014,7 +3014,7 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 #if defined(DEBUG)
                                 ,
                             (compiler->compCodeOpt() != Compiler::SMALL_CODE) &&
-                                !(compiler->opts.eeFlags & CORJIT_FLG_PREJIT)
+                                !compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT)
 #endif
 #ifdef LEGACY_BACKEND
                                 ,
@@ -7817,7 +7817,7 @@ void CodeGen::genPrologPadForReJit()
     assert(compiler->compGeneratingProlog);
 
 #ifdef _TARGET_XARCH_
-    if (!(compiler->opts.eeFlags & CORJIT_FLG_PROF_REJIT_NOPS))
+    if (!compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PROF_REJIT_NOPS))
     {
         return;
     }

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -12895,7 +12895,7 @@ void CodeGen::genCodeForBBlist()
             // harmless "inc" instruction (does not interfere with the exception
             // object).
 
-            if ((compiler->opts.eeFlags & CORJIT_FLG_BBINSTR) && (stmt == block->bbTreeList) &&
+            if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR) && (stmt == block->bbTreeList) &&
                 (block->bbCatchTyp && handlerGetsXcptnObj(block->bbCatchTyp)))
             {
                 nonVarPtrRegs &= ~RBM_EXCEPTION_OBJECT;
@@ -19875,7 +19875,7 @@ regMaskTP CodeGen::genCodeForCall(GenTreePtr call, bool valUsed)
 #if defined(_TARGET_X86_)
     if (call->gtFlags & GTF_CALL_UNMANAGED)
     {
-        if ((compiler->opts.eeFlags & CORJIT_FLG_PINVOKE_RESTORE_ESP) ||
+        if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PINVOKE_RESTORE_ESP) ||
             compiler->compStressCompile(Compiler::STRESS_PINVOKE_RESTORE_ESP, 50))
         {
             // P/Invoke signature mismatch resilience - restore ESP to pre-call value. We would ideally

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7434,9 +7434,8 @@ public:
 
     struct Options
     {
-        CORJIT_FLAGS* jitFlags;  // all flags passed from the EE
-        unsigned      eeFlags;   // CorJitFlag flags passed from the EE
-        unsigned      compFlags; // method attributes
+        JitFlags* jitFlags;  // all flags passed from the EE
+        unsigned  compFlags; // method attributes
 
         codeOptimize compCodeOpt; // what type of code optimizations
 
@@ -7505,7 +7504,7 @@ public:
 #ifdef FEATURE_READYTORUN_COMPILER
         inline bool IsReadyToRun()
         {
-            return (eeFlags & CORJIT_FLG_READYTORUN) != 0;
+            return jitFlags->IsSet(JitFlags::JIT_FLAG_READYTORUN);
         }
 #else
         inline bool IsReadyToRun()
@@ -7519,7 +7518,7 @@ public:
         inline bool ShouldUsePInvokeHelpers()
         {
 #if COR_JIT_EE_VERSION > 460
-            return (jitFlags->corJitFlags2 & CORJIT_FLG2_USE_PINVOKE_HELPERS) != 0;
+            return jitFlags->IsSet(JitFlags::JIT_FLAG_USE_PINVOKE_HELPERS);
 #else
             return false;
 #endif
@@ -7530,7 +7529,7 @@ public:
         inline bool IsReversePInvoke()
         {
 #if COR_JIT_EE_VERSION > 460
-            return (jitFlags->corJitFlags2 & CORJIT_FLG2_REVERSE_PINVOKE) != 0;
+            return jitFlags->IsSet(JitFlags::JIT_FLAG_REVERSE_PINVOKE);
 #else
             return false;
 #endif
@@ -7540,7 +7539,7 @@ public:
         inline bool IsJit32Compat()
         {
 #if defined(_TARGET_X86_) && COR_JIT_EE_VERSION > 460
-            return (jitFlags->corJitFlags2 & CORJIT_FLG2_DESKTOP_QUIRKS) != 0;
+            return jitFlags->IsSet(JitFlags::JIT_FLAG_DESKTOP_QUIRKS);
 #else
             return false;
 #endif
@@ -7550,7 +7549,7 @@ public:
         inline bool IsJit64Compat()
         {
 #if defined(_TARGET_AMD64_) && COR_JIT_EE_VERSION > 460
-            return (jitFlags->corJitFlags2 & CORJIT_FLG2_DESKTOP_QUIRKS) != 0;
+            return jitFlags->IsSet(JitFlags::JIT_FLAG_DESKTOP_QUIRKS);
 #elif defined(_TARGET_AMD64_) && !defined(FEATURE_CORECLR)
             return true;
 #else
@@ -8095,14 +8094,14 @@ public:
                     CORINFO_METHOD_INFO*  methodInfo,
                     void**                methodCodePtr,
                     ULONG*                methodCodeSize,
-                    CORJIT_FLAGS*         compileFlags);
+                    JitFlags*             compileFlags);
     void compCompileFinish();
     int compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
                           COMP_HANDLE                      compHnd,
                           CORINFO_METHOD_INFO*             methodInfo,
                           void**                           methodCodePtr,
                           ULONG*                           methodCodeSize,
-                          CORJIT_FLAGS*                    compileFlags,
+                          JitFlags*                        compileFlags,
                           CorInfoInstantiationVerification instVerInfo);
 
     ArenaAllocator* compGetAllocator();
@@ -8335,7 +8334,7 @@ public:
 protected:
     size_t compMaxUncheckedOffsetForNullObject;
 
-    void compInitOptions(CORJIT_FLAGS* compileFlags);
+    void compInitOptions(JitFlags* compileFlags);
 
     void compSetProcessor();
     void compInitDebuggingInfo();
@@ -8343,7 +8342,7 @@ protected:
 #ifdef _TARGET_ARMARCH_
     bool compRsvdRegCheck(FrameLayoutState curState);
 #endif
-    void compCompile(void** methodCodePtr, ULONG* methodCodeSize, CORJIT_FLAGS* compileFlags);
+    void compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags* compileFlags);
 
 #ifdef PROFILING_SUPPORTED
     // Data required for generating profiler Enter/Leave/TailCall hooks

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4108,7 +4108,7 @@ inline bool Compiler::compIsProfilerHookNeeded()
     return compProfilerHookNeeded
            // IL stubs are excluded by VM and we need to do the same even running
            // under a complus env hook to generate profiler hooks
-           || (opts.compJitELTHookEnabled && !(opts.eeFlags & CORJIT_FLG_IL_STUB));
+           || (opts.compJitELTHookEnabled && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB));
 #else  // !PROFILING_SUPPORTED
     return false;
 #endif // !PROFILING_SUPPORTED
@@ -4200,7 +4200,7 @@ inline bool Compiler::impIsDUP_LDVIRTFTN_TOKEN(const BYTE* delegateCreateStart, 
 
 inline bool Compiler::compIsForImportOnly()
 {
-    return ((opts.eeFlags & CORJIT_FLG_IMPORT_ONLY) != 0);
+    return opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IMPORT_ONLY);
 }
 
 /*****************************************************************************

--- a/src/jit/ee_il_dll.hpp
+++ b/src/jit/ee_il_dll.hpp
@@ -21,7 +21,11 @@ class CILJit : public ICorJitCompiler
     void getVersionIdentifier(GUID* versionIdentifier /* OUT */
                               );
 
+#if COR_JIT_EE_VERSION > 460
+    unsigned getMaxIntrinsicSIMDVectorLength(CORJIT_FLAGS cpuCompileFlags);
+#else
     unsigned getMaxIntrinsicSIMDVectorLength(DWORD cpuCompileFlags);
+#endif
 
     void setRealJit(ICorJitCompiler* realJitCompiler);
 };

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1264,9 +1264,9 @@ void* emitter::emitAllocInstr(size_t sz, emitAttr opsz)
     //     ARM - This is currently broken on _TARGET_ARM_
     //     When nopSize is odd we misalign emitCurIGsize
     //
-    if (!(emitComp->opts.eeFlags & CORJIT_FLG_PREJIT) && !emitInInstrumentation &&
-        !emitIGisInProlog(emitCurIG) // don't do this in prolog or epilog
-        && !emitIGisInEpilog(emitCurIG) &&
+    if (!emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) && !emitInInstrumentation &&
+        !emitIGisInProlog(emitCurIG) && // don't do this in prolog or epilog
+        !emitIGisInEpilog(emitCurIG) &&
         emitRandomNops // sometimes we turn off where exact codegen is needed (pinvoke inline)
         )
     {

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5488,7 +5488,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                         costSz += 2;
                     }
                 }
-                else if ((opts.eeFlags & CORJIT_FLG_PREJIT) == 0)
+                else if (!opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT))
                 {
                     costEx += 2;
                     costSz += 6;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3910,7 +3910,7 @@ void Compiler::verHandleVerificationFailure(BasicBlock* block DEBUGARG(bool logM
 #endif // DEBUG
 
     // Add the non verifiable flag to the compiler
-    if ((opts.eeFlags & CORJIT_FLG_IMPORT_ONLY) != 0)
+    if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IMPORT_ONLY))
     {
         tiIsVerifiableCode = FALSE;
     }
@@ -16527,7 +16527,7 @@ void Compiler::impImport(BasicBlock* method)
             // coupled with the JIT64 IL Verification logic.  Look inside verHandleVerificationFailure
             // method for further explanation on why we raise this exception instead of making the jitted
             // code throw the verification exception during execution.
-            if (tiVerificationNeeded && (opts.eeFlags & CORJIT_FLG_IMPORT_ONLY) != 0)
+            if (tiVerificationNeeded && opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IMPORT_ONLY))
             {
                 BADCODE("Basic block marked as not verifiable");
             }

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -1354,7 +1354,7 @@ void InlineStrategy::DumpDataEnsurePolicyIsSet()
     // successful policy, so fake one up.
     if (m_LastSuccessfulPolicy == nullptr)
     {
-        const bool isPrejitRoot = (opts.eeFlags & CORJIT_FLG_PREJIT) != 0;
+        const bool isPrejitRoot = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT);
         m_LastSuccessfulPolicy  = InlinePolicy::GetPolicy(m_Compiler, isPrejitRoot);
 
         // Add in a bit of data....
@@ -1484,7 +1484,7 @@ void InlineStrategy::DumpXml(FILE* file, unsigned indent)
     const Compiler::Info&    info = m_Compiler->info;
     const Compiler::Options& opts = m_Compiler->opts;
 
-    const bool isPrejitRoot  = (opts.eeFlags & CORJIT_FLG_PREJIT) != 0;
+    const bool isPrejitRoot  = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT);
     const bool isForceInline = (info.compFlags & CORINFO_FLG_FORCEINLINE) != 0;
 
     // We'd really like the method identifier to be unique and

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -85,11 +85,6 @@ const unsigned int MAX_INL_ARGS = 10; // does not include obj pointer
 const unsigned int MAX_INL_LCLS = 8;
 #endif // LEGACY_BACKEND
 
-// Flags lost during inlining.
-
-#define CORJIT_FLG_LOST_WHEN_INLINING                                                                                  \
-    (CORJIT_FLG_BBOPT | CORJIT_FLG_BBINSTR | CORJIT_FLG_PROF_ENTERLEAVE | CORJIT_FLG_DEBUG_EnC | CORJIT_FLG_DEBUG_INFO)
-
 // Forward declarations
 
 class InlineStrategy;

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -3054,7 +3054,7 @@ bool CodeGenInterface::validImmForBL(ssize_t addr)
     return
         // If we are running the altjit for NGEN, then assume we can use the "BL" instruction.
         // This matches the usual behavior for NGEN, since we normally do generate "BL".
-        (!compiler->info.compMatchedVM && (compiler->opts.eeFlags & CORJIT_FLG_PREJIT)) ||
+        (!compiler->info.compMatchedVM && compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT)) ||
         (compiler->eeGetRelocTypeHint((void*)addr) == IMAGE_REL_BASED_THUMB_BRANCH24);
 }
 bool CodeGen::arm_Valid_Imm_For_BL(ssize_t addr)

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -210,6 +210,7 @@
 
 #include "corhdr.h"
 #include "corjit.h"
+#include "jitee.h"
 
 #define __OPERATOR_NEW_INLINE 1 // indicate that I will define these
 #define __PLACEMENT_NEW_INLINE  // don't bring in the global placement new, it is easy to make a mistake
@@ -829,7 +830,7 @@ extern int jitNativeCode(CORINFO_METHOD_HANDLE methodHnd,
                          CORINFO_METHOD_INFO*  methodInfo,
                          void**                methodCodePtr,
                          ULONG*                methodCodeSize,
-                         CORJIT_FLAGS*         compileFlags,
+                         JitFlags*             compileFlags,
                          void*                 inlineInfoPtr);
 
 #ifdef _HOST_64BIT_

--- a/src/jit/jitee.h
+++ b/src/jit/jitee.h
@@ -1,0 +1,264 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This class wraps the CORJIT_FLAGS type in the JIT-EE interface (in corjit.h) such that the JIT can
+// build with either the old flags (COR_JIT_EE_VERSION <= 460) or the new flags (COR_JIT_EE_VERSION > 460).
+// It actually is exactly the same as the new definition, and must be kept up-to-date with the new definition.
+// When built against an old JIT-EE interface, the old flags are converted into this structure.
+class JitFlags
+{
+public:
+    // clang-format off
+    enum JitFlag
+    {
+        JIT_FLAG_SPEED_OPT               = 0,
+        JIT_FLAG_SIZE_OPT                = 1,
+        JIT_FLAG_DEBUG_CODE              = 2, // generate "debuggable" code (no code-mangling optimizations)
+        JIT_FLAG_DEBUG_EnC               = 3, // We are in Edit-n-Continue mode
+        JIT_FLAG_DEBUG_INFO              = 4, // generate line and local-var info
+        JIT_FLAG_MIN_OPT                 = 5, // disable all jit optimizations (not necesarily debuggable code)
+        JIT_FLAG_GCPOLL_CALLS            = 6, // Emit calls to JIT_POLLGC for thread suspension.
+        JIT_FLAG_MCJIT_BACKGROUND        = 7, // Calling from multicore JIT background thread, do not call JitComplete
+
+    #if defined(_TARGET_X86_)
+
+        JIT_FLAG_PINVOKE_RESTORE_ESP     = 8, // Restore ESP after returning from inlined PInvoke
+        JIT_FLAG_TARGET_P4               = 9,
+        JIT_FLAG_USE_FCOMI               = 10, // Generated code may use fcomi(p) instruction
+        JIT_FLAG_USE_CMOV                = 11, // Generated code may use cmov instruction
+        JIT_FLAG_USE_SSE2                = 12, // Generated code may use SSE-2 instructions
+
+    #else // !defined(_TARGET_X86_)
+
+        JIT_FLAG_UNUSED1                 = 8,
+        JIT_FLAG_UNUSED2                 = 9,
+        JIT_FLAG_UNUSED3                 = 10,
+        JIT_FLAG_UNUSED4                 = 11,
+        JIT_FLAG_UNUSED5                 = 12,
+
+    #endif // !defined(_TARGET_X86_)
+
+    #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+
+        JIT_FLAG_USE_SSE3_4              = 13,
+        JIT_FLAG_USE_AVX                 = 14,
+        JIT_FLAG_USE_AVX2                = 15,
+        JIT_FLAG_USE_AVX_512             = 16,
+        JIT_FLAG_FEATURE_SIMD            = 17,
+
+    #else // !defined(_TARGET_X86_) && !defined(_TARGET_AMD64_)
+
+        JIT_FLAG_UNUSED6                 = 13,
+        JIT_FLAG_UNUSED7                 = 14,
+        JIT_FLAG_UNUSED8                 = 15,
+        JIT_FLAG_UNUSED9                 = 16,
+        JIT_FLAG_UNUSED10                = 17,
+
+    #endif // !defined(_TARGET_X86_) && !defined(_TARGET_AMD64_)
+
+        JIT_FLAG_MAKEFINALCODE           = 18, // Use the final code generator, i.e., not the interpreter.
+        JIT_FLAG_READYTORUN              = 19, // Use version-resilient code generation
+        JIT_FLAG_PROF_ENTERLEAVE         = 20, // Instrument prologues/epilogues
+        JIT_FLAG_PROF_REJIT_NOPS         = 21, // Insert NOPs to ensure code is re-jitable
+        JIT_FLAG_PROF_NO_PINVOKE_INLINE  = 22, // Disables PInvoke inlining
+        JIT_FLAG_SKIP_VERIFICATION       = 23, // (lazy) skip verification - determined without doing a full resolve. See comment below
+        JIT_FLAG_PREJIT                  = 24, // jit or prejit is the execution engine.
+        JIT_FLAG_RELOC                   = 25, // Generate relocatable code
+        JIT_FLAG_IMPORT_ONLY             = 26, // Only import the function
+        JIT_FLAG_IL_STUB                 = 27, // method is an IL stub
+        JIT_FLAG_PROCSPLIT               = 28, // JIT should separate code into hot and cold sections
+        JIT_FLAG_BBINSTR                 = 29, // Collect basic block profile information
+        JIT_FLAG_BBOPT                   = 30, // Optimize method based on profile information
+        JIT_FLAG_FRAMED                  = 31, // All methods have an EBP frame
+        JIT_FLAG_ALIGN_LOOPS             = 32, // add NOPs before loops to align them at 16 byte boundaries
+        JIT_FLAG_PUBLISH_SECRET_PARAM    = 33, // JIT must place stub secret param into local 0.  (used by IL stubs)
+        JIT_FLAG_GCPOLL_INLINE           = 34, // JIT must inline calls to GCPoll when possible
+        JIT_FLAG_SAMPLING_JIT_BACKGROUND = 35, // JIT is being invoked as a result of stack sampling for hot methods in the background
+        JIT_FLAG_USE_PINVOKE_HELPERS     = 36, // The JIT should use the PINVOKE_{BEGIN,END} helpers instead of emitting inline transitions
+        JIT_FLAG_REVERSE_PINVOKE         = 37, // The JIT should insert REVERSE_PINVOKE_{ENTER,EXIT} helpers into method prolog/epilog
+        JIT_FLAG_DESKTOP_QUIRKS          = 38, // The JIT should generate desktop-quirk-compatible code
+    };
+    // clang-format on
+
+    JitFlags() : m_jitFlags(0)
+    {
+        // empty
+    }
+
+    // Convenience constructor to set exactly one flags.
+    JitFlags(JitFlag flag) : m_jitFlags(0)
+    {
+        Set(flag);
+    }
+
+    void Reset()
+    {
+        m_jitFlags = 0;
+    }
+
+    void Set(JitFlag flag)
+    {
+        m_jitFlags |= 1ULL << (unsigned __int64)flag;
+    }
+
+    void Clear(JitFlag flag)
+    {
+        m_jitFlags &= ~(1ULL << (unsigned __int64)flag);
+    }
+
+    bool IsSet(JitFlag flag) const
+    {
+        return (m_jitFlags & (1ULL << (unsigned __int64)flag)) != 0;
+    }
+
+    void Add(const JitFlags& other)
+    {
+        m_jitFlags |= other.m_jitFlags;
+    }
+
+    void Remove(const JitFlags& other)
+    {
+        m_jitFlags &= ~other.m_jitFlags;
+    }
+
+    bool IsEmpty() const
+    {
+        return m_jitFlags == 0;
+    }
+
+#if COR_JIT_EE_VERSION <= 460
+
+    void SetFromOldFlags(unsigned corJitFlags, unsigned corJitFlags2)
+    {
+        Reset();
+
+#define CONVERT_OLD_FLAG(oldf, newf)                                                                                   \
+    if ((corJitFlags & (oldf)) != 0)                                                                                   \
+        this->Set(JitFlags::newf);
+#define CONVERT_OLD_FLAG2(oldf, newf)                                                                                  \
+    if ((corJitFlags & (oldf)) != 0)                                                                                   \
+        this->Set(JitFlags::newf);
+
+        CONVERT_OLD_FLAG(CORJIT_FLG_SPEED_OPT, JIT_FLAG_SPEED_OPT)
+        CONVERT_OLD_FLAG(CORJIT_FLG_SIZE_OPT, JIT_FLAG_SIZE_OPT)
+        CONVERT_OLD_FLAG(CORJIT_FLG_DEBUG_CODE, JIT_FLAG_DEBUG_CODE)
+        CONVERT_OLD_FLAG(CORJIT_FLG_DEBUG_EnC, JIT_FLAG_DEBUG_EnC)
+        CONVERT_OLD_FLAG(CORJIT_FLG_DEBUG_INFO, JIT_FLAG_DEBUG_INFO)
+        CONVERT_OLD_FLAG(CORJIT_FLG_MIN_OPT, JIT_FLAG_MIN_OPT)
+        CONVERT_OLD_FLAG(CORJIT_FLG_GCPOLL_CALLS, JIT_FLAG_GCPOLL_CALLS)
+        CONVERT_OLD_FLAG(CORJIT_FLG_MCJIT_BACKGROUND, JIT_FLAG_MCJIT_BACKGROUND)
+
+#if defined(_TARGET_X86_)
+
+        CONVERT_OLD_FLAG(CORJIT_FLG_PINVOKE_RESTORE_ESP, JIT_FLAG_PINVOKE_RESTORE_ESP)
+        CONVERT_OLD_FLAG(CORJIT_FLG_TARGET_P4, JIT_FLAG_TARGET_P4)
+        CONVERT_OLD_FLAG(CORJIT_FLG_USE_FCOMI, JIT_FLAG_USE_FCOMI)
+        CONVERT_OLD_FLAG(CORJIT_FLG_USE_CMOV, JIT_FLAG_USE_CMOV)
+        CONVERT_OLD_FLAG(CORJIT_FLG_USE_SSE2, JIT_FLAG_USE_SSE2)
+
+#elif defined(_TARGET_AMD64_)
+
+        CONVERT_OLD_FLAG(CORJIT_FLG_USE_SSE3_4, JIT_FLAG_USE_SSE3_4)
+        CONVERT_OLD_FLAG(CORJIT_FLG_USE_AVX, JIT_FLAG_USE_AVX)
+        CONVERT_OLD_FLAG(CORJIT_FLG_USE_AVX2, JIT_FLAG_USE_AVX2)
+        CONVERT_OLD_FLAG(CORJIT_FLG_USE_AVX_512, JIT_FLAG_USE_AVX_512)
+        CONVERT_OLD_FLAG(CORJIT_FLG_FEATURE_SIMD, JIT_FLAG_FEATURE_SIMD)
+
+#endif // !defined(_TARGET_X86_) && !defined(_TARGET_AMD64_)
+
+        CONVERT_OLD_FLAG(CORJIT_FLG_MAKEFINALCODE, JIT_FLAG_MAKEFINALCODE)
+        CONVERT_OLD_FLAG(CORJIT_FLG_READYTORUN, JIT_FLAG_READYTORUN)
+        CONVERT_OLD_FLAG(CORJIT_FLG_PROF_ENTERLEAVE, JIT_FLAG_PROF_ENTERLEAVE)
+        CONVERT_OLD_FLAG(CORJIT_FLG_PROF_REJIT_NOPS, JIT_FLAG_PROF_REJIT_NOPS)
+        CONVERT_OLD_FLAG(CORJIT_FLG_PROF_NO_PINVOKE_INLINE, JIT_FLAG_PROF_NO_PINVOKE_INLINE)
+        CONVERT_OLD_FLAG(CORJIT_FLG_SKIP_VERIFICATION, JIT_FLAG_SKIP_VERIFICATION)
+        CONVERT_OLD_FLAG(CORJIT_FLG_PREJIT, JIT_FLAG_PREJIT)
+        CONVERT_OLD_FLAG(CORJIT_FLG_RELOC, JIT_FLAG_RELOC)
+        CONVERT_OLD_FLAG(CORJIT_FLG_IMPORT_ONLY, JIT_FLAG_IMPORT_ONLY)
+        CONVERT_OLD_FLAG(CORJIT_FLG_IL_STUB, JIT_FLAG_IL_STUB)
+        CONVERT_OLD_FLAG(CORJIT_FLG_PROCSPLIT, JIT_FLAG_PROCSPLIT)
+        CONVERT_OLD_FLAG(CORJIT_FLG_BBINSTR, JIT_FLAG_BBINSTR)
+        CONVERT_OLD_FLAG(CORJIT_FLG_BBOPT, JIT_FLAG_BBOPT)
+        CONVERT_OLD_FLAG(CORJIT_FLG_FRAMED, JIT_FLAG_FRAMED)
+        CONVERT_OLD_FLAG(CORJIT_FLG_ALIGN_LOOPS, JIT_FLAG_ALIGN_LOOPS)
+        CONVERT_OLD_FLAG(CORJIT_FLG_PUBLISH_SECRET_PARAM, JIT_FLAG_PUBLISH_SECRET_PARAM)
+        CONVERT_OLD_FLAG(CORJIT_FLG_GCPOLL_INLINE, JIT_FLAG_GCPOLL_INLINE)
+
+        CONVERT_OLD_FLAG2(CORJIT_FLG2_SAMPLING_JIT_BACKGROUND, JIT_FLAG_SAMPLING_JIT_BACKGROUND)
+
+#undef CONVERT_OLD_FLAG
+#undef CONVERT_OLD_FLAG2
+    }
+
+#else // COR_JIT_EE_VERSION > 460
+
+    void SetFromFlags(CORJIT_FLAGS flags)
+    {
+        // We don't want to have to check every one, so we assume it is exactly the same values as the JitFlag
+        // values defined in this type.
+        m_jitFlags = flags.GetFlagsRaw();
+
+        C_ASSERT(sizeof(m_jitFlags) == sizeof(CORJIT_FLAGS));
+
+#define FLAGS_EQUAL(a, b) C_ASSERT((unsigned)(a) == (unsigned)(b))
+
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SPEED_OPT, JIT_FLAG_SPEED_OPT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SIZE_OPT, JIT_FLAG_SIZE_OPT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE, JIT_FLAG_DEBUG_CODE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_EnC, JIT_FLAG_DEBUG_EnC);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_INFO, JIT_FLAG_DEBUG_INFO);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_MIN_OPT, JIT_FLAG_MIN_OPT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_GCPOLL_CALLS, JIT_FLAG_GCPOLL_CALLS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_MCJIT_BACKGROUND, JIT_FLAG_MCJIT_BACKGROUND);
+
+#if defined(_TARGET_X86_)
+
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PINVOKE_RESTORE_ESP, JIT_FLAG_PINVOKE_RESTORE_ESP);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_TARGET_P4, JIT_FLAG_TARGET_P4);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_FCOMI, JIT_FLAG_USE_FCOMI);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_CMOV, JIT_FLAG_USE_CMOV);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE2, JIT_FLAG_USE_SSE2);
+
+#endif
+
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE3_4, JIT_FLAG_USE_SSE3_4);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX, JIT_FLAG_USE_AVX);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX2, JIT_FLAG_USE_AVX2);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX_512, JIT_FLAG_USE_AVX_512);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_FEATURE_SIMD, JIT_FLAG_FEATURE_SIMD);
+
+#endif
+
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_MAKEFINALCODE, JIT_FLAG_MAKEFINALCODE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_READYTORUN, JIT_FLAG_READYTORUN);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROF_ENTERLEAVE, JIT_FLAG_PROF_ENTERLEAVE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROF_REJIT_NOPS, JIT_FLAG_PROF_REJIT_NOPS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROF_NO_PINVOKE_INLINE, JIT_FLAG_PROF_NO_PINVOKE_INLINE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SKIP_VERIFICATION, JIT_FLAG_SKIP_VERIFICATION);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PREJIT, JIT_FLAG_PREJIT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_RELOC, JIT_FLAG_RELOC);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_IMPORT_ONLY, JIT_FLAG_IMPORT_ONLY);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB, JIT_FLAG_IL_STUB);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROCSPLIT, JIT_FLAG_PROCSPLIT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_BBINSTR, JIT_FLAG_BBINSTR);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_BBOPT, JIT_FLAG_BBOPT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_FRAMED, JIT_FLAG_FRAMED);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_ALIGN_LOOPS, JIT_FLAG_ALIGN_LOOPS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM, JIT_FLAG_PUBLISH_SECRET_PARAM);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_GCPOLL_INLINE, JIT_FLAG_GCPOLL_INLINE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SAMPLING_JIT_BACKGROUND, JIT_FLAG_SAMPLING_JIT_BACKGROUND);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS, JIT_FLAG_USE_PINVOKE_HELPERS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE, JIT_FLAG_REVERSE_PINVOKE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DESKTOP_QUIRKS, JIT_FLAG_DESKTOP_QUIRKS);
+
+#undef FLAGS_EQUAL
+    }
+
+#endif // COR_JIT_EE_VERSION > 460
+
+private:
+    unsigned __int64 m_jitFlags;
+};

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2638,7 +2638,7 @@ void Lowering::InsertPInvokeMethodProlog()
     CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef _TARGET_64BIT_
-    if (comp->opts.eeFlags & CORJIT_FLG_IL_STUB)
+    if (comp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB))
     {
         // Push a frame - if we are NOT in an IL stub, this is done right before the call
         // The init routine sets InlinedCallFrame's m_pNext, so we just set the thead's top-of-stack
@@ -2714,7 +2714,7 @@ void Lowering::InsertPInvokeMethodEpilog(BasicBlock* returnBB DEBUGARG(GenTreePt
     CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef _TARGET_64BIT_
-    if (comp->opts.eeFlags & CORJIT_FLG_IL_STUB)
+    if (comp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB))
 #endif // _TARGET_64BIT_
     {
         GenTree* frameUpd = CreateFrameLinkUpdate(PopFrame);
@@ -2857,7 +2857,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
     CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef _TARGET_64BIT_
-    if (!(comp->opts.eeFlags & CORJIT_FLG_IL_STUB))
+    if (!comp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB))
     {
         // Set the TCB's frame to be the one we just created.
         // Note the init routine for the InlinedCallFrame (CORINFO_HELP_INIT_PINVOKE_FRAME)
@@ -2925,7 +2925,7 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
     CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef _TARGET_64BIT_
-    if (!(comp->opts.eeFlags & CORJIT_FLG_IL_STUB))
+    if (!comp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB))
     {
         tree = CreateFrameLinkUpdate(PopFrame);
         BlockRange().InsertBefore(insertionPoint, LIR::SeqTree(comp, tree));
@@ -2945,7 +2945,7 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
 GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
 {
     // PInvoke lowering varies depending on the flags passed in by the EE. By default,
-    // GC transitions are generated inline; if CORJIT_FLG2_USE_PINVOKE_HELPERS is specified,
+    // GC transitions are generated inline; if CORJIT_FLAG_USE_PINVOKE_HELPERS is specified,
     // GC transitions are instead performed using helper calls. Examples of each case are given
     // below. Note that the data structure that is used to store information about a call frame
     // containing any P/Invoke calls is initialized in the method prolog (see

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -62,7 +62,7 @@ instruction CodeGen::getOpForSIMDIntrinsic(SIMDIntrinsicID intrinsicId, var_type
                 // AVX supports broadcast instructions to populate YMM reg with a single float/double value from memory.
                 // AVX2 supports broadcast instructions to populate YMM reg with a single value from memory or mm reg.
                 // If we decide to use AVX2 only, we can remove this assert.
-                if ((compiler->opts.eeFlags & CORJIT_FLG_USE_AVX2) == 0)
+                if (!compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_USE_AVX2))
                 {
                     assert(baseType == TYP_FLOAT || baseType == TYP_DOUBLE);
                 }

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -584,7 +584,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define REG_PINVOKE_TARGET_PARAM REG_EAX
   #define RBM_PINVOKE_TARGET_PARAM RBM_EAX
 
-  // IL stub's secret parameter (CORJIT_FLG_PUBLISH_SECRET_PARAM)
+  // IL stub's secret parameter (JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM)
   #define REG_SECRET_STUB_PARAM    REG_EAX
   #define RBM_SECRET_STUB_PARAM    RBM_EAX
 
@@ -977,7 +977,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_PINVOKE_TARGET_PARAM          RBM_R10
   #define PREDICT_REG_PINVOKE_TARGET_PARAM  PREDICT_REG_R10
 
-  // IL stub's secret MethodDesc parameter (CORJIT_FLG_PUBLISH_SECRET_PARAM)
+  // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM)
   #define REG_SECRET_STUB_PARAM    REG_R10
   #define RBM_SECRET_STUB_PARAM    RBM_R10
 
@@ -1349,7 +1349,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_PINVOKE_TARGET_PARAM          RBM_R12
   #define PREDICT_REG_PINVOKE_TARGET_PARAM  PREDICT_REG_R12
 
-  // IL stub's secret MethodDesc parameter (CORJIT_FLG_PUBLISH_SECRET_PARAM)
+  // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM)
   #define REG_SECRET_STUB_PARAM     REG_R12
   #define RBM_SECRET_STUB_PARAM     RBM_R12
 
@@ -1630,7 +1630,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_PINVOKE_TARGET_PARAM          RBM_R14
   #define PREDICT_REG_PINVOKE_TARGET_PARAM  PREDICT_REG_R14
 
-  // IL stub's secret MethodDesc parameter (CORJIT_FLG_PUBLISH_SECRET_PARAM)
+  // IL stub's secret MethodDesc parameter (JitFlags::JIT_FLAG_PUBLISH_SECRET_PARAM)
   #define REG_SECRET_STUB_PARAM     REG_R12
   #define RBM_SECRET_STUB_PARAM     RBM_R12
 

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -15911,9 +15911,9 @@ void Module::ExpandAll()
                                                                                  pMD->GetMDImport(),
                                                                                  &ignored));
 #ifdef FEATURE_INTERPRETER
-                pMD->MakeJitWorker(pHeader, CORJIT_FLG_MAKEFINALCODE, 0);
+                pMD->MakeJitWorker(pHeader, CORJIT_FLAGS(CORJIT_FLAGS::CORJIT_FLAG_MAKEFINALCODE));
 #else
-                pMD->MakeJitWorker(pHeader, 0, 0);
+                pMD->MakeJitWorker(pHeader, CORJIT_FLAGS());
 #endif
             }
         }

--- a/src/vm/cgensys.h
+++ b/src/vm/cgensys.h
@@ -103,21 +103,21 @@ inline void GetSpecificCpuInfo(CORINFO_CPU * cpuInfo)
 
 #endif // !_TARGET_X86_
 
-#if defined(_TARGET_AMD64_) && !defined(CROSSGEN_COMPILE)
+#if (defined(_TARGET_X86_) || defined(_TARGET_AMD64_)) && !defined(CROSSGEN_COMPILE)
 extern "C" DWORD __stdcall getcpuid(DWORD arg, unsigned char result[16]);
-#endif // defined(_TARGET_AMD64_)
+#endif
 
 inline bool TargetHasAVXSupport()
 {
-#if defined(_TARGET_AMD64_) && !defined(CROSSGEN_COMPILE)
+#if (defined(_TARGET_X86_) || defined(_TARGET_AMD64_)) && !defined(CROSSGEN_COMPILE)
     unsigned char buffer[16];
-    // All AMD64 targets support cpuid.
+    // All x86/AMD64 targets support cpuid.
     (void) getcpuid(1, buffer);
     // getcpuid executes cpuid with eax set to its first argument, and ecx cleared.
     // It returns the resulting eax, ebx, ecx and edx (in that order) in buffer[].
     // The AVX feature is ECX bit 28.
     return ((buffer[11] & 0x10) != 0);
-#endif // defined(_TARGET_AMD64_) && !defined(CROSSGEN_COMPILE)
+#endif // (defined(_TARGET_X86_) || defined(_TARGET_AMD64_)) && !defined(CROSSGEN_COMPILE)
     return false;
 }
 

--- a/src/vm/codeman.h
+++ b/src/vm/codeman.h
@@ -1146,17 +1146,17 @@ public:
 #endif // !DACCESS_COMPILE
 
 private:
-    DWORD               m_dwCPUCompileFlags;
+    CORJIT_FLAGS m_CPUCompileFlags;
 
 #if !defined CROSSGEN_COMPILE && !defined DACCESS_COMPILE
     void SetCpuInfo();
 #endif
 
 public:
-    inline DWORD GetCPUCompileFlags()
+    inline CORJIT_FLAGS GetCPUCompileFlags()
     {
         LIMITED_METHOD_CONTRACT;
-        return m_dwCPUCompileFlags;
+        return m_CPUCompileFlags;
     }
 
 private :

--- a/src/vm/commethodrental.cpp
+++ b/src/vm/commethodrental.cpp
@@ -102,9 +102,9 @@ void QCALLTYPE COMMethodRental::SwapMethodBody(EnregisteredTypeHandle cls, INT32
             COMPlusThrowHR(VLDTR_E_MD_BADHEADER);
 
 #ifdef FEATURE_INTERPRETER
-        pMethodDesc->MakeJitWorker(&header, CORJIT_FLG_MAKEFINALCODE, 0);
+        pMethodDesc->MakeJitWorker(&header, CORJIT_FLAGS(CORJIT_FLAGS::CORJIT_FLAG_MAKEFINALCODE));
 #else // !FEATURE_INTERPRETER
-        pMethodDesc->MakeJitWorker(&header, 0, 0);
+        pMethodDesc->MakeJitWorker(&header, CORJIT_FLAGS());
 #endif // !FEATURE_INTERPRETER
     }
 

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1487,7 +1487,7 @@ void CEECompileInfo::CompressDebugInfo(
 
 HRESULT CEECompileInfo::GetBaseJitFlags(
         IN  CORINFO_METHOD_HANDLE   hMethod,
-        OUT DWORD                  *pFlags)
+        OUT CORJIT_FLAGS           *pFlags)
 {
     STANDARD_VM_CONTRACT;
 
@@ -6680,9 +6680,9 @@ MethodDesc * CEEPreloader::CompileMethodStubIfNeeded(
     {
         if (!pStubMD->AsDynamicMethodDesc()->GetILStubResolver()->IsCompiled())
         {
-            DWORD dwJitFlags = pStubMD->AsDynamicMethodDesc()->GetILStubResolver()->GetJitFlags();
+            CORJIT_FLAGS jitFlags = pStubMD->AsDynamicMethodDesc()->GetILStubResolver()->GetJitFlags();
 
-            pfnCallback(pCallbackContext, (CORINFO_METHOD_HANDLE)pStubMD, dwJitFlags);
+            pfnCallback(pCallbackContext, (CORINFO_METHOD_HANDLE)pStubMD, jitFlags);
         }
 
 #ifndef FEATURE_FULL_NGEN // Deduplication

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -377,7 +377,7 @@ class CEECompileInfo : public ICorCompileInfo
 
     HRESULT GetBaseJitFlags(
             IN  CORINFO_METHOD_HANDLE    hMethod,
-            OUT DWORD                   *pFlags);
+            OUT CORJIT_FLAGS            *pFlags);
 
 #ifdef _WIN64
     SIZE_T  getPersonalityValue();

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -1024,7 +1024,7 @@ public:
             pcsUnmarshal->EmitRET();
         }
 
-        DWORD dwJitFlags = CORJIT_FLG_IL_STUB;
+        CORJIT_FLAGS jitFlags(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB);
                 
         if (m_slIL.HasInteropParamExceptionInfo())
         {
@@ -1049,7 +1049,7 @@ public:
         else
         {
             // All other IL stubs will need to use the secret parameter.
-            dwJitFlags |= CORJIT_FLG_PUBLISH_SECRET_PARAM;
+            jitFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM);
         }
 
         if (SF_IsReverseStub(m_dwStubFlags))
@@ -1114,7 +1114,7 @@ public:
         m_slIL.GenerateCode(pbBuffer, cbCode);
         m_slIL.GetLocalSig(pbLocalSig, cbSig);
 
-        pResolver->SetJitFlags(dwJitFlags);
+        pResolver->SetJitFlags(jitFlags);
 
 #ifdef LOGGING
         LOG((LF_STUBS, LL_INFO1000, "---------------------------------------------------------------------\n"));
@@ -1153,7 +1153,7 @@ public:
 
             LogILStubFlags(LF_STUBS, LL_INFO1000, m_dwStubFlags);
 
-            m_slIL.LogILStub(dwJitFlags);
+            m_slIL.LogILStub(jitFlags);
         }
         LOG((LF_STUBS, LL_INFO1000, "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"));
 #endif // LOGGING
@@ -1170,7 +1170,7 @@ public:
                 pStubMD, 
                 pbLocalSig, 
                 cbSig,
-                dwJitFlags,
+                jitFlags,
                 &convertToHRTryCatch,
                 &cleanupTryFinally,
                 maxStack,
@@ -1188,7 +1188,7 @@ public:
         MethodDesc *    pStubMD, 
         PCCOR_SIGNATURE pbLocalSig, 
         DWORD           cbSig, 
-        DWORD           dwJitFlags, 
+        CORJIT_FLAGS    jitFlags,
         ILStubEHClause * pConvertToHRTryCatchBounds,
         ILStubEHClause * pCleanupTryFinallyBounds,
         DWORD           maxStack, 
@@ -1256,7 +1256,7 @@ public:
         strILStubCode.AppendPrintf(W(".maxstack %d \n"), maxStack);
         strILStubCode.AppendPrintf(W(".locals %s\n"), strLocalSig.GetUnicode());
         
-        m_slIL.LogILStub(dwJitFlags, &strILStubCode);
+        m_slIL.LogILStub(jitFlags, &strILStubCode);
 
         if (pConvertToHRTryCatchBounds->cbTryLength != 0 && pConvertToHRTryCatchBounds->cbHandlerLength != 0)
         {
@@ -5947,8 +5947,8 @@ PCODE JitILStub(MethodDesc* pStubMD)
             // A dynamically generated IL stub
             //
             
-            DWORD dwFlags = pStubMD->AsDynamicMethodDesc()->GetILStubResolver()->GetJitFlags();
-            pCode = pStubMD->MakeJitWorker(NULL, dwFlags, 0);
+            CORJIT_FLAGS jitFlags = pStubMD->AsDynamicMethodDesc()->GetILStubResolver()->GetJitFlags();
+            pCode = pStubMD->MakeJitWorker(NULL, jitFlags);
 
             _ASSERTE(pCode == pStubMD->GetNativeCode());            
         }

--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -1320,7 +1320,7 @@ MethodDesc* UMThunkMarshInfo::GetILStubMethodDesc(MethodDesc* pInvokeMD, PInvoke
     dwStubFlags |= NDIRECTSTUB_FL_REVERSE_INTEROP;  // could be either delegate interop or not--that info is passed in from the caller
 
 #if defined(DEBUGGING_SUPPORTED)
-    if (GetDebuggerCompileFlags(pSigInfo->GetModule(), 0) & CORJIT_FLG_DEBUG_CODE)
+    if (GetDebuggerCompileFlags(pSigInfo->GetModule(), CORJIT_FLAGS()).IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE))
     {
         dwStubFlags |= NDIRECTSTUB_FL_GENERATEDEBUGGABLEIL;
     }
@@ -1394,7 +1394,7 @@ VOID UMThunkMarshInfo::RunTimeInit()
         DWORD dwStubFlags = NDIRECTSTUB_FL_NGENEDSTUB | NDIRECTSTUB_FL_REVERSE_INTEROP | NDIRECTSTUB_FL_DELEGATE;
 
 #if defined(DEBUGGING_SUPPORTED)
-        if (GetDebuggerCompileFlags(GetModule(), 0) & CORJIT_FLG_DEBUG_CODE)
+        if (GetDebuggerCompileFlags(GetModule(), CORJIT_FLAGS()).IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE))
         {
             dwStubFlags |= NDIRECTSTUB_FL_GENERATEDEBUGGABLEIL;
         }

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -1682,7 +1682,7 @@ void ResumeAtJit(PCONTEXT pContext, LPVOID oldESP)
 
 #pragma warning(push)
 #pragma warning(disable: 4035)
-DWORD getcpuid(DWORD arg, unsigned char result[16])
+extern "C" DWORD __stdcall getcpuid(DWORD arg, unsigned char result[16])
 {
     LIMITED_METHOD_CONTRACT
 
@@ -1709,7 +1709,7 @@ DWORD getcpuid(DWORD arg, unsigned char result[16])
 //     Arg3 is a pointer to the return buffer
 //   No need to check whether or not CPUID is supported because we have already called CPUID with success to come here.
 
-DWORD getextcpuid(DWORD arg1, DWORD arg2, unsigned char result[16])
+extern "C" DWORD __stdcall getextcpuid(DWORD arg1, DWORD arg2, unsigned char result[16])
 {
     LIMITED_METHOD_CONTRACT
 
@@ -1727,6 +1727,27 @@ DWORD getextcpuid(DWORD arg1, DWORD arg2, unsigned char result[16])
         mov     [esi+12], edx
         pop     esi
         pop     ebx
+    }
+}
+
+extern "C" DWORD __stdcall xmmYmmStateSupport()
+{
+    // No CONTRACT
+    STATIC_CONTRACT_NOTHROW;
+    STATIC_CONTRACT_GC_NOTRIGGER;
+
+    __asm
+    {
+        mov     ecx, 0                  ; Specify xcr0
+        xgetbv                          ; result in EDX:EAX
+        and eax, 06H
+        cmp eax, 06H                    ; check OS has enabled both XMM and YMM state support
+        jne     not_supported
+        mov     eax, 1
+        jmp     done
+    not_supported:
+        mov     eax, 0
+    done:
     }
 }
 

--- a/src/vm/ilstubcache.cpp
+++ b/src/vm/ilstubcache.cpp
@@ -128,7 +128,7 @@ MethodDesc* ILStubCache::CreateAndLinkNewILStubMethodDesc(LoaderAllocator* pAllo
         pStubLinker->GenerateCode(pbBuffer, cbCode);
         pStubLinker->GetLocalSig(pbLocalSig, cbSig);
 
-        pResolver->SetJitFlags(CORJIT_FLG_IL_STUB);
+        pResolver->SetJitFlags(CORJIT_FLAGS(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB));
     }
 
     pResolver->SetTokenLookupMap(pStubLinker->GetTokenLookupMap());

--- a/src/vm/ilstubresolver.cpp
+++ b/src/vm/ilstubresolver.cpp
@@ -299,7 +299,7 @@ ILStubResolver::ILStubResolver() :
     m_pStubMD(dac_cast<PTR_MethodDesc>(nullptr)),
     m_pStubTargetMD(dac_cast<PTR_MethodDesc>(nullptr)),
     m_type(Unassigned),
-    m_dwJitFlags(0)
+    m_jitFlags()
 {
     LIMITED_METHOD_CONTRACT;
     
@@ -488,16 +488,16 @@ bool ILStubResolver::IsILGenerated()
     return (dac_cast<TADDR>(m_pCompileTimeState) != ILNotYetGenerated);
 }
 
-void ILStubResolver::SetJitFlags(DWORD dwFlags)
+void ILStubResolver::SetJitFlags(CORJIT_FLAGS jitFlags)
 {
     LIMITED_METHOD_CONTRACT;
-    m_dwJitFlags = dwFlags;
+    m_jitFlags = jitFlags;
 }
 
-DWORD ILStubResolver::GetJitFlags()
+CORJIT_FLAGS ILStubResolver::GetJitFlags()
 {
     LIMITED_METHOD_CONTRACT;
-    return m_dwJitFlags;
+    return m_jitFlags;
 }
 
 // static

--- a/src/vm/ilstubresolver.h
+++ b/src/vm/ilstubresolver.h
@@ -64,8 +64,8 @@ public:
 
     void SetTokenLookupMap(TokenLookupMap* pMap);
 
-    void SetJitFlags(DWORD dwJitFlags);
-    DWORD GetJitFlags();
+    void SetJitFlags(CORJIT_FLAGS jitFlags);
+    CORJIT_FLAGS GetJitFlags();
 
     static void StubGenFailed(ILStubResolver* pResolver);
 
@@ -116,7 +116,7 @@ protected:
     PTR_MethodDesc          m_pStubMD;
     PTR_MethodDesc          m_pStubTargetMD;
     ILStubType              m_type;
-    DWORD                   m_dwJitFlags;
+    CORJIT_FLAGS            m_jitFlags;
 };
 
 typedef Holder<ILStubResolver*, DoNothing<ILStubResolver*>, ILStubResolver::StubGenFailed, NULL> ILStubGenHolder;

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -1736,13 +1736,13 @@ void Interpreter::JitMethodIfAppropriate(InterpreterMethodInfo* interpMethInfo, 
                 fprintf(GetLogFile(), "JITting method %s:%s.\n", md->m_pszDebugClassName, md->m_pszDebugMethodName);
             }
 #endif // _DEBUG
-            DWORD dwFlags = CORJIT_FLG_MAKEFINALCODE;
+            CORJIT_FLAGS jitFlags(CORJIT_FLAGS::CORJIT_FLAG_MAKEFINALCODE);
             NewHolder<COR_ILMETHOD_DECODER> pDecoder(NULL);
             // Dynamic methods (e.g., IL stubs) do not have an IL decoder but may
             // require additional flags.  Ordinary methods require the opposite.
             if (md->IsDynamicMethod())
             {
-                dwFlags |= md->AsDynamicMethodDesc()->GetILStubResolver()->GetJitFlags();
+                jitFlags.Add(md->AsDynamicMethodDesc()->GetILStubResolver()->GetJitFlags());
             }
             else
             {
@@ -1751,7 +1751,7 @@ void Interpreter::JitMethodIfAppropriate(InterpreterMethodInfo* interpMethInfo, 
                                                     md->GetMDImport(),
                                                     &status);
             }
-            PCODE res = md->MakeJitWorker(pDecoder, dwFlags, 0);
+            PCODE res = md->MakeJitWorker(pDecoder, jitFlags);
             interpMethInfo->m_jittedCode = res;
         }
     }

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -54,7 +54,7 @@ void InitJITHelpers1();
 void InitJITHelpers2();
 
 PCODE UnsafeJitFunction(MethodDesc* ftn, COR_ILMETHOD_DECODER* header,
-                        DWORD flags, DWORD flags2, ULONG* sizeOfCode = NULL);
+                        CORJIT_FLAGS flags, ULONG* sizeOfCode = NULL);
 
 void getMethodInfoHelper(MethodDesc * ftn,
                          CORINFO_METHOD_HANDLE ftnHnd,
@@ -647,7 +647,7 @@ public:
             );
 
     // Returns that compilation flags that are shared between JIT and NGen
-    static DWORD GetBaseCompileFlags(MethodDesc * ftn);
+    static CORJIT_FLAGS GetBaseCompileFlags(MethodDesc * ftn);
 
     // Resolve metadata token into runtime method handles.
     void resolveToken(/* IN, OUT */ CORINFO_RESOLVED_TOKEN * pResolvedToken);
@@ -1691,7 +1691,7 @@ public:
     static FCDECL3(void, UnsafeSetArrayElement, PtrArray* pPtrArray, INT32 index, Object* object);
 };
 
-DWORD GetDebuggerCompileFlags(Module* pModule, DWORD flags);
+CORJIT_FLAGS GetDebuggerCompileFlags(Module* pModule, CORJIT_FLAGS flags);
 
 bool TrackAllocationsEnabled();
 

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -1078,7 +1078,7 @@ BOOL MethodDesc::IsVerifiable()
 #endif // _VER_EE_VERIFICATION_ENABLED
     }
 
-    UnsafeJitFunction(this, pHeader, CORJIT_FLG_IMPORT_ONLY, 0);
+    UnsafeJitFunction(this, pHeader, CORJIT_FLAGS(CORJIT_FLAGS::CORJIT_FLAG_IMPORT_ONLY));
     _ASSERTE(IsVerified());
 
     return (IsVerified() && (m_wFlags & mdcVerifiable));

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1649,7 +1649,7 @@ public:
 
     PCODE DoPrestub(MethodTable *pDispatchingMT);
 
-    PCODE MakeJitWorker(COR_ILMETHOD_DECODER* ILHeader, DWORD  flags, DWORD flags2);
+    PCODE MakeJitWorker(COR_ILMETHOD_DECODER* ILHeader, CORJIT_FLAGS flags);
 
     VOID GetMethodInfo(SString &namespaceOrClassName, SString &methodName, SString &methodSignature);
     VOID GetMethodInfoWithNewSig(SString &namespaceOrClassName, SString &methodName, SString &methodSignature);

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -1245,8 +1245,8 @@ BOOL MethodTableBuilder::CheckIfSIMDAndUpdateSize()
     EEJitManager *jitMgr = ExecutionManager::GetEEJitManager();
     if (jitMgr->LoadJIT())
     {
-        DWORD cpuCompileFlags = jitMgr->GetCPUCompileFlags();
-        if ((cpuCompileFlags & CORJIT_FLG_FEATURE_SIMD) != 0)
+        CORJIT_FLAGS cpuCompileFlags = jitMgr->GetCPUCompileFlags();
+        if (cpuCompileFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_FEATURE_SIMD))
         {
             unsigned intrinsicSIMDVectorLength = jitMgr->m_jit->getMaxIntrinsicSIMDVectorLength(cpuCompileFlags);
             if (intrinsicSIMDVectorLength != 0)

--- a/src/vm/multicorejitplayer.cpp
+++ b/src/vm/multicorejitplayer.cpp
@@ -556,7 +556,7 @@ bool MulticoreJitProfilePlayer::CompileMethodDesc(Module * pModule, MethodDesc *
 #endif
 
         // MakeJitWorker calls back to MulticoreJitCodeStorage::StoreMethodCode under MethodDesc lock
-        pMD->MakeJitWorker(& header, CORJIT_FLG_MCJIT_BACKGROUND, 0);
+        pMD->MakeJitWorker(& header, CORJIT_FLAGS(CORJIT_FLAGS::CORJIT_FLAG_MCJIT_BACKGROUND));
 
         return true;
     }

--- a/src/vm/rejit.cpp
+++ b/src/vm/rejit.cpp
@@ -178,22 +178,22 @@ CrstStatic ReJitManager::s_csGlobalRequest;
 //---------------------------------------------------------------------------------------
 // Helpers
 
-inline DWORD JitFlagsFromProfCodegenFlags(DWORD dwCodegenFlags)
+inline CORJIT_FLAGS JitFlagsFromProfCodegenFlags(DWORD dwCodegenFlags)
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    DWORD jitFlags = 0;
+    CORJIT_FLAGS jitFlags;
 
     // Note: COR_PRF_CODEGEN_DISABLE_INLINING is checked in
     // code:CEEInfo::canInline#rejit (it has no equivalent CORJIT flag).
 
     if ((dwCodegenFlags & COR_PRF_CODEGEN_DISABLE_ALL_OPTIMIZATIONS) != 0)
     {
-        jitFlags |= CORJIT_FLG_DEBUG_CODE;
+        jitFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE);
     }
 
     // In the future more flags may be added that need to be converted here (e.g.,
-    // COR_PRF_CODEGEN_ENTERLEAVE / CORJIT_FLG_PROF_ENTERLEAVE)
+    // COR_PRF_CODEGEN_ENTERLEAVE / CORJIT_FLAG_PROF_ENTERLEAVE)
 
     return jitFlags;
 }
@@ -2170,8 +2170,7 @@ PCODE ReJitManager::DoReJit(ReJitInfo * pInfo)
     pCodeOfRejittedCode = UnsafeJitFunction(
         pInfo->GetMethodDesc(),
         &ILHeader,
-        JitFlagsFromProfCodegenFlags(pInfo->m_pShared->m_dwCodegenFlags),
-        0);
+        JitFlagsFromProfCodegenFlags(pInfo->m_pShared->m_dwCodegenFlags));
 
     _ASSERTE(pCodeOfRejittedCode != NULL);
 

--- a/src/vm/stacksampler.cpp
+++ b/src/vm/stacksampler.cpp
@@ -154,7 +154,7 @@ bool IsGoodMethodDesc(MethodDesc* pMD)
 //
 // An opportunity to record the parameters passed to the JIT at the time of JITting this method.
 /* static */
-void StackSampler::RecordJittingInfo(MethodDesc* pMD, DWORD dwFlags, DWORD dwFlags2)
+void StackSampler::RecordJittingInfo(MethodDesc* pMD, CORJIT_FLAGS flags)
 {
     WRAPPER_NO_CONTRACT;
     if (g_pStackSampler == nullptr)
@@ -167,10 +167,10 @@ void StackSampler::RecordJittingInfo(MethodDesc* pMD, DWORD dwFlags, DWORD dwFla
         return;
     }
     // Record in the hash map.
-    g_pStackSampler->RecordJittingInfoInternal(pMD, dwFlags);
+    g_pStackSampler->RecordJittingInfoInternal(pMD, flags);
 }
 
-void StackSampler::RecordJittingInfoInternal(MethodDesc* pMD, DWORD dwFlags)
+void StackSampler::RecordJittingInfoInternal(MethodDesc* pMD, CORJIT_FLAGS flags)
 {
     ADID dwDomainId = GetThread()->GetDomain()->GetId();
     JitInfoHashEntry entry(pMD, dwDomainId);
@@ -426,7 +426,7 @@ void StackSampler::JitAndCollectTrace(MethodDesc* pMD, const ADID& adId)
 
     // Indicate to the JIT or the JIT interface that we are JITting
     // in the background for stack sampling.
-    DWORD dwFlags2 = CORJIT_FLG2_SAMPLING_JIT_BACKGROUND;
+    CORJIT_FLAGS flags(CORJIT_FLAGS::CORJIT_FLAG_SAMPLING_JIT_BACKGROUND);
 
     _ASSERTE(pMD->IsIL());
 
@@ -447,7 +447,7 @@ void StackSampler::JitAndCollectTrace(MethodDesc* pMD, const ADID& adId)
             LOG((LF_JIT, LL_INFO100000, "%s:%s\n", pMD->GetMethodTable()->GetClass()->GetDebugClassName(), pMD->GetName())); 
 #endif
 
-            PCODE pCode = UnsafeJitFunction(pMD, pDecoder, 0, dwFlags2);
+            PCODE pCode = UnsafeJitFunction(pMD, pDecoder, flags);
         }
         END_DOMAIN_TRANSITION;
 

--- a/src/vm/stacksampler.h
+++ b/src/vm/stacksampler.h
@@ -21,7 +21,7 @@ class StackSampler
 public:
     // Interface
     static void Init();
-    static void RecordJittingInfo(MethodDesc* pMD, DWORD dwFlags, DWORD dwFlags2);
+    static void RecordJittingInfo(MethodDesc* pMD, CORJIT_FLAGS flags);
 
 private:
 
@@ -41,7 +41,7 @@ private:
 
     void JitAndCollectTrace(MethodDesc* pMD, const ADID& adId);
 
-    void RecordJittingInfoInternal(MethodDesc* pMD, DWORD flags);
+    void RecordJittingInfoInternal(MethodDesc* pMD, CORJIT_FLAGS flags);
     ADID GetDomainId(MethodDesc* pMD, const ADID& defaultId);
 
 

--- a/src/vm/stubgen.h
+++ b/src/vm/stubgen.h
@@ -431,7 +431,7 @@ public:
 
     void ClearCodeStreams();
 
-    void LogILStub(DWORD dwJitFlags, SString *pDumpILStubCode = NULL);
+    void LogILStub(CORJIT_FLAGS jitFlags, SString *pDumpILStubCode = NULL);
 protected:
     void LogILStubWorker(ILInstruction* pInstrBuffer, UINT numInstr, size_t* pcbCode, INT* piCurStack, SString *pDumpILStubCode = NULL);
     void LogILInstruction(size_t curOffset, bool isLabeled, INT iCurStack, ILInstruction* pInstruction, SString *pDumpILStubCode = NULL);

--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -2069,16 +2069,9 @@ lDone:
 #define CACHE_PARTITION_BITS    0x003FF000      // number of cache Physical Partitions is returned in EBX[21:12] (10 bits) using cpuid function 4
 #define CACHE_LINESIZE_BITS     0x00000FFF      // Linesize returned in EBX[11:0] (12 bits) using cpuid function 4
 
-#if defined(_TARGET_X86_)
-    // these are defined in cgenx86.cpp
-    extern DWORD getcpuid(DWORD arg1, unsigned char result[16]);
-    extern DWORD getextcpuid(DWORD arg1, DWORD arg2, unsigned char result[16]);
-#elif defined(_TARGET_AMD64_)
-    // these are defined in  src\VM\AMD64\asmhelpers.asm
-    extern "C" DWORD __stdcall getcpuid(DWORD arg1, unsigned char result[16]);
-    extern "C" DWORD __stdcall getextcpuid(DWORD arg1, DWORD arg2, unsigned char result[16]);
-#endif
-
+// these are defined in src\VM\AMD64\asmhelpers.asm / cgenx86.cpp
+extern "C" DWORD __stdcall getcpuid(DWORD arg1, unsigned char result[16]);
+extern "C" DWORD __stdcall getextcpuid(DWORD arg1, DWORD arg2, unsigned char result[16]);
 
 // The following function uses a deterministic mechanism for enumerating/calculating the details of the cache hierarychy at runtime
 // by using deterministic cache parameter leafs on Prescott and higher processors. 

--- a/src/zap/zapimage.h
+++ b/src/zap/zapimage.h
@@ -656,7 +656,7 @@ public:
                          NOT_COMPILED    =  0, COMPILE_EXCLUDED =  1,       // Info
                          COMPILE_SUCCEED = 10, ALREADY_COMPILED = 11};      // Success
 
-    static void __stdcall TryCompileMethodStub(LPVOID pContext, CORINFO_METHOD_HANDLE hStub, DWORD dwJitFlags);
+    static void __stdcall TryCompileMethodStub(LPVOID pContext, CORINFO_METHOD_HANDLE hStub, CORJIT_FLAGS jitFlags);
 
     BOOL IsVTableGapMethod(mdMethodDef md);
 

--- a/src/zap/zapinfo.h
+++ b/src/zap/zapinfo.h
@@ -231,7 +231,7 @@ class ZapInfo
 
     void InitMethodName();
 
-    int ComputeJitFlags(CORINFO_METHOD_HANDLE handle);
+    CORJIT_FLAGS ComputeJitFlags(CORINFO_METHOD_HANDLE handle);
 
     ZapDebugInfo * EmitDebugInfo();
     ZapGCInfo * EmitGCInfo();

--- a/src/zap/zapmetadata.cpp
+++ b/src/zap/zapmetadata.cpp
@@ -299,7 +299,7 @@ void ZapILMetaData::CopyMetaData()
 
         // unless we're producing an instrumented version - the IBC logging for meta data doesn't
         // work for the hot/cold split version.
-        if (m_pImage->m_zapper->m_pOpt->m_compilerFlags & CORJIT_FLG_BBINSTR)
+        if (m_pImage->m_zapper->m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_BBINSTR))
             IfFailThrow(pIMetaDataCorProfileData->SetCorProfileData(NULL));
         else
             IfFailThrow(pIMetaDataCorProfileData->SetCorProfileData(m_pImage->GetProfileData()));
@@ -308,7 +308,7 @@ void ZapILMetaData::CopyMetaData()
     // If we are ngening with the tuning option, the IBC data that is
     // generated gets reordered and may be  inconsistent with the
     // metadata in the original IL image. Let's just skip that case.
-    if (!(m_pImage->m_zapper->m_pOpt->m_compilerFlags & CORJIT_FLG_BBINSTR))
+    if (!m_pImage->m_zapper->m_pOpt->m_compilerFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_BBINSTR))
     {
         // Communicate the reordering option for saving
         NonVMComHolder<IMDInternalMetadataReorderingOptions> pIMDInternalMetadataReorderingOptions;


### PR DESCRIPTION
The "JIT flags" currently passed between the EE and the JIT have traditionally
been bit flags in a 32-bit word. Recently, a second 32-bit word was added to
accommodate additional flags, but that set of flags is definitely "2nd class":
they are not universally passed, and require using a separate set of bit
definitions, and comparing those bits against the proper, 2nd word.

This change replaces all uses of bare DWORD or 'unsigned int' types
representing flags with CORJIT_FLAGS, which is now an opaque type. All
flag names were renamed from CORJIT_FLG_* to CORJIT_FLAG_* to ensure all
cases were changed to use the new names, which are also scoped within the
CORJIT_FLAGS type itself.

Another motivation to do this, besides cleaner code, is to allow enabling the
SSE/AVX flags for x86. For x86, we had fewer bits available in the "first
word", so would have to either put them in the "second word", which, as
stated, was very much 2nd class and not plumbed through many usages, or
we could move other bits to the "second word", with the same issues. Neither
was a good option.

RyuJIT compiles with both COR_JIT_EE_VERSION > 460 and <= 460. I introduced
a JitFlags adapter class in jitee.h to handle both JIT flag types. All JIT
code uses this JitFlags type, which operates identically to the new
CORJIT_FLAGS type.

In addition to introducing the new CORJIT_FLAGS type, the SSE/AVX flags are
enabled for x86.

The JIT-EE interface GUID is changed, as this is a breaking change.