### PR TITLE
Remove need for separate test build in ilasm round trip scenario

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -324,7 +324,6 @@ echo     1: Build all tests with priority 0 and 1
 echo     666: Build all tests with priority 0, 1 ... 666
 echo -sequential: force a non-parallel build ^(default is to build in parallel
 echo     using all processors^).
-echo -ilasmroundtrip: enables ilasm round trip build and run of the tests before executing them.
 echo -verbose: enables detailed file logging for the msbuild tasks into the msbuild log file.
 exit /b 1
 

--- a/config.json
+++ b/config.json
@@ -234,12 +234,6 @@
       "values": [],
       "defaultValue": ""
     },
-    "IlasmRoundTrip": {
-      "description": "Sets ilasm round trip property.",
-      "valueType": "property",
-      "values": [ true, false ],
-      "defaultValue": true
-    },
     "CreateTestOverlay": {
       "description": "Runs CreateTestOverlay target.",
       "valueType": "target",

--- a/netci.groovy
+++ b/netci.groovy
@@ -2041,6 +2041,7 @@ combinedScenarios.each { scenario ->
                                             scenario == 'default' ||
                                             scenario == 'r2r' ||
                                             scenario == 'jitdiff' ||
+                                            scenario == 'ilrt' ||
                                             Constants.r2rJitStressScenarios.indexOf(scenario) != -1) {
                                         buildOpts += enableCorefxTesting ? ' skiptests' : ''
                                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts}"
@@ -2054,11 +2055,6 @@ combinedScenarios.each { scenario ->
 
                                     else if (scenario == 'pri1' || scenario == 'pri1r2r' || scenario == 'gcstress15_pri1r2r'|| scenario == 'coverage') {
                                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts} -priority=1"
-                                    }
-                                    else if (scenario == 'ilrt') {
-                                        // First do the build with skiptests and then build the tests with ilasm roundtrip
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
-                                        buildCommands += "set __TestIntermediateDir=int&&build-test.cmd ${lowerConfiguration} ${arch} -ilasmroundtrip"
                                     }
                                     else if (isLongGc(scenario)) {
                                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
@@ -2089,6 +2085,7 @@ combinedScenarios.each { scenario ->
                                         def runjitmioptsStr = ''
                                         def runjitforcerelocsStr = ''
                                         def runjitdisasmStr = ''
+                                        def runilasmroundtripStr = ''
                                         def gcstressStr = ''
                                         def runtestArguments = ''
                                         def gcTestArguments = ''
@@ -2144,11 +2141,16 @@ combinedScenarios.each { scenario ->
                                             runjitdisasmStr = 'jitdisasm crossgen'
                                         }
 
+                                        if (scenario == 'ilrt')
+                                        {
+                                            runilasmroundtripStr = 'ilasmroundtrip'
+                                        }
+                                        
                                         if (isLongGc(scenario)) {
                                             gcTestArguments = "${scenario} sequential"
                                         }
 
-                                        runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${gcTestArguments}"
+                                        runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${runilasmroundtripStr} ${gcTestArguments}"
 
                                         if (Constants.jitStressModeScenarios.containsKey(scenario)) {
                                             if (enableCorefxTesting) {
@@ -2644,6 +2646,7 @@ combinedScenarios.each { scenario ->
                     def runjitmioptsStr = ''
                     def runjitforcerelocsStr = ''
                     def runjitdisasmStr = ''
+                    def runilasmroundtripStr = ''
                     def gcstressStr = ''
 
                     if (scenario == 'r2r' ||
@@ -2862,7 +2865,7 @@ combinedScenarios.each { scenario ->
                 --coreFxBinDir=\"\${WORKSPACE}/bin/${osGroup}.AnyCPU.Release;\${WORKSPACE}/bin/Unix.AnyCPU.Release;\${WORKSPACE}/bin/AnyOS.AnyCPU.Release\" \\
                 --coreFxNativeBinDir=\"\${WORKSPACE}/bin/${osGroup}.${architecture}.Release\" \\
                 --limitedDumpGeneration \\
-                ${testEnvOpt} ${serverGCString} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${sequentialString} ${playlistString}""")
+                ${testEnvOpt} ${serverGCString} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${runilasmroundtripStr} ${sequentialString} ${playlistString}""")
                             }
                         }
                     }

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -33,6 +33,7 @@ set __LongGCTests=
 set __GCSimulatorTests=
 set __AgainstPackages=
 set __JitDisasm=
+set __IlasmRoundTrip=
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -69,6 +70,7 @@ if /i "%1" == "jitstressregs"         (set COMPlus_JitStressRegs=%2&shift&shift&
 if /i "%1" == "jitminopts"            (set COMPlus_JITMinOpts=1&shift&shift&goto Arg_Loop)
 if /i "%1" == "jitforcerelocs"        (set COMPlus_ForceRelocs=1&shift&shift&goto Arg_Loop)
 if /i "%1" == "jitdisasm"             (set __JitDisasm=1&shift&goto Arg_Loop)
+if /i "%1" == "ilasmroundtrip"        (set __IlasmRoundTrip=1&shift&goto Arg_Loop)
 if /i "%1" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
 if /i "%1" == "PerfTests"             (set __PerfTests=true&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"      (set RunCrossGen=true&shift&goto Arg_Loop)
@@ -378,6 +380,11 @@ if defined __JitDisasm (
     set RunningJitDisasm=1
 )
 
+if defined __IlasmRoundTrip (
+    echo Running Ilasm round trip
+    set RunningIlasmRoundTrip=1
+)
+
 set __BuildLogRootName=Tests_GenerateRuntimeLayout
 call :msbuild "%__ProjectFilesDir%\runtest.proj" /p:GenerateRuntimeLayout=true 
 if errorlevel 1 (
@@ -412,6 +419,7 @@ echo jitstressregs n    - Runs the tests with COMPlus_JitStressRegs=n
 echo jitminopts         - Runs the tests with COMPlus_JITMinOpts=1
 echo jitforcerelocs     - Runs the tests with COMPlus_ForceRelocs=1
 echo jitdisasm          - Runs jit-dasm on the tests
+echo ilasmroundtrip     - Runs ilasm round trip on the tests
 echo gcstresslevel n    - Runs the tests with COMPlus_GCStress=n
 echo     0: None                                1: GC on all allocs and 'easy' places
 echo     2: GC on transitions to preemptive GC  4: GC on every allowable JITed instr

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -51,6 +51,7 @@ function print_usage {
     echo '  --jitminopts                     : Runs the tests with COMPlus_JITMinOpts=1'
     echo '  --jitforcerelocs                 : Runs the tests with COMPlus_ForceRelocs=1'
     echo '  --jitdisasm                      : Runs jit-dasm on the tests'
+    echo '  --ilasmroundtrip                 : Runs ilasm round trip on the tests'
     echo '  --gcstresslevel n                : Runs the tests with COMPlus_GCStress=n'
     echo '    0: None                                1: GC on all allocs and '"'easy'"' places'
     echo '    2: GC on transitions to preemptive GC  4: GC on every allowable JITed instr'
@@ -988,6 +989,7 @@ limitedCoreDumps=
 verbose=0
 doCrossgen=0
 jitdisasm=0
+ilasmroundtrip=0
 
 for i in "$@"
 do
@@ -1016,6 +1018,9 @@ do
             ;;
         --jitdisasm)
             jitdisasm=1
+            ;;
+        --ilasmroundtrip)
+            ((ilasmroundtrip = 1))
             ;;
         --testRootDir=*)
             testRootDir=${i#*=}
@@ -1146,6 +1151,11 @@ fi
 if [ ! -z "$jitdisasm" ]; then
     echo "Running jit disasm"
     export RunningJitDisasm=1
+fi
+
+if [ ! -z "$ilasmroundtrip" ]; then
+    echo "Running Ilasm round trip"
+    export RunningIlasmRoundTrip=1
 fi
 
 # If this is a coverage run, make sure the appropriate args have been passed

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -18,41 +18,6 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target
-    Name="GetIlasmRoundTripBashScript"
-    Returns="$(IlasmRoundTripBashScript)">
-    <PropertyGroup>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
-      <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>
-
-      <IlasmRoundTrip Condition="'$(ReferenceLocalMscorlib)'!=''">false</IlasmRoundTrip>
-
-      <IlasmRoundTripBashScript Condition="'$(IlasmRoundTrip)'=='true'">
-      <![CDATA[
-echo "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
-"$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
-_ERRORLEVEL=$?
-if [  $ERRORLEVEL -ne 0 ]
-then
-  echo EXECUTION OF ILDASM - FAILED $ERRORLEVEL
-  exit 1
-fi
-
-echo "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-"$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-_ERRORLEVEL=$?
-if [ $ERRORLEVEL -ne 0 ]
-then
-  echo EXECUTION OF ILASM - FAILED $ERRORLEVEL
-  exit 1
-fi
-      ]]>
-      </IlasmRoundTripBashScript>
-    </PropertyGroup>
-  </Target>
-
   <!-- This is here because of this bug: http://blogs.msdn.com/b/msbuild/archive/2006/01/03/508629.aspx-->
   <Target Name="FetchExternalPropertiesForXpalt">
     <!--Call GetExecuteShFullPath to get ToRunProject cmd file Path  -->
@@ -183,13 +148,16 @@ fi
     <PropertyGroup>
       <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun"</_CLRTestRunFile>
       <BashCLRTestLaunchCmds Condition="'$(IlasmRoundTrip)'=='true'"><![CDATA[
-echo $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
-$(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
-if [  $? -ne $CLRTestExpectedExitCode ]
+if [ ! -z $RunningIlasmRoundTrip ]
 then
-  echo END EXECUTION OF IL{D}ASM BINARY - FAILED $? vs $CLRTestExpectedExitCode
-  echo FAILED
-  exit 1
+    echo $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
+    $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
+    if [  $? -ne $CLRTestExpectedExitCode ]
+    then
+      echo END EXECUTION OF IL{D}ASM BINARY - FAILED $? vs $CLRTestExpectedExitCode
+      echo FAILED
+      exit 1
+    fi
 fi
       ]]></BashCLRTestLaunchCmds>
 
@@ -308,7 +276,6 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 $(BashCLRTestArgPrep)
 $(BashCLRTestExitCodePrep)
 $(JitDisasmBashScript)
-# IlasmRoundTrip Script
 $(IlasmRoundTripBashScript)
 # PreCommands
 $(BashCLRTestPreCommands)

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -18,38 +18,6 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target
-    Name="GetIlasmRoundTripBatchScript"
-    Returns="$(IlasmRoundTripBatchScript)">
-    <PropertyGroup>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
-      <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>
-
-      <!-- If a test is built against mscorlib instead of dotnet Core, permission attributes can be embedded, which CoreCLR does not support. -->
-      <IlasmRoundTrip Condition="'$(ReferenceLocalMscorlib)'!=''">false</IlasmRoundTrip>
-
-       <!-- https://github.com/dotnet/coreclr/issues/2481. Delete /raweh to ildasm once it is resolved.-->
-      <IlasmRoundTripBatchScript Condition="'$(IlasmRoundTrip)'=='true'">
-      <![CDATA[
-ECHO %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
-%CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
-IF NOT "!ERRORLEVEL!"=="0" (
-  ECHO EXECUTION OF ILDASM - FAILED !ERRORLEVEL!
-  Exit /b 1
-)
-ECHO %CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-%CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-IF NOT "!ERRORLEVEL!"=="0" (
-  ECHO EXECUTION OF ILASM - FAILED !ERRORLEVEL!
-  Exit /b 1
-)
-      ]]>
-      </IlasmRoundTripBatchScript>
-    </PropertyGroup>
-  </Target>
-
   <!-- This is here because of this bug: http://blogs.msdn.com/b/msbuild/archive/2006/01/03/508629.aspx-->
   <Target Name="FetchExternalProperties">
     <!--Call GetExecuteCmdFullPath to get ToRunProject cmd file Path  -->
@@ -211,16 +179,16 @@ IF NOT "%CLRCustomTestLauncher%"=="" (
 ) ELSE (
   set LAUNCHER=%_DebuggerFullPath% $(_CLRTestRunFile)
 )
-      ]]></BatchCLRTestLaunchCmds>
-      <BatchCLRTestLaunchCmds Condition=" '$(IlasmRoundTrip)'=='true' "><![CDATA[
-$(BatchCLRTestLaunchCmds)
-ECHO %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
-%LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
 
-IF NOT "!ERRORLEVEL!"=="%CLRTestExpectedExitCode%" (
-  ECHO END EXECUTION OF IL{D}ASM BINARY - FAILED !ERRORLEVEL! vs %CLRTestExpectedExitCode%
-  ECHO FAILED
-  Exit /b 1
+if defined RunningIlasmRoundTrip (
+  ECHO %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
+  %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
+  
+  IF NOT "!ERRORLEVEL!"=="%CLRTestExpectedExitCode%" (
+    ECHO END EXECUTION OF IL{D}ASM BINARY - FAILED !ERRORLEVEL! vs %CLRTestExpectedExitCode%
+    ECHO FAILED
+    Exit /b 1
+  )
 )
       ]]></BatchCLRTestLaunchCmds>
       <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'"><![CDATA[
@@ -329,7 +297,6 @@ $(BatchCLRTestEnvironmentCompatibilityCheck)
 
 $(JitDisasmBatchScript)
 
-REM IlasmRoundTrip Script
 $(IlasmRoundTripBatchScript)
 
 REM Precommands

--- a/tests/src/CLRTest.Jit.targets
+++ b/tests/src/CLRTest.Jit.targets
@@ -66,6 +66,79 @@ if defined RunningJitDisasm (
       </JitDisasmBatchScript>
     </PropertyGroup>
   </Target>
+
+  <Target
+      Name="GetIlasmRoundTripBashScript"
+      Returns="$(IlasmRoundTripBashScript)">
+    <PropertyGroup>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
+      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
+      <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>
+      
+      <IlasmRoundTrip Condition="'$(ReferenceLocalMscorlib)'!=''">false</IlasmRoundTrip>
+      
+      <IlasmRoundTripBashScript>
+        <![CDATA[
+# IlasmRoundTrip Script
+if [ ! -z $RunningIlasmRoundTrip ]
+then
+    echo "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
+    "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
+    _ERRORLEVEL=$?
+    if [  $ERRORLEVEL -ne 0 ]
+    then
+      echo EXECUTION OF ILDASM - FAILED $ERRORLEVEL
+      exit 1
+    fi
+
+    echo "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+    "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+    _ERRORLEVEL=$?
+    if [ $ERRORLEVEL -ne 0 ]
+    then
+      echo EXECUTION OF ILASM - FAILED $ERRORLEVEL
+      exit 1
+    fi
+fi
+        ]]>
+      </IlasmRoundTripBashScript>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="GetIlasmRoundTripBatchScript"
+          Returns="$(IlasmRoundTripBatchScript)">
+    <PropertyGroup>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
+      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
+      <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>
+      
+      <!-- If a test is built against mscorlib instead of dotnet Core, permission attributes can be embedded, which CoreCLR does not support. -->
+      <IlasmRoundTrip Condition="'$(ReferenceLocalMscorlib)'!=''">false</IlasmRoundTrip>
+        
+      <!-- https://github.com/dotnet/coreclr/issues/2481. Delete /raweh to ildasm once it is resolved.-->
+      <IlasmRoundTripBatchScript>
+        <![CDATA[
+REM IlasmRoundTrip Script
+if defined RunningIlasmRoundTrip (
+  echo %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
+  %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
+  IF NOT "!ERRORLEVEL!"=="0" (
+    ECHO EXECUTION OF ILDASM - FAILED !ERRORLEVEL!
+    Exit /b 1
+  )
+  ECHO %CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+  %CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+  IF NOT "!ERRORLEVEL!"=="0" (
+    ECHO EXECUTION OF ILASM - FAILED !ERRORLEVEL!
+    Exit /b 1
+  )
+)
+        ]]>
+      </IlasmRoundTripBatchScript>
+    </PropertyGroup>
+  </Target>
   
   <PropertyGroup Condition="$(RunWithGcStress) != ''" >
     <CLRTestBatchPreCommands>


### PR DESCRIPTION
This change removes the -ilasmroundtrip flag from the test build, and always emits the ilasmroundtrip code in the test wrapper scripts. These scripts check whether we are running in the ilasmroundtrip scenario at test runtime, and this scenario can be enabled by passing a flag to runtests. I also updated the ilrt scenario in netci.groovy to reflect these changes.