### PR TITLE
Abstract `gtRegNum` into RegAt{Def,Use}.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1422,11 +1422,11 @@ TempDsc* CodeGenInterface::getSpillTempDsc(GenTree* tree)
 
     // Get the tree's SpillDsc.
     RegSet::SpillDsc* prevDsc;
-    RegSet::SpillDsc* spillDsc = regSet.rsGetSpillInfo(tree, tree->gtRegNum, &prevDsc);
+    RegSet::SpillDsc* spillDsc = regSet.rsGetSpillInfo(tree, tree->RegAtDef(), &prevDsc);
     assert(spillDsc != nullptr);
 
     // Get the temp desc.
-    TempDsc* temp = regSet.rsGetSpillTempWord(tree->gtRegNum, spillDsc, prevDsc);
+    TempDsc* temp = regSet.rsGetSpillTempWord(tree->RegAtDef(), spillDsc, prevDsc);
     return temp;
 }
 

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -311,10 +311,6 @@ public:
 
 #endif // FEATURE_STACK_FP_X87
 
-#ifndef LEGACY_BACKEND
-    regNumber genGetAssignedReg(GenTreePtr tree);
-#endif // !LEGACY_BACKEND
-
 #ifdef LEGACY_BACKEND
     // Changes GT_LCL_VAR nodes to GT_REG_VAR nodes if possible.
     bool genMarkLclVar(GenTreePtr tree);

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2812,7 +2812,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     {
         lclField = src->AsLclFld();
     }
-    else if (dst->isLclField() && dst->gtRegNum == REG_NA)
+    else if (dst->isLclField() && dst->RegAtUse() == REG_NA)
     {
         lclField = dst->AsLclFld();
     }
@@ -2927,7 +2927,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
         }
         else // The memory op is in the dest position.
         {
-            assert(dst->gtRegNum == REG_NA || dst->IsRegOptional());
+            assert(dst->RegAtUse() == REG_NA);
 
             // src could be int or reg
             if (src->isContainedIntOrIImmed())
@@ -2950,7 +2950,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
             emitComp->tmpRlsTemp(tmpDsc);
         }
 
-        return dst->gtRegNum;
+        return dst->RegAtUse();
     }
 
     // Now we are left with only the cases where the instruction has some kind of a memory operand
@@ -2993,7 +2993,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
             }
         }
 
-        return dst->gtRegNum;
+        return dst->RegAtUse();
     }
 
     // Finally we handle addressing modes case [regBase + regIndex*scale + const]
@@ -3083,7 +3083,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     regNumber result = REG_NA;
     if (src == mem)
     {
-        result = dst->gtRegNum;
+        result = dst->RegAtUse();
     }
 
     id->idCodeSize(sz);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1698,7 +1698,7 @@ bool GenTree::gtHasReg() const
         }
         else
         {
-            hasReg = (gtRegNum != REG_NA);
+            hasReg = (GetRawRegNum() != REG_NA);
         }
     }
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -603,7 +603,7 @@ public:
         return (isContained() && isMemoryOp()) || isContainedLclVar() || isContainedSpillTemp();
     }
 
-    regNumber GetRegNum() const
+    regNumber GetRawRegNum() const
     {
         assert((gtRegTag == GT_REGTAG_REG) || (gtRegTag == GT_REGTAG_NONE)); // TODO-Cleanup: get rid of the NONE case,
                                                                              // and fix everyplace that reads undefined
@@ -613,6 +613,12 @@ public:
                                                // undefined values
                (reg >= REG_FIRST && reg <= REG_COUNT));
         return reg;
+    }
+
+    regNumber GetRegNum() const
+    {
+        assert((gtRegTag == GT_REGTAG_NONE) || !isContained());
+        return GetRawRegNum();
     }
 
     void SetRegNum(regNumber reg)
@@ -1746,6 +1752,15 @@ public:
     // a local variable; sets "*pLclVarTree" to that local variable instance; and, if "pIsEntire" is non-null,
     // sets "*pIsEntire" to true if this assignment writes the full width of the local.
     bool DefinesLocalAddr(Compiler* comp, unsigned width, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire);
