### PR TITLE
Jit: spill stack for non-candidate calls

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7520,6 +7520,13 @@ DONE_CALL:
                 // TODO: Still using the widened type.
                 call = gtNewInlineCandidateReturnExpr(call, genActualType(callRetTyp));
             }
+            else
+            {
+                // For non-candidates we must also spill, since we
+                // might have locals live on the eval stack that this
+                // call can modify.
+                impSpillSideEffects(true, CHECK_SPILL_ALL DEBUGARG("non-inline candidate call"));
+            }
         }
 
         if (!bIntrinsicImported)

--- a/tests/src/JIT/Regression/JitBlue/GitHub_7907/GitHub_7907.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_7907/GitHub_7907.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable 472
+
+public class Bug7907
+{
+    int _position = 10;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int G(int z, ref int r)
+    {
+        r -= z;
+        return 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int F0(int count)
+    {
+        int initialCount = count;
+
+        _position += G(_position, ref count);
+
+        if (initialCount == count)
+        {
+            count--;
+        }
+
+        return initialCount - count;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int F1(int count)
+    {
+        // " != null" is known to be true - just to remove control flow
+        // since that by itself may force spilling and mask the bug
+        count -= (_position += G(_position, ref count)) != null ? count : 1;
+
+        return count;
+    }
+
+    public static int Main(string[] args)
+    {
+        int result0 = new Bug7907().F0(10);
+        int result1 = new Bug7907().F1(10);
+        Console.WriteLine("R0={0} R1={1}", result0, result1);
+        return (result0 == 10 && result1 == 10 ? 100 : -1);
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_7907/GitHub_7907.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_7907/GitHub_7907.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Closes #7907.

Spill the evaluation stack at non-candidate calls since the call may
modify locals or args that are currently live on the stack.

In the attached test case I can't get the problematic IL sequence to
happen for the `F0` variant, but it is there for the `F1` variant.

No diffs seen in corlib or any of the framework assemblies that are
run via jit-dasm.