### PR TITLE
While unassigning a phyReg, establish association with a previous interval only if it is different from the one it is being unassigned

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6184,7 +6184,8 @@ void LinearScan::unassignPhysReg(RegRecord* regRec, RefPosition* spillRefPositio
     {
         assignedInterval->assignedReg = regRec;
     }
-    else if (regRec->previousInterval != nullptr && regRec->previousInterval->assignedReg == regRec &&
+    else if (regRec->previousInterval != nullptr && regRec->previousInterval != assignedInterval &&
+             regRec->previousInterval->assignedReg == regRec &&
              regRec->previousInterval->getNextRefPosition() != nullptr)
     {
         regRec->assignedInterval = regRec->previousInterval;


### PR DESCRIPTION
This issue repros for a big method under Jitstress=1 and JitStressRegs=8 on x86 RyuJIT.

Repro case description:
Very early in the method LclVar v26 gets allocated eax and remains allocated to it for a significant duration. In that duration each time v26 becomes active it gets eax.  v44 and v19 gets allocated eax within life-time holes of v26.  As a result, eax's RegRecord->PreviousInterval is set to interval of v26.    Since eax is allocated to v26, eax's RegRecord->assignedInterval is equal to interval of v26.   After reaching this state, interval v26 becomes inactive for some time and in that duration eax never gets allocated to any other ref position.

Now allocation encounters the following  two ref positions:

566: Def of v26 with candidate set = { ebx, esi, edi }
567: Use of v26 with candidate set = {ebx}  // because v26 is involved in a byte type storeind operation

While allocating to Def of v26 , LSRA (allocateRegisters() method) notices that currently assigned eax reg is not the one needed. Hence it un-assigns eax without spilling - i.e. calls unassignPhysRegNoSpill(), which in turn calls unassignPhysReg().   The latter, has logic to establish the association between RegRecord and its previousInterval under the following condition:

```
    else if (regRec->previousInterval != nullptr && 
             regRec->previousInterval->assignedReg == regRec &&
             regRec->previousInterval->getNextRefPosition() != nullptr)
```

In case of eax's RegRecord, since previousInterval is same as assignedInterval, the above condition will be true and RegRecord->assignedInterval is still set to interval of v26 incorrectly.

Now back in allocateRegisers(), regsToFree is set to eax and v26 is allocated a new free register esi.  Now while allocating above mentioned Use position (567) of v26, LSRA frees registers given by regsToFree (which is eax).  This goes through the following call chain

freeRegisters() --> freeRegister(eax's RegRecord) 

freeRegister() will find eax's RegRecord->assignedInterval is non-null and will mark it inactive (i.e. active=false).  That is essentially, an active v26 interval gets marked as in-active incorrectly.  This leads the following assert in allocateRegisters().

```
                if (RefTypeIsUse(refType))
                {
                    assert(inVarToRegMaps[curBBNum][currentInterval->getVarIndex(compiler)] == REG_STK &&
                           previousRefPosition->nodeLocation <= curBBStartLocation);
                    isInRegister = false;
                }
```

Fix:  The issue is that while unassigning eax from v26, the condition wasn't checking that previousInterval  != assignedInterval.  As a result, its ends up incorrectly maintaining the association between eax's RegRecord and interval of v26.

Super PMI asm diffs:
By reverting back to the changeset where SPMI works, I have verified this fix has no diffs on Amd64 windows.

Fixes VSO 282972