### PR TITLE
Fix runtest.sh: delete ni file and lock correctly

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -795,6 +795,7 @@ function finish_remaining_tests {
 
 function prep_test {
     local scriptFilePath=$1
+    local scriptFileDir=$(dirname "$scriptFilePath")
 
     test "$verbose" == 1 && echo "Preparing $scriptFilePath"
 
@@ -807,8 +808,8 @@ function prep_test {
     chmod +x "$scriptFilePath"
 
     #remove any NI and Locks
-    rm -f *.ni.*
-    rm -rf lock
+    rm -f $scriptFileDir/*.ni.*
+    rm -rf $scriptFileDir/lock
 }
 
 function start_test {


### PR DESCRIPTION
Fix prep_test to delete `*.ni.*` file and `lock` file correctly
These file can be generated by crossgen.