### PR TITLE
Links 'sos' with 'coreclrpal'

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -134,6 +134,7 @@ else(WIN32)
     dbgutil
     # share the PAL in the dac module
     mscordaccore
+    coreclrpal
     palrt
   )
 


### PR DESCRIPTION
At e1189d69095, '_i64tow' is moved from 'palrt' into 'coreclrpal', but
SOS plugin is linked only with 'palrt', which results in load failure
discussed in #8050.

This commit links 'sos' with 'coreclrpal' in order to fix #8050.