### PR TITLE
Enable binclash logger

### DIFF
--- a/config.json
+++ b/config.json
@@ -414,7 +414,8 @@
         "settings": {
           "MsBuildLog": "default",
           "MsBuildWrn": "default",
-          "MsBuildErr": "default"
+          "MsBuildErr": "default",
+          "MsBuildEventLogging": "default"
         }
       }
     },


### PR DESCRIPTION
There is a race condition in the System.Private.Corelib build.  Enabling binclash logger to help diagnose why System.Private.CoreLib.dll is getting built twice...

2>Project "D:\A\_work\8\s\src\build.proj" (2) is building "D:\A\_work\8\s\src\mscorlib\System.Private.CoreLib.csproj" (4) on node 2 
5>Project "D:\A\_work\8\s\src\mscorlib\facade\mscorlib.csproj" (5) is building "D:\A\_work\8\s\src\mscorlib\System.Private.CoreLib.csproj" (4:2) on node 3 (default targets).

/cc @ericstj @gkhanna79 