### PR TITLE
Use nameof throughout mscorlib

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/Calendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/Calendar.cs
@@ -172,7 +172,7 @@ namespace System.Globalization
         [System.Runtime.InteropServices.ComVisible(false)]
         public static Calendar ReadOnly(Calendar calendar)
         {
-            if (calendar == null) { throw new ArgumentNullException("calendar"); }
+            if (calendar == null) { throw new ArgumentNullException(nameof(calendar)); }
             Contract.EndContractBlock();
             if (calendar.IsReadOnly) { return (calendar); }
 
@@ -248,7 +248,7 @@ namespace System.Globalization
             double tempMillis = (value * scale + (value >= 0 ? 0.5 : -0.5));
             if (!((tempMillis > -(double)MaxMillis) && (tempMillis < (double)MaxMillis)))
             {
-                throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_AddValue);
+                throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_AddValue);
             }
 
             long millis = (long)tempMillis;
@@ -652,7 +652,7 @@ namespace System.Globalization
             if ((int)firstDayOfWeek < 0 || (int)firstDayOfWeek > 6)
             {
                 throw new ArgumentOutOfRangeException(
-                    "firstDayOfWeek", SR.Format(SR.ArgumentOutOfRange_Range,
+                    nameof(firstDayOfWeek), SR.Format(SR.ArgumentOutOfRange_Range,
                     DayOfWeek.Sunday, DayOfWeek.Saturday));
             }
             Contract.EndContractBlock();
@@ -666,7 +666,7 @@ namespace System.Globalization
                     return (GetWeekOfYearFullDays(time, (int)firstDayOfWeek, 4));
             }
             throw new ArgumentOutOfRangeException(
-                "rule", SR.Format(SR.ArgumentOutOfRange_Range,
+                nameof(rule), SR.Format(SR.ArgumentOutOfRange_Range,
                 CalendarWeekRule.FirstDay, CalendarWeekRule.FirstFourDayWeek));
         }
 
@@ -824,7 +824,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();
@@ -846,7 +846,7 @@ namespace System.Globalization
                 if (millisecond < 0 || millisecond >= MillisPerSecond)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "millisecond",
+                                nameof(millisecond),
                                 String.Format(
                                     CultureInfo.InvariantCulture,
                                     SR.Format(SR.ArgumentOutOfRange_Range, 0, MillisPerSecond - 1)));

--- a/src/mscorlib/corefx/System/Globalization/CharUnicodeInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/CharUnicodeInfo.cs
@@ -233,11 +233,11 @@ namespace System.Globalization
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
             if (index < 0 || index >= s.Length)
             {
-                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             }
             Contract.EndContractBlock();
             return (InternalGetNumericValue(InternalConvertToUtf32(s, index)));
