### PR TITLE
Cleanup: remove BitArray from mscorlib

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -607,38 +607,6 @@
       <Member Name="get_IsCompliant" />
       <Member MemberType="Property" Name="IsCompliant" />
     </Type>
-    <Type Name="System.Collections.BitArray">
-      <Member Name="#ctor(System.Int32)" />
-      <Member Name="#ctor(System.Int32,System.Boolean)" />
-      <Member Name="#ctor(System.Byte[])" />
-      <Member Name="#ctor(System.Boolean[])" />
-      <Member Name="#ctor(System.Int32[])" />
-      <Member Name="#ctor(System.Collections.BitArray)" />
-      <Member Name="Get(System.Int32)" />
-      <Member Name="Set(System.Int32,System.Boolean)" />
-      <Member Name="SetAll(System.Boolean)" />
-      <Member Name="And(System.Collections.BitArray)" />
-      <Member Name="Or(System.Collections.BitArray)" />
-      <Member Name="Xor(System.Collections.BitArray)" />
-      <Member Name="Not" />
-      <Member Name="set_Item(System.Int32,System.Boolean)" />
-      <Member Name="get_Item(System.Int32)" />
-      <Member MemberType="Property" Name="Item(System.Int32)" />
-      <Member Name="get_Length" />
-      <Member Name="set_Length(System.Int32)" />
-      <Member MemberType="Property" Name="Length" />
-      <Member Name="CopyTo(System.Array,System.Int32)" />
-      <Member Name="get_Count" />
-      <Member MemberType="Property" Name="Count" />
-      <Member Name="get_IsReadOnly" />
-      <Member MemberType="Property" Name="IsReadOnly" />
-      <Member Name="get_IsSynchronized" />
-      <Member MemberType="Property" Name="IsSynchronized" />
-      <Member Name="get_SyncRoot" />
-      <Member MemberType="Property" Name="SyncRoot" />
-      <Member Name="Clone" />
-      <Member Name="GetEnumerator" />
-    </Type>
     <Type Name="System.Collections.CollectionBase">
       <Member Name="#ctor" />
       <Member Name="get_List" />

--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -60,7 +60,7 @@
   <ItemGroup>
     <CollectionsSources Include="$(BclSourcesRoot)\System\Collections\CollectionBase.cs" />
     <CollectionsSources Include="$(BclSourcesRoot)\System\Collections\ArrayList.cs" />
