### PR TITLE
Mark NonRandomizedStringEqualityComparer as serializable

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -301,7 +301,7 @@ namespace System.Collections.Generic
     // We use NonRandomizedStringEqualityComparer as default comparer as it doesnt use the randomized string hashing which 
     // keep the perofrmance not affected till we hit collision threshold and then we switch to the comparer which is using 
     // randomized string hashing GenericEqualityComparer<string>
-
+    [Serializable]
     internal class NonRandomizedStringEqualityComparer : GenericEqualityComparer<string> {
         static IEqualityComparer<string> s_nonRandomizedComparer;
         


### PR DESCRIPTION
cc: @danmosemsft 
Contributes to https://github.com/dotnet/corefx/issues/13283