### PR TITLE
Check pointer before dereferencing it

### DIFF
--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -1187,12 +1187,12 @@ NativeImageDumper::DumpNativeImage()
             mscorlib->fIsMscorlib = TRUE;
             _ASSERTE(mscorlib->fIsHardbound);
         }
+
+        _ASSERTE(mscorlib != NULL);
         if( mscorlib->fIsHardbound )
         {
             m_isMscorlibHardBound = true;
         }
-
-        _ASSERTE(mscorlib != NULL);
         if( m_isMscorlibHardBound )
         {
             //go through the module to the binder.


### PR DESCRIPTION
This was found with Cppcheck. The original code dereferences the pointer first, then checks it with assertion. This makes no sense here - it should first check the pointer, then dereference it.