### PR TITLE
Initial RyuJIT x86 SIMD support

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -8,8 +8,8 @@ include_directories("../inc")
 # add_definitions(-DALT_JIT)
 
 if (CLR_CMAKE_TARGET_ARCH_AMD64)
-  add_definitions(-DFEATURE_SIMD) 
-  add_definitions(-DFEATURE_AVX_SUPPORT) 
+  add_definitions(-DFEATURE_SIMD)
+  add_definitions(-DFEATURE_AVX_SUPPORT)
 endif ()
 
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -3395,7 +3395,7 @@ void CodeGen::genStructPutArgRepMovs(GenTreePutArgStk* putArgNode)
 // must be cleared to zeroes. The native compiler doesn't clear the upper bits
 // and there is no way to know if the caller is native or not. So, the upper
 // 32 bits of Vector argument on stack are always cleared to zero.
-#ifdef FEATURE_SIMD
+#if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING) && defined(FEATURE_SIMD)
 void CodeGen::genClearStackVec3ArgUpperBits()
 {
 #ifdef DEBUG
@@ -3439,7 +3439,7 @@ void CodeGen::genClearStackVec3ArgUpperBits()
         }
     }
 }
-#endif // FEATURE_SIMD
+#endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING) && defined(FEATURE_SIMD)
 #endif // FEATURE_PUT_STRUCT_ARG_STK
 
 // Generate code for CpObj nodes wich copy structs that have interleaved

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2274,7 +2274,7 @@ void Compiler::compSetProcessor()
 #if defined(_TARGET_ARM_)
     info.genCPU = CPU_ARM;
 #elif defined(_TARGET_AMD64_)
-    info.genCPU = CPU_X64;
+    info.genCPU         = CPU_X64;
 #elif defined(_TARGET_X86_)
     if (jitFlags.IsSet(JitFlags::JIT_FLAG_TARGET_P4))
         info.genCPU = CPU_X86_PENTIUM_4;
@@ -2287,11 +2287,7 @@ void Compiler::compSetProcessor()
     //
     CLANG_FORMAT_COMMENT_ANCHOR;
 
-#ifdef _TARGET_AMD64_
-    opts.compUseFCOMI   = false;
-    opts.compUseCMOV    = true;
-    opts.compCanUseSSE2 = true;
-
+#ifdef _TARGET_XARCH_
 #ifdef FEATURE_AVX_SUPPORT
     // COMPlus_EnableAVX can be used to disable using AVX if available on a target machine.
     // Note that FEATURE_AVX_SUPPORT is not enabled for ctpjit
@@ -2307,10 +2303,14 @@ void Compiler::compSetProcessor()
             }
         }
     }
-#endif
-#endif //_TARGET_AMD64_
+#endif // FEATURE_AVX_SUPPORT
+#endif // _TARGET_XARCH_
 
-#ifdef _TARGET_X86_
+#ifdef _TARGET_AMD64_
+    opts.compUseFCOMI   = false;
+    opts.compUseCMOV    = true;
+    opts.compCanUseSSE2 = true;
+#elif defined(_TARGET_X86_)
     opts.compUseFCOMI   = jitFlags.IsSet(JitFlags::JIT_FLAG_USE_FCOMI);
     opts.compUseCMOV    = jitFlags.IsSet(JitFlags::JIT_FLAG_USE_CMOV);
     opts.compCanUseSSE2 = jitFlags.IsSet(JitFlags::JIT_FLAG_USE_SSE2);
@@ -2981,10 +2981,8 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 #endif // DEBUG
 
 #ifdef FEATURE_SIMD
-#ifdef _TARGET_AMD64_
-    // Minimum bar for availing SIMD benefits is SSE2 on AMD64.
+    // Minimum bar for availing SIMD benefits is SSE2 on AMD64/x86.
     featureSIMD = jitFlags->IsSet(JitFlags::JIT_FLAG_FEATURE_SIMD);
