### PR TITLE
Enabling Type.Getype with overloads for assembly and type resolvers

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -4023,7 +4023,9 @@
       <Member MemberType="Property" Name="Location" />
       <Member MemberType="Property" Name="ManifestModule" />
       <Member MemberType="Property" Name="SecurityRuleSet" />
-      <Member Status="ImplRoot" MemberType="Event" Name="ModuleResolve" />
+      <Member MemberType="Event" Name="ModuleResolve" />
+      <Member Name="add_ModuleResolve(System.Reflection.ModuleResolveEventHandler)" />
+      <Member Name="remove_ModuleResolve(System.Reflection.ModuleResolveEventHandler)" />
     </Type>
     <Type Name="System.Reflection.IntrospectionExtensions">
       <Member Name="GetTypeInfo(System.Type)" />
@@ -8779,6 +8781,9 @@
       <Member Name="GetType(System.String)" />
       <Member Name="GetType(System.String,System.Boolean)" />
       <Member Name="GetType(System.String,System.Boolean,System.Boolean)" />
+      <Member Name="GetType(System.String,System.Func&lt;System.Reflection.AssemblyName,System.Reflection.Assembly&gt;,System.Func&lt;System.Reflection.Assembly,System.String,System.Boolean,System.Type&gt;)" />
+      <Member Name="GetType(System.String,System.Func&lt;System.Reflection.AssemblyName,System.Reflection.Assembly&gt;,System.Func&lt;System.Reflection.Assembly,System.String,System.Boolean,System.Type&gt;,System.Boolean)" />
+      <Member Name="GetType(System.String,System.Func&lt;System.Reflection.AssemblyName,System.Reflection.Assembly&gt;,System.Func&lt;System.Reflection.Assembly,System.String,System.Boolean,System.Type&gt;,System.Boolean,System.Boolean)" />
       <Member Name="GetTypeArray(System.Object[])" />
       <Member Name="GetTypeCode(System.Type)" />
       <Member Name="GetTypeCodeImpl" />
@@ -8801,6 +8806,9 @@
       <Member Name="IsAssignableFrom(System.Type)" />
       <Member Name="IsByRefImpl" />
       <Member Name="IsCOMObjectImpl" />
