### PR TITLE
Arm64 add missing G flag and possibly X flags

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5012,7 +5012,16 @@ GenTreePtr Compiler::fgMorphMultiregStructArg(GenTreePtr arg, fgArgTabEntryPtr f
                     curAddr = baseAddr;
                 }
                 GenTreePtr curItem = gtNewOperNode(GT_IND, type[inx], curAddr);
-                listEntry          = new (this, GT_FIELD_LIST) GenTreeFieldList(curItem, offset, type[inx], listEntry);
+
+                // For safety all GT_IND should have at least GT_GLOB_REF set.
+                curItem->gtFlags |= GTF_GLOB_REF;
+                if (fgAddrCouldBeNull(curItem))
+                {
+                    // This indirection can cause a GPF if the address could be null.
+                    curItem->gtFlags |= GTF_EXCEPT;
+                }
+
+                listEntry = new (this, GT_FIELD_LIST) GenTreeFieldList(curItem, offset, type[inx], listEntry);
                 if (newArg == nullptr)
                 {
                     newArg = listEntry;


### PR DESCRIPTION
For indirections created by morphing obj(16) make sure the G and
X flag are set.

Fixes #7969.

@dotnet/jit-contrib @erozenfeld @erozenfeld @briansull ptal.

