### PR TITLE
Changing JIT perf test names to fix how they are organized on BenchView

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -20,7 +20,7 @@ def static getOSGroup(def os) {
         'OpenSUSE13.2': 'Linux',
         'OpenSUSE42.1': 'Linux',
         'LinuxARMEmulator': 'Linux']
-    def osGroup = osGroupMap.get(os, null) 
+    def osGroup = osGroupMap.get(os, null)
     assert osGroup != null : "Could not find os group for ${os}"
     return osGroupMap[os]
 }
@@ -42,18 +42,19 @@ def static getOSGroup(def os) {
 
 				steps {
 					// Batch
-					
-					batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory C:\\tools -Prerelease -ExcludeVersion")
+
+					batchFile("if exist \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\" rmdir /s /q \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\"")
+					batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory \"%WORKSPACE%\" -Prerelease -ExcludeVersion")
 					//Do this here to remove the origin but at the front of the branch name as this is a problem for BenchView
 					//we have to do it all as one statement because cmd is called each time and we lose the set environment variable
 					batchFile("if [%GIT_BRANCH:~0,7%] == [origin/] (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH:origin/=%) else (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH%)\n" +
-					"py C:\\tools\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py --name " + "\"" + benchViewName + "\"" + " --user " + "\"dotnet-bot@microsoft.com\"\n" +
-					"py C:\\tools\\Microsoft.BenchView.JSONFormat\\tools\\build.py git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type " + runType)
-					batchFile("py C:\\tools\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py")
+					"py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name " + "\"" + benchViewName + "\"" + " --user " + "\"dotnet-bot@microsoft.com\"\n" +
+					"py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type " + runType)
+					batchFile("py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
 					batchFile("set __TestIntermediateDir=int&&build.cmd release ${architecture}")
 					batchFile("tests\\runtest.cmd release ${architecture} GenerateLayoutOnly")
-					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${architecture} -configuration ${configuration} -testBinLoc bin\\tests\\Windows_NT.${architecture}.Release\\performance\\perflab\\Perflab -library -uploadToBenchview C:\\Tools\\Microsoft.Benchview.JSONFormat\\tools -runtype " + runType)
-					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${architecture} -configuration ${configuration} -testBinLoc bin\\tests\\Windows_NT.${architecture}.Release\\Jit\\Performance\\CodeQuality -uploadToBenchview C:\\Tools\\Microsoft.Benchview.JSONFormat\\tools -runtype " + runType)
+					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${architecture} -configuration ${configuration} -testBinLoc bin\\tests\\Windows_NT.${architecture}.Release\\performance\\perflab\\Perflab -library -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype " + runType)
+					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${architecture} -configuration ${configuration} -testBinLoc bin\\tests\\Windows_NT.${architecture}.Release\\Jit\\Performance\\CodeQuality -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype " + runType)
 				}
 			}
 
