### PR TITLE
StreamWriter/BinaryWriter: Use same cached encoding instance

### DIFF
--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -794,6 +794,7 @@
     <IoSources Include="$(BclSourcesRoot)\System\IO\DirectoryNotFoundException.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\DriveInfo.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\DriveNotFoundException.cs" />
+    <IoSources Include="$(BclSourcesRoot)\System\IO\EncodingCache.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\EndOfStreamException.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\File.cs" />
     <IoSources Include="$(BclSourcesRoot)\System\IO\FileAccess.cs" />

--- a/src/mscorlib/src/System/IO/BinaryWriter.cs
+++ b/src/mscorlib/src/System/IO/BinaryWriter.cs
@@ -58,11 +58,11 @@ namespace System.IO {
         {
             OutStream = Stream.Null;
             _buffer = new byte[16];
-            _encoding = new UTF8Encoding(false, true);
+            _encoding = EncodingCache.UTF8NoBOM;
             _encoder = _encoding.GetEncoder();
         }
     
-        public BinaryWriter(Stream output) : this(output, new UTF8Encoding(false, true), false)
+        public BinaryWriter(Stream output) : this(output, EncodingCache.UTF8NoBOM, false)
         {
         }
 

--- a/src/mscorlib/src/System/IO/EncodingCache.cs
+++ b/src/mscorlib/src/System/IO/EncodingCache.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace System.IO
+{
+    internal static class EncodingCache
+    {
+        internal static readonly Encoding UTF8NoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    }
+}

--- a/src/mscorlib/src/System/IO/StreamWriter.cs
+++ b/src/mscorlib/src/System/IO/StreamWriter.cs
@@ -48,7 +48,7 @@ namespace System.IO
         private const Int32 DontCopyOnWriteLineThreshold = 512;
 
         // Bit bucket - Null has no backing store. Non closable.
-        public new static readonly StreamWriter Null = new StreamWriter(Stream.Null, new UTF8Encoding(false, true), MinBufferSize, true);
+        public new static readonly StreamWriter Null = new StreamWriter(Stream.Null, UTF8NoBOM, MinBufferSize, true);
 
         private Stream stream;
         private Encoding encoding;
@@ -93,20 +93,9 @@ namespace System.IO
         // Even Close() will hit the exception as it would try to flush the unwritten data. 
         // Maybe we can add a DiscardBufferedData() method to get out of such situation (like 
         // StreamReader though for different reason). Either way, the buffered data will be lost!
-        private static volatile Encoding _UTF8NoBOM;
-        
         internal static Encoding UTF8NoBOM {
             [FriendAccessAllowed]
-            get { 
-                if (_UTF8NoBOM == null) {
-                    // No need for double lock - we just want to avoid extra
-                    // allocations in the common case.
-                    UTF8Encoding noBOM = new UTF8Encoding(false, true);
-                    Thread.MemoryBarrier();
-                    _UTF8NoBOM = noBOM;
-                }
-                return _UTF8NoBOM;
-            }
+            get { return EncodingCache.UTF8NoBOM; }
         }
                 
 


### PR DESCRIPTION
Port of https://github.com/dotnet/corefx/pull/13412

`StreamWriter` lazily allocates and caches a `UTF8NoBOM` instance, while `BinaryWriter` always allocates new instances. Instead, the same cached instance can be shared between both writers.

cc: @ianhays, @stephentoub