### PR TITLE
Jit: fix regression in non-AVX SIMD codegen

### DIFF
--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -2389,14 +2389,14 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
 
         case SIMDIntrinsicDotProduct:
         {
-#if defined(_TARGET_XARCH_) && defined(DEBUG)
+#if defined(_TARGET_XARCH_)
             // Right now dot product is supported only for float/double vectors and
             // int vectors on AVX.
             if (!varTypeIsFloating(baseType) && !(baseType == TYP_INT && canUseAVX()))
             {
                 return nullptr;
             }
-#endif // _TARGET_XARCH_ && DEBUG
+#endif // _TARGET_XARCH_
 
             // op1 is a SIMD variable that is the first source and also "this" arg.
             // op2 is a SIMD variable which is the second source.


### PR DESCRIPTION
Vector codegen for dot product was inadvertenly altered in non-DEBUG
builds.

Closes #7977.