### PR TITLE
Inliner: Fix LegacyPolicyAssert; Dump prejit noinline reasons

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -5748,10 +5748,19 @@ void Compiler::fgFindBasicBlocks()
 
     if (compIsForInlining())
     {
-        // If fgFindJumpTargets marked this as "no return"  there really should be no BBJ_RETURN blocks in the method
-        assert((retBlocks == 0 && ((impInlineInfo->iciCall->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) ==
-                                   GTF_CALL_M_DOES_NOT_RETURN)) ||
-               (retBlocks >= 1 && ((impInlineInfo->iciCall->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) == 0)));
+
+#ifdef DEBUG
+        // If fgFindJumpTargets marked the call as "no return" there
+        // really should be no BBJ_RETURN blocks in the method.
+        //
+        // Note LegacyPolicy does not mark calls as no return, so if
+        // it's active, skip the check.
+        if (!compInlineResult->UsesLegacyPolicy())
+        {
+            bool markedNoReturn = (impInlineInfo->iciCall->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) != 0;
+            assert((markedNoReturn && (retBlocks == 0)) || (!markedNoReturn && (retBlocks >= 1)));
+        }
+#endif // DEBUG
 
         if (compInlineResult->IsFailure())
         {

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -646,10 +646,11 @@ void InlineResult::Report()
     m_Reported = true;
 
 #ifdef DEBUG
-    const char* callee = nullptr;
+    const char* callee      = nullptr;
+    const bool  showInlines = (JitConfig.JitPrintInlinedMethods() == 1);
 
     // Optionally dump the result
-    if (VERBOSE)
+    if (VERBOSE || showInlines)
     {
         const char* format = "INLINER: during '%s' result '%s' reason '%s' for '%s' calling '%s'\n";
         const char* caller = (m_Caller == nullptr) ? "n/a" : m_RootCompiler->eeGetMethodFullName(m_Caller);
@@ -689,10 +690,16 @@ void InlineResult::Report()
 
 #ifdef DEBUG
 
+            const char* obsString = InlGetObservationString(obs);
+
             if (VERBOSE)
             {
-                const char* obsString = InlGetObservationString(obs);
                 JITDUMP("\nINLINER: Marking %s as NOINLINE because of %s\n", callee, obsString);
+            }
+
+            if (showInlines)
+            {
+                printf("Marking %s as NOINLINE because of %s\n", callee, obsString);
             }
 
 #endif // DEBUG


### PR DESCRIPTION
The LegacyPolicy does not do the no-return deduction, so if it's active,
skip the validating assert in `fgFindBasicBlocks`.

When tracing inlines, dump the reason why a prejit root can't be inlined,
so it's easier to track this down later.
