### PR TITLE
Use the alt JIT for S.P.CoreLib if altjitcrossgen is specified and change crossgen to always pass USE_SSE2 to the JIT.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -367,7 +367,12 @@ set PATH=%PATH%;%WinDir%\Microsoft.Net\Framework64\V4.0.30319;%WinDir%\Microsoft
 
 if %__BuildNativeCoreLib% EQU 1 (
     echo %__MsgPrefix%Generating native image of System.Private.CoreLib for %__BuildOS%.%__BuildArch%.%__BuildType%
-	
+
+    if "%__AltJitCrossgen%"=="1" (
+        set COMPlus_AltJitNgen=*
+        set COMPlus_AltJitName=protojit.dll
+    )
+
     echo "%__CrossgenExe%" /Platform_Assemblies_Paths "%__BinDir%" /out "%__BinDir%\System.Private.CoreLib.ni.dll" "%__BinDir%\System.Private.CoreLib.dll"
     "%__CrossgenExe%" /Platform_Assemblies_Paths "%__BinDir%" /out "%__BinDir%\System.Private.CoreLib.ni.dll" "%__BinDir%\System.Private.CoreLib.dll" > "%__CrossGenCoreLibLog%" 2>&1
     if NOT !errorlevel! == 0 (
@@ -386,11 +391,6 @@ if %__BuildNativeCoreLib% EQU 1 (
 
     set "__CrossGenCoreLibLog=%__LogsDir%\CrossgenMSCoreLib_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
     set "__CrossgenExe=%__CrossComponentBinDir%\crossgen.exe"
-
-    if "%__AltJitCrossgen%"=="1" (
-        set COMPlus_AltJitNgen=*
-        set COMPlus_AltJitName=protojit.dll
-    )
 
     "!__CrossgenExe!" /Platform_Assemblies_Paths "%__BinDir%" /out "%__BinDir%\mscorlib.ni.dll" "%__BinDir%\mscorlib.dll" > "!__CrossGenCoreLibLog!" 2>&1
     set err=!errorlevel!

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -3382,10 +3382,15 @@ void Zapper::InitializeCompilerFlags(CORCOMPILE_VERSION_INFO * pVersionInfo)
         m_pOpt->m_compilerFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_FCOMI);
     }
 
+#if !defined(FEATURE_CORECLR)
     if (CPU_X86_USE_SSE2(pVersionInfo->cpuInfo.dwFeatures))
     {
         m_pOpt->m_compilerFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE2);
     }
+#else
+    // .NET Core requires SSE2.
+    m_pOpt->m_compilerFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE2);
+#endif // !defined(FEATURE_CORECLR)
 
 #endif // _TARGET_X86_
 


### PR DESCRIPTION
The check for altjitcrossgen was previously located s.t. only mscorlib
was being crossgen'd using the alt JIT (which is not very insteresting,
as mscorlib is just a facade these days). This change moves the check
back s.t. the alt JIT is also used for System.Private.CoreLib.

Moving this check revealed that the JIT wil now assert if SSE2 is not
enabled on x86. These changes also update crossgen to always pass
USE_SSE2 for FEATURE_CORECLR.