### PR TITLE
Generate "inc/dec [mem]" instead of "add/sub [mem], 1" for Read-Modify-Write (RMW) operations.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4533,6 +4533,22 @@ void CodeGen::genStoreInd(GenTreePtr node)
                     assert(rmwSrc == data->gtGetOp2());
                     genCodeForShiftRMW(storeInd);
                 }
+                else if (data->OperGet() == GT_ADD && rmwSrc->IsIntegralConst(1))
+                {
+                    // Generate inc [mem] instead of "add [mem], 1".
+                    // Note that we don't need to check for GT_SUB of -1 because
+                    // global morph would transform it to GT_ADD of 1.
+                    assert(rmwSrc->isContainedIntOrIImmed());
+                    getEmitter()->emitInsRMW(INS_inc, emitTypeSize(storeInd), storeInd);
+                }
+                else if (data->OperGet() == GT_ADD && rmwSrc->IsIntegralConst(-1))
+                {
+                    // Generate dec [mem] instead of "add [mem], -1".
+                    // Note that we don't need to check for GT_SUB of 1 because
+                    // global morph would transform it to GT_ADD of -1.
+                    assert(rmwSrc->isContainedIntOrIImmed());
+                    getEmitter()->emitInsRMW(INS_dec, emitTypeSize(storeInd), storeInd);
+                }
                 else
                 {
                     // generate code for remaining binary RMW memory ops like add/sub/and/or/xor


### PR DESCRIPTION
Happened to observe the below code sequence while analyzing method 
`System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:AddIfNotPresent(ref):bool:this`

```
IN0074: 0001CD add      dword ptr [rsi+40], 1
IN0075: 0001D1 add      dword ptr [rsi+52], 1
```
The above instructions are generated for RMW operations.  Preferring inc/dec would result in a smaller instruction.

SuperPMI asm diffs: 3KB of code size win across all desktop fx assemblies
```
00.71:         <filename>                                            baseline        diff improvement  %improvement    #funcs
00.71:         CQ_PERF_Clean_Thin_Unique_all.dasm                      202538      201889         649          0.32       347
04.46:         All_FX_Clean_Thin_Unique_all.dasm                      1165984     1162171        3813          0.33      2677
```

