### PR TITLE
Revise mismatch tests so they don't rely on undefined behavior

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -204,12 +204,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\smallFrame\smallFrame.cmd">
             <Issue>tail. call pop ret is only supported on amd64</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\regression\mismatch32\mismatch32\mismatch32.cmd">
-            <Issue>needs triage: System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\regression\mismatch64\mismatch64\mismatch64.cmd">
-            <Issue>needs triage: System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd">
             <Issue>2420. x86 JIT doesn't support implicit tail call optimization or tail. call pop ret sequence</Issue>
         </ExcludeList>

--- a/tests/src/JIT/opt/Inline/regression/mismatch32/mismatch32.il
+++ b/tests/src/JIT/opt/Inline/regression/mismatch32/mismatch32.il
@@ -5,6 +5,10 @@
 // When the jit considers inlining B it can get itself into
 // trouble because of the type mismatch. This test tries to
 // ensure the jit backs out of the inline successfully.
+//
+// By default (when no args are passed) execution avoids
+// the problematic callsite, and the app should run without
+// failing.
 
 .assembly extern mscorlib { }
 .assembly extern System.Console
@@ -39,7 +43,7 @@
    ldarg.0
    ldlen
    ldc.i4 1
-   bgt DONE
+   blt DONE
    newobj instance void F::.ctor()
    ldc.i4 33
    call  int32 B(int32, int32)

--- a/tests/src/JIT/opt/Inline/regression/mismatch64/mismatch64.il
+++ b/tests/src/JIT/opt/Inline/regression/mismatch64/mismatch64.il
@@ -5,6 +5,10 @@
 // When the jit considers inlining B it can get itself into
 // trouble because of the type mismatch. This test tries to
 // ensure the jit backs out of the inline successfully.
+//
+// By default (when no args are passed) execution avoids
+// the problematic callsite, and the app should run without
+// failing.
 
 .assembly extern mscorlib { }
 .assembly extern System.Console
@@ -39,7 +43,7 @@
    ldarg.0
    ldlen
    ldc.i4 1
-   bgt DONE
+   blt DONE
    newobj instance void F::.ctor()
    ldc.i8 44
    call  int64 B(int64, int64)


### PR DESCRIPTION
The mismatch32 and mismatch64 tests ensure that the jit will avoid
inlining in cases where there are bad type mismatches at call sites.

This change modifies the tests so that by default the call with the
bad type mismatch is not hit at runtime, since execution of this code
exposes undefined behavior that can be arch or jit specific (eg failing
on x86 and passing on other architectures).

The problematic call can still be hit at runtime by passing at least one
command line argument.

Remove the associated test exclusions for x86.

Fixes #8152.