### PR TITLE
Remove delegate allocation per ThreadPoolBoundHandleOverlapped

### DIFF
--- a/src/mscorlib/corefx/System/Threading/ClrThreadPoolBoundHandleOverlapped.cs
+++ b/src/mscorlib/corefx/System/Threading/ClrThreadPoolBoundHandleOverlapped.cs
@@ -9,6 +9,8 @@ namespace System.Threading
     /// </summary>
     internal sealed class ThreadPoolBoundHandleOverlapped : Overlapped
     {
+        private static readonly unsafe IOCompletionCallback s_completionCallback = CompletionCallback;
+
         private readonly IOCompletionCallback _userCallback;
         internal readonly object _userState;
         internal PreAllocatedOverlapped _preAllocated;
@@ -22,7 +24,7 @@ namespace System.Threading
             _userState = state;
             _preAllocated = preAllocated;
 
-            _nativeOverlapped = Pack(CompletionCallback, pinData);
+            _nativeOverlapped = Pack(s_completionCallback, pinData);
             _nativeOverlapped->OffsetLow = 0;        // CLR reuses NativeOverlapped instances and does not reset these
             _nativeOverlapped->OffsetHigh = 0;
         }


### PR DESCRIPTION
cc: @kouvel, @jkotas