### PR TITLE
Inliner: enable inlining of methods with conditional throws

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3205,8 +3205,6 @@ private:
     static LONG jitNestingLevel;
 #endif // DEBUG
 
-    bool seenConditionalJump;
-
     static BOOL impIsAddressInLocal(GenTreePtr tree, GenTreePtr* lclVarTreeOut);
 
     void impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, InlineResult* inlineResult);

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -65,10 +65,10 @@ void Compiler::impInit()
 {
 
 #ifdef DEBUG
-    impTreeList = impTreeLast = nullptr;
+    impTreeList        = nullptr;
+    impTreeLast        = nullptr;
     impInlinedCodeSize = 0;
 #endif
-
 }
 
 /*****************************************************************************

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -63,15 +63,12 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 void Compiler::impInit()
 {
+
 #ifdef DEBUG
     impTreeList = impTreeLast = nullptr;
-#endif
-
-#if defined(DEBUG)
     impInlinedCodeSize = 0;
 #endif
 
-    seenConditionalJump = false;
 }
 
 /*****************************************************************************
@@ -11107,8 +11104,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
             COND_JUMP:
 
-                seenConditionalJump = true;
-
                 /* Fold comparison if we can */
 
                 op1 = gtFoldExpr(op1);
@@ -14145,20 +14140,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         /* if not, just don't inline the method */
 
                         compInlineResult->NoteFatal(InlineObservation::CALLEE_THROW_WITH_INVALID_STACK);
-                        return;
-                    }
-
-                    /* Don't inline non-void conditionals that have a throw in one of the branches */
-
-                    /* NOTE: If we do allow this, note that we can't simply do a
-                      checkLiveness() to match the liveness at the end of the "then"
-                      and "else" branches of the GT_COLON. The branch with the throw
-                      will keep nothing live, so we should use the liveness at the
-                      end of the non-throw branch. */
-
-                    if (seenConditionalJump && (impInlineInfo->inlineCandidateInfo->fncRetType != TYP_VOID))
-                    {
-                        compInlineResult->NoteFatal(InlineObservation::CALLSITE_CONDITIONAL_THROW);
                         return;
                     }
                 }

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -122,7 +122,6 @@ INLINE_OBSERVATION(CANT_EMBED_VARARGS_COOKIE, bool,   "can't embed varargs cooki
 INLINE_OBSERVATION(CLASS_INIT_FAILURE_SPEC,   bool,   "speculative class init failed", FATAL,       CALLSITE)
 INLINE_OBSERVATION(COMPILATION_ERROR,         bool,   "compilation error",             FATAL,       CALLSITE)
 INLINE_OBSERVATION(COMPILATION_FAILURE,       bool,   "failed to compile",             FATAL,       CALLSITE)
-INLINE_OBSERVATION(CONDITIONAL_THROW,         bool,   "conditional throw",             FATAL,       CALLSITE)
 INLINE_OBSERVATION(CROSS_BOUNDARY_CALLI,      bool,   "cross-boundary calli",          FATAL,       CALLSITE)
 INLINE_OBSERVATION(CROSS_BOUNDARY_SECURITY,   bool,   "cross-boundary security check", FATAL,       CALLSITE)
 INLINE_OBSERVATION(EXCEEDS_THRESHOLD,         bool,   "exceeds profit threshold",      FATAL,       CALLSITE)


### PR DESCRIPTION
Remove inlining limitation for methods that return values and have
conditional throws. This limitation was most likely a vestige of an
older inlining implementation that did not break trees at inline
call sites.

Also removed the now-unused observation and the `seenConditionalJump`
member variable. Merged ifdef blocks in `impInit`.

Ran full desktop testing, no issues.

Enables a handful of inlines in the various code size suites. For the
most part these slightly increase code size but can often shorten the
non-EH paths in the code.