### PR TITLE
Fix conversion from CorJitFlag2 enum to JitFlag.

### DIFF
--- a/src/jit/jitee.h
+++ b/src/jit/jitee.h
@@ -137,7 +137,7 @@ public:
     if ((corJitFlags & (oldf)) != 0)                                                                                   \
         this->Set(JitFlags::newf);
 #define CONVERT_OLD_FLAG2(oldf, newf)                                                                                  \
-    if ((corJitFlags & (oldf)) != 0)                                                                                   \
+    if ((corJitFlags2 & (oldf)) != 0)                                                                                  \
         this->Set(JitFlags::newf);
 
         CONVERT_OLD_FLAG(CORJIT_FLG_SPEED_OPT, JIT_FLAG_SPEED_OPT)


### PR DESCRIPTION
It looks like #7837 had a copy and paste error in the JitFlags class it introduced. The method SetFromOldFlags defines the macros CONVERT_OLD_FLAG and CONVERT_OLD_FLAG2 identically and ignores the corJitFlags2 parameter.
This commit changes CONVERT_OLD_FLAG2 to compare flags against the corJitFlags2 parameter.