### PR TITLE
Fix VSO 278376.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -6726,7 +6726,7 @@ void CodeGen::genFloatToFloatCast(GenTreePtr treeNode)
     assert(varTypeIsFloating(srcType) && varTypeIsFloating(dstType));
 
     genConsumeOperands(treeNode->AsOp());
-    if (srcType == dstType && targetReg == op1->gtRegNum)
+    if (srcType == dstType && (!op1->isContained() && (targetReg == op1->gtRegNum)))
     {
         // source and destinations types are the same and also reside in the same register.
         // we just need to consume and produce the reg in this case.

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.cs
@@ -1,0 +1,36 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// NOTE: the bug for this test was an assertion in RyuJIT/x86 when generating code for a double-returning call that
+//       was spilled by the RA and subsequently used. The call in question is the call to `C.GetDouble` in `C.Test`.
+//       To ensure that its return value is spilled, `C.GetDouble` is implemented as a P/Invoke method: the return
+//       value ends up spilled because there is a call to `TrapReturningThreads` between the call and the use of the
+//       return value by the cast. Because the bug is a simple assert, there is no need for the problematic code to
+//       actually run, so the implementation of `GetDouble` does not need to actually exist.
+
+sealed class C
+{
+    [DllImport("nonexistent.dll")]
+    extern static double GetDouble();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void UseDouble(double d)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test(bool condition)
+    {
+        if (condition)
+        {
+            UseDouble((double)GetDouble());
+        }
+
+        return 100;
+    }
+    
+    static int Main(string[] args)
+    {
+        return Test(false);
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_278376.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
genFloatToFloatCast was not checking whether or not its source operand
was an in-memory, register-optional node before comparing its source
register against its target register. This caused an assert in checked
builds (and SBCG in release builds) because the source temp was never
released.
