### PR TITLE
Fix value numbering for FieldSeqStore::NotAField.

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -2692,7 +2692,7 @@ ValueNum ValueNumStore::ExtendPtrVN(GenTreePtr opA, FieldSeqNode* fldSeq)
         assert(GetVNFunc(VNNormVal(opA->GetVN(VNK_Conservative)), &consFuncApp) && consFuncApp.Equals(funcApp));
 #endif
         ValueNum fldSeqVN = VNForFieldSeq(fldSeq);
-        res               = VNForFunc(TYP_BYREF, VNF_PtrToLoc, funcApp.m_args[0], FieldSeqVNAppend(funcApp.m_args[1], fldSeqVN));
+        res = VNForFunc(TYP_BYREF, VNF_PtrToLoc, funcApp.m_args[0], FieldSeqVNAppend(funcApp.m_args[1], fldSeqVN));
     }
     else if (funcApp.m_func == VNF_PtrToStatic)
     {
@@ -6075,7 +6075,9 @@ void Compiler::fgValueNumberTree(GenTreePtr tree, bool evalAsgLhsInd)
                 if (newVN == ValueNumStore::NoVN)
                 {
                     assert(arg->gtLclVarCommon.GetSsaNum() != ValueNumStore::NoVN);
-                    newVN = vnStore->VNForFunc(TYP_BYREF, VNF_PtrToLoc, vnStore->VNForIntCon(arg->gtLclVarCommon.GetLclNum()), vnStore->VNForFieldSeq(fieldSeq));
+                    newVN = vnStore->VNForFunc(TYP_BYREF, VNF_PtrToLoc,
+                                               vnStore->VNForIntCon(arg->gtLclVarCommon.GetLclNum()),
+                                               vnStore->VNForFieldSeq(fieldSeq));
                 }
                 tree->gtVNPair.SetBoth(newVN);
             }

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -76,7 +76,6 @@ ValueNumStore::ValueNumStore(Compiler* comp, IAllocator* alloc)
     , m_VNFunc2Map(nullptr)
     , m_VNFunc3Map(nullptr)
     , m_VNFunc4Map(nullptr)
