### PR TITLE
If the very first ref position of an interval has a register assignment of RBM_NONE indicate it could also be a regOptional

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -8576,8 +8576,8 @@ void LinearScan::resolveRegisters()
                     }
                     if (firstRefPosition->registerAssignment == RBM_NONE || firstRefPosition->spillAfter)
                     {
-                        // Either this RefPosition is spilled, or it is not a "real" def or use
-                        assert(firstRefPosition->spillAfter ||
+                        // Either this RefPosition is spilled, or regOptional or it is not a "real" def or use
+                        assert(firstRefPosition->spillAfter || firstRefPosition->AllocateIfProfitable() ||
                                (firstRefPosition->refType != RefTypeDef && firstRefPosition->refType != RefTypeUse));
                         varDsc->lvRegNum = REG_STK;
                     }


### PR DESCRIPTION
This is a PMI run exposed issue under COMPLUS_JitStressBBProf=1.

Under this stress mode, profile weights of basic blocks get randomly set based on method hash and IL offset of basic block - see fgGetProfileWeightForBasicBlock() for details.

It so happens due to weights assigned to repro method blocks that LSRA block sequence orders Use of V11 as first RefPosition of interval V11.  Further this use is marked as regOptional and wasn't allocated a reg during allocation phase.

After resolution of registers along edges, resolveRegisters(), has logic to verify register assignments on variables.  This logic asserts that if firstRefPosition->registerAssignment == RBM_NONE then it must be marked as spillAfter or not a real def or use.  But the firstRefPosition of V11 is a regOptional RefTypeUse which isn't marked as spillAfter and hence the assert.

Fix:
Updated assert to check that firstRefPosition could also be regOptional.

Fixes VSO 288806