### PR TITLE
Fix Deadlock associated with ETW commands happening during dispose.  

### DIFF
--- a/Documentation/workflow/UsingYourBuild.md
+++ b/Documentation/workflow/UsingYourBuild.md
@@ -54,7 +54,7 @@ use this in the next step.
 
 ### Step 3: Modify the Project.json for the App to refer to your Runtime.     
 
-Replace the HelloWorld\project.json with (project.json)[../../tests/src/Common/netcoreapp/project.json], and update 
+Replace the HelloWorld\project.json with [project.json](../../tests/src/Common/netcoreapp/project.json), and update 
 `1.2.0-beta-XXXXX-X` version number in the dependencies section with the version number for your build of the runtime.
 This is the line that tells the tools that you want YOUR version of the CoreCLR runtime.
 ```


### PR DESCRIPTION
ETW has a lock as does EventSource.   Thus the potential for two threads to take the locks in opposite order and cause a deadlock.   This can happen because ETW commands first take the ETW lock then the EventSource lock, and EventSource Disposal takes the EventSource lock and then the ETW lock (in unregister).   

To fix this problem we do the ETW unregistration outside the EventSourceLock.    To do this, we removed the Deregister method, and brought is functionality into Dispose.    I also changed EventUnregister to take a parameter so we can aggressively set the m_retHandle to 0 (in particular inside the lock).   The changed functions are only called from Dispose().   

There is also an unrelated trivial fix  (to a hyperlink) to documentation (UsingYourBuild.md) that got mixed in and is more trouble to separate out at this point.  

@davmason 