### PR TITLE
Fix ordering of operands on GT_RSZ

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -1108,7 +1108,6 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
             case GT_RSZ:
             {
                 Range().Remove(gtLong);
-                Range().Remove(loOp1);
 
                 if (count < 32)
                 {
@@ -1119,8 +1118,7 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
 
                     hiOp1                = RepresentOpAsLocalVar(hiOp1, gtLong, &gtLong->gtOp.gtOp2);
                     unsigned hiOp1LclNum = hiOp1->AsLclVarCommon()->gtLclNum;
-                    Range().Remove(hiOp1);
-                    GenTree* hiCopy = m_compiler->gtNewLclvNode(hiOp1LclNum, TYP_INT);
+                    GenTree* hiCopy      = m_compiler->gtNewLclvNode(hiOp1LclNum, TYP_INT);
 
                     GenTree* shiftByHi = m_compiler->gtNewIconNode(count, TYP_INT);
                     GenTree* shiftByLo = m_compiler->gtNewIconNode(count, TYP_INT);
@@ -1134,12 +1132,13 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
                     GenTree* loOp = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loOp1, hiCopy);
                     loResult      = m_compiler->gtNewOperNode(GT_RSH_LO, TYP_INT, loOp, shiftByLo);
 
-                    Range().InsertBefore(tree, loOp1, hiCopy, loOp);
+                    Range().InsertBefore(tree, hiCopy, loOp);
                     Range().InsertBefore(tree, shiftByLo, loResult);
-                    Range().InsertBefore(tree, hiOp1, shiftByHi, hiResult);
+                    Range().InsertBefore(tree, shiftByHi, hiResult);
                 }
                 else
                 {
+                    Range().Remove(loOp1);
                     Range().Remove(hiOp1);
                     assert(count >= 32);
                     if (count < 64)

--- a/tests/src/JIT/CodeGenBringUpTests/Shift.cs
+++ b/tests/src/JIT/CodeGenBringUpTests/Shift.cs
@@ -45,6 +45,13 @@ public class Test
         return x;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ulong shr1_32_add(ulong shift, ulong addit)
+    {
+        ulong x = (addit + (shift >> 1)) >> 31;
+        return x;
+    }
+
     public static int Main()
     {
         const int Pass = 100;
@@ -52,16 +59,25 @@ public class Test
 
         if (shl64_32_inplace(0x123456789abcdef, 0) != shl64(0x123456789abcdef, 32))
         {
+            Console.WriteLine("shl64_32");
             return Fail;
         }
 
         if (shl64_33_inplace(0x123456789abcdef, 0) != shl64(0x123456789abcdef, 33))
         {
+            Console.WriteLine("shl64_33");
             return Fail;
         }
 
         if (shr64_32_inplace(0x123456789abcdef, 0) != shr64(0x123456789abcdef, 32))
         {
+            Console.WriteLine("shr64_32 {0:X} {1:X}", shr64_32_inplace(0x123456789abcdef, 0), shr64(0x123456789abcdef, 32));
+            return Fail;
+        }
+
+        if (shr1_32_add(0x123456789abcdef, 0) != shr64(0x123456789abcdef, 32))
+        {
+            Console.WriteLine("HAHAHAHAHAHAHA {0:X}", shr1_32_add(0x123456789abcdef, 0));
             return Fail;
         }
 


### PR DESCRIPTION
By removing hiOp1 and loOp1 from LIR and then putting them back in, we
inadvertantly reversed the order of operations for high and lo. This is an
issue when op1 is a long add or sub where the order of operations is
important.

Fixes #8171.