-#endif // _TARGET_AMD64_
 #endif // FEATURE_SIMD
 
     if (compIsForInlining() || compIsForImportOnly())

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7113,7 +7113,7 @@ private:
     // and small int base type vectors.
     SIMDIntrinsicID impSIMDIntegralRelOpGreaterThanOrEqual(
         CORINFO_CLASS_HANDLE typeHnd, unsigned simdVectorSize, var_types baseType, GenTree** op1, GenTree** op2);
-#endif // defined(_TARGET_AMD64_) && !defined(LEGACY_BACKEND)
+#endif // defined(_TARGET_XARCH_) && !defined(LEGACY_BACKEND)
 
     void setLclRelatedToSIMDIntrinsic(GenTreePtr tree);
     bool areFieldsContiguous(GenTreePtr op1, GenTreePtr op2);
@@ -7446,8 +7446,8 @@ public:
 
 #ifdef FEATURE_AVX_SUPPORT
         bool compCanUseAVX; // Allow CodeGen to use AVX 256-bit vectors for SIMD operations
-#endif
-#endif
+#endif                      // FEATURE_AVX_SUPPORT
+#endif                      // _TARGET_XARCH_
 
 // optimize maximally and/or favor speed over size?
 

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -401,7 +401,8 @@ unsigned CILJit::getMaxIntrinsicSIMDVectorLength(DWORD cpuCompileFlags)
     jitFlags.SetFromOldFlags(cpuCompileFlags, 0);
 #endif // COR_JIT_EE_VERSION <= 460
 
-#ifdef _TARGET_AMD64_
+#ifdef FEATURE_SIMD
+#ifdef _TARGET_XARCH_
 #ifdef FEATURE_AVX_SUPPORT
     if (!jitFlags.IsSet(JitFlags::JIT_FLAG_PREJIT) && jitFlags.IsSet(JitFlags::JIT_FLAG_FEATURE_SIMD) &&
         jitFlags.IsSet(JitFlags::JIT_FLAG_USE_AVX2))
@@ -413,9 +414,10 @@ unsigned CILJit::getMaxIntrinsicSIMDVectorLength(DWORD cpuCompileFlags)
     }
 #endif // FEATURE_AVX_SUPPORT
     return 16;
-#else  // !_TARGET_AMD64_
+#endif // _TARGET_XARCH_
+#else  // !FEATURE_SIMD
     return 0;
-#endif // !_TARGET_AMD64_
+#endif // !FEATURE_SIMD
 }
 
 void CILJit::setRealJit(ICorJitCompiler* realJitCompiler)

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -382,6 +382,8 @@ size_t emitter::AddRexPrefix(instruction ins, size_t code)
     return code | 0x4000000000ULL;
 }
 
+#endif //_TARGET_AMD64_
+
 bool isPrefix(BYTE b)
 {
     assert(b != 0);    // Caller should check this
@@ -398,8 +400,6 @@ bool isPrefix(BYTE b)
     //      Scalar Double  Scalar Single  Packed Double
     return ((b == 0xF2) || (b == 0xF3) || (b == 0x66));
 }
-
-#endif //_TARGET_AMD64_
 
 // Outputs VEX prefix (in case of AVX instructions) and REX.R/X/W/B otherwise.
 unsigned emitter::emitOutputRexOrVexPrefixIfNeeded(instruction ins, BYTE* dst, size_t& code)
@@ -3483,7 +3483,7 @@ void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t
         sz += emitGetRexPrefixSize(ins);
     }
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && defined(LEGACY_BACKEND)
     assert(reg < 8);
 #endif
 

--- a/src/jit/protojit/CMakeLists.txt
+++ b/src/jit/protojit/CMakeLists.txt
@@ -6,6 +6,12 @@ add_definitions(-DSELF_NO_HOST)
 add_definitions(-DFEATURE_READYTORUN_COMPILER)
 remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
