### PR TITLE
Enable unrolling of SIMD_LIMIT loops

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -2861,7 +2861,7 @@ void Compiler::optUnrollLoops()
             int        llim;         // limit value for iterator
             unsigned   lvar;         // iterator lclVar #
             int        iterInc;      // value to increment the iterator
-            genTreeOps iterOper;     // type of iterator increment (i.e. ASG_ADD, ASG_SUB, etc.)
+            genTreeOps iterOper;     // type of iterator increment (i.e. ADD, SUB, etc.)
             var_types  iterOperType; // type result of the oper (for overflow instrs)
             genTreeOps testOper;     // type of loop test (i.e. GT_LE, GT_GE, etc.)
             bool       unsTest;      // Is the comparison u/int
@@ -2965,7 +2965,7 @@ void Compiler::optUnrollLoops()
                 - limit constant
                 - iterator
                 - iterator increment
-                - increment operation type (i.e. ASG_ADD, ASG_SUB, etc...)
+                - increment operation type (i.e. ADD, SUB, etc...)
                 - loop test type (i.e. GT_GE, GT_LT, etc...)
              */
 
@@ -3040,19 +3040,20 @@ void Compiler::optUnrollLoops()
             incr = incr->gtStmt.gtStmtExpr;
 
             // Don't unroll loops we don't understand.
-            if (incr->gtOper == GT_ASG)
+            if (incr->gtOper != GT_ASG)
             {
                 continue;
             }
