### PR TITLE
Move remaining NETCoreApp references from 1.0 to 1.1

### DIFF
--- a/tests/src/JIT/config/extra/project.json
+++ b/tests/src/JIT/config/extra/project.json
@@ -18,7 +18,7 @@
     "System.Runtime.InteropServices": "4.4.0-beta-24631-01"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/config/minimal/project.json
+++ b/tests/src/JIT/config/minimal/project.json
@@ -7,7 +7,7 @@
     "System.Runtime.InteropServices": "4.4.0-beta-24631-01"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/config/threading+thread/project.json
+++ b/tests/src/JIT/config/threading+thread/project.json
@@ -9,7 +9,7 @@
     "System.Threading.Thread": "4.4.0-beta-24631-01"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/JIT/config/threading/project.json
+++ b/tests/src/JIT/config/threading/project.json
@@ -7,7 +7,7 @@
     "System.Threading": "4.4.0-beta-24631-01"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x86": {},

--- a/tests/src/TestWrappersConfig/project.json
+++ b/tests/src/TestWrappersConfig/project.json
@@ -6,7 +6,7 @@
     "xunit.runner.msbuild": "2.2.0-beta2-build3300"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",  
         "portable-net45+win8"


### PR DESCRIPTION
This gets us down from "a zillion" warnings to just "a lot."

There are still warnings after this change.  Some are just source issues, but some are due to intentional references to NETStandard1.4 instead of NetCoreApp.  Not sure how to address those.

Related: #7626