### PR TITLE
Handle simd checks in OptimizeRangeCheck

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1443,6 +1443,26 @@ public:
         return (gtOper == GT_JTRUE) || (gtOper == GT_JCC);
     }
 
+    static bool OperIsBoundsCheck(genTreeOps op)
+    {
+        if (op == GT_ARR_BOUNDS_CHECK)
+        {
+            return true;
+        }
+#ifdef FEATURE_SIMD
+        if (op == GT_SIMD_CHK)
+        {
+            return true;
+        }
+#endif // FEATURE_SIMD
+        return false;
+    }
+
+    bool OperIsBoundsCheck() const
+    {
+        return OperIsBoundsCheck(OperGet());
+    }
+
     // Requires that "op" is an op= operator.  Returns
     // the corresponding "op".
     static genTreeOps OpAsgToOper(genTreeOps op);

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -7266,7 +7266,7 @@ void Compiler::optRemoveRangeCheck(
 
     noway_assert(stmt->gtOper == GT_STMT);
     noway_assert(tree->gtOper == GT_COMMA);
-    noway_assert(tree->gtOp.gtOp1->gtOper == GT_ARR_BOUNDS_CHECK);
+    noway_assert(tree->gtOp.gtOp1->OperIsBoundsCheck());
     noway_assert(forceRemove || optIsRangeCheckRemovable(tree->gtOp.gtOp1));
 
     GenTreeBoundsChk* bndsChk = tree->gtOp.gtOp1->AsBoundsChk();

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -208,7 +208,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTreePtr stmt, GenTreeP
 
     // If we are not looking at array bounds check, bail.
     GenTreePtr tree = treeParent->gtOp.gtOp1;
-    if (tree->gtOper != GT_ARR_BOUNDS_CHECK)
+    if (!tree->OperIsBoundsCheck())
     {
         return;
     }
@@ -233,6 +233,9 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTreePtr stmt, GenTreeP
         }
     }
     else
+#ifdef FEATURE_SIMD
+        if (tree->gtOper != GT_SIMD_CHK)
+#endif // FEATURE_SIMD
     {
         arrSize = GetArrLength(arrLenVn);
     }


### PR DESCRIPTION
When the index is a constant, this code applies to `GT_SIMD_CHK` equally
well as it applies to `GT_ARR_BOUNDS_CHECK`.