### PR TITLE
Inliner: capture new observations

### DIFF
--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -78,6 +78,7 @@ INLINE_OBSERVATION(BELOW_ALWAYS_INLINE_SIZE,  bool,   "below ALWAYS_INLINE size"
 INLINE_OBSERVATION(CLASS_PROMOTABLE,          bool,   "promotable value class",        INFORMATION, CALLEE)
 INLINE_OBSERVATION(DOES_NOT_RETURN,           bool,   "does not return",               INFORMATION, CALLEE)
 INLINE_OBSERVATION(END_OPCODE_SCAN,           bool,   "done looking at opcodes",       INFORMATION, CALLEE)
+INLINE_OBSERVATION(HAS_GC_STRUCT,             bool,   "has gc field in struct local",  INFORMATION, CALLEE)
 INLINE_OBSERVATION(HAS_SIMD,                  bool,   "has SIMD arg, local, or ret",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                    INFORMATION, CALLEE)
 INLINE_OBSERVATION(IL_CODE_SIZE,              int,    "number of bytes of IL",         INFORMATION, CALLEE)

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -247,14 +247,15 @@ private:
 
 #endif // DEBUG
 
-// DiscretionaryPolicy is a variant of the legacy policy.  It differs
-// in that there is no ALWAYS_INLINE class, there is no IL size limit,
-// it does not try and maintain legacy compatabilty, and in prejit mode,
-// discretionary failures do not set the "NEVER" inline bit.
+// DiscretionaryPolicy is a variant of the enhanced legacy policy.  It
+// differs in that there is no ALWAYS_INLINE class, there is no IL
+// size limit, it does not try and maintain legacy compatabilty, and
+// in prejit mode, discretionary failures do not set the "NEVER"
+// inline bit.
 //
 // It is useful for gathering data about inline costs.
 
-class DiscretionaryPolicy : public LegacyPolicy
+class DiscretionaryPolicy : public EnhancedLegacyPolicy
 {
 public:
     // Construct a DiscretionaryPolicy
@@ -346,6 +347,7 @@ protected:
     bool        m_IsSameThis;
     bool        m_CallerHasNewArray;
     bool        m_CallerHasNewObj;
+    bool        m_CalleeHasGCStruct;
 };
 
 // ModelPolicy is an experimental policy that uses the results


### PR DESCRIPTION
Rebase the DiscretionaryPolicy on the EnhancedLegacyPolicy, and
capture and report some of the new observations that have been added
recently.

This change adds a new HAS_GC_STRUCT observation in addition to the
more specific RARE_GC_STRUCT, so that the DiscretionaryPolicy can
be notified of GC struct locals and temps for all candidates, not
just ones invoked from rare call sites.

No changes in codegen.