### PR TITLE
Add missing clear of G flag on aliasable local var

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -11249,6 +11249,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
             if (oper == GT_ADDR && (op1->gtOper == GT_LCL_VAR || op1->gtOper == GT_CLS_VAR))
             {
                 tree->gtFlags &= ~GTF_GLOB_REF;
+                op1->gtFlags &= ~GTF_GLOB_REF;
             }
         } // if (op1)
 


### PR DESCRIPTION
GTF_GLOB_REF flag is cleared for the parent node of the tree in some
cases while not clearing its child. This leads to an incorrect assert
stating there are unmecessary flags in the parent.