+
+    regNumber RegAtDef() const
+    {
+        return GetRawRegNum();
+    }
+    regNumber RegAtUse() const
+    {
+        return isContained() ? REG_NA : GetRawRegNum();
+    }
 
     bool IsRegVar() const
     {
@@ -3035,7 +3050,7 @@ struct GenTreeCall final : public GenTree
 
         if (idx == 0)
         {
-            return gtRegNum;
+            return GetRawRegNum();
         }
 
 #if FEATURE_MULTIREG_RET

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -9697,7 +9697,7 @@ void TreeNodeInfo::Initialize(LinearScan* lsra, GenTree* node, LsraLocation loca
     // if there is a reg indicated on the tree node, use that for dstCandidates
     // the exception is the NOP, which sometimes show up around late args.
     // TODO-Cleanup: get rid of those NOPs.
-    if (node->gtRegNum == REG_NA || node->gtOper == GT_NOP)
+    if (node->GetRawRegNum() == REG_NA || node->gtOper == GT_NOP)
     {
         dstCandidates = lsra->allRegs(node->TypeGet());
     }

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -592,7 +592,7 @@ void CodeGen::genSIMDIntrinsicInit(GenTreeSIMD* simdNode)
 
     GenTree*  op1       = simdNode->gtGetOp1();
     var_types baseType  = simdNode->gtSIMDBaseType;
-    regNumber targetReg = simdNode->gtRegNum;
+    regNumber targetReg = simdNode->RegAtDef();
     assert(targetReg != REG_NA);
     var_types      targetType = simdNode->TypeGet();
     InstructionSet iset       = compiler->getSIMDInstructionSet();
@@ -734,7 +734,7 @@ void CodeGen::genSIMDIntrinsicInitN(GenTreeSIMD* simdNode)
     var_types baseType = simdNode->gtSIMDBaseType;
     noway_assert(baseType == TYP_FLOAT);
 
-    regNumber targetReg = simdNode->gtRegNum;
+    regNumber targetReg = simdNode->RegAtDef();
     assert(targetReg != REG_NA);
 
     var_types targetType = simdNode->TypeGet();
@@ -816,7 +816,7 @@ void CodeGen::genSIMDIntrinsicUnOp(GenTreeSIMD* simdNode)
 
     GenTree*  op1       = simdNode->gtGetOp1();
     var_types baseType  = simdNode->gtSIMDBaseType;
-    regNumber targetReg = simdNode->gtRegNum;
+    regNumber targetReg = simdNode->RegAtDef();
     assert(targetReg != REG_NA);
     var_types targetType = simdNode->TypeGet();
 
@@ -852,7 +852,7 @@ void CodeGen::genSIMDIntrinsicBinOp(GenTreeSIMD* simdNode)
     GenTree*  op1       = simdNode->gtGetOp1();
     GenTree*  op2       = simdNode->gtGetOp2();
     var_types baseType  = simdNode->gtSIMDBaseType;
-    regNumber targetReg = simdNode->gtRegNum;
+    regNumber targetReg = simdNode->RegAtDef();
     assert(targetReg != REG_NA);
     var_types      targetType = simdNode->TypeGet();
     InstructionSet iset       = compiler->getSIMDInstructionSet();
@@ -1036,13 +1036,13 @@ void CodeGen::genSIMDIntrinsicRelOp(GenTreeSIMD* simdNode)
     GenTree*       op1        = simdNode->gtGetOp1();
     GenTree*       op2        = simdNode->gtGetOp2();
     var_types      baseType   = simdNode->gtSIMDBaseType;
-    regNumber      targetReg  = simdNode->gtRegNum;
+    regNumber      targetReg  = simdNode->RegAtDef();
     var_types      targetType = simdNode->TypeGet();
     InstructionSet iset       = compiler->getSIMDInstructionSet();
 
     genConsumeOperands(simdNode);
     regNumber op1Reg   = op1->gtRegNum;
-    regNumber op2Reg   = op2->gtRegNum;
+    regNumber op2Reg   = op2->RegAtUse();
     regNumber otherReg = op2Reg;
 
     switch (simdNode->gtSIMDIntrinsicID)
@@ -1300,7 +1300,7 @@ void CodeGen::genSIMDIntrinsicDotProduct(GenTreeSIMD* simdNode)
         simdType = TYP_SIMD8;
     }
     var_types simdEvalType = (simdType == TYP_SIMD12) ? TYP_SIMD16 : simdType;
-    regNumber targetReg    = simdNode->gtRegNum;
+    regNumber targetReg    = simdNode->RegAtDef();
     assert(targetReg != REG_NA);
 
     var_types targetType = simdNode->TypeGet();
@@ -1526,7 +1526,7 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
     }
 
     var_types baseType  = simdNode->gtSIMDBaseType;
-    regNumber targetReg = simdNode->gtRegNum;
+    regNumber targetReg = simdNode->RegAtDef();
     assert(targetReg != REG_NA);
     var_types targetType = simdNode->TypeGet();
     assert(targetType == genActualType(baseType));
@@ -1535,7 +1535,7 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
     // - the source of SIMD type (op1)
     // - the index of the value to be returned.
     genConsumeOperands(simdNode);
-    regNumber srcReg = op1->gtRegNum;
+    regNumber srcReg = op1->RegAtUse();
 
     // Optimize the case of op1 is in memory and trying to access ith element.
     if (op1->isMemoryOp())
@@ -1813,7 +1813,7 @@ void CodeGen::genSIMDIntrinsicSetItem(GenTreeSIMD* simdNode)
     GenTree* op2 = simdNode->gtGetOp2();
 
     var_types baseType  = simdNode->gtSIMDBaseType;
-    regNumber targetReg = simdNode->gtRegNum;
+    regNumber targetReg = simdNode->RegAtDef();
     assert(targetReg != REG_NA);
     var_types targetType = simdNode->TypeGet();
     assert(varTypeIsSIMD(targetType));
