### PR TITLE
Fix codegen for `(umod (gt_long) (const int))`.

### DIFF
--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -16,6 +16,10 @@ void genCodeForTreeNode(GenTreePtr treeNode);
 
 void genCodeForBinary(GenTreePtr treeNode);
 
+#if defined(_TARGET_X86_)
+void genCodeForLongUMod(GenTreeOp* node);
+#endif // _TARGET_X86_
+
 void genCodeForDivMod(GenTreeOp* treeNode);
 
 void genCodeForMulHi(GenTreeOp* treeNode);

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2493,6 +2493,10 @@ void Lowering::TreeNodeInfoInitModDiv(GenTree* tree)
         assert(op2->IsCnsIntOrI());
         info->srcCount++;
 
+        // This situation also requires an internal register.
+        info->internalIntCount = 1;
+        info->setInternalCandidates(l, l->allRegs(TYP_INT));
+
         loVal->gtLsraInfo.setSrcCandidates(l, RBM_EAX);
         hiVal->gtLsraInfo.setSrcCandidates(l, RBM_EDX);
     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8170/GitHub_8170.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8170/GitHub_8170.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+// This test checks for proper behavior w.r.t. overflow for expressions of the form `val % constant` where `val` is an
+// unsigned long and `constant` is a 32- or 64-bit integer constant in the range [2,0x3fffffff]. These expressions
+// should never produce an overflow exception.
+
+static class C
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static uint M(ulong l)
+    {
+        return (uint)(l % 10000000);
+    }
+
+    static int Main()
+    {
+        return M(ulong.MaxValue) == 9551615 ? 100 : 101;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8170/GitHub_8170.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8170/GitHub_8170.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_8170.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
When targeting x86, we opt not to use a helper call to implement the
64-bit unsigned modulus operator if we have a tree of either of the
following forms:
- `(umod ulong (x ulong) (cast ulong (const int const_val)))`
- `(umod ulong (x ulong) (const ulong const_val))`
where `const_val` falls in the range `[2, 0x3fffffff]`.

We eventually decompose this into `(umod uint (gt_long lo hi) (const int const_val))`.
This was then emitted as:

      mov eax, lo
      mov edx, hi
      mov reg, const_val

      div edx:eax reg

Unfortunately, this generated code does not take into account the fact
that the result of the modulus may not fit into 32 bits. This can cause
an overflow exception at runtime despite the fact that the modulus
originally produced a 64-bit result.

This change fixes the code generation to check for overflow before
performing the modulus and perform a 64-bit division if the result would
overflow. This results in generated code like the following:

      mov eax, lo
      mov edx, hi
      mov reg, const_val

      cmp edx, reg
      jb noOverflow
      mov temp, eax
      mov edx, eax
      xor edx, edx
      div edx:eax, const_val
      mov eax, temp

    noOverflow:
      div edx:eax, const_val

Which is identical to the code produced by JIT32 and the legacy backend.

Fixes #8170.