### PR TITLE
Fix PAL tests that verify wait times to use the same clock as the wait

### DIFF
--- a/src/pal/tests/palsuite/threading/Sleep/test1/Sleep.cpp
+++ b/src/pal/tests/palsuite/threading/Sleep/test1/Sleep.cpp
@@ -19,7 +19,7 @@
 
 #include <palsuite.h>
 
-DWORD SleepTimes[] =
+int SleepTimes[] =
 {
     0,
     50,
@@ -29,14 +29,13 @@ DWORD SleepTimes[] =
 };
 
 /* Milliseconds of error which are acceptable Function execution time, etc. */
-DWORD AcceptableTimeError = 150;
+const int AcceptableEarlyDiff = -100;
 
 int __cdecl main( int argc, char **argv ) 
 {
-    UINT64 OldTimeStamp;
-    UINT64 NewTimeStamp;
-    DWORD MaxDelta;
-    DWORD TimeDelta;
+    DWORD OldTimeStamp;
+    DWORD NewTimeStamp;
+    int TimeDelta;
     DWORD i;
 
     if(0 != (PAL_Initialize(argc, argv)))
@@ -44,35 +43,27 @@ int __cdecl main( int argc, char **argv )
         return ( FAIL );
     }
 
-    LARGE_INTEGER performanceFrequency;
-    if (!QueryPerformanceFrequency(&performanceFrequency))
+    for( i = 0; i < sizeof(SleepTimes) / sizeof(SleepTimes[0]); i++)
     {
-        return FAIL;
-    }
-
-    for( i = 0; i < sizeof(SleepTimes) / sizeof(DWORD); i++)
-    {
-        OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
+        OldTimeStamp = GetTickCount();
         Sleep(SleepTimes[i]);
-        NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
+        NewTimeStamp = GetTickCount();
 
-        TimeDelta = NewTimeStamp - OldTimeStamp;
+        TimeDelta = static_cast<int>(NewTimeStamp - OldTimeStamp);
 
         /* For longer intervals use a 10 percent tolerance */
-        if ((SleepTimes[i] * 0.1) > AcceptableTimeError)
+        int AcceptableLateDiff = 300;
+        if ((SleepTimes[i] * 0.1) > AcceptableLateDiff)
         {
-            MaxDelta = SleepTimes[i] + (DWORD)(SleepTimes[i] * 0.1);
-        }
-        else
-        {
-            MaxDelta = SleepTimes[i] + AcceptableTimeError;
+            AcceptableLateDiff = (int)(SleepTimes[i] * 0.1);
         }
 
-        if ( TimeDelta<SleepTimes[i] || TimeDelta>MaxDelta )
+        int diff = TimeDelta - SleepTimes[i];
+        if (diff < AcceptableEarlyDiff || diff > AcceptableLateDiff)
         {
             Fail("The sleep function slept for %d ms when it should have "
              "slept for %d ms\n", TimeDelta, SleepTimes[i]);
-       }
+        }
     }
     PAL_Terminate();
     return ( PASS );

--- a/src/pal/tests/palsuite/threading/Sleep/test1/Sleep.cpp
+++ b/src/pal/tests/palsuite/threading/Sleep/test1/Sleep.cpp
@@ -29,12 +29,12 @@ int SleepTimes[] =
 };
 
 /* Milliseconds of error which are acceptable Function execution time, etc. */
-const int AcceptableEarlyDiff = -100;
+const int AcceptableEarlyDiff = -300;
 
 int __cdecl main( int argc, char **argv ) 
 {
-    DWORD OldTimeStamp;
-    DWORD NewTimeStamp;
+    UINT64 OldTimeStamp;
+    UINT64 NewTimeStamp;
     int TimeDelta;
     DWORD i;
 
@@ -43,11 +43,17 @@ int __cdecl main( int argc, char **argv )
         return ( FAIL );
     }
 
