### PR TITLE
Clear GTF_VAR_USEDEF when folding <op>= forms

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13653,6 +13653,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
                         /* The target is used as well as being defined */
                         if (op1->OperIsLocal())
                         {
+                            op1->gtFlags &= ~GTF_VAR_USEDEF;
                             op1->gtFlags |= GTF_VAR_USEASG;
                         }
 


### PR DESCRIPTION
The `GTF_VAR_USEDEF` flag is applied to the def of an expression like "x =
x + y".  The `GTF_VAR_USEASG` flag is applied to the op1 of an expression
like "x += y".  Update the code to clear the `GTF_VAR_USEDEF` flag (in
addition to setting the `GTF_VAR_USEASG` flag) when folding the former to
the latter.