### PR TITLE
ARM-CI : Fix segmentation faults on running tests

### DIFF
--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -169,41 +169,54 @@ function mount_with_checking {
 #Mount emulator to the target mount path
 function mount_emulator {
     #Check if the mount path exists and create if neccessary
+    set +x
+
     if [ ! -d "$__ARMRootfsMountPath" ]; then
         sudo mkdir "$__ARMRootfsMountPath"
     fi
 
-    set +x
-    mount_with_checking "" "$__ARMEmulPath/platform/rootfs-t30.ext4" "$__ARMRootfsMountPath"
-    mount_with_checking "-t proc" "/proc"    "$__ARMRootfsMountPath/proc"
-    mount_with_checking "-o bind" "/dev/"    "$__ARMRootfsMountPath/dev"
-    mount_with_checking "-o bind" "/dev/pts" "$__ARMRootfsMountPath/dev/pts"
-    mount_with_checking "-t tmpfs" "shm"     "$__ARMRootfsMountPath/run/shm"
-    mount_with_checking "-o bind" "/sys"     "$__ARMRootfsMountPath/sys"
-    if [ ! -d "$__ARMRootfsMountPath/bindings/tmp" ]; then
-        sudo mkdir -p "$__ARMRootfsMountPath/bindings/tmp"
+    if [ ! -d "$__ARMEmulRootfs" ]; then
+		sudo mkdir "$__ARMEmulRootfs"
+	fi
+
+	if [ ! -f "$__ARMEmulRootfs/arm-emulator-rootfs.tar" ]; then
+		mount_with_checking "" "$__ARMEmulPath/platform/rootfs-t30.ext4" "$__ARMRootfsMountPath"
+		cd $__ARMRootfsMountPath
+		sudo tar -cf "$__ARMEmulRootfs/arm-emulator-rootfs.tar" *
+		cd -
+	fi
+
+	sudo tar -xf "$__ARMEmulRootfs/arm-emulator-rootfs.tar" -C "$__ARMEmulRootfs"
+
+    mount_with_checking "-t proc" "/proc"    "$__ARMEmulRootfs/proc"
+    mount_with_checking "-o bind" "/dev/"    "$__ARMEmulRootfs/dev"
+    mount_with_checking "-o bind" "/dev/pts" "$__ARMEmulRootfs/dev/pts"
+    mount_with_checking "-t tmpfs" "shm"     "$__ARMEmulRootfs/run/shm"
+    mount_with_checking "-o bind" "/sys"     "$__ARMEmulRootfs/sys"
+    if [ ! -d "$__ARMEmulRootfs/bindings/tmp" ]; then
+        sudo mkdir -p "$__ARMEmulRootfs/bindings/tmp"
     fi
-    mount_with_checking "-o bind" "/mnt"     "$__ARMRootfsMountPath/bindings/tmp"
+    mount_with_checking "-o bind" "/mnt"     "$__ARMEmulRootfs/bindings/tmp"
 }
 
 #Cross builds coreclr
 function cross_build_coreclr {
 #Export the needed environment variables
     (set +x; echo 'Exporting LINUX_ARM_* environment variable')
-    source "$__ARMRootfsMountPath"/dotnet/setenv/setenv_incpath.sh "$__ARMRootfsMountPath"
+    source "$__ARMEmulRootfs"/dotnet/setenv/setenv_incpath.sh "$__ARMEmulRootfs"
 
     #Apply the changes needed to build for the emulator rootfs
     (set +x; echo 'Applying cross build patch to suit Linux ARM emulator rootfs')
-    git am < "$__ARMRootfsMountPath"/dotnet/setenv/coreclr_cross.patch
+    git am < "$__ARMEmulRootfs"/dotnet/setenv/coreclr_cross.patch
 
     #Apply release optimization patch if needed
     if [[ "$__buildConfig" == "Release" ]]; then
         (set +x; echo 'Applying release optimization patch to build in Release mode')
-        git am < "$__ARMRootfsMountPath"/dotnet/setenv/coreclr_release.patch
+        git am < "$__ARMEmulRootfs"/dotnet/setenv/coreclr_release.patch
     fi
 
     #Cross building for emulator rootfs
-    ROOTFS_DIR="$__ARMRootfsMountPath" CPLUS_INCLUDE_PATH=$LINUX_ARM_INCPATH CXXFLAGS=$LINUX_ARM_CXXFLAGS ./build.sh $__buildArch cross $__verboseFlag $__skipMscorlib clang3.5 $__buildConfig -rebuild
+    ROOTFS_DIR="$__ARMEmulRootfs" CPLUS_INCLUDE_PATH=$LINUX_ARM_INCPATH CXXFLAGS=$LINUX_ARM_CXXFLAGS ./build.sh $__buildArch cross $__verboseFlag $__skipMscorlib clang3.5 $__buildConfig -rebuild
 
     #Reset the code to the upstream version
     (set +x; echo 'Rewinding HEAD to master code')
@@ -268,9 +281,10 @@ function copy_to_emulator {
 
 #Runs tests in an emulated mode
 function run_tests {
-    sudo chroot $__ARMRootfsMountPath /bin/bash -x <<EOF
+    sudo chroot $__ARMEmulRootfs /bin/bash -x <<EOF
         cd "$__ARMEmulCoreclr"
-        ./tests/runtest.sh --testRootDir=$__testRootDirBase \
+        ./tests/runtest.sh --sequential\
+		           --testRootDir=$__testRootDirBase \
                            --mscorlibDir=$__mscorlibDirBase \
                            --coreFxNativeBinDir=$__coreFxNativeBinDirBase \
                            --coreFxBinDir="$__coreFxBinDirBase" \
@@ -281,6 +295,7 @@ EOF
 }
 
 #Define script variables
+__ARMEmulRootfs=/mnt/arm-emulator-rootfs
 __ARMEmulPath=
 __ARMRootfsMountPath=
 __buildConfig=
@@ -402,8 +417,8 @@ if [ ! -d "$__TempFolder" ]; then
     mkdir "$__TempFolder"
 fi
 
-__ARMRootfsCoreclrPath="$__ARMRootfsMountPath/$__TempFolder/coreclr"
-__ARMRootfsCorefxPath="$__ARMRootfsMountPath/$__TempFolder/corefx"
+__ARMRootfsCoreclrPath="$__ARMEmulRootfs/$__TempFolder/coreclr"
+__ARMRootfsCorefxPath="$__ARMEmulRootfs/$__TempFolder/corefx"
 __ARMEmulCoreclr="/$__TempFolder/coreclr"
 __ARMEmulCorefx="/$__TempFolder/corefx"
 __testRootDirBase=

--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -203,7 +203,7 @@ function mount_emulator {
     mount_with_checking "-o bind" "/mnt"     "$__ARMEmulRootfs/bindings/tmp"
 
 	if [ ! -d "$__ARMEmulRootfs/$__TempFolder" ]; then
-        mkdir "$__ARMEmulRootfs/$__TempFolder"
+        sudo mkdir "$__ARMEmulRootfs/$__TempFolder"
 	fi
 }
 

--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -129,10 +129,6 @@ function clean_env {
     #Check for revert of git changes
     check_git_head
 
-    if [ -d "$__ARMEmulRootfs/bindings/tmp" ]; then
-	    sudo umount -l "$__ARMEmulRootfs/bindings/tmp"
-	fi
-
     sudo rm -rf "/mnt/arm32_ci_temp"
 }
 


### PR DESCRIPTION
To make sure the reason of test failure ramdomly( #6298 ),
We checked segmentation faults occurred from mounted rootfs and the multi thread processing.

So I changed root-fs to the archived root-fs and run tests with --sequential option.

PS. The location of root-fs folder was changed from '/opt' wrote on reverted commit(#7991) to '/mnt' for resolving no space issue.