### PR TITLE
Fix VSO 279380.

### DIFF
--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1969,9 +1969,9 @@ VARSET_VALRET_TP Compiler::fgComputeLifeLIR(VARSET_VALARG_TP lifeArg, BasicBlock
         else if (node->OperIsNonPhiLocal() || node->OperIsLocalAddr())
         {
             bool isDeadStore = fgComputeLifeLocal(life, keepAliveVars, node, node);
-            if (isDeadStore)
+            if (isDeadStore && fgTryRemoveDeadLIRStore(blockRange, node, &next))
             {
-                fgTryRemoveDeadLIRStore(blockRange, node, &next);
+                fgStmtRemoved = true;
             }
         }
     }


### PR DESCRIPTION
The liveness pass attempts to remove dead stores that it encounters
during its liveness computation. Successfully removing a dead store,
however, may invalidate the results of the computation. Therefore, the
pass operates as a fixed-point algorithm: it recomputes liveness until
either the contents of the function do not change or the removed code
does not change the results.

When running liveness on LIR, the correct flag--`fgStmtRemoved`--was not
being set if a dead store was succesfully removed. This caused the
liveness pass to terminate early and produce invalid results in certain
cases. This fix sets `fgStmtRemoved` when a dead store is successfully
removed in an LIR block.