### PR TITLE
Removed unnecessary null check, followed code style more closely

### DIFF
--- a/src/mscorlib/src/System/Reflection/IntrospectionExtensions.cs
+++ b/src/mscorlib/src/System/Reflection/IntrospectionExtensions.cs
@@ -8,28 +8,21 @@
 ** 
 **
 **
-** Purpose: go from type to type info
+** Purpose: Get the underlying TypeInfo from a Type
 **
 **
 =============================================================================*/
-
 namespace System.Reflection
 {
-    using System.Reflection;
-
     public static class IntrospectionExtensions
     {
-	    public static TypeInfo GetTypeInfo(this Type type){
-            if(type == null){
+	    public static TypeInfo GetTypeInfo(this Type type)
+        {
+            if (type == null)
                 throw new ArgumentNullException(nameof(type));
-            }
+            
             var rcType=(IReflectableType)type;
-            if(rcType==null){
-                return null;
-            }else{
-                return rcType.GetTypeInfo();
-            }
-        }   
+            return rcType.GetTypeInfo();
+        }
     }
 }
-


### PR DESCRIPTION
1. A few tweaks were made to follow the [Coding Style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md).
2. A `null` check was done after doing a simple cast (`(IReflectableType)type`), but `rcType` cannot be `null` (it could only be `null` if a [`as`](https://msdn.microsoft.com/en-us/library/cc488006.aspx) cast was done).