### PR TITLE
Do not use FP registers when soft-fp ABI is used

### DIFF
--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -1341,11 +1341,15 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ComputeReturnFlags()
         break;
 
     case ELEMENT_TYPE_R4:
+#ifndef ARM_SOFTFP
         flags |= sizeof(float) << RETURN_FP_SIZE_SHIFT;
+#endif
         break;
 
     case ELEMENT_TYPE_R8:
+#ifndef ARM_SOFTFP
         flags |= sizeof(double) << RETURN_FP_SIZE_SHIFT;
+#endif
         break;
 
     case ELEMENT_TYPE_VALUETYPE:


### PR DESCRIPTION
Soft FP ABI enforces a return value to be passed via integer registers
even though it is of float/double type (which means that 'r0 ~ r4' should
be preseved even for functions that return a float/double value).

The current implement of 'HasFloatRegister' and 'GetFPReturnSize' does
not consider this ABI difference, which makes 'CallDescrWorkerInternal'
function to preserve FP registers instead of 'r0 ~ r4' (and spoils
'r0/r1' during preservation), which leads to #7868.

This commit revises these functions in order to fix #7868.
