### PR TITLE
Get latest behavior when missing TFM for BinaryCompatibility class 

### DIFF
--- a/src/mscorlib/src/System/Runtime/Versioning/BinaryCompatibility.cs
+++ b/src/mscorlib/src/System/Runtime/Versioning/BinaryCompatibility.cs
@@ -461,7 +461,13 @@ namespace System.Runtime.Versioning
             int fxVersion = 0;
             if (targetFrameworkName == null)
             {
+#if FEATURE_CORECLR
+                // We are going to default to the latest value for version that we have in our code.
+                fxId = TargetFrameworkId.NetFramework;
+                fxVersion = 50000; 
+#else
                 fxId = TargetFrameworkId.Unspecified;
+#endif
             }
             else if (!ParseTargetFrameworkMonikerIntoEnum(targetFrameworkName, out fxId, out fxVersion))
                 fxId = TargetFrameworkId.Unrecognized;


### PR DESCRIPTION
When reading the TFM for the BinaryCompatibility class on CoreCLR, set the TFM to be the latest version we have in our code.

This ensures that we are going to get the latest behavior (4.5.2+) for all the quirks that were using that class.

Fixes #7892