-    , m_uPtrToLocNotAFieldCount(1)
 {
     // We have no current allocation chunks.
     for (unsigned i = 0; i < TYP_COUNT; i++)
@@ -604,6 +603,7 @@ ValueNumStore::Chunk::Chunk(
     switch (attribs)
     {
         case CEA_None:
+        case CEA_NotAField:
             break; // Nothing to do.
         case CEA_Const:
             switch (typ)
@@ -911,6 +911,7 @@ class Object* ValueNumStore::s_specialRefConsts[] = {nullptr, nullptr, nullptr};
 ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func)
 {
     assert(VNFuncArity(func) == 0);
+    assert(func != VNF_NotAField);
 
     ValueNum res;
 
@@ -2551,6 +2552,11 @@ ValueNumPair ValueNumStore::VNPairApplySelectors(ValueNumPair map, FieldSeqNode*
     return ValueNumPair(liberalVN, conservVN);
 }
 
+bool ValueNumStore::IsVNNotAField(ValueNum vn)
+{
+    return m_chunks.GetNoExpand(GetChunkNum(vn))->m_attribs == CEA_NotAField;
+}
+
 ValueNum ValueNumStore::VNForFieldSeq(FieldSeqNode* fieldSeq)
 {
     if (fieldSeq == nullptr)
@@ -2559,7 +2565,11 @@ ValueNum ValueNumStore::VNForFieldSeq(FieldSeqNode* fieldSeq)
     }
     else if (fieldSeq == FieldSeqStore::NotAField())
     {
-        return VNForNotAField();
+        // We always allocate a new, unique VN in this call.
+        Chunk*   c                 = GetAllocChunk(TYP_REF, CEA_NotAField);
+        unsigned offsetWithinChunk = c->AllocVN();
+        ValueNum result            = c->m_baseVN + offsetWithinChunk;
+        return result;
     }
     else
     {
@@ -2591,22 +2601,22 @@ FieldSeqNode* ValueNumStore::FieldSeqVNToFieldSeq(ValueNum vn)
     {
         return nullptr;
     }
-    else if (vn == VNForNotAField())
+
+    assert(IsVNFunc(vn));
+
+    VNFuncApp funcApp;
+    GetVNFunc(vn, &funcApp);
+    if (funcApp.m_func == VNF_NotAField)
     {
         return FieldSeqStore::NotAField();
     }
-    else
-    {
-        assert(IsVNFunc(vn));
-        VNFuncApp funcApp;
-        GetVNFunc(vn, &funcApp);
-        assert(funcApp.m_func == VNF_FieldSeq);
-        ssize_t       fieldHndVal = ConstantValue<ssize_t>(funcApp.m_args[0]);
-        FieldSeqNode* head =
-            m_pComp->GetFieldSeqStore()->CreateSingleton(reinterpret_cast<CORINFO_FIELD_HANDLE>(fieldHndVal));
-        FieldSeqNode* tail = FieldSeqVNToFieldSeq(funcApp.m_args[1]);
-        return m_pComp->GetFieldSeqStore()->Append(head, tail);
-    }
+
+    assert(funcApp.m_func == VNF_FieldSeq);
+    const ssize_t fieldHndVal = ConstantValue<ssize_t>(funcApp.m_args[0]);
+    FieldSeqNode* head =
+        m_pComp->GetFieldSeqStore()->CreateSingleton(reinterpret_cast<CORINFO_FIELD_HANDLE>(fieldHndVal));
+    FieldSeqNode* tail = FieldSeqVNToFieldSeq(funcApp.m_args[1]);
+    return m_pComp->GetFieldSeqStore()->Append(head, tail);
 }
 
 ValueNum ValueNumStore::FieldSeqVNAppend(ValueNum fsVN1, ValueNum fsVN2)
@@ -2615,40 +2625,31 @@ ValueNum ValueNumStore::FieldSeqVNAppend(ValueNum fsVN1, ValueNum fsVN2)
     {
         return fsVN2;
     }
-    else if (fsVN1 == VNForNotAField() || fsVN2 == VNForNotAField())
+
+    assert(IsVNFunc(fsVN1));
+
+    VNFuncApp funcApp1;
+    GetVNFunc(fsVN1, &funcApp1);
+
+    if ((funcApp1.m_func == VNF_NotAField) || IsVNNotAField(fsVN2))
     {
-        return VNForNotAField();
+        return VNForFieldSeq(FieldSeqStore::NotAField());
     }
-    else
-    {
-        assert(IsVNFunc(fsVN1));
-        VNFuncApp funcApp1;
-        GetVNFunc(fsVN1, &funcApp1);
-        assert(funcApp1.m_func == VNF_FieldSeq);
-        ValueNum tailRes    = FieldSeqVNAppend(funcApp1.m_args[1], fsVN2);
-        ValueNum fieldSeqVN = VNForFunc(TYP_REF, VNF_FieldSeq, funcApp1.m_args[0], tailRes);
+
+    assert(funcApp1.m_func == VNF_FieldSeq);
+    ValueNum tailRes    = FieldSeqVNAppend(funcApp1.m_args[1], fsVN2);
+    ValueNum fieldSeqVN = VNForFunc(TYP_REF, VNF_FieldSeq, funcApp1.m_args[0], tailRes);
 
 #ifdef DEBUG
-        if (m_pComp->verbose)
-        {
-            printf("  fieldSeq " STR_VN "%x is ", fieldSeqVN);
-            vnDump(m_pComp, fieldSeqVN);
-            printf("\n");
-        }
+    if (m_pComp->verbose)
+    {
+        printf("  fieldSeq " STR_VN "%x is ", fieldSeqVN);
+        vnDump(m_pComp, fieldSeqVN);
+        printf("\n");
+    }
 #endif
 
-        return fieldSeqVN;
-    }
-}
-
-ValueNum ValueNumStore::VNForPtrToLoc(var_types typ, ValueNum lclVarVN, ValueNum fieldSeqVN)
-{
-    if (fieldSeqVN == VNForNotAField())
-    {
-        // To distinguish two different not a fields, append a unique value.
-        return VNForFunc(typ, VNF_PtrToLoc, lclVarVN, fieldSeqVN, VNForIntCon(++m_uPtrToLocNotAFieldCount));
-    }
-    return VNForFunc(typ, VNF_PtrToLoc, lclVarVN, fieldSeqVN, VNForIntCon(0));
+    return fieldSeqVN;
 }
 
 ValueNum ValueNumStore::ExtendPtrVN(GenTreePtr opA, GenTreePtr opB)
@@ -2691,7 +2692,7 @@ ValueNum ValueNumStore::ExtendPtrVN(GenTreePtr opA, FieldSeqNode* fldSeq)
         assert(GetVNFunc(VNNormVal(opA->GetVN(VNK_Conservative)), &consFuncApp) && consFuncApp.Equals(funcApp));
 #endif
         ValueNum fldSeqVN = VNForFieldSeq(fldSeq);
-        res               = VNForPtrToLoc(TYP_BYREF, funcApp.m_args[0], FieldSeqVNAppend(funcApp.m_args[1], fldSeqVN));
+        res               = VNForFunc(TYP_BYREF, VNF_PtrToLoc, funcApp.m_args[0], FieldSeqVNAppend(funcApp.m_args[1], fldSeqVN));
     }
     else if (funcApp.m_func == VNF_PtrToStatic)
     {
@@ -3405,6 +3406,7 @@ bool ValueNumStore::IsVNFunc(ValueNum vn)
     Chunk* c = m_chunks.GetNoExpand(GetChunkNum(vn));
     switch (c->m_attribs)
     {
+        case CEA_NotAField:
         case CEA_Func0:
         case CEA_Func1:
         case CEA_Func2:
@@ -3437,8 +3439,8 @@ bool ValueNumStore::GetVNFunc(ValueNum vn, VNFuncApp* funcApp)
             funcApp->m_args[1]   = farg4->m_arg1;
             funcApp->m_args[2]   = farg4->m_arg2;
             funcApp->m_args[3]   = farg4->m_arg3;
-        }
             return true;
+        }
         case CEA_Func3:
         {
             VNDefFunc3Arg* farg3 = &reinterpret_cast<VNDefFunc3Arg*>(c->m_defs)[offset];
@@ -3447,8 +3449,8 @@ bool ValueNumStore::GetVNFunc(ValueNum vn, VNFuncApp* funcApp)
             funcApp->m_args[0]   = farg3->m_arg0;
             funcApp->m_args[1]   = farg3->m_arg1;
             funcApp->m_args[2]   = farg3->m_arg2;
-        }
             return true;
+        }
         case CEA_Func2:
         {
             VNDefFunc2Arg* farg2 = &reinterpret_cast<VNDefFunc2Arg*>(c->m_defs)[offset];
@@ -3456,23 +3458,29 @@ bool ValueNumStore::GetVNFunc(ValueNum vn, VNFuncApp* funcApp)
             funcApp->m_arity     = 2;
             funcApp->m_args[0]   = farg2->m_arg0;
             funcApp->m_args[1]   = farg2->m_arg1;
-        }
             return true;
