### PR TITLE
Save registers xmm8..15 on Mac OSX

### DIFF
--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -1033,7 +1033,7 @@ CONTEXT_GetThreadContextFromThreadState(
                     memcpy(&lpContext->FltSave.FloatRegisters[i], (&pState->__fpu_stmm0)[i].__mmst_reg, 10);
 
                 // AMD64's FLOATING_POINT includes the xmm registers.
-                memcpy(&lpContext->Xmm0, &pState->__fpu_xmm0, 8 * 16);
+                memcpy(&lpContext->Xmm0, &pState->__fpu_xmm0, 16 * 16);
             }
             break;
 #else


### PR DESCRIPTION
On x64, JIT can generate code that uses all 16 xmm registers.
However, on Mac OSX, we currently only save 8 of these registers.
Thus after a context save/restore, xmm8 through xmm15 are
corrupted. This commit fixes the code to save all 16 xmm
registers. It resolves issue #2266.