@@ -252,12 +252,12 @@ namespace System.Globalization
         {
             if (s == null) 
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
             
             if (index < 0 || index >= s.Length) 
             {
-                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             }
             Contract.EndContractBlock();
 
@@ -273,12 +273,12 @@ namespace System.Globalization
         {
             if (s == null) 
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
             
             if (index < 0 || index >= s.Length) 
             {
-                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             }
             
             Contract.EndContractBlock();
@@ -293,10 +293,10 @@ namespace System.Globalization
         public static UnicodeCategory GetUnicodeCategory(String s, int index)
         {
             if (s == null)
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             if (((uint)index) >= ((uint)s.Length))
             {
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
             Contract.EndContractBlock();
             return InternalGetUnicodeCategory(s, index);

--- a/src/mscorlib/corefx/System/Globalization/ChineseLunisolarCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/ChineseLunisolarCalendar.cs
@@ -342,13 +342,13 @@ namespace System.Globalization
         {
             if (era != CurrentEra && era != ChineseEra)
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
 
             if (year < MIN_LUNISOLAR_YEAR || year > MAX_LUNISOLAR_YEAR)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range, MIN_LUNISOLAR_YEAR, MAX_LUNISOLAR_YEAR));

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -241,12 +241,12 @@ namespace System.Globalization
         
         private unsafe SortKey CreateSortKey(String source, CompareOptions options)
         {
-            if (source==null) { throw new ArgumentNullException("source"); }
+            if (source==null) { throw new ArgumentNullException(nameof(source)); }
             Contract.EndContractBlock();
 
             if ((options & ValidSortkeyCtorMaskOffFlags) != 0)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), "options");
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
             }
             
             byte [] keyData;

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Windows.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Windows.cs
@@ -356,12 +356,12 @@ namespace System.Globalization
 
         private unsafe SortKey CreateSortKey(String source, CompareOptions options)
         {
-            if (source==null) { throw new ArgumentNullException("source"); }
+            if (source==null) { throw new ArgumentNullException(nameof(source)); }
             Contract.EndContractBlock();
 
             if ((options & ValidSortkeyCtorMaskOffFlags) != 0)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), "options");
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
             }
 
             throw new NotImplementedException();

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.cs
@@ -92,7 +92,7 @@ namespace System.Globalization
             // Parameter checking.
             if (assembly == null)
             {
-                throw new ArgumentNullException("assembly");
+                throw new ArgumentNullException(nameof(assembly));
             }
             if (assembly != typeof(Object).Module.Assembly) 
             {
@@ -119,7 +119,7 @@ namespace System.Globalization
         {
             if (name == null || assembly == null)
             {
-                throw new ArgumentNullException(name == null ? "name" : "assembly");
+                throw new ArgumentNullException(name == null ? nameof(name) : nameof(assembly));
             }
             Contract.EndContractBlock();
 
@@ -146,7 +146,7 @@ namespace System.Globalization
             if (CultureData.IsCustomCultureId(culture))
             {
                 // Customized culture cannot be created by the LCID.
-                throw new ArgumentException(SR.Argument_CustomCultureCannotBePassedByNumber, "culture");
+                throw new ArgumentException(SR.Argument_CustomCultureCannotBePassedByNumber, nameof(culture));
             }
 
             return CultureInfo.GetCultureInfo(culture).CompareInfo;
@@ -165,7 +165,7 @@ namespace System.Globalization
         {
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
             Contract.EndContractBlock();
 
@@ -185,7 +185,7 @@ namespace System.Globalization
             if (text == null) 
             {
                 // A null param is invalid here.
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             }
 
             if (0 == text.Length)
@@ -285,14 +285,14 @@ namespace System.Globalization
             {
                 if (options != CompareOptions.Ordinal)
                 {
-                    throw new ArgumentException(SR.Argument_CompareOptionOrdinal, "options");
+                    throw new ArgumentException(SR.Argument_CompareOptionOrdinal, nameof(options));
                 }
                 return String.CompareOrdinal(string1, string2);
             }
 
             if ((options & ValidCompareMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, "options");
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
             }
 
             //Our paradigm is that null sorts less than any other string and
@@ -359,31 +359,31 @@ namespace System.Globalization
             // Verify inputs
             if (length1 < 0 || length2 < 0)
             {
-                throw new ArgumentOutOfRangeException((length1 < 0) ? "length1" : "length2", SR.ArgumentOutOfRange_NeedPosNum);
+                throw new ArgumentOutOfRangeException((length1 < 0) ? nameof(length1) : nameof(length2), SR.ArgumentOutOfRange_NeedPosNum);
             }
             if (offset1 < 0 || offset2 < 0)
             {
-                throw new ArgumentOutOfRangeException((offset1 < 0) ? "offset1" : "offset2", SR.ArgumentOutOfRange_NeedPosNum);
+                throw new ArgumentOutOfRangeException((offset1 < 0) ? nameof(offset1) : nameof(offset2), SR.ArgumentOutOfRange_NeedPosNum);
             }
             if (offset1 > (string1 == null ? 0 : string1.Length) - length1)
             {
-                throw new ArgumentOutOfRangeException("string1", SR.ArgumentOutOfRange_OffsetLength);
+                throw new ArgumentOutOfRangeException(nameof(string1), SR.ArgumentOutOfRange_OffsetLength);
             }
             if (offset2 > (string2 == null ? 0 : string2.Length) - length2)
             {
-                throw new ArgumentOutOfRangeException("string2", SR.ArgumentOutOfRange_OffsetLength);
+                throw new ArgumentOutOfRangeException(nameof(string2), SR.ArgumentOutOfRange_OffsetLength);
             }
             if ((options & CompareOptions.Ordinal) != 0)
             {
                 if (options != CompareOptions.Ordinal)
                 {
                     throw new ArgumentException(SR.Argument_CompareOptionOrdinal,
-                                                "options");
+                                                nameof(options));
                 }
             }
             else if ((options & ValidCompareMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, "options");
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
             }
 
             //
@@ -487,7 +487,7 @@ namespace System.Globalization
         {
             if (source == null || prefix == null)
             {
-                throw new ArgumentNullException((source == null ? "source" : "prefix"),
+                throw new ArgumentNullException((source == null ? nameof(source) : nameof(prefix)),
                     SR.ArgumentNull_String);
             }
             Contract.EndContractBlock();
@@ -514,7 +514,7 @@ namespace System.Globalization
 
             if ((options & ValidIndexMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, "options");
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
             }
 
             return StartsWith(source, prefix, options);
@@ -537,7 +537,7 @@ namespace System.Globalization
         {
             if (source == null || suffix == null)
             {
-                throw new ArgumentNullException((source == null ? "source" : "suffix"),
+                throw new ArgumentNullException((source == null ? nameof(source) : nameof(suffix)),
                     SR.ArgumentNull_String);
             }
             Contract.EndContractBlock();
@@ -564,7 +564,7 @@ namespace System.Globalization
 
             if ((options & ValidIndexMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, "options");
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
             }
 
             return EndsWith(source, suffix, options);
@@ -593,7 +593,7 @@ namespace System.Globalization
         public unsafe virtual int IndexOf(String source, char value)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             return IndexOf(source, value, 0, source.Length, CompareOptions.None);
@@ -603,7 +603,7 @@ namespace System.Globalization
         public unsafe virtual int IndexOf(String source, String value)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             return IndexOf(source, value, 0, source.Length, CompareOptions.None);
@@ -613,7 +613,7 @@ namespace System.Globalization
         public unsafe virtual int IndexOf(String source, char value, CompareOptions options)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             return IndexOf(source, value, 0, source.Length, options);
@@ -623,7 +623,7 @@ namespace System.Globalization
         public unsafe virtual int IndexOf(String source, String value, CompareOptions options)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             return IndexOf(source, value, 0, source.Length, options);
@@ -632,7 +632,7 @@ namespace System.Globalization
         public unsafe virtual int IndexOf(String source, char value, int startIndex)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             return IndexOf(source, value, startIndex, source.Length - startIndex, CompareOptions.None);
@@ -641,7 +641,7 @@ namespace System.Globalization
         public unsafe virtual int IndexOf(String source, String value, int startIndex)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             return IndexOf(source, value, startIndex, source.Length - startIndex, CompareOptions.None);
@@ -650,7 +650,7 @@ namespace System.Globalization
         public unsafe virtual int IndexOf(String source, char value, int startIndex, CompareOptions options)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             return IndexOf(source, value, startIndex, source.Length - startIndex, options);
@@ -660,7 +660,7 @@ namespace System.Globalization
         public unsafe virtual int IndexOf(String source, String value, int startIndex, CompareOptions options)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             return IndexOf(source, value, startIndex, source.Length - startIndex, options);
@@ -682,13 +682,13 @@ namespace System.Globalization
         {
             // Validate inputs
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
 
             if (startIndex < 0 || startIndex > source.Length)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
 
             if (count < 0 || startIndex > source.Length - count)
-                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
             Contract.EndContractBlock();
 
             if (options == CompareOptions.OrdinalIgnoreCase)
@@ -699,7 +699,7 @@ namespace System.Globalization
             // Validate CompareOptions
             // Ordinal can't be selected with other flags
             if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
-                throw new ArgumentException(SR.Argument_InvalidFlag, "options");
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
 
             return IndexOfCore(source, new string(value, 1), startIndex, count, options);
         }
@@ -709,13 +709,13 @@ namespace System.Globalization
         {
             // Validate inputs
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             if (value == null)
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
 
             if (startIndex > source.Length)
             {
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
             }
             Contract.EndContractBlock();
 
@@ -732,11 +732,11 @@ namespace System.Globalization
 
             if (startIndex < 0)
             {
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
             }
 
             if (count < 0 || startIndex > source.Length - count)
-                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
             if (options == CompareOptions.OrdinalIgnoreCase)
             {
@@ -746,7 +746,7 @@ namespace System.Globalization
             // Validate CompareOptions
             // Ordinal can't be selected with other flags
             if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
-                throw new ArgumentException(SR.Argument_InvalidFlag, "options");
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
 
             return IndexOfCore(source, value, startIndex, count, options);
         }
@@ -768,7 +768,7 @@ namespace System.Globalization
         public unsafe virtual int LastIndexOf(String source, char value)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             // Can't start at negative index, so make sure we check for the length == 0 case.
@@ -780,7 +780,7 @@ namespace System.Globalization
         public virtual int LastIndexOf(String source, String value)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             // Can't start at negative index, so make sure we check for the length == 0 case.
@@ -792,7 +792,7 @@ namespace System.Globalization
         public virtual int LastIndexOf(String source, char value, CompareOptions options)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             // Can't start at negative index, so make sure we check for the length == 0 case.
@@ -803,7 +803,7 @@ namespace System.Globalization
         public unsafe virtual int LastIndexOf(String source, String value, CompareOptions options)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             // Can't start at negative index, so make sure we check for the length == 0 case.
@@ -850,7 +850,7 @@ namespace System.Globalization
         {
             // Verify Arguments
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             Contract.EndContractBlock();
 
             // Validate CompareOptions
@@ -858,7 +858,7 @@ namespace System.Globalization
             if ((options & ValidIndexMaskOffFlags) != 0 &&
                 (options != CompareOptions.Ordinal) &&
                 (options != CompareOptions.OrdinalIgnoreCase))
-                throw new ArgumentException(SR.Argument_InvalidFlag, "options");
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
 
             // Special case for 0 length input strings
             if (source.Length == 0 && (startIndex == -1 || startIndex == 0))
@@ -866,7 +866,7 @@ namespace System.Globalization
 
             // Make sure we're not out of range
             if (startIndex < 0 || startIndex > source.Length)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
 
             // Make sure that we allow startIndex == source.Length
             if (startIndex == source.Length)
@@ -878,7 +878,7 @@ namespace System.Globalization
 
             // 2nd have of this also catches when startIndex == MAXINT, so MAXINT - 0 + 1 == -1, which is < 0.
             if (count < 0 || startIndex - count + 1 < 0)
-                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
             if (options == CompareOptions.OrdinalIgnoreCase)
             {
@@ -893,9 +893,9 @@ namespace System.Globalization
         {
             // Verify Arguments
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             if (value == null)
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             Contract.EndContractBlock();
 
             // Validate CompareOptions
@@ -903,7 +903,7 @@ namespace System.Globalization
             if ((options & ValidIndexMaskOffFlags) != 0 &&
                 (options != CompareOptions.Ordinal) &&
                 (options != CompareOptions.OrdinalIgnoreCase))
-                throw new ArgumentException(SR.Argument_InvalidFlag, "options");
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
 
             // Special case for 0 length input strings
             if (source.Length == 0 && (startIndex == -1 || startIndex == 0))
@@ -911,7 +911,7 @@ namespace System.Globalization
 
             // Make sure we're not out of range
             if (startIndex < 0 || startIndex > source.Length)
-                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
 
             // Make sure that we allow startIndex == source.Length
             if (startIndex == source.Length)
@@ -927,7 +927,7 @@ namespace System.Globalization
 
             // 2nd half of this also catches when startIndex == MAXINT, so MAXINT - 0 + 1 == -1, which is < 0.
             if (count < 0 || startIndex - count + 1 < 0)
-                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
             if (options == CompareOptions.OrdinalIgnoreCase)
             {
@@ -1027,12 +1027,12 @@ namespace System.Globalization
             //
             if (null == source)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
 
             if ((options & ValidHashCodeOfStringMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, "options");
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
             }
             Contract.EndContractBlock();
 
@@ -1043,7 +1043,7 @@ namespace System.Globalization
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
 
             if (options == CompareOptions.Ordinal)

--- a/src/mscorlib/corefx/System/Globalization/CultureData.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureData.cs
@@ -418,7 +418,7 @@ namespace System.Globalization
                                                         CultureTypes.ReplacementCultures | CultureTypes.WindowsOnlyCultures |
                                                         CultureTypes.FrameworkCultures)) != 0)
             {
-                throw new ArgumentOutOfRangeException("types", 
+                throw new ArgumentOutOfRangeException(nameof(types), 
                               SR.Format(SR.ArgumentOutOfRange_Range, CultureTypes.NeutralCultures, CultureTypes.FrameworkCultures));
             }
 
@@ -681,7 +681,7 @@ namespace System.Globalization
 
             // If not successful, throw
             if (retVal == null)
-                throw new CultureNotFoundException("culture", culture, SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(culture), culture, SR.Argument_CultureNotSupported);
 
             // Return the one we found
             return retVal;

--- a/src/mscorlib/corefx/System/Globalization/CultureInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureInfo.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -206,7 +206,7 @@ namespace System.Globalization
         {
             if (name == null)
             {
-                throw new ArgumentNullException("name",
+                throw new ArgumentNullException(nameof(name),
                     SR.ArgumentNull_String);
             }
 
@@ -222,7 +222,7 @@ namespace System.Globalization
             // We don't check for other invalid LCIDS here...
             if (culture < 0)
             {
-                throw new ArgumentOutOfRangeException("culture", SR.ArgumentOutOfRange_NeedPosNum);
+                throw new ArgumentOutOfRangeException(nameof(culture), SR.ArgumentOutOfRange_NeedPosNum);
             }
             Contract.EndContractBlock();
 
@@ -240,7 +240,7 @@ namespace System.Globalization
                 case LOCALE_CUSTOM_UNSPECIFIED:
                     // Can't support unknown custom cultures and we do not support neutral or
                     // non-custom user locales.
-                    throw new CultureNotFoundException("culture", culture, SR.Argument_CultureNotSupported);
+                    throw new CultureNotFoundException(nameof(culture), culture, SR.Argument_CultureNotSupported);
 
                 default:
                     // Now see if this LCID is supported in the system default CultureData table.
@@ -258,7 +258,7 @@ namespace System.Globalization
 
             if (this.m_cultureData == null)
             {
-                throw new CultureNotFoundException("name", name, SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(name), name, SR.Argument_CultureNotSupported);
             }
 
             this.m_name = this.m_cultureData.CultureName;
@@ -275,13 +275,13 @@ namespace System.Globalization
         {
             if (cultureName == null)
             {
-                throw new ArgumentNullException("cultureName",SR.ArgumentNull_String);
+                throw new ArgumentNullException(nameof(cultureName),SR.ArgumentNull_String);
             }
             Contract.EndContractBlock();
 
             m_cultureData = CultureData.GetCultureData(cultureName, false);
             if (m_cultureData == null)
-                throw new CultureNotFoundException("cultureName", cultureName, SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(cultureName), cultureName, SR.Argument_CultureNotSupported);
             
             m_name = m_cultureData.CultureName;
 
@@ -492,7 +492,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
                 
                 if (s_asyncLocalCurrentCulture == null)
@@ -540,7 +540,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 CultureInfo.VerifyCultureName(value, true);
@@ -979,7 +979,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value", SR.ArgumentNull_Obj);
+                    throw new ArgumentNullException(nameof(value), SR.ArgumentNull_Obj);
                 }
                 VerifyWritable();
                 numInfo = value;
@@ -1013,7 +1013,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value", SR.ArgumentNull_Obj);
+                    throw new ArgumentNullException(nameof(value), SR.ArgumentNull_Obj);
                 }
                 VerifyWritable();
                 dateTimeInfo = value;
@@ -1189,7 +1189,7 @@ namespace System.Globalization
         {
             if (ci == null)
             {
-                throw new ArgumentNullException("ci");
+                throw new ArgumentNullException(nameof(ci));
             }
             Contract.Ensures(Contract.Result<CultureInfo>() != null);
             Contract.EndContractBlock();
@@ -1413,14 +1413,14 @@ namespace System.Globalization
             // Also check for zero as this would fail trying to add as a key to the hash.
             if (culture <= 0) 
             {
-                throw new ArgumentOutOfRangeException("culture", SR.ArgumentOutOfRange_NeedPosNum);
+                throw new ArgumentOutOfRangeException(nameof(culture), SR.ArgumentOutOfRange_NeedPosNum);
             }
             Contract.Ensures(Contract.Result<CultureInfo>() != null);
             Contract.EndContractBlock();
             CultureInfo retval = GetCultureInfoHelper(culture, null, null);
             if (null == retval)
             {
-                throw new CultureNotFoundException("culture", culture, SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(culture), culture, SR.Argument_CultureNotSupported);
             }
             return retval;
         }
@@ -1432,14 +1432,14 @@ namespace System.Globalization
             // Make sure we have a valid, non-zero length string as name
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             CultureInfo retval = GetCultureInfoHelper(0, name, null);
             if (retval == null)
             {
                 throw new CultureNotFoundException(
-                    "name", name, SR.Argument_CultureNotSupported);
+                    nameof(name), name, SR.Argument_CultureNotSupported);
             }
             return retval;
         }
@@ -1451,12 +1451,12 @@ namespace System.Globalization
             // Make sure we have a valid, non-zero length string as name
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
 
             if (altName == null)
             {
-                throw new ArgumentNullException("altName");
+                throw new ArgumentNullException(nameof(altName));
             }
             
             Contract.Ensures(Contract.Result<CultureInfo>() != null);
@@ -1479,7 +1479,7 @@ namespace System.Globalization
             // Disallow old zh-CHT/zh-CHS names
             if (name == "zh-CHT" || name == "zh-CHS")
             {
-                throw new CultureNotFoundException("name", SR.Format(SR.Argument_CultureIetfNotSupported, name));
+                throw new CultureNotFoundException(nameof(name), SR.Format(SR.Argument_CultureIetfNotSupported, name));
             }
             
             CultureInfo ci = GetCultureInfo(name);
@@ -1487,7 +1487,7 @@ namespace System.Globalization
             // Disallow alt sorts and es-es_TS
             if (ci.LCID > 0xffff || ci.LCID == 0x040a)
             {
-                throw new CultureNotFoundException("name", SR.Format(SR.Argument_CultureIetfNotSupported, name));
+                throw new CultureNotFoundException(nameof(name), SR.Format(SR.Argument_CultureIetfNotSupported, name));
             }
             
             return ci;

--- a/src/mscorlib/corefx/System/Globalization/CultureNotFoundException.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureNotFoundException.cs
@@ -71,7 +71,7 @@ namespace System.Globalization
         {
             if (info == null)
             {
-                throw new ArgumentNullException("info");
+                throw new ArgumentNullException(nameof(info));
             }
 
             base.GetObjectData(info, context);

--- a/src/mscorlib/corefx/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/DateTimeFormatInfo.cs
@@ -536,7 +536,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -562,7 +562,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value", SR.ArgumentNull_Obj);
+                    throw new ArgumentNullException(nameof(value), SR.ArgumentNull_Obj);
                 }
                 Contract.EndContractBlock();
                 if (value == calendar)
@@ -640,7 +640,7 @@ namespace System.Globalization
                 }
 
                 // The assigned calendar is not a valid calendar for this culture, throw
-                throw new ArgumentOutOfRangeException("value", SR.Argument_InvalidCalendar);
+                throw new ArgumentOutOfRangeException(nameof(value), SR.Argument_InvalidCalendar);
             }
         }
 
@@ -669,7 +669,7 @@ namespace System.Globalization
         {
             if (eraName == null)
             {
-                throw new ArgumentNullException("eraName",
+                throw new ArgumentNullException(nameof(eraName),
                     SR.ArgumentNull_String);
             }
             Contract.EndContractBlock();
@@ -758,7 +758,7 @@ namespace System.Globalization
             {
                 return (m_eraNames[era]);
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         internal String[] AbbreviatedEraNames
@@ -790,7 +790,7 @@ namespace System.Globalization
             {
                 return (m_abbrevEraNames[era]);
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         internal String[] AbbreviatedEnglishEraNames
@@ -827,7 +827,7 @@ namespace System.Globalization
 
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value", SR.ArgumentNull_String);
+                    throw new ArgumentNullException(nameof(value), SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
                 ClearTokenHashTable();
@@ -859,7 +859,7 @@ namespace System.Globalization
                 else
                 {
                     throw new ArgumentOutOfRangeException(
-                        "value", SR.Format(SR.ArgumentOutOfRange_Range,
+                        nameof(value), SR.Format(SR.ArgumentOutOfRange_Range,
                         DayOfWeek.Sunday, DayOfWeek.Saturday));
                 }
             }
@@ -888,7 +888,7 @@ namespace System.Globalization
                 else
                 {
                     throw new ArgumentOutOfRangeException(
-                        "value", SR.Format(SR.ArgumentOutOfRange_Range,
+                        nameof(value), SR.Format(SR.ArgumentOutOfRange_Range,
                         CalendarWeekRule.FirstDay, CalendarWeekRule.FirstFourDayWeek));
                 }
             }
@@ -911,7 +911,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -945,7 +945,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -986,7 +986,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -1025,7 +1025,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -1054,7 +1054,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -1097,7 +1097,7 @@ namespace System.Globalization
                 if (IsReadOnly)
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_String);
                 Contract.EndContractBlock();
 
@@ -1139,7 +1139,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -1296,7 +1296,7 @@ namespace System.Globalization
 
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value", SR.ArgumentNull_String);
+                    throw new ArgumentNullException(nameof(value), SR.ArgumentNull_String);
                 }
 
                 Contract.EndContractBlock();
@@ -1338,7 +1338,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -1382,12 +1382,12 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_Array);
                 }
                 if (value.Length != 7)
                 {
-                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 7), "value");
+                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 7), nameof(value));
                 }
                 Contract.EndContractBlock();
                 CheckNullValue(value, value.Length);
@@ -1411,12 +1411,12 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_Array);
                 }
                 if (value.Length != 7)
                 {
-                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 7), "value");
+                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 7), nameof(value));
                 }
                 Contract.EndContractBlock();
                 CheckNullValue(value, value.Length);
@@ -1438,12 +1438,12 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_Array);
                 }
                 if (value.Length != 7)
                 {
-                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 7), "value");
+                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 7), nameof(value));
                 }
                 Contract.EndContractBlock();
                 CheckNullValue(value, value.Length);
@@ -1467,12 +1467,12 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_Array);
                 }
                 if (value.Length != 13)
                 {
-                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 13), "value");
+                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 13), nameof(value));
                 }
                 Contract.EndContractBlock();
                 CheckNullValue(value, value.Length - 1);
@@ -1495,12 +1495,12 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_Array);
                 }
                 if (value.Length != 13)
                 {
-                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 13), "value");
+                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 13), nameof(value));
                 }
                 Contract.EndContractBlock();
                 CheckNullValue(value, value.Length - 1);
