### PR TITLE
Curtail loop unroller epliog generation

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -3067,8 +3067,8 @@ void Compiler::optUnrollLoops()
 
             ClrSafeInt<unsigned> fixedLoopCostSz(8);
 
-            ClrSafeInt<int> unrollCostSz((loopCostSz * ClrSafeInt<unsigned>(totalIter)) -
-                                         (loopCostSz + fixedLoopCostSz));
+            ClrSafeInt<int> unrollCostSz = ClrSafeInt<int>(loopCostSz * ClrSafeInt<unsigned>(totalIter)) -
+                                           ClrSafeInt<int>(loopCostSz + fixedLoopCostSz);
 
             /* Don't unroll if too much code duplication would result. */
 


### PR DESCRIPTION
The Jit32 GC encoder puts a hard limit on the number of epilogs (at 4); in
this configuration, avoid unrolling any loops containing enough BBJ_RETURN
blocks to push us over that limit, the same way loop cloning is limited.

Also remove an unnecessary loop flag update to set DONT_UNROLL on some
unprofitable loops -- the loop unroller logic has been rearranged to avoid
reprocessing loops in the first place.

Fixes #8179.

Also includes a change to the overflow check in unroll cost calculation to
perform the subtraction on signed rather than unsigned ints; if the unroll
size is actually smaller than the fixed size estimate, unrolling is
profitable.