### PR TITLE
Fix missing exports in mscordaccore.so

### DIFF
--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -45,6 +45,10 @@ if(CLR_CMAKE_PLATFORM_LINUX OR CLR_CMAKE_PLATFORM_FREEBSD OR CLR_CMAKE_PLATFORM_
     set(START_LIBRARY_GROUP -Wl,--start-group)
     set(END_LIBRARY_GROUP -Wl,--end-group)
 
+    # These options are used to force every object to be included even if it's unused.
+    set(START_WHOLE_ARCHIVE -Wl,--whole-archive)
+    set(END_WHOLE_ARCHIVE -Wl,--no-whole-archive) 
+
     # Add linker exports file option
     set(EXPORTS_LINKER_OPTION -Wl,--version-script=${EXPORTS_FILE})
 endif(CLR_CMAKE_PLATFORM_LINUX OR CLR_CMAKE_PLATFORM_FREEBSD OR CLR_CMAKE_PLATFORM_NETBSD)
@@ -112,7 +116,9 @@ if(WIN32)
 else(WIN32)
     list(APPEND COREDAC_LIBRARIES
         mscorrc_debug
+        ${START_WHOLE_ARCHIVE} # force all PAL objects to be included so all exports are available  
         coreclrpal
+        ${END_WHOLE_ARCHIVE}
         palrt
     )
 endif(WIN32)


### PR DESCRIPTION
I have recently added some exports to the mscordaccore.so and it was
found that they were not honored and libsos.so got some unresolved
symbols.
I have found that the issue is that unlike for libcoreclr.so, we
were not asking linker to include the whole PAL and so it has
eliminated those functions due to the fact they were not called
from the PAL itself.
This change fixes it.