+        }
         case CEA_Func1:
         {
             VNDefFunc1Arg* farg1 = &reinterpret_cast<VNDefFunc1Arg*>(c->m_defs)[offset];
             funcApp->m_func      = farg1->m_func;
             funcApp->m_arity     = 1;
             funcApp->m_args[0]   = farg1->m_arg0;
-        }
             return true;
+        }
         case CEA_Func0:
         {
             VNDefFunc0Arg* farg0 = &reinterpret_cast<VNDefFunc0Arg*>(c->m_defs)[offset];
             funcApp->m_func      = farg0->m_func;
             funcApp->m_arity     = 0;
-        }
             return true;
+        }
+        case CEA_NotAField:
+        {
+            funcApp->m_func  = VNF_NotAField;
+            funcApp->m_arity = 0;
+            return true;
+        }
         default:
             return false;
     }
@@ -3864,10 +3872,9 @@ static const char* s_reservedNameArr[] = {
     "$VN.No",           // -1  NoVN
     "$VN.Null",         //  0  VNForNull()
     "$VN.ZeroMap",      //  1  VNForZeroMap()
-    "$VN.NotAField",    //  2  VNForNotAField()
-    "$VN.ReadOnlyHeap", //  3  VNForROH()
-    "$VN.Void",         //  4  VNForVoid()
-    "$VN.EmptyExcSet"   //  5  VNForEmptyExcSet()
+    "$VN.ReadOnlyHeap", //  2  VNForROH()
+    "$VN.Void",         //  3  VNForVoid()
+    "$VN.EmptyExcSet"   //  4  VNForEmptyExcSet()
 };
 
 // Returns the string name of "vn" when it is a reserved value number, nullptr otherwise
