### PR TITLE
Force store of lcl var for shift/rotate by 32

### DIFF
--- a/tests/src/JIT/CodeGenBringUpTests/Rotate.cs
+++ b/tests/src/JIT/CodeGenBringUpTests/Rotate.cs
@@ -120,6 +120,14 @@ public class Test
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong rol64_32_inplace(ulong value, ulong added)
+    {
+        ulong x = value + added;
+        x = (x >> (64 - 32)) | (x << 32);
+        return x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     static ulong rol64_33(ulong value)
     {
         return (value >> (64 - 33)) | (value << 33);
@@ -167,6 +175,14 @@ public class Test
     static ulong ror64_33(ulong value)
     {
         return (value << (64 - 33)) | (value >> 33);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong ror64_32_inplace(ulong value, ulong added)
+    {
+        ulong x = value + added;
+        x = (x << (64 - 32)) | (x >> 32);
+        return x;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -295,6 +311,11 @@ public class Test
             return Fail;
         }
 
+        if (rol64_32_inplace(0x123456789abcdef, 0) != rol64(0x123456789abcdef, 32))
+        {
+            return Fail;
+        }
+
         if (ror64(0x123456789abcdef, 0) != 0x123456789abcdef)
         {
             return Fail;
@@ -321,6 +342,11 @@ public class Test
         }
 
         if (ror64_33(0x123456789abcdef) != ror64(0x123456789abcdef, 33))
+        {
+            return Fail;
+        }
+
+        if (ror64_32_inplace(0x123456789abcdef, 0) != ror64(0x123456789abcdef, 32))
         {
             return Fail;
         }

--- a/tests/src/JIT/CodeGenBringUpTests/Shift.cs
+++ b/tests/src/JIT/CodeGenBringUpTests/Shift.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class Test
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong shl64(ulong shift, int count)
+    {
+        return shift << count;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong shl64_32_inplace(ulong shift, ulong addit)
+    {
+        ulong x = shift + addit;
+        x = x << 32;
+        return x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong shl64_33_inplace(ulong shift, ulong addit)
+    {
+        ulong x = shift + addit;
+        x = x << 33;
+        return x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong shr64(ulong shift, int count)
+    {
+        return shift >> count;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong shr64_32_inplace(ulong shift, ulong addit)
+    {
+        ulong x = shift + addit;
+        x = x >> 32;
+        return x;
+    }
+
+    public static int Main()
+    {
+        const int Pass = 100;
+        const int Fail = -1;
+
+        if (shl64_32_inplace(0x123456789abcdef, 0) != shl64(0x123456789abcdef, 32))
+        {
+            return Fail;
+        }
+
+        if (shl64_33_inplace(0x123456789abcdef, 0) != shl64(0x123456789abcdef, 33))
+        {
+            return Fail;
+        }
+
+        if (shr64_32_inplace(0x123456789abcdef, 0) != shr64(0x123456789abcdef, 32))
+        {
+            return Fail;
+        }
+
+        return Pass;
+    }
+}

--- a/tests/src/JIT/CodeGenBringUpTests/Shift.csproj
+++ b/tests/src/JIT/CodeGenBringUpTests/Shift.csproj
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{AF7F2478-9B49-4776-BEAF-0BF8916E2D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Shift.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)threading+thread\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)threading+thread\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
In the shift/rotate by 32 case, we move the lo op into the high op. In the
shift case, we set the lo op to 0, in the rotate case, we are swapping lo
and hi, so we also move hi into lo. In the instance that we are reusing
the same lclvars, we need to explicitly store the ops that we are moving
so that we don't overwrite the vars before using them. This change
explicitly replaces the uses of the ops with lclvars so we don't overwrite
vars before finishing the swap.