### PR TITLE
Add verification of System.Globalization.Native.so symbols

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -217,6 +217,15 @@ build_coreclr()
         echo "Failed to build coreclr components."
         exit 1
     fi
+
+    echo "Verifying System.Globalization.Native.so dependencies"
+
+    ldd -r $__BinDir/System.Globalization.Native.so | awk 'BEGIN {count=0} /undefined symbol:/ { if (count==0) {print "Undefined symbol(s) found:"} print " " $3; count++ } END {if (count>0) exit(1)}'
+    if [ $? != 0 ]; then
+        echo "Failed. System.Globalization.Native.so has undefined dependencies. These are likely ICU APIs that need to be added to icushim.h"
+        exit 1
+    fi
+
 	popd
 }
 


### PR DESCRIPTION
This change adds check of undefined dependencies of the System.Globalization.Native.so
to the build.sh. The recent change that made the ICU APIs resolving driven by the
shared library itself creates a potential for someone adding usage of an ICU API that
is not defined in the icushim.h.
With this change, such problem will be caught during the build and cause it to fail.