@@ -6068,8 +6075,7 @@ void Compiler::fgValueNumberTree(GenTreePtr tree, bool evalAsgLhsInd)
                 if (newVN == ValueNumStore::NoVN)
                 {
                     assert(arg->gtLclVarCommon.GetSsaNum() != ValueNumStore::NoVN);
-                    newVN = vnStore->VNForPtrToLoc(TYP_BYREF, vnStore->VNForIntCon(arg->gtLclVarCommon.GetLclNum()),
-                                                   vnStore->VNForFieldSeq(fieldSeq));
+                    newVN = vnStore->VNForFunc(TYP_BYREF, VNF_PtrToLoc, vnStore->VNForIntCon(arg->gtLclVarCommon.GetLclNum()), vnStore->VNForFieldSeq(fieldSeq));
                 }
                 tree->gtVNPair.SetBoth(newVN);
             }

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -841,16 +841,16 @@ private:
 
     DECLARE_TYPED_ENUM(ChunkExtraAttribs, BYTE)
     {
-        CEA_None,      // No extra attributes.
-        CEA_Const,     // This chunk contains constant values.
-        CEA_Handle,    // This chunk contains handle constants.
-        CEA_NotAField, // This chunk contains "not a field" values.
-        CEA_Func0,     // Represents functions of arity 0.
-        CEA_Func1,     // ...arity 1.
-        CEA_Func2,     // ...arity 2.
-        CEA_Func3,     // ...arity 3.
-        CEA_Func4,     // ...arity 4.
-        CEA_Count
+        CEA_None,          // No extra attributes.
+            CEA_Const,     // This chunk contains constant values.
+            CEA_Handle,    // This chunk contains handle constants.
+            CEA_NotAField, // This chunk contains "not a field" values.
+            CEA_Func0,     // Represents functions of arity 0.
+            CEA_Func1,     // ...arity 1.
+            CEA_Func2,     // ...arity 2.
+            CEA_Func3,     // ...arity 3.
+            CEA_Func4,     // ...arity 4.
+            CEA_Count
     }
     END_DECLARE_TYPED_ENUM(ChunkExtraAttribs, BYTE);
 

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -297,13 +297,6 @@ public:
         return ValueNum(SRC_ZeroMap);
     }
 
-    // The value number for the special "NotAField" field sequence.
-    static ValueNum VNForNotAField()
-    {
-        // We reserve Chunk 0 for "special" VNs.  Let SRC_NotAField (== 2) be the "not a field seq".
-        return ValueNum(SRC_NotAField);
-    }
-
     // The ROH map is the map for the "read-only heap".  We assume that this is never mutated, and always
     // has the same value number.
     static ValueNum VNForROH()
@@ -504,6 +497,9 @@ public:
                                bool         srcIsUnsigned    = false,
                                bool         hasOverflowCheck = false);
 
+    // Returns true iff the VN represents an application of VNF_NotAField.
+    bool IsVNNotAField(ValueNum vn);
+
     // PtrToLoc values need to express a field sequence as one of their arguments.  VN for null represents
     // empty sequence, otherwise, "FieldSeq(VN(FieldHandle), restOfSeq)".
     ValueNum VNForFieldSeq(FieldSeqNode* fieldSeq);
@@ -515,12 +511,6 @@ public:
     // Both argument must represent field sequences; returns the value number representing the
     // concatenation "fsVN1 || fsVN2".
     ValueNum FieldSeqVNAppend(ValueNum fsVN1, ValueNum fsVN2);
-
-    // Requires "lclVarVN" be a value number for a GT_LCL_VAR pointer tree.
-    // Requires "fieldSeqVN" be a field sequence value number.
-    // Requires "typ" to be a TYP_REF/TYP_BYREF used for VNF_PtrToLoc.
-    // When "fieldSeqVN" is VNForNotAField, a unique VN is generated using m_uPtrToLocNotAFieldCount.
-    ValueNum VNForPtrToLoc(var_types typ, ValueNum lclVarVN, ValueNum fieldSeqVN);
 
     // If "opA" has a PtrToLoc, PtrToArrElem, or PtrToStatic application as its value numbers, and "opB" is an integer
     // with a "fieldSeq", returns the VN for the pointer form extended with the field sequence; or else NoVN.
