### PR TITLE
Tweak params

### DIFF
--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -837,9 +837,9 @@ namespace System
     public static partial class Console
     {
         [System.Security.SecuritySafeCriticalAttribute]
-        public static void Write(string s) { }
+        public static void Write(string value) { }
         public static void WriteLine() { }
-        public static void WriteLine(string s) { }
+        public static void WriteLine(string value) { }
     }
     public static partial class Convert
     {


### PR DESCRIPTION
This isn't the implementation of Console we ship, apparently it's only here for CLR tests, or maybe shouldn't be at all. Just tweaking the param names to match what we ship so it doesn't show up in the diffs.