### PR TITLE
x86: not all fields of promoted struct need regs

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1186,14 +1186,15 @@ void CodeGen::genConsumeRegs(GenTree* tree)
 #ifdef _TARGET_XARCH_
         else if (tree->OperGet() == GT_LCL_VAR)
         {
-            // A contained lcl var must be living on stack and marked as reg optional.
+            // A contained lcl var must be living on stack and marked as reg optional, or not be a
+            // register candidate.
             unsigned   varNum = tree->AsLclVarCommon()->GetLclNum();
             LclVarDsc* varDsc = compiler->lvaTable + varNum;
 
             noway_assert(varDsc->lvRegNum == REG_STK);
-            noway_assert(tree->IsRegOptional());
+            noway_assert(tree->IsRegOptional() || !varDsc->lvLRACandidate);
 
-            // Update the life of reg optional lcl var.
+            // Update the life of the lcl var.
             genUpdateLife(tree);
         }
 #endif // _TARGET_XARCH_

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -167,7 +167,9 @@ void genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode);
 
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
 #ifdef _TARGET_X86_
-bool genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk, bool isSrcInMemory);
+bool genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk);
+void genPushReg(var_types type, regNumber srcReg);
+void genPutArgStkFieldList(GenTreePutArgStk* putArgStk);
 #endif // _TARGET_X86_
 
 void genPutStructArgStk(GenTreePutArgStk* treeNode);

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -571,10 +571,11 @@ void CodeGen::genCodeForLongUMod(GenTreeOp* node)
     assert(!dividendLo->isContained());
     assert(!dividendHi->isContained());
 
-    GenTreeIntCon* const divisor = node->gtOp2->AsIntCon();
-    assert(!divisor->isContained());
-    assert(divisor->gtIconVal >= 2);
-    assert(divisor->gtIconVal <= 0x3fffffff);
+    GenTree* const divisor = node->gtOp2;
+    assert(divisor->gtSkipReloadOrCopy()->OperGet() == GT_CNS_INT);
+    assert(!divisor->gtSkipReloadOrCopy()->isContained());
+    assert(divisor->gtSkipReloadOrCopy()->AsIntCon()->gtIconVal >= 2);
+    assert(divisor->gtSkipReloadOrCopy()->AsIntCon()->gtIconVal <= 0x3fffffff);
 
     // dividendLo must be in RAX; dividendHi must be in RDX
     genCopyRegIfNeeded(dividendLo, REG_EAX);

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -564,6 +564,8 @@ void CodeGen::genCodeForLongUMod(GenTreeOp* node)
     assert(dividend->OperGet() == GT_LONG);
     assert(varTypeIsLong(dividend));
 
+    genConsumeOperands(node);
+
     GenTree* const dividendLo = dividend->gtOp1;
     GenTree* const dividendHi = dividend->gtOp2;
     assert(!dividendLo->isContained());
@@ -573,8 +575,6 @@ void CodeGen::genCodeForLongUMod(GenTreeOp* node)
     assert(!divisor->isContained());
     assert(divisor->gtIconVal >= 2);
     assert(divisor->gtIconVal <= 0x3fffffff);
-
-    genConsumeOperands(node);
 
     // dividendLo must be in RAX; dividendHi must be in RDX
     genCopyRegIfNeeded(dividendLo, REG_EAX);
@@ -3349,6 +3349,8 @@ void CodeGen::genStructPutArgUnroll(GenTreePutArgStk* putArgNode)
     regNumber intTmpReg  = REG_NA;
     regNumber longTmpReg = REG_NA;
 #ifdef _TARGET_X86_
+    // On x86 we use an XMM register for both 16 and 8-byte chunks, but if it's
+    // less than 16 bytes, we will just be using pushes
     if (size >= 8)
     {
         xmmTmpReg  = genRegNumFromMask(putArgNode->gtRsvdRegs & RBM_ALLFLOAT);
@@ -3359,6 +3361,7 @@ void CodeGen::genStructPutArgUnroll(GenTreePutArgStk* putArgNode)
         intTmpReg = genRegNumFromMask(putArgNode->gtRsvdRegs & RBM_ALLINT);
     }
 #else  // !_TARGET_X86_
