### PR TITLE
Make dotnet/coreclr reference corresponding dotnet/corefx branch

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1588,7 +1588,7 @@ combinedScenarios.each { scenario ->
                                                 // thinks that %workspace% is the project base directory.
                                                 buildCommands += "powershell new-item clr -type directory -force"
                                                 buildCommands += 'powershell foreach ($x in get-childitem -force) { if (\$x.name -ne \'clr\') { move-item $x clr }}'
-                                                buildCommands += "git clone https://github.com/dotnet/corefx fx"
+                                                buildCommands += "git clone -b $branch --single-branch https://github.com/dotnet/corefx fx"
                                                 
                                                 buildCommands += getStressModeEnvSetCmd(os, scenario);
                                                 
@@ -1729,7 +1729,7 @@ combinedScenarios.each { scenario ->
                                         buildCommands += "rm -rf .clr; mkdir .clr; mv * .clr; mv .git .clr; mv .clr clr"
                                         
                                         // Get corefx
-                                        buildCommands += "git clone https://github.com/dotnet/corefx fx"
+                                        buildCommands += "git clone -b $branch --single-branch https://github.com/dotnet/corefx fx"
                                         
                                         // Set environment variable
                                         def setEnvVar = getStressModeEnvSetCmd(os, scenario)                                        


### PR DESCRIPTION
We run CoreFx tests under JitStress modes in CoreCLR.  Previously, we were
always pulling down CoreFx master, which is bad for CoreCLR release
branches when things are out of synch.