### PR TITLE
Use memset instead of ZeroMemory

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -6924,7 +6924,7 @@ GenTreePtr Compiler::fgGetSharedCCtor(CORINFO_CLASS_HANDLE cls)
     if (opts.IsReadyToRun())
     {
         CORINFO_RESOLVED_TOKEN resolvedToken;
-        ZeroMemory(&resolvedToken, sizeof(resolvedToken));
+        memset(&resolvedToken, 0, sizeof(resolvedToken));
         resolvedToken.hClass = cls;
 
         return impReadyToRunHelperToTree(&resolvedToken, CORINFO_HELP_READYTORUN_STATIC_BASE, TYP_BYREF);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16214,7 +16214,7 @@ GenTreePtr Compiler::fgInitThisClass()
         if (opts.IsReadyToRun() && eeGetEEInfo()->targetAbi == CORINFO_CORERT_ABI)
         {
             CORINFO_RESOLVED_TOKEN resolvedToken;
-            ZeroMemory(&resolvedToken, sizeof(resolvedToken));
+            memset(&resolvedToken, 0, sizeof(resolvedToken));
 
             GenTreePtr ctxTree = getRuntimeContextTree(kind.runtimeLookupKind);
 


### PR DESCRIPTION
`CORINFO_HELP_READYTORUN_STATIC_BASE` and
`CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE` both use a mostly/fully
zeroed out `resolvedToken`, the common practice is to zero out with
`memset` in this codebase.