### PR TITLE
Fix check for initial induction variable value

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -1217,10 +1217,14 @@ void Compiler::optRecordLoop(BasicBlock*   head,
         }
 
         // Make sure the "iterVar" initialization is never skipped,
-        // i.e. HEAD dominates the ENTRY.
-        if (!fgDominate(head, entry))
+        // i.e. every pred of ENTRY other than HEAD is in the loop.
+        for (flowList* predEdge = entry->bbPreds; predEdge; predEdge = predEdge->flNext)
         {
-            goto DONE_LOOP;
+            BasicBlock* predBlock = predEdge->flBlock;
+            if ((predBlock != head) && !optLoopTable[loopInd].lpContains(predBlock))
+            {
+                goto DONE_LOOP;
+            }
         }
 
         if (!optPopulateInitInfo(loopInd, init, iterVar))

--- a/tests/src/JIT/Regression/JitBlue/GitHub_7906/GitHub_7906.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_7906/GitHub_7906.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Regression test for insufficient guard on inference of initial values
+// of induction variables.
+using System.Numerics;
+
+namespace N
+{
+    public static class C
+    {
+        public static int Main(string[] args)
+        {
+            int x = 0;
+
+            // When bottom-testing sees this loop, it (questionably for performance,
+            // but correctly) copies only the first part of the disjunctive loop condition
+            // so we get
+            //
+            // B1: i = Count                // initialization
+            // B2: if (i < Count) goto B6   // duplicated loop condition (note the "zero trip" case goes to the 2nd loop condition disjunct)
+            // B3: x += i                   // loop body
+            // B4: ++i                      // increment
+            // B5: if (i < Count) goto B3   // first disjunct of loop condition
+            // B6: if (i < 20) goto B3      // second disjunct of loop condition
+            // B7: return x - 84            // post-loop
+            //
+            // At which point B3..B6 is an irreducible loop, but B3..B5 is a natural loop.
+            // This is a regression test for a bug where optRecordLoop would incorrectly
+            // identify B1 as the initial value of loop B3..B5 -- this is incorrect because
+            // the edge from B6 to B3 enters the loop with different values of i.
+            //
+            // The testcase is intentionally structured so that loop unrolling will try
+            // to unroll loop B3..B5 and generate incorrect code due to the incorrect
+            // initial value.
+            for (int i = Vector<int>.Count; i < Vector<int>.Count || i < 20; ++i)
+            {
+                x += i;
+            }
+
+            // After running the loop above, the value of x should be (Count + 19) * (20 - Count) / 2.
+            // Return 100 + x - (expected x) so the test will return 100 on success.
+            return 100 + x - ((Vector<int>.Count + 19) * (20 - Vector<int>.Count) / 2);
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_7906/GitHub_7906.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_7906/GitHub_7906.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{76E69AA0-8C5A-4F76-8561-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)benchmark\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)benchmark\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Checking that `head` dominates `entry` is insufficient, becuase there may
be a codepath from `head` through other nodes that modify the induction
variable to `entry`.  Check instead that all preds of `entry` are either
`head` or in the loop.

Resolves #7906.