### PR TITLE
.cctor for inlined method in R2R.

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -2968,7 +2968,7 @@ public:
                         BOOL                            fEmbedParent, // TRUE - embeds parent type handle of the field/method handle
                         CORINFO_GENERICHANDLE_RESULT *  pResult) = 0;
 
-    // Return information used to locate the exact enclosing type of the current method.
+    // Return information used to locate the exact enclosing type of the context method.
     // Used only to invoke .cctor method from code shared across generic instantiations
     //   !needsRuntimeLookup       statically known (enclosing type of method itself)
     //   needsRuntimeLookup:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3548,6 +3548,8 @@ public:
 
     bool fgShouldCreateAssignOp(GenTreePtr tree, bool* bReverse);
 
+    GenTreePtr fgInitClass(CORINFO_CONTEXT_HANDLE context, GenTreePtr thisArg);
+
     GenTreePtr fgInitThisClass();
 
     GenTreePtr fgGetStaticsCCtorHelper(CORINFO_CLASS_HANDLE cls, CorInfoHelpFunc helper);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -22228,18 +22228,17 @@ GenTreePtr Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
     if (inlineInfo->inlineCandidateInfo->initClassResult & CORINFO_INITCLASS_USE_HELPER)
     {
         CORINFO_CONTEXT_HANDLE exactContext = inlineInfo->inlineCandidateInfo->exactContextHnd;
-        CORINFO_CLASS_HANDLE exactClass;
-
-        if (((SIZE_T)exactContext & CORINFO_CONTEXTFLAGS_MASK) == CORINFO_CONTEXTFLAGS_CLASS)
+        GenTreePtr thisArg = nullptr;
+        if (inlineInfo->argCnt > 0)
         {
-            exactClass = CORINFO_CLASS_HANDLE((SIZE_T)exactContext & ~CORINFO_CONTEXTFLAGS_MASK);
+            int thisArgNumb = 0;
+            InlArgInfo thisArgInfo = inlineInfo->inlArgInfo[thisArgNumb];
+            if (thisArgInfo.argIsThis)
+            {
+                thisArg = thisArgInfo.argNode;
+            }
         }
-        else
-        {
-            exactClass = info.compCompHnd->getMethodClass(CORINFO_METHOD_HANDLE((SIZE_T)exactContext & ~CORINFO_CONTEXTFLAGS_MASK));
-        }
-
-        tree = fgGetSharedCCtor(exactClass);
+        tree = fgInitClass(exactContext, thisArg);
         newStmt = gtNewStmt(tree, callILOffset);
         afterStmt = fgInsertStmtAfter(block, afterStmt, newStmt);
     }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16283,6 +16283,63 @@ void Compiler::fgSetOptions()
     // printf("method will %s be fully interruptible\n", genInterruptible ? "   " : "not");
 }
 
+//------------------------------------------------------------------------------
+// fgInitClass : Init class that is described by context and this argument.
+//
+// Arguments:
+//    context  - exact context of method,
+//    thisArgAsLocalVar - this arg to get vtable pointer, can be null for static methods.
+//
+// Return Value:
+//    GenTreePtr that contains call to .cctor for targeted class.
+GenTreePtr Compiler::fgInitClass(CORINFO_CONTEXT_HANDLE context, GenTreePtr thisArg)
+{
+    CORINFO_CLASS_HANDLE exactClass;
+    bool isInstantiatedType = (((SIZE_T)context & CORINFO_CONTEXTFLAGS_MASK) == CORINFO_CONTEXTFLAGS_CLASS);
+    if (isInstantiatedType)
+    {
+        exactClass = CORINFO_CLASS_HANDLE((SIZE_T)context & ~CORINFO_CONTEXTFLAGS_MASK);
+        return fgGetSharedCCtor(exactClass);
+    }
+    else
+    {
+        CORINFO_METHOD_HANDLE exactMethod = CORINFO_METHOD_HANDLE((SIZE_T)context & ~CORINFO_CONTEXTFLAGS_MASK);
+        exactClass                        = info.compCompHnd->getMethodClass(exactMethod);
+        CORINFO_LOOKUP_KIND kind          = info.compCompHnd->getLocationOfThisType(exactMethod);
+        assert(kind.runtimeLookupKind == CORINFO_LOOKUP_THISOBJ);
+        if (!kind.needsRuntimeLookup)
+        {
+            return fgGetSharedCCtor(exactClass);
+        }
+#ifdef FEATURE_READYTORUN_COMPILER
+        // Only CoreRT understands CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE. Don't do this on CoreCLR.
+        assert(eeGetEEInfo()->targetAbi != CORINFO_CORERT_ABI || opts.IsReadyToRun());
+        if (thisArg != NULL)
+        {
+            CORINFO_RESOLVED_TOKEN resolvedToken;
+            memset(&resolvedToken, 0, sizeof(resolvedToken));
+
+            GenTreePtr ctxTree = thisArg;
+
+            // Vtable pointer of this object
+            ctxTree = gtNewOperNode(GT_IND, TYP_I_IMPL, ctxTree);
+            ctxTree->gtFlags |= GTF_EXCEPT; // Null-pointer exception
+            ctxTree->gtFlags |= GTF_IND_INVARIANT;
+            return impReadyToRunHelperToTree(&resolvedToken, CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE, TYP_BYREF,
+                                             gtNewArgList(ctxTree), &kind);
+        }
+        else
+        {
+            noway_assert(!"there is no R2R helper that finds R2R generic static base for static method handle");
+            UNREACHABLE();
+        }
+#else
+        noway_assert(!"needsRuntimeLookup can'be true when not ready to run");
+        UNREACHABLE();
+#endif
+    }
+}
+
 /*****************************************************************************/
 
 GenTreePtr Compiler::fgInitThisClass()


### PR DESCRIPTION
When we inline a method that requires class initialization we should call an appropriate helper.

Fix dotnet/corert#2210.