### PR TITLE
Remove project lock files before zipping

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1885,6 +1885,8 @@ combinedScenarios.each { scenario ->
                                     
                                         // Zip up the tests directory so that we don't use so much space/time copying
                                         // 10s of thousands of files around.
+                                        // First delete all files underneath named "project.lock".  Since there are around 9 gigs of them
+                                        buildCommands += "del /S .\\bin\\tests\\${osGroup}.${arch}.${configuration}\\project.lock"
                                         buildCommands += "powershell -Command \"Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('.\\bin\\tests\\${osGroup}.${arch}.${configuration}', '.\\bin\\tests\\tests.zip')\"";
                                         
                                         if (!Constants.jitStressModeScenarios.containsKey(scenario)) {


### PR DESCRIPTION
There are approximately 10k project lock files totalling 9GB in a typical test dump.  We don't need them for running on the target, so just remove.

This should improve archive times (drops about 600MB)

/cc @gkhanna79