### PR TITLE
Make a few VN methods tolerant of NoVN.

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -2918,6 +2918,11 @@ ValueNum Compiler::fgValueNumberArrIndexVal(GenTreePtr           tree,
 
 var_types ValueNumStore::TypeOfVN(ValueNum vn)
 {
+    if (vn == NoVN)
+    {
+        return TYP_UNDEF;
+    }
+
     Chunk* c = m_chunks.GetNoExpand(GetChunkNum(vn));
     return c->m_typ;
 }
@@ -2937,6 +2942,11 @@ var_types ValueNumStore::TypeOfVN(ValueNum vn)
 
 BasicBlock::loopNumber ValueNumStore::LoopOfVN(ValueNum vn)
 {
+    if (vn == NoVN)
+    {
+        return MAX_LOOP_NUM;
+    }
+
     Chunk* c = m_chunks.GetNoExpand(GetChunkNum(vn));
     return c->m_loopNum;
 }
@@ -3402,6 +3412,11 @@ bool ValueNumStore::IsVNFunc(ValueNum vn)
 
 bool ValueNumStore::GetVNFunc(ValueNum vn, VNFuncApp* funcApp)
 {
+    if (vn == NoVN)
+    {
+        return false;
+    }
+
     Chunk*   c      = m_chunks.GetNoExpand(GetChunkNum(vn));
     unsigned offset = ChunkOffset(vn);
     assert(offset < c->m_numUsed);

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_280123/DevDiv_280123.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_280123/DevDiv_280123.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+// This test ensures that the value number store (and its users) behave properly in the event that VN data is requested
+// for trees without value numbers. The original repro was a rather large method with a significant amount of dead code
+// due to the pattern exhibited in C.N: an entry block that was not transformed from a conditional return to an
+// unconditional return followed by dead code that must be kept due to the presence of EH. Value numbering does not
+// assign value numbers to the dead code, but assertion prop still runs over the dead code and attempts to use VN info,
+// which resulted in a number of asserts.
+
+static class C
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int N(ref int i)
+    {
+        bool b = true;
+        if (b)
+        {
+            return 100;
+        }
+
+        try
+        {
+            b = i != 1;
+        }
+        finally
+        {
+            b = i != 0;
+        }
+
+        return b ? 0 : 1;
+    }
+
+    static int Main(string[] args)
+    {
+        int i = args.Length;
+        return N(ref i);
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_280123/DevDiv_280123.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_280123/DevDiv_280123.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_280123.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
There were a few methods on the VN store that were not resilient to
being provided with the "no value number" sentinel value. This lack of
resilience caused assertion failures during assertion propagation when
generating assertions for trees marked with "no value number".