### PR TITLE
Add Linux perf support to Jenkins

### DIFF
--- a/tests/scripts/perf-prep.sh
+++ b/tests/scripts/perf-prep.sh
@@ -44,39 +44,35 @@ echo "branch = $perfBranch"
 echo "architecture = $perfArch"
 echo "configuration = $perfConfig"
 
-# Install nuget to download benchview package, which includes the script machinedata.py for machine data collection
-wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-chmod u+x ./nuget.exe
-./nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory ./tests/scripts -Prerelease -ExcludeVersion
+# Since not all perf machines have Mono we cannot run nuget locally to get the Benchview tools
+# Instead we curl the package feed and use grep and sed to find the newest package.
+# We grep for content type and that returns us strings that contain the path to the nupkg
+# Then we match only the last line using '$' and use the s command to replace the entire line
+# with what we find inside of the quotes after src=.  We then jump to label x on a match and if 
+# we don't match we delete the line.  This returns just the address of the last nupkg to curl.
+curl "http://benchviewtestfeed.azurewebsites.net/nuget/FindPackagesById()?id='Microsoft.BenchView.JSONFormat'" | grep "content type" | sed "$ s/.*src=\"\([^\"]*\)\".*/\1/;tx;d;:x" | xargs curl -o benchview.zip
+unzip -q -o benchview.zip -d ./tests/scripts/Microsoft.BenchView.JSONFormat
 
 # Install python 3.5.2 to run machinedata.py for machine data collection
-sudo add-apt-repository ppa:fkrull/deadsnakes
-sudo apt-get update
-sudo apt-get --assume-yes install python3.5
 python3.5 --version
 python3.5 ./tests/scripts/Microsoft.BenchView.JSONFormat/tools/machinedata.py
 
 # Set up the copies
 # Coreclr build containing the tests and mscorlib
-curl http://dotnet-ci.cloudapp.net/job/$perfBranch/job/master/job/release_windows_nt/lastSuccessfulBuild/artifact/bin/tests/tests.zip -o tests.zip
+curl http://ci.dot.net/job/$perfBranch/job/master/job/release_windows_nt/lastSuccessfulBuild/artifact/bin/tests/tests.zip -o tests.zip
 
-# Coreclr build we are trying to test
-curl http://dotnet-ci.cloudapp.net/job/$perfBranch/job/master/job/release_ubuntu/lastSuccessfulBuild/artifact/*zip*/archive.zip -o bin.zip
 
 # Corefx components.  We now have full stack builds on all distros we test here, so we can copy straight from CoreFX jobs.
-curl http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/master/job/ubuntu14.04_release/lastSuccessfulBuild/artifact/bin/build.tar.gz -o build.tar.gz
+mkdir corefx
+curl http://ci.dot.net/job/dotnet_corefx/job/master/job/ubuntu14.04_release/lastSuccessfulBuild/artifact/bin/build.tar.gz -o ./corefx/build.tar.gz
 
 # Unpack the corefx binaries
+pushd corefx > /dev/null
 tar -xf build.tar.gz
-
-# Unzip the coreclr binaries
-unzip -q -o bin.zip
-
-# Copy coreclr binaries to the right dir
-cp -R ./archive/bin/obj ./bin
-cp -R ./archive/bin/Product ./bin
+popd > /dev/null
 
 # Unzip the tests first.  Exit with 0
-mkdir ./bin/tests
+mkdir bin
+mkdir bin/tests
 unzip -q -o tests.zip -d ./bin/tests/Windows_NT.$perfArch.$perfConfig || exit 0
 echo "unzip tests to ./bin/tests/Windows_NT.$perfArch.$perfConfig"


### PR DESCRIPTION
This change adds perf support for CoreCLR on Ubuntu 14.04 to Jenkins.
This is mostly work extending what Smile had already done.  The main
changes were to build CoreCLR rather then grab it from CI, and work to
get the upload portion finished.