+    LARGE_INTEGER performanceFrequency;
+    if (!QueryPerformanceFrequency(&performanceFrequency))
+    {
+        return FAIL;
+    }
+
     for( i = 0; i < sizeof(SleepTimes) / sizeof(SleepTimes[0]); i++)
     {
-        OldTimeStamp = GetTickCount();
+        OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
         Sleep(SleepTimes[i]);
-        NewTimeStamp = GetTickCount();
+        NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
         TimeDelta = static_cast<int>(NewTimeStamp - OldTimeStamp);
 

--- a/src/pal/tests/palsuite/threading/Sleep/test2/sleep.cpp
+++ b/src/pal/tests/palsuite/threading/Sleep/test2/sleep.cpp
@@ -21,7 +21,7 @@
  * times in 10^(-3) seconds
  */
 
-DWORD SleepTimes[] =
+int SleepTimes[] =
 {
     60000,
     300000,
@@ -30,14 +30,14 @@ DWORD SleepTimes[] =
 };
 
 /* Milliseconds of error which are acceptable Function execution time, etc. */
-DWORD AcceptableTimeError = 150;
+const int AcceptableEarlyDiff = -100;
 
 int __cdecl main( int argc, char **argv ) 
 {
-    UINT64 OldTimeStamp;
-    UINT64 NewTimeStamp;
-    DWORD MaxDelta;
-    DWORD TimeDelta;
+    DWORD OldTimeStamp;
+    DWORD NewTimeStamp;
+    int MaxDelta;
+    int TimeDelta;
     DWORD i;
 
     if(0 != (PAL_Initialize(argc, argv)))
@@ -45,27 +45,27 @@ int __cdecl main( int argc, char **argv )
         return ( FAIL );
     }
 
-    LARGE_INTEGER performanceFrequency;
-    if (!QueryPerformanceFrequency(&performanceFrequency))
+    for( i = 0; i < sizeof(SleepTimes) / sizeof(SleepTimes[0]); i++)
     {
-        return FAIL;
-    }
-
-    for( i = 0; i < sizeof(SleepTimes) / sizeof(DWORD); i++)
-    {
-        OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
+        OldTimeStamp = GetTickCount();
         Sleep(SleepTimes[i]);
-        NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
+        NewTimeStamp = GetTickCount();
 
-        TimeDelta = NewTimeStamp - OldTimeStamp;
+        TimeDelta = static_cast<int>(NewTimeStamp - OldTimeStamp);
 
-        MaxDelta = SleepTimes[i] + AcceptableTimeError;
+        /* For longer intervals use a 10 percent tolerance */
+        int AcceptableLateDiff = 300;
+        if ((SleepTimes[i] * 0.1) > AcceptableLateDiff)
+        {
+            AcceptableLateDiff = (int)(SleepTimes[i] * 0.1);
+        }
 
-        if ( TimeDelta<SleepTimes[i] || TimeDelta>MaxDelta )
+        int diff = TimeDelta - SleepTimes[i];
+        if (diff < AcceptableEarlyDiff || diff > AcceptableLateDiff)
         {
             Fail("The sleep function slept for %u ms when it should have "
              "slept for %u ms\n", TimeDelta, SleepTimes[i]);
-       }
+        }
     }
     PAL_Terminate();
     return ( PASS );

--- a/src/pal/tests/palsuite/threading/Sleep/test2/sleep.cpp
+++ b/src/pal/tests/palsuite/threading/Sleep/test2/sleep.cpp
@@ -30,12 +30,12 @@ int SleepTimes[] =
 };
 
 /* Milliseconds of error which are acceptable Function execution time, etc. */
-const int AcceptableEarlyDiff = -100;
+const int AcceptableEarlyDiff = -300;
 
 int __cdecl main( int argc, char **argv ) 
 {
-    DWORD OldTimeStamp;
-    DWORD NewTimeStamp;
+    UINT64 OldTimeStamp;
+    UINT64 NewTimeStamp;
     int MaxDelta;
     int TimeDelta;
     DWORD i;
@@ -45,11 +45,17 @@ int __cdecl main( int argc, char **argv )
         return ( FAIL );
     }
 
+    LARGE_INTEGER performanceFrequency;
+    if (!QueryPerformanceFrequency(&performanceFrequency))
+    {
+        return FAIL;
+    }
+
     for( i = 0; i < sizeof(SleepTimes) / sizeof(SleepTimes[0]); i++)
     {
-        OldTimeStamp = GetTickCount();
+        OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
         Sleep(SleepTimes[i]);
-        NewTimeStamp = GetTickCount();
+        NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
         TimeDelta = static_cast<int>(NewTimeStamp - OldTimeStamp);
 

--- a/src/pal/tests/palsuite/threading/SleepEx/test1/test1.cpp
+++ b/src/pal/tests/palsuite/threading/SleepEx/test1/test1.cpp
@@ -36,12 +36,12 @@ testCase testCases[] =
 };
 
 /* Milliseconds of error which are acceptable Function execution time, etc. */
-const int AcceptableEarlyDiff = -100;
+const int AcceptableEarlyDiff = -300;
 
 int __cdecl main( int argc, char **argv ) 
 {
-    DWORD OldTimeStamp;
-    DWORD NewTimeStamp;
+    UINT64 OldTimeStamp;
+    UINT64 NewTimeStamp;
     int TimeDelta;
     DWORD i;
 
@@ -50,13 +50,19 @@ int __cdecl main( int argc, char **argv )
         return FAIL;
     }
 
