### PR TITLE
Fix a issue where ETW was losing RCW and CCW in heap dumps.

### DIFF
--- a/src/vm/eventtracepriv.h
+++ b/src/vm/eventtracepriv.h
@@ -23,7 +23,10 @@
 #define _countof(_array) (sizeof(_array)/sizeof(_array[0]))
 #endif
 
-const UINT cbMaxEtwEvent = 64 * 1024;
+// ETW has a limitation of 64K for TOTAL event Size, however there is overhead associated with 
+// the event headers.   It is unclear exactly how much that is, but 1K should be sufficiently
+// far away to avoid problems without sacrificing the perf of bulk processing.  
+const UINT cbMaxEtwEvent = 63 * 1024;
 
 //---------------------------------------------------------------------------------------
 // C++ copies of ETW structures


### PR DESCRIPTION
Basically our builk events for RCWs and CCWs were too big, causing ETW to reject them, and thus losing information.

However you have to have at least several hundred befor you have enough to force the problem.

I have an ad-hoc test case that confirms the fix works. 

The fix is trivial.  Lower the cutoff used to determine how many bulk items will be placed in a single ETW event.  

@brianrob  @daklimek 