### PR TITLE
Do not fold (ind (addr (lclVar))) in certain cases.

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2903,6 +2903,11 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
         varNum = tmpDsc->tdTempNum();
         offset = 0;
     }
+    else if (memBase->OperGet() == GT_LCL_VAR_ADDR)
+    {
+        varNum = memBase->AsLclVarCommon()->GetLclNum();
+        offset = 0;
+    }
 
     // Spill temp numbers are negative and start with -1
     // which also happens to be BAD_VAR_NUM. For this reason
@@ -2910,7 +2915,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     if (varNum != BAD_VAR_NUM || tmpDsc != nullptr)
     {
         // Is the memory op in the source position?
-        if (src->isContainedLclField() || src->isContainedLclVar() || src->isContainedSpillTemp())
+        if (src->isContainedLclField() || src->isContainedLclVar() || src->isContainedSpillTemp() || src->isContainedMemoryOp())
         {
             if (instrHasImplicitRegPairDest(ins))
             {

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2915,7 +2915,8 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     if (varNum != BAD_VAR_NUM || tmpDsc != nullptr)
     {
         // Is the memory op in the source position?
-        if (src->isContainedLclField() || src->isContainedLclVar() || src->isContainedSpillTemp() || src->isContainedMemoryOp())
+        if (src->isContainedLclField() || src->isContainedLclVar() || src->isContainedSpillTemp() ||
+            src->isContainedMemoryOp())
         {
             if (instrHasImplicitRegPairDest(ins))
             {

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2903,10 +2903,18 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
         varNum = tmpDsc->tdTempNum();
         offset = 0;
     }
-    else if (memBase->OperGet() == GT_LCL_VAR_ADDR)
+    else
     {
-        varNum = memBase->AsLclVarCommon()->GetLclNum();
-        offset = 0;
+        // At this point we must have a memory operand that is a contained indir: if we do not, we should have handled
+        // this instruction above in the reg/imm or reg/reg case.
+        assert(mem != nullptr);
+        assert(memBase != nullptr);
+
+        if (memBase->OperGet() == GT_LCL_VAR_ADDR)
+        {
+            varNum = memBase->AsLclVarCommon()->GetLclNum();
+            offset = 0;
+        }
     }
 
     // Spill temp numbers are negative and start with -1
@@ -2915,8 +2923,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     if (varNum != BAD_VAR_NUM || tmpDsc != nullptr)
     {
         // Is the memory op in the source position?
-        if (src->isContainedLclField() || src->isContainedLclVar() || src->isContainedSpillTemp() ||
-            src->isContainedMemoryOp())
+        if (src->isContainedMemoryOp())
         {
             if (instrHasImplicitRegPairDest(ins))
             {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -12760,12 +12760,13 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                 {
                     assert(temp->OperIsLocal());
 
-                    const unsigned   lclNum  = temp->AsLclVarCommon()->gtLclNum;
-                    LclVarDsc* const varDsc  = &lvaTable[lclNum];
+                    const unsigned   lclNum = temp->AsLclVarCommon()->gtLclNum;
+                    LclVarDsc* const varDsc = &lvaTable[lclNum];
 
-                    const var_types tempTyp      = temp->TypeGet();
-                    const bool      useExactSize = varTypeIsStruct(tempTyp) || (tempTyp == TYP_BLK) || (tempTyp == TYP_LCLBLK);
-                    const unsigned  varSize      = useExactSize ? varDsc->lvExactSize : genTypeSize(temp);
+                    const var_types tempTyp = temp->TypeGet();
+                    const bool      useExactSize =
+                        varTypeIsStruct(tempTyp) || (tempTyp == TYP_BLK) || (tempTyp == TYP_LCLBLK);
+                    const unsigned varSize = useExactSize ? varDsc->lvExactSize : genTypeSize(temp);
 
                     // If the size of the load is greater than the size of the lclVar, we cannot fold this access into
                     // a lclFld: the access represented by an lclFld node must begin at or after the start of the

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_279396/DevDiv_279396.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_279396/DevDiv_279396.il
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly DevDiv_279396 {}
+.module DevDiv_279396.exe
+
+// This test originally triggered an assertion in the emitter that ensured that no lclVar or lclFld access exceeded the
+// bounds of its containing method's frame. The problematic access was created during morphing by folding
+// `(ind long (addr int (lclVar int V0)))` into `(lclFld long V0 0)`. This corresponds to the body of `C::Test` below.
+
+.class private abstract auto ansi sealed beforefieldinit C extends [mscorlib]System.Object
+{
+    .method private static int64 Test(int32 i) noinlining
+    {
+        ldarga.s i
+        ldind.i8
+        ret
+    }
+
+    .method private static int32 Main()
+    {
+        .entrypoint
+
+        ldc.i4 100
+        dup
+        call int64 C::Test(int32)
+        conv.i4
+        bne.un.s fail
+
+        ldc.i4 100
+        ret
+
+fail:
+        ldc.i4 101
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_279396/DevDiv_279396.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_279396/DevDiv_279396.ilproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_279396.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Specifically, do not fold these trees into (lclFld) or (lclVar) if the
size of the access is larger than the size of the lclVar. Furthermore,
mark the lclVar as unenregisterable, as the indirection requires the
lclVar to be in memory.