-    <CollectionsSources Include="$(BclSourcesRoot)\System\Collections\BitArray.cs" />
+    <CollectionsSources Condition="'$(FeatureCoreClr)'!='true'" Include="$(BclSourcesRoot)\System\Collections\BitArray.cs" />
     <CollectionsSources Include="$(BclSourcesRoot)\System\Collections\Stack.cs" />
     <CollectionsSources Include="$(BclSourcesRoot)\System\Collections\Comparer.cs" />
     <CollectionsSources Include="$(BclSourcesRoot)\System\Collections\CompatibleComparer.cs" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -4279,32 +4279,6 @@ namespace System
 namespace System.Collections
 {
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class BitArray : System.Collections.ICollection, System.Collections.IEnumerable, System.ICloneable
-    {
-        public BitArray(bool[] values) { }
-        public BitArray(byte[] bytes) { }
-        public BitArray(System.Collections.BitArray bits) { }
-        public BitArray(int length) { }
-        public BitArray(int length, bool defaultValue) { }
-        public BitArray(int[] values) { }
-        public int Count { get { throw null; } }
-        public bool IsReadOnly { get { throw null; } }
-        public bool IsSynchronized { get { throw null; } }
-        public bool this[int index] { get { throw null; } set { } }
-        public int Length { get { throw null; } set { } }
-        public object SyncRoot { get { throw null; } }
-        public System.Collections.BitArray And(System.Collections.BitArray value) { throw null; }
-        public object Clone() { throw null; }
-        public void CopyTo(System.Array array, int index) { }
-        public bool Get(int index) { throw null; }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public System.Collections.BitArray Not() { throw null; }
-        public System.Collections.BitArray Or(System.Collections.BitArray value) { throw null; }
-        public void Set(int index, bool value) { }
-        public void SetAll(bool value) { }
-        public System.Collections.BitArray Xor(System.Collections.BitArray value) { throw null; }
-    }
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public abstract partial class CollectionBase : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
     {
         protected CollectionBase() { }

--- a/src/mscorlib/src/System/Collections/BitArray.cs
+++ b/src/mscorlib/src/System/Collections/BitArray.cs
@@ -365,49 +365,17 @@ namespace System.Collections {
 
             if (array is int[])
             {
-                int last = GetArrayLength(m_length, BitsPerInt32) - 1;
-                int bits = m_length % BitsPerInt32;
-
-                if (bits == 0)
-                {
-                    // we have perfect bit alignment, no need to sanitize, just copy
-                    Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32));
-                }
-                else
-                {
-                    // do not copy the last int, as it is not completely used
-                    Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32) - 1);
-
-                    // the last int needs to be masked
-                    ((int[])array)[last] = m_array[last] & (1 << bits) - 1;
-                }
+                Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32));
             }
             else if (array is byte[])
             {
-                int bits = m_length % BitsPerByte;
-
                 int arrayLength = GetArrayLength(m_length, BitsPerByte);
                 if ((array.Length - index) < arrayLength)
-                    throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
-
-                if (bits > 0)
-                {
-                    // last byte is not aligned, we will directly copy one less byte
-                    arrayLength -= 1;
-                }
+                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
 
                 byte [] b = (byte[])array;
-
-                // copy all the perfectly-aligned bytes
                 for (int i = 0; i < arrayLength; i++)
                     b[index + i] = (byte)((m_array[i/4] >> ((i%4)*8)) & 0x000000FF); // Shift to bring the required byte to LSB, then mask
-
-                if (bits > 0)
-                {
-                    // mask the final byte
-                    int i = arrayLength;
-                    b[index + i] = (byte)((m_array[i/4] >> ((i%4)*8)) & 0x000000FF & ((1 << bits) - 1));
-                }
             }
             else if (array is bool[])
             {

--- a/src/mscorlib/src/System/Collections/BitArray.cs
+++ b/src/mscorlib/src/System/Collections/BitArray.cs
@@ -365,17 +365,49 @@ namespace System.Collections {
 
             if (array is int[])
             {
-                Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32));
+                int last = GetArrayLength(m_length, BitsPerInt32) - 1;
+                int bits = m_length % BitsPerInt32;
+
+                if (bits == 0)
+                {
+                    // we have perfect bit alignment, no need to sanitize, just copy
+                    Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32));
+                }
+                else
+                {
+                    // do not copy the last int, as it is not completely used
+                    Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32) - 1);
+
+                    // the last int needs to be masked
+                    ((int[])array)[last] = m_array[last] & (1 << bits) - 1;
+                }
             }
             else if (array is byte[])
             {
+                int bits = m_length % BitsPerByte;
+
                 int arrayLength = GetArrayLength(m_length, BitsPerByte);
                 if ((array.Length - index) < arrayLength)
-                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
+                    throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
+
+                if (bits > 0)
+                {
+                    // last byte is not aligned, we will directly copy one less byte
+                    arrayLength -= 1;
+                }
 
                 byte [] b = (byte[])array;
+
+                // copy all the perfectly-aligned bytes
                 for (int i = 0; i < arrayLength; i++)
                     b[index + i] = (byte)((m_array[i/4] >> ((i%4)*8)) & 0x000000FF); // Shift to bring the required byte to LSB, then mask
+
+                if (bits > 0)
+                {
+                    // mask the final byte
+                    int i = arrayLength;
+                    b[index + i] = (byte)((m_array[i/4] >> ((i%4)*8)) & 0x000000FF & ((1 << bits) - 1));
+                }
             }
             else if (array is bool[])
             {


### PR DESCRIPTION
As discussed in #7634, this PR finalizes the relocation of BitArray from mscorlib into corefx.

The PR on the corefx side [link](https://github.com/dotnet/corefx/pull/12597) has been merged.