+      <Member Name="get_IsContextful" />
+      <Member MemberType="Property" Name="IsContextful" />
+      <Member Name="IsContextfulImpl" />
       <Member Name="IsInstanceOfType(System.Object)" />
       <Member Name="IsMarshalByRefImpl" />
       <Member Name="IsPointerImpl" />

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -3660,7 +3660,11 @@ namespace System
         [System.Security.SecuritySafeCritical]  // auto-generated
         protected override bool IsContextfulImpl() 
         {
+#if FEATURE_REMOTING
             return RuntimeTypeHandle.IsContextful(this);
+#else
+            return false;
+#endif
         }
 
         /*

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -1043,7 +1043,7 @@ FCFuncStart(gTypeNameBuilder)
     QCFuncElement("Clear", TypeNameBuilder::_Clear)
 FCFuncEnd()
 
-#ifndef FEATURE_CORECLR
+
 FCFuncStart(gSafeTypeNameParserHandle)
     QCFuncElement("_ReleaseTypeNameParser", TypeName::QReleaseTypeNameParser)
 FCFuncEnd()
@@ -1055,7 +1055,6 @@ FCFuncStart(gTypeNameParser)
     QCFuncElement("_GetModifiers",          TypeName::QGetModifiers)
     QCFuncElement("_GetAssemblyName",       TypeName::QGetAssemblyName)
 FCFuncEnd()
-#endif //!FEATURE_CORECLR
 
 #ifdef FEATURE_CAS_POLICY
 FCFuncStart(gPEFileFuncs)
@@ -2395,9 +2394,8 @@ FCClassElement("SafePEFileHandle", "Microsoft.Win32.SafeHandles", gPEFileFuncs)
 #ifdef FEATURE_CRYPTO
 FCClassElement("SafeProvHandle", "System.Security.Cryptography", gSafeProvHandleFuncs)
 #endif
-#ifndef FEATURE_CORECLR
 FCClassElement("SafeTypeNameParserHandle", "System", gSafeTypeNameParserHandle)
-#endif //!FEATURE_CORECLR
+
 #if defined(FEATURE_IMPERSONATION) || defined(FEATURE_COMPRESSEDSTACK)
 FCClassElement("SecurityContext", "System.Security", gCOMSecurityContextFuncs)
 #endif // defined(FEATURE_IMPERSONATION) || defined(FEATURE_COMPRESSEDSTACK)
@@ -2438,9 +2436,7 @@ FCClassElement("TypeLibConverter", "System.Runtime.InteropServices", gTypeLibCon
 #endif
 FCClassElement("TypeLoadException", "System", gTypeLoadExceptionFuncs)
 FCClassElement("TypeNameBuilder", "System.Reflection.Emit", gTypeNameBuilder)
-#ifndef FEATURE_CORECLR
 FCClassElement("TypeNameParser", "System", gTypeNameParser)
-#endif //!FEATURE_CORECLR
 FCClassElement("TypedReference", "System", gTypedReferenceFuncs)
 FCClassElement("URLString", "System.Security.Util", gCOMUrlStringFuncs)
 #ifdef FEATURE_COMINTEROP

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -1393,9 +1393,7 @@ DEFINE_CLASS(SAFE_PEFILE_HANDLE,    SafeHandles,            SafePEFileHandle)
 DEFINE_CLASS(SAFE_TOKENHANDLE, SafeHandles, SafeAccessTokenHandle)
 #endif
 
-#ifndef FEATURE_CORECLR
 DEFINE_CLASS(SAFE_TYPENAMEPARSER_HANDLE,    System,         SafeTypeNameParserHandle)
-#endif //!FEATURE_CORECLR
 
 #ifdef FEATURE_COMPRESSEDSTACK
 DEFINE_CLASS(SAFE_CSHANDLE, Threading, SafeCompressedStackHandle)

--- a/src/vm/typeparse.cpp
+++ b/src/vm/typeparse.cpp
@@ -364,7 +364,7 @@ HRESULT __stdcall TypeName::GetAssemblyName(BSTR* pszAssemblyName)
     return hr;
 }
 
-#if !defined(FEATURE_CORECLR) && !defined(CROSSGEN_COMPILE)
+#if!defined(CROSSGEN_COMPILE)
 SAFEHANDLE TypeName::GetSafeHandle()
 {
     CONTRACTL
@@ -588,7 +588,7 @@ void QCALLTYPE TypeName::QGetAssemblyName(TypeName * pTypeName, QCall::StringHan
 
     END_QCALL;
 }
-#endif //!FEATURE_CORECLR && !CROSSGEN_COMPILE
+#endif//!CROSSGEN_COMPILE
 
 //
 // TypeName::TypeNameParser

--- a/src/vm/typeparse.h
+++ b/src/vm/typeparse.h
@@ -311,14 +311,14 @@ public:
     virtual ~TypeName();
     
 public:
-#ifndef FEATURE_CORECLR
+#ifndef CROSSGEN_COMPILE
     static void QCALLTYPE QCreateTypeNameParser (LPCWSTR wszTypeName, QCall::ObjectHandleOnStack pNames, BOOL throwOnError);
     static void QCALLTYPE QReleaseTypeNameParser(TypeName * pTypeName);
     static void QCALLTYPE QGetNames             (TypeName * pTypeName, QCall::ObjectHandleOnStack pNames);
     static void QCALLTYPE QGetTypeArguments     (TypeName * pTypeName, QCall::ObjectHandleOnStack pTypeArguments);
     static void QCALLTYPE QGetModifiers         (TypeName * pTypeName, QCall::ObjectHandleOnStack pModifiers);
     static void QCALLTYPE QGetAssemblyName      (TypeName * pTypeName, QCall::StringHandleOnStack pAssemblyName);
-#endif //!FEATURE_CORECLR
+#endif //CROSSGEN_COMPILE
 
     //-------------------------------------------------------------------------------------------
     // Retrieves a type from an assembly. It requires the caller to know which assembly
@@ -451,10 +451,7 @@ private:
         return GetTypeHaveAssemblyHelper(pAssembly, bThrowIfNotFound, bIgnoreCase, pKeepAlive, TRUE);
     }
     TypeHandle GetTypeHaveAssemblyHelper(Assembly* pAssembly, BOOL bThrowIfNotFound, BOOL bIgnoreCase, OBJECTREF *pKeepAlive, BOOL bRecurse);
-
-#ifndef FEATURE_CORECLR
     SAFEHANDLE GetSafeHandle();
-#endif //!FEATURE_CORECLR
 
 private:
     BOOL m_bIsGenericArgument;


### PR DESCRIPTION
@jkotas @kouvel @rahku  PTAL

this constitute the coreclr side of changes for https://github.com/dotnet/corefx/issues/12309

will remove the tests before checkin