### PR TITLE
Specify .NETCoreApp,Version=v1.1 for test projects

### DIFF
--- a/tests/src/Common/empty/project.json
+++ b/tests/src/Common/empty/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/dir.props
+++ b/tests/src/dir.props
@@ -85,5 +85,8 @@
   <PropertyGroup>
     <ProjectJson>$(SourceDir)Common\test_dependencies\project.json</ProjectJson>
     <ProjectLockJson>$(SourceDir)Common\test_dependencies\project.lock.json</ProjectLockJson>
+
+    <!-- Specify the target framework of the common test dependency project.json. -->
+    <NuGetTargetMoniker>.NETCoreApp,Version=v1.1</NuGetTargetMoniker>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This fixes warnings caused by the project.jsons being updated to 1.1, but the build still using 1.0 due to the default: https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets#L41

There was also a missed 1.0 in the empty project.json that I fixed to 1.1.

I'm not completely sure `tests/src/dir.props` is the best place to specify this value, but I don't see a reason why not.

Should fix https://github.com/dotnet/coreclr/issues/7626.