### PR TITLE
Add JitOptRepeat debug config flags

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -353,6 +353,10 @@ struct BasicBlock : private LIR::Range
                                        // BBJ_CALLFINALLY block, as well as, on x86, the final step block out of a
                                        // finally.
 
+// Flags that relate blocks to loop structure.
+
+#define BBF_LOOP_FLAGS (BBF_LOOP_PREHEADER | BBF_LOOP_HEAD | BBF_LOOP_CALL0 | BBF_LOOP_CALL1)
+
     bool isRunRarely()
     {
         return ((bbFlags & BBF_RUN_RARELY) != 0);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4650,6 +4650,21 @@ void Compiler::ResetOptAnnotations()
                 tree->ClearVN();
                 tree->ClearAssertion();
                 tree->gtCSEnum = NO_CSE;
+
+                // Clear any *_ASG_LHS flags -- these are set during SSA construction,
+                // and the heap live-in calculation depends on them being unset coming
+                // into SSA construction (without clearing them, a block that has a
+                // heap def via one of these before any heap use is treated as not having
+                // an upwards-exposed heap use, even though subsequent heap uses may not
+                // be killed by the store; this seems to be a bug, worked around here).
+                if (tree->OperIsIndir())
+                {
+                    tree->gtFlags &= ~GTF_IND_ASG_LHS;
+                }
+                else if (tree->OperGet() == GT_CLS_VAR)
+                {
+                    tree->gtFlags &= ~GTF_CLS_VAR_ASG_LHS;
+                }
             }
         }
     }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4635,6 +4635,7 @@ void Compiler::ResetOptAnnotations()
     fgResetForSsa();
     vnStore               = nullptr;
     m_opAsgnVarDefSsaNums = nullptr;
+    m_blockToEHPreds      = nullptr;
     fgSsaPassesCompleted  = 0;
     fgVNPassesCompleted   = 0;
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7621,6 +7621,7 @@ public:
         bool altJit;     // True if we are an altjit and are compiling this method
 
 #ifdef DEBUG
+        bool optRepeat;                // Repeat optimizer phases k times
         bool compProcedureSplittingEH; // Separate cold code from hot code for functions with EH
         bool dspCode;                  // Display native code generated
         bool dspEHTable;               // Display the EH table reported to the VM
@@ -8344,6 +8345,12 @@ protected:
     bool compRsvdRegCheck(FrameLayoutState curState);
 #endif
     void compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags* compileFlags);
+
+    // Clear annotations produced during optimizations; to be used between iterations when repeating opts.
+    void ResetOptAnnotations();
+
+    // Regenerate loop descriptors; to be used between iterations when repeating opts.
+    void RecomputeLoopInfo();
 
 #ifdef PROFILING_SUPPORTED
     // Data required for generating profiler Enter/Leave/TailCall hooks

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16229,6 +16229,17 @@ void GenTree::ParseArrayAddress(
             // TODO-Review: A NotAField here indicates a failure to properly maintain the field sequence
             // See test case self_host_tests_x86\jit\regression\CLR-x86-JIT\v1-m12-beta2\ b70992\ b70992.exe
             // Safest thing to do here is to drop back to MinOpts
+            CLANG_FORMAT_COMMENT_ANCHOR;
+
+#ifdef DEBUG
+            if (comp->opts.optRepeat)
+            {
+                // We don't guarantee preserving these annotations through the entire optimizer, so
+                // just conservatively return null if under optRepeat.
+                *pArr = nullptr;
+                return;
+            }
+#endif // DEBUG
             noway_assert(!"fldSeqIter is NotAField() in ParseArrayAddress");
         }
 

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -154,10 +154,12 @@ CONFIG_METHODSET(JitNoProcedureSplittingEH, W("JitNoProcedureSplittingEH")) // D
                                                                             // exception handling
 CONFIG_METHODSET(JitStressOnly, W("JitStressOnly")) // Internal Jit stress mode: stress only the specified method(s)
 CONFIG_METHODSET(JitUnwindDump, W("JitUnwindDump")) // Dump the unwind codes for the method