+# Enable SIMD support for RyuJIT/x86.
+if (CLR_CMAKE_PLATFORM_ARCH_I386)
+  add_definitions(-DFEATURE_SIMD)
+  add_definitions(-DFEATURE_AVX_SUPPORT)
+endif (CLR_CMAKE_PLATFORM_ARCH_I386)
+
 add_library_clr(protojit
    SHARED
    ${SHARED_LIB_SOURCES}

--- a/src/jit/simd.h
+++ b/src/jit/simd.h
@@ -29,14 +29,14 @@ struct SIMDIntrinsicInfo
     var_types       supportedBaseTypes[SIMD_INTRINSIC_MAX_BASETYPE_COUNT];
 };
 
-#ifdef _TARGET_AMD64_
+#ifdef _TARGET_XARCH_
 // SSE2 Shuffle control byte to shuffle vector <W, Z, Y, X>
 // These correspond to shuffle immediate byte in shufps SSE2 instruction.
 #define SHUFFLE_XXXX 0x00
 #define SHUFFLE_ZWYX 0xB1
 #define SHUFFLE_WWYY 0xF5
 #define SHUFFLE_ZZXX 0xA0
-#endif
+#endif // _TARGET_XARCH_
 
 #endif // FEATURE_SIMD
 

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -17,7 +17,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 #ifndef LEGACY_BACKEND // This file is ONLY used for the RyuJIT backend that uses the linear scan register allocator.
 
-#ifdef _TARGET_AMD64_
+#ifdef _TARGET_XARCH_
 #include "emit.h"
 #include "codegen.h"
 #include "sideeffects.h"
@@ -2240,5 +2240,5 @@ void CodeGen::genSIMDIntrinsic(GenTreeSIMD* simdNode)
 }
 
 #endif // FEATURE_SIMD
-#endif //_TARGET_AMD64_
+#endif //_TARGET_XARCH_
 #endif // !LEGACY_BACKEND

--- a/src/jit/simdintrinsiclist.h
+++ b/src/jit/simdintrinsiclist.h
@@ -20,7 +20,7 @@
             e) TODO-Cleanup: when we plumb TYP_SIMD through front-end, replace TYP_STRUCT with TYP_SIMD.
      */
 
-#ifdef _TARGET_AMD64_
+#ifdef _TARGET_XARCH_
 
 // Max number of parameters that we model in the table for SIMD intrinsic methods.
 #define SIMD_INTRINSIC_MAX_MODELED_PARAM_COUNT       3
@@ -138,9 +138,9 @@ SIMD_INTRINSIC("UpperRestore",              false,       UpperRestore,          
 SIMD_INTRINSIC(nullptr,                     false,       Invalid,                  "Invalid",                TYP_UNDEF,      0,      {TYP_UNDEF,  TYP_UNDEF,  TYP_UNDEF},   {TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF, TYP_UNDEF})
 #undef SIMD_INTRINSIC
 
-#else //_TARGET_AMD64_
+#else //_TARGET_XARCH_
 #error SIMD intrinsics not defined for target arch
-#endif //!_TARGET_AMD64_
+#endif //!_TARGET_XARCH_
 
 #endif //FEATURE_SIMD
 // clang-format on

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -1218,7 +1218,7 @@ BOOL MethodTableBuilder::CheckIfSIMDAndUpdateSize()
 {
     STANDARD_VM_CONTRACT;
 
-#ifdef _TARGET_AMD64_
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
     if (!GetAssembly()->IsSIMDVectorAssembly())
         return false;
 
@@ -1262,7 +1262,7 @@ BOOL MethodTableBuilder::CheckIfSIMDAndUpdateSize()
         }
     }
 #endif // !CROSSGEN_COMPILE
-#endif // _TARGET_AMD64_
+#endif // defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
     return false;
 }
 


### PR DESCRIPTION
This changes adds initial SIMD support for RyuJIT x86. It is not enabled by default, as COMPlus_FeatureSIMD and COMPlus_EnableAVX are still zero (false) by default.

While many tests do run correctly with SIMD intrinsics enabled, there are a number of known issues, including #7860, #7862, #7863.