+            incr = incr->gtOp.gtOp2;
 
             /* Make sure everything looks ok */
             if ((init->gtOper != GT_ASG) || (init->gtOp.gtOp1->gtOper != GT_LCL_VAR) ||
                 (init->gtOp.gtOp1->gtLclVarCommon.gtLclNum != lvar) || (init->gtOp.gtOp2->gtOper != GT_CNS_INT) ||
                 (init->gtOp.gtOp2->gtIntCon.gtIconVal != lbeg) ||
 
-                !((incr->gtOper == GT_ASG_ADD) || (incr->gtOper == GT_ASG_SUB)) ||
-                (incr->gtOp.gtOp1->gtOper != GT_LCL_VAR) || (incr->gtOp.gtOp1->gtLclVarCommon.gtLclNum != lvar) ||
-                (incr->gtOp.gtOp2->gtOper != GT_CNS_INT) || (incr->gtOp.gtOp2->gtIntCon.gtIconVal != iterInc) ||
+                !((incr->gtOper == GT_ADD) || (incr->gtOper == GT_SUB)) || (incr->gtOp.gtOp1->gtOper != GT_LCL_VAR) ||
+                (incr->gtOp.gtOp1->gtLclVarCommon.gtLclNum != lvar) || (incr->gtOp.gtOp2->gtOper != GT_CNS_INT) ||
+                (incr->gtOp.gtOp2->gtIntCon.gtIconVal != iterInc) ||
 
                 (test->gtOper != GT_JTRUE))
             {
@@ -3183,16 +3184,16 @@ void Compiler::optUnrollLoops()
 
                 switch (iterOper)
                 {
-                    case GT_ASG_ADD:
+                    case GT_ADD:
                         lval += iterInc;
                         break;
 
-                    case GT_ASG_SUB:
+                    case GT_SUB:
                         lval -= iterInc;
                         break;
 
-                    case GT_ASG_RSH:
-                    case GT_ASG_LSH:
+                    case GT_RSH:
+                    case GT_LSH:
                         noway_assert(!"Unrolling not implemented for this loop iterator");
                         goto DONE_LOOP;
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -2834,299 +2834,294 @@ void Compiler::optUnrollLoops()
 #endif
     /* Look for loop unrolling candidates */
 
-    /*  Double loop so that after unrolling an inner loop we set change to true
-     *  and we then go back over all of the loop candidates and try to unroll
-     *  the next outer loop, until we don't unroll any loops,
-     *  then change will be false and we are done.
-     */
-    for (;;)
+    bool change = false;
+
+    // Visit loops from highest to lowest number to vist them in innermost
+    // to outermost order
+    for (unsigned lnum = optLoopCount - 1; lnum != ~0U; --lnum)
     {
-        bool change = false;
+        BasicBlock* block;
+        BasicBlock* head;
+        BasicBlock* bottom;
 
-        for (unsigned lnum = 0; lnum < optLoopCount; lnum++)
+        GenTree* loop;
+        GenTree* test;
+        GenTree* incr;
+        GenTree* phdr;
+        GenTree* init;
+
+        bool       dupCond;
+        int        lval;
+        int        lbeg;         // initial value for iterator
+        int        llim;         // limit value for iterator
+        unsigned   lvar;         // iterator lclVar #
+        int        iterInc;      // value to increment the iterator
+        genTreeOps iterOper;     // type of iterator increment (i.e. ADD, SUB, etc.)
+        var_types  iterOperType; // type result of the oper (for overflow instrs)
+        genTreeOps testOper;     // type of loop test (i.e. GT_LE, GT_GE, etc.)
+        bool       unsTest;      // Is the comparison u/int
+
+        unsigned totalIter;     // total number of iterations in the constant loop
+        unsigned loopCostSz;    // Cost is size of one iteration
+        unsigned loopFlags;     // actual lpFlags
+        unsigned requiredFlags; // required lpFlags
+
+        GenTree* loopList; // new stmt list of the unrolled loop
+        GenTree* loopLast;
+
+        static const int ITER_LIMIT[COUNT_OPT_CODE + 1] = {
+            10, // BLENDED_CODE
+            0,  // SMALL_CODE
+            20, // FAST_CODE
+            0   // COUNT_OPT_CODE
+        };
+
+        noway_assert(ITER_LIMIT[SMALL_CODE] == 0);
+        noway_assert(ITER_LIMIT[COUNT_OPT_CODE] == 0);
+
+        unsigned iterLimit = (unsigned)ITER_LIMIT[compCodeOpt()];
+
+#ifdef DEBUG
+        if (compStressCompile(STRESS_UNROLL_LOOPS, 50))
         {
-            BasicBlock* block;
-            BasicBlock* head;
-            BasicBlock* bottom;
-
-            GenTree* loop;
-            GenTree* test;
-            GenTree* incr;
-            GenTree* phdr;
-            GenTree* init;
-
-            bool       dupCond;
-            int        lval;
-            int        lbeg;         // initial value for iterator
-            int        llim;         // limit value for iterator
-            unsigned   lvar;         // iterator lclVar #
-            int        iterInc;      // value to increment the iterator
-            genTreeOps iterOper;     // type of iterator increment (i.e. ADD, SUB, etc.)
-            var_types  iterOperType; // type result of the oper (for overflow instrs)
-            genTreeOps testOper;     // type of loop test (i.e. GT_LE, GT_GE, etc.)
-            bool       unsTest;      // Is the comparison u/int
-
-            unsigned totalIter;     // total number of iterations in the constant loop
-            unsigned loopCostSz;    // Cost is size of one iteration
-            unsigned loopFlags;     // actual lpFlags
-            unsigned requiredFlags; // required lpFlags
-
-            GenTree* loopList; // new stmt list of the unrolled loop
-            GenTree* loopLast;
-
-            static const int ITER_LIMIT[COUNT_OPT_CODE + 1] = {
-                10, // BLENDED_CODE
-                0,  // SMALL_CODE
-                20, // FAST_CODE
-                0   // COUNT_OPT_CODE
-            };
-
-            noway_assert(ITER_LIMIT[SMALL_CODE] == 0);
-            noway_assert(ITER_LIMIT[COUNT_OPT_CODE] == 0);
-
-            unsigned iterLimit = (unsigned)ITER_LIMIT[compCodeOpt()];
-
-#ifdef DEBUG
-            if (compStressCompile(STRESS_UNROLL_LOOPS, 50))
-            {
-                iterLimit *= 10;
-            }
+            iterLimit *= 10;
+        }
 #endif
 
-            static const int UNROLL_LIMIT_SZ[COUNT_OPT_CODE + 1] = {
-                30, // BLENDED_CODE
-                0,  // SMALL_CODE
-                60, // FAST_CODE
-                0   // COUNT_OPT_CODE
-            };
+        static const int UNROLL_LIMIT_SZ[COUNT_OPT_CODE + 1] = {
+            30, // BLENDED_CODE
+            0,  // SMALL_CODE
+            60, // FAST_CODE
+            0   // COUNT_OPT_CODE
+        };
 
-            noway_assert(UNROLL_LIMIT_SZ[SMALL_CODE] == 0);
-            noway_assert(UNROLL_LIMIT_SZ[COUNT_OPT_CODE] == 0);
+        noway_assert(UNROLL_LIMIT_SZ[SMALL_CODE] == 0);
+        noway_assert(UNROLL_LIMIT_SZ[COUNT_OPT_CODE] == 0);
 
-            int unrollLimitSz = (unsigned)UNROLL_LIMIT_SZ[compCodeOpt()];
-
-#ifdef DEBUG
-            if (compStressCompile(STRESS_UNROLL_LOOPS, 50))
-            {
-                unrollLimitSz *= 10;
-            }
-#endif
-
-            loopFlags     = optLoopTable[lnum].lpFlags;
-            requiredFlags = LPFLG_DO_WHILE | LPFLG_ONE_EXIT | LPFLG_CONST;
-
-            /* Ignore the loop if we don't have a do-while with a single exit
-               that has a constant number of iterations */
-
-            if ((loopFlags & requiredFlags) != requiredFlags)
-            {
-                continue;
-            }
-
-            /* ignore if removed or marked as not unrollable */
-
-            if (optLoopTable[lnum].lpFlags & (LPFLG_DONT_UNROLL | LPFLG_REMOVED))
-            {
-                continue;
-            }
-
-            head = optLoopTable[lnum].lpHead;
-            noway_assert(head);
-            bottom = optLoopTable[lnum].lpBottom;
-            noway_assert(bottom);
-
-            /* The single exit must be at the bottom of the loop */
-            noway_assert(optLoopTable[lnum].lpExit);
-            if (optLoopTable[lnum].lpExit != bottom)
-            {
-                continue;
-            }
-
-            /* Unrolling loops with jumps in them is not worth the headache
-             * Later we might consider unrolling loops after un-switching */
-
-            block = head;
-            do
-            {
-                block = block->bbNext;
-                noway_assert(block);
-
-                if (block->bbJumpKind != BBJ_NONE)
-                {
-                    if (block != bottom)
-                    {
-                        goto DONE_LOOP;
-                    }
-                }
-            } while (block != bottom);
-
-            /* Get the loop data:
-                - initial constant
-                - limit constant
-                - iterator
-                - iterator increment
-                - increment operation type (i.e. ADD, SUB, etc...)
-                - loop test type (i.e. GT_GE, GT_LT, etc...)
-             */
-
-            lbeg     = optLoopTable[lnum].lpConstInit;
-            llim     = optLoopTable[lnum].lpConstLimit();
-            testOper = optLoopTable[lnum].lpTestOper();
-
-            lvar     = optLoopTable[lnum].lpIterVar();
-            iterInc  = optLoopTable[lnum].lpIterConst();
-            iterOper = optLoopTable[lnum].lpIterOper();
-
-            iterOperType = optLoopTable[lnum].lpIterOperType();
-            unsTest      = (optLoopTable[lnum].lpTestTree->gtFlags & GTF_UNSIGNED) != 0;
-
-            if (lvaTable[lvar].lvAddrExposed)
-            { // If the loop iteration variable is address-exposed then bail
-                continue;
-            }
-            if (lvaTable[lvar].lvIsStructField)
-            { // If the loop iteration variable is a promoted field from a struct then
-                // bail
-                continue;
-            }
-
-            /* Locate the pre-header and initialization and increment/test statements */
-
-            phdr = head->bbTreeList;
-            noway_assert(phdr);
-            loop = bottom->bbTreeList;
-            noway_assert(loop);
-
-            init = head->lastStmt();
-            noway_assert(init && (init->gtNext == nullptr));
-            test = bottom->lastStmt();
-            noway_assert(test && (test->gtNext == nullptr));
-            incr = test->gtPrev;
-            noway_assert(incr);
-
-            if (init->gtFlags & GTF_STMT_CMPADD)
-            {
-                /* Must be a duplicated loop condition */
-                noway_assert(init->gtStmt.gtStmtExpr->gtOper == GT_JTRUE);
-
-                dupCond = true;
-                init    = init->gtPrev;
-                noway_assert(init);
-            }
-            else
-            {
-                dupCond = false;
-            }
-
-            /* Find the number of iterations - the function returns false if not a constant number */
-
-            if (!optComputeLoopRep(lbeg, llim, iterInc, iterOper, iterOperType, testOper, unsTest, dupCond, &totalIter))
-            {
-                continue;
-            }
-
-            /* Forget it if there are too many repetitions or not a constant loop */
-
-            if (totalIter > iterLimit)
-            {
-                continue;
-            }
-
-            noway_assert(init->gtOper == GT_STMT);
-            init = init->gtStmt.gtStmtExpr;
-            noway_assert(test->gtOper == GT_STMT);
-            test = test->gtStmt.gtStmtExpr;
-            noway_assert(incr->gtOper == GT_STMT);
-            incr = incr->gtStmt.gtStmtExpr;
-
-            // Don't unroll loops we don't understand.
-            if (incr->gtOper != GT_ASG)
-            {
-                continue;
-            }
-            incr = incr->gtOp.gtOp2;
-
-            /* Make sure everything looks ok */
-            if ((init->gtOper != GT_ASG) || (init->gtOp.gtOp1->gtOper != GT_LCL_VAR) ||
-                (init->gtOp.gtOp1->gtLclVarCommon.gtLclNum != lvar) || (init->gtOp.gtOp2->gtOper != GT_CNS_INT) ||
-                (init->gtOp.gtOp2->gtIntCon.gtIconVal != lbeg) ||
-
-                !((incr->gtOper == GT_ADD) || (incr->gtOper == GT_SUB)) || (incr->gtOp.gtOp1->gtOper != GT_LCL_VAR) ||
-                (incr->gtOp.gtOp1->gtLclVarCommon.gtLclNum != lvar) || (incr->gtOp.gtOp2->gtOper != GT_CNS_INT) ||
-                (incr->gtOp.gtOp2->gtIntCon.gtIconVal != iterInc) ||
-
-                (test->gtOper != GT_JTRUE))
-            {
-                noway_assert(!"Bad precondition in Compiler::optUnrollLoops()");
-                continue;
-            }
-
-            /* heuristic - Estimated cost in code size of the unrolled loop */
-
-            loopCostSz = 0;
-
-            block = head;
-
-            do
-            {
-                block = block->bbNext;
-
-                /* Visit all the statements in the block */
-
-                for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
-                {
-                    /* Get the expression and stop if end reached */
-
-                    GenTreePtr expr = stmt->gtStmtExpr;
-                    if (expr == incr)
-                    {
-                        break;
-                    }
-
-                    /* Calculate gtCostSz */
-                    gtSetStmtInfo(stmt);
-
-                    /* Update loopCostSz */
-                    loopCostSz += stmt->gtCostSz;
-                }
-            } while (block != bottom);
-
-            /* Compute the estimated increase in code size for the unrolled loop */
-
-            unsigned int fixedLoopCostSz;
-            fixedLoopCostSz = 8;
-
-            int unrollCostSz;
-            unrollCostSz = (loopCostSz * totalIter) - (loopCostSz + fixedLoopCostSz);
-
-            /* Don't unroll if too much code duplication would result. */
-
-            if (unrollCostSz > unrollLimitSz)
-            {
-                /* prevent this loop from being revisited */
-                optLoopTable[lnum].lpFlags |= LPFLG_DONT_UNROLL;
-                goto DONE_LOOP;
-            }
-
-            /* Looks like a good idea to unroll this loop, let's do it! */
-            CLANG_FORMAT_COMMENT_ANCHOR;
+        int unrollLimitSz = (unsigned)UNROLL_LIMIT_SZ[compCodeOpt()];
 
 #ifdef DEBUG
-            if (verbose)
-            {
-                printf("\nUnrolling loop BB%02u", head->bbNext->bbNum);
-                if (head->bbNext->bbNum != bottom->bbNum)
-                {
-                    printf("..BB%02u", bottom->bbNum);
-                }
-                printf(" over V%02u from %u to %u", lvar, lbeg, llim);
-                printf(" unrollCostSz = %d\n", unrollCostSz);
-                printf("\n");
-            }
+        if (compStressCompile(STRESS_UNROLL_LOOPS, 50))
+        {
+            unrollLimitSz *= 10;
+        }
 #endif
 
-            /* Create the unrolled loop statement list */
+        loopFlags     = optLoopTable[lnum].lpFlags;
+        requiredFlags = LPFLG_DO_WHILE | LPFLG_ONE_EXIT | LPFLG_CONST;
 
+        /* Ignore the loop if we don't have a do-while with a single exit
+            that has a constant number of iterations */
+
+        if ((loopFlags & requiredFlags) != requiredFlags)
+        {
+            continue;
+        }
+
+        /* ignore if removed or marked as not unrollable */
+
+        if (optLoopTable[lnum].lpFlags & (LPFLG_DONT_UNROLL | LPFLG_REMOVED))
+        {
+            continue;
+        }
+
+        head = optLoopTable[lnum].lpHead;
+        noway_assert(head);
+        bottom = optLoopTable[lnum].lpBottom;
+        noway_assert(bottom);
+
+        /* The single exit must be at the bottom of the loop */
+        noway_assert(optLoopTable[lnum].lpExit);
+        if (optLoopTable[lnum].lpExit != bottom)
+        {
+            continue;
+        }
+
+        /* Unrolling loops with jumps in them is not worth the headache
+            * Later we might consider unrolling loops after un-switching */
+
+        block = head;
+        do
+        {
+            block = block->bbNext;
+            noway_assert(block);
+
+            if (block->bbJumpKind != BBJ_NONE)
+            {
+                if (block != bottom)
+                {
+                    goto DONE_LOOP;
+                }
+            }
+        } while (block != bottom);
+
+        /* Get the loop data:
+            - initial constant
+            - limit constant
+            - iterator
+            - iterator increment
+            - increment operation type (i.e. ADD, SUB, etc...)
+            - loop test type (i.e. GT_GE, GT_LT, etc...)
+            */
+
+        lbeg     = optLoopTable[lnum].lpConstInit;
+        llim     = optLoopTable[lnum].lpConstLimit();
+        testOper = optLoopTable[lnum].lpTestOper();
+
+        lvar     = optLoopTable[lnum].lpIterVar();
+        iterInc  = optLoopTable[lnum].lpIterConst();
+        iterOper = optLoopTable[lnum].lpIterOper();
+
+        iterOperType = optLoopTable[lnum].lpIterOperType();
+        unsTest      = (optLoopTable[lnum].lpTestTree->gtFlags & GTF_UNSIGNED) != 0;
+
+        if (lvaTable[lvar].lvAddrExposed)
+        { // If the loop iteration variable is address-exposed then bail
+            continue;
+        }
+        if (lvaTable[lvar].lvIsStructField)
+        { // If the loop iteration variable is a promoted field from a struct then
+            // bail
+            continue;
+        }
+
+        /* Locate the pre-header and initialization and increment/test statements */
+
+        phdr = head->bbTreeList;
+        noway_assert(phdr);
+        loop = bottom->bbTreeList;
+        noway_assert(loop);
+
+        init = head->lastStmt();
+        noway_assert(init && (init->gtNext == nullptr));
+        test = bottom->lastStmt();
+        noway_assert(test && (test->gtNext == nullptr));
+        incr = test->gtPrev;
+        noway_assert(incr);
+
+        if (init->gtFlags & GTF_STMT_CMPADD)
+        {
+            /* Must be a duplicated loop condition */
+            noway_assert(init->gtStmt.gtStmtExpr->gtOper == GT_JTRUE);
+
+            dupCond = true;
+            init    = init->gtPrev;
+            noway_assert(init);
+        }
+        else
+        {
+            dupCond = false;
+        }
+
+        /* Find the number of iterations - the function returns false if not a constant number */
+
+        if (!optComputeLoopRep(lbeg, llim, iterInc, iterOper, iterOperType, testOper, unsTest, dupCond, &totalIter))
+        {
+            continue;
+        }
+
+        /* Forget it if there are too many repetitions or not a constant loop */
+
+        if (totalIter > iterLimit)
+        {
+            continue;
+        }
+
+        noway_assert(init->gtOper == GT_STMT);
+        init = init->gtStmt.gtStmtExpr;
+        noway_assert(test->gtOper == GT_STMT);
+        test = test->gtStmt.gtStmtExpr;
+        noway_assert(incr->gtOper == GT_STMT);
+        incr = incr->gtStmt.gtStmtExpr;
+
+        // Don't unroll loops we don't understand.
+        if (incr->gtOper != GT_ASG)
+        {
+            continue;
+        }
+        incr = incr->gtOp.gtOp2;
+
+        /* Make sure everything looks ok */
+        if ((init->gtOper != GT_ASG) || (init->gtOp.gtOp1->gtOper != GT_LCL_VAR) ||
+            (init->gtOp.gtOp1->gtLclVarCommon.gtLclNum != lvar) || (init->gtOp.gtOp2->gtOper != GT_CNS_INT) ||
+            (init->gtOp.gtOp2->gtIntCon.gtIconVal != lbeg) ||
+
+            !((incr->gtOper == GT_ADD) || (incr->gtOper == GT_SUB)) || (incr->gtOp.gtOp1->gtOper != GT_LCL_VAR) ||
+            (incr->gtOp.gtOp1->gtLclVarCommon.gtLclNum != lvar) || (incr->gtOp.gtOp2->gtOper != GT_CNS_INT) ||
+            (incr->gtOp.gtOp2->gtIntCon.gtIconVal != iterInc) ||
+
+            (test->gtOper != GT_JTRUE))
+        {
+            noway_assert(!"Bad precondition in Compiler::optUnrollLoops()");
+            continue;
+        }
+
+        /* heuristic - Estimated cost in code size of the unrolled loop */
+
+        loopCostSz = 0;
+
+        block = head;
+
+        do
+        {
+            block = block->bbNext;
+
+            /* Visit all the statements in the block */
+
+            for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+            {
+                /* Get the expression and stop if end reached */
+
+                GenTreePtr expr = stmt->gtStmtExpr;
+                if (expr == incr)
+                {
+                    break;
+                }
+
+                /* Calculate gtCostSz */
+                gtSetStmtInfo(stmt);
+
+                /* Update loopCostSz */
+                loopCostSz += stmt->gtCostSz;
+            }
+        } while (block != bottom);
+
+        /* Compute the estimated increase in code size for the unrolled loop */
+
+        unsigned int fixedLoopCostSz;
+        fixedLoopCostSz = 8;
+
+        int unrollCostSz;
+        unrollCostSz = (loopCostSz * totalIter) - (loopCostSz + fixedLoopCostSz);
+
+        /* Don't unroll if too much code duplication would result. */
+
+        if (unrollCostSz > unrollLimitSz)
+        {
+            /* prevent this loop from being revisited */
+            optLoopTable[lnum].lpFlags |= LPFLG_DONT_UNROLL;
+            goto DONE_LOOP;
+        }
+
+        /* Looks like a good idea to unroll this loop, let's do it! */
+        CLANG_FORMAT_COMMENT_ANCHOR;
+
+#ifdef DEBUG
+        if (verbose)
+        {
+            printf("\nUnrolling loop BB%02u", head->bbNext->bbNum);
+            if (head->bbNext->bbNum != bottom->bbNum)
+            {
+                printf("..BB%02u", bottom->bbNum);
+            }
+            printf(" over V%02u from %u to %u", lvar, lbeg, llim);
+            printf(" unrollCostSz = %d\n", unrollCostSz);
+            printf("\n");
+        }
+#endif
+
+        /* Create the unrolled loop statement list */
+        {
             loopList = loopLast = nullptr;
 
             for (lval = lbeg; totalIter; totalIter--)
@@ -3239,8 +3234,8 @@ void Compiler::optUnrollLoops()
             fgRemoveRefPred(head->bbNext, bottom);
 
             /* Now change the initialization statement in the HEAD to "lvar = lval;"
-             * (the last value of the iterator in the loop)
-             * and drop the jump condition since the unrolled loop will always execute */
+                * (the last value of the iterator in the loop)
+                * and drop the jump condition since the unrolled loop will always execute */
 
             init->gtOp.gtOp2->gtIntCon.gtIconVal = lval;
 
@@ -3302,18 +3297,13 @@ void Compiler::optUnrollLoops()
             /* Make sure to update loop table */
 
             /* Use the LPFLG_REMOVED flag and update the bbLoopMask acordingly
-             * (also make head and bottom NULL - to hit an assert or GPF) */
+                * (also make head and bottom NULL - to hit an assert or GPF) */
 
             optLoopTable[lnum].lpFlags |= LPFLG_REMOVED;
             optLoopTable[lnum].lpHead = optLoopTable[lnum].lpBottom = nullptr;
-
-        DONE_LOOP:;
         }
 
-        if (!change)
-        {
-            break;
-        }
+    DONE_LOOP:;
     }
 
 #ifdef DEBUG

--- a/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using System;
+using System.Numerics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+using System.Collections.Generic;
+using Xunit;
+
+[assembly: OptimizeForBenchmarks]
+[assembly: MeasureInstructionsRetired]
+
+public static class SeekUnroll
+{
+
+    // The purpose of this micro-benchmark is to measure the effect of unrolling
+    // on this loop (taken from https://github.com/aspnet/KestrelHttpServer/pull/1138)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static int FindByte(ref Vector<byte> byteEquals)
+    {
+        var vector64 = Vector.AsVectorInt64(byteEquals);
+        long longValue = 0;
+        var i = 0;
+        for (; i < Vector<long>.Count; i++)
+        {
+            longValue = vector64[i];
+            if (longValue == 0) continue;
+            break;
+        }
+
+        // Flag least significant power of two bit
+        var powerOfTwoFlag = (ulong)(longValue ^ (longValue - 1));
+        // Shift all powers of two into the high byte and extract
+        var foundByteIndex = (int)((powerOfTwoFlag * _xorPowerOfTwoToHighByte) >> 57);
+        // Single LEA instruction with jitted const (using function result)
+        return i * 8 + foundByteIndex;
+    }
+
+    // Magic constant used in FindByte
+    const ulong _xorPowerOfTwoToHighByte = (0x07ul |
+                                            0x06ul << 8 |
+                                            0x05ul << 16 |
+                                            0x04ul << 24 |
+                                            0x03ul << 32 |
+                                            0x02ul << 40 |
+                                            0x01ul << 48) + 1;
+
+    // Inner loop to repeatedly call FindByte
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void InnerLoop(ref int foundIndex, ref Vector<Byte> vector)
+    {
+        for (int i = 0; i < InnerIterations; i++)
+        {
+            foundIndex = FindByte(ref vector);
+        }
+    }
+
+    // Iteration counts for inner loop set to have each call take 1 or
+    // 2 seconds or so in release, finish quickly in debug.
+#if DEBUG
+    const int InnerIterations = 1;
+#else
+    const int InnerIterations = 1000000000;
+#endif
+
+    // Function to meaure InnerLoop using the xunit-perf benchmark measurement facilities
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void XunitBenchmarkLoop(ref int foundIndex, ref Vector<Byte> vector)
+    {
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                InnerLoop(ref foundIndex, ref vector);
+            }
+        }
+    }
+
+    // Function to measure InnerLoop with manual use of a stopwatch timer
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static void ManualTimerLoop(ref int foundIndex, ref Vector<Byte> vector)
+    {
+        for (int iteration = 0; iteration < ManualLoopTimes.Length; ++iteration)
+        {
+            var timer = System.Diagnostics.Stopwatch.StartNew();
+            InnerLoop(ref foundIndex, ref vector);
+            timer.Stop();
+            ManualLoopTimes[iteration] = timer.ElapsedMilliseconds;
+        }
+    }
+    static long[] ManualLoopTimes;
+
+    // Function that tests one input, dispatching to either the xunit-perf
+    // loop or the manual timer loop
+    static bool Test(int index, bool isXunitBenchmark)
+    {
+        if (index >= Vector<Byte>.Count)
+        {
+            // FindByte assumes index is in range
+            index = 0;
+        }
+        var bytes = new Byte[Vector<Byte>.Count];
+        bytes[index] = 255;
+        Vector<Byte> vector = new Vector<Byte>(bytes);
+
+        int foundIndex = -1;
+
+        if (isXunitBenchmark)
+        {
+            XunitBenchmarkLoop(ref foundIndex, ref vector);
+        }
+        else
+        {
+            ManualTimerLoop(ref foundIndex, ref vector);
+        }
+
+        Assert.Equal(index, foundIndex);
+        return (index == foundIndex);
+    }
+
+    // Set of indices to pass to Test(int, bool)
+    static int[] IndicesToTest = new int[] { 1, 3, 11, 19, 27 };
+
+    // Entrypoint for xunit-perf to call the benchmark
+    [Benchmark]
+    [MemberData(nameof(ArrayedBoxedIndicesToTest))]
+    public static bool Test(object boxedIndex)
+    {
+        return Test((int)boxedIndex, true);
+    }
+
+    // IndicesToTest wrapped up in arrays of boxes since that's
+    // what xunit-perf needs
+    public static IEnumerable<object[]> ArrayedBoxedIndicesToTest =
+        IndicesToTest.Select((int index) => new object[] { index });
+
+
+    // Main method entrypoint runs the manual timer loop
+    public static int Main()
+    {
+        int failures = 0;
+        foreach(int index in IndicesToTest)
+        {
+            ManualLoopTimes = new long[10];
+            bool passed = Test(index, false);
+            if (!passed)
+            {
+                ++failures;
+            }
+            Console.WriteLine("Index {0}, times (ms) [{1}]", index, String.Join(", ", ManualLoopTimes));
+        }
+
+        return 100 + failures;
+    }
+}

--- a/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.csproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9AE6E18D-B3F9-4216-9809-125824387175}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SeekUnroll.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)benchmark\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)benchmark\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Since the Vector<T> abstraction has a `Count` that is not a
C#-compile-time constant, it encourages use of iteration to
search/aggregate individual elements using symbolic indexing, which in
turn leads to codegen that spills the vector to memory for each element
access, and performs bounds checks for each access.  These loops will have
low trip counts that are jit-compile-time constant, and constant indexing
into Vector<T> allows more efficient register-to-register sequences and
bounds-check elision.  This change enables RyuJit's loop unroller when
such a loop is discovered, and increases the size threshold to target
optimizing such loops much more aggressively than the unroller's previous
incarnation.

Add a test with a motivating loop from aspnet/KestrelHttpServer#1138 to the
Performance/CodeQuality/SIMD suite.

Closes #7843.