### PR TITLE
Properly update block flags during branch opt.

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -14163,15 +14163,15 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
     //
     gtReverseCond(condTree);
 
+    // We need to update the following flags of the bJump block if they were set in the bbJumpDest block
+    bJump->bbFlags |= (bDest->bbFlags &
+                       (BBF_HAS_NEWOBJ | BBF_HAS_NEWARRAY | BBF_HAS_NULLCHECK | BBF_HAS_IDX_LEN | BBF_HAS_VTABREF));
+
     bJump->bbJumpKind = BBJ_COND;
     bJump->bbJumpDest = bDest->bbNext;
 
     /* Mark the jump dest block as being a jump target */
     bJump->bbJumpDest->bbFlags |= BBF_JMP_TARGET | BBF_HAS_LABEL;
-
-    // We need to update the following flags of the bJump block if they were set in the bbJumpDest block
-    bJump->bbFlags |= (bJump->bbJumpDest->bbFlags &
-                       (BBF_HAS_NEWOBJ | BBF_HAS_NEWARRAY | BBF_HAS_NULLCHECK | BBF_HAS_IDX_LEN | BBF_HAS_VTABREF));
 
     /* Update bbRefs and bbPreds */
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -14163,9 +14163,9 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
     //
     gtReverseCond(condTree);
 
-    // We need to update the following flags of the bJump block if they were set in the bbJumpDest block
-    bJump->bbFlags |= (bDest->bbFlags &
-                       (BBF_HAS_NEWOBJ | BBF_HAS_NEWARRAY | BBF_HAS_NULLCHECK | BBF_HAS_IDX_LEN | BBF_HAS_VTABREF));
+    // We need to update the following flags of the bJump block if they were set in the bDest block
+    bJump->bbFlags |=
+        (bDest->bbFlags & (BBF_HAS_NEWOBJ | BBF_HAS_NEWARRAY | BBF_HAS_NULLCHECK | BBF_HAS_IDX_LEN | BBF_HAS_VTABREF));
 
     bJump->bbJumpKind = BBJ_COND;
     bJump->bbJumpDest = bDest->bbNext;


### PR DESCRIPTION
`fgOptimizeBranch` was updating the flags for the predecessor block
using the flags from the wrong destination block. This was causing an
assert in `AllocateObjects` when verifying that all blocks that contain
`allocObj` nodes are properly marked with `BBF_HAS_NEWOBJ`.