### PR TITLE
Remove redundant statement

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -13702,7 +13702,6 @@ ULONG ADUnloadSink::Release()
     if (ulRef == 0)
     {
         delete this;
-        return 0;
     }
     return ulRef;
 };


### PR DESCRIPTION
`ulRef` is a local variable, no need to `return 0` - that's just extra line and with this extra line code looks suspicious as if `return m_cRef` was used as the last line which can cause rare race conditions.