### PR TITLE
Avoid repeated delegate allocations in FileStream.FlushAsync

### DIFF
--- a/src/mscorlib/corefx/System/IO/FileStream.Win32.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.Win32.cs
@@ -1715,7 +1715,7 @@ namespace System.IO
             if (CanWrite)
             {
                 return Task.Factory.StartNew(
-                    state => FlushOSBuffer(),
+                    state => ((FileStream)state).FlushOSBuffer(),
                     this,
                     cancellationToken,
                     TaskCreationOptions.DenyChildAttach,


### PR DESCRIPTION
Avoid the `Action<object>` allocation on each invocation of `FileStream.FlushAsync` on Windows. This change makes the Win32 implementation match [Unix](https://github.com/dotnet/coreclr/blob/39273bf1814bd8d5da932b134ac1164f53416e08/src/mscorlib/corefx/System/IO/FileStream.Unix.cs#L316).

cc: @JeremyKuhne, @ianhays, @stephentoub 