+    LARGE_INTEGER performanceFrequency;
+    if (!QueryPerformanceFrequency(&performanceFrequency))
+    {
+        return FAIL;
+    }
+
     for (i = 0; i<sizeof(testCases) / sizeof(testCases[0]); i++)
     {
-        OldTimeStamp = GetTickCount();
+        OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
         SleepEx(testCases[i].SleepTime, testCases[i].Alertable);
 
-        NewTimeStamp = GetTickCount();
+        NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
         TimeDelta = static_cast<int>(NewTimeStamp - OldTimeStamp);
 

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.cpp
@@ -176,20 +176,26 @@ VOID PALAPI APCFunc(ULONG_PTR dwParam)
 /* Entry Point for child thread. */
 DWORD PALAPI WaiterProc(LPVOID lpParameter)
 {
-    DWORD OldTimeStamp;
-    DWORD NewTimeStamp;
+    UINT64 OldTimeStamp;
+    UINT64 NewTimeStamp;
     BOOL Alertable;
     DWORD ret;
 
     Alertable = (BOOL) lpParameter;
 
-    OldTimeStamp = GetTickCount();
+    LARGE_INTEGER performanceFrequency;
+    if (!QueryPerformanceFrequency(&performanceFrequency))
+    {
+        Fail("Failed to query performance frequency!");
+    }
+
+    OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
     ret = WaitForSingleObjectEx(	hMutex, 
 								ChildThreadWaitTime, 
         							Alertable);
     
-    NewTimeStamp = GetTickCount();
+    NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
     if (Alertable && ret != WAIT_IO_COMPLETION)
     {

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.cpp
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.cpp
@@ -128,10 +128,16 @@ VOID PALAPI APCFunc(ULONG_PTR dwParam)
 DWORD PALAPI WaiterProc(LPVOID lpParameter)
 {
     HANDLE hSemaphore;
-    DWORD OldTimeStamp;
-    DWORD NewTimeStamp;
+    UINT64 OldTimeStamp;
+    UINT64 NewTimeStamp;
     BOOL Alertable;
     DWORD ret;
+
+    LARGE_INTEGER performanceFrequency;
+    if (!QueryPerformanceFrequency(&performanceFrequency))
+    {
+        Fail("Failed to query performance frequency!");
+    }
 
     /* Create a semaphore that is not in the signalled state */
     hSemaphore = CreateSemaphoreW(NULL, 0, 1, NULL);
@@ -144,13 +150,13 @@ DWORD PALAPI WaiterProc(LPVOID lpParameter)
 
     Alertable = (BOOL) lpParameter;
 
-    OldTimeStamp = GetTickCount();
+    OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
     ret = WaitForSingleObjectEx(	hSemaphore, 
 								ChildThreadWaitTime, 
         							Alertable);
     
-    NewTimeStamp = GetTickCount();
+    NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
 
     if (Alertable && ret != WAIT_IO_COMPLETION)

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.cpp
@@ -131,8 +131,8 @@ VOID PALAPI APCFunc(ULONG_PTR dwParam)
 DWORD PALAPI WaiterProc(LPVOID lpParameter)
 {
     HANDLE hWaitThread;
-    DWORD OldTimeStamp;
-    DWORD NewTimeStamp;
+    UINT64 OldTimeStamp;
+    UINT64 NewTimeStamp;
     BOOL Alertable;
     DWORD ret;
     DWORD dwThreadId = 0;
@@ -158,13 +158,19 @@ satisfying any threads that were waiting on the object.
 
     Alertable = (BOOL) lpParameter;
 
-    OldTimeStamp = GetTickCount();
+    LARGE_INTEGER performanceFrequency;
+    if (!QueryPerformanceFrequency(&performanceFrequency))
+    {
+        Fail("Failed to query performance frequency!");
+    }
+
+    OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
     ret = WaitForSingleObjectEx(	hWaitThread, 
 								ChildThreadWaitTime, 
         							Alertable);
     
-    NewTimeStamp = GetTickCount();
+    NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
 
     if (Alertable && ret != WAIT_IO_COMPLETION)


### PR DESCRIPTION
Fixes #7941:
- The tests were using the high precision clock, and the wait infrastructure would use the system clock. The high precision counter usually has higher drift and is not good for accurately measuring long spans of time. Changed tests to use the system clock as well.
- Fixed wait/interrupt time verification to have some tolerance for an early wait completion (earlier than requested, which is possible), and more tolerance for late wait completion
- Fixed verification conditions. Some were inconsistent, some were broken.