### PR TITLE
Disable GUI dialogs for assertion failures on Windows by default

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -1128,12 +1128,12 @@ CONFIG_DWORD_INFO_EX(INTERNAL_MscorsnLogging, W("MscorsnLogging"), 0, "Enables s
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_NativeImageRequire, W("NativeImageRequire"), 0, "", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_NestedEhOom, W("NestedEhOom"), 0, "", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_NO_SO_NOT_MAINLINE, W("NO_SO_NOT_MAINLINE"), 0, "", CLRConfig::REGUTIL_default)
-#if defined(CROSSGEN_COMPILE)
+#if defined(CROSSGEN_COMPILE) || defined(FEATURE_CORECLR)
 #define INTERNAL_NoGuiOnAssert_Default 1
 #else
 #define INTERNAL_NoGuiOnAssert_Default 0
 #endif
-CONFIG_DWORD_INFO_EX(INTERNAL_NoGuiOnAssert, W("NoGuiOnAssert"), INTERNAL_NoGuiOnAssert_Default, "", CLRConfig::REGUTIL_default)
+RETAIL_CONFIG_DWORD_INFO_EX(INTERNAL_NoGuiOnAssert, W("NoGuiOnAssert"), INTERNAL_NoGuiOnAssert_Default, "", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_NoProcedureSplitting, W("NoProcedureSplitting"), 0, "", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_NoStringInterning, W("NoStringInterning"), 1, "Disallows string interning. I see no value in it anymore.", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(EXTERNAL_NotifyBadAppCfg, W("NotifyBadAppCfg"), "Whether to show a message box for bad application config file.")

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -5170,6 +5170,11 @@ template<class T> void DeleteExecutable(T *p)
 
 INDEBUG(BOOL DbgIsExecutable(LPVOID lpMem, SIZE_T length);)
 
+BOOL NoGuiOnAssert();
+#ifdef _DEBUG
+VOID TerminateOnAssert();
+#endif // _DEBUG
+
 class HighCharHelper {
 public:
     static inline BOOL IsHighChar(int c) {

--- a/src/utilcode/debug.cpp
+++ b/src/utilcode/debug.cpp
@@ -76,16 +76,6 @@ BOOL ContinueOnAssert()
     return fNoGui.val(CLRConfig::INTERNAL_ContinueOnAssert);
 }
 
-BOOL NoGuiOnAssert()
-{
-    STATIC_CONTRACT_NOTHROW;
-    STATIC_CONTRACT_GC_NOTRIGGER;
-    STATIC_CONTRACT_DEBUG_ONLY;
-
-    static ConfigDWORD fNoGui;
-    return fNoGui.val(CLRConfig::INTERNAL_NoGuiOnAssert);
-}
-
 void DoRaiseExceptionOnAssert(DWORD chance)
 {
     STATIC_CONTRACT_NOTHROW;
@@ -793,6 +783,16 @@ bool GetStackTraceAtContext(SString & s, CONTEXT * pContext)
 } // GetStackTraceAtContext
 #endif // !defined(DACCESS_COMPILE)
 #endif // _DEBUG
+
+BOOL NoGuiOnAssert()
+{
+    STATIC_CONTRACT_NOTHROW;
+    STATIC_CONTRACT_GC_NOTRIGGER;
+    STATIC_CONTRACT_DEBUG_ONLY;
+
+    static ConfigDWORD fNoGui;
+    return fNoGui.val(CLRConfig::INTERNAL_NoGuiOnAssert);
+}
 
 // This helper will throw up a message box without allocating or using stack if possible, and is
 // appropriate for either low memory or low stack situations.

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -4644,7 +4644,6 @@ VOID STDMETHODCALLTYPE LogHelp_LogAssert( LPCSTR szFile, int iLine, LPCSTR expr)
 
 }
 
-extern BOOL NoGuiOnAssert();
 extern "C"
 //__declspec(dllexport)
 BOOL STDMETHODCALLTYPE LogHelp_NoGuiOnAssert()
@@ -4657,7 +4656,6 @@ BOOL STDMETHODCALLTYPE LogHelp_NoGuiOnAssert()
     return fRet;
 }
 
-extern VOID TerminateOnAssert();
 extern "C"
 //__declspec(dllexport)
 VOID STDMETHODCALLTYPE LogHelp_TerminateOnAssert()

--- a/src/vm/debugdebugger.cpp
+++ b/src/vm/debugdebugger.cpp
@@ -1367,6 +1367,11 @@ FCIMPL4(INT32, DebuggerAssert::ShowDefaultAssertDialog,
     
     int         result          = IDRETRY;
 
+    if (NoGuiOnAssert())
+    {
+        return FailTerminate;
+    }
+
     struct _gc {
         STRINGREF strCondition;
         STRINGREF strMessage;
@@ -1403,7 +1408,7 @@ FCIMPL4(INT32, DebuggerAssert::ShowDefaultAssertDialog,
     }
     msgText.Append(W("Description: "));
     msgText.Append(message);
-    
+
     StackSString stackTraceText;
     if (gc.strStackTrace != NULL) {
         stackTraceText.Append(W("Stack Trace:\n"));
@@ -1419,7 +1424,7 @@ FCIMPL4(INT32, DebuggerAssert::ShowDefaultAssertDialog,
     // Also, varargs and StackSString don't mix.  Convert to string first.
     const WCHAR* msgTextAsUnicode = msgText.GetUnicode();
     result = EEMessageBoxNonLocalizedNonFatal(W("%s"), windowTitle, stackTraceText, MB_ABORTRETRYIGNORE | MB_ICONEXCLAMATION, msgTextAsUnicode);
-    
+
     // map the user's choice to the values recognized by 
     // the System.Diagnostics.Assert package
     if (result == IDRETRY)


### PR DESCRIPTION
This change disables creating pop-up dialog boxes by default on Windows
when assertions fail.  The change consists of three pieces:

1) Make COMPlus_NoGuiOnAssert effective in Release builds (currently
only Debug/Checked builds)
2) Make DebuggerAssert::ShowDefaultAssertDialog honor the
COMPlus_NoGuiOnAssert variable.
3) Make COMPlus_NoGuiOnAssert=1 by default.

Note that COMPlus_NoGuiOnAssert was already honored for assertions
originating from native code such as the JIT.  If pop-ups are desired,
one can still set COMPlus_NoGuiOnAssert=0.

Fixes #7678