### PR TITLE
Avoid boxing in calls to enum's GetHashCode

### DIFF
--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -841,8 +841,9 @@ namespace System
         [System.Security.SecuritySafeCritical]
         public override unsafe int GetHashCode()
         {
-            // Avoid boxing by inlining GetValue()
-            // return GetValue().GetHashCode();
+            // CONTRACT with the runtime: GetHashCode of enum types is implemented as GetHashCode of the underlying type.
+            // The runtime can bypass calls to Enum::GetHashCode and call the underlying type's GetHashCode directly
+            // to avoid boxing the enum.
 
             fixed (void* pValue = &JitHelpers.GetPinningHelper(this).m_data)
             {

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5093,6 +5093,20 @@ void CEEInfo::getCallInfo(
         // shared generic code - it may just resolve it to a candidate suitable for
         // JIT compilation, and require a runtime lookup for the actual code pointer
         // to call.
+		if (constrainedType.IsEnum())
+		{
+			// Optimize constrained calls to enum's GetHashCode method. TryResolveConstraintMethodApprox would return
+			// null since the virtual method resolves to System.Enum's implementation and that's a reference type.
+			// We can't do this for any other method since ToString and Equals have different semantics for enums
+			// and their underlying type.
+			LPCUTF8 pMethodName = pMD->GetName();
+			if (strcmp(pMethodName, "GetHashCode") == 0)
+			{
+				// Pretend this was a "constrained. UnderlyingType" instruction prefix
+				constrainedType = TypeHandle(MscorlibBinder::GetElementType(constrainedType.GetVerifierCorElementType()));
+			}
+		}
+
         MethodDesc * directMethod = constrainedType.GetMethodTable()->TryResolveConstraintMethodApprox(
             exactType, 
             pMD, 

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5093,19 +5093,18 @@ void CEEInfo::getCallInfo(
         // shared generic code - it may just resolve it to a candidate suitable for
         // JIT compilation, and require a runtime lookup for the actual code pointer
         // to call.
-		if (constrainedType.IsEnum())
-		{
-			// Optimize constrained calls to enum's GetHashCode method. TryResolveConstraintMethodApprox would return
-			// null since the virtual method resolves to System.Enum's implementation and that's a reference type.
-			// We can't do this for any other method since ToString and Equals have different semantics for enums
-			// and their underlying type.
-			LPCUTF8 pMethodName = pMD->GetName();
-			if (strcmp(pMethodName, "GetHashCode") == 0)
-			{
-				// Pretend this was a "constrained. UnderlyingType" instruction prefix
-				constrainedType = TypeHandle(MscorlibBinder::GetElementType(constrainedType.GetVerifierCorElementType()));
-			}
-		}
+        if (constrainedType.IsEnum())
+        {
+            // Optimize constrained calls to enum's GetHashCode method. TryResolveConstraintMethodApprox would return
+            // null since the virtual method resolves to System.Enum's implementation and that's a reference type.
+            // We can't do this for any other method since ToString and Equals have different semantics for enums
+            // and their underlying type.
+            if (pMD->GetSlot() == MscorlibBinder::GetMethod(METHOD__OBJECT__GET_HASH_CODE)->GetSlot())
+            {
+                // Pretend this was a "constrained. UnderlyingType" instruction prefix
+                constrainedType = TypeHandle(MscorlibBinder::GetElementType(constrainedType.GetVerifierCorElementType()));
+            }
+        }
 
         MethodDesc * directMethod = constrainedType.GetMethodTable()->TryResolveConstraintMethodApprox(
             exactType, 


### PR DESCRIPTION
A real world app prompted me to look into this. I know this is not a huge deal because `EqualityComparer<T>.Default` has special casing for enums, but it's actually pretty easy to hit this anyway (even System.Private.CoreLib has a couple hits) and people on the internet are always puzzled about this one.

``` csharp
enum Mine { One, Two }

class Program
{
    static void Main()
    {
        return Mine.Two.GetHashCode();
    }
}
```

The code generated for the above has an unexpected boxing operation in it. I say unexpected, because e.g. `1.GetHashCode()` wouldn't have boxing.

The reason why we end up with boxing is because in the constrained call to `System.Object::GetHashCode`, the constraint resolution ends up resolving the method to `System.Enum::GetHashCode()` and `System.Enum` is a reference type. Bodies for instance methods on reference types expect a boxed this, while bodies on value types expect a byref.

I'm patching it up to pretend the constrained call was to the underlying type's `GetHashCode` method. I don't pretend it's a great solution and unfortunately it won't cover `Equals`. I'll understand if there's pushback against merging this.
## Before the change

``` nasm
G_M15495_IG01:
       4883EC28             sub      rsp, 40
       90                   nop

G_M15495_IG02:
       488D0D00000000       lea      rcx, [(reloc)]
       E800000000           call     CORINFO_HELP_NEWSFAST
       C7400801000000       mov      dword ptr [rax+8], 1
       488BC8               mov      rcx, rax
       488B00               mov      rax, qword ptr [rax]
       488B4048             mov      rax, qword ptr [rax+72]
       FF5010               call     qword ptr [rax+16]System.Object:GetHashCode():int:this
       90                   nop

G_M15495_IG03:
       4883C428             add      rsp, 40
       C3                   ret
```
## After the change

``` nasm
G_M15496_IG01:
       0F1F440000           nop

G_M15496_IG02:
       B801000000           mov      eax, 1

G_M15496_IG03:
       C3                   ret
```
