### PR TITLE
Fix two bugs revealed during internal testing.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -13920,8 +13920,8 @@ GenTreePtr Compiler::gtNewTempAssign(unsigned tmp, GenTreePtr val)
     var_types valTyp = val->TypeGet();
     if (val->OperGet() == GT_LCL_VAR && lvaTable[val->gtLclVar.gtLclNum].lvNormalizeOnLoad())
     {
-        valTyp = lvaGetRealType(val->gtLclVar.gtLclNum);
-        val    = gtNewLclvNode(val->gtLclVar.gtLclNum, valTyp, val->gtLclVar.gtLclILoffs);
+        valTyp      = lvaGetRealType(val->gtLclVar.gtLclNum);
+        val->gtType = valTyp;
     }
     var_types dstTyp = varDsc->TypeGet();
 

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -257,7 +257,7 @@ unsigned LIR::Use::ReplaceWithLclVar(Compiler* compiler, unsigned blockWeight, u
     assert(m_range->Contains(m_user));
     assert(m_range->Contains(*m_edge));
 
-    GenTree* node = *m_edge;
+    GenTree* const node = *m_edge;
 
     if (lclNum == BAD_VAR_NUM)
     {
@@ -268,9 +268,11 @@ unsigned LIR::Use::ReplaceWithLclVar(Compiler* compiler, unsigned blockWeight, u
     compiler->lvaTable[lclNum].incRefCnts(blockWeight, compiler);
     compiler->lvaTable[lclNum].incRefCnts(blockWeight, compiler);
 
-    GenTreeLclVar* store = compiler->gtNewTempAssign(lclNum, node)->AsLclVar();
+    GenTreeLclVar* const store = compiler->gtNewTempAssign(lclNum, node)->AsLclVar();
+    assert(store != nullptr);
+    assert(store->gtOp1 == node);
 
-    GenTree* load =
+    GenTree* const load =
         new (compiler, GT_LCL_VAR) GenTreeLclVar(store->TypeGet(), store->AsLclVarCommon()->GetLclNum(), BAD_IL_OFFSET);
 
     m_range->InsertAfter(node, store, load);

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3679,11 +3679,10 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
         return next;
     }
 
-    // We're committed to the conversion now. Go find the use.
+    // We're committed to the conversion now. Go find the use if any.
     LIR::Use use;
     if (!BlockRange().TryGetUse(node, &use))
     {
-        assert(!"signed DIV/MOD node is unused");
         return next;
     }
 


### PR DESCRIPTION
- gtNewTempAssign was unnecessarily creating a new node to represent the
  value being assigned to a temp if the value was a normalize-on-load
  lclVar. This caused problems when using `gtNewTempAssign` as part of
  `LIR::Use::ReplaceWithLclVar`, which assumes that `gtNewTempAssign`
  only creates a single node (the new `st.lclVar` node). Instead of
  creating a new lclVar node, simply change the type of the existing
  node.
- LowerSignedDivOrMod contained an unnecessarily strong assertion. This
  assertion has been removed.