### PR TITLE
Improve Math.DivRem performance

### DIFF
--- a/src/mscorlib/src/System/Globalization/IdnMapping.cs
+++ b/src/mscorlib/src/System/Globalization/IdnMapping.cs
@@ -710,8 +710,10 @@ namespace System.Globalization
                                             k >= bias + tmax ? tmax : k - bias;
                                     if (q < t) break;
                                     Contract.Assert(punycodeBase != t, "[IdnMapping.punycode_encode]Expected punycodeBase (36) to be != t");
-                                    output.Append(encode_digit(t + (q - t) % (punycodeBase - t)));
-                                    q = (q - t) / (punycodeBase - t);
+
+                                    int mod;
+                                    q = Math.DivRem(q - t, punycodeBase - t, out mod);
+                                    output.Append(encode_digit(t + mod));
                                 }
 
                                 output.Append(encode_digit(q));

--- a/src/mscorlib/src/System/Math.cs
+++ b/src/mscorlib/src/System/Math.cs
@@ -726,13 +726,21 @@ namespace System {
         }
 
         public static int DivRem(int a, int b, out int result) {
-            result =  a%b;
-            return a/b;
+            // TODO https://github.com/dotnet/coreclr/issues/3439:
+            // Restore to using % and / when the JIT is able to eliminate one of the idivs.
+            // In the meantime, a * and - is measurably faster than an extra /.
+            int div = a / b;
+            result = a - (div * b);
+            return div;
         }
 
         public static long DivRem(long a, long b, out long result) {
-            result =  a%b;
-            return a/b;
+            // TODO https://github.com/dotnet/coreclr/issues/3439:
+            // Restore to using % and / when the JIT is able to eliminate one of the idivs.
+            // In the meantime, a * and - is measurably faster than an extra /.
+            long div = a / b;
+            result = a - (div * b);
+            return div;
         }
     }
 }


### PR DESCRIPTION
Per the discussion at https://github.com/dotnet/coreclr/issues/3439, this PR at least temporarily changes the implementation of Math.DivRem to avoid two idiv instructions.  It then replaces a few % and / pairs in mscorlib with Math.DivRem.

Perf test:
```C#
using System;
using System.Diagnostics;

class Program
{
    static long div, rem, a, b;

    static void Main()
    {
        // Various sets of a/b inputs
        var pairs = new[]
        {
            Tuple.Create<long, long>(0, 1),
            Tuple.Create<long, long>(4, 2),
            Tuple.Create<long, long>(99, 10),
            Tuple.Create<long, long>(-99, -10),
            Tuple.Create<long, long>(-99, 10),
            Tuple.Create<long, long>(4, 12),
            Tuple.Create<long, long>(1, long.MaxValue),
            Tuple.Create<long, long>(long.MaxValue, 1),
            Tuple.Create<long, long>(long.MaxValue, 3),
            Tuple.Create<long, long>(long.MaxValue, long.MaxValue - 1),
        };
        const int Iters = 50000000;

        // Time the old and the new on each input
        var sw = new Stopwatch();
        foreach (Tuple<long, long> t in pairs)
        {
            a = t.Item1;
            b = t.Item2;

            sw.Restart();
            for (int i = 0; i < Iters; i++) div = DivRem_Old(a, b, out rem);
            sw.Stop();
            TimeSpan oldTime = sw.Elapsed;

            sw.Restart();
            for (int i = 0; i < Iters; i++) div = DivRem_New(a, b, out rem);
            sw.Stop();
            TimeSpan newTime = sw.Elapsed;

            Console.WriteLine($"Old: {oldTime} New: {newTime}");
        }
    }

    public static long DivRem_Old(long a, long b, out long result)
    {
        result = a % b;
        return a / b;
    }

    public static long DivRem_New(long a, long b, out long result)
    {
        long div = a / b;
        result = a - (div * b);
        return div;
    }
}
```
outputs for me:
```
> corerun divremtest.exe
Old: 00:00:01.0659336 New: 00:00:00.5490556
Old: 00:00:01.0559024 New: 00:00:00.5516266
Old: 00:00:01.0675624 New: 00:00:00.5485116
Old: 00:00:01.0537601 New: 00:00:00.5483118
Old: 00:00:01.0612407 New: 00:00:00.5526581
Old: 00:00:01.0874783 New: 00:00:00.5545691
Old: 00:00:01.1375759 New: 00:00:00.5528239
Old: 00:00:01.0875608 New: 00:00:00.5720249
Old: 00:00:01.1346930 New: 00:00:00.6171032
Old: 00:00:01.1621859 New: 00:00:00.5689636
```

cc: @jkotas, @mikedn, @redknightlois