@@ -1890,7 +1890,7 @@ void CodeGen::genSIMDIntrinsicShuffleSSE2(GenTreeSIMD* simdNode)
     int       shuffleControl = (int)op2->AsIntConCommon()->IconValue();
     var_types baseType       = simdNode->gtSIMDBaseType;
     var_types targetType     = simdNode->TypeGet();
-    regNumber targetReg      = simdNode->gtRegNum;
+    regNumber targetReg      = simdNode->RegAtDef();
     assert(targetReg != REG_NA);
 
     regNumber op1Reg = genConsumeReg(op1);
@@ -1966,7 +1966,7 @@ void CodeGen::genLoadIndTypeSIMD12(GenTree* treeNode)
 {
     assert(treeNode->OperGet() == GT_IND);
 
-    regNumber  targetReg = treeNode->gtRegNum;
+    regNumber  targetReg = treeNode->RegAtDef();
     GenTreePtr op1       = treeNode->gtOp.gtOp1;
     assert(!op1->isContained());
     regNumber operandReg = genConsumeReg(op1);
@@ -2043,7 +2043,7 @@ void CodeGen::genLoadLclFldTypeSIMD12(GenTree* treeNode)
 {
     assert(treeNode->OperGet() == GT_LCL_FLD);
 
-    regNumber targetReg = treeNode->gtRegNum;
+    regNumber targetReg = treeNode->RegAtDef();
     unsigned  offs      = treeNode->gtLclFld.gtLclOffs;
     unsigned  varNum    = treeNode->gtLclVarCommon.gtLclNum;
     assert(varNum < compiler->lvaCount);
@@ -2093,7 +2093,7 @@ void CodeGen::genSIMDIntrinsicUpperSave(GenTreeSIMD* simdNode)
 
     GenTree* op1 = simdNode->gtGetOp1();
     assert(op1->IsLocal() && op1->TypeGet() == TYP_SIMD32);
-    regNumber targetReg = simdNode->gtRegNum;
+    regNumber targetReg = simdNode->RegAtDef();
     regNumber op1Reg    = genConsumeReg(op1);
     assert(op1Reg != REG_NA);
     assert(targetReg != REG_NA);
@@ -2129,7 +2129,7 @@ void CodeGen::genSIMDIntrinsicUpperRestore(GenTreeSIMD* simdNode)
 
     GenTree* op1 = simdNode->gtGetOp1();
     assert(op1->IsLocal() && op1->TypeGet() == TYP_SIMD32);
-    regNumber srcReg    = simdNode->gtRegNum;
+    regNumber srcReg    = simdNode->RegAtDef();
     regNumber lclVarReg = genConsumeReg(op1);
     unsigned  varNum    = op1->AsLclVarCommon()->gtLclNum;
     assert(lclVarReg != REG_NA);

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.cs
@@ -1,0 +1,36 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// NOTE: the bug for this test was an assertion in RyuJIT/x86 when generating code for a double-returning call that
+//       was spilled by the RA and subsequently used. The call in question is the call to `C.GetDouble` in `C.Test`.
+//       To ensure that its return value is spilled, `C.GetDouble` is implemented as a P/Invoke method: the return
+//       value ends up spilled because there is a call to `TrapReturningThreads` between the call and the use of the
+//       return value by the cast. Because the bug is a simple assert, there is no need for the problematic code to
+//       actually run, so the implementation of `GetDouble` does not need to actually exist.
+
+sealed class C
+{
+    [DllImport("nonexistent.dll")]
+    extern static double GetDouble();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void UseDouble(double d)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test(bool condition)
+    {
+        if (condition)
+        {
+            UseDouble((double)GetDouble());
+        }
+
+        return 100;
+    }
+    
+    static int Main(string[] args)
+    {
+        return Test(false);
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_278376.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
With the advent of operands that are register-optional at the point of
use, the validity of `gtRegNum` has become dependent on whether or not
an operand is in fact in a register at the point of use: if the operand
is in a register, then `gtRegNum` is the register that it occupies at
the point of use; if it is not in a register, then `gtRegNum` is the
register that the operand occupied at the point of def. Failing to
observe this distinction can result in silent bad code generation, as
was observed in VSO 278376: in this case, the spilled result of a
double-returning call that was used by a double->double cast was never
moved into the cast's destination register because the code generator
was using `gtRegNum` to determine whether or not a move was necessary.

To fix this issue, this change introduces two new APIs on GenTree:
`GenTree::RegAtDef` and `GenTree::RegAtUse`. The former returns the
register defined by a node (if any), and the latter returns the register
in which the node's value is available at the point at which it is used.
`gtRegNum` has also been changed to assert that the node is not contained,
in which case `gtRegNum` may return an invalid result for reg-optional
operands.

The new APIs should be used as follows:
- When generating code for a node, `RegAtDef()` should be used to
  determine the register that will contain the node's value
- When generating code that consumes a particular node, if the node may be
  contained (either because it was marked as such during lowering or
  because it is register-optional), `RegAtUse()` should be used to
  determine the register in which the node's value is available. If the node
  may not be a memory operand, `gtRegNum` should be used instead.