### PR TITLE
SOS: Automatically find a managed thread with an exception on Linux/OSX core dumps

### DIFF
--- a/src/ToolBox/SOS/NETCore/project.json
+++ b/src/ToolBox/SOS/NETCore/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1",
     "System.IO.FileSystem": "4.0.1",
     "System.Runtime.InteropServices": "4.1.0",
-    "System.Reflection.Metadata": "1.4.1-beta-24417-02"
+    "System.Reflection.Metadata": "1.4.1"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/src/ToolBox/SOS/Strike/sosdocsunix.txt
+++ b/src/ToolBox/SOS/Strike/sosdocsunix.txt
@@ -844,7 +844,7 @@ corruption bug caused by invalid GCEncoding for a particular method.
 
 COMMAND: bpmd.
 bpmd [-nofuturemodule] <module name> <method name> [<il offset>]
-!BPMD <source file name>:<line number>
+bpmd <source file name>:<line number>
 bpmd -md <MethodDesc>
 bpmd -list
 bpmd -clear <pending breakpoint number>

--- a/src/ToolBox/SOS/Strike/sosdocsunix.txt
+++ b/src/ToolBox/SOS/Strike/sosdocsunix.txt
@@ -844,6 +844,7 @@ corruption bug caused by invalid GCEncoding for a particular method.
 
 COMMAND: bpmd.
 bpmd [-nofuturemodule] <module name> <method name> [<il offset>]
+!BPMD <source file name>:<line number>
 bpmd -md <MethodDesc>
 bpmd -list
 bpmd -clear <pending breakpoint number>


### PR DESCRIPTION
To be used in the debugger tests repo for SOS dump testing on Linux/OSX.

Added the "clrthreads -managedexception" option to switch to the first managed thread
that has thrown an exception.

Issue #6518