@@ -1566,7 +1566,7 @@ namespace System.Globalization
             if ((month < 1) || (month > monthNamesArray.Length))
             {
                 throw new ArgumentOutOfRangeException(
-                    "month", SR.Format(SR.ArgumentOutOfRange_Range,
+                    nameof(month), SR.Format(SR.ArgumentOutOfRange_Range,
                     1, monthNamesArray.Length));
             }
             return (monthNamesArray[month - 1]);
@@ -1627,7 +1627,7 @@ namespace System.Globalization
             if ((int)dayofweek < 0 || (int)dayofweek > 6)
             {
                 throw new ArgumentOutOfRangeException(
-                    "dayofweek", SR.Format(SR.ArgumentOutOfRange_Range,
+                    nameof(dayofweek), SR.Format(SR.ArgumentOutOfRange_Range,
                     DayOfWeek.Sunday, DayOfWeek.Saturday));
             }
             Contract.EndContractBlock();
@@ -1644,7 +1644,7 @@ namespace System.Globalization
             if ((int)dayOfWeek < 0 || (int)dayOfWeek > 6)
             {
                 throw new ArgumentOutOfRangeException(
-                    "dayOfWeek", SR.Format(SR.ArgumentOutOfRange_Range,
+                    nameof(dayOfWeek), SR.Format(SR.ArgumentOutOfRange_Range,
                     DayOfWeek.Sunday, DayOfWeek.Saturday));
             }
             Contract.EndContractBlock();
@@ -1749,7 +1749,7 @@ namespace System.Globalization
                     result = this.AllYearMonthPatterns;
                     break;
                 default:
-                    throw new ArgumentException(SR.Format_BadFormatSpecifier, "format");
+                    throw new ArgumentException(SR.Format_BadFormatSpecifier, nameof(format));
             }
             return (result);
         }
@@ -1760,7 +1760,7 @@ namespace System.Globalization
             if ((int)dayofweek < 0 || (int)dayofweek > 6)
             {
                 throw new ArgumentOutOfRangeException(
-                    "dayofweek", SR.Format(SR.ArgumentOutOfRange_Range,
+                    nameof(dayofweek), SR.Format(SR.ArgumentOutOfRange_Range,
                     DayOfWeek.Sunday, DayOfWeek.Saturday));
             }
             Contract.EndContractBlock();
@@ -1776,7 +1776,7 @@ namespace System.Globalization
             if (month < 1 || month > 13)
             {
                 throw new ArgumentOutOfRangeException(
-                    "month", SR.Format(SR.ArgumentOutOfRange_Range,
+                    nameof(month), SR.Format(SR.ArgumentOutOfRange_Range,
                     1, 13));
             }
             Contract.EndContractBlock();
@@ -1790,7 +1790,7 @@ namespace System.Globalization
             if (month < 1 || month > 13)
             {
                 throw new ArgumentOutOfRangeException(
-                    "month", SR.Format(SR.ArgumentOutOfRange_Range,
+                    nameof(month), SR.Format(SR.ArgumentOutOfRange_Range,
                     1, 13));
             }
             Contract.EndContractBlock();
@@ -1995,7 +1995,7 @@ namespace System.Globalization
         {
             if (dtfi == null)
             {
-                throw new ArgumentNullException("dtfi",
+                throw new ArgumentNullException(nameof(dtfi),
                     SR.ArgumentNull_Obj);
             }
             Contract.EndContractBlock();
@@ -2057,12 +2057,12 @@ namespace System.Globalization
 
             if (patterns == null)
             {
-                throw new ArgumentNullException("patterns", SR.ArgumentNull_Array);
+                throw new ArgumentNullException(nameof(patterns), SR.ArgumentNull_Array);
             }
 
             if (patterns.Length == 0)
             {
-                throw new ArgumentException(SR.Arg_ArrayZeroError, "patterns");
+                throw new ArgumentException(SR.Arg_ArrayZeroError, nameof(patterns));
             }
 
             Contract.EndContractBlock();
@@ -2105,7 +2105,7 @@ namespace System.Globalization
                     break;
 
                 default:
-                    throw new ArgumentException(SR.Format_BadFormatSpecifier, "format");
+                    throw new ArgumentException(SR.Format_BadFormatSpecifier, nameof(format));
             }
 
             // Clear the token hash table, note that even short dates could require this
@@ -2125,12 +2125,12 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_Array);
                 }
                 if (value.Length != 13)
                 {
-                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 13), "value");
+                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 13), nameof(value));
                 }
                 Contract.EndContractBlock();
                 CheckNullValue(value, value.Length - 1);
@@ -2152,12 +2152,12 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                         SR.ArgumentNull_Array);
                 }
                 if (value.Length != 13)
                 {
-                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 13), "value");
+                    throw new ArgumentException(SR.Format(SR.Argument_InvalidArrayLength, 13), nameof(value));
                 }
                 Contract.EndContractBlock();
                 CheckNullValue(value, value.Length - 1);

--- a/src/mscorlib/corefx/System/Globalization/EastAsianLunisolarCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/EastAsianLunisolarCalendar.cs
@@ -68,7 +68,7 @@ namespace System.Globalization
             if ((sexagenaryYear < 1) || (sexagenaryYear > 60))
             {
                 throw new ArgumentOutOfRangeException(
-                                "sexagenaryYear",
+                                nameof(sexagenaryYear),
                                 SR.Format(SR.ArgumentOutOfRange_Range, 1, 60));
             }
             Contract.EndContractBlock();
@@ -85,7 +85,7 @@ namespace System.Globalization
             if ((sexagenaryYear < 1) || (sexagenaryYear > 60))
             {
                 throw new ArgumentOutOfRangeException(
-                                "sexagenaryYear",
+                                nameof(sexagenaryYear),
                                 SR.Format(SR.ArgumentOutOfRange_Range, 1, 60));
             }
             Contract.EndContractBlock();
@@ -132,7 +132,7 @@ namespace System.Globalization
                     return (mEraInfo[i].minEraYear);
                 }
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         internal int MaxEraCalendarYear(int era)
@@ -161,7 +161,7 @@ namespace System.Globalization
                     return (mEraInfo[i].maxEraYear);
                 }
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         internal EastAsianLunisolarCalendar()
@@ -189,7 +189,7 @@ namespace System.Globalization
 
             if ((era < GetEra(MinDate)) || (era > GetEra(MaxDate)))
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
         }
 
@@ -201,7 +201,7 @@ namespace System.Globalization
             if ((year < MinCalendarYear) || (year > MaxCalendarYear))
             {
                 throw new ArgumentOutOfRangeException(
-                                "year",
+                                nameof(year),
                                 SR.Format(SR.ArgumentOutOfRange_Range, MinEraCalendarYear(era), MaxEraCalendarYear(era)));
             }
             return year;
@@ -215,12 +215,12 @@ namespace System.Globalization
             {
                 //Reject if there is no leap month this year
                 if (GetYearInfo(year, LeapMonth) == 0)
-                    throw new ArgumentOutOfRangeException("month", SR.ArgumentOutOfRange_Month);
+                    throw new ArgumentOutOfRangeException(nameof(month), SR.ArgumentOutOfRange_Month);
             }
 
             if (month < 1 || month > 13)
             {
-                throw new ArgumentOutOfRangeException("month", SR.ArgumentOutOfRange_Month);
+                throw new ArgumentOutOfRangeException(nameof(month), SR.ArgumentOutOfRange_Month);
             }
             return year;
         }
@@ -265,7 +265,7 @@ namespace System.Globalization
             if (day < 1 || day > daysInMonth)
             {
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             SR.Format(SR.ArgumentOutOfRange_Day, daysInMonth, month));
             }
 
@@ -446,7 +446,7 @@ namespace System.Globalization
             if (months < -120000 || months > 120000)
             {
                 throw new ArgumentOutOfRangeException(
-                            "months",
+                            nameof(months),
                             SR.Format(SR.ArgumentOutOfRange_Range, -120000, 120000));
             }
             Contract.EndContractBlock();
@@ -626,7 +626,7 @@ namespace System.Globalization
             if (day < 1 || day > daysInMonth)
             {
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             SR.Format(SR.ArgumentOutOfRange_Day, daysInMonth, month));
             }
             int m = GetYearInfo(year, LeapMonth);
@@ -693,7 +693,7 @@ namespace System.Globalization
                 if (value < 99 || value > MaxCalendarYear)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "value",
+                                nameof(value),
                                 SR.Format(SR.ArgumentOutOfRange_Range, 99, MaxCalendarYear));
                 }
                 twoDigitYearMax = value;
@@ -705,7 +705,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();

--- a/src/mscorlib/corefx/System/Globalization/GregorianCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/GregorianCalendar.cs
@@ -123,7 +123,7 @@ namespace System.Globalization
             if ((int)type < (int)GregorianCalendarTypes.Localized || (int)type > (int)GregorianCalendarTypes.TransliteratedFrench)
             {
                 throw new ArgumentOutOfRangeException(
-                            "type",
+                            nameof(type),
                             SR.Format(SR.ArgumentOutOfRange_Range,
                     GregorianCalendarTypes.Localized, GregorianCalendarTypes.TransliteratedFrench));
             }
