### PR TITLE
Add missing std::move to one exception throw

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4730,7 +4730,7 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
         }
     }
 
-    throw ex;
+    throw std::move(ex);
 }
 
 #ifdef _AMD64_


### PR DESCRIPTION
We had the std::move missing in one of the exception throws. For some reason,
the current clang didn't complain about it even though the copy constructor was
deleted. Discovered when attempting to compile with clang 3.9.