### PR TITLE
Avoid failures when allocate memory in native

### DIFF
--- a/src/corefx/System.Globalization.Native/collation.cpp
+++ b/src/corefx/System.Globalization.Native/collation.cpp
@@ -335,6 +335,8 @@ extern "C" int32_t GlobalizationNative_GetSortVersion()
 
 extern "C" ResultCode GlobalizationNative_GetSortHandle(const char* lpLocaleName, SortHandle** ppSortHandle)
 {
+    assert(ppSortHandle != nullptr);
+    
     *ppSortHandle = new (std::nothrow) SortHandle();
     if ((*ppSortHandle) == nullptr)
     {

--- a/src/corefx/System.Globalization.Native/collation.cpp
+++ b/src/corefx/System.Globalization.Native/collation.cpp
@@ -331,13 +331,19 @@ extern "C" int32_t GlobalizationNative_GetSortVersion()
     return UCOL_RUNTIME_VERSION << 16 | UCOL_BUILDER_VERSION;
 }
 
-extern "C" SortHandle* GlobalizationNative_GetSortHandle(const char* lpLocaleName)
+extern "C" SortHandle* GlobalizationNative_GetSortHandle(const char* lpLocaleName, int32_t *errorCode)
 {
-    SortHandle* pSortHandle = new SortHandle();
+    SortHandle* pSortHandle = new (std::nothrow) SortHandle();
+    if (pSortHandle == nullptr)
+    {
+        *errorCode = U_MEMORY_ALLOCATION_ERROR;
+        return nullptr;
+    }
 
     UErrorCode err = U_ZERO_ERROR;
 
     pSortHandle->regular = ucol_open(lpLocaleName, &err);
+    *errorCode = err;
 
     if (U_FAILURE(err))
     {

--- a/src/corefx/System.Globalization.Native/collation.cpp
+++ b/src/corefx/System.Globalization.Native/collation.cpp
@@ -10,6 +10,8 @@
 #include <map>
 
 #include "icushim.h"
+#include "locale.hpp"
+#include "errors.h"
 
 const int32_t CompareOptionsIgnoreCase = 0x1;
 const int32_t CompareOptionsIgnoreNonSpace = 0x2;
@@ -331,30 +333,28 @@ extern "C" int32_t GlobalizationNative_GetSortVersion()
     return UCOL_RUNTIME_VERSION << 16 | UCOL_BUILDER_VERSION;
 }
 
-extern "C" SortHandle* GlobalizationNative_GetSortHandle(const char* lpLocaleName, int32_t *errorCode)
+extern "C" ResultCode GlobalizationNative_GetSortHandle(const char* lpLocaleName, SortHandle** ppSortHandle)
 {
-    SortHandle* pSortHandle = new (std::nothrow) SortHandle();
-    if (pSortHandle == nullptr)
+    *ppSortHandle = new (std::nothrow) SortHandle();
+    if ((*ppSortHandle) == nullptr)
     {
-        *errorCode = U_MEMORY_ALLOCATION_ERROR;
-        return nullptr;
+        return GetResultCode(U_MEMORY_ALLOCATION_ERROR);
     }
 
     UErrorCode err = U_ZERO_ERROR;
 
-    pSortHandle->regular = ucol_open(lpLocaleName, &err);
-    *errorCode = err;
+    (*ppSortHandle)->regular = ucol_open(lpLocaleName, &err);
 
     if (U_FAILURE(err))
     {
-        if (pSortHandle->regular != nullptr)
-              ucol_close(pSortHandle->regular);
+        if ((*ppSortHandle)->regular != nullptr)
+            ucol_close((*ppSortHandle)->regular);
 
-        delete pSortHandle;
-        pSortHandle = nullptr;
+        delete (*ppSortHandle);
+        (*ppSortHandle) = nullptr;
     }
 
-    return pSortHandle;
+    return GetResultCode(err);
 }
 
 extern "C" void GlobalizationNative_CloseSortHandle(SortHandle* pSortHandle)

--- a/src/corefx/System.Globalization.Native/errors.h
+++ b/src/corefx/System.Globalization.Native/errors.h
@@ -13,6 +13,7 @@ enum ResultCode : int32_t
     Success = 0,
     UnknownError = 1,
     InsufficentBuffer = 2,
+    OutOfMemory = 3
 };
 
 /*
@@ -23,6 +24,11 @@ static ResultCode GetResultCode(UErrorCode err)
     if (err == U_BUFFER_OVERFLOW_ERROR || err == U_STRING_NOT_TERMINATED_WARNING)
     {
         return InsufficentBuffer;
+    }
+    
+    if (err == U_MEMORY_ALLOCATION_ERROR)
+    {
+        return OutOfMemory;
     }
 
     if (U_SUCCESS(err))

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
@@ -11,9 +11,12 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
+        // ICU U_MEMORY_ALLOCATION_ERROR error code 
+        internal const int U_MEMORY_ALLOCATION_ERROR = 7;
+         
         [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortHandle")]
-        internal unsafe static extern SafeSortHandle GetSortHandle(byte[] localeName);
+        internal unsafe static extern SafeSortHandle GetSortHandle(byte[] localeName, ref int errorCode);
 
         [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CloseSortHandle")]

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
@@ -11,12 +11,9 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
-        // ICU U_MEMORY_ALLOCATION_ERROR error code 
-        internal const int U_MEMORY_ALLOCATION_ERROR = 7;
-         
         [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortHandle")]
-        internal unsafe static extern SafeSortHandle GetSortHandle(byte[] localeName, ref int errorCode);
+        internal unsafe static extern ResultCode GetSortHandle(byte[] localeName, out SafeSortHandle sortHandle);
 
         [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CloseSortHandle")]

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.ResultCode.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.ResultCode.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
             Success = 0,
             UnknownError = 1,
             InsufficentBuffer = 2,
+            OutOfMemory = 3
         }
     }
 }

--- a/src/mscorlib/corefx/SR.cs
+++ b/src/mscorlib/corefx/SR.cs
@@ -11,6 +11,11 @@ internal static class SR
         get { return Environment.GetResourceString("Arg_ArrayZeroError"); }
     }
 
+    public static string Arg_ExternalException
+    {
+        get { return Environment.GetResourceString("Arg_ExternalException"); }
+    }
+
     public static string Arg_HexStyleNotSupported
     {
         get { return Environment.GetResourceString("Arg_HexStyleNotSupported"); }

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -29,6 +29,8 @@ namespace System.Globalization
             Interop.GlobalizationInterop.ResultCode resultCode = Interop.GlobalizationInterop.GetSortHandle(GetNullTerminatedUtf8String(_sortName), out _sortHandle); 
             if (resultCode != Interop.GlobalizationInterop.ResultCode.Success)
             {
+                _sortHandle.Dispose();
+                
                 if (resultCode == Interop.GlobalizationInterop.ResultCode.OutOfMemory)
                     throw new OutOfMemoryException();
                 

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -26,14 +26,13 @@ namespace System.Globalization
         private void InitSort(CultureInfo culture)
         {
             _sortName = culture.SortName;
-            int errorCode = 0;
-            _sortHandle = Interop.GlobalizationInterop.GetSortHandle(GetNullTerminatedUtf8String(_sortName), ref errorCode);
-            if (_sortHandle == null || _sortHandle.IsInvalid)
+            Interop.GlobalizationInterop.ResultCode resultCode = Interop.GlobalizationInterop.GetSortHandle(GetNullTerminatedUtf8String(_sortName), out _sortHandle); 
+            if (resultCode != Interop.GlobalizationInterop.ResultCode.Success)
             {
-                if (errorCode == Interop.GlobalizationInterop.U_MEMORY_ALLOCATION_ERROR)
+                if (resultCode == Interop.GlobalizationInterop.ResultCode.OutOfMemory)
                     throw new OutOfMemoryException();
                 
-                throw new ExternalException(SR.Arg_ExternalException, errorCode);
+                throw new ExternalException(SR.Arg_ExternalException);
             }
             _isAsciiEqualityOrdinal = (_sortName == "en-US" || _sortName == "");
         }

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -26,7 +26,15 @@ namespace System.Globalization
         private void InitSort(CultureInfo culture)
         {
             _sortName = culture.SortName;
-            _sortHandle = Interop.GlobalizationInterop.GetSortHandle(GetNullTerminatedUtf8String(_sortName));
+            int errorCode = 0;
+            _sortHandle = Interop.GlobalizationInterop.GetSortHandle(GetNullTerminatedUtf8String(_sortName), ref errorCode);
+            if (_sortHandle == null || _sortHandle.IsInvalid)
+            {
+                if (errorCode == Interop.GlobalizationInterop.U_MEMORY_ALLOCATION_ERROR)
+                    throw new OutOfMemoryException();
+                
+                throw new ExternalException(SR.Arg_ExternalException, errorCode);
+            }
             _isAsciiEqualityOrdinal = (_sortName == "en-US" || _sortName == "");
         }
 


### PR DESCRIPTION
using new in the native side can throw and the app will shutdown. instead we detect the failure and throw a managed exception