### PR TITLE
RyuJIT/x86: Implement TYP_SIMD12 support

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -3146,7 +3146,8 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
        We need to relax the assert as our estimation won't include code-gen
        stack changes (which we know don't affect fgAddCodeRef()) */
     noway_assert(getEmitter()->emitMaxStackDepth <=
-                 (compiler->fgPtrArgCntMax + compiler->compHndBBtabCount + // Return address for locally-called finallys
+                 (compiler->fgPtrArgCntMax +              // Max number of pointer-sized stack arguments.
+                  compiler->compHndBBtabCount +           // Return address for locally-called finallys
                   genTypeStSz(TYP_LONG) +                 // longs/doubles may be transferred via stack, etc
                   (compiler->compTailCallUsed ? 4 : 0))); // CORINFO_HELP_TAILCALL args
 #endif

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -853,7 +853,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             GenTreeLclVarCommon* lcl    = unspillTree->AsLclVarCommon();
             LclVarDsc*           varDsc = &compiler->lvaTable[lcl->gtLclNum];
 
-// TODO-Cleanup: The following code could probably be further merged and cleand up.
+// TODO-Cleanup: The following code could probably be further merged and cleaned up.
 #ifdef _TARGET_XARCH_
             // Load local variable from its home location.
             // In most cases the tree type will indicate the correct type to use for the load.

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -94,7 +94,10 @@ void genSIMDCheck(GenTree* treeNode);
 void genStoreIndTypeSIMD12(GenTree* treeNode);
 void genStoreLclFldTypeSIMD12(GenTree* treeNode);
 void genLoadIndTypeSIMD12(GenTree* treeNode);
-void genLoadLclFldTypeSIMD12(GenTree* treeNode);
+void genLoadLclTypeSIMD12(GenTree* treeNode);
+#ifdef _TARGET_X86_
+void genPutArgStkSIMD12(GenTree* treeNode);
+#endif // _TARGET_X86_
 #endif // FEATURE_SIMD
 
 #if !defined(_TARGET_64BIT_)

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -3238,7 +3238,7 @@ instruction CodeGen::ins_Move_Extend(var_types srcType, bool srcInReg)
  *
  *  Parameters
  *      srcType   - source type
- *      aligned   - whether source is 16-byte aligned if srcType is a SIMD type
+ *      aligned   - whether source is properly aligned if srcType is a SIMD type
  */
 instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*/)
 {
@@ -3256,8 +3256,7 @@ instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*
 #endif // FEATURE_SIMD
             if (compiler->canUseAVX())
         {
-            // TODO-CQ: consider alignment of AVX vectors.
-            return INS_movupd;
+            return (aligned) ? INS_movapd : INS_movupd;
         }
         else
         {
@@ -3402,7 +3401,7 @@ instruction CodeGen::ins_Copy(var_types dstType)
  *
  *  Parameters
  *      dstType   - destination type
- *      aligned   - whether destination is 16-byte aligned if dstType is a SIMD type
+ *      aligned   - whether destination is properly aligned if dstType is a SIMD type
  */
 instruction CodeGenInterface::ins_Store(var_types dstType, bool aligned /*=false*/)
 {
@@ -3420,8 +3419,7 @@ instruction CodeGenInterface::ins_Store(var_types dstType, bool aligned /*=false
 #endif // FEATURE_SIMD
             if (compiler->canUseAVX())
         {
-            // TODO-CQ: consider alignment of AVX vectors.
-            return INS_movupd;
+            return (aligned) ? INS_movapd : INS_movupd;
         }
         else
         {

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2036,7 +2036,7 @@ void Compiler::lvaSetStruct(unsigned varNum, CORINFO_CLASS_HANDLE typeHnd, bool 
     }
 
 #ifndef _TARGET_64BIT_
-    bool fDoubleAlignHint = FALSE;
+    BOOL fDoubleAlignHint = FALSE;
 #ifdef _TARGET_X86_
     fDoubleAlignHint = TRUE;
 #endif

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -177,6 +177,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             break;
 
         case GT_LCL_FLD:
+        case GT_LCL_VAR:
             info->srcCount = 0;
             info->dstCount = 1;
 
@@ -2195,6 +2196,18 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* putArgStk)
         return;
     }
 #endif // _TARGET_X86_
+
+#if defined(FEATURE_SIMD) && defined(_TARGET_X86_)
+    // For PutArgStk of a TYP_SIMD12, we need an extra register.
+    if (putArgStk->TypeGet() == TYP_SIMD12)
+    {
+        info->srcCount           = putArgStk->gtOp1->gtLsraInfo.dstCount;
+        info->dstCount           = 0;
+        info->internalFloatCount = 1;
+        info->setInternalCandidates(l, l->allSIMDRegs());
+        return;
+    }
+#endif // defined(FEATURE_SIMD) && defined(_TARGET_X86_)
 
     if (putArgStk->TypeGet() != TYP_STRUCT)
     {

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -593,7 +593,7 @@ private:
     regNumber rotateBlockStartLocation(Interval* interval, regNumber targetReg, regMaskTP availableRegs);
 
     // This controls whether we always insert a GT_RELOAD instruction after a spill
-    // Note that this can be combined with LsraSpillAlways (or not)
+    // Note that this can be combined with LSRA_SPILL_ALWAYS (or not)
     enum LsraReload{LSRA_NO_RELOAD_IF_SAME = 0, LSRA_ALWAYS_INSERT_RELOAD = 0x400, LSRA_RELOAD_MASK = 0x400};
     LsraReload getLsraReload()
     {

--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -3175,6 +3175,16 @@ var_types Compiler::tmpNormalizeType(var_types type)
 
     type = genActualType(type);
 
+#if defined(FEATURE_SIMD) && !defined(_TARGET_64BIT_)
+    // For SIMD on 32-bit platforms, we always spill SIMD12 to a 16-byte SIMD16 temp.
+    // This is because we don't have a single instruction to store 12 bytes. We also
+    // allocate non-argument locals as 16 bytes; see lvSize().
+    if (type == TYP_SIMD12)
+    {
+        type = TYP_SIMD16;
+    }
+#endif // defined(FEATURE_SIMD) && !defined(_TARGET_64BIT_)
+
 #else  // LEGACY_BACKEND
     if (!varTypeIsGC(type))
     {

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -360,6 +360,9 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
 
 #endif // !LEGACY_BACKEND
 
+#ifdef FEATURE_SIMD
+  #define ALIGN_SIMD_TYPES         1       // whether SIMD type locals are to be aligned
+#endif // FEATURE_SIMD
 
   #define FEATURE_WRITE_BARRIER    1       // Generate the proper WriteBarrier calls for GC
   #define FEATURE_FIXED_OUT_ARGS   0       // X86 uses push instructions to pass args


### PR DESCRIPTION
There is no native load/store instruction for Vector3/TYP_SIMD12,
so we need to break this type down into two loads or two stores,
with an additional instruction to put the values together in the
xmm target register. AMD64 SIMD support already implements most of
this. For RyuJIT/x86, we need to implement stack argument support
(both incoming and outgoing), which is different from the AMD64 ABI.

In addition, this change implements accurate alignment-sensitive
codegen for all SIMD types. For RyuJIT/x86, the stack is only 4
byte aligned (unless we have double alignment), so SIMD locals are
not known to be aligned (TYP_SIMD8 could be with double alignment).
For AMD64, we were unnecessarily pessimizing alignment information,
and were always generating unaligned moves when on AVX2 hardware.
Now, all SIMD types are given their preferred alignment in
getSIMDTypeAlignment() and alignment determination in
isSIMDTypeLocalAligned() takes into account stack alignment (it
still needs support for x86 dynamic alignment). X86 still needs to
consider dynamic stack alignment for SIMD locals.

Fixes #7863