### PR TITLE
Don't transform GT_SUB tree outside the global morph phase.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -12244,38 +12244,42 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                     goto CM_OVF_OP;
                 }
 
-                /* Check for "op1 - cns2" , we change it to "op1 + (-cns2)" */
-
-                noway_assert(op2);
-                if (op2->IsCnsIntOrI())
+                // TODO #4104: there are a lot of other places where
+                // this condition is not checked before transformations.
+                if (fgGlobalMorph)
                 {
-                    /* Negate the constant and change the node to be "+" */
+                    /* Check for "op1 - cns2" , we change it to "op1 + (-cns2)" */
 
-                    op2->gtIntConCommon.SetIconValue(-op2->gtIntConCommon.IconValue());
-                    oper = GT_ADD;
-                    tree->ChangeOper(oper);
-                    goto CM_ADD_OP;
+                    noway_assert(op2);
+                    if (op2->IsCnsIntOrI())
+                    {
+                        /* Negate the constant and change the node to be "+" */
+
+                        op2->gtIntConCommon.SetIconValue(-op2->gtIntConCommon.IconValue());
+                        oper = GT_ADD;
+                        tree->ChangeOper(oper);
+                        goto CM_ADD_OP;
+                    }
+
+                    /* Check for "cns1 - op2" , we change it to "(cns1 + (-op2))" */
+
+                    noway_assert(op1);
+                    if (op1->IsCnsIntOrI())
+                    {
+                        noway_assert(varTypeIsIntOrI(tree));
+
+                        tree->gtOp.gtOp2 = op2 = gtNewOperNode(GT_NEG, tree->gtType, op2); // The type of the new GT_NEG
+                                                                                           // node should be the same
+                        // as the type of the tree, i.e. tree->gtType.
+                        fgMorphTreeDone(op2);
+
+                        oper = GT_ADD;
+                        tree->ChangeOper(oper);
+                        goto CM_ADD_OP;
+                    }
+
+                    /* No match - exit */
                 }
-
-                /* Check for "cns1 - op2" , we change it to "(cns1 + (-op2))" */
-
-                noway_assert(op1);
-                if (op1->IsCnsIntOrI())
-                {
-                    noway_assert(varTypeIsIntOrI(tree));
-
-                    tree->gtOp.gtOp2 = op2 =
-                        gtNewOperNode(GT_NEG, tree->gtType, op2); // The type of the new GT_NEG node should be the same
-                                                                  // as the type of the tree, i.e. tree->gtType.
-                    fgMorphTreeDone(op2);
-
-                    oper = GT_ADD;
-                    tree->ChangeOper(oper);
-                    goto CM_ADD_OP;
-                }
-
-                /* No match - exit */
-
                 break;
 
 #ifdef _TARGET_ARM64_

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278526/DevDiv_278526.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278526/DevDiv_278526.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This test was originally a repro for an assertion regarding incorrect value number of the tree in cse.
+// The repro requires that the tree and its child are considered by cse and child is binary sub (a - b).
+// Cse calls morph of the parent tree and morphs child to (a + (-b)) and sets the clean VN state to the child.
+// It causes assert when cse processes the child with the clean vn state.
+
+
+using System;
+
+
+class Program
+{
+      public sealed class Variables
+    {
+        public static byte[] decryptedApplicationData
+        {
+            get;
+            set;
+        }
+    }
+
+    private static bool VerifyMacvalueSSlV2(string sourceIP)
+    {
+        if (sourceIP == "skip")
+            return false;        
+
+        byte[] array3 = new byte[0];
+
+        // Assert happens on the next two statements.
+        int l = Variables.decryptedApplicationData.Length - array3.Length - 16;
+        byte[] array2 = new byte[l];       
+        
+        if (array3[0] != array2[0])
+            return false;      
+        return true;
+    }
+
+    public static int Main(string[] args)
+    {
+        string s = "skip"; // Test checks commpilation process.
+        VerifyMacvalueSSlV2(s);
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278526/DevDiv_278526.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278526/DevDiv_278526.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_278526.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
fgMorphBlockStmt can be called from phases after value numbering, for example from cse.
fgMorphBlockStmt  can call changeOper and set VN for a tree to clear state, it causes assert fails in PMI.
PR saves VN when morph doesn't change the expression result.
Fix VSO 278526