-CONFIG_METHODSET(NgenDisasm, W("NgenDisasm"))       // Same as JitDisasm, but for ngen
-CONFIG_METHODSET(NgenDump, W("NgenDump"))           // Same as JitDump, but for ngen
-CONFIG_METHODSET(NgenDumpIR, W("NgenDumpIR"))       // Same as JitDumpIR, but for ngen
-CONFIG_METHODSET(NgenEHDump, W("NgenEHDump"))       // Dump the EH table for the method, as reported to the VM
+CONFIG_METHODSET(JitOptRepeat, W("JitOptRepeat"))   // Runs optimizer multiple times on the method
+CONFIG_INTEGER(JitOptRepeatCount, W("JitOptRepeatCount"), 2) // Number of times to repeat opts when repeating
+CONFIG_METHODSET(NgenDisasm, W("NgenDisasm"))                // Same as JitDisasm, but for ngen
+CONFIG_METHODSET(NgenDump, W("NgenDump"))                    // Same as JitDump, but for ngen
+CONFIG_METHODSET(NgenDumpIR, W("NgenDumpIR"))                // Same as JitDumpIR, but for ngen
+CONFIG_METHODSET(NgenEHDump, W("NgenEHDump"))                // Dump the EH table for the method, as reported to the VM
 CONFIG_METHODSET(NgenGCDump, W("NgenGCDump"))
 CONFIG_METHODSET(NgenUnwindDump, W("NgenUnwindDump")) // Dump the unwind codes for the method
 CONFIG_STRING(JitDumpFg, W("JitDumpFg"))              // Dumps Xml/Dot Flowgraph for specified method

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -1085,9 +1085,24 @@ bool Compiler::optExtractInitTestIncr(
     // If it is a duplicated loop condition, skip it.
     if (init->gtFlags & GTF_STMT_CMPADD)
     {
-        // Must be a duplicated loop condition.
-        noway_assert(init->gtStmt.gtStmtExpr->gtOper == GT_JTRUE);
-        init = init->gtPrev;
+        bool doGetPrev = true;
+#ifdef DEBUG
+        if (opts.optRepeat)
+        {
+            // Previous optimization passes may have inserted compiler-generated
+            // statements other than duplicated loop conditions.
+            doGetPrev = (init->gtPrev != nullptr);
+        }
+        else
+        {
+            // Must be a duplicated loop condition.
+            noway_assert(init->gtStmt.gtStmtExpr->gtOper == GT_JTRUE);
+        }
+#endif // DEBUG
+        if (doGetPrev)
+        {
+            init = init->gtPrev;
+        }
         noway_assert(init != nullptr);
     }
 

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -103,6 +103,8 @@ void Compiler::fgResetForSsa()
     {
         lvaTable[i].lvPerSsaData.Reset();
     }
+    lvHeapPerSsaData.Reset();
+    m_heapSsaMap = nullptr;
     for (BasicBlock* blk = fgFirstBB; blk != nullptr; blk = blk->bbNext)
     {
         // Eliminate phis.

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -118,6 +118,32 @@ void Compiler::fgResetForSsa()
                 blk->bbTreeList->gtPrev = last;
             }
         }
+
+        // Clear post-order numbers and SSA numbers; SSA construction will overwrite these,
+        // but only for reachable code, so clear them to avoid analysis getting confused
+        // by stale annotations in unreachable code.
+        blk->bbPostOrderNum = 0;
+        for (GenTreeStmt* stmt = blk->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        {
+            for (GenTreePtr tree = stmt->gtStmt.gtStmtList; tree != nullptr; tree = tree->gtNext)
+            {
+                if (tree->IsLocal())
+                {
+                    tree->gtLclVarCommon.SetSsaNum(SsaConfig::RESERVED_SSA_NUM);
+                    continue;
+                }
+
+                Compiler::IndirectAssignmentAnnotation* pIndirAssign = nullptr;
+                if ((tree->OperGet() != GT_ASG) || !GetIndirAssignMap()->Lookup(tree, &pIndirAssign) ||
+                    (pIndirAssign == nullptr))
+                {
+                    continue;
+                }
+
+                pIndirAssign->m_defSsaNum = SsaConfig::RESERVED_SSA_NUM;
+                pIndirAssign->m_useSsaNum = SsaConfig::RESERVED_SSA_NUM;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Add flag JitOptRepeat that specifies a set of methods on which to
iteratively perform global optimizations multiple times, and flag
JitOptRepeatCount to set the number of iterations (default 2) to apply
when JitOptRepeat kicks in.

These flags are debug-only; they are intended to facilitate performing
experiments investigating optimization opportunities missed due to phase
ordering issues.

Also update `fgResetForSsa` (which is called between iterations) to clear heap data, defnums, and post-order numbers.