@@ -851,15 +841,16 @@ private:
 
     DECLARE_TYPED_ENUM(ChunkExtraAttribs, BYTE)
     {
-        CEA_None,       // No extra attributes.
-            CEA_Const,  // This chunk contains constant values.
-            CEA_Handle, // This chunk contains handle constants.
-            CEA_Func0,  // Represents functions of arity 0.
-            CEA_Func1,  // ...arity 1.
-            CEA_Func2,  // ...arity 2.
-            CEA_Func3,  // ...arity 3.
-            CEA_Func4,  // ...arity 4.
-            CEA_Count
+        CEA_None,      // No extra attributes.
+        CEA_Const,     // This chunk contains constant values.
+        CEA_Handle,    // This chunk contains handle constants.
+        CEA_NotAField, // This chunk contains "not a field" values.
+        CEA_Func0,     // Represents functions of arity 0.
+        CEA_Func1,     // ...arity 1.
+        CEA_Func2,     // ...arity 2.
+        CEA_Func3,     // ...arity 3.
+        CEA_Func4,     // ...arity 4.
+        CEA_Count
     }
     END_DECLARE_TYPED_ENUM(ChunkExtraAttribs, BYTE);
 
@@ -1260,17 +1251,12 @@ private:
     {
         SRC_Null,
         SRC_ZeroMap,
-        SRC_NotAField,
         SRC_ReadOnlyHeap,
         SRC_Void,
         SRC_EmptyExcSet,
 
         SRC_NumSpecialRefConsts
     };
-
-    // Counter to keep track of all the unique not a field sequences that have been assigned to
-    // PtrToLoc, because the ptr was added to an offset that was not a field.
-    unsigned m_uPtrToLocNotAFieldCount;
 
     // The "values" of special ref consts will be all be "null" -- their differing meanings will
     // be carried by the distinct value numbers.

--- a/src/jit/valuenumfuncs.h
+++ b/src/jit/valuenumfuncs.h
@@ -11,9 +11,10 @@ ValueNumFuncDef(MapStore, 3, false, false, false)
 ValueNumFuncDef(MapSelect, 2, false, false, false)
 
 ValueNumFuncDef(FieldSeq, 2, false, false, false)   // Sequence (VN of null == empty) of (VN's of) field handles.
+ValueNumFuncDef(NotAField, 0, false, false, false)  // Value number function for FieldSeqStore::NotAField.
 ValueNumFuncDef(ZeroMap, 0, false, false, false)    // The "ZeroMap": indexing at any index yields "zero of the desired type".
 
