### PR TITLE
Don't create cast for tail call return value.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7737,12 +7737,34 @@ GenTreePtr Compiler::fgMorphCall(GenTreeCall* call)
 #ifdef DEBUG
         // Tail call needs to be in one of the following IR forms
         //    Either a call stmt or
-        //    GT_RETURN(GT_CALL(..)) or
-        //    var = call
-        noway_assert((stmtExpr->gtOper == GT_CALL && stmtExpr == call) ||
-                     (stmtExpr->gtOper == GT_RETURN &&
-                      (stmtExpr->gtOp.gtOp1 == call || stmtExpr->gtOp.gtOp1->gtOp.gtOp1 == call)) ||
-                     (stmtExpr->gtOper == GT_ASG && stmtExpr->gtOp.gtOp2 == call));
+        //    GT_RETURN(GT_CALL(..)) or GT_RETURN(GT_CAST(GT_CALL(..)))
+        //    var = GT_CALL(..) or var = (GT_CAST(GT_CALL(..)))
+        genTreeOps stmtOper = stmtExpr->gtOper;
+        if (stmtOper == GT_CALL)
+        {
+            noway_assert(stmtExpr == call);
+        }
+        else
+        {
+            noway_assert(stmtOper == GT_RETURN || stmtOper == GT_ASG);
+            GenTreePtr treeWithCall;
+            if (stmtOper == GT_RETURN)
+            {
+                treeWithCall = stmtExpr->gtGetOp1();
+            }
+            else
+            {
+                treeWithCall = stmtExpr->gtGetOp2();
+            }
+            if (treeWithCall->gtOper == GT_CAST)
+            {
+                noway_assert(treeWithCall->gtGetOp1() == call && !treeWithCall->gtOverflow());
+            }
+            else
+            {
+                noway_assert(treeWithCall == call);
+            }
+        }
 #endif
 
         // For void calls, we would have created a GT_CALL in the stmt list.

--- a/tests/src/JIT/Regression/JitBlue/GitHub_CoreRT_2073/GitHub_CoreRT_2073.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_CoreRT_2073/GitHub_CoreRT_2073.il
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Test for a issue when tail call with small return type 
+// doesn't pass tail call pattern assert.
+// In addition there is "call->branch on return->return" tail call pattern check.
+
+
+.assembly extern mscorlib {}
+
+.assembly GitHub_CoreRT_2073.exe {}
+
+.class public Test
+{
+
+.method private hidebysig static bool  tailAsgReturn(int32 deep) cil managed
+{
+    // Code size       24 (0x18)
+    .maxstack  20
+    IL_0000:  ldarg.0
+    IL_0001:  ldc.i4.s   -100
+    IL_0003:  bgt.s      IL_0007
+    IL_0005:  ldc.i4.1
+    IL_0006:  ret
+    IL_0007:  ldarg.0
+    IL_0008:  ldc.i4.0
+    IL_0009:  bgt.s      IL_000f
+
+    IL_000a:  ldarg.0
+    IL_000b:  ldc.i4.1
+    IL_000c:  sub
+    IL_000d:  call       bool Test::tailAsgReturn(int32)
+    IL_000e:  br IL_0017
+    IL_000f:  ldarg.0
+    IL_0010:  ldc.i4.2
+    IL_0011:  sub
+    IL_0012:  call       bool Test::tailAsgReturn(int32)
+    IL_0017:  ret
+} // end of method Test::tailAsgReturn
+
+.method public hidebysig static int32  Main(string[] args) cil managed
+{
+  .entrypoint
+  // Code size       14 (0xe)
+  .maxstack  8
+  IL_0000:  ldc.i4.s   100
+  IL_0002:  call       bool Test::tailAsgReturn(int32)
+  IL_0007:  brtrue.s   IL_000b
+  IL_0009:  ldc.i4.m1
+  IL_000a:  ret
+  IL_000b:  ldc.i4.s   100
+  IL_000d:  ret
+} // end of method Test::Main
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_CoreRT_2073/GitHub_CoreRT_2073.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_CoreRT_2073/GitHub_CoreRT_2073.ilproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_CoreRT_2073.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Don't create cast from small type to bigger stack type when it is tail call tree. 
Return value is not  presented on the stack and does not require cast.
Fix dotnet/corert#2073.