### PR TITLE
Reduce variable scope

### DIFF
--- a/src/debug/daccess/enummem.cpp
+++ b/src/debug/daccess/enummem.cpp
@@ -796,10 +796,9 @@ HRESULT ClrDataAccess::EnumMemWalkStackHelper(CLRDataEnumMemoryFlags flags,
         currentSP = dac_cast<TADDR>(pThread->GetCachedStackLimit()) + sizeof(TADDR);
 
         // exhaust the frames using DAC api
-        bool frameHadContext;
         for (; status == S_OK; )
         {
-            frameHadContext = false;
+            bool frameHadContext = false;
             status = pStackWalk->GetFrame(&pFrame);
             PCODE addr = NULL;
             if (status == S_OK && pFrame != NULL)


### PR DESCRIPTION
This was found with Cppcheck. The variable scope is too wide and is misleading - it looks like the variable needs to persist its values between loop iterations. In fact it is reassigned a new value when each iteration starts, to it's more readable when it's declared inside the loop body.