### PR TITLE
Remove email publishing calls

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -282,17 +282,6 @@ def static getJobName(def configuration, def architecture, def os, def scenario,
     return baseName + suffix
 }
 
-static void addEmailPublisher(def job, def recipient) {
-    job.with {
-        publishers {
-            extendedEmail(recipient, '$DEFAULT_SUBJECT', '$DEFAULT_CONTENT') {
-                trigger('Aborted', '$PROJECT_DEFAULT_SUBJECT', '$PROJECT_DEFAULT_CONTENT', null, true, true, true, true)
-                trigger('Failure', '$PROJECT_DEFAULT_SUBJECT', '$PROJECT_DEFAULT_CONTENT', null, true, true, true, true)
-            }
-        }
-    }
-}
-
 // **************************
 // Define the basic inner loop builds for PR and commit.  This is basically just the set
 // of coreclr builds over linux/osx/freebsd/windows and debug/release/checked.  In addition, the windows
@@ -328,7 +317,8 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                     case 'arm64':
                         if (os == 'Windows_NT') {
                             Utilities.addGithubPushTrigger(job)
-                            addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
+                            // TODO: Add once external email sending is available again
+                            // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
                         }
                         break
                     default:
@@ -385,7 +375,8 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                     else if (architecture == 'arm64') {
                         if (os == 'Windows_NT') {
                             Utilities.addPeriodicTrigger(job, 'H H/12 * * *')
-                            addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
+                            // TODO: Add once external email sending is available again
+                            // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
                         }
                     }
                 }
@@ -432,14 +423,16 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                 assert configuration == 'Release'
                 assert architecture == 'x64'
                 Utilities.addPeriodicTrigger(job, '@daily')
-                addEmailPublisher(job, 'dotnetgctests@microsoft.com')
+                // TODO: Add once external email sending is available again
+                // addEmailPublisher(job, 'dotnetgctests@microsoft.com')
                 break
             case 'gcsimulator':
                 assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX')
                 assert configuration == 'Release'
                 assert architecture == 'x64'
                 Utilities.addPeriodicTrigger(job, 'H H * * 3,6') // some time every Wednesday and Saturday
-                addEmailPublisher(job, 'dotnetgctests@microsoft.com')
+                // TODO: Add once external email sending is available again
+                // addEmailPublisher(job, 'dotnetgctests@microsoft.com')
                 break
             case 'ilrt':
                 assert !(os in bidailyCrossList)
@@ -505,7 +498,8 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                     if (architecture == 'arm64') {
                         assert (os == 'Windows_NT')
                         Utilities.addPeriodicTrigger(job, '@daily')
-                        addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
+                        // TODO: Add once external email sending is available again
+                        // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
                     }
                     else {
                         Utilities.addPeriodicTrigger(job, '@weekly')
@@ -526,6 +520,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                         assert (os == 'Windows_NT')
                         // TODO: Enable a periodic trigger after tests are updated.
                         // Utilities.addPeriodicTrigger(job, '@daily')
+                        // TODO: Add once external email sending is available again
                         // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
                     }
                     else {
@@ -2499,7 +2494,8 @@ combinedScenarios.each { scenario ->
                     if (scenario == 'coverage') {
                         // Publish coverage reports
                         Utilities.addHtmlPublisher(newJob, '${WORKSPACE}/coverage/Coverage/reports', 'Code Coverage Report', 'coreclr.html')
-                        addEmailPublisher(newJob, 'clrcoverage@microsoft.com')
+                        // TODO: Add once external email sending is available again
+                        // addEmailPublisher(newJob, 'clrcoverage@microsoft.com')
                     }
 
                     // Experimental: If on Ubuntu 14.04, then attempt to pull in crash dump links


### PR DESCRIPTION
The new server's email plugin version has different syntax and the email publishing doesn't work currently anyway.  Will be re-enabled at a future time