### PR TITLE
Fixed string Join method

### DIFF
--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -558,15 +558,13 @@ namespace System
                 throw new ArgumentNullException(nameof(values));
             Contract.EndContractBlock();
 
-            if (values.Length == 0 || values[0] == null)
+            if (values.Length == 0)
                 return string.Empty;
 
-            string firstString = values[0].ToString();
+            string firstString = values[0]?.ToString();
 
             if (values.Length == 1)
-            {
                 return firstString ?? string.Empty;
-            }
 
             StringBuilder result = StringBuilderCache.Acquire();
             result.Append(firstString);


### PR DESCRIPTION
Fixed string Join(string separator, params object[] values) method.
Calling string.Join(",", null, 1, 2, 3); return empty string but should ",1,2,3".