@@ -286,7 +286,7 @@ namespace System.Globalization
             if (months < -120000 || months > 120000)
             {
                 throw new ArgumentOutOfRangeException(
-                            "months",
+                            nameof(months),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -375,17 +375,17 @@ namespace System.Globalization
             {
                 if (year < 1 || year > MaxYear)
                 {
-                    throw new ArgumentOutOfRangeException("year", SR.Format(SR.ArgumentOutOfRange_Range,
+                    throw new ArgumentOutOfRangeException(nameof(year), SR.Format(SR.ArgumentOutOfRange_Range,
                         1, MaxYear));
                 }
                 if (month < 1 || month > 12)
                 {
-                    throw new ArgumentOutOfRangeException("month", SR.ArgumentOutOfRange_Month);
+                    throw new ArgumentOutOfRangeException(nameof(month), SR.ArgumentOutOfRange_Month);
                 }
                 int[] days = ((year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? DaysToMonth366 : DaysToMonth365);
                 return (days[month] - days[month - 1]);
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         // Returns the number of days in the year given by the year argument for the current era.
@@ -400,14 +400,14 @@ namespace System.Globalization
                     return ((year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? 366 : 365);
                 }
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
                                 1,
                                 MaxYear));
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         // Returns the era for the specified DateTime value.
@@ -447,14 +447,14 @@ namespace System.Globalization
                     return (12);
                 }
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
                                 1,
                                 MaxYear));
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         // Returns the year part of the specified DateTime. The returned value is an
@@ -474,25 +474,25 @@ namespace System.Globalization
         {
             if (month < 1 || month > 12)
             {
-                throw new ArgumentOutOfRangeException("month", SR.Format(SR.ArgumentOutOfRange_Range,
+                throw new ArgumentOutOfRangeException(nameof(month), SR.Format(SR.ArgumentOutOfRange_Range,
                     1, 12));
             }
             Contract.EndContractBlock();
 
             if (era != CurrentEra && era != ADEra)
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
             if (year < 1 || year > MaxYear)
             {
                 throw new ArgumentOutOfRangeException(
-                                "year",
+                                nameof(year),
                                 SR.Format(SR.ArgumentOutOfRange_Range, 1, MaxYear));
             }
 
             if (day < 1 || day > GetDaysInMonth(year, month))
             {
-                throw new ArgumentOutOfRangeException("day", SR.Format(SR.ArgumentOutOfRange_Range,
+                throw new ArgumentOutOfRangeException(nameof(day), SR.Format(SR.ArgumentOutOfRange_Range,
                     1, GetDaysInMonth(year, month)));
             }
             if (!IsLeapYear(year))
@@ -515,12 +515,12 @@ namespace System.Globalization
         {
             if (era != CurrentEra && era != ADEra)
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
             if (year < 1 || year > MaxYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range, 1, MaxYear));
@@ -537,13 +537,13 @@ namespace System.Globalization
         {
             if (era != CurrentEra && era != ADEra)
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
 
             if (year < 1 || year > MaxYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range, 1, MaxYear));
@@ -551,7 +551,7 @@ namespace System.Globalization
 
             if (month < 1 || month > 12)
             {
-                throw new ArgumentOutOfRangeException("month", SR.Format(SR.ArgumentOutOfRange_Range,
+                throw new ArgumentOutOfRangeException(nameof(month), SR.Format(SR.ArgumentOutOfRange_Range,
                     1, 12));
             }
             Contract.EndContractBlock();
@@ -572,12 +572,12 @@ namespace System.Globalization
                 }
 
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range, 1, MaxYear));
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         // Returns the date and time converted to a DateTime value.  Throws an exception if the n-tuple is invalid.
@@ -589,7 +589,7 @@ namespace System.Globalization
             {
                 return new DateTime(year, month, day, hour, minute, second, millisecond);
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         internal override Boolean TryToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era, out DateTime result)
@@ -652,7 +652,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();
@@ -660,7 +660,7 @@ namespace System.Globalization
             if (year > MaxYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range, 1, MaxYear));

--- a/src/mscorlib/corefx/System/Globalization/GregorianCalendarHelper.cs
+++ b/src/mscorlib/corefx/System/Globalization/GregorianCalendarHelper.cs
@@ -148,7 +148,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();
@@ -165,7 +165,7 @@ namespace System.Globalization
                     if (year < m_EraInfo[i].minEraYear || year > m_EraInfo[i].maxEraYear)
                     {
                         throw new ArgumentOutOfRangeException(
-                                    "year",
+                                    nameof(year),
                                     String.Format(
                                         CultureInfo.CurrentCulture,
                                         SR.ArgumentOutOfRange_Range,
@@ -175,7 +175,7 @@ namespace System.Globalization
                     return (m_EraInfo[i].yearOffset + year);
                 }
             }
-            throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+            throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
         }
 
         internal bool IsValidYear(int year, int era)
@@ -308,7 +308,7 @@ namespace System.Globalization
                 if (millisecond < 0 || millisecond >= MillisPerSecond)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "millisecond",
+                                nameof(millisecond),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -358,7 +358,7 @@ namespace System.Globalization
             if (months < -120000 || months > 120000)
             {
                 throw new ArgumentOutOfRangeException(
-                            "months",
+                            nameof(months),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -446,7 +446,7 @@ namespace System.Globalization
             year = GetGregorianYear(year, era);
             if (month < 1 || month > 12)
             {
-                throw new ArgumentOutOfRangeException("month", SR.ArgumentOutOfRange_Month);
+                throw new ArgumentOutOfRangeException(nameof(month), SR.ArgumentOutOfRange_Month);
             }
             int[] days = ((year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? DaysToMonth366 : DaysToMonth365);
             return (days[month] - days[month - 1]);
@@ -476,7 +476,7 @@ namespace System.Globalization
                     return (m_EraInfo[i].era);
                 }
             }
-            throw new ArgumentOutOfRangeException("time", SR.ArgumentOutOfRange_Era);
+            throw new ArgumentOutOfRangeException(nameof(time), SR.ArgumentOutOfRange_Era);
         }
 
 
@@ -558,7 +558,7 @@ namespace System.Globalization
             if (day < 1 || day > GetDaysInMonth(year, month, era))
             {
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -598,7 +598,7 @@ namespace System.Globalization
             if (month < 1 || month > 12)
             {
                 throw new ArgumentOutOfRangeException(
-                            "month",
+                            nameof(month),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -640,7 +640,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedPosNum);
             }
             Contract.EndContractBlock();
@@ -654,7 +654,7 @@ namespace System.Globalization
             if (year < m_minYear || year > m_maxYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range, m_minYear, m_maxYear));

--- a/src/mscorlib/corefx/System/Globalization/HebrewCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/HebrewCalendar.cs
@@ -379,7 +379,7 @@ namespace System.Globalization
             if (month < 1 || month > monthsInYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "month",
+                            nameof(month),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -405,7 +405,7 @@ namespace System.Globalization
             if (day < 1 || day > daysInMonth)
             {
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -418,7 +418,7 @@ namespace System.Globalization
         {
             if (era != CurrentEra && era != HebrewEra)
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
         }
 
@@ -478,7 +478,7 @@ namespace System.Globalization
             int index = gregorianYear - FirstGregorianTableYear;
             if (index < 0 || index > TABLESIZE)
             {
-                throw new ArgumentOutOfRangeException("gregorianYear");
+                throw new ArgumentOutOfRangeException(nameof(gregorianYear));
             }
 
             index *= 2;
@@ -713,7 +713,7 @@ namespace System.Globalization
             catch (ArgumentException)
             {
                 throw new ArgumentOutOfRangeException(
-                            "months",
+                            nameof(months),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_AddValue));
@@ -736,7 +736,7 @@ namespace System.Globalization
             int d = GetDatePart(time.Ticks, DatePartDay);
 
             y += years;
-            CheckHebrewYearValue(y, Calendar.CurrentEra, "years");
+            CheckHebrewYearValue(y, Calendar.CurrentEra, nameof(years));
 
             int months = GetMonthsInYear(y, CurrentEra);
             if (m > months)
@@ -779,7 +779,7 @@ namespace System.Globalization
 
         internal static int GetHebrewYearType(int year, int era)
         {
-            CheckHebrewYearValue(year, era, "year");
+            CheckHebrewYearValue(year, era, nameof(year));
             // The HebrewTable is indexed by Gregorian year and starts from FirstGregorianYear.
             // So we need to convert year (Hebrew year value) to Gregorian Year below.
             return (s_hebrewTable[(year - HebrewYearOf1AD - FirstGregorianTableYear) * 2 + 1]);
@@ -832,7 +832,7 @@ namespace System.Globalization
             int monthDays = s_lunarMonthLen[hebrewYearType * MaxMonthPlusOne + month];
             if (monthDays == 0)
             {
-                throw new ArgumentOutOfRangeException("month", SR.ArgumentOutOfRange_Month);
+                throw new ArgumentOutOfRangeException(nameof(month), SR.ArgumentOutOfRange_Month);
             }
             return (monthDays);
         }
@@ -964,7 +964,7 @@ namespace System.Globalization
 
         public override bool IsLeapYear(int year, int era)
         {
-            CheckHebrewYearValue(year, era, "year");
+            CheckHebrewYearValue(year, era, nameof(year));
             return (((7 * (long)year + 1) % 19) < 7);
         }
 
@@ -1055,7 +1055,7 @@ namespace System.Globalization
 
         public override DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era)
         {
-            CheckHebrewYearValue(year, era, "year");
+            CheckHebrewYearValue(year, era, nameof(year));
             CheckHebrewMonthValue(year, month, era);
             CheckHebrewDayValue(year, month, day, era);
             DateTime dt = HebrewToGregorian(year, month, day, hour, minute, second, millisecond);
@@ -1086,7 +1086,7 @@ namespace System.Globalization
                 }
                 else
                 {
-                    CheckHebrewYearValue(value, HebrewEra, "value");
+                    CheckHebrewYearValue(value, HebrewEra, nameof(value));
                 }
                 twoDigitYearMax = value;
             }
@@ -1097,7 +1097,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();
@@ -1110,7 +1110,7 @@ namespace System.Globalization
             if (year > MaxHebrewYear || year < MinHebrewYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,

--- a/src/mscorlib/corefx/System/Globalization/HijriCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/HijriCalendar.cs
@@ -230,7 +230,7 @@ namespace System.Globalization
         {
             if (era != CurrentEra && era != HijriEra)
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
         }
 
@@ -240,7 +240,7 @@ namespace System.Globalization
             if (year < 1 || year > MaxCalendarYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -257,7 +257,7 @@ namespace System.Globalization
                 if (month > MaxCalendarMonth)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "month",
+                                nameof(month),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -268,7 +268,7 @@ namespace System.Globalization
 
             if (month < 1 || month > 12)
             {
-                throw new ArgumentOutOfRangeException("month", SR.ArgumentOutOfRange_Month);
+                throw new ArgumentOutOfRangeException(nameof(month), SR.ArgumentOutOfRange_Month);
             }
         }
 
@@ -395,7 +395,7 @@ namespace System.Globalization
             if (months < -120000 || months > 120000)
             {
                 throw new ArgumentOutOfRangeException(
-                            "months",
+                            nameof(months),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -551,7 +551,7 @@ namespace System.Globalization
             if (day < 1 || day > daysInMonth)
             {
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Day,
@@ -602,7 +602,7 @@ namespace System.Globalization
             if (day < 1 || day > daysInMonth)
             {
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Day,
@@ -642,7 +642,7 @@ namespace System.Globalization
                 if (value < 99 || value > MaxCalendarYear)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "value",
+                                nameof(value),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -658,7 +658,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();
@@ -671,7 +671,7 @@ namespace System.Globalization
             if (year > MaxCalendarYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,

--- a/src/mscorlib/corefx/System/Globalization/JapaneseCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/JapaneseCalendar.cs
@@ -311,7 +311,7 @@ namespace System.Globalization
         {
             if (year <= 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedPosNum);
             }
             Contract.EndContractBlock();
@@ -319,7 +319,7 @@ namespace System.Globalization
             if (year > helper.MaxYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,

--- a/src/mscorlib/corefx/System/Globalization/JulianCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/JulianCalendar.cs
@@ -94,7 +94,7 @@ namespace System.Globalization
         {
             if (era != CurrentEra && era != JulianEra)
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
         }
 
@@ -104,7 +104,7 @@ namespace System.Globalization
             if (year <= 0 || year > MaxYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -117,7 +117,7 @@ namespace System.Globalization
         {
             if (month < 1 || month > 12)
             {
-                throw new ArgumentOutOfRangeException("month", SR.ArgumentOutOfRange_Month);
+                throw new ArgumentOutOfRangeException(nameof(month), SR.ArgumentOutOfRange_Month);
             }
         }
 
@@ -148,7 +148,7 @@ namespace System.Globalization
             if (day < 1 || day > monthDays)
             {
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -220,7 +220,7 @@ namespace System.Globalization
             if (months < -120000 || months > 120000)
             {
                 throw new ArgumentOutOfRangeException(
-                            "months",
+                            nameof(months),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -380,7 +380,7 @@ namespace System.Globalization
             if (millisecond < 0 || millisecond >= MillisPerSecond)
             {
                 throw new ArgumentOutOfRangeException(
-                            "millisecond",
+                            nameof(millisecond),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -428,7 +428,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();
@@ -436,7 +436,7 @@ namespace System.Globalization
             if (year > MaxYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Bounds_Lower_Upper,

--- a/src/mscorlib/corefx/System/Globalization/KoreanCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/KoreanCalendar.cs
@@ -262,7 +262,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();

--- a/src/mscorlib/corefx/System/Globalization/KoreanLunisolarCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/KoreanLunisolarCalendar.cs
@@ -1275,12 +1275,12 @@ namespace System.Globalization
         internal override int GetGregorianYear(int year, int era)
         {
             if (era != CurrentEra && era != GregorianEra)
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
 
             if (year < MIN_LUNISOLAR_YEAR || year > MAX_LUNISOLAR_YEAR)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range, MIN_LUNISOLAR_YEAR, MAX_LUNISOLAR_YEAR));

--- a/src/mscorlib/corefx/System/Globalization/NumberFormatInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/NumberFormatInfo.cs
@@ -838,7 +838,7 @@ namespace System.Globalization
         {
             if (nfi == null)
             {
-                throw new ArgumentNullException("nfi");
+                throw new ArgumentNullException(nameof(nfi));
             }
             Contract.EndContractBlock();
             if (nfi.IsReadOnly)
@@ -862,7 +862,7 @@ namespace System.Globalization
             // Check for undefined flags
             if ((style & InvalidNumberStyles) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidNumberStyles, "style");
+                throw new ArgumentException(SR.Argument_InvalidNumberStyles, nameof(style));
             }
             Contract.EndContractBlock();
             if ((style & NumberStyles.AllowHexSpecifier) != 0)
@@ -879,7 +879,7 @@ namespace System.Globalization
             // Check for undefined flags
             if ((style & InvalidNumberStyles) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidNumberStyles, "style");
+                throw new ArgumentException(SR.Argument_InvalidNumberStyles, nameof(style));
             }
             Contract.EndContractBlock();
             if ((style & NumberStyles.AllowHexSpecifier) != 0)

--- a/src/mscorlib/corefx/System/Globalization/PersianCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/PersianCalendar.cs
@@ -136,7 +136,7 @@ namespace System.Globalization
         {
             if (era != CurrentEra && era != PersianEra)
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
         }
 
@@ -146,7 +146,7 @@ namespace System.Globalization
             if (year < 1 || year > MaxCalendarYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -163,7 +163,7 @@ namespace System.Globalization
                 if (month > MaxCalendarMonth)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "month",
+                                nameof(month),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -174,7 +174,7 @@ namespace System.Globalization
 
             if (month < 1 || month > 12)
             {
-                throw new ArgumentOutOfRangeException("month", SR.ArgumentOutOfRange_Month);
+                throw new ArgumentOutOfRangeException(nameof(month), SR.ArgumentOutOfRange_Month);
             }
         }
 
@@ -288,7 +288,7 @@ namespace System.Globalization
             if (months < -120000 || months > 120000)
             {
                 throw new ArgumentOutOfRangeException(
-                            "months",
+                            nameof(months),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -469,7 +469,7 @@ namespace System.Globalization
             if (day < 1 || day > daysInMonth)
             {
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Day,
@@ -529,7 +529,7 @@ namespace System.Globalization
             {
                 // BCLDebug.Log("year = " + year + ", month = " + month + ", day = " + day);
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Day,
@@ -568,7 +568,7 @@ namespace System.Globalization
                 if (value < 99 || value > MaxCalendarYear)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "value",
+                                nameof(value),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -585,7 +585,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();
@@ -598,7 +598,7 @@ namespace System.Globalization
             if (year > MaxCalendarYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,

--- a/src/mscorlib/corefx/System/Globalization/RegionInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/RegionInfo.cs
@@ -60,11 +60,11 @@ namespace System.Globalization
         public RegionInfo(String name)
         {
             if (name == null)
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
 
             if (name.Length == 0) //The InvariantCulture has no matching region
             {
-                throw new ArgumentException(SR.Argument_NoRegionInvariantCulture, "name");
+                throw new ArgumentException(SR.Argument_NoRegionInvariantCulture, nameof(name));
             }
 
             Contract.EndContractBlock();
@@ -77,12 +77,12 @@ namespace System.Globalization
                 throw new ArgumentException(
                     String.Format(
                         CultureInfo.CurrentCulture,
-                        SR.Argument_InvalidCultureName, name), "name");
+                        SR.Argument_InvalidCultureName, name), nameof(name));
 
 
             // Not supposed to be neutral
             if (_cultureData.IsNeutralCulture)
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidNeutralRegionName, name), "name");
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidNeutralRegionName, name), nameof(name));
 
             SetName(name);
         }
@@ -98,13 +98,13 @@ namespace System.Globalization
             if (culture == CultureInfo.LOCALE_NEUTRAL)
             {
                 // Not supposed to be neutral
-                throw new ArgumentException(SR.Format(SR.Argument_CultureIsNeutral, culture), "culture");
+                throw new ArgumentException(SR.Format(SR.Argument_CultureIsNeutral, culture), nameof(culture));
             }
 
             if (culture == CultureInfo.LOCALE_CUSTOM_DEFAULT)
             {
                 // Not supposed to be neutral
-                throw new ArgumentException(SR.Format(SR.Argument_CustomCultureCannotBePassedByNumber, culture), "culture");
+                throw new ArgumentException(SR.Format(SR.Argument_CustomCultureCannotBePassedByNumber, culture), nameof(culture));
             }
             
             _cultureData = CultureData.GetCultureData(culture, true);
@@ -113,7 +113,7 @@ namespace System.Globalization
             if (_cultureData.IsNeutralCulture)
             {
                 // Not supposed to be neutral
-                throw new ArgumentException(SR.Format(SR.Argument_CultureIsNeutral, culture), "culture");
+                throw new ArgumentException(SR.Format(SR.Argument_CultureIsNeutral, culture), nameof(culture));
             }
         }
 

--- a/src/mscorlib/corefx/System/Globalization/SortKey.cs
+++ b/src/mscorlib/corefx/System/Globalization/SortKey.cs
@@ -118,7 +118,7 @@ namespace System.Globalization {
         {
             if (sortkey1==null || sortkey2==null)
             {
-                throw new ArgumentNullException((sortkey1 == null ? "sortkey1" : "sortkey2"));
+                throw new ArgumentNullException((sortkey1 == null ? nameof(sortkey1) : nameof(sortkey2)));
             }
             Contract.EndContractBlock();
     

--- a/src/mscorlib/corefx/System/Globalization/StringInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/StringInfo.cs
@@ -127,11 +127,11 @@ namespace System.Globalization
                 // Just decide which error to give depending on the param they gave us....
                 if (startingTextElement < 0) 
                 {
-                    throw new ArgumentOutOfRangeException("startingTextElement", SR.ArgumentOutOfRange_NeedPosNum);
+                    throw new ArgumentOutOfRangeException(nameof(startingTextElement), SR.ArgumentOutOfRange_NeedPosNum);
                 }
                 else
                 {
-                    throw new ArgumentOutOfRangeException("startingTextElement", SR.Arg_ArgumentOutOfRangeException);
+                    throw new ArgumentOutOfRangeException(nameof(startingTextElement), SR.Arg_ArgumentOutOfRangeException);
                 }
             }
             return (SubstringByTextElements(startingTextElement, Indexes.Length - startingTextElement));
@@ -141,22 +141,22 @@ namespace System.Globalization
         {
             if (startingTextElement < 0)
             {
-                throw new ArgumentOutOfRangeException("startingTextElement", SR.ArgumentOutOfRange_NeedPosNum);
+                throw new ArgumentOutOfRangeException(nameof(startingTextElement), SR.ArgumentOutOfRange_NeedPosNum);
             }
 
             if (this.String.Length == 0 || startingTextElement >= Indexes.Length)
             {
-                throw new ArgumentOutOfRangeException("startingTextElement", SR.Arg_ArgumentOutOfRangeException);
+                throw new ArgumentOutOfRangeException(nameof(startingTextElement), SR.Arg_ArgumentOutOfRangeException);
             }
 
             if (lengthInTextElements < 0)
             {
-                throw new ArgumentOutOfRangeException("lengthInTextElements", SR.ArgumentOutOfRange_NeedPosNum);
+                throw new ArgumentOutOfRangeException(nameof(lengthInTextElements), SR.ArgumentOutOfRange_NeedPosNum);
             }
 
             if (startingTextElement > Indexes.Length - lengthInTextElements)
             {
-                throw new ArgumentOutOfRangeException("lengthInTextElements", SR.Arg_ArgumentOutOfRangeException);
+                throw new ArgumentOutOfRangeException(nameof(lengthInTextElements), SR.Arg_ArgumentOutOfRangeException);
             }
 
             int start = Indexes[startingTextElement];
@@ -281,7 +281,7 @@ namespace System.Globalization
             //
             if (str == null)
             {
-                throw new ArgumentNullException("str");
+                throw new ArgumentNullException(nameof(str));
             }
             Contract.EndContractBlock();
 
@@ -292,7 +292,7 @@ namespace System.Globalization
                 {
                     return (String.Empty);
                 }
-                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             }
 
             int charLen;
@@ -312,14 +312,14 @@ namespace System.Globalization
             //
             if (str == null)
             {
-                throw new ArgumentNullException("str");
+                throw new ArgumentNullException(nameof(str));
             }
             Contract.EndContractBlock();
 
             int len = str.Length;
             if (index < 0 || (index > len))
             {
-                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+                throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             }
 
             return (new TextElementEnumerator(str, index, len));
@@ -341,7 +341,7 @@ namespace System.Globalization
         {
             if (str == null)
             {
-                throw new ArgumentNullException("str");
+                throw new ArgumentNullException(nameof(str));
             }
             Contract.EndContractBlock();
 

--- a/src/mscorlib/corefx/System/Globalization/TaiwanCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/TaiwanCalendar.cs
@@ -269,7 +269,7 @@ namespace System.Globalization
         {
             if (year <= 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedPosNum);
             }
             Contract.EndContractBlock();
@@ -277,7 +277,7 @@ namespace System.Globalization
             if (year > helper.MaxYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,

--- a/src/mscorlib/corefx/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.cs
@@ -256,7 +256,7 @@ namespace System.Globalization
         [System.Runtime.InteropServices.ComVisible(false)]
         public static TextInfo ReadOnly(TextInfo textInfo)
         {
-            if (textInfo == null) { throw new ArgumentNullException("textInfo"); }
+            if (textInfo == null) { throw new ArgumentNullException(nameof(textInfo)); }
             Contract.EndContractBlock();
             if (textInfo.IsReadOnly) { return (textInfo); }
 
@@ -302,7 +302,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value", SR.ArgumentNull_String);
+                    throw new ArgumentNullException(nameof(value), SR.ArgumentNull_String);
                 }
                 VerifyWritable();
                 _listSeparator = value;
@@ -328,7 +328,7 @@ namespace System.Globalization
 
         public unsafe virtual String ToLower(String str)
         {
-            if (str == null) { throw new ArgumentNullException("str"); }
+            if (str == null) { throw new ArgumentNullException(nameof(str)); }
 
             return ChangeCase(str, toUpper: false);
         }
@@ -361,7 +361,7 @@ namespace System.Globalization
 
         public unsafe virtual String ToUpper(String str)
         {
-            if (str == null) { throw new ArgumentNullException("str"); }
+            if (str == null) { throw new ArgumentNullException(nameof(str)); }
 
             return ChangeCase(str, toUpper: true);
         }
@@ -471,7 +471,7 @@ namespace System.Globalization
         {
             if (str == null)  
             {
-                throw new ArgumentNullException("str");
+                throw new ArgumentNullException(nameof(str));
             }
             Contract.EndContractBlock();
             if (str.Length == 0) 
@@ -700,7 +700,7 @@ namespace System.Globalization
             // Validate inputs
             if (str == null)
             {
-                throw new ArgumentNullException("str");
+                throw new ArgumentNullException(nameof(str));
             }
 
             // This code assumes that ASCII casing is safe for whatever context is passed in.

--- a/src/mscorlib/corefx/System/Globalization/ThaiBuddhistCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/ThaiBuddhistCalendar.cs
@@ -230,7 +230,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();

--- a/src/mscorlib/corefx/System/Globalization/UmAlQuraCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/UmAlQuraCalendar.cs
@@ -376,7 +376,7 @@ namespace System.Globalization
         {
             if (era != CurrentEra && era != UmAlQuraEra)
             {
-                throw new ArgumentOutOfRangeException("era", SR.ArgumentOutOfRange_InvalidEraValue);
+                throw new ArgumentOutOfRangeException(nameof(era), SR.ArgumentOutOfRange_InvalidEraValue);
             }
         }
 
@@ -386,7 +386,7 @@ namespace System.Globalization
             if (year < MinCalendarYear || year > MaxCalendarYear)
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -400,7 +400,7 @@ namespace System.Globalization
             CheckYearRange(year, era);
             if (month < 1 || month > 12)
             {
-                throw new ArgumentOutOfRangeException("month", SR.ArgumentOutOfRange_Month);
+                throw new ArgumentOutOfRangeException(nameof(month), SR.ArgumentOutOfRange_Month);
             }
         }
 
@@ -518,7 +518,7 @@ namespace System.Globalization
             if (months < -120000 || months > 120000)
             {
                 throw new ArgumentOutOfRangeException(
-                            "months",
+                            nameof(months),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
@@ -719,7 +719,7 @@ namespace System.Globalization
             if (day < 1 || day > daysInMonth)
             {
                 throw new ArgumentOutOfRangeException(
-                            "day",
+                            nameof(day),
                             String.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Day,
@@ -783,7 +783,7 @@ namespace System.Globalization
             if (day < 1 || day > daysInMonth)
             {
                 throw new ArgumentOutOfRangeException(
-                           "day",
+                           nameof(day),
                            String.Format(
                                CultureInfo.CurrentCulture,
                                SR.ArgumentOutOfRange_Day,
@@ -823,7 +823,7 @@ namespace System.Globalization
                 if (value != 99 && (value < MinCalendarYear || value > MaxCalendarYear))
                 {
                     throw new ArgumentOutOfRangeException(
-                                "value",
+                                nameof(value),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -843,7 +843,7 @@ namespace System.Globalization
         {
             if (year < 0)
             {
-                throw new ArgumentOutOfRangeException("year",
+                throw new ArgumentOutOfRangeException(nameof(year),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
             }
             Contract.EndContractBlock();
@@ -856,7 +856,7 @@ namespace System.Globalization
             if ((year < MinCalendarYear) || (year > MaxCalendarYear))
             {
                 throw new ArgumentOutOfRangeException(
-                            "year",
+                            nameof(year),
                             String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,

--- a/src/mscorlib/corefx/System/IO/FileStream.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.cs
@@ -141,11 +141,11 @@ namespace System.IO
             string badArg = null;
 
             if (mode < FileMode.CreateNew || mode > FileMode.Append)
-                badArg = "mode";
+                badArg = nameof(mode);
             else if (access < FileAccess.Read || access > FileAccess.ReadWrite)
-                badArg = "access";
+                badArg = nameof(access);
             else if (tempshare < FileShare.None || tempshare > (FileShare.ReadWrite | FileShare.Delete))
-                badArg = "share";
+                badArg = nameof(share);
 
             if (badArg != null)
                 throw new ArgumentOutOfRangeException(badArg, SR.ArgumentOutOfRange_Enum);

--- a/src/mscorlib/corefx/System/Security/SecureString.Unix.cs
+++ b/src/mscorlib/corefx/System/Security/SecureString.Unix.cs
@@ -201,7 +201,7 @@ namespace System.Security
             // Make sure the requested capacity doesn't exceed SecureString's defined limit
             if (capacity > MaxLength)
             {
-                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_Capacity);
+                throw new ArgumentOutOfRangeException(nameof(capacity), SR.ArgumentOutOfRange_Capacity);
             }
 
             // If we already have enough space allocated, we're done

--- a/src/mscorlib/src/System/Collections/ArrayList.cs
+++ b/src/mscorlib/src/System/Collections/ArrayList.cs
@@ -68,7 +68,7 @@ namespace System.Collections {
         // before any reallocations are required.
         // 
          public ArrayList(int capacity) {
-             if (capacity < 0) throw new ArgumentOutOfRangeException(nameof(capacity), Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", "capacity"));
+             if (capacity < 0) throw new ArgumentOutOfRangeException(nameof(capacity), Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", nameof(capacity)));
              Contract.EndContractBlock();
 
              if (capacity == 0)
@@ -539,7 +539,7 @@ namespace System.Collections {
         // 
         public virtual int LastIndexOf(Object value, int startIndex, int count) {
             if (Count != 0 && (startIndex < 0 || count < 0))
-                throw new ArgumentOutOfRangeException((startIndex<0 ? "startIndex" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((startIndex<0 ? nameof(startIndex) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             Contract.Ensures(Contract.Result<int>() < Count);
             Contract.EndContractBlock();
 
@@ -547,7 +547,7 @@ namespace System.Collections {
                 return -1;
 
             if (startIndex >= _size || count > startIndex + 1) 
-                throw new ArgumentOutOfRangeException((startIndex>=_size ? "startIndex" : "count"), Environment.GetResourceString("ArgumentOutOfRange_BiggerThanCollection"));
+                throw new ArgumentOutOfRangeException((startIndex>=_size ? nameof(startIndex) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_BiggerThanCollection"));
 
             return Array.LastIndexOf((Array)_items, value, startIndex, count);
         }
@@ -684,7 +684,7 @@ namespace System.Collections {
     
         public virtual ArrayList GetRange(int index, int count) {
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (_size - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             Contract.Ensures(Contract.Result<ArrayList>() != null);
@@ -854,7 +854,7 @@ namespace System.Collections {
             public override int BinarySearch(int index, int count, Object value, IComparer comparer) 
             {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (this.Count - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();
@@ -908,7 +908,7 @@ namespace System.Collections {
                 if (array==null)
                     throw new ArgumentNullException(nameof(array));
                 if (index < 0 || arrayIndex < 0)
-                    throw new ArgumentOutOfRangeException((index < 0) ? "index" : "arrayIndex", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index < 0) ? nameof(index) : nameof(arrayIndex), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if( count < 0)
                     throw new ArgumentOutOfRangeException( nameof(count) , Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));                 
                 if (array.Length - arrayIndex < count)
@@ -930,7 +930,7 @@ namespace System.Collections {
     
             public override IEnumerator GetEnumerator(int index, int count) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
@@ -1039,7 +1039,7 @@ namespace System.Collections {
     
             public override void RemoveRange(int index, int count) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
@@ -1055,7 +1055,7 @@ namespace System.Collections {
     
             public override void Reverse(int index, int count) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
@@ -1092,7 +1092,7 @@ namespace System.Collections {
     
             public override ArrayList GetRange(int index, int count) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
@@ -1101,7 +1101,7 @@ namespace System.Collections {
 
             public override void Sort(int index, int count, IComparer comparer) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 Contract.EndContractBlock();
                 if (_list.Count - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
@@ -1806,7 +1806,7 @@ namespace System.Collections {
 
             public override ArrayList GetRange(int index, int count) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (Count - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();
@@ -2062,7 +2062,7 @@ namespace System.Collections {
     
             public override ArrayList GetRange(int index, int count) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (Count - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();
@@ -2207,7 +2207,7 @@ namespace System.Collections {
             // Other overloads with automatically work 
             public override int BinarySearch(int index, int count, Object value, IComparer comparer) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (_baseSize - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();
@@ -2284,7 +2284,7 @@ namespace System.Collections {
                 if (array.Rank != 1)
                     throw new ArgumentException(Environment.GetResourceString("Arg_RankMultiDimNotSupported"));
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (array.Length - arrayIndex < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 if (_baseSize - index < count)
@@ -2320,7 +2320,7 @@ namespace System.Collections {
 
             public override IEnumerator GetEnumerator(int index, int count) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (_baseSize - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();
@@ -2331,7 +2331,7 @@ namespace System.Collections {
 
             public override ArrayList GetRange(int index, int count) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (_baseSize - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();
@@ -2449,7 +2449,7 @@ namespace System.Collections {
 
             public override void RemoveRange(int index, int count) {            
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (_baseSize - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();
@@ -2466,7 +2466,7 @@ namespace System.Collections {
 
             public override void Reverse(int index, int count) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (_baseSize - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();
@@ -2488,7 +2488,7 @@ namespace System.Collections {
 
             public override void Sort(int index, int count, IComparer comparer) {
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (_baseSize - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();

--- a/src/mscorlib/src/System/DateTime.cs
+++ b/src/mscorlib/src/System/DateTime.cs
@@ -1008,7 +1008,7 @@ namespace System {
         }
 
         public static DateTime Parse(String s, IFormatProvider provider, DateTimeStyles styles) {
-            DateTimeFormatInfo.ValidateStyles(styles, "styles");
+            DateTimeFormatInfo.ValidateStyles(styles, nameof(styles));
             return (DateTimeParse.Parse(s, DateTimeFormatInfo.GetInstance(provider), styles));
         }
         
@@ -1025,12 +1025,12 @@ namespace System {
         // Leading and trailing whitespace characters are allowed.
         // 
         public static DateTime ParseExact(String s, String format, IFormatProvider provider, DateTimeStyles style) {
-            DateTimeFormatInfo.ValidateStyles(style, "style");
+            DateTimeFormatInfo.ValidateStyles(style, nameof(style));
             return (DateTimeParse.ParseExact(s, format, DateTimeFormatInfo.GetInstance(provider), style));
         }    
 
         public static DateTime ParseExact(String s, String[] formats, IFormatProvider provider, DateTimeStyles style) {
-            DateTimeFormatInfo.ValidateStyles(style, "style");
+            DateTimeFormatInfo.ValidateStyles(style, nameof(style));
             return DateTimeParse.ParseExactMultiple(s, formats, DateTimeFormatInfo.GetInstance(provider), style);
         }
 
@@ -1166,17 +1166,17 @@ namespace System {
         }
         
         public static Boolean TryParse(String s, IFormatProvider provider, DateTimeStyles styles, out DateTime result) {
-            DateTimeFormatInfo.ValidateStyles(styles, "styles");
+            DateTimeFormatInfo.ValidateStyles(styles, nameof(styles));
             return DateTimeParse.TryParse(s, DateTimeFormatInfo.GetInstance(provider), styles, out result);
         }    
             
         public static Boolean TryParseExact(String s, String format, IFormatProvider provider, DateTimeStyles style, out DateTime result) {
-            DateTimeFormatInfo.ValidateStyles(style, "style");
+            DateTimeFormatInfo.ValidateStyles(style, nameof(style));
             return DateTimeParse.TryParseExact(s, format, DateTimeFormatInfo.GetInstance(provider), style, out result);
         }    
 
         public static Boolean TryParseExact(String s, String[] formats, IFormatProvider provider, DateTimeStyles style, out DateTime result) {
-            DateTimeFormatInfo.ValidateStyles(style, "style");
+            DateTimeFormatInfo.ValidateStyles(style, nameof(style));
             return DateTimeParse.TryParseExactMultiple(s, formats, DateTimeFormatInfo.GetInstance(provider), style, out result);
         }
             

--- a/src/mscorlib/src/System/DateTimeOffset.cs
+++ b/src/mscorlib/src/System/DateTimeOffset.cs
@@ -563,7 +563,7 @@ namespace System {
         }
         
         public static DateTimeOffset Parse(String input, IFormatProvider formatProvider, DateTimeStyles styles) {
-            styles = ValidateStyles(styles, "styles");
+            styles = ValidateStyles(styles, nameof(styles));
             TimeSpan offset;
             DateTime dateResult = DateTimeParse.Parse(input, 
                                                       DateTimeFormatInfo.GetInstance(formatProvider), 
@@ -585,7 +585,7 @@ namespace System {
         // Leading and trailing whitespace characters are allowed.
         // 
         public static DateTimeOffset ParseExact(String input, String format, IFormatProvider formatProvider, DateTimeStyles styles) {
-            styles = ValidateStyles(styles, "styles");
+            styles = ValidateStyles(styles, nameof(styles));
             TimeSpan offset;
             DateTime dateResult = DateTimeParse.ParseExact(input, 
                                                            format, 
@@ -596,7 +596,7 @@ namespace System {
         }    
 
         public static DateTimeOffset ParseExact(String input, String[] formats, IFormatProvider formatProvider, DateTimeStyles styles) {
-            styles = ValidateStyles(styles, "styles");
+            styles = ValidateStyles(styles, nameof(styles));
             TimeSpan offset;
             DateTime dateResult = DateTimeParse.ParseExactMultiple(input, 
                                                                    formats, 
@@ -693,7 +693,7 @@ namespace System {
         }
         
         public static Boolean TryParse(String input, IFormatProvider formatProvider, DateTimeStyles styles, out DateTimeOffset result) {
-            styles = ValidateStyles(styles, "styles");
+            styles = ValidateStyles(styles, nameof(styles));
             TimeSpan offset;
             DateTime dateResult;
             Boolean parsed = DateTimeParse.TryParse(input, 
@@ -707,7 +707,7 @@ namespace System {
             
         public static Boolean TryParseExact(String input, String format, IFormatProvider formatProvider, DateTimeStyles styles,
                                             out DateTimeOffset result) {
-            styles = ValidateStyles(styles, "styles");
+            styles = ValidateStyles(styles, nameof(styles));
             TimeSpan offset;
             DateTime dateResult;
             Boolean parsed = DateTimeParse.TryParseExact(input, 
@@ -722,7 +722,7 @@ namespace System {
 
         public static Boolean TryParseExact(String input, String[] formats, IFormatProvider formatProvider, DateTimeStyles styles,
                                             out DateTimeOffset result) {
-            styles = ValidateStyles(styles, "styles");
+            styles = ValidateStyles(styles, nameof(styles));
             TimeSpan offset;
             DateTime dateResult;
             Boolean parsed = DateTimeParse.TryParseExactMultiple(input, 

--- a/src/mscorlib/src/System/Diagnostics/LogSwitch.cs
+++ b/src/mscorlib/src/System/Diagnostics/LogSwitch.cs
@@ -55,7 +55,7 @@ namespace System.Diagnostics {
                 Log.AddLogSwitch (this);
             }
             else
-                throw new ArgumentNullException ((name==null ? "name" : "parent"));
+                throw new ArgumentNullException ((name==null ? nameof(name) : nameof(parent)));
         }
     
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -410,7 +410,7 @@ namespace System
                 throw new ArgumentException(Environment.GetResourceString("Arg_MustBeEnum"), nameof(enumType));
 
             if (value == null) {
-                parseResult.SetFailure(ParseFailureKind.ArgumentNull, "value");
+                parseResult.SetFailure(ParseFailureKind.ArgumentNull, nameof(value));
                 return false;
             }
 

--- a/src/mscorlib/src/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.cs
@@ -485,11 +485,11 @@ namespace System.Globalization {
             // Verify inputs
             if (length1 < 0 || length2 < 0)
             {
-                throw new ArgumentOutOfRangeException((length1 < 0) ? "length1" : "length2", Environment.GetResourceString("ArgumentOutOfRange_NeedPosNum"));
+                throw new ArgumentOutOfRangeException((length1 < 0) ? nameof(length1) : nameof(length2), Environment.GetResourceString("ArgumentOutOfRange_NeedPosNum"));
             }
             if (offset1 < 0 || offset2 < 0)
             {
-                throw new ArgumentOutOfRangeException((offset1 < 0) ? "offset1" : "offset2", Environment.GetResourceString("ArgumentOutOfRange_NeedPosNum"));
+                throw new ArgumentOutOfRangeException((offset1 < 0) ? nameof(offset1) : nameof(offset2), Environment.GetResourceString("ArgumentOutOfRange_NeedPosNum"));
             }
             if (offset1 > (string1 == null ? 0 : string1.Length) - length1)
             {

--- a/src/mscorlib/src/System/Globalization/DateTimeParse.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeParse.cs
@@ -97,11 +97,11 @@ namespace System {
 
         internal static bool TryParseExact(String s, String format, DateTimeFormatInfo dtfi, DateTimeStyles style, ref DateTimeResult result) {
             if (s == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "s");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(s));
                 return false;
             }
             if (format == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "format");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(format));
                 return false;
             }
             if (s.Length == 0) {
@@ -178,11 +178,11 @@ namespace System {
         internal static bool TryParseExactMultiple(String s, String[] formats,
                                                 DateTimeFormatInfo dtfi, DateTimeStyles style, ref DateTimeResult result) {
             if (s == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "s");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(s));
                 return false;
             }
             if (formats == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "formats");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(formats));
                 return false;
             }
 
@@ -2319,7 +2319,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
         [System.Security.SecuritySafeCritical]  // auto-generated
         internal static bool TryParse(String s, DateTimeFormatInfo dtfi, DateTimeStyles styles, ref DateTimeResult result) {
             if (s == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "s");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(s));
                 return false;
             }
             if (s.Length == 0) {

--- a/src/mscorlib/src/System/Globalization/EncodingTable.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/EncodingTable.Unix.cs
@@ -30,7 +30,7 @@ namespace System.Globalization
         {
             if (name == null)
             {
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
             }
             Contract.EndContractBlock();
 
@@ -44,7 +44,7 @@ namespace System.Globalization
             throw new ArgumentException(
                 string.Format(
                     CultureInfo.CurrentCulture,
-                    Environment.GetResourceString("Argument_EncodingNotSupported"), name), "name");
+                    Environment.GetResourceString("Argument_EncodingNotSupported"), name), nameof(name));
         }
 
         internal static CodePageDataItem GetCodePageDataItem(int codepage)

--- a/src/mscorlib/src/System/Globalization/HebrewCalendar.cs
+++ b/src/mscorlib/src/System/Globalization/HebrewCalendar.cs
@@ -727,7 +727,7 @@ namespace System.Globalization {
             int d = GetDatePart(time.Ticks, DatePartDay);
 
             y += years;
-            CheckHebrewYearValue(y, Calendar.CurrentEra, "years");
+            CheckHebrewYearValue(y, Calendar.CurrentEra, nameof(years));
 
             int months = GetMonthsInYear(y, CurrentEra);
             if (m > months) {
@@ -765,7 +765,7 @@ namespace System.Globalization {
         }
 
         static internal int GetHebrewYearType(int year, int era) {
-            CheckHebrewYearValue(year, era, "year");
+            CheckHebrewYearValue(year, era, nameof(year));
             // The HebrewTable is indexed by Gregorian year and starts from FirstGregorianYear.
             // So we need to convert year (Hebrew year value) to Gregorian Year below.
             return (HebrewTable[(year - HebrewYearOf1AD - FirstGregorianTableYear) * 2 + 1]);
@@ -931,7 +931,7 @@ namespace System.Globalization {
         //
 
         public override bool IsLeapYear(int year, int era) {
-           CheckHebrewYearValue(year, era, "year");
+           CheckHebrewYearValue(year, era, nameof(year));
            return (((7 * (long)year + 1) % 19) < 7);
         }
 
@@ -1015,7 +1015,7 @@ namespace System.Globalization {
         //
 
         public override DateTime ToDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int era) {
-            CheckHebrewYearValue(year, era, "year");
+            CheckHebrewYearValue(year, era, nameof(year));
             CheckHebrewMonthValue(year, month, era);
             CheckHebrewDayValue(year, month, day, era);
             DateTime dt = HebrewToGregorian(year, month, day, hour, minute, second, millisecond);
@@ -1042,7 +1042,7 @@ namespace System.Globalization {
                 }
                 else
                 {
-                    CheckHebrewYearValue(value, HebrewEra, "value");
+                    CheckHebrewYearValue(value, HebrewEra, nameof(value));
                 }
                 twoDigitYearMax = value;
             }

--- a/src/mscorlib/src/System/Globalization/IdnMapping.cs
+++ b/src/mscorlib/src/System/Globalization/IdnMapping.cs
@@ -202,7 +202,7 @@ namespace System.Globalization
         {
             if (ascii==null) throw new ArgumentNullException(nameof(ascii));
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0) ? "index" : "count",
+                throw new ArgumentOutOfRangeException((index < 0) ? nameof(index) : nameof(count),
                       Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (index > ascii.Length)
                 throw new ArgumentOutOfRangeException(nameof(index),
@@ -791,7 +791,7 @@ namespace System.Globalization
             if (ascii.Length > M_defaultNameLimit - (IsDot(ascii[ascii.Length-1]) ? 0 : 1))
                 throw new ArgumentException(Environment.GetResourceString(
                     "Argument_IdnBadNameSize",
-                    M_defaultNameLimit - (IsDot(ascii[ascii.Length-1]) ? 0 : 1)), "ascii");
+                    M_defaultNameLimit - (IsDot(ascii[ascii.Length-1]) ? 0 : 1)), nameof(ascii));
 
             // output stringbuilder
             StringBuilder output = new StringBuilder(ascii.Length);
@@ -1056,7 +1056,7 @@ namespace System.Globalization
             if (output.Length > M_defaultNameLimit - (IsDot(output[output.Length-1]) ? 0 : 1))
                 throw new ArgumentException(Environment.GetResourceString(
                     "Argument_IdnBadNameSize",
-                    M_defaultNameLimit -(IsDot(output[output.Length-1]) ? 0 : 1)), "ascii");
+                    M_defaultNameLimit -(IsDot(output[output.Length-1]) ? 0 : 1)), nameof(ascii));
 
             // Return our output string
             return output.ToString();

--- a/src/mscorlib/src/System/Globalization/TimeSpanParse.cs
+++ b/src/mscorlib/src/System/Globalization/TimeSpanParse.cs
@@ -627,7 +627,7 @@ namespace System.Globalization {
         // 
         private static Boolean TryParseTimeSpan(String input, TimeSpanStandardStyles style, IFormatProvider formatProvider, ref TimeSpanResult result) {
             if (input == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "input");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(input));
                 return false;
             }
 
@@ -1117,11 +1117,11 @@ namespace System.Globalization {
         // 
         private static Boolean TryParseExactTimeSpan(String input, String format, IFormatProvider formatProvider, TimeSpanStyles styles, ref TimeSpanResult result) {
             if (input == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "input");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(input));
                 return false;
             }
             if (format == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "format");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(format));
                 return false;
             }
             if (format.Length == 0) {
@@ -1376,7 +1376,7 @@ namespace System.Globalization {
                 result.parsedTimeSpan._ticks = 0;
 
                 if (input == null) {
-                    result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "input");
+                    result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(input));
                     return false;
                 }
                 str = input;
@@ -1511,11 +1511,11 @@ namespace System.Globalization {
         // 
         private static Boolean TryParseExactMultipleTimeSpan(String input, String[] formats, IFormatProvider formatProvider, TimeSpanStyles styles, ref TimeSpanResult result) {
             if (input == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "input");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(input));
                 return false;
             }
             if (formats == null) {
-                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, "formats");
+                result.SetFailure(ParseFailureKind.ArgumentNull, "ArgumentNull_String", null, nameof(formats));
                 return false;
             }
 

--- a/src/mscorlib/src/System/IO/FileStream.cs
+++ b/src/mscorlib/src/System/IO/FileStream.cs
@@ -534,15 +534,15 @@ namespace System.IO {
             String badArg = null;
 
             if (mode < FileMode.CreateNew || mode > FileMode.Append)
-                badArg = "mode";
+                badArg = nameof(mode);
             else if (!useRights && (access < FileAccess.Read || access > FileAccess.ReadWrite))
-                badArg = "access";
+                badArg = nameof(access);
 #if FEATURE_MACL
             else if (useRights && (fileSystemRights < FileSystemRights.ReadData || fileSystemRights > FileSystemRights.FullControl))
                 badArg = "rights";
 #endif            
             else if (tempshare < FileShare.None || tempshare > (FileShare.ReadWrite | FileShare.Delete))
-                badArg = "share";
+                badArg = nameof(share);
             
             if (badArg != null)
                 throw new ArgumentOutOfRangeException(badArg, Environment.GetResourceString("ArgumentOutOfRange_Enum"));
@@ -2257,7 +2257,7 @@ namespace System.IO {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public virtual void Lock(long position, long length) {
             if (position < 0 || length < 0)
-                throw new ArgumentOutOfRangeException((position < 0 ? "position" : "length"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((position < 0 ? nameof(position) : nameof(length)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             Contract.EndContractBlock();
             if (_handle.IsClosed) __Error.FileNotOpen();
 
@@ -2273,7 +2273,7 @@ namespace System.IO {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public virtual void Unlock(long position, long length) {
             if (position < 0 || length < 0)
-                throw new ArgumentOutOfRangeException((position < 0 ? "position" : "length"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((position < 0 ? nameof(position) : nameof(length)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             Contract.EndContractBlock();
             if (_handle.IsClosed) __Error.FileNotOpen();
 

--- a/src/mscorlib/src/System/IO/StreamReader.cs
+++ b/src/mscorlib/src/System/IO/StreamReader.cs
@@ -360,7 +360,7 @@ namespace System.IO
             if (buffer==null)
                 throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             Contract.EndContractBlock();
@@ -418,7 +418,7 @@ namespace System.IO
             if (buffer==null)
                 throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             Contract.EndContractBlock();
@@ -900,7 +900,7 @@ namespace System.IO
             if (buffer==null)
                 throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             Contract.EndContractBlock();
@@ -1088,7 +1088,7 @@ namespace System.IO
             if (buffer==null)
                 throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/IO/StringReader.cs
+++ b/src/mscorlib/src/System/IO/StringReader.cs
@@ -31,7 +31,7 @@ namespace System.IO {
     
         public StringReader(String s) {
             if (s == null)
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             Contract.EndContractBlock();
             _s = s;
             _length = s == null? 0: s.Length;
@@ -80,11 +80,11 @@ namespace System.IO {
         //
         public override int Read([In, Out] char[] buffer, int index, int count) {
             if (buffer==null)
-                throw new ArgumentNullException("buffer", Environment.GetResourceString("ArgumentNull_Buffer"));
+                throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0)
-                throw new ArgumentOutOfRangeException("index", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException(nameof(index), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (count < 0)
-                throw new ArgumentOutOfRangeException("count", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException(nameof(count), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             Contract.EndContractBlock();
@@ -158,9 +158,9 @@ namespace System.IO {
         public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)
         {
             if (buffer==null)
-                throw new ArgumentNullException("buffer", Environment.GetResourceString("ArgumentNull_Buffer"));
+                throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
 
@@ -173,9 +173,9 @@ namespace System.IO {
         public override Task<int> ReadAsync(char[] buffer, int index, int count)
         {
             if (buffer==null)
-                throw new ArgumentNullException("buffer", Environment.GetResourceString("ArgumentNull_Buffer"));
+                throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/IO/StringWriter.cs
+++ b/src/mscorlib/src/System/IO/StringWriter.cs
@@ -52,7 +52,7 @@ namespace System.IO {
 
         public StringWriter(StringBuilder sb, IFormatProvider formatProvider) : base(formatProvider) {
             if (sb==null)
-                throw new ArgumentNullException("sb", Environment.GetResourceString("ArgumentNull_Buffer"));
+                throw new ArgumentNullException(nameof(sb), Environment.GetResourceString("ArgumentNull_Buffer"));
             Contract.EndContractBlock();
             _sb = sb;
             _isOpen = true;
@@ -104,11 +104,11 @@ namespace System.IO {
         //
         public override void Write(char[] buffer, int index, int count) {
             if (buffer==null)
-                throw new ArgumentNullException("buffer", Environment.GetResourceString("ArgumentNull_Buffer"));
+                throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0)
-                throw new ArgumentOutOfRangeException("index", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException(nameof(index), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (count < 0)
-                throw new ArgumentOutOfRangeException("count", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException(nameof(count), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/IO/TextReader.cs
+++ b/src/mscorlib/src/System/IO/TextReader.cs
@@ -204,7 +204,7 @@ namespace System.IO {
             if (buffer==null)
                 throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
             Contract.EndContractBlock();
@@ -235,7 +235,7 @@ namespace System.IO {
             if (buffer==null)
                 throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (buffer.Length - index < count)
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
 
@@ -381,7 +381,7 @@ namespace System.IO {
                 if (buffer==null)
                     throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (buffer.Length - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
 
@@ -397,7 +397,7 @@ namespace System.IO {
                 if (buffer==null)
                     throw new ArgumentNullException(nameof(buffer), Environment.GetResourceString("ArgumentNull_Buffer"));
                 if (index < 0 || count < 0)
-                    throw new ArgumentOutOfRangeException((index < 0 ? "index" : "count"), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                    throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 if (buffer.Length - index < count)
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidOffLen"));
                 Contract.EndContractBlock();

--- a/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
@@ -221,7 +221,7 @@ namespace System.IO {
             if (pointer == null)
                 throw new ArgumentNullException(nameof(pointer));
             if (length < 0 || capacity < 0)
-                throw new ArgumentOutOfRangeException((length < 0) ? "length" : "capacity", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException((length < 0) ? nameof(length) : nameof(capacity), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             if (length > capacity)
                 throw new ArgumentOutOfRangeException(nameof(length), Environment.GetResourceString("ArgumentOutOfRange_LengthGreaterThanCapacity"));
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/IO/UnmanagedMemoryStreamWrapper.cs
+++ b/src/mscorlib/src/System/IO/UnmanagedMemoryStreamWrapper.cs
@@ -160,7 +160,7 @@ namespace System.IO {
                 throw new ObjectDisposedException(null, Environment.GetResourceString("ObjectDisposed_StreamClosed"));
 
             if (!destination.CanRead && !destination.CanWrite)
-                throw new ObjectDisposedException("destination", Environment.GetResourceString("ObjectDisposed_StreamClosed"));
+                throw new ObjectDisposedException(nameof(destination), Environment.GetResourceString("ObjectDisposed_StreamClosed"));
 
             if (!CanRead)
                 throw new NotSupportedException(Environment.GetResourceString("NotSupported_UnreadableStream"));

--- a/src/mscorlib/src/System/Random.cs
+++ b/src/mscorlib/src/System/Random.cs
@@ -195,7 +195,7 @@ namespace System {
       ==============================================================================*/
       public virtual int Next(int minValue, int maxValue) {
           if (minValue>maxValue) {
-              throw new ArgumentOutOfRangeException(nameof(minValue),Environment.GetResourceString("Argument_MinMaxValue", "minValue", "maxValue"));
+              throw new ArgumentOutOfRangeException(nameof(minValue),Environment.GetResourceString("Argument_MinMaxValue", nameof(minValue), nameof(maxValue)));
           }
           Contract.EndContractBlock();
           
@@ -216,7 +216,7 @@ namespace System {
       ==============================================================================*/
       public virtual int Next(int maxValue) {
           if (maxValue<0) {
-              throw new ArgumentOutOfRangeException(nameof(maxValue), Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", "maxValue"));
+              throw new ArgumentOutOfRangeException(nameof(maxValue), Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", nameof(maxValue)));
           }
           Contract.EndContractBlock();
           return (int)(Sample()*maxValue);

--- a/src/mscorlib/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/SignatureHelper.cs
@@ -835,10 +835,10 @@ namespace System.Reflection.Emit
         public void AddArguments(Type[] arguments, Type[][] requiredCustomModifiers, Type[][] optionalCustomModifiers)
         {
             if (requiredCustomModifiers != null && (arguments == null || requiredCustomModifiers.Length != arguments.Length))
-                throw new ArgumentException(Environment.GetResourceString("Argument_MismatchedArrays", "requiredCustomModifiers", nameof(arguments)));
+                throw new ArgumentException(Environment.GetResourceString("Argument_MismatchedArrays", nameof(requiredCustomModifiers), nameof(arguments)));
 
             if (optionalCustomModifiers != null && (arguments == null || optionalCustomModifiers.Length != arguments.Length))
-                throw new ArgumentException(Environment.GetResourceString("Argument_MismatchedArrays", "optionalCustomModifiers", nameof(arguments)));
+                throw new ArgumentException(Environment.GetResourceString("Argument_MismatchedArrays", nameof(optionalCustomModifiers), nameof(arguments)));
 
             if (arguments != null)
             {

--- a/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -1698,10 +1698,10 @@ namespace System.Reflection.Emit {
             if (parameterTypes != null)
             {
                 if (parameterTypeOptionalCustomModifiers != null && parameterTypeOptionalCustomModifiers.Length != parameterTypes.Length)
-                    throw new ArgumentException(Environment.GetResourceString("Argument_MismatchedArrays", "parameterTypeOptionalCustomModifiers", nameof(parameterTypes)));
+                    throw new ArgumentException(Environment.GetResourceString("Argument_MismatchedArrays", nameof(parameterTypeOptionalCustomModifiers), nameof(parameterTypes)));
 
                 if (parameterTypeRequiredCustomModifiers != null && parameterTypeRequiredCustomModifiers.Length != parameterTypes.Length)
-                    throw new ArgumentException(Environment.GetResourceString("Argument_MismatchedArrays", "parameterTypeRequiredCustomModifiers", nameof(parameterTypes)));
+                    throw new ArgumentException(Environment.GetResourceString("Argument_MismatchedArrays", nameof(parameterTypeRequiredCustomModifiers), nameof(parameterTypes)));
             }
 
             ThrowIfCreated();

--- a/src/mscorlib/src/System/Security/securestring.cs
+++ b/src/mscorlib/src/System/Security/securestring.cs
@@ -105,15 +105,15 @@ namespace System.Security {
         [CLSCompliant(false)]
         public unsafe SecureString(char* value, int length) {
             if( value == null) {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             if( length < 0) {
-                throw new ArgumentOutOfRangeException("length", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException(nameof(length), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             }
 
             if( length > MaxLength) {
-                throw new ArgumentOutOfRangeException("length", Environment.GetResourceString("ArgumentOutOfRange_Length"));
+                throw new ArgumentOutOfRangeException(nameof(length), Environment.GetResourceString("ArgumentOutOfRange_Length"));
             }
             Contract.EndContractBlock();
 
@@ -192,7 +192,7 @@ namespace System.Security {
 #endif // FEATURE_CORRUPTING_EXCEPTIONS
         public void InsertAt( int index, char c ) {
             if( index < 0 || index > m_length) {
-                throw new ArgumentOutOfRangeException("index", Environment.GetResourceString("ArgumentOutOfRange_IndexString"));
+                throw new ArgumentOutOfRangeException(nameof(index), Environment.GetResourceString("ArgumentOutOfRange_IndexString"));
             }
             Contract.EndContractBlock();
 
@@ -251,7 +251,7 @@ namespace System.Security {
             EnsureNotReadOnly();
 
             if( index < 0 || index >= m_length) {
-                throw new ArgumentOutOfRangeException("index", Environment.GetResourceString("ArgumentOutOfRange_IndexString"));
+                throw new ArgumentOutOfRangeException(nameof(index), Environment.GetResourceString("ArgumentOutOfRange_IndexString"));
             }
 
             unsafe
@@ -290,7 +290,7 @@ namespace System.Security {
 #endif // FEATURE_CORRUPTING_EXCEPTIONS
         public void SetAt( int index, char c ) {
             if( index < 0 || index >= m_length) {
-                throw new ArgumentOutOfRangeException("index", Environment.GetResourceString("ArgumentOutOfRange_IndexString"));
+                throw new ArgumentOutOfRangeException(nameof(index), Environment.GetResourceString("ArgumentOutOfRange_IndexString"));
             }
             Contract.EndContractBlock();
             Contract.Assert(index <= Int32.MaxValue / sizeof(char));
@@ -341,7 +341,7 @@ namespace System.Security {
         [System.Security.SecurityCritical]  // auto-generated
         private void EnsureCapacity(int capacity) {            
             if( capacity > MaxLength) {
-                throw new ArgumentOutOfRangeException("capacity", Environment.GetResourceString("ArgumentOutOfRange_Capacity"));
+                throw new ArgumentOutOfRangeException(nameof(capacity), Environment.GetResourceString("ArgumentOutOfRange_Capacity"));
             }
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -557,13 +557,13 @@ namespace System
 
             if (indexA < 0 || indexB < 0)
             {
-                string paramName = indexA < 0 ? "indexA" : "indexB";
+                string paramName = indexA < 0 ? nameof(indexA) : nameof(indexB);
                 throw new ArgumentOutOfRangeException(paramName, Environment.GetResourceString("ArgumentOutOfRange_Index"));
             }
 
             if (strA.Length - indexA < 0 || strB.Length - indexB < 0)
             {
-                string paramName = strA.Length - indexA < 0 ? "indexA" : "indexB";
+                string paramName = strA.Length - indexA < 0 ? nameof(indexA) : nameof(indexB);
                 throw new ArgumentOutOfRangeException(paramName, Environment.GetResourceString("ArgumentOutOfRange_Index"));
             }
 
@@ -662,7 +662,7 @@ namespace System
 
             if (indexA < 0 || indexB < 0)
             {
-                string paramName = indexA < 0 ? "indexA" : "indexB";
+                string paramName = indexA < 0 ? nameof(indexA) : nameof(indexB);
                 throw new ArgumentOutOfRangeException(paramName, Environment.GetResourceString("ArgumentOutOfRange_Index"));
             }
             
@@ -671,7 +671,7 @@ namespace System
 
             if (lengthA < 0 || lengthB < 0)
             {
-                string paramName = lengthA < 0 ? "indexA" : "indexB";
+                string paramName = lengthA < 0 ? nameof(indexA) : nameof(indexB);
                 throw new ArgumentOutOfRangeException(paramName, Environment.GetResourceString("ArgumentOutOfRange_Index"));
             }
 

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -519,7 +519,7 @@ namespace System {
             else if (count == 0)
                 return String.Empty;
             else
-                throw new ArgumentOutOfRangeException(nameof(count), Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", "count"));
+                throw new ArgumentOutOfRangeException(nameof(count), Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", nameof(count)));
         }
 
         [System.Security.SecurityCritical]  // auto-generated

--- a/src/mscorlib/src/System/Text/Encoder.cs
+++ b/src/mscorlib/src/System/Text/Encoder.cs
@@ -194,7 +194,7 @@ namespace System.Text
                     Environment.GetResourceString("ArgumentNull_Array"));
 
             if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
+                throw new ArgumentOutOfRangeException((charCount<0 ? nameof(charCount) : nameof(byteCount)),
                     Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             Contract.EndContractBlock();
 
@@ -252,11 +252,11 @@ namespace System.Text
                       Environment.GetResourceString("ArgumentNull_Array"));
 
             if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
+                throw new ArgumentOutOfRangeException((charIndex<0 ? nameof(charIndex) : nameof(charCount)),
                       Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
 
             if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? "byteIndex" : "byteCount"),
+                throw new ArgumentOutOfRangeException((byteIndex<0 ? nameof(byteIndex) : nameof(byteCount)),
                       Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
 
             if (chars.Length - charIndex < charCount)
@@ -311,7 +311,7 @@ namespace System.Text
                 throw new ArgumentNullException(bytes == null ? nameof(bytes) : nameof(chars),
                     Environment.GetResourceString("ArgumentNull_Array"));
                 if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
+                throw new ArgumentOutOfRangeException((charCount<0 ? nameof(charCount) : nameof(byteCount)),
                     Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
                 Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/Text/EncoderNLS.cs
+++ b/src/mscorlib/src/System/Text/EncoderNLS.cs
@@ -86,7 +86,7 @@ namespace System.Text
                       Environment.GetResourceString("ArgumentNull_Array"));
 
             if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? "index" : "count"),
+                throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)),
                       Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
 
             if (chars.Length - index < count)
@@ -135,7 +135,7 @@ namespace System.Text
                       Environment.GetResourceString("ArgumentNull_Array"));
 
             if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
+                throw new ArgumentOutOfRangeException((charIndex<0 ? nameof(charIndex) : nameof(charCount)),
                       Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
 
             if (chars.Length - charIndex < charCount)
@@ -172,7 +172,7 @@ namespace System.Text
                       Environment.GetResourceString("ArgumentNull_Array"));
 
             if (byteCount < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((byteCount<0 ? "byteCount" : "charCount"),
+                throw new ArgumentOutOfRangeException((byteCount<0 ? nameof(byteCount) : nameof(charCount)),
                       Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             Contract.EndContractBlock();
 
@@ -194,11 +194,11 @@ namespace System.Text
                       Environment.GetResourceString("ArgumentNull_Array"));
 
             if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? "charIndex" : "charCount"),
+                throw new ArgumentOutOfRangeException((charIndex<0 ? nameof(charIndex) : nameof(charCount)),
                       Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
 
             if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? "byteIndex" : "byteCount"),
+                throw new ArgumentOutOfRangeException((byteIndex<0 ? nameof(byteIndex) : nameof(byteCount)),
                       Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
 
             if (chars.Length - charIndex < charCount)
@@ -240,7 +240,7 @@ namespace System.Text
                 throw new ArgumentNullException(bytes == null ? nameof(bytes) : nameof(chars),
                     Environment.GetResourceString("ArgumentNull_Array"));
             if (charCount < 0 || byteCount < 0)
-            throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
+            throw new ArgumentOutOfRangeException((charCount<0 ? nameof(charCount) : nameof(byteCount)),
                 Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -443,7 +443,7 @@ namespace System.Text
                 case CodePageNoThread:                           // 3 CP_THREAD_ACP
                 case CodePageNoSymbol:                           // 42 CP_SYMBOL
                     throw new ArgumentException(Environment.GetResourceString(
-                        "Argument_CodepageNotSupported", codepage), "codepage");
+                        "Argument_CodepageNotSupported", codepage), nameof(codepage));
             }
 
 #if FEATURE_CODEPAGES_FILE
@@ -1034,7 +1034,7 @@ namespace System.Text
                     Environment.GetResourceString("ArgumentNull_Array"));
 
             if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? "charCount" : "byteCount"),
+                throw new ArgumentOutOfRangeException((charCount<0 ? nameof(charCount) : nameof(byteCount)),
                     Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             Contract.EndContractBlock();
 
@@ -1193,7 +1193,7 @@ namespace System.Text
                     Environment.GetResourceString("ArgumentNull_Array"));
 
             if (byteCount < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((byteCount<0 ? "byteCount" : "charCount"),
+                throw new ArgumentOutOfRangeException((byteCount<0 ? nameof(byteCount) : nameof(charCount)),
                     Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -43,7 +43,7 @@ namespace System.Text
             }
             if (index < 0 || count < 0)
             {
-                throw new ArgumentOutOfRangeException(index < 0 ? "index" : "count", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             }
             if (chars.Length - index < count)
             {
@@ -66,7 +66,7 @@ namespace System.Text
             Contract.Assert(encoding != null);
             if (s == null)
             {
-                string paramName = encoding is ASCIIEncoding ? "chars" : "s"; // ASCIIEncoding calls the string chars
+                string paramName = encoding is ASCIIEncoding ? "chars" : nameof(s); // ASCIIEncoding calls the string chars
                 // UTF8Encoding does this as well, but it originally threw an ArgumentNull for "s" so don't check for that
                 throw new ArgumentNullException(paramName);
             }
@@ -207,7 +207,7 @@ namespace System.Text
             }
             if (index < 0 || count < 0)
             {
-                throw new ArgumentOutOfRangeException(index < 0 ? "index" : "count", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+                throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             }
             if (bytes.Length - index < count)
             {

--- a/src/mscorlib/src/System/Text/ISCIIEncoding.cs
+++ b/src/mscorlib/src/System/Text/ISCIIEncoding.cs
@@ -78,7 +78,7 @@ namespace System.Text
             // This shouldn't really be possible
             if (defaultCodePage < CodeDevanagari || defaultCodePage > CodePunjabi)
                 throw new ArgumentException(Environment.GetResourceString(
-                       "Argument_CodepageNotSupported", codePage), "codePage");
+                       "Argument_CodepageNotSupported", codePage), nameof(codePage));
         }
 
         // Constructor called by serialization.

--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -121,11 +121,11 @@ namespace System.Text {
         public StringBuilder(String value, int startIndex, int length, int capacity) {
             if (capacity<0) {
                 throw new ArgumentOutOfRangeException(nameof(capacity),
-                                                      Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", "capacity"));
+                                                      Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", nameof(capacity)));
             }
             if (length<0) {
                 throw new ArgumentOutOfRangeException(nameof(length),
-                                                      Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", "length"));
+                                                      Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", nameof(length)));
             }
             if (startIndex<0) {
                 throw new ArgumentOutOfRangeException(nameof(startIndex), Environment.GetResourceString("ArgumentOutOfRange_StartIndex"));
@@ -165,7 +165,7 @@ namespace System.Text {
             }
             if (capacity<0) {
                 throw new ArgumentOutOfRangeException(nameof(capacity),
-                                                      Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", "capacity"));
+                                                      Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", nameof(capacity)));
             }
             Contract.EndContractBlock();
 
@@ -566,7 +566,7 @@ namespace System.Text {
             // We are doing the check here to prevent the corruption of the StringBuilder.
             int newLength = Length + repeatCount;
             if (newLength > m_MaxCapacity || newLength < repeatCount) {
-                throw new ArgumentOutOfRangeException("repeatCount", Environment.GetResourceString("ArgumentOutOfRange_LengthGreaterThanCapacity"));
+                throw new ArgumentOutOfRangeException(nameof(repeatCount), Environment.GetResourceString("ArgumentOutOfRange_LengthGreaterThanCapacity"));
             }
 
             int idx = m_ChunkLength;
@@ -750,7 +750,7 @@ namespace System.Text {
 
             if (destinationIndex < 0) {
                 throw new ArgumentOutOfRangeException(nameof(destinationIndex),
-                    Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", "destinationIndex"));
+                    Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", nameof(destinationIndex)));
             }
 
             if (destinationIndex > destination.Length - count) {
@@ -1724,7 +1724,7 @@ namespace System.Text {
             // We are doing the check here to prevent the corruption of the StringBuilder.
             int newLength = Length + valueCount;
             if (newLength > m_MaxCapacity || newLength < valueCount) {
-                throw new ArgumentOutOfRangeException("valueCount", Environment.GetResourceString("ArgumentOutOfRange_LengthGreaterThanCapacity"));
+                throw new ArgumentOutOfRangeException(nameof(valueCount), Environment.GetResourceString("ArgumentOutOfRange_LengthGreaterThanCapacity"));
             }
 
             // This case is so common we want to optimize for it heavily. 

--- a/src/mscorlib/src/System/Threading/WaitHandleExtensions.cs
+++ b/src/mscorlib/src/System/Threading/WaitHandleExtensions.cs
@@ -21,7 +21,7 @@ namespace System.Threading
         {
             if (waitHandle == null)
             {
-                throw new ArgumentNullException("waitHandle");
+                throw new ArgumentNullException(nameof(waitHandle));
             }
 
             return waitHandle.SafeWaitHandle;
@@ -37,7 +37,7 @@ namespace System.Threading
         {
             if (waitHandle == null)
             {
-                throw new ArgumentNullException("waitHandle");
+                throw new ArgumentNullException(nameof(waitHandle));
             }
 
             waitHandle.SafeWaitHandle = value;

--- a/src/mscorlib/src/System/TimeSpan.cs
+++ b/src/mscorlib/src/System/TimeSpan.cs
@@ -289,11 +289,11 @@ namespace System {
             return TimeSpanParse.ParseExactMultiple(input, formats, formatProvider, TimeSpanStyles.None);
         }
         public static TimeSpan ParseExact(String input, String format, IFormatProvider formatProvider, TimeSpanStyles styles) {
-            TimeSpanParse.ValidateStyles(styles, "styles");
+            TimeSpanParse.ValidateStyles(styles, nameof(styles));
             return TimeSpanParse.ParseExact(input, format, formatProvider, styles);
         }
         public static TimeSpan ParseExact(String input, String[] formats, IFormatProvider formatProvider, TimeSpanStyles styles) {
-            TimeSpanParse.ValidateStyles(styles, "styles");
+            TimeSpanParse.ValidateStyles(styles, nameof(styles));
             return TimeSpanParse.ParseExactMultiple(input, formats, formatProvider, styles);
         }
         public static Boolean TryParse(String s, out TimeSpan result) {
@@ -309,11 +309,11 @@ namespace System {
             return TimeSpanParse.TryParseExactMultiple(input, formats, formatProvider, TimeSpanStyles.None, out result);
         }
         public static Boolean TryParseExact(String input, String format, IFormatProvider formatProvider, TimeSpanStyles styles, out TimeSpan result) {
-            TimeSpanParse.ValidateStyles(styles, "styles");
+            TimeSpanParse.ValidateStyles(styles, nameof(styles));
             return TimeSpanParse.TryParseExact(input, format, formatProvider, styles, out result);
         }
         public static Boolean TryParseExact(String input, String[] formats, IFormatProvider formatProvider, TimeSpanStyles styles, out TimeSpan result) {
-            TimeSpanParse.ValidateStyles(styles, "styles");
+            TimeSpanParse.ValidateStyles(styles, nameof(styles));
             return TimeSpanParse.TryParseExactMultiple(input, formats, formatProvider, styles, out result);
         }
         public override String ToString() {

--- a/src/mscorlib/src/System/Version.cs
+++ b/src/mscorlib/src/System/Version.cs
@@ -252,7 +252,7 @@ namespace System {
         // AppendPositiveNumber is an optimization to append a number to a StringBuilder object without
         // doing any boxing and not even creating intermediate string.
         // Note: as we always have positive numbers then it is safe to convert the number to string 
-        // regardless of the current culture as we’ll not have any punctuation marks in the number
+        // regardless of the current culture as we'll not have any punctuation marks in the number
         //
         private const int ZERO_CHAR_VALUE = (int) '0';
         private static void AppendPositiveNumber(int num, StringBuilder sb)
@@ -277,7 +277,7 @@ namespace System {
             Contract.EndContractBlock();
 
             VersionResult r = new VersionResult();
-            r.Init("input", true);
+            r.Init(nameof(input), true);
             if (!TryParseVersion(input, ref r)) {
                 throw r.GetVersionParseException();
             }
@@ -286,7 +286,7 @@ namespace System {
 
         public static bool TryParse(string input, out Version result) {
             VersionResult r = new VersionResult();
-            r.Init("input", false);
+            r.Init(nameof(input), false);
             bool b = TryParseVersion(input, ref r);
             result = r.m_parsedVersion;
             return b;
@@ -307,11 +307,11 @@ namespace System {
                 return false;
             }
 
-            if (!TryParseComponent(parsedComponents[0], "version", ref result, out major)) {
+            if (!TryParseComponent(parsedComponents[0], nameof(version), ref result, out major)) {
                 return false;
             }
 
-            if (!TryParseComponent(parsedComponents[1], "version", ref result, out minor)) {
+            if (!TryParseComponent(parsedComponents[1], nameof(version), ref result, out minor)) {
                 return false;
             }
 


### PR DESCRIPTION
As a follow-on to https://github.com/dotnet/coreclr/pull/7867, cleans up remaining cases where nameof can be used.