### PR TITLE
Admit more dest addresses in block assign value-numbering.

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -2656,7 +2656,7 @@ ValueNum ValueNumStore::ExtendPtrVN(GenTreePtr opA, GenTreePtr opB)
     if (opB->OperGet() == GT_CNS_INT)
     {
         FieldSeqNode* fldSeq = opB->gtIntCon.gtFieldSeq;
-        if ((fldSeq != nullptr) && (fldSeq != FieldSeqStore::NotAField()))
+        if (fldSeq != nullptr)
         {
             return ExtendPtrVN(opA, opB->gtIntCon.gtFieldSeq);
         }
@@ -2666,8 +2666,9 @@ ValueNum ValueNumStore::ExtendPtrVN(GenTreePtr opA, GenTreePtr opB)
 
 ValueNum ValueNumStore::ExtendPtrVN(GenTreePtr opA, FieldSeqNode* fldSeq)
 {
+    assert(fldSeq != nullptr);
+
     ValueNum res = NoVN;
-    assert(fldSeq != FieldSeqStore::NotAField());
 
     ValueNum opAvnWx = opA->gtVNPair.GetLiberal();
     assert(VNIsValid(opAvnWx));
@@ -4982,17 +4983,21 @@ void Compiler::fgValueNumberBlockAssignment(GenTreePtr tree, bool evalAsgLhsInd)
                         assert(lhs->OperGet() == GT_IND);
                         lhsAddr = lhs->gtOp.gtOp1;
                     }
+
                     // For addr-of-local expressions, lib/cons shouldn't matter.
                     assert(lhsAddr->gtVNPair.BothEqual());
                     ValueNum lhsAddrVN = lhsAddr->GetVN(VNK_Liberal);
 
                     // Unpack the PtrToLoc value number of the address.
                     assert(vnStore->IsVNFunc(lhsAddrVN));
+
                     VNFuncApp lhsAddrFuncApp;
                     vnStore->GetVNFunc(lhsAddrVN, &lhsAddrFuncApp);
+
                     assert(lhsAddrFuncApp.m_func == VNF_PtrToLoc);
                     assert(vnStore->IsVNConstant(lhsAddrFuncApp.m_args[0]) &&
                            vnStore->ConstantValue<unsigned>(lhsAddrFuncApp.m_args[0]) == lhsLclNum);
+
                     lhsFldSeq = vnStore->FieldSeqVNToFieldSeq(lhsAddrFuncApp.m_args[1]);
                 }
 

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.il
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly a {}
+.module a.exe
+
+// This test originally triggered an assert when computing the value number for a block assignment. In particular, the
+// VN framework expected any block assignments to a tracked lclVar to have a destination address of the form
+// `(addr (lclVar))` or `(addr (lclFld))`. The check that it was using to determine whether or not a block assignment
+// targets a lclVar also admitted addresses formed by some combination of adds of constants to these patterns (e.g.
+// `(add (const 4) (add (addr lclVar) (const 4)))`. The bits of IL that trigger the assert are called out in the method
+// bodies below. They differ for 32- and 64-bit targets because on 64-bit targets, the importer will insert an
+// int->long conversion when adding a constant int to any long. Due to the cast, the resulting IR is not considered to
+// be an add of a constant and a lclVar address. In order to repro the bug on a 64-bit target, the input IL must
+// directly produce a long constant.
+
+.class private sequential ansi sealed beforefieldinit S extends [mscorlib]System.ValueType
+{
+    .field public uint8 m_fld
+    .field public uint8 m_fld1
+    .field public uint8 m_fld2
+    .field public uint8 m_fld3
+    .field public uint8 m_fld4
+    .field public uint8 m_fld5
+    .field public uint8 m_fld6
+}
+
+.class private sequential ansi sealed beforefieldinit T extends [mscorlib]System.ValueType
+{
+    .field public int32 m_int
+    .field public valuetype S m_fld
+}
+
+.class private abstract auto ansi sealed beforefieldinit C extends [mscorlib]System.Object
+{
+    .method private static int32 Test32Bit(int32 i) noinlining
+    {
+        .locals init (valuetype S V_0, valuetype T V_1)
+
+        ldloca.s V_0
+        ldarg.0
+        conv.u1
+        stfld uint8 S::m_fld6
+
+        // This sequence of IL repros the issue.
+        ldloca.s V_1
+        ldc.i4.4
+        add
+        ldloc.0
+        stobj S
+
+        ldloca.s V_1
+        ldfld valuetype S T::m_fld
+        ldfld uint8 S::m_fld6
+        conv.i4
+        ret
+    }
+
+    .method private static int32 Test64Bit(int32 i) noinlining
+    {
+        .locals init (valuetype S V_0, valuetype T V_1)
+
+        ldloca.s V_0
+        ldarg.0
+        conv.u1
+        stfld uint8 S::m_fld6
+
+        // This sequence of IL repros the issue. Note that the `ldc.i8` is necessary (rather than an `ldc.i4` that is
+        // implicitly converted to a long byt the `add`).
+        ldloca.s V_1
+        ldc.i8 4
+        add
+        ldloc.0
+        stobj S
+
+        ldloca.s V_1
+        ldfld valuetype S T::m_fld
+        ldfld uint8 S::m_fld6
+        conv.i4
+        ret
+    }
+
+    .method private static int32 Main()
+    {
+        .entrypoint
+        .locals init (int32 V_0)
+
+        ldc.i4 100
+        dup
+
+        sizeof [mscorlib]System.IntPtr
+        ldc.i4 8
+        beq.s _64bit
+
+        call int32 C::Test32Bit(int32)
+        bne.un.s fail
+        br.s success
+
+_64bit:
+        call int32 C::Test64Bit(int32)
+        bne.un.s fail
+
+success:
+        ldc.i4 100
+        ret
+
+fail:
+        ldc.i4 101
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_278523/DevDiv_278523.ilproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_278523.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Internal testing revealed an assertion when computing the value number
for block assignments: the VN framework expected any block assignments
to a tracked lclVar to have a destination address of the form
`(addr (lclVar))` or `(addr (lclFld))`. However, the check that it
uses to determine whether or not a block assignment targets a lclVar
also admits addresses formed by some combination of adds of constants
to these patterns (e.g. `(add (const 4) (add (addr lclVar) (const 4)))`.

This fix admits these additional patterns in value numbering and handles
them by assigning a new, unique value number to the destination.