### PR TITLE
Fix int->long cast folding for 32-bit platforms.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -12658,9 +12658,6 @@ GenTreePtr Compiler::gtFoldExprConst(GenTreePtr tree)
                             case TYP_ULONG:
                                 if (!(tree->gtFlags & GTF_UNSIGNED) && tree->gtOverflow() && i1 < 0)
                                 {
-                                    op1->ChangeOperConst(GT_CNS_NATIVELONG); // need type of oper to be same as tree
-                                    op1->gtType = TYP_LONG;
-                                    // We don't care about the value as we are throwing an exception
                                     goto LNG_OVF;
                                 }
                                 lval1 = UINT64(UINT32(i1));


### PR DESCRIPTION
The RyuJIT frontend does not allow for the folding of an int->long cast
that is known to overflow into a throw outside of global morph. The
folding, however, was unconditionally changing the operand to the cast
from an integer constant to a long constant, which can change the
behavior of the cast. This rewrite is not necessary, so this change
simply removes it.