### PR TITLE
make the returning of DTFI & NFI in CultureInfo atomic

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CultureInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureInfo.cs
@@ -971,7 +971,7 @@ namespace System.Globalization
                 {
                     NumberFormatInfo temp = new NumberFormatInfo(this.m_cultureData);
                     temp.isReadOnly = m_isReadOnly;
-                    numInfo = temp;
+                    Interlocked.CompareExchange(ref numInfo, temp, null);
                 }
                 return (numInfo);
             }
@@ -1003,8 +1003,7 @@ namespace System.Globalization
                     // Change the calendar of DTFI to the specified calendar of this CultureInfo.
                     DateTimeFormatInfo temp = new DateTimeFormatInfo(this.m_cultureData, this.Calendar);
                     temp._isReadOnly = m_isReadOnly;
-                    System.Threading.Interlocked.MemoryBarrier();
-                    dateTimeInfo = temp;
+                    Interlocked.CompareExchange(ref dateTimeInfo, temp, null);
                 }
                 return (dateTimeInfo);
             }

--- a/src/mscorlib/src/System/Globalization/CultureInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CultureInfo.cs
@@ -1351,7 +1351,7 @@ namespace System.Globalization {
                 if (numInfo == null) {
                     NumberFormatInfo temp = new NumberFormatInfo(this.m_cultureData);
                     temp.isReadOnly = m_isReadOnly;
-                    numInfo = temp;
+                    Interlocked.CompareExchange(ref numInfo, temp, null);
                 }
                 return (numInfo);
             }
@@ -1385,8 +1385,7 @@ namespace System.Globalization {
                     DateTimeFormatInfo temp = new DateTimeFormatInfo(
                         this.m_cultureData, this.Calendar);
                     temp.m_isReadOnly = m_isReadOnly;
-                    System.Threading.Thread.MemoryBarrier();
-                    dateTimeInfo = temp;
+                    Interlocked.CompareExchange(ref dateTimeInfo, temp, null);
                 }
                 return (dateTimeInfo);
             }


### PR DESCRIPTION
we got some cases when more than one thread trying to get DTFI or NFI from the shared current culture object which can result returning different instances.
Although the returned objects contents will be exactly same but it'll be better to return same instance as apps may assume that. also returning the same instance will help reduce re-initializing more deeper fields when get requested as we'll initialize one object instead of 2.