### PR TITLE
Use normal verbosity logging when building tests

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -235,7 +235,7 @@ set __BuildLogRootName=Tests_Managed
 set __BuildLog=%__LogsDir%\%__BuildLogRootName%_%__BuildOS%__%__BuildArch%__%__BuildType%.log
 set __BuildWrn=%__LogsDir%\%__BuildLogRootName%_%__BuildOS%__%__BuildArch%__%__BuildType%.wrn
 set __BuildErr=%__LogsDir%\%__BuildLogRootName%_%__BuildOS%__%__BuildArch%__%__BuildType%.err
-set __msbuildLog=/flp:Verbosity=diag;LogFile="%__BuildLog%"
+set __msbuildLog=/flp:Verbosity=normal;LogFile="%__BuildLog%"
 set __msbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __msbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 


### PR DESCRIPTION
Test build log file is ~4GB with diag verbosity. With normal it's about 20MB.
This seems to speed up the test build for me considerably.

See #7916.