### PR TITLE
Exclude six sizeof related tests from ARM

### DIFF
--- a/tests/testsUnsupportedOnARM32.txt
+++ b/tests/testsUnsupportedOnARM32.txt
@@ -3,3 +3,9 @@ JIT/Methodical/tailcall_v4/hijacking/hijacking.sh
 JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271/DevDiv_902271.sh
 JIT/Methodical/tailcall_v4/smallFrame/smallFrame.sh
 JIT/jit64/opt/cse/HugeArray1/HugeArray1.sh
+JIT/Methodical/xxobj/sizeof/_il_dbgsizeof/_il_dbgsizeof.sh
+JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32/_il_dbgsizeof32.sh
+JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64/_il_dbgsizeof64.sh
+JIT/Methodical/xxobj/sizeof/_il_relsizeof/_il_relsizeof.sh
+JIT/Methodical/xxobj/sizeof/_il_relsizeof32/_il_relsizeof32.sh
+JIT/Methodical/xxobj/sizeof/_il_relsizeof64/_il_relsizeof64.sh


### PR DESCRIPTION
I think it's time to decide to remove following tests from ARM as discussed in issue #6680
unless there is a plan to enable building tests for ARM. The issue was opened 2 months ago and there is no simple way to enable these tests for ARM by now. So let's skip them in ARM.

JIT/Methodical/xxobj/sizeof/_il_dbgsizeof/_il_dbgsizeof.sh
JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32/_il_dbgsizeof32.sh
JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64/_il_dbgsizeof64.sh
JIT/Methodical/xxobj/sizeof/_il_relsizeof/_il_relsizeof.sh
JIT/Methodical/xxobj/sizeof/_il_relsizeof32/_il_relsizeof32.sh
JIT/Methodical/xxobj/sizeof/_il_relsizeof64/_il_relsizeof64.sh