@@ -64,7 +65,7 @@ def static getOSGroup(def os) {
 			Utilities.addArchival(newJob, archiveSettings)
 
 			Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-			
+
 			if (isPR) {
 				TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
 				builder.setGithubContext("${os} CoreCLR Perf Tests")

--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -26,8 +26,10 @@ if NOT EXIST %CORECLR_OVERLAY% (
 
 @echo --- setting up sandbox
 
-rd /s /q sandbox
-mkdir sandbox
+if exist sandbox rd /s /q sandbox
+if exist sandbox echo ERROR: Failed to remove the sandbox folder& exit /b 1
+if not exist sandbox mkdir sandbox
+if not exist sandbox echo ERROR: Failed to create the sandbox folder& exit /b 1
 pushd sandbox
 
 @rem stage stuff we need
@@ -41,6 +43,22 @@ xcopy /sy %CORECLR_REPO%\bin\tests\Windows_NT.%TEST_ARCH%.%TEST_CONFIG%\Tests\Co
 @rem find and stage the tests
 for /R %CORECLR_PERF% %%T in (*.%TEST_FILE_EXT%) do (
   call :DOIT %%T
+)
+
+@rem optionally upload results to benchview
+if not [%BENCHVIEW_PATH%] == [] (
+  py %BENCHVIEW_PATH%\submission.py measurement.json ^
+                                    --build ..\build.json ^
+                                    --machine-data ..\machinedata.json ^
+                                    --metadata ..\submission-metadata.json ^
+                                    --group "CoreCLR" ^
+                                    --type "%RUN_TYPE%" ^
+                                    --config-name "%TEST_CONFIG%" ^
+                                    --config Configuration "%TEST_CONFIG%" ^
+                                    --config OS "Windows_NT" ^
+                                    --arch "%TEST_ARCH%" ^
+                                    --machinepool "PerfSnake"
+  py %BENCHVIEW_PATH%\upload.py submission.json --container coreclr
 )
 
 goto :EOF
@@ -60,28 +78,16 @@ xunit.performance.run.exe %BENCHNAME%.%TEST_FILE_EXT% -runner xunit.console.netc
 
 xunit.performance.analysis.exe %PERFOUT%.xml -xml %XMLOUT% > %BENCHNAME%-analysis.out
 
-@rem optionally upload results to benchview
+@rem optionally generate results for benchview
 if not [%BENCHVIEW_PATH%] == [] (
-  py %BENCHVIEW_PATH%\measurement.py xunit perf-%BENCHNAME%.xml --better desc --drop-first-value
-  py %BENCHVIEW_PATH%\submission.py measurement.json ^
-                                    --build ..\build.json ^
-                                    --machine-data ..\machinedata.json ^
-                                    --metadata ..\submission-metadata.json ^
-                                    --group "CoreCLR" ^
-                                    --type "%RUN_TYPE%" ^
-                                    --config-name "%TEST_CONFIG%" ^
-                                    --config Configuration "%TEST_CONFIG%" ^
-                                    --config OS "Windows_NT" ^
-                                    --arch "%TEST_ARCH%" ^
-                                    --machinepool "PerfSnake"
-  py %BENCHVIEW_PATH%\upload.py submission.json --container coreclr
+  py %BENCHVIEW_PATH%\measurement.py xunit perf-%BENCHNAME%.xml --better desc --drop-first-value --append
   REM Save off the results to the root directory for recovery later in Jenkins
   xcopy perf-%BENCHNAME%*.xml %CORECLR_REPO%\
   xcopy perf-%BENCHNAME%*.etl %CORECLR_REPO%\
 ) else (
-  type %XMLOUT% | findstr "test name" 
-  type %XMLOUT% | findstr Duration 
-  type %XMLOUT% | findstr InstRetired 
+  type %XMLOUT% | findstr "test name"
+  type %XMLOUT% | findstr Duration
+  type %XMLOUT% | findstr InstRetired
 )
 
 goto :EOF
@@ -146,3 +152,5 @@ echo -uploadtoBenchview is used to specify a path to the Benchview tooling and w
 echo set we will upload the results of the tests to the coreclr container in benchviewupload.
 echo Runtype sets the runtype that we upload to Benchview, rolling for regular runs, and private for
 echo PRs.
+
+goto :EOF

--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -47,7 +47,7 @@ for /R %CORECLR_PERF% %%T in (*.%TEST_FILE_EXT%) do (
 
 @rem optionally upload results to benchview
 if not [%BENCHVIEW_PATH%] == [] (
-  py %BENCHVIEW_PATH%\submission.py measurement.json ^
+  py "%BENCHVIEW_PATH%\submission.py" measurement.json ^
                                     --build ..\build.json ^
                                     --machine-data ..\machinedata.json ^
                                     --metadata ..\submission-metadata.json ^
@@ -58,7 +58,7 @@ if not [%BENCHVIEW_PATH%] == [] (
                                     --config OS "Windows_NT" ^
                                     --arch "%TEST_ARCH%" ^
                                     --machinepool "PerfSnake"
-  py %BENCHVIEW_PATH%\upload.py submission.json --container coreclr
+  py "%BENCHVIEW_PATH%\upload.py" submission.json --container coreclr
 )
 
 goto :EOF
@@ -80,7 +80,7 @@ xunit.performance.analysis.exe %PERFOUT%.xml -xml %XMLOUT% > %BENCHNAME%-analysi
 
 @rem optionally generate results for benchview
 if not [%BENCHVIEW_PATH%] == [] (
-  py %BENCHVIEW_PATH%\measurement.py xunit perf-%BENCHNAME%.xml --better desc --drop-first-value --append
+  py "%BENCHVIEW_PATH%\measurement.py" xunit "perf-%BENCHNAME%.xml" --better desc --drop-first-value --append
   REM Save off the results to the root directory for recovery later in Jenkins
   xcopy perf-%BENCHNAME%*.xml %CORECLR_REPO%\
   xcopy perf-%BENCHNAME%*.etl %CORECLR_REPO%\

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.cs
@@ -18,6 +18,8 @@ using Microsoft.Xunit.Performance;
 [assembly: MeasureInstructionsRetired]
 #endif // XUNIT_PERF
 
+namespace Benchstone.benchf
+{
 public static class Adams
 {
 #if DEBUG
@@ -41,7 +43,7 @@ public static class Adams
 
 #if VERBOSE
         Console.WriteLine(" ADAMS-MOULTON METHOD ");
-#endif // VERBOSE 
+#endif // VERBOSE
 
         n = 4;
         h = 1.0 / 32.0;
@@ -67,7 +69,7 @@ public static class Adams
             f[i] = xn + yn;
 #if VERBOSE
             Console.WriteLine("{0},  {1},  {2},  {3},  {4}", k, xn, yn, dn, en);
-#endif // VERBOSE 
+#endif // VERBOSE
         }
 
         for (k = 4; k <= nstep; k++)
@@ -137,7 +139,7 @@ public static class Adams
 
         bool result = true;
         // Note: we can't check xn or yn better because of the precision
-        // with which original results are given 
+        // with which original results are given
         result &= System.Math.Abs(g_xn_base - g_xn) <= 1.5e-7;
         result &= System.Math.Abs(g_yn_base - g_yn) <= 1.5e-7;
         result &= System.Math.Abs(g_dn) <= 2.5e-9;
@@ -160,4 +162,5 @@ public static class Adams
         Console.WriteLine("Test iterations: {0}; Total time: {1} sec", Iterations, sw.Elapsed.TotalSeconds);
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.cs
@@ -18,7 +18,7 @@ using Microsoft.Xunit.Performance;
 [assembly: MeasureInstructionsRetired]
 #endif // XUNIT_PERF
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class Adams
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMk2/BenchMk2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMk2/BenchMk2.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class BenchMk2
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMk2/BenchMk2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMk2/BenchMk2.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class BenchMk2
 {
 #if DEBUG
@@ -63,4 +65,5 @@ public static class BenchMk2
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMrk/BenchMrk.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMrk/BenchMrk.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class BenchMrk
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMrk/BenchMrk.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMrk/BenchMrk.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class BenchMrk
 {
 #if DEBUG
@@ -63,4 +65,5 @@ public static class BenchMrk
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class Bisect
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class Bisect
 {
 #if DEBUG
@@ -160,4 +162,5 @@ public static class Bisect
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/DMath/DMath.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/DMath/DMath.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class DMath
 {
 #if DEBUG
@@ -109,5 +111,6 @@ public static class DMath
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/DMath/DMath.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/DMath/DMath.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class DMath
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.cs
@@ -13,7 +13,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class FFT
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class FFT
 {
 #if DEBUG
@@ -150,4 +152,5 @@ public static class FFT
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/InProd/InProd.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/InProd/InProd.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class InProd
 {
 #if DEBUG
@@ -131,4 +133,5 @@ public static class InProd
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/InProd/InProd.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/InProd/InProd.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class InProd
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class InvMt
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class InvMt
 {
 #if DEBUG
@@ -134,4 +136,5 @@ public static class InvMt
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.cs
@@ -60,6 +60,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public class LLoops
 {
 #if DEBUG
@@ -647,4 +649,5 @@ public class LLoops
         bool result = lloops.TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.cs
@@ -60,7 +60,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public class LLoops
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class Lorenz
 {
 #if DEBUG
@@ -131,4 +133,5 @@ public static class Lorenz
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class Lorenz
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
@@ -10,7 +10,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class MatInv4
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
@@ -10,6 +10,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class MatInv4
 {
 #if DEBUG
@@ -217,11 +219,11 @@ public static class MatInv4
                 // 0 < ik <= n^2
                 ik = nk + i;
                 hold = a[ik - 1];
-                // -n < ij <= 0 
+                // -n < ij <= 0
                 ij = i - n;
                 for (j = 1; j <= n; ++j)
                 {
-                    // i <= n, ij <= n + n + ... + n (n times) or ij <= n * n 
+                    // i <= n, ij <= n + n + ... + n (n times) or ij <= n * n
                     ij = ij + n;
                     if (j == k)
                     {
@@ -237,7 +239,7 @@ public static class MatInv4
             kj = k - n;
             for (j = 1; j <= n; ++j)
             {
-                // k <= n, kj <= n + n + ... + n (n times) or kj <= n * n 
+                // k <= n, kj <= n + n + ... + n (n times) or kj <= n * n
                 kj = kj + n;
                 if (j == k)
                 {
@@ -268,11 +270,11 @@ public static class MatInv4
         jr = n * (i - 1);
         for (j = 1; j <= n; ++j)
         {
-            // jk <= n^2 - n + n 
+            // jk <= n^2 - n + n
             // jk <= n^2
             jk = jq + j;
             hold = a[jk - 1];
-            // ji <= n^2 - n + n 
+            // ji <= n^2 - n + n
             // ji <= n^2
             ji = jr + j;
             a[jk - 1] = -a[ji - 1];
@@ -288,7 +290,7 @@ public static class MatInv4
         ki = k - n;
         for (i = 1; i <= n; ++i)
         {
-            // ki <= n + n + ... + n (n times) or ki <= n * n 
+            // ki <= n + n + ... + n (n times) or ki <= n * n
             ki = ki + n;
             hold = a[ki - 1];
             // if i=1, ji = (1 + (n-1) * n) - 1 + n ==> ij = n^2
@@ -378,7 +380,7 @@ public static class MatInv4
                 {
                     if (j != k)
                     {
-                        // Accessing upto n^2 - n + n - 1 ==> n^2 - 1                            
+                        // Accessing upto n^2 - n + n - 1 ==> n^2 - 1
                         a[(i - 1) * n + (j - 1)] = a[(i - 1) * n + (k - 1)] * a[(k - 1) * n + (j - 1)] + a[(i - 1) * n + (j - 1)];
                     }
                 }
@@ -492,4 +494,5 @@ public static class MatInv4
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.cs
@@ -13,7 +13,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class NewtE
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class NewtE
 {
 #if DEBUG
@@ -132,4 +134,5 @@ public static class NewtE
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class NewtR
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class NewtR
 {
 #if DEBUG
@@ -128,4 +130,5 @@ public static class NewtR
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class Regula
 {
 #if DEBUG
@@ -190,4 +192,5 @@ public static class Regula
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class Regula
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class Romber
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class Romber
 {
 #if DEBUG
@@ -166,4 +168,5 @@ public static class Romber
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class Secant
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class Secant
 {
 #if DEBUG
@@ -139,4 +141,5 @@ public static class Secant
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class Simpsn
 {
 #if DEBUG
@@ -90,4 +92,5 @@ public static class Simpsn
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class Simpsn
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class SqMtx
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class SqMtx
 {
 #if DEBUG
@@ -100,4 +102,5 @@ public static class SqMtx
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class Trap
 {
 #if DEBUG
@@ -93,4 +95,5 @@ public static class Trap
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class Trap
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchf
+{
 public static class Whetsto
 {
 #if DEBUG
@@ -239,4 +241,5 @@ public static class Whetsto
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchf
+namespace Benchstone.BenchF
 {
 public static class Whetsto
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/8Queens/8Queens.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/8Queens/8Queens.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class EightQueens
 {
 
@@ -68,7 +70,7 @@ public static class EightQueens
             }
             i = i + 1;
         }
-        
+
         TryMe(1, ref q, b, a);
 
         return (q == 1);
@@ -92,9 +94,10 @@ public static class EightQueens
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/8Queens/8Queens.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/8Queens/8Queens.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class EightQueens
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Ackermann/Ackermann.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Ackermann/Ackermann.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class Ackermann
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Ackermann/Ackermann.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Ackermann/Ackermann.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class Ackermann
 {
 
@@ -40,7 +42,7 @@ public static class Ackermann
         int a33 = Acker(3, 3);
         return (a00 == 1) && (a11 == 3) && (a22 == 7) & (a33 == 61);
     }
-    
+
     [Benchmark]
     public static void Test() {
         foreach (var iteration in Benchmark.Iterations) {
@@ -59,9 +61,10 @@ public static class Ackermann
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray/AddArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray/AddArray.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class AddArray
 {
 
@@ -48,14 +50,14 @@ public static class AddArray
             m = j;
             flags4[m] = flags3[l] + m + m + m + m;
         }
-        
+
         for (j = 0; j <= Size; j++) {
             k = j;
             l = j;
             m = j;
             flags1[j] = flags1[j] + flags2[k] + flags3[l] + flags4[m] - flags2[k - j + l];
         }
-        
+
         // Escape each flags array so that their elements will appear live-out
         Escape(flags1);
         Escape(flags2);
@@ -83,9 +85,10 @@ public static class AddArray
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray/AddArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray/AddArray.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class AddArray
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray2/AddArray2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray2/AddArray2.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class AddArray2
 {
 #if DEBUG
@@ -128,4 +130,5 @@ public static class AddArray2
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray2/AddArray2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray2/AddArray2.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class AddArray2
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Array1/Array1.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Array1/Array1.cs
@@ -18,6 +18,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class Array1
 {
 #if DEBUG
@@ -151,4 +153,5 @@ public static class Array1
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Array1/Array1.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Array1/Array1.cs
@@ -18,7 +18,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class Array1
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Array2/Array2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Array2/Array2.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class Array2
 {
 
@@ -75,7 +77,7 @@ public static class Array2
         }
 
         bool result = VerifyCopy(s, d);
-        
+
         return result;
     }
 
@@ -92,9 +94,10 @@ public static class Array2
         bool result = Bench(Iterations);
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Array2/Array2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Array2/Array2.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class Array2
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BenchE/BenchE.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BenchE/BenchE.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class BenchE
 {
 #if DEBUG
@@ -114,4 +116,5 @@ public static class BenchE
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BenchE/BenchE.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BenchE/BenchE.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class BenchE
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort/BubbleSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort/BubbleSort.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class BubbleSort
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort/BubbleSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort/BubbleSort.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class BubbleSort
 {
 
@@ -43,7 +45,7 @@ public static class BubbleSort
                 return false;
             }
         }
-        
+
         return true;
     }
 
@@ -79,9 +81,10 @@ public static class BubbleSort
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort2/BubbleSort2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort2/BubbleSort2.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class BubbleSort2
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort2/BubbleSort2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort2/BubbleSort2.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class BubbleSort2
 {
 
@@ -82,9 +84,10 @@ public static class BubbleSort2
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/CSieve/CSieve.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/CSieve/CSieve.cs
@@ -12,6 +12,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class CSieve
 {
 
@@ -74,9 +76,10 @@ public static class CSieve
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/CSieve/CSieve.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/CSieve/CSieve.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class CSieve
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Fib/Fib.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Fib/Fib.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class Fib
 {
 
@@ -30,7 +32,7 @@ public static class Fib
             return 1;
         }
     }
-    
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     static bool Bench() {
         int fib = Fibonacci(Number);
@@ -55,9 +57,10 @@ public static class Fib
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Fib/Fib.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Fib/Fib.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class Fib
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/HeapSort/HeapSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/HeapSort/HeapSort.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class HeapSort
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/HeapSort/HeapSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/HeapSort/HeapSort.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class HeapSort
 {
 
@@ -32,7 +34,7 @@ public static class HeapSort
             j = i;
             k = j / 2;
             m = x[i];
-            
+
             // 0 < k <= (n / 2)
             // 1 <= j <= n
             while (k > 0) {
@@ -113,9 +115,10 @@ public static class HeapSort
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/IniArray/IniArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/IniArray/IniArray.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class IniArray
 {
 
@@ -52,9 +54,10 @@ public static class IniArray
         bool result = Bench();
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/IniArray/IniArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/IniArray/IniArray.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class IniArray
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/LogicArray/LogicArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/LogicArray/LogicArray.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class LogicArray
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/LogicArray/LogicArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/LogicArray/LogicArray.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class LogicArray
 {
 
@@ -89,9 +91,10 @@ public static class LogicArray
         bool result = Bench();
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Midpoint/Midpoint.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Midpoint/Midpoint.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class Midpoint
 {
 
@@ -96,9 +98,10 @@ public static class Midpoint
         bool result = Bench();
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Midpoint/Midpoint.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Midpoint/Midpoint.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class Midpoint
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/MulMatrix/MulMatrix.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/MulMatrix/MulMatrix.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class MulMatrix
 {
 
@@ -19,7 +21,7 @@ public static class MulMatrix
 #else
     public const int Iterations = 100;
 #endif
-    
+
     const int Size = 75;
     static volatile object VolatileObject;
 
@@ -132,9 +134,10 @@ public static class MulMatrix
         bool result = Bench();
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/MulMatrix/MulMatrix.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/MulMatrix/MulMatrix.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class MulMatrix
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/NDhrystone/NDhrystone.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/NDhrystone/NDhrystone.cs
@@ -7,7 +7,7 @@
 // Dhrystone: a synthetic systems programming benchmark
 // Reinhold P. Weicker
 // Communications of the ACM, Volume 27 Issue 10, Oct 1984, Pages 1013-1030
- 
+
 using Microsoft.Xunit.Performance;
 using System;
 using System.Runtime.CompilerServices;
@@ -16,6 +16,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class NDhrystone
 {
 
@@ -63,9 +65,9 @@ public static class NDhrystone
         int intLoc2;
         int intLoc3 = 0;
         Enumeration enumLoc;
-        
+
         int i;   /* modification */
-        
+
         m_ptrGlb.PtrComp = m_ptrGlbNext;
         m_ptrGlb.Discr = Enumeration.Ident1;
         m_ptrGlb.EnumComp = Enumeration.Ident3;
@@ -117,12 +119,12 @@ public static class NDhrystone
             ptrParIn = ptrParIn.PtrComp;
         }
     }
-    
+
     static void Proc2(ref int intParIO) {
         int intLoc;
         Enumeration enumLoc = Enumeration.Ident2;
         intLoc = intParIO + 10;
-        
+
         for (;;) {
             if (s_char1Glob == 'A') {
                 --intLoc;
@@ -142,17 +144,17 @@ public static class NDhrystone
         else {
             s_intGlob = 100;
         }
-        
+
         Proc7(10, s_intGlob, ref m_ptrGlb.IntComp);
     }
-    
+
     static void Proc4() {
         bool boolLoc;
         boolLoc = s_char1Glob == 'A';
         boolLoc |= s_boolGlob;
         s_char2Glob = 'B';
     }
-    
+
     static void Proc5() {
         s_char1Glob = 'A';
         s_boolGlob = false;
@@ -163,12 +165,12 @@ public static class NDhrystone
         if (!Func3(enumParIn)) {
             enumParOut = Enumeration.Ident4;
         }
-        
+
         switch (enumParIn) {
-            case Enumeration.Ident1: 
+            case Enumeration.Ident1:
                 enumParOut = Enumeration.Ident1;
                 break;
-            case Enumeration.Ident2: 
+            case Enumeration.Ident2:
                 if (s_intGlob > 100) {
                     enumParOut = Enumeration.Ident1;
                 }
@@ -176,12 +178,12 @@ public static class NDhrystone
                     enumParOut = Enumeration.Ident4;
                 }
                 break;
-            case Enumeration.Ident3: 
+            case Enumeration.Ident3:
                 enumParOut = Enumeration.Ident2;
                 break;
-            case Enumeration.Ident4: 
+            case Enumeration.Ident4:
                 break;
-            case Enumeration.Ident5: 
+            case Enumeration.Ident5:
                 enumParOut = Enumeration.Ident3;
                 break;
         }
@@ -192,7 +194,7 @@ public static class NDhrystone
         intLoc = intParI1 + 2;
         intParOut = intParI2 + intLoc;
     }
-    
+
     static void Proc8(int[] array1Par, int[][] array2Par, int intParI1, int intParI2) {
         int intLoc;
         intLoc = intParI1 + 5;
@@ -206,7 +208,7 @@ public static class NDhrystone
         array2Par[intLoc + 20][intLoc] = array1Par[intLoc];
         s_intGlob = 5;
     }
-    
+
     static Enumeration Func1(char charPar1, char charPar2) {
         char charLoc1;
         char charLoc2;
@@ -219,7 +221,7 @@ public static class NDhrystone
             return (Enumeration.Ident2);
         }
     }
-    
+
     static bool Func2(char[] strParI1, char[] strParI2) {
         int intLoc;
         char charLoc = '\0';
@@ -243,18 +245,18 @@ public static class NDhrystone
                     return true;
                 }
             }
-            
+
             return false;
         }
     }
-    
+
     static bool Func3(Enumeration enumParIn) {
         Enumeration enumLoc;
         enumLoc = enumParIn;
         if (enumLoc == Enumeration.Ident3) {
             return true;
         }
-        
+
         return false;
     }
 
@@ -278,9 +280,10 @@ public static class NDhrystone
         bool result = Bench();
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/NDhrystone/NDhrystone.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/NDhrystone/NDhrystone.cs
@@ -16,7 +16,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class NDhrystone
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Permutate/Permutate.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Permutate/Permutate.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public class Permutate
 {
 #if DEBUG
@@ -113,4 +115,5 @@ public class Permutate
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Permutate/Permutate.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Permutate/Permutate.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public class Permutate
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Pi/Pi.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Pi/Pi.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class Pi
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Pi/Pi.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Pi/Pi.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class Pi
 {
 
@@ -78,9 +80,10 @@ public static class Pi
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Puzzle/Puzzle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Puzzle/Puzzle.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public class Puzzle
 {
 #if DEBUG
@@ -390,4 +392,5 @@ public class Puzzle
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Puzzle/Puzzle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Puzzle/Puzzle.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public class Puzzle
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/QuickSort/QuickSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/QuickSort/QuickSort.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class QuickSort
 {
 
@@ -52,7 +54,7 @@ public static class QuickSort
                     arr[j] = temp;
                 }
             }
-            
+
             // need to swap the pivot and a[i](or a[j] as i==j) so
             // that the pivot will be at its final place in the sorted array
 
@@ -108,9 +110,10 @@ public static class QuickSort
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/QuickSort/QuickSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/QuickSort/QuickSort.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class QuickSort
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/TreeInsert/TreeInsert.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/TreeInsert/TreeInsert.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public class TreeInsert
 {
 #if DEBUG
@@ -135,4 +137,5 @@ public class TreeInsert
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/TreeInsert/TreeInsert.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/TreeInsert/TreeInsert.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public class TreeInsert
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/TreeSort/TreeSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/TreeSort/TreeSort.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class TreeSort
 {
 
@@ -74,7 +76,7 @@ public static class TreeSort
             else {
                 Insert(n, t.Left);
             }
-        } 
+        }
         else if (n < t.Val) {
             if (t.Right == null) {
                 t.Right = new Node(n);
@@ -117,7 +119,7 @@ public static class TreeSort
         bool result = CheckTree(tree);
         return result;
     }
-    
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     static bool Bench() {
         int[] sortList = new int[SortElements + 1];
@@ -143,9 +145,10 @@ public static class TreeSort
         }
         return result;
     }
-    
+
     public static int Main() {
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/TreeSort/TreeSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/TreeSort/TreeSort.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class TreeSort
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/XposMatrix/XposMatrix.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/XposMatrix/XposMatrix.cs
@@ -11,6 +11,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Benchstone.benchi
+{
 public static class XposMatrix
 {
     public const int ArraySize = 100;
@@ -48,11 +50,11 @@ public static class XposMatrix
                 matrix[i][j] = 1;
             }
         }
-        
+
         if (matrix[n][n] != 1) {
             return false;
         }
-        
+
         Inner(matrix, n);
 
         if (matrix[n][n] != 1) {
@@ -87,4 +89,5 @@ public static class XposMatrix
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/XposMatrix/XposMatrix.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/XposMatrix/XposMatrix.cs
@@ -11,7 +11,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Benchstone.benchi
+namespace Benchstone.BenchI
 {
 public static class XposMatrix
 {

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/binarytrees/binarytrees.csharp.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/binarytrees/binarytrees.csharp.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/ 
+   http://benchmarksgame.alioth.debian.org/
 
-   contributed by Marek Safar  
+   contributed by Marek Safar
 
    modified for use with xunit-performance
 */
@@ -17,6 +17,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace BenchmarksGame
+{
 public class BinaryTrees
 {
     private const int minDepth = 4;
@@ -148,4 +150,5 @@ public class BinaryTrees
         bool result = TestBase();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fasta/fasta.csharp-2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fasta/fasta.csharp-2.cs
@@ -18,6 +18,8 @@ using System.Text;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace BenchmarksGame
+{
 public class Fasta
 {
 #if DEBUG
@@ -217,4 +219,5 @@ public class Fasta
         if (s_index != 0)
             s.Write(s_buf, 0, s_index);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fastaredux/fastaredux.csharp.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fastaredux/fastaredux.csharp.cs
@@ -18,6 +18,8 @@ using System.Text;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace BenchmarksGame
+{
 public static class FastaRedux
 {
 #if DEBUG
@@ -180,5 +182,6 @@ public static class FastaRedux
         if (lr < LINE_LEN) s_buf[BUF_LEN - (br--)] = LF;
         if (br < BUF_LEN) s.Write(s_buf, 0, BUF_LEN - br);
     }
+}
 }
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/nbody/nbody.csharp-3.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/nbody/nbody.csharp-3.cs
@@ -15,6 +15,8 @@ using System;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace BenchmarksGame
+{
 public class NBody
 {
     public static int Main(String[] args)
@@ -152,5 +154,6 @@ internal class NBodySystem
         }
         return e;
     }
+}
 }
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/pidigits/pi-digits.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/pidigits/pi-digits.cs
@@ -6,7 +6,7 @@
  *
  * Port of the C code that uses GMP
  * Just switched it to use C#'s BigInteger instead
- * 
+ *
  * To compile use csc /o+ /r:System.Numerics.dll
  *
  * modified for use with xunit-performance
@@ -20,6 +20,8 @@ using System.Text;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace BenchmarksGame
+{
 public class pidigits
 {
 #if DEBUG
@@ -110,5 +112,6 @@ public class pidigits
             }
         }
     }
+}
 }
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/spectralnorm/spectralnorm.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/spectralnorm/spectralnorm.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
- 
-   contributed by Isaac Gouy 
+
+   contributed by Isaac Gouy
 
    modified for use with xunit-performance
 */
@@ -15,6 +15,8 @@ using System;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace BenchmarksGame
+{
 public class SpectralNorm
 {
 #if DEBUG
@@ -78,7 +80,7 @@ public class SpectralNorm
         }
 
         // B=AtA         A multiplied by A transposed
-        // v.Bv /(v.v)   eigenvalue of v 
+        // v.Bv /(v.v)   eigenvalue of v
         double vBv = 0, vv = 0;
         for (int i = 0; i < n; i++)
         {
@@ -123,4 +125,5 @@ public class SpectralNorm
         MultiplyAv(n, v, u);
         MultiplyAtv(n, u, AtAv);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsByte.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsByte.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsByte
 {
 
@@ -927,4 +929,5 @@ public static class ConstantArgsByte
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsChar.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsChar.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsChar
 {
 
@@ -927,4 +929,5 @@ public static class ConstantArgsChar
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsDouble.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsDouble.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsDouble
 {
 
@@ -807,4 +809,5 @@ public static class ConstantArgsDouble
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsFloat.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsFloat.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsFloat
 {
 
@@ -807,4 +809,5 @@ public static class ConstantArgsFloat
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsInt.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsInt.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsInt
 {
 
@@ -927,4 +929,5 @@ public static class ConstantArgsInt
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsLong.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsLong.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsLong
 {
 
@@ -927,4 +929,5 @@ public static class ConstantArgsLong
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsSByte.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsSByte.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsSByte
 {
 
@@ -927,4 +929,5 @@ public static class ConstantArgsSByte
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsShort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsShort.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsShort
 {
 
@@ -927,4 +929,5 @@ public static class ConstantArgsShort
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsString.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsString.cs
@@ -16,6 +16,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsString
 {
 
@@ -327,4 +329,5 @@ public static class ConstantArgsString
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsUInt.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsUInt.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsUInt
 {
 
@@ -887,4 +889,5 @@ public static class ConstantArgsUInt
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsULong.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsULong.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsULong
 {
 
@@ -887,4 +889,5 @@ public static class ConstantArgsULong
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsUShort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/ConstantArgsUShort.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class ConstantArgsUShort
 {
 
@@ -927,4 +929,5 @@ public static class ConstantArgsUShort
 
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/InlineGCStruct.cs
@@ -22,6 +22,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public class InlineGCStruct
 {
 #if DEBUG
@@ -141,5 +143,6 @@ public class InlineGCStruct
 
         return (withFormat && withoutFormat ? 100 : -1);
     }
+}
 }
 

--- a/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Inlining/NoThrowInline.cs
@@ -13,6 +13,8 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Inlining
+{
 public static class NoThrowInline
 {
 #if DEBUG
@@ -34,7 +36,7 @@ public static class NoThrowInline
 
     //
     // We expect ThrowArgumentNullException to not be inlined into Bench, the throw code is pretty
-    // large and throws are extremly slow. However, we need to be careful not to degrade the 
+    // large and throws are extremly slow. However, we need to be careful not to degrade the
     // non-exception path performance by preserving registers across the call. For this the compiler
     // will have to understand that ThrowArgumentNullException never returns and omit the register
     // preservation code.
@@ -72,4 +74,5 @@ public static class NoThrowInline
     {
         return (Bench("a", "bc", "def", "ghij") == 10) ? 100 : -1;
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
@@ -11,9 +11,9 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace ConsoleMandel
+namespace SIMD
 {
-    public static class Program
+    public static class ConsoleMandel
     {
         private const int Pass = 100;
         private const int Fail = -1;

--- a/tests/src/JIT/Performance/CodeQuality/SIMD/RayTracer/RayTracerBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/RayTracer/RayTracerBench.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 //
-// Based on the Raytracer example from 
-// Samples for Parallel Programming with the .NET Framework 
+// Based on the Raytracer example from
+// Samples for Parallel Programming with the .NET Framework
 // https://code.msdn.microsoft.com/windowsdesktop/Samples-for-Parallel-b4b76364
 
 using Microsoft.Xunit.Performance;
@@ -16,6 +16,8 @@ using System.Collections.Concurrent;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace SIMD
+{
 public class RayTracerBench
 {
 #if DEBUG
@@ -141,4 +143,5 @@ public class RayTracerBench
         bool result = r.Run();
         return (result ? 100 : -1);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Serialization/Deserialize.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Serialization/Deserialize.cs
@@ -28,7 +28,7 @@ public class JsonBenchmarks
     public const int JsonNetIterations = 90000;
 #endif
 
-    const string DataContractXml = @"<JsonBenchmarks.TestObject xmlns=""http://schemas.datacontract.org/2004/07/Serialization/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Id>33</Id><Name>SqMtx</Name><Results xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:double>101.3</a:double><a:double>99.8</a:double><a:double>99.6</a:double><a:double>100.4</a:double></Results><WhenRun>2015-01-01T00:00:00-08:00</WhenRun></JsonBenchmarks.TestObject>";
+    const string DataContractXml = @"<JsonBenchmarks.TestObject xmlns=""http://schemas.datacontract.org/2004/07/Serialization"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Id>33</Id><Name>SqMtx</Name><Results xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:double>101.3</a:double><a:double>99.8</a:double><a:double>99.6</a:double><a:double>100.4</a:double></Results><WhenRun>2015-01-01T00:00:00-08:00</WhenRun></JsonBenchmarks.TestObject>";
 
     const string DataContractJson = @"{""Id"":33,""Name"":""SqMtx"",""Results"":[101.3,99.8,99.6,100.4],""WhenRun"":""\/Date(1420099200000-0800)\/""}";
 

--- a/tests/src/JIT/Performance/CodeQuality/Serialization/Deserialize.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Serialization/Deserialize.cs
@@ -28,7 +28,7 @@ public class JsonBenchmarks
     public const int JsonNetIterations = 90000;
 #endif
 
-    const string DataContractXml = @"<JsonBenchmarks.TestObject xmlns=""http://schemas.datacontract.org/2004/07/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Id>33</Id><Name>SqMtx</Name><Results xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:double>101.3</a:double><a:double>99.8</a:double><a:double>99.6</a:double><a:double>100.4</a:double></Results><WhenRun>2015-01-01T00:00:00-08:00</WhenRun></JsonBenchmarks.TestObject>";
+    const string DataContractXml = @"<JsonBenchmarks.TestObject xmlns=""http://schemas.datacontract.org/2004/07/Serialization/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Id>33</Id><Name>SqMtx</Name><Results xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:double>101.3</a:double><a:double>99.8</a:double><a:double>99.6</a:double><a:double>100.4</a:double></Results><WhenRun>2015-01-01T00:00:00-08:00</WhenRun></JsonBenchmarks.TestObject>";
 
     const string DataContractJson = @"{""Id"":33,""Name"":""SqMtx"",""Results"":[101.3,99.8,99.6,100.4],""WhenRun"":""\/Date(1420099200000-0800)\/""}";
 

--- a/tests/src/JIT/Performance/CodeQuality/Serialization/Deserialize.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Serialization/Deserialize.cs
@@ -15,6 +15,8 @@ using Microsoft.Xunit.Performance;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Serialization
+{
 public class JsonBenchmarks
 {
 
@@ -83,7 +85,7 @@ public class JsonBenchmarks
     }
 
     [Benchmark]
-    private void DeserializeDataContract() 
+    private void DeserializeDataContract()
     {
         foreach (var iteration in Benchmark.Iterations) {
             using (iteration.StartMeasurement()) {
@@ -198,4 +200,5 @@ public class JsonBenchmarks
         bool result = tests.Deserialize();
         return result ? 100 : -1;
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/Serialization/Serialize.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Serialization/Serialize.cs
@@ -14,6 +14,8 @@ using Microsoft.Xunit.Performance;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
+namespace Serialization
+{
 public class JsonBenchmarks
 {
 
@@ -72,7 +74,7 @@ public class JsonBenchmarks
     }
 
     [Benchmark]
-    private void SerializeDataContract() 
+    private void SerializeDataContract()
     {
         foreach (var iteration in Benchmark.Iterations) {
             using (iteration.StartMeasurement()) {
@@ -185,4 +187,5 @@ public class JsonBenchmarks
         bool result = tests.Serialize();
         return result ? 100 : -1;
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
+++ b/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
@@ -46,7 +46,7 @@ using System.Globalization;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-namespace Crypto
+namespace V8.Crypto
 {
     public class Support
     {

--- a/tests/src/JIT/Performance/CodeQuality/V8/DeltaBlue/DeltaBlue.cs
+++ b/tests/src/JIT/Performance/CodeQuality/V8/DeltaBlue/DeltaBlue.cs
@@ -24,13 +24,15 @@ using System.Collections;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-/* 
+/*
 Strengths are used to measure the relative importance of constraints.
 New strengths may be inserted in the strength hierarchy without
 disrupting current constraints.  Strengths cannot be created outside
 this class, so pointer comparison can be used for value comparison.
 */
 
+namespace V8
+{
 internal class Strength
 {
     private int _strengthValue;
@@ -1065,4 +1067,5 @@ public class deltablue
     {
         throw new Exception(s);
     }
+}
 }

--- a/tests/src/JIT/Performance/CodeQuality/V8/Richards/Richards.cs
+++ b/tests/src/JIT/Performance/CodeQuality/V8/Richards/Richards.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 // using System.Diagnostics;
 // using System.Text.RegularExpressions;
 
-namespace Richards
+namespace V8.Richards
 {
     /// <summary>
     /// Support is used for a place to generate any 'miscellaneous' methods generated as part
@@ -501,7 +501,7 @@ namespace Richards
 
         public
 #if !INTF_FOR_TASK
-            override 
+            override
 #endif
             TaskControlBlock run(Packet packet)
         {
@@ -521,7 +521,7 @@ namespace Richards
 
         public
 #if !INTF_FOR_TASK
-            override 
+            override
 #endif
             String toString()
         {
@@ -548,7 +548,7 @@ namespace Richards
 
         public
 #if !INTF_FOR_TASK
-             override 
+             override
 #endif
              TaskControlBlock run(Packet packet)
         {
@@ -568,7 +568,7 @@ namespace Richards
 
         public
 #if !INTF_FOR_TASK
-             override 
+             override
 #endif
              String toString()
         {
@@ -598,7 +598,7 @@ namespace Richards
 
         public
 #if !INTF_FOR_TASK
-             override 
+             override
 #endif
              TaskControlBlock run(Packet packet)
         {
@@ -630,7 +630,7 @@ namespace Richards
 
         public
 #if !INTF_FOR_TASK
-             override 
+             override
 #endif
              String toString()
         {
@@ -658,7 +658,7 @@ namespace Richards
 
         public
 #if !INTF_FOR_TASK
-             override 
+             override
 #endif
              TaskControlBlock run(Packet packet)
         {
@@ -700,7 +700,7 @@ namespace Richards
 
         public
 #if !INTF_FOR_TASK
-             override 
+             override
 #endif
              String toString()
         {


### PR DESCRIPTION
The names used on the BenchView reporting site are taken from the fully qualified names of the methods running the benchmarks (marked with the xunit performance attribute [Benchmark]). Before these changes, a lot of the classes/methods were in the global namespace, and all the tests would show up in a long list. Now, after these changes, tests are grouped.

In addition, I append the all the BenchView results into a single file and upload it once.
