### PR TITLE
Set pRetVal as NULL on error inside 'VIRTUALCommitMemory'

### DIFF
--- a/src/pal/src/map/virtual.cpp
+++ b/src/pal/src/map/virtual.cpp
@@ -1157,10 +1157,10 @@ error:
             pRetVal = NULL;
             goto done;
         }
-        pInformation = NULL;
-        pRetVal = NULL;
     }
 
+    pInformation = NULL;
+    pRetVal = NULL;
 done:
 
     LogVaOperation(


### PR DESCRIPTION
The current implementation of ``VIRTUALCommitMemory`` resets pRetVal only when ``flAllocationType`` is ``MEM_RESERVE`` or ``IsLocallyReserved`` is set.

It seems that this implement allows ``VIRTUALCommitMomory`` to return an invalid memory address as it does not reset ``pRetVal`` specified at line 1099 even when error happens, which leads to #7919.

This commit tries to reset ``pRetVal`` whenever error happens to fix #7919.