### PR TITLE
Ensure the module slot in R2R image can be located

### DIFF
--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -447,9 +447,7 @@ static bool AcquireImage(Module * pModule, PEImageLayout * pLayout, READYTORUN_H
         }
     }
 
-    // Some Ready-to-Run images have no code (e.g., facade assemblies), and don't have Module import.
-    // If we reach here, just accept the image.
-    return true;
+    return false;
 }
 
 PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker *pamTracker)

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -291,6 +291,12 @@ void ZapImage::InitializeSectionsForReadyToRun()
     // Always allocate slot for module - it is used to determine that the image is used
     //
     m_pImportTable->GetPlacedHelperImport(READYTORUN_HELPER_Module);
+
+    //
+    // Make sure the import sections table is in the image, so we can find the slot for module
+    //
+    _ASSERTE(m_pImportSectionsTable->GetSize() != 0);
+    GetReadyToRunHeader()->RegisterSection(READYTORUN_SECTION_IMPORT_SECTIONS, m_pImportSectionsTable);
 }
 #endif // FEATURE_READYTORUN_COMPILER
 

--- a/src/zap/zapreadytorun.cpp
+++ b/src/zap/zapreadytorun.cpp
@@ -291,9 +291,6 @@ void ZapImage::OutputEntrypointsTableForReadyToRun()
     pReadyToRunHeader->RegisterSection(READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS, pHashtableBlob);
     pReadyToRunHeader->RegisterSection(READYTORUN_SECTION_RUNTIME_FUNCTIONS, m_pRuntimeFunctionSection);
 
-    if (m_pImportSectionsTable->GetSize() != 0)
-        pReadyToRunHeader->RegisterSection(READYTORUN_SECTION_IMPORT_SECTIONS, m_pImportSectionsTable);
-
     if (m_pLazyMethodCallHelperSection->GetNodeCount() != 0)
         pReadyToRunHeader->RegisterSection(READYTORUN_SECTION_DELAYLOAD_METHODCALL_THUNKS, m_pLazyMethodCallHelperSection);
 


### PR DESCRIPTION
Each Ready-to-Run image has a slot for storing a pointer to the Module
object associated with this image. However, if the image contains no
code (e.g., facade assemblies), the import table needed to locate
this slot wasn't written out, so the runtime couldn't find this slot.
This casued "crossgen /createpdb" command to fail on facade assemblies
after PR #7809, and required a workaround (commit c4d8994).

This commit ensures writing the import table needed to locate the
slot for module. It also removes the workaround in commit c4d8994,
which is no longer necessary.