### PR TITLE
Save registers xmm8..15 on Mac OSX

### DIFF
--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -991,7 +991,7 @@ CONTEXT_GetThreadContextFromThreadState(
                     memcpy(&lpContext->FltSave.FloatRegisters[i], (&pState->__fpu_stmm0)[i].__mmst_reg, 10);
 
                 // AMD64's FLOATING_POINT includes the xmm registers.
-                memcpy(&lpContext->Xmm0, &pState->__fpu_xmm0, 8 * 16);
+                memcpy(&lpContext->Xmm0, &pState->__fpu_xmm0, 16 * 16);
             }
             break;
 #else

--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -1218,7 +1218,7 @@ CONTEXT_SetThreadContextOnPort(
             for (int i = 0; i < 8; i++)
                 memcpy((&State.__fpu_stmm0)[i].__mmst_reg, &lpContext->FltSave.FloatRegisters[i], 10);
 
-            memcpy(&State.__fpu_xmm0, &lpContext->Xmm0, 8 * 16);
+            memcpy(&State.__fpu_xmm0, &lpContext->Xmm0, 16 * 16);
 #else
 #error Unexpected architecture.
 #endif


### PR DESCRIPTION
On x64, JIT can generate code that uses all 16 xmm registers.
However, on Mac OSX, we currently only save 8 of these registers.
Thus after a context save/restore, xmm8 through xmm15 are
corrupted. This commit fixes the code to save all 16 xmm
registers. It resolves issue #2266.