+    // On x64 we use an XMM register only for 16-byte chunks.
     if (size >= XMM_REGSIZE_BYTES)
     {
         xmmTmpReg = genRegNumFromMask(putArgNode->gtRsvdRegs & RBM_ALLFLOAT);
@@ -7486,28 +7489,233 @@ unsigned CodeGen::getBaseVarForPutArgStk(GenTreePtr treeNode)
 //
 // Arguments:
 //    putArgStk - the putArgStk node.
-//    isSrcInMemory - true if the source of the putArgStk node is in
-//                    memory; false otherwise.
 //
 // Returns: true if the stack pointer was adjusted; false otherwise.
 //
-bool CodeGen::genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk, bool isSrcInMemory)
+bool CodeGen::genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk)
 {
-    assert(isSrcInMemory || (putArgStk->gtOp1->OperGet() == GT_FIELD_LIST));
-
-    // If this argument contains any GC pointers or is less than 16 bytes in size and is either in memory or composed
-    // entirely of slot-like fields (i.e. integral-types, 4-byte-aligned fields that take up 4 bytes including any
-    // padding), we will use a sequence of `push` instructions to store the argument to the stack.
     const unsigned argSize = putArgStk->getArgSize();
-    if ((putArgStk->gtNumberReferenceSlots != 0) ||
-        ((argSize < 16) && (isSrcInMemory || (putArgStk->gtPutArgStkKind == GenTreePutArgStk::Kind::AllSlots))))
+
+    // If the gtPutArgStkKind is one of the push types, we do not pre-adjust the stack.
+    // This is set in Lowering, and is true if and only if:
+    // - This argument contains any GC pointers OR
+    // - It is a GT_FIELD_LIST OR
+    // - It is less than 16 bytes in size.
+    CLANG_FORMAT_COMMENT_ANCHOR;
+
+#ifdef DEBUG
+    switch (putArgStk->gtPutArgStkKind)
     {
+        case GenTreePutArgStk::Kind::RepInstr:
+        case GenTreePutArgStk::Kind::Unroll:
+            assert((putArgStk->gtNumberReferenceSlots == 0) && (putArgStk->gtGetOp1()->OperGet() != GT_FIELD_LIST) &&
+                   (argSize >= 16));
+            break;
+        case GenTreePutArgStk::Kind::Push:
+        case GenTreePutArgStk::Kind::PushAllSlots:
+            assert((putArgStk->gtNumberReferenceSlots != 0) || (putArgStk->gtGetOp1()->OperGet() == GT_FIELD_LIST) ||
+                   (argSize < 16));
+            break;
+        case GenTreePutArgStk::Kind::Invalid:
+        default:
+            assert(!"Uninitialized GenTreePutArgStk::Kind");
+            break;
+    }
+#endif // DEBUG
+
+    if (putArgStk->isPushKind())
+    {
+        m_pushStkArg = true;
         return false;
     }
-
+    m_pushStkArg = false;
     inst_RV_IV(INS_sub, REG_SPBASE, argSize, EA_PTRSIZE);
     genStackLevel += argSize;
     return true;
+}
+
+//---------------------------------------------------------------------
+// genPutArgStkFieldList - generate code for passing an arg on the stack.
+//
+// Arguments
+//    treeNode      - the GT_PUTARG_STK node
+//    targetType    - the type of the treeNode
+//
+// Return value:
+//    None
+//
+void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
+{
+    GenTreeFieldList* const fieldList = putArgStk->gtOp1->AsFieldList();
+    assert(fieldList != nullptr);
+
+    // Set m_pushStkArg and pre-adjust the stack if necessary.
+    const bool preAdjustedStack = genAdjustStackForPutArgStk(putArgStk);
+    // For now, we only support the "push" case; we will push a full slot for the first field of each slot
+    // within the struct.
+    assert((putArgStk->isPushKind()) && !preAdjustedStack && m_pushStkArg);
+
+    // If we have pre-adjusted the stack and are simply storing the fields in order) set the offset to 0.
+    // (Note that this mode is not currently being used.)
+    // If we are pushing the arguments (i.e. we have not pre-adjusted the stack), then we are pushing them
+    // in reverse order, so we start with the current field offset at the size of the struct arg (which must be
+    // a multiple of the target pointer size).
+    unsigned  currentOffset   = (preAdjustedStack) ? 0 : putArgStk->getArgSize();
+    unsigned  prevFieldOffset = currentOffset;
+    regNumber tmpReg          = REG_NA;
+    if (putArgStk->gtRsvdRegs != RBM_NONE)
+    {
+        assert(genCountBits(putArgStk->gtRsvdRegs) == 1);
+        tmpReg = genRegNumFromMask(putArgStk->gtRsvdRegs);
+        assert(genIsValidIntReg(tmpReg));
+    }
+    for (GenTreeFieldList* current = fieldList; current != nullptr; current = current->Rest())
+    {
+        GenTree* const fieldNode   = current->Current();
+        const unsigned fieldOffset = current->gtFieldOffset;
+        var_types      fieldType   = current->gtFieldType;
+
+        // Long-typed nodes should have been handled by the decomposition pass, and lowering should have sorted the
+        // field list in descending order by offset.
+        assert(!varTypeIsLong(fieldType));
+        assert(fieldOffset <= prevFieldOffset);
+
+        // Consume the register, if any, for this field. Note that genConsumeRegs() will appropriately
+        // update the liveness info for a lclVar that has been marked RegOptional, which hasn't been
+        // assigned a register, and which is therefore contained.
+        // Unlike genConsumeReg(), it handles the case where no registers are being consumed.
+        genConsumeRegs(fieldNode);
+        regNumber argReg = fieldNode->isContainedSpillTemp() ? REG_NA : fieldNode->gtRegNum;
+
+        // If the field is slot-like, we can use a push instruction to store the entire register no matter the type.
+        //
+        // The GC encoder requires that the stack remain 4-byte aligned at all times. Round the adjustment up
+        // to the next multiple of 4. If we are going to generate a `push` instruction, the adjustment must
+        // not require rounding.
+        // NOTE: if the field is of GC type, we must use a push instruction, since the emitter is not otherwise
+        // able to detect stores into the outgoing argument area of the stack on x86.
+        const bool fieldIsSlot = ((fieldOffset % 4) == 0) && ((prevFieldOffset - fieldOffset) >= 4);
+        int        adjustment  = roundUp(currentOffset - fieldOffset, 4);
+        if (fieldIsSlot)
+        {
+            fieldType         = genActualType(fieldType);
+            unsigned pushSize = genTypeSize(fieldType);
+            assert((pushSize % 4) == 0);
+            adjustment -= pushSize;
+            while (adjustment != 0)
+            {
+                inst_IV(INS_push, 0);
+                currentOffset -= pushSize;
+                genStackLevel += pushSize;
+                adjustment -= pushSize;
+            }
+            m_pushStkArg = true;
+        }
+        else
+        {
+            m_pushStkArg = false;
+            // We always "push" floating point fields (i.e. they are full slot values that don't
+            // require special handling).
+            assert(varTypeIsIntegralOrI(fieldNode));
+            // If we can't push this field, it needs to be in a register so that we can store
+            // it to the stack location.
+            assert(tmpReg != REG_NA);
+            if (adjustment != 0)
+            {
+                // This moves the stack pointer to fieldOffset.
+                // For this case, we must adjust the stack and generate stack-relative stores rather than pushes.
+                // Adjust the stack pointer to the next slot boundary.
+                inst_RV_IV(INS_sub, REG_SPBASE, adjustment, EA_PTRSIZE);
+                currentOffset -= adjustment;
+                genStackLevel += adjustment;
+            }
+
+            // Does it need to be in a byte register?
+            // If so, we'll use tmpReg, which must have been allocated as a byte register.
+            // If it's already in a register, but not a byteable one, then move it.
+            if (varTypeIsByte(fieldType) && ((argReg == REG_NA) || ((genRegMask(argReg) & RBM_BYTE_REGS) == 0)))
+            {
+                noway_assert((genRegMask(tmpReg) & RBM_BYTE_REGS) != 0);
+                if (argReg != REG_NA)
+                {
+                    inst_RV_RV(INS_mov, tmpReg, argReg, fieldType);
+                    argReg = tmpReg;
+                }
+            }
+        }
+
+        if (argReg == REG_NA)
+        {
+            if (m_pushStkArg)
+            {
+                if (fieldNode->isContainedSpillTemp())
+                {
+                    assert(fieldNode->IsRegOptional());
+                    TempDsc* tmp = getSpillTempDsc(fieldNode);
+                    getEmitter()->emitIns_S(INS_push, emitActualTypeSize(fieldNode->TypeGet()), tmp->tdTempNum(), 0);
+                    compiler->tmpRlsTemp(tmp);
+                }
+                else
+                {
+                    assert(varTypeIsIntegralOrI(fieldNode));
+                    switch (fieldNode->OperGet())
+                    {
+                        case GT_LCL_VAR:
+                            inst_TT(INS_push, fieldNode, 0, 0, emitActualTypeSize(fieldNode->TypeGet()));
+                            break;
+                        case GT_CNS_INT:
+                            if (fieldNode->IsIconHandle())
+                            {
+                                inst_IV_handle(INS_push, fieldNode->gtIntCon.gtIconVal);
+                            }
+                            else
+                            {
+                                inst_IV(INS_push, fieldNode->gtIntCon.gtIconVal);
+                            }
+                            break;
+                        default:
+                            unreached();
+                    }
+                }
+                currentOffset -= TARGET_POINTER_SIZE;
+                genStackLevel += TARGET_POINTER_SIZE;
+            }
+            else
+            {
+                // The stack has been adjusted and we will load the field to tmpReg and then store it on the stack.
+                assert(varTypeIsIntegralOrI(fieldNode));
+                switch (fieldNode->OperGet())
+                {
+                    case GT_LCL_VAR:
+                        inst_RV_TT(INS_mov, tmpReg, fieldNode);
+                        break;
+                    case GT_CNS_INT:
+                        genSetRegToConst(tmpReg, fieldNode->TypeGet(), fieldNode);
+                        break;
+                    default:
+                        unreached();
+                }
+                genStoreRegToStackArg(fieldType, tmpReg, fieldOffset - currentOffset);
+            }
+        }
+        else
+        {
+            genStoreRegToStackArg(fieldType, argReg, fieldOffset - currentOffset);
+            if (m_pushStkArg)
+            {
+                // We always push a slot-rounded size
+                currentOffset -= genTypeSize(fieldType);
+            }
+        }
+
+        prevFieldOffset = fieldOffset;
+    }
+    if (currentOffset != 0)
+    {
+        // We don't expect padding at the beginning of a struct, but it could happen with explicit layout.
+        inst_RV_IV(INS_sub, REG_SPBASE, currentOffset, EA_PTRSIZE);
+        genStackLevel += currentOffset;
+    }
 }
 #endif // _TARGET_X86_
 
@@ -7527,7 +7735,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
 #ifdef _TARGET_X86_
     if (varTypeIsStruct(targetType))
     {
-        m_pushStkArg = !genAdjustStackForPutArgStk(putArgStk, true);
+        (void)genAdjustStackForPutArgStk(putArgStk);
         genPutStructArgStk(putArgStk);
         return;
     }
@@ -7541,10 +7749,9 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
     // a separate putarg_stk for each of the upper and lower halves.
     noway_assert(targetType != TYP_LONG);
 
-    int argSize = genTypeSize(genActualType(targetType));
-    genStackLevel += argSize;
+    const unsigned argSize = putArgStk->getArgSize();
+    assert((argSize % TARGET_POINTER_SIZE) == 0);
 