-ValueNumFuncDef(PtrToLoc, 3, false, false, false)           // Pointer (byref) to a local variable.  Args: VN's of: 0: var num, 1: FieldSeq, 2: Unique value for this PtrToLoc.
+ValueNumFuncDef(PtrToLoc, 2, false, false, false)           // Pointer (byref) to a local variable.  Args: VN's of: 0: var num, 1: FieldSeq.
 ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: FieldSeq.
 ValueNumFuncDef(PtrToStatic, 1, false, false, false)        // Pointer (byref) to a static variable (or possibly a field thereof, if the static variable is a struct).  Args: 0: FieldSeq, first element
                                                      // of which is the static var.

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8133/GitHub_8133.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8133/GitHub_8133.il
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly a {}
+
+// The original repro for this test was SBCG due to incorrect computation of value numbers for the ref-typed locals
+// in Test::Main(). Despite the fact that each local refers to a different array element, all of the locals were
+// assigned the same value number.
+
+.class Test extends [mscorlib]System.Object
+{
+    .method static void Equal(int32 i, int32 j) cil noinlining
+    {
+        ldarg.0
+        ldarg.1
+        bne.un.s fail
+        ret
+
+fail:
+        newobj instance void [mscorlib]System.Exception::.ctor()
+        throw
+    }
+
+    .method static !!0& Add<T>(!!0& addr, int32 offset)
+    {
+        ldarg.0
+        ldarg.1
+        sizeof !!0
+        conv.i
+        mul
+        add
+        ret
+    }
+
+    .method public hidebysig static int32 RefAdd() cil managed
+    {
+        .entrypoint
+
+        .locals init (
+            [0] int32[] a,
+            [1] int32& r1,
+            [2] int32& r2,
+            [3] int32& r3)
+
+        ldc.i4.4
+        newarr [mscorlib]System.Int32
+        dup
+        ldtoken field valuetype '<PrivateImplementationDetails>'/'__StaticArrayInitTypeSize=16' '<PrivateImplementationDetails>'::'6E9F9131664668938673AFE814BBDE210C6AE91F'
+        call void [mscorlib]System.Runtime.CompilerServices.RuntimeHelpers::InitializeArray(class [mscorlib]System.Array, valuetype [mscorlib]System.RuntimeFieldHandle)
+        stloc.0
+
+        ldloc.0
+        ldc.i4.0
+        ldelema [mscorlib]System.Int32
+        ldc.i4.1
+        call !!0& Test::Add<int32>(!!0&, int32)
+        stloc.1
+        ldc.i4     0x234
+        ldloc.1
+        ldind.i4
+        call void Test::Equal(int32, int32)
+
+        ldloc.1
+        ldc.i4.2
+        call !!0& Test::Add<int32>(!!0&, int32)
+        stloc.2
+        ldc.i4 0x456
+        ldloc.2
+        ldind.i4
+        call void Test::Equal(int32, int32)
+
+        ldloc.2
+        ldc.i4.s   -3
+        call !!0& Test::Add<int32>(!!0&, int32)
+        stloc.3
+        ldc.i4 0x123
+        ldloc.3
+        ldind.i4
+        call void Test::Equal(int32, int32)
+
+        ldc.i4 100
+        ret
+    }
+}
+
+.class private auto ansi sealed '<PrivateImplementationDetails>'
+       extends [mscorlib]System.Object
+{
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .class explicit ansi sealed nested private '__StaticArrayInitTypeSize=16'
+         extends [mscorlib]System.ValueType
+    {
+        .pack 1
+        .size 16
+    }
+
+    .field static assembly initonly int32 '4C55E5E5FC2235CC8C201E69A345F7FAB3FB46FA' at I_000054DC
+    .field static assembly initonly int64 '67423EBFA8454F19AC6F4686D6C0DC731A3DDD6B' at I_000054E4
+    .field static assembly initonly valuetype '<PrivateImplementationDetails>'/'__StaticArrayInitTypeSize=16' '6E9F9131664668938673AFE814BBDE210C6AE91F' at I_000054EC
+    .field static assembly initonly int32 '9BCE73D0C8B9ECA4F24154F3BD3B8AA473B1C3A9' at I_000054FC
+}
+
+.data cil I_000054DC = bytearray (
+                 42 42 42 42)                                     // BBBB
+.data cil I_000054E4 = bytearray (
+                 00 01 02 03 04 05 06 07) 
+.data cil I_000054EC = bytearray (
+                 23 01 00 00 34 02 00 00 45 03 00 00 56 04 00 00) // #...4...E...V...
+.data cil I_000054FC = bytearray (
+                 12 34 56 78)                                     // .4Vx

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8133/GitHub_8133.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8133/GitHub_8133.ilproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_8133.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Before this change, value numbering produced the same value number for
each occurrence of `FieldSeqStore::NotAField`. This semantics is not
logically consistent with the semantics of `NotAField`, however:
`NotAField` indicates that we cannot reason about the address expression
that it annotates, therefore we cannot reason about the value stored at
the corresponding location. A recent change to admit the VN for
`NotAField` in `ExtendPtrVN` exposed SBCG due to this mismatch in
semantics: distinct array elements were assigned the same value number
because each had the same base coupled with the `NotAField` VN.

This change revises the representation of `NotAField` during value
numbering: instead of reusing the same value number for each
occurrence of `NotAField`, each occurrence is instead assigned a new,
unique value number. These value numbers are represented using a new
chunk attribute to retain the ability to decide whether or not a value
number represents `NotAField` without the use of a more heavyweight map
(e.g. a `VNMap`).

Fixes #8133.