### PR TITLE
BinaryReader: Use cached default encoding instance

### DIFF
--- a/src/mscorlib/src/System/IO/BinaryReader.cs
+++ b/src/mscorlib/src/System/IO/BinaryReader.cs
@@ -40,7 +40,7 @@ namespace System.IO {
         private bool     m_isMemoryStream; // "do we sit on MemoryStream?" for Read/ReadInt32 perf
         private bool     m_leaveOpen;
 
-        public BinaryReader(Stream input) : this(input, new UTF8Encoding(), false) {
+        public BinaryReader(Stream input) : this(input, Encoding.UTF8, false) {
         }
 
         public BinaryReader(Stream input, Encoding encoding) : this(input, encoding, false) {


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/13414

A new instance of `UTF8Encoding` is created every time `BinaryReader.ctor(Stream)` is called, which creates an instance of `UTF8Encoding` that has no preamble. However, `BinaryReader` does not use the preamble at all, so it doesn't matter if the encoding has a preamble or not. Thus, the cached `Encoding.UTF8` instance can be used instead (which has a preamble).

Note: I considered adding an ifdef for non-CoreCLR to continue to use an instance of `UTF8Encoding` without a preamble, out of an abundance of caution to maintain the exact same serialization output of the `m_decoder` field when that `BinaryReader` ctor is used, but decided it wasn't worth the added complexity.

cc: @jkotas, @ianhays, @stephentoub