### PR TITLE
Memory growth algorithm improvement in coreconsole

### DIFF
--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -44,8 +44,8 @@ public:
             m_buffer = new wchar_t[m_defaultSize];
             m_capacity = m_defaultSize;
         }
-        while (m_length + strLen + 1 > m_capacity) {
-            size_t newCapacity = m_capacity * 3 / 2;
+        if (m_length + strLen + 1 > m_capacity) {
+            size_t newCapacity = (m_length + strLen + 1) * 2;
             wchar_t* newBuffer = new wchar_t[newCapacity];
             wcsncpy_s(newBuffer, newCapacity, m_buffer, m_length);
             delete[] m_buffer;

--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -45,7 +45,7 @@ public:
             m_capacity = m_defaultSize;
         }
         while (m_length + strLen + 1 > m_capacity) {
-            size_t newCapacity = m_capacity * 1.5f;
+            size_t newCapacity = m_capacity * 3 / 2;
             wchar_t* newBuffer = new wchar_t[newCapacity];
             wcsncpy_s(newBuffer, newCapacity, m_buffer, m_length);
             delete[] m_buffer;

--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -44,8 +44,8 @@ public:
             m_buffer = new wchar_t[m_defaultSize];
             m_capacity = m_defaultSize;
         }
-        if (m_length + strLen + 1 > m_capacity) {
-            size_t newCapacity = m_capacity * 2;
+        while (m_length + strLen + 1 > m_capacity) {
+            size_t newCapacity = m_capacity * 1.5f;
             wchar_t* newBuffer = new wchar_t[newCapacity];
             wcsncpy_s(newBuffer, newCapacity, m_buffer, m_length);
             delete[] m_buffer;


### PR DESCRIPTION
In my version _Append_ will work properly if _strLen_ is **very** big (for example 3*_m_capacity_). And I used value _1.5_ as memory growth factor because it is better (strictly speaking because 2 is the worst value).
Please not that I didn't change program logic in this commit. I've just changed the way how new value is computed. I made this code rock-solid and invulnerable to big input.
