### PR TITLE
Fix exception.StackTrace race condition.  Issue #12467.

### DIFF
--- a/src/debug/ee/functioninfo.cpp
+++ b/src/debug/ee/functioninfo.cpp
@@ -950,6 +950,11 @@ void DebuggerJitInfo::LazyInitBounds()
             }
             m_fAttemptInit = true;
         }
+        else
+        {
+            DeleteInteropSafe(pMap);
+            DeleteInteropSafe(pVars);
+        }
         // DebuggerDataLockHolder out of scope - release implied
     }
     EX_CATCH
@@ -968,10 +973,7 @@ void DebuggerJitInfo::SetVars(ULONG32 cVars, ICorDebugInfo::NativeVarInfo *pVars
 {
     LIMITED_METHOD_CONTRACT;
 
-    if (m_varNativeInfo)
-    {
-        return;
-    }
+    _ASSERTE(m_varNativeInfo == NULL);
 
     m_varNativeInfo = pVars;
     m_varNativeInfoCount = cVars;
@@ -1025,14 +1027,10 @@ void DebuggerJitInfo::SetBoundaries(ULONG32 cMap, ICorDebugInfo::OffsetMapping *
 
     LOG((LF_CORDB,LL_EVERYTHING, "DJI::SetBoundaries: this=0x%x cMap=0x%x pMap=0x%x\n", this, cMap, pMap));
     _ASSERTE((cMap == 0) == (pMap == NULL));
+    _ASSERTE(m_sequenceMap == NULL);
 
     if (cMap == 0)
         return;
-
-    if (m_sequenceMap)
-    {
-        return;
-    }
 
     ULONG ilLast = 0;
 #ifdef _DEBUG

--- a/src/debug/ee/functioninfo.cpp
+++ b/src/debug/ee/functioninfo.cpp
@@ -890,7 +890,6 @@ DebuggerJitInfo::~DebuggerJitInfo()
     LOG((LF_CORDB,LL_EVERYTHING, "DJI::~DJI : deleted at 0x%p\n", this));
 }
 
-
 // Lazy initialize the Debugger-Jit-Info
 void DebuggerJitInfo::LazyInitBounds()
 {
@@ -903,31 +902,28 @@ void DebuggerJitInfo::LazyInitBounds()
         PRECONDITION(!g_pDebugger->HasDebuggerDataLock());
     } CONTRACTL_END;
 
-    //@todo: this method is not synchronized. Mei-chin's recent work should cover this one
+    LOG((LF_CORDB, LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%x m_fAttemptInit %s\n", this, m_fAttemptInit == true ? "true": "false"));
+
     // Only attempt lazy-init once
-    // new LOG message
-    LOG((LF_CORDB,LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%x m_fAttemptInit %s\n", this, m_fAttemptInit == true? "true": "false"));
     if (m_fAttemptInit)
     {
         return;
     }
-    m_fAttemptInit = true;
 
     EX_TRY
     {
-        LOG((LF_CORDB,LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%x Initing\n", this));
+        LOG((LF_CORDB, LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%x Initing\n", this));
+
         // Should have already been jitted
         _ASSERTE(this->m_jitComplete);
 
         MethodDesc * mdesc = this->m_fd;
-
         DebugInfoRequest request;
 
         _ASSERTE(this->m_addrOfCode != NULL); // must have address to disambguate the Enc cases.
         // Caller already resolved generics when they craeted the DJI, so we don't need to repeat.
         // Note the MethodDesc may not yet have the jitted info, so we'll also use the starting address we got in the jit complete callback.
         request.InitFromStartingAddr(mdesc, (PCODE)this->m_addrOfCode);
-
 
         // Bounds info.
         ULONG32 cMap = 0;
@@ -940,12 +936,21 @@ void DebuggerJitInfo::LazyInitBounds()
             InteropSafeNew, NULL, // allocator
             &cMap, &pMap,
             &cVars, &pVars);
+
         LOG((LF_CORDB,LL_EVERYTHING, "DJI::LazyInitBounds: this=0x%x GetBoundariesAndVars success=0x%x\n", this, fSuccess));
-        if (fSuccess)
+
+        Debugger::DebuggerDataLockHolder debuggerDataLockHolder(g_pDebugger);
+
+        if (!m_fAttemptInit)
         {
-            this->SetBoundaries(cMap, pMap);
-            this->SetVars(cVars, pVars);
+            if (fSuccess)
+            {
+                this->SetBoundaries(cMap, pMap);
+                this->SetVars(cVars, pVars);
+            }
+            m_fAttemptInit = true;
         }
+        // DebuggerDataLockHolder out of scope - release implied
     }
     EX_CATCH
     {


### PR DESCRIPTION
There was a race in DebuggerJitInfo::LazyInitBounds causing the native offset to il offset lookup to fail/return 0 when multiple threads are trying to get the il offset of the same function for an exception's stack trace,

The fix is to protect LazyInitBounds with a crst.  I chose the debugger data lock (CrstDebuggerJitInfo) because it seemed at the right level and convenient. The lock is around the code that sets the various DebuggerJitInfo members and the init flag (m_fAttemptInit) and not around the whole function to minimalize the code called holding the lock (especially not calling GetBoundariesAndVars holding the lock which is in the jit). The code in the SetBoundaries function does call other locks but they are lower level than the debugger data lock and shouldn't cause any problems.

Not having the lock around the check of m_fAttemptInit at the beginning of the function may allow multiple threads race to get the boundary info but only one thread now will set it. 