### PR TITLE
Disabling checks in MemoryFailPoint for Xplat

### DIFF
--- a/src/mscorlib/src/System/Runtime/MemoryFailPoint.cs
+++ b/src/mscorlib/src/System/Runtime/MemoryFailPoint.cs
@@ -160,6 +160,7 @@ namespace System.Runtime
                 throw new ArgumentOutOfRangeException("sizeInMegabytes", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             Contract.EndContractBlock();
 
+#if !FEATURE_PAL // Remove this when CheckForAvailableMemory is able to provide legitimate estimates
             ulong size = ((ulong)sizeInMegabytes) << 20;
             _reservedMemory = size;
 
@@ -302,6 +303,7 @@ namespace System.Runtime
                 SharedStatics.AddMemoryFailPointReservation((long) size);
                 _mustSubtractReservation = true;
             }
+#endif
         }
 
         [System.Security.SecurityCritical]  // auto-generated
@@ -324,9 +326,6 @@ namespace System.Runtime
         [System.Security.SecurityCritical]  // auto-generated
         private static unsafe bool CheckForFreeAddressSpace(ulong size, bool shouldThrow)
         {
-#if FEATURE_PAL // Remove this when GlobalMemoryStatusEx is able to provide legitimate estimates
-            return true;
-#endif
             // Start walking the address space at 0.  VirtualAlloc may wrap
             // around the address space.  We don't need to find the exact
             // pages that VirtualAlloc would return - we just need to


### PR DESCRIPTION
I missed a few test cases for this feature. To make it fully functional we would need to implement VirtualQuery properly, 

As CheckForFreeAddressSpace actaully uses it to estimate the amount of virtual memory available on the system

i am disabling the checks and letting the constructor succeed


@janvorli @jkotas  PTAL 

follow up on https://github.com/dotnet/coreclr/issues/7807