### PR TITLE
Adds ALIGN_ACCESS constant for S.P.CoreLib.dll build (for ARM)

### DIFF
--- a/src/mscorlib/src/System/IO/UnmanagedMemoryAccessor.cs
+++ b/src/mscorlib/src/System/IO/UnmanagedMemoryAccessor.cs
@@ -377,7 +377,7 @@ namespace System.IO {
                     // check if pointer is aligned
                     if (((int)pointer & (sizeOfType - 1)) == 0) {
 #endif
-                    result = *((Single*)(pointer));
+                    result = BitConverter.Int32BitsToSingle(*((int*)(pointer)));
 #if ALIGN_ACCESS
                     }
                     else {
@@ -413,7 +413,7 @@ namespace System.IO {
                     // check if pointer is aligned
                     if (((int)pointer & (sizeOfType - 1)) == 0) {
 #endif
-                    result = *((Double*)(pointer));
+                    result = BitConverter.Int64BitsToDouble(*((long*)(pointer)));
 #if ALIGN_ACCESS
                     }
                     else {
@@ -904,7 +904,7 @@ namespace System.IO {
                     // check if pointer is aligned
                     if (((int)pointer & (sizeOfType - 1)) == 0) {
 #endif
-                    *((Single*)pointer) = value;
+                    *((int*)pointer) = BitConverter.SingleToInt32Bits(value);
 #if ALIGN_ACCESS
                     }
                     else {
@@ -940,7 +940,7 @@ namespace System.IO {
                     // check if pointer is aligned
                     if (((int)pointer & (sizeOfType - 1)) == 0) {
 #endif
-                    *((Double*)pointer) = value;
+                    *((long*)pointer) = BitConverter.DoubleToInt64Bits(value);
 #if ALIGN_ACCESS
                     }
                     else {


### PR DESCRIPTION
It seems that ALIGN_ACCESS flag is currently disabled for System.Private.CoreLib.dll, and thus ' UnmanagedMemoryAccessor' throws System.DataMisalignedException (discussed in #7992).

This commit enables ALIGN_ACCESS flag for ARM Core CLR to fix #7992.