### PR TITLE
Fixing Typo in variable name in DateTime

### DIFF
--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -1011,8 +1011,8 @@ namespace System {
         internal static string FastFormatRoundtrip(DateTime dateTime, TimeSpan offset)
         {
             // yyyy-MM-ddTHH:mm:ss.fffffffK
-            const int roundTrimFormatLength = 28;
-            StringBuilder result = StringBuilderCache.Acquire(roundTrimFormatLength);
+            const int roundTripFormatLength = 28;
+            StringBuilder result = StringBuilderCache.Acquire(roundTripFormatLength);
 
             AppendNumber(result, dateTime.Year, 4);
             result.Append('-');

--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -139,8 +139,13 @@ namespace System {
         internal const String RoundtripFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffffK";
         internal const String RoundtripDateTimeUnfixed = "yyyy'-'MM'-'ddTHH':'mm':'ss zzz";
     
-        private const int DEFAULT_ALL_DATETIMES_SIZE = 132; 
-        
+        private const int DEFAULT_ALL_DATETIMES_SIZE = 132;
+
+        internal static readonly DateTimeFormatInfo FormatInfo = CultureInfo.InvariantCulture.DateTimeFormat;
+        internal static readonly string[] AbbreviatedMonthNames = FormatInfo.AbbreviatedMonthNames;
+        internal static readonly string[] AbbreviatedDayNames = FormatInfo.AbbreviatedDayNames;
+        internal const string Gmt = "GMT";
+
         internal static String[] fixedNumberFormats = new String[] {
             "0",
             "00",
@@ -739,7 +744,7 @@ namespace System {
                     // 'zzz*' or longer format e.g "-07:30"
                     result.AppendFormat(CultureInfo.InvariantCulture, ":{0:00}", offset.Minutes);
                 }
-            }        
+            }
         }
 
         // output the 'K' format, which is for round-tripping the data
@@ -960,7 +965,12 @@ namespace System {
 
             if (format.Length == 1) {
                 if (format[0] == 'o' || format[0] == 'O') {
-                        return FastFormatRoundtrip(dateTime, offset);
+                    return FastFormatRoundtrip(dateTime, offset);
+                }
+
+                if (format[0] == 'r' || format[0] == 'R')
+                {
+                    return FastFormatRfc1123(dateTime, offset, dtfi);
                 }
 
                 format = ExpandPredefinedFormat(format, ref dateTime, ref dtfi, ref offset);
@@ -969,8 +979,30 @@ namespace System {
             return (FormatCustomized(dateTime, format, dtfi, offset));
         }
 
+        internal static string FastFormatRfc1123(DateTime dateTime, TimeSpan offset, DateTimeFormatInfo dtfi)
+        {
+            // ddd, dd MMM yyyy HH:mm:ss GMT
+            StringBuilder result = StringBuilderCache.Acquire();
+
+            result.Append(AbbreviatedDayNames[(int)dateTime.DayOfWeek]);
+            result.Append(',');
+            result.Append(' ');
+            AppendNumber(result, dateTime.Day, 2);
+            result.Append(' ');
+            result.Append(AbbreviatedMonthNames[dateTime.Month - 1]);
+            result.Append(' ');
+            AppendNumber(result, dateTime.Year, 4);
+            result.Append(' ');
+            AppendTimeOfDay(result, dateTime);
+            result.Append(' ');
+            result.Append(Gmt);
+
+            return StringBuilderCache.GetStringAndRelease(result);
+        }
+
         internal static string FastFormatRoundtrip(DateTime dateTime, TimeSpan offset)
         {
+            // yyyy-MM-ddTHH:mm:ss.fffffffK
             StringBuilder result = StringBuilderCache.Acquire();
 
             AppendNumber(result, dateTime.Year, 4);
@@ -979,11 +1011,7 @@ namespace System {
             result.Append('-');
             AppendNumber(result, dateTime.Day, 2);
             result.Append('T');
-            AppendNumber(result, dateTime.Hour, 2);
-            result.Append(':');
-            AppendNumber(result, dateTime.Minute, 2);
-            result.Append(':');
-            AppendNumber(result, dateTime.Second, 2);
+            AppendTimeOfDay(result, dateTime);
             result.Append('.');
 
             long fraction = dateTime.Ticks % TimeSpan.TicksPerSecond;
@@ -993,7 +1021,17 @@ namespace System {
 
             return StringBuilderCache.GetStringAndRelease(result);
         }
-        
+
+        private static void AppendTimeOfDay(StringBuilder result, DateTime dateTime)
+        {
+            // HH:mm:ss
+            AppendNumber(result, dateTime.Hour, 2);
+            result.Append(':');
+            AppendNumber(result, dateTime.Minute, 2);
+            result.Append(':');
+            AppendNumber(result, dateTime.Second, 2);
+        }
+
         internal static void AppendNumber(StringBuilder builder, long val, int digits)
         {
             for (int i = 0; i < digits; i++)

--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -968,8 +968,7 @@ namespace System {
                     return FastFormatRoundtrip(dateTime, offset);
                 }
 
-                if (format[0] == 'r' || format[0] == 'R')
-                {
+                if (format[0] == 'r' || format[0] == 'R') {
                     return FastFormatRfc1123(dateTime, offset, dtfi);
                 }
 

--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -986,6 +986,12 @@ namespace System {
             const int Rfc1123FormatLength = 29;
             StringBuilder result = StringBuilderCache.Acquire(Rfc1123FormatLength);
 
+            if (offset != NullOffset)
+            {
+                // Convert to UTC invariants
+                dateTime = dateTime - offset;
+            }
+
             result.Append(InvariantAbbreviatedDayNames[(int)dateTime.DayOfWeek]);
             result.Append(',');
             result.Append(' ');


### PR DESCRIPTION
Missed a small piece of CR feedback. This is the correction.