-    // TODO-Cleanup: Handle this in emitInsMov() in emitXArch.cpp?
     if (data->isContainedIntOrIImmed())
     {
         if (data->IsIconHandle())
@@ -7555,115 +7762,18 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
         {
             inst_IV(INS_push, data->gtIntCon.gtIconVal);
         }
+        genStackLevel += argSize;
     }
     else if (data->OperGet() == GT_FIELD_LIST)
     {
-        GenTreeFieldList* const fieldList = data->AsFieldList();
-        assert(fieldList != nullptr);
-
-        m_pushStkArg      = false;
-        const int argSize = putArgStk->getArgSize();
-        assert((argSize % TARGET_POINTER_SIZE) == 0);
-
-        const bool preAdjustedStack = genAdjustStackForPutArgStk(putArgStk, false);
-
-        // If the stack was not pre-adjusted, set the current field offset to the size of the struct arg (which must be
-        // a multiple of the target pointer size). Otherwise, set the offset to 0.
-        int      currentOffset   = preAdjustedStack ? 0 : argSize;
-        unsigned prevFieldOffset = argSize;
-        for (GenTreeFieldList* current = fieldList; current != nullptr; current = current->Rest())
-        {
-            GenTree* const fieldNode   = current->Current();
-            const unsigned fieldOffset = current->gtFieldOffset;
-            var_types      fieldType   = current->gtFieldType;
-
-            // Long-typed nodes should have been handled by the decomposition pass, and lowering should have sorted the
-            // field list in descending order by offset.
-            assert(!varTypeIsLong(fieldType));
-            assert(fieldOffset <= prevFieldOffset);
-
-            // TODO-X86-CQ: If this is not a register candidate, or is not in a register,
-            // make it contained.
-            genConsumeReg(fieldNode);
-
-            // If the field is slot-like, we can store the entire register no matter the type.
-            const bool fieldIsSlot =
-                varTypeIsIntegralOrI(fieldType) && ((fieldOffset % 4) == 0) && ((prevFieldOffset - fieldOffset) >= 4);
-            if (fieldIsSlot)
-            {
-                fieldType = genActualType(fieldType);
-                assert(genTypeSize(fieldType) == 4);
-            }
-
-            // We can use a push instruction for any slot-like field.
-            //
-            // NOTE: if the field is of GC type, we must use a push instruction, since the emitter is not otherwise
-            // able to detect stores into the outgoing argument area of the stack on x86.
-            const bool usePush = !preAdjustedStack && fieldIsSlot;
-            assert(usePush || !varTypeIsGC(fieldType));
-
-            // Adjust the stack if necessary. If we are going to generate a `push` instruction, this moves the stack
-            // pointer to (fieldOffset + sizeof(fieldType)) to account for the `push`.
-            const int fieldSize     = genTypeSize(fieldType);
-            const int desiredOffset = current->gtFieldOffset + (usePush ? fieldSize : 0);
-            if (currentOffset > desiredOffset)
-            {
-                assert(!preAdjustedStack);
-
-                // The GC encoder requires that the stack remain 4-byte aligned at all times. Round the adjustment up
-                // to the next multiple of 4. If we are going to generate a `push` instruction, the adjustment must
-                // not require rounding.
-                const int adjustment = roundUp(currentOffset - desiredOffset, 4);
-                assert(!usePush || (adjustment == (currentOffset - desiredOffset)));
-                inst_RV_IV(INS_sub, REG_SPBASE, adjustment, EA_PTRSIZE);
-                currentOffset -= adjustment;
-                genStackLevel += adjustment;
-            }
-
-            // Note that the argReg may not be the lcl->gtRegNum, if it has been copied
-            // or reloaded to a different register.
-            const regNumber argReg = fieldNode->gtRegNum;
-            if (usePush)
-            {
-                // Adjust the stack if necessary and push the field.
-                // Push the field.
-                inst_RV(INS_push, argReg, fieldType, emitTypeSize(fieldType));
-                currentOffset -= fieldSize;
-                genStackLevel += fieldSize;
-            }
-            else
-            {
-                assert(!m_pushStkArg);
-                genStoreRegToStackArg(fieldType, argReg, desiredOffset - currentOffset);
-            }
-
-            prevFieldOffset = fieldOffset;
-        }
-
-        // Adjust the stack if necessary.
-        if (currentOffset != 0)
-        {
-            inst_RV_IV(INS_sub, REG_SPBASE, currentOffset, EA_PTRSIZE);
-            genStackLevel += currentOffset;
-        }
-    }
-    else if (data->isContained())
-    {
-        NYI_X86("Contained putarg_stk of non-constant");
+        genPutArgStkFieldList(putArgStk);
     }
     else
     {
+        // We should not see any contained nodes that are not immediates.
+        assert(!data->isContained());
         genConsumeReg(data);
-        if (varTypeIsIntegralOrI(targetType))
-        {
-            inst_RV(INS_push, data->gtRegNum, targetType);
-        }
-        else
-        {
-            // Decrement SP.
-            inst_RV_IV(INS_sub, REG_SPBASE, argSize, emitActualTypeSize(TYP_I_IMPL));
-            getEmitter()->emitIns_AR_R(ins_Store(targetType), emitTypeSize(targetType), data->gtRegNum, REG_SPBASE, 0);
-        }
+        genPushReg(targetType, data->gtRegNum);
     }
 #else // !_TARGET_X86_
     {
@@ -7711,6 +7821,48 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
     }
 #endif // !_TARGET_X86_
 }
+
+#ifdef _TARGET_X86_
+// genPushReg: Push a register value onto the stack and adjust the stack level
+//
+// Arguments:
+//    type   - the type of value to be stored
+//    reg    - the register containing the value
+//
+// Notes:
+//    For TYP_LONG, the srcReg must be a floating point register.
+//    Otherwise, the register type must be consistent with the given type.
+//
+void CodeGen::genPushReg(var_types type, regNumber srcReg)
+{
+    unsigned size = genTypeSize(type);
+    if (varTypeIsIntegralOrI(type) && type != TYP_LONG)
+    {
+        assert(genIsValidIntReg(srcReg));
+        inst_RV(INS_push, srcReg, type);
+    }
+    else
+    {
+        instruction ins;
+        emitAttr    attr = emitTypeSize(type);
+        if (type == TYP_LONG)
+        {
+            // On x86, the only way we can push a TYP_LONG from a register is if it is in an xmm reg.
+            // This is only used when we are pushing a struct from memory to memory, and basically is
+            // handling an 8-byte "chunk", as opposed to strictly a long type.
+            ins = INS_movq;
+        }
+        else
+        {
+            ins = ins_Store(type);
+        }
+        assert(genIsValidFloatReg(srcReg));
+        inst_RV_IV(INS_sub, REG_SPBASE, size, EA_PTRSIZE);
+        getEmitter()->emitIns_AR_R(ins, attr, srcReg, REG_SPBASE, 0);
+    }
+    genStackLevel += size;
+}
+#endif // _TARGET_X86_
 
 #if defined(FEATURE_PUT_STRUCT_ARG_STK)
 // genStoreRegToStackArg: Store a register value into the stack argument area
