### PR TITLE
Do not fold `(x + null)` in certain cases.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -12378,7 +12378,8 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                             // Dereferencing the pointer in either case will have the
                             // same effect.
 
-                            if (!optValnumCSE_phase && varTypeIsGC(op2->TypeGet()) && ((op1->gtFlags & GTF_ALL_EFFECT) == 0))
+                            if (!optValnumCSE_phase && varTypeIsGC(op2->TypeGet()) &&
+                                ((op1->gtFlags & GTF_ALL_EFFECT) == 0))
                             {
                                 op2->gtType = tree->gtType;
                                 DEBUG_DESTROY_NODE(op1);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -12378,7 +12378,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                             // Dereferencing the pointer in either case will have the
                             // same effect.
 
-                            if (!gtIsActiveCSE_Candidate(op1) && varTypeIsGC(op2->TypeGet()))
+                            if (!optValnumCSE_phase && varTypeIsGC(op2->TypeGet()) && ((op1->gtFlags & GTF_ALL_EFFECT) == 0))
                             {
                                 op2->gtType = tree->gtType;
                                 DEBUG_DESTROY_NODE(op1);

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -240,6 +240,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_255294\DevDiv_255294\DevDiv_255294.cmd">
             <Issue>The test is too large for x86 and causes OutOfMemory exception.</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_283795\DevDiv_283795\DevDiv_283795.cmd">
+            <Issue>8077</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -240,9 +240,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_255294\DevDiv_255294\DevDiv_255294.cmd">
             <Issue>The test is too large for x86 and causes OutOfMemory exception.</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_283795\DevDiv_283795\DevDiv_283795.cmd">
-            <Issue>8077</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+class C
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static int[] M()
+    {
+        return null;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool Test(int i, int j, bool execute)
+    {
+        if (execute)
+        {
+            return M()[checked(i + j)] == 0;
+        }
+
+        return true;
+    }
+
+    static int Main()
+    {
+        // The original repro of the bug associated with this test involved an assert after re-morphing a tree modified
+        // by CSE: the original tree contained both a CSE def and a CSE use, and re-morphing eliminated the use, causing
+        // CSE to assert when attempting to replace the use with a reference to the CSE lclVar. This call to `Test` is
+        // intended to trigger that assert.
+        bool test1 = Test(0, 0, false);
+
+        // The associated code in morph involves folding `(x + null)` to `x`. During the investigation of the original
+        // issue, it was found that the folding code also failed to check for side effects in `x` resulting in SBCG if
+        // side effects were in fact present in `x`. This call to `Test` is intended to ensure that the fold is not
+        // performed in the face of a tree that contains side-effects: in particular, the overflowing add in the
+        // called method should occur before any other exception.
+        bool test2 = false;
+        try
+        {
+            Test(int.MaxValue, int.MaxValue, true);
+        }
+        catch (System.OverflowException)
+        {
+            test2 = true;
+        }
+        catch (System.Exception e)
+        {
+            System.Console.WriteLine(e);
+        }
+
+        return test1 && test2 ? 100 : 101;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_283795.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/testsUnsupportedOnARM32.txt
+++ b/tests/testsUnsupportedOnARM32.txt
@@ -1,11 +1,12 @@
 JIT/Directed/tailcall/tailcall/tailcall.sh
 JIT/Methodical/tailcall_v4/hijacking/hijacking.sh
-JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271/DevDiv_902271.sh
 JIT/Methodical/tailcall_v4/smallFrame/smallFrame.sh
-JIT/jit64/opt/cse/HugeArray1/HugeArray1.sh
 JIT/Methodical/xxobj/sizeof/_il_dbgsizeof/_il_dbgsizeof.sh
 JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32/_il_dbgsizeof32.sh
 JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64/_il_dbgsizeof64.sh
 JIT/Methodical/xxobj/sizeof/_il_relsizeof/_il_relsizeof.sh
 JIT/Methodical/xxobj/sizeof/_il_relsizeof32/_il_relsizeof32.sh
 JIT/Methodical/xxobj/sizeof/_il_relsizeof64/_il_relsizeof64.sh
+JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795/DevDiv_283795.sh
+JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271/DevDiv_902271.sh
+JIT/jit64/opt/cse/HugeArray1/HugeArray1.sh

--- a/tests/x86_jit32_issues.targets
+++ b/tests/x86_jit32_issues.targets
@@ -518,6 +518,8 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_255294\DevDiv_255294\DevDiv_255294.cmd">
             <Issue>times out</Issue>
         </ExcludeList>
- 
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_283795\DevDiv_283795\DevDiv_283795.cmd">
+            <Issue>8077</Issue>
+        </ExcludeList>
     </ItemGroup>
 </Project>

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -439,5 +439,8 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b409748\b409748\b409748.cmd">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_283795\DevDiv_283795\DevDiv_283795.cmd">
+            <Issue>8077</Issue>
+        </ExcludeList>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Morph attempts to fold `(x + null)` into `null` under the logic that the
resulting address is out-of-bounds by definition (in other words, adding
an offset to `null` always produces `null`). Under certain
circumstances, however, this transformation is either incorrect or
undesirable:
- If `x` contains side effects, the add should not be folded, as doing
  so incorrectly discards the side effects
- If we have called morph during CSE, the add should not be folded, as
  doing so may invalidate some of CSE's internal state (in particular,
  the removed tree may contain a subtree that is scheduled for CSE)

This change excludes the folding transformation in both of these cases.