### PR TITLE
Add RuntimeHelpers.Equals

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6421,6 +6421,7 @@
       <Member MemberType="Field" Name="value__" />
     </Type>
     <Type Name="System.Runtime.CompilerServices.RuntimeHelpers">
+      <Member Name="Equals(System.Object,System.Object)" />
       <Member Name="GetUninitializedObject(System.Type)" />
       <Member Name="EnsureSufficientExecutionStack" />
       <Member Name="TryEnsureSufficientExecutionStack" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -10276,6 +10276,7 @@ namespace System.Runtime.CompilerServices
     }
     public static partial class RuntimeHelpers
     {
+        public static new bool Equals(object o1, object o2) { throw null; }    
         public static int OffsetToStringData { get { throw null; } }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.InternalCall)][System.Security.SecuritySafeCriticalAttribute]
         public static void EnsureSufficientExecutionStack() { }


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/13692

We added this to the ref in 19fa781 but it was not present in the impl. The tools didn't flag this perhaps because Equals is available on Object, although since this is a `new` it really ought to know it wasn't referring to the Object one.

@AlexGhiondea 