@@ -7776,16 +7928,7 @@ void CodeGen::genStoreRegToStackArg(var_types type, regNumber srcReg, int offset
 #ifdef _TARGET_X86_
     if (m_pushStkArg)
     {
-        if (varTypeIsIntegralOrI(type) && type != TYP_LONG)
-        {
-            inst_RV(INS_push, srcReg, type);
-        }
-        else
-        {
-            inst_RV_IV(INS_sub, REG_SPBASE, size, EA_PTRSIZE);
-            getEmitter()->emitIns_AR_R(ins, attr, srcReg, REG_SPBASE, 0);
-        }
-        genStackLevel += size;
+        genPushReg(type, srcReg);
     }
     else
     {
@@ -7832,6 +7975,9 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
                 genStructPutArgRepMovs(putArgStk);
                 break;
             case GenTreePutArgStk::Kind::Unroll:
+                genStructPutArgUnroll(putArgStk);
+                break;
+            case GenTreePutArgStk::Kind::Push:
                 genStructPutArgUnroll(putArgStk);
                 break;
             default:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11287,19 +11287,62 @@ void Compiler::gtDispTree(GenTreePtr   tree,
         {
             printf(" (last use)");
         }
-        if (tree->OperIsCopyBlkOp())
+        if (tree->OperIsBlkOp())
         {
-            printf(" (copy)");
-        }
-        else if (tree->OperIsInitBlkOp())
-        {
-            printf(" (init)");
+            if (tree->OperIsCopyBlkOp())
+            {
+                printf(" (copy)");
+            }
+            else if (tree->OperIsInitBlkOp())
+            {
+                printf(" (init)");
+            }
+            if (tree->OperIsStoreBlk() && (tree->AsBlk()->gtBlkOpKind != GenTreeBlk::BlkOpKindInvalid))
+            {
+                switch (tree->AsBlk()->gtBlkOpKind)
+                {
+                    case GenTreeBlk::BlkOpKindRepInstr:
+                        printf(" (RepInstr)");
+                        break;
+                    case GenTreeBlk::BlkOpKindUnroll:
+                        printf(" (Unroll)");
+                        break;
+                    case GenTreeBlk::BlkOpKindHelper:
+                        printf(" (Helper)");
+                        break;
+                    default:
+                        unreached();
+                }
+            }
         }
         else if (tree->OperIsFieldList())
         {
             printf(" %s at offset %d", varTypeName(tree->AsFieldList()->gtFieldType),
                    tree->AsFieldList()->gtFieldOffset);
         }
+#if FEATURE_PUT_STRUCT_ARG_STK
+        else if ((tree->OperGet() == GT_PUTARG_STK) &&
+                 (tree->AsPutArgStk()->gtPutArgStkKind != GenTreePutArgStk::Kind::Invalid))
+        {
+            switch (tree->AsPutArgStk()->gtPutArgStkKind)
+            {
+                case GenTreePutArgStk::Kind::RepInstr:
+                    printf(" (RepInstr)");
+                    break;
+                case GenTreePutArgStk::Kind::Unroll:
+                    printf(" (Unroll)");
+                    break;
+                case GenTreePutArgStk::Kind::Push:
+                    printf(" (Push)");
+                    break;
+                case GenTreePutArgStk::Kind::PushAllSlots:
+                    printf(" (PushAllSlots)");
+                    break;
+                default:
+                    unreached();
+            }
+        }
+#endif // FEATURE_PUT_STRUCT_ARG_STK
 
         IndirectAssignmentAnnotation* pIndirAnnote;
         if (tree->gtOper == GT_ASG && GetIndirAssignMap()->Lookup(tree, &pIndirAnnote))

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -566,7 +566,7 @@ public:
 
     bool isContainedIntOrIImmed() const
     {
-        return isContained() && IsCnsIntOrI();
+        return isContained() && IsCnsIntOrI() && !isContainedSpillTemp();
     }
 
     bool isContainedFltOrDblImmed() const
@@ -4649,10 +4649,14 @@ struct GenTreePutArgStk : public GenTreeUnOp
     // block node.
 
     enum class Kind : __int8{
-        Invalid, RepInstr, Unroll, AllSlots,
+        Invalid, RepInstr, Unroll, Push, PushAllSlots,
     };
 
     Kind gtPutArgStkKind;
+    bool isPushKind()
+    {
+        return (gtPutArgStkKind == Kind::Push) || (gtPutArgStkKind == Kind::PushAllSlots);
+    }
 
     unsigned gtNumSlots;             // Number of slots for the argument to be passed on stack
     unsigned gtNumberReferenceSlots; // Number of reference slots.

--- a/tests/src/JIT/Methodical/structs/systemvbringup/structpinvoketests.cs
+++ b/tests/src/JIT/Methodical/structs/systemvbringup/structpinvoketests.cs
@@ -364,650 +364,698 @@ namespace structinreg
             s1.y = 2;
             s1.z = 3;
             s1.w = 4;
-            
-            InvokeCallback1((par) => {
-                Console.WriteLine("S1: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
-                {
-                    throw new System.Exception();
-                }
-            }, s1);
 
-            S2 s2;
-            s2.x = 1;
-            s2.y = 2;
-            s2.z = 3;
-            InvokeCallback2((par) => {
-                Console.WriteLine("S2: {0}, {1}, {2}", par.x, par.y, par.z);
-                if (par.x != 1 || par.y != 2 || par.z != 3)
-                {
-                    throw new System.Exception();
-                }
-            }, s2);
-
-            S3 s3;
-            s3.x = 1;
-            s3.y = 2;
-            s3.z = 3;
-            InvokeCallback3((par) => {
-                Console.WriteLine("S3: {0}, {1}, {2}", par.x, par.y, par.z);
-                if (par.x != 1 || par.y != 2 || par.z != 3)
-                {
-                    throw new System.Exception();
-                }
-            }, s3);
-
-            S4 s4;
-            s4.x = 1;
-            s4.y = 2;
-            InvokeCallback4((par) => {
-                Console.WriteLine("S4: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
-                {
-                    throw new System.Exception();
-                }
-            }, s4);
-
-            S5 s5;
-            s5.x = 1;
-            s5.y = 2;
-            InvokeCallback5((par) => {
-                Console.WriteLine("S5: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
-                {
-                    throw new System.Exception();
-                }
-            }, s5);
-
-            S6 s6;
-            s6.x = 1;
-            s6.y = 2;
-            s6.z = 3;
-            s6.w = 4;
-            InvokeCallback6((par) => {
-                Console.WriteLine("S6: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
-                {
-                    throw new System.Exception();
-                }
-            }, s6);
-
-            S7 s7;
-            s7.x = 1;
-            s7.y = 2;
-            s7.z = 3;
-            InvokeCallback7((par) => {
-                Console.WriteLine("S7: {0}, {1}, {2}", par.x, par.y, par.z);
-                if (par.x != 1 || par.y != 2 || par.z != 3)
-                {
-                    throw new System.Exception();
-                }
-            }, s7);
-
-            S8 s8;
-            s8.x = 1;
-            s8.y = 2;
-            InvokeCallback8((par) => {
-                Console.WriteLine("S8: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
-                {
-                    throw new System.Exception();
-                }
-            }, s8);
-
-            S9 s9;
-            s9.x = 1;
-            s9.y = 2;
-            s9.z = 3;
-            s9.w = 4;
-            InvokeCallback9((par) => {
-                Console.WriteLine("S9: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
-                {
-                    throw new System.Exception();
-                }
-            }, s9);
-            
-            S10 s10;
-            s10.a = 1;
-            s10.b = 2;
-            s10.c = 3;
-            s10.d = 4;
-            s10.e = 5;
-            s10.f = 6;
-            s10.g = 7;
-            s10.h = 8;
-            InvokeCallback10((par) => {
-                Console.WriteLine("S10: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h);
-                if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
-                    par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8)
-                {
-                    throw new System.Exception();
-                }
-            }, s10);
-
-            S11 s11;
-            s11.a = 1;
-            s11.b = 2;
-            s11.c = 3;
-            s11.d = 4;
-            s11.e = 5;
-            InvokeCallback11((par) => {
-                Console.WriteLine("S11: {0}, {1}, {2}, {3}, {4}", par.a, par.b, par.c, par.d, par.e);
-                if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 || par.e != 5)
-                {
-                    throw new System.Exception();
-                }
-            }, s11);
-
-            S12 s12;
-            s12.a = 1;
-            s12.b = 2;
-            s12.c = 3;
-            s12.d = 4;
-            s12.e = 5;
-            s12.f = 6;
-            s12.g = 7;
-            s12.h = 8;
-            s12.i = 9;
-            InvokeCallback12((par) => {
-                Console.WriteLine("S12: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h, par.i);
-                if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
-                    par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8 || par.i != 9)
-                {
-                    throw new System.Exception();
-                }
-            }, s12);
-
-            S13 s13;
-            s13.hasValue = 1;
-            s13.x = 2;
-            InvokeCallback13((par) => {
-                Console.WriteLine("S13: {0}, {1}", par.hasValue, par.x);
-                if (par.hasValue != 1 || par.x != 2)
-                {
-                    throw new System.Exception();
-                }
-            }, s13);
-
-            S14 s14;
-            s14.x = 1;
-            s14.y = 2;
-            InvokeCallback14((par) => {
-                Console.WriteLine("S14: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
-                {
-                    throw new System.Exception();
-                }
-            }, s14);
-
-            S15 s15;
-            s15.a = 1;
-            s15.b = 2;
-            s15.c = 3;
-            s15.d = 4;
-            s15.e = 5;
-            s15.f = 6;
-            s15.g = 7;
-            s15.h = 8;
-            s15.i = 9;
-            InvokeCallback15((par) => {
-                Console.WriteLine("S15: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h, par.i);
-                if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
-                    par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8 || par.i != 9)
-                {
-                    throw new System.Exception();
-                }
-            }, s15);
-
-            S16 s16;
-            s16.x = 1;
-            s16.y = 2;
-            InvokeCallback16((par) => {
-                Console.WriteLine("S16: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
-                {
-                    throw new System.Exception();
-                }
-            }, s16);
-
-            S17 s17;
-            s17.x = 1;
-            s17.y = 2;
-            InvokeCallback17((par) => {
-                Console.WriteLine("S17: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
-                {
-                    throw new System.Exception();
-                }
-            }, s17);
-
-            S18 s18;
-            s18.x = 1;
-            s18.y = 2;
-            s18.z = 3;
-            InvokeCallback18((par) => {
-                Console.WriteLine("S18: {0}, {1}, {2}", par.x, par.y, par.z);
-                if (par.x != 1 || par.y != 2 || par.z != 3)
-                {
-                    throw new System.Exception();
-                }
-            }, s18);
-
-            S19 s19;
-            s19.x = 1;
-            s19.y = 2;
-            s19.z = 3;
-            s19.w = 4;
-            InvokeCallback19((par) => {
-                Console.WriteLine("S19: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
-                {
-                    throw new System.Exception();
-                }
-            }, s19);
-
-            S20 s20;
-            s20.x = 1;
-            s20.y = 2;
-            s20.z = 3;
-            s20.w = 4;
-            InvokeCallback20((par) => {
-                Console.WriteLine("S20: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
-                {
-                    throw new System.Exception();
-                }
-            }, s20);
-
-/* These tests are not working on non Windows CoreCLR.  Enable this when GH Issue #2076 is resolved.
-            TestClass testClass = new TestClass();
-            S28 s28;
-            s28.x = null;
-            s28.y = 1;
-
-            InvokeCallback28((par) => {
-                Console.WriteLine("S28: {0}, {1}", par.x == null ? "Null" : "Not null", par.y);
-                if (par.x != null || par.y != 1)
-                {
-                    throw new System.Exception();
-                }
-            }, s28);
-
-            s28.x = testClass;
-            s28.y = 5;
-
-            InvokeCallback28((par) => {
-                Console.WriteLine("S28: {0}, {1}", par.x == null ? "Null" : "Not null", par.y);
-                if (par.x != testClass || par.y != 5)
-                {
-                    throw new System.Exception();
-                }
-            }, s28);
-
-            S29 s29;
-            s29.x = 1;
-            s29.y = null;
-
-            InvokeCallback29((par) => {
-                Console.WriteLine("S29: {0}, {1}", par.x, par.y == null ? "Null" : "Not null");
-                if (par.x != 1 || par.y != null)
-                {
-                    throw new System.Exception();
-                }
-            }, s29);
-
-            s29.x = 5;
-            s29.y = testClass;
-            
-            InvokeCallback29((par) => {
-                Console.WriteLine("S29: {0}, {1}", par.x, par.y == null ? "Null" : "Not null");
-                if (par.x != 5 || par.y != testClass)
-                {
-                    throw new System.Exception();
-                }
-            }, s29);
- Enable this when GH Issue #2076 is resolved. */
-            S30 s30;
-            s30.x = 1;
-            s30.y = 2;
-
-            S30 s30_2;
-            s30_2.x = 3;
-            s30_2.y = 4;
-            
-            S30 s30_3;
-            s30_3.x = 5;
-            s30_3.y = 6;
-            
-            // Program p = new Program();
-            InvokeCallback30(p.Test30, s30, s30_2, s30_3);
-            S1 s1r = InvokeCallback1R((par) => {
-                Console.WriteLine("S1: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
-                {
-                    throw new System.Exception();
-                }
-
-            }, s1);
-            Console.WriteLine("S1R: {0}, {1}, {2}, {3}", s1r.x, s1r.y, s1r.z, s1r.w);
-            if (s1r.x != 1 || s1r.y != 2 || s1r.z != 3 || s1r.w != 4)
+            try
             {
-                throw new System.Exception();
-            }
+                InvokeCallback1((par) =>
+                {
+                    Console.WriteLine("S1: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s1);
 
-            S2 s2r = InvokeCallback2R((par) => {
-                Console.WriteLine("S2: {0}, {1}, {2}", par.x, par.y, par.z);
-                if (par.x != 1 || par.y != 2 || par.z != 3)
+                S2 s2;
+                s2.x = 1;
+                s2.y = 2;
+                s2.z = 3;
+                InvokeCallback2((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s2);
-            Console.WriteLine("S2R: {0}, {1}, {2}", s2r.x, s2r.y, s2r.z);
-            if (s2r.x != 1 || s2r.y != 2 || s2r.z != 3)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S2: {0}, {1}, {2}", par.x, par.y, par.z);
+                    if (par.x != 1 || par.y != 2 || par.z != 3)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s2);
 
-            S3 s3r = InvokeCallback3R((par) => {
-                Console.WriteLine("S3: {0}, {1}, {2}", par.x, par.y, par.z);
-                if (par.x != 1 || par.y != 2 || par.z != 3)
+                S3 s3;
+                s3.x = 1;
+                s3.y = 2;
+                s3.z = 3;
+                InvokeCallback3((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s3);
-            Console.WriteLine("S3R: {0}, {1}, {2}", s3r.x, s3r.y, s3r.z);
-            if (s3r.x != 1 || s3r.y != 2 || s3r.z != 3)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S3: {0}, {1}, {2}", par.x, par.y, par.z);
+                    if (par.x != 1 || par.y != 2 || par.z != 3)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s3);
 
-            S4 s4r = InvokeCallback4R((par) => {
-                Console.WriteLine("S4: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
+                S4 s4;
+                s4.x = 1;
+                s4.y = 2;
+                InvokeCallback4((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s4);
-            Console.WriteLine("S4R: {0}, {1}", s4r.x, s4r.y);
-            if (s4r.x != 1 || s4r.y != 2)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S4: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s4);
 
-            S5 s5r = InvokeCallback5R((par) => {
-                Console.WriteLine("S5: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
+                S5 s5;
+                s5.x = 1;
+                s5.y = 2;
+                InvokeCallback5((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s5);
-            Console.WriteLine("S5R: {0}, {1}", s5r.x, s5r.y);
-            if (s5r.x != 1 || s5r.y != 2)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S5: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s5);
 
-            S6 s6r = InvokeCallback6R((par) => {
-                Console.WriteLine("S6: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                S6 s6;
+                s6.x = 1;
+                s6.y = 2;
+                s6.z = 3;
+                s6.w = 4;
+                InvokeCallback6((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s6);
-            Console.WriteLine("S6R: {0}, {1}, {2}, {3}", s6r.x, s6r.y, s6r.z, s6r.w);
-            if (s6r.x != 1 || s6r.y != 2 || s6r.z != 3 || s6r.w != 4)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S6: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s6);
 
-            S7 s7r = InvokeCallback7R((par) => {
-                Console.WriteLine("S7: {0}, {1}, {2}", par.x, par.y, par.z);
-                if (par.x != 1 || par.y != 2 || par.z != 3)
+                S7 s7;
+                s7.x = 1;
+                s7.y = 2;
+                s7.z = 3;
+                InvokeCallback7((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s7);
-            Console.WriteLine("S7R: {0}, {1}, {2}", s7r.x, s7r.y, s7r.z);
-            if (s7r.x != 1 || s7r.y != 2 || s7r.z != 3)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S7: {0}, {1}, {2}", par.x, par.y, par.z);
+                    if (par.x != 1 || par.y != 2 || par.z != 3)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s7);
 
-            S8 s8r = InvokeCallback8R((par) => {
-                Console.WriteLine("S8: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
+                S8 s8;
+                s8.x = 1;
+                s8.y = 2;
+                InvokeCallback8((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s8);
-            Console.WriteLine("S8R: {0}, {1}", s8r.x, s8r.y);
-            if (s8r.x != 1 || s8r.y != 2)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S8: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s8);
 
-            S9 s9r = InvokeCallback9R((par) => {
-                Console.WriteLine("S9: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                S9 s9;
+                s9.x = 1;
+                s9.y = 2;
+                s9.z = 3;
+                s9.w = 4;
+                InvokeCallback9((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s9);
-            Console.WriteLine("S9R: {0}, {1}, {2}, {3}", s9r.x, s9r.y, s9r.z, s9r.w);
-            if (s9r.x != 1 || s9r.y != 2 || s9r.z != 3 || s9r.w != 4)
-            {
-                throw new System.Exception();
-            }
-            
-            S10 s10r = InvokeCallback10R((par) => {
-                Console.WriteLine("S10: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h);
-                if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
-                    par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8)
-                {
-                    throw new System.Exception();
-                }
-            }, s10);
-            Console.WriteLine("S10R: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", s10r.a, s10r.b, s10r.c, s10r.d, s10r.e, s10r.f, s10r.g, s10r.h);
-            if (s10r.a != 1 || s10r.b != 2 || s10r.c != 3 || s10r.d != 4 ||
-                s10r.e != 5 || s10r.f != 6 || s10r.g != 7 || s10r.h != 8)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S9: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s9);
 
-            S11 s11r = InvokeCallback11R((par) => {
-                Console.WriteLine("S11: {0}, {1}, {2}, {3}, {4}", par.a, par.b, par.c, par.d, par.e);
-                if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 || par.e != 5)
+                S10 s10;
+                s10.a = 1;
+                s10.b = 2;
+                s10.c = 3;
+                s10.d = 4;
+                s10.e = 5;
+                s10.f = 6;
+                s10.g = 7;
+                s10.h = 8;
+                InvokeCallback10((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s11);
-            Console.WriteLine("S11R: {0}, {1}, {2}, {3}, {4}", s11r.a, s11r.b, s11r.c, s11r.d, s11r.e);
-            if (s11r.a != 1 || s11r.b != 2 || s11r.c != 3 || s11r.d != 4 || s11r.e != 5)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S10: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h);
+                    if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
+                        par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s10);
 
-            S12 s12r = InvokeCallback12R((par) => {
-                Console.WriteLine("S12: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h, par.i);
-                if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
-                    par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8 || par.i != 9)
+                S11 s11;
+                s11.a = 1;
+                s11.b = 2;
+                s11.c = 3;
+                s11.d = 4;
+                s11.e = 5;
+                InvokeCallback11((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s12);
-            Console.WriteLine("S12R: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", s12r.a, s12r.b, s12r.c, s12r.d, s12r.e, s12r.f, s12r.g, s12r.h, s12r.i);
-            if (s12r.a != 1 || s12r.b != 2 || s12r.c != 3 || s12r.d != 4 ||
-                s12r.e != 5 || s12r.f != 6 || s12r.g != 7 || s12r.h != 8 || s12r.i != 9)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S11: {0}, {1}, {2}, {3}, {4}", par.a, par.b, par.c, par.d, par.e);
+                    if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 || par.e != 5)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s11);
 
-            S13 s13r = InvokeCallback13R((par) => {
-                Console.WriteLine("S13: {0}, {1}", par.hasValue, par.x);
-                if (par.hasValue != 1 || par.x != 2)
+                S12 s12;
+                s12.a = 1;
+                s12.b = 2;
+                s12.c = 3;
+                s12.d = 4;
+                s12.e = 5;
+                s12.f = 6;
+                s12.g = 7;
+                s12.h = 8;
+                s12.i = 9;
+                InvokeCallback12((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s13);
-            Console.WriteLine("S13R: {0}, {1}", s13r.hasValue, s13r.x);
-            if (s13r.hasValue != 1 || s13r.x != 2)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S12: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h, par.i);
+                    if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
+                        par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8 || par.i != 9)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s12);
 
-            S14 s14r = InvokeCallback14R((par) => {
-                Console.WriteLine("S14: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
+                S13 s13;
+                s13.hasValue = 1;
+                s13.x = 2;
+                InvokeCallback13((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s14);
-            Console.WriteLine("S14R: {0}, {1}", s14r.x, s14r.y);
-            if (s14r.x != 1 || s14r.y != 2)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S13: {0}, {1}", par.hasValue, par.x);
+                    if (par.hasValue != 1 || par.x != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s13);
 
-            S15 s15r = InvokeCallback15R((par) => {
-                Console.WriteLine("S15: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h, par.i);
-                if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
-                    par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8 || par.i != 9)
+                S14 s14;
+                s14.x = 1;
+                s14.y = 2;
+                InvokeCallback14((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s15);
-            Console.WriteLine("S15R: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", s15r.a, s15r.b, s15r.c, s15r.d, s15r.e, s15r.f, s15r.g, s15r.h, s15r.i);
-            if (s15r.a != 1 || s15r.b != 2 || s15r.c != 3 || s15r.d != 4 ||
-                s15r.e != 5 || s15r.f != 6 || s15r.g != 7 || s15r.h != 8 || s15r.i != 9)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S14: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s14);
 
-            S16 s16r = InvokeCallback16R((par) => {
-                Console.WriteLine("S16: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y != 2)
+                S15 s15;
+                s15.a = 1;
+                s15.b = 2;
+                s15.c = 3;
+                s15.d = 4;
+                s15.e = 5;
+                s15.f = 6;
+                s15.g = 7;
+                s15.h = 8;
+                s15.i = 9;
+                InvokeCallback15((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s16);
-            Console.WriteLine("S16R: {0}, {1}", s16r.x, s16r.y);
-            if (s16r.x != 1 || s16r.y != 2)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S15: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h, par.i);
+                    if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
+                        par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8 || par.i != 9)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s15);
 
-            S17 s17r = InvokeCallback17R((par) => {
-                Console.WriteLine("S17: {0}, {1}", par.x, par.y);
-                if (par.x != 1 || par.y!= 2)
+                S16 s16;
+                s16.x = 1;
+                s16.y = 2;
+                InvokeCallback16((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s17);
-            Console.WriteLine("S17R: {0}, {1}", s17r.x, s17r.y);
-            if (s17r.x != 1 || s17r.y != 2)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S16: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s16);
 
-            S18 s18r = InvokeCallback18R((par) => {
-                Console.WriteLine("S18: {0}, {1}, {2}", par.x, par.y, par.z);
-                if (par.x != 1 || par.y != 2 || par.z != 3)
+                S17 s17;
+                s17.x = 1;
+                s17.y = 2;
+                InvokeCallback17((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s18);
-            Console.WriteLine("S18R: {0}, {1}, {2}", s18r.x, s18r.y, s18r.z);
-            if (s18r.x != 1 || s18r.y != 2 || s18r.z != 3)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S17: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s17);
 
-            S19 s19r = InvokeCallback19R((par) => {
-                Console.WriteLine("S19: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                S18 s18;
+                s18.x = 1;
+                s18.y = 2;
+                s18.z = 3;
+                InvokeCallback18((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s19);
-            Console.WriteLine("S19R: {0}, {1}, {2}, {3}", s19r.x, s19r.y, s19r.z, s19r.w);
-            if (s19r.x != 1 || s19r.y != 2 || s19r.z != 3 || s19r.w != 4)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S18: {0}, {1}, {2}", par.x, par.y, par.z);
+                    if (par.x != 1 || par.y != 2 || par.z != 3)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s18);
 
-            S20 s20r = InvokeCallback20R((par) => {
-                Console.WriteLine("S20: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
-                if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                S19 s19;
+                s19.x = 1;
+                s19.y = 2;
+                s19.z = 3;
+                s19.w = 4;
+                InvokeCallback19((par) =>
                 {
-                    throw new System.Exception();
-                }
-            }, s20);
-            Console.WriteLine("S20R: {0}, {1}, {2}, {3}", s20r.x, s20r.y, s20r.z, s20r.w);
-            if (s20r.x != 1 || s20r.y != 2 || s20r.z != 3 || s20r.w != 4)
-            {
-                throw new System.Exception();
-            }
-/* These tests are not working on non Windows CoreCLR.  Enable this when GH Issue #2076 is resolved.
-            s28.x = null;
-            S28 s28r = InvokeCallback28R((par) => {
-                Console.WriteLine("S28: {0}, {1}", par.x == null ? "Null" : "Not null", par.y);
-                if (par.x == null || par.y != 5)
-                {
-                    throw new System.Exception();
-                }
-            }, s28);
-            Console.WriteLine("S28R: {0}, {1}", s28r.x == null ? "Null" : "Not null", s28r.y);
-            if (s28r.x == null || s28r.y != 5)
-            {
-                throw new System.Exception();
-            }
+                    Console.WriteLine("S19: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s19);
 
-            s28.x = testClass;
-            s28.y = 5;
+                S20 s20;
+                s20.x = 1;
+                s20.y = 2;
+                s20.z = 3;
+                s20.w = 4;
+                InvokeCallback20((par) =>
+                {
+                    Console.WriteLine("S20: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s20);
 
-            s28r = InvokeCallback28R((par) => {
-                Console.WriteLine("S28: {0}, {1}", par.x == null ? "Null" : "Not null", par.y);
-                if (par.x != testClass || par.y != 5)
+                /* These tests are not working on non Windows CoreCLR.  Enable this when GH Issue #2076 is resolved.
+                TestClass testClass = new TestClass();
+                S28 s28;
+                s28.x = null;
+                s28.y = 1;
+
+                InvokeCallback28((par) => {
+                    Console.WriteLine("S28: {0}, {1}", par.x == null ? "Null" : "Not null", par.y);
+                    if (par.x != null || par.y != 1)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s28);
+
+                s28.x = testClass;
+                s28.y = 5;
+
+                InvokeCallback28((par) => {
+                    Console.WriteLine("S28: {0}, {1}", par.x == null ? "Null" : "Not null", par.y);
+                    if (par.x != testClass || par.y != 5)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s28);
+
+                S29 s29;
+                s29.x = 1;
+                s29.y = null;
+
+                InvokeCallback29((par) => {
+                    Console.WriteLine("S29: {0}, {1}", par.x, par.y == null ? "Null" : "Not null");
+                    if (par.x != 1 || par.y != null)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s29);
+
+                s29.x = 5;
+                s29.y = testClass;
+
+                InvokeCallback29((par) => {
+                    Console.WriteLine("S29: {0}, {1}", par.x, par.y == null ? "Null" : "Not null");
+                    if (par.x != 5 || par.y != testClass)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s29);
+                 Enable this when GH Issue #2076 is resolved. */
+                S30 s30;
+                s30.x = 1;
+                s30.y = 2;
+
+                S30 s30_2;
+                s30_2.x = 3;
+                s30_2.y = 4;
+
+                S30 s30_3;
+                s30_3.x = 5;
+                s30_3.y = 6;
+
+                // Program p = new Program();
+                InvokeCallback30(p.Test30, s30, s30_2, s30_3);
+                S1 s1r = InvokeCallback1R((par) =>
+                {
+                    Console.WriteLine("S1: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+
+                }, s1);
+                Console.WriteLine("S1R: {0}, {1}, {2}, {3}", s1r.x, s1r.y, s1r.z, s1r.w);
+                if (s1r.x != 1 || s1r.y != 2 || s1r.z != 3 || s1r.w != 4)
                 {
                     throw new System.Exception();
                 }
-            }, s28);
-            Console.WriteLine("S28R: {0}, {1}", s28r.x == null ? "Null" : "Not null", s28r.y);
-            if (s28r.x != testClass || s28r.y != 5)
-            {
-                throw new System.Exception();
-            }
 
-            s29.y = null;
-            S29 s29r = InvokeCallback29R((par) => {
-                Console.WriteLine("S29: {0}, {1}", par.x, par.y == null ? "Null" : "Not null");
-                if (par.x != 5 || par.y == null)
+                S2 s2r = InvokeCallback2R((par) =>
+                {
+                    Console.WriteLine("S2: {0}, {1}, {2}", par.x, par.y, par.z);
+                    if (par.x != 1 || par.y != 2 || par.z != 3)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s2);
+                Console.WriteLine("S2R: {0}, {1}, {2}", s2r.x, s2r.y, s2r.z);
+                if (s2r.x != 1 || s2r.y != 2 || s2r.z != 3)
                 {
                     throw new System.Exception();
                 }
-            }, s29);
-            Console.WriteLine("S29R: {0}, {1}", s29r.x, s29r.y == null ? "Null" : "Not null");
-            if (s29r.x != 5 || s29r.y == null)
-            {
-                throw new System.Exception();
-            }
 
-            s29.x = 5;
-            s29.y = testClass;
-            s29r = InvokeCallback29R((par) => {
-                Console.WriteLine("S29: {0}, {1}", par.x, par.y == null ? "Null" : "Not null");
-                if (par.x != 5 || par.y != testClass)
+                S3 s3r = InvokeCallback3R((par) =>
+                {
+                    Console.WriteLine("S3: {0}, {1}, {2}", par.x, par.y, par.z);
+                    if (par.x != 1 || par.y != 2 || par.z != 3)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s3);
+                Console.WriteLine("S3R: {0}, {1}, {2}", s3r.x, s3r.y, s3r.z);
+                if (s3r.x != 1 || s3r.y != 2 || s3r.z != 3)
                 {
                     throw new System.Exception();
                 }
-            }, s29);            
-            Console.WriteLine("S29R: {0}, {1}", s29r.x, s29r.y == null ? "Null" : "Not null");
-            if (s29r.x != 5 || s29r.y != testClass)
-            {
-                throw new System.Exception();
+
+                S4 s4r = InvokeCallback4R((par) =>
+                {
+                    Console.WriteLine("S4: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s4);
+                Console.WriteLine("S4R: {0}, {1}", s4r.x, s4r.y);
+                if (s4r.x != 1 || s4r.y != 2)
+                {
+                    throw new System.Exception();
+                }
+
+                S5 s5r = InvokeCallback5R((par) =>
+                {
+                    Console.WriteLine("S5: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s5);
+                Console.WriteLine("S5R: {0}, {1}", s5r.x, s5r.y);
+                if (s5r.x != 1 || s5r.y != 2)
+                {
+                    throw new System.Exception();
+                }
+
+                S6 s6r = InvokeCallback6R((par) =>
+                {
+                    Console.WriteLine("S6: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s6);
+                Console.WriteLine("S6R: {0}, {1}, {2}, {3}", s6r.x, s6r.y, s6r.z, s6r.w);
+                if (s6r.x != 1 || s6r.y != 2 || s6r.z != 3 || s6r.w != 4)
+                {
+                    throw new System.Exception();
+                }
+
+                S7 s7r = InvokeCallback7R((par) =>
+                {
+                    Console.WriteLine("S7: {0}, {1}, {2}", par.x, par.y, par.z);
+                    if (par.x != 1 || par.y != 2 || par.z != 3)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s7);
+                Console.WriteLine("S7R: {0}, {1}, {2}", s7r.x, s7r.y, s7r.z);
+                if (s7r.x != 1 || s7r.y != 2 || s7r.z != 3)
+                {
+                    throw new System.Exception();
+                }
+
+                S8 s8r = InvokeCallback8R((par) =>
+                {
+                    Console.WriteLine("S8: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s8);
+                Console.WriteLine("S8R: {0}, {1}", s8r.x, s8r.y);
+                if (s8r.x != 1 || s8r.y != 2)
+                {
+                    throw new System.Exception();
+                }
+
+                S9 s9r = InvokeCallback9R((par) =>
+                {
+                    Console.WriteLine("S9: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s9);
+                Console.WriteLine("S9R: {0}, {1}, {2}, {3}", s9r.x, s9r.y, s9r.z, s9r.w);
+                if (s9r.x != 1 || s9r.y != 2 || s9r.z != 3 || s9r.w != 4)
+                {
+                    throw new System.Exception();
+                }
+
+                S10 s10r = InvokeCallback10R((par) =>
+                {
+                    Console.WriteLine("S10: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h);
+                    if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
+                        par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s10);
+                Console.WriteLine("S10R: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", s10r.a, s10r.b, s10r.c, s10r.d, s10r.e, s10r.f, s10r.g, s10r.h);
+                if (s10r.a != 1 || s10r.b != 2 || s10r.c != 3 || s10r.d != 4 ||
+                    s10r.e != 5 || s10r.f != 6 || s10r.g != 7 || s10r.h != 8)
+                {
+                    throw new System.Exception();
+                }
+
+                S11 s11r = InvokeCallback11R((par) =>
+                {
+                    Console.WriteLine("S11: {0}, {1}, {2}, {3}, {4}", par.a, par.b, par.c, par.d, par.e);
+                    if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 || par.e != 5)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s11);
+                Console.WriteLine("S11R: {0}, {1}, {2}, {3}, {4}", s11r.a, s11r.b, s11r.c, s11r.d, s11r.e);
+                if (s11r.a != 1 || s11r.b != 2 || s11r.c != 3 || s11r.d != 4 || s11r.e != 5)
+                {
+                    throw new System.Exception();
+                }
+
+                S12 s12r = InvokeCallback12R((par) =>
+                {
+                    Console.WriteLine("S12: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h, par.i);
+                    if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
+                        par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8 || par.i != 9)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s12);
+                Console.WriteLine("S12R: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", s12r.a, s12r.b, s12r.c, s12r.d, s12r.e, s12r.f, s12r.g, s12r.h, s12r.i);
+                if (s12r.a != 1 || s12r.b != 2 || s12r.c != 3 || s12r.d != 4 ||
+                    s12r.e != 5 || s12r.f != 6 || s12r.g != 7 || s12r.h != 8 || s12r.i != 9)
+                {
+                    throw new System.Exception();
+                }
+
+                S13 s13r = InvokeCallback13R((par) =>
+                {
+                    Console.WriteLine("S13: {0}, {1}", par.hasValue, par.x);
+                    if (par.hasValue != 1 || par.x != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s13);
+                Console.WriteLine("S13R: {0}, {1}", s13r.hasValue, s13r.x);
+                if (s13r.hasValue != 1 || s13r.x != 2)
+                {
+                    throw new System.Exception();
+                }
+
+                S14 s14r = InvokeCallback14R((par) =>
+                {
+                    Console.WriteLine("S14: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s14);
+                Console.WriteLine("S14R: {0}, {1}", s14r.x, s14r.y);
+                if (s14r.x != 1 || s14r.y != 2)
+                {
+                    throw new System.Exception();
+                }
+
+                S15 s15r = InvokeCallback15R((par) =>
+                {
+                    Console.WriteLine("S15: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", par.a, par.b, par.c, par.d, par.e, par.f, par.g, par.h, par.i);
+                    if (par.a != 1 || par.b != 2 || par.c != 3 || par.d != 4 ||
+                        par.e != 5 || par.f != 6 || par.g != 7 || par.h != 8 || par.i != 9)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s15);
+                Console.WriteLine("S15R: {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", s15r.a, s15r.b, s15r.c, s15r.d, s15r.e, s15r.f, s15r.g, s15r.h, s15r.i);
+                if (s15r.a != 1 || s15r.b != 2 || s15r.c != 3 || s15r.d != 4 ||
+                    s15r.e != 5 || s15r.f != 6 || s15r.g != 7 || s15r.h != 8 || s15r.i != 9)
+                {
+                    throw new System.Exception();
+                }
+
+                S16 s16r = InvokeCallback16R((par) =>
+                {
+                    Console.WriteLine("S16: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s16);
+                Console.WriteLine("S16R: {0}, {1}", s16r.x, s16r.y);
+                if (s16r.x != 1 || s16r.y != 2)
+                {
+                    throw new System.Exception();
+                }
+
+                S17 s17r = InvokeCallback17R((par) =>
+                {
+                    Console.WriteLine("S17: {0}, {1}", par.x, par.y);
+                    if (par.x != 1 || par.y != 2)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s17);
+                Console.WriteLine("S17R: {0}, {1}", s17r.x, s17r.y);
+                if (s17r.x != 1 || s17r.y != 2)
+                {
+                    throw new System.Exception();
+                }
+
+                S18 s18r = InvokeCallback18R((par) =>
+                {
+                    Console.WriteLine("S18: {0}, {1}, {2}", par.x, par.y, par.z);
+                    if (par.x != 1 || par.y != 2 || par.z != 3)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s18);
+                Console.WriteLine("S18R: {0}, {1}, {2}", s18r.x, s18r.y, s18r.z);
+                if (s18r.x != 1 || s18r.y != 2 || s18r.z != 3)
+                {
+                    throw new System.Exception();
+                }
+
+                S19 s19r = InvokeCallback19R((par) =>
+                {
+                    Console.WriteLine("S19: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s19);
+                Console.WriteLine("S19R: {0}, {1}, {2}, {3}", s19r.x, s19r.y, s19r.z, s19r.w);
+                if (s19r.x != 1 || s19r.y != 2 || s19r.z != 3 || s19r.w != 4)
+                {
+                    throw new System.Exception();
+                }
+
+                S20 s20r = InvokeCallback20R((par) =>
+                {
+                    Console.WriteLine("S20: {0}, {1}, {2}, {3}", par.x, par.y, par.z, par.w);
+                    if (par.x != 1 || par.y != 2 || par.z != 3 || par.w != 4)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s20);
+                Console.WriteLine("S20R: {0}, {1}, {2}, {3}", s20r.x, s20r.y, s20r.z, s20r.w);
+                if (s20r.x != 1 || s20r.y != 2 || s20r.z != 3 || s20r.w != 4)
+                {
+                    throw new System.Exception();
+                }
+                /* These tests are not working on non Windows CoreCLR.  Enable this when GH Issue #2076 is resolved.
+                s28.x = null;
+                S28 s28r = InvokeCallback28R((par) => {
+                    Console.WriteLine("S28: {0}, {1}", par.x == null ? "Null" : "Not null", par.y);
+                    if (par.x == null || par.y != 5)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s28);
+                Console.WriteLine("S28R: {0}, {1}", s28r.x == null ? "Null" : "Not null", s28r.y);
+                if (s28r.x == null || s28r.y != 5)
+                {
+                    throw new System.Exception();
+                }
+
+                s28.x = testClass;
+                s28.y = 5;
+
+                s28r = InvokeCallback28R((par) => {
+                    Console.WriteLine("S28: {0}, {1}", par.x == null ? "Null" : "Not null", par.y);
+                    if (par.x != testClass || par.y != 5)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s28);
+                Console.WriteLine("S28R: {0}, {1}", s28r.x == null ? "Null" : "Not null", s28r.y);
+                if (s28r.x != testClass || s28r.y != 5)
+                {
+                    throw new System.Exception();
+                }
+
+                s29.y = null;
+                S29 s29r = InvokeCallback29R((par) => {
+                    Console.WriteLine("S29: {0}, {1}", par.x, par.y == null ? "Null" : "Not null");
+                    if (par.x != 5 || par.y == null)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s29);
+                Console.WriteLine("S29R: {0}, {1}", s29r.x, s29r.y == null ? "Null" : "Not null");
+                if (s29r.x != 5 || s29r.y == null)
+                {
+                    throw new System.Exception();
+                }
+
+                s29.x = 5;
+                s29.y = testClass;
+                s29r = InvokeCallback29R((par) => {
+                    Console.WriteLine("S29: {0}, {1}", par.x, par.y == null ? "Null" : "Not null");
+                    if (par.x != 5 || par.y != testClass)
+                    {
+                        throw new System.Exception();
+                    }
+                }, s29);            
+                Console.WriteLine("S29R: {0}, {1}", s29r.x, s29r.y == null ? "Null" : "Not null");
+                if (s29r.x != 5 || s29r.y != testClass)
+                {
+                    throw new System.Exception();
+                }
+                 Enable this when GH Issue #2076 is resolved. */
             }
- Enable this when GH Issue #2076 is resolved. */
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return -1;
+            }
             return 100;
         }
         

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278375/DevDiv_278375.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278375/DevDiv_278375.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Runtime.CompilerServices;
+
+struct MyStruct
+{
+    // Struct containing 4 fields, 3 of which are longs that will be decomposed.
+    // The bug was that this resulted in 7 input registers to the GT_FIELD_LIST
+    // parameter, which can't be accommodated by the register allocator.
+
+    public MyStruct(long l1, long l2, long l3, int i)
+    {
+        f1 = l1;
+        f2 = l2;
+        f3 = l3;
+        f4 = new int[i];
+        f4[0] = i;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static MyStruct newMyStruct(long l1, long l2, long l3, int i)
+    {
+        return new MyStruct(l1, l2, l3, i);
+    }
+
+    public long f1;
+    public long f2;
+    public long f3;
+    public int[] f4;
+}
+
+struct MyStruct2
+{
+    // This is a variation that includes a double field, to ensure that a mix of
+    // field types are supported.
+    public MyStruct2(long l1, long l2, double d, int i)
+    {
+        f1 = l1;
+        f2 = l2;
+        f3 = d;
+        f4 = new int[i];
+        f4[0] = i;
+    }
+
+    public long f1;
+    public long f2;
+    public double f3;
+    public int[] f4;
+}
+
+struct MyStruct3
+{
+    // And finally one that includes longs and a double, but no ref.
+    public MyStruct3(long l1, long l2, double d, int i)
+    {
+        f1 = l1;
+        f2 = l2;
+        f3 = d;
+        f4 = i;
+    }
+
+    public long f1;
+    public long f2;
+    public double f3;
+    public int f4;
+}
+
+class Program
+{
+
+    static int Pass = 100;
+    static int Fail = -1;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int AddFields(MyStruct s)
+    {
+        return (int)(s.f1 + s.f2 + s.f3 + s.f4[0]);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int AddFields2(MyStruct2 s)
+    {
+        return (int)(s.f1 + s.f2 + (int)s.f3 + s.f4[0]);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int AddFields3(MyStruct3 s)
+    {
+        return (int)(s.f1 + s.f2 + (int)s.f3 + s.f4);
+    }
+
+    static int Main(string[] args)
+    {
+        int returnVal = Pass;
+        MyStruct s = new MyStruct(1, 2, 3, 4);
+        int sum = AddFields(s);
+        if (sum != 10)
+        {
+            Console.WriteLine("Failed first call");
+            returnVal = Fail;
+        }
+        s = MyStruct.newMyStruct(1, 2, 3, 4);
+        sum = AddFields(s);
+        if (sum != 10)
+        {
+            Console.WriteLine("Failed second call");
+            returnVal = Fail;
+        }
+        MyStruct2 s2 = new MyStruct2(1, 2, 3.0, 4);
+        sum = AddFields2(s2);
+        if (sum != 10)
+        {
+            Console.WriteLine("Failed third call");
+            returnVal = Fail;
+        }
+        MyStruct3 s3 = new MyStruct3(1, 2, 3.0, 4);
+        sum = AddFields3(s3);
+        if (sum != 10)
+        {
+            Console.WriteLine("Failed fourth call");
+            returnVal = Fail;
+        }
+        if (returnVal == Pass)
+        {
+            Console.WriteLine("Pass");
+        }
+        return returnVal;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278375/DevDiv_278375.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278375/DevDiv_278375.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_278375.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
This fixes DevDiv bug 278375, and includes a test case. It also improves the code generation for the general case of promoted structs, though tuning is still needed.
The bug was a case where, after decomposing the long fields, we had 7 entries in the GT_FIELD_LIST, each of which was requesting a register.
Since Lowering won't know which fields may be in registers, it must be prepared to handle fields in memory. Also, if the fields are not register candidates, we should make them contained and push them directly.
In most cases, we should use push for promoted structs (they are generally small-ish, and pushes of lclVars and constants are cheaper than loading into a register).
This could be optimized for consecutive float or double fields.
