### PR TITLE
Generic Dictionary - add constructor that accepts IEnumerable

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -644,6 +644,8 @@
       <Member Name="#ctor" />
       <Member Name="#ctor(System.Collections.Generic.IDictionary&lt;TKey,TValue&gt;)" />
       <Member Name="#ctor(System.Collections.Generic.IDictionary&lt;TKey,TValue&gt;,System.Collections.Generic.IEqualityComparer&lt;TKey&gt;)" />
+      <Member Name="#ctor(System.Collections.Generic.IEnumerable&lt;System.Collections.Generic.KeyValuePair&lt;TKey,TValue&gt;&gt;)" />
+      <Member Name="#ctor(System.Collections.Generic.IEnumerable&lt;System.Collections.Generic.KeyValuePair&lt;TKey,TValue&gt;&gt;,System.Collections.Generic.IEqualityComparer&lt;TKey&gt;)" />
       <Member Name="#ctor(System.Collections.Generic.IEqualityComparer&lt;TKey&gt;)" />
       <Member Name="#ctor(System.Int32)" />
       <Member Name="#ctor(System.Int32,System.Collections.Generic.IEqualityComparer&lt;TKey&gt;)" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -4473,6 +4473,8 @@ namespace System.Collections.Generic
         public Dictionary() { }
         public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+        public Dictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection) { }
+        public Dictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
         public Dictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
         public Dictionary(int capacity) { }
         public Dictionary(int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }

--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -129,6 +129,21 @@ namespace System.Collections.Generic {
             }
         }
 
+        public Dictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection):
+            this(collection, null) { }
+
+        public Dictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey> comparer):
+            this((collection as ICollection<KeyValuePair<TKey, TValue>>)?.Count ?? 0, comparer)
+        {
+            if (collection == null) {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);
+            }
+
+            foreach (KeyValuePair<TKey, TValue> pair in collection) {
+                Add(pair.Key, pair.Value);
+            }
+        }
+
         protected Dictionary(SerializationInfo info, StreamingContext context) {
             //We can't do anything with the keys and values until the entire graph has been deserialized
             //and we have a resonable estimate that GetHashCode is not going to fail.  For the time being,


### PR DESCRIPTION
Hi,

during the conversation on https://github.com/dotnet/corefx/issues/1378 I was explained that I need to update mscorelib dictionary first.

This pull request add two Dictionary constructors. One that takes only IEnumerable and use default comparer and another that takes IEnumerable and comparer.

You may notice that there is no test attached to that pull request. That's because I noticed that none of the generic classes have test in mscorelib and assumed that the test will be added in CoreFx after commiting the changes in CoreClr. If I'm wrong, I'm happy to add additional tests for mscorelib.

