### PR TITLE
Return Type.GUID for Marshal.GenerateGuidForType in CoreCLR

### DIFF
--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -2370,7 +2370,7 @@ namespace System.Runtime.InteropServices
         public static Guid GenerateGuidForType(Type type)
         {
 #if FEATURE_CORECLR
-            throw new PlatformNotSupportedException();
+            return type.GUID;
         }
 #else
             Guid result = new Guid ();


### PR DESCRIPTION
@yizhang82 @stephentoub 

As per our discussion on my PR on corefx(https://github.com/dotnet/corefx/pull/13479/files/102b3570e37dd71944d912d83395d5d874bef67b#diff-5108de73494fc7e0154a6b0edc87d192) returning type.GUID instead of PlatformNotSupportedException