### PR TITLE
Fix x86 long compares that produce a result

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5802,10 +5802,6 @@ void CodeGen::genCompareLong(GenTreePtr treeNode)
         emitJumpKind jumpKindLo = genJumpKindForOper(tree->gtOper, CK_UNSIGNED);
 
         inst_SET(jumpKindLo, targetReg);
-        // Set the higher bytes to 0
-        inst_RV_RV(ins_Move_Extend(TYP_UBYTE, true), targetReg, targetReg, TYP_UBYTE, emitTypeSize(TYP_UBYTE));
-        genProduceReg(tree);
-
         inst_JMP(EJ_jmp, labelFinal);
 
         // Define the label for hi jump target here. If we have jumped here, we want to set
@@ -5814,11 +5810,10 @@ void CodeGen::genCompareLong(GenTreePtr treeNode)
         genDefineTempLabel(labelHi);
         inst_SET(genJumpKindForOper(tree->gtOper, compareKind), targetReg);
 
+        genDefineTempLabel(labelFinal);
         // Set the higher bytes to 0
         inst_RV_RV(ins_Move_Extend(TYP_UBYTE, true), targetReg, targetReg, TYP_UBYTE, emitTypeSize(TYP_UBYTE));
         genProduceReg(tree);
-
-        genDefineTempLabel(labelFinal);
     }
     else
     {


### PR DESCRIPTION
Remove the duplicate genProduceReg call. Also remove an unnecessary movzx.

Fixes #8163 

The code generated now is
```
       FF500C       call     dword ptr [eax+12]System.Func`2[Nullable`1,Nullable`1][System.Nullable`1[System.Int64],System.Nullable`1[System.Int64]]:Invoke(struct):struct:this
       8B4DB8       mov      ecx, dword ptr [ebp-48H]
       8B45BC       mov      eax, dword ptr [ebp-44H]
       3BC3         cmp      eax, ebx
       7507         jne      SHORT G_M55891_IG13
       3BCF         cmp      ecx, edi
       0F97C2       seta     dl
       EB03         jmp      SHORT G_M55891_IG14

G_M55891_IG13:
       0F9FC2       setg     dl

G_M55891_IG14:
       0FB6D2       movzx    edx, dl
       899568FFFFFF mov      dword ptr [ebp-98H], edx
       8B55B0       mov      edx, dword ptr [ebp-50H]
       0FB6D2       movzx    edx, dl
       239568FFFFFF and      edx, dword ptr [ebp-98H]
```
