### PR TITLE
Fix the transformation of `(call ARRADDR_ST x, y, null)`.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8155,8 +8155,7 @@ NO_TAIL_CALL:
             }
 
 #ifdef DEBUG
-            auto resetMorphedFlag = [](GenTree** slot, fgWalkData* data) -> fgWalkResult
-            {
+            auto resetMorphedFlag = [](GenTree** slot, fgWalkData* data) -> fgWalkResult {
                 (*slot)->gtDebugFlags &= ~GTF_DEBUG_NODE_MORPHED;
                 return WALK_CONTINUE;
             };
@@ -8176,7 +8175,7 @@ NO_TAIL_CALL:
             {
                 assert(argSetupCursor != nullptr);
                 argSetupCursor->gtOp2 = result;
-                result = argSetup;
+                result                = argSetup;
             }
 
             return result;


### PR DESCRIPTION
`fgMorphCall` transforms `(call ARRADDR_ST x, y, null)` into
`(assign (arrindex x y) null)`. The transformation was not taking into
account the fact that the operands to the call might have been spilled
to temps, and was therefore silently dropping code in the case that they
had been.

This change collects all argument setup nodes in `gtCallArgs` in a
sequence of comma nodes if any exist and attaches the assignment
expression as the ultimate RHS of the comma tree.

Fixes #8150.