### PR TITLE
Fix warnings in native test code

### DIFF
--- a/tests/src/Common/Platform/platformdefines.cpp
+++ b/tests/src/Common/Platform/platformdefines.cpp
@@ -89,7 +89,7 @@ int TP_slen(LPWSTR str)
 	return len;
 }
 
-int TP_scmp_s(LPSTR str1, LPSTR str2)
+int TP_scmp_s(LPCSTR str1, LPCSTR str2)
 {
 	// < 0 str1 less than str2
 	// 0  str1 identical to str2

--- a/tests/src/Common/Platform/platformdefines.h
+++ b/tests/src/Common/Platform/platformdefines.h
@@ -97,7 +97,7 @@ typedef WCHAR OLECHAR;
 error_t TP_scpy_s(LPWSTR strDestination, size_t sizeInWords, LPCWSTR strSource);
 error_t TP_scat_s(LPWSTR strDestination, size_t sizeInWords, LPCWSTR strSource);
 int TP_slen(LPWSTR str);
-int TP_scmp_s(LPSTR str1, LPSTR str2);
+int TP_scmp_s(LPCSTR str1, LPCSTR str2);
 int TP_wcmp_s(LPWSTR str1, LPWSTR str2);
 error_t TP_getenv_s(size_t* pReturnValue, LPWSTR buffer, size_t sizeInWords, LPCWSTR varname);
 error_t TP_putenv_s(LPTSTR name, LPTSTR value);

--- a/tests/src/Interop/RefCharArray/RefCharArrayNative.cpp
+++ b/tests/src/Interop/RefCharArray/RefCharArrayNative.cpp
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-size_t LEN = 10;
+const int LEN = 10;
 extern "C" BOOL DLL_EXPORT _cdecl MarshalRefCharArray_Cdecl(char ** pstr)
 {
     //Check the Input

--- a/tests/src/Interop/SimpleStruct/SimpleStructNative.cpp
+++ b/tests/src/Interop/SimpleStruct/SimpleStructNative.cpp
@@ -30,7 +30,7 @@ DLL_EXPORT BOOL _cdecl CdeclSimpleStructByRef(Sstr *p)
 {
   p->a = 100;
   p->b=1;
-  strncpy(p->str,"after",6);
+  strcpy_s(p->str, 7, "after");
   return TRUE;
 }
 

--- a/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
+++ b/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
@@ -167,22 +167,10 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut3(CharSetAns
 }
 extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut3(CharSetAnsiSequential* str1)
 {
-	char const* strSource = "change string";
-	int len = strlen(strSource);
-	LPCSTR temp = (LPCSTR)TP_CoTaskMemAlloc((sizeof(char)*len)+1);
-	if(temp != NULL)
-	{
-		TP_CoTaskMemFree((void*)(str1->f1));
-		strcpy((char*)temp,strSource);		
-		str1->f1 = temp;
-		str1->f2 = 'n';
-		return TRUE;
-	}
-	else
-	{
-		printf("Memory Allocated Failed !");
-		return FALSE;
-	}
+	TP_CoTaskMemFree((void*)(str1->f1));
+	str1->f1 = CoStrDup("change string");
+	str1->f2 = 'n';
+	return TRUE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -663,7 +651,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal14(S11 str1)
 {
 	if( str1.i32 != 0 || str1.i != 32 )
 		return FALSE;
-	str1.i32 = (LPINT)(long)(str1.i);
+	str1.i32 = reinterpret_cast<LPINT>(static_cast<INT_PTR>(str1.i));
 	str1.i = 64;
 	return TRUE;
 }
@@ -673,7 +661,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef14(S11* str1)
 		return FALSE;
 	else
 	{
-		str1->i32 = (LPINT)(long)(str1->i);
+		str1->i32 = reinterpret_cast<LPINT>(static_cast<INT_PTR>(str1->i));
 		str1->i = 64;
 		return TRUE;
 	}
@@ -684,7 +672,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn14(S11* str1)
 		return FALSE;
 	else
 	{
-		str1->i32 = (LPINT)(long)(str1->i);
+		str1->i32 = reinterpret_cast<LPINT>(static_cast<INT_PTR>(str1->i));
 		str1->i = 64;
 		return TRUE;
 	}
@@ -698,7 +686,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut14(S11 str1)
 }
 extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut14(S11* str1)
 {
-	str1->i32 = (LPINT)(long)(str1->i);
+	str1->i32 = reinterpret_cast<LPINT>(static_cast<INT_PTR>(str1->i));
 	str1->i = 64;
 	return TRUE;
 }
@@ -817,7 +805,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValInnerArrayExpli
 			return FALSE;
 		}
 	}
-	if(memcmp((&outer2)->f4,"some string2",12) != 0)
+	if(memcmp((&outer2)->s.f4,"some string2",12) != 0)
 	{
 		printf("\tMarshalStructAsParam_AsExpByVal3:InnerArrayExplicit param f4 not as expected\n");
 		return FALSE;
@@ -835,7 +823,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInnerArrayExpli
 			return FALSE;
 		}
 	}
-	if(memcmp(outer2->f4,"some string2",12) != 0)
+	if(memcmp(outer2->s.f4,"some string2",12) != 0)
 	{
 		printf("\tMarshalStructAsParam_AsExpByRef3:InnerArrayExplicit param f4 not as expected\n");
 		return FALSE;
@@ -844,11 +832,8 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInnerArrayExpli
 	{
 		outer2->arr[i].f1 = 77;
 	}
-	char const * temp = "change string2";
-	size_t len = strlen(temp);
-	LPCSTR str = (LPCSTR)TP_CoTaskMemAlloc( sizeof(char)*(len+1) );
-	strcpy((char*)str,temp);
-	outer2->f4 = str;
+
+	outer2->s.f4 = CoStrDup("change string2");
 	return TRUE;
 }
 
@@ -862,7 +847,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInInnerArrayExp
 			return FALSE;
 		}
 	}
-	if(memcmp(outer2->f4, "some string2",12*(sizeof(char))) != 0)
+	if(memcmp(outer2->s.f4, "some string2",12*(sizeof(char))) != 0)
 	{
 		printf("\tMarshalStructAsParam_AsExpByRefIn3:InnerArrayExplicit param f4 not as expected\n");
 		return FALSE;
@@ -871,11 +856,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInInnerArrayExp
 	{
 		outer2->arr[i].f1 = 77;
 	}
-	char const * temp = "change string2";
-	size_t len = strlen(temp);
-	LPCSTR str = (LPCSTR)TP_CoTaskMemAlloc( sizeof(char)*(len+1) );
-	strcpy((char*)str,temp);
-	outer2->f4 = str;
+	outer2->s.f4 = CoStrDup("change string2");
 	return TRUE;
 }
 extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutInnerArrayExplicit(InnerArrayExplicit* outer2)
@@ -884,11 +865,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutInnerArrayEx
 	{
 		outer2->arr[i].f1 = 77;
 	}
-	char const * temp = "change string2";
-	size_t len = strlen(temp);
-	LPCSTR str = (LPCSTR)TP_CoTaskMemAlloc( sizeof(char)*(len+1) );
-	strcpy((char*)str,temp);
-	outer2->f4 = str;
+    outer2->s.f4 = CoStrDup("change string2");
 	return TRUE;
 }
 

--- a/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.h
+++ b/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.h
@@ -1,6 +1,17 @@
 #include "platformdefines.cpp"
 #include <xplatform.h>
 
+inline char* CoStrDup(const char* str)
+{
+	size_t size = strlen(str) + 1;
+	char* dup = (char *)TP_CoTaskMemAlloc(size);
+    if (dup != nullptr)
+    {
+        strcpy_s(dup, size, str);
+    }
+    return dup;
+}
+
 const int NumArrElements = 2;
 struct InnerSequential
 {
@@ -19,20 +30,7 @@ void ChangeInnerSequential(InnerSequential* p)
 {
 	p->f1 = 77;
 	p->f2 = 77.0;
-
-	char const * lpstr = "changed string";
-	size_t size = sizeof(char) * (strlen(lpstr) + 1);
-	LPSTR temp = (LPSTR)TP_CoTaskMemAlloc( size );
-	memset(temp, 0, size);
-	if(temp)
-	{
-		strcpy( (char*)temp, lpstr );
-		p->f3 = temp;
-	}
-	else
-	{
-		printf("Memory Allocated Failed!");
-	}
+	p->f3 = CoStrDup("changed string");
 }
 
 bool IsCorrectInnerSequential(InnerSequential* p)
@@ -41,13 +39,7 @@ bool IsCorrectInnerSequential(InnerSequential* p)
 		return false;
 	if(p->f2 != 1.0)
 		return false;
-
-	char const * lpstr = "some string";
-	size_t size = sizeof(char) * (strlen(lpstr) + 1);
-	LPSTR temp = (LPSTR)TP_CoTaskMemAlloc( size );
-	memset(temp, 0, size);
-
-	if( strcmp((char*)p->f3, temp) != 0 )
+	if(strcmp(p->f3, "") != 0)
 		return false;
 
 	return true;
@@ -62,6 +54,7 @@ typedef unsigned short WORD;
 typedef short SHORT;
 typedef float FLOAT;
 typedef double DOUBLE;
+typedef long INT_PTR;
 #endif
 
 struct INNER2 // size = 12 bytes
@@ -74,11 +67,7 @@ void ChangeINNER2(INNER2* p)
 {
 	p->f1 = 77;
 	p->f2 = 77.0;
-	char const * temp = "changed string";
-	size_t len = strlen(temp);
-	LPCSTR str = (LPCSTR)TP_CoTaskMemAlloc( sizeof(char)*(len+1) );
-	strcpy((char*)str,temp);
-	p->f3 = str;
+	p->f3 = CoStrDup("changed string");
 }
 void PrintINNER2(INNER2* p, char const * name)
 {
@@ -132,12 +121,7 @@ void PrintInnerExplicit(InnerExplicit* p, char const * name)
 void ChangeInnerExplicit(InnerExplicit* p)
 {
 	p->f1 = 77;
-
-	char const * temp = "changed string";
-	size_t len = strlen(temp);
-	LPCSTR str = (LPCSTR)TP_CoTaskMemAlloc( sizeof(char)*(len+1) );
-	strcpy((char*)str,temp);
-	p->f3 = str;
+	p->f3 = CoStrDup("changed string");
 }
 
 struct InnerArraySequential
@@ -157,25 +141,11 @@ void PrintInnerArraySequential(InnerArraySequential* p, char const * name)
 
 void ChangeInnerArraySequential(InnerArraySequential* p)
 {
-	char const * lpstr = "changed string";
-	LPSTR temp;
 	for(int i = 0; i < NumArrElements; i++)
 	{
 		(p->arr)[i].f1 = 77;
 		(p->arr)[i].f2 = 77.0;
-
-		size_t size = sizeof(char) * (strlen(lpstr) + 1);
-		temp = (LPSTR)TP_CoTaskMemAlloc( size );
-		memset(temp, 0, size);
-		if(temp)
-		{
-			strcpy( (char*)temp, lpstr );
-			(p->arr)[i].f3 = temp;
-		}
-		else
-		{
-			printf("Memory Allocated Failed!");
-		}
+		(p->arr)[i].f3 = CoStrDup("changed string");
 	}
 }
 
@@ -199,13 +169,14 @@ union InnerArrayExplicit // size = 32 bytes
 	{
 		LONG64 _unused0;
 		LPCSTR f4;
-	}; 
-
+	} s; 
 };
 
 
 #ifdef WINDOWS
 	#ifdef _WIN64
+        #pragma warning(push) 
+        #pragma warning(disable: 4201) // nonstandard extension used: nameless struct/union
 		union OUTER3 // size = 32 bytes
 		{
 			struct InnerSequential arr[2];
@@ -215,6 +186,7 @@ union InnerArrayExplicit // size = 32 bytes
 				LPCSTR f4;
 			};
 		};
+        #pragma warning(pop)
 	#else
 		struct OUTER3 // size = 28 bytes
 		{
@@ -244,22 +216,14 @@ void PrintOUTER3(OUTER3* p, char const * name)
 }
 void ChangeOUTER3(OUTER3* p)
 {
-	char const * temp = "changed string";
-	size_t len = strlen(temp);
-	LPCSTR str = NULL;
 	for(int i = 0; i < NumArrElements; i++)
 	{
 		(p->arr)[i].f1 = 77;
 		(p->arr)[i].f2 = 77.0;
-	
-		str = (LPCSTR)TP_CoTaskMemAlloc( sizeof(char)*(len+1) );
-		strcpy((char*)str,temp);
-		(p->arr)[i].f3 = str;
+		(p->arr)[i].f3 = CoStrDup("changed string");
 	}
 
-	str = (LPCSTR)TP_CoTaskMemAlloc( sizeof(char)*(len+1) );
-	strcpy((char*)str,temp);
-	p->f4 = str;
+	p->f4 = CoStrDup("changed string");
 }
 bool IsCorrectOUTER3(OUTER3* p)
 {
@@ -293,19 +257,8 @@ void PrintCharSetAnsiSequential(CharSetAnsiSequential* p, char const * name)
 
 void ChangeCharSetAnsiSequential(CharSetAnsiSequential* p)
 {
-	char const * strSource = "change string";
-	size_t size = strlen(strSource) + 1;
-	LPSTR temp = (LPSTR)TP_CoTaskMemAlloc(size);
-	if(temp != NULL)
-	{
-		strcpy((char*)temp,strSource);
-		p->f1 = temp;
-		p->f2 = 'n';
-	}
-	else
-	{
-		printf("Memory Allocated Failed!");
-	}
+	p->f1 = CoStrDup("change string");
+	p->f2 = 'n';
 }
 
 bool IsCorrectCharSetAnsiSequential(CharSetAnsiSequential* p)
@@ -325,7 +278,11 @@ struct CharSetUnicodeSequential
 };
 void PrintCharSetUnicodeSequential(CharSetUnicodeSequential* p, char const * name)
 {
+#ifdef _WIN32
+	wprintf(L"\t%S.f1 = %s\n", name, p->f1);
+#else
 	wprintf(L"\t%s.f1 = %S\n", name, p->f1);
+#endif
 	printf("\t%s.f2 = %c\n", name, p->f2);
 }
 
@@ -336,7 +293,7 @@ void ChangeCharSetUnicodeSequential(CharSetUnicodeSequential* p)
 #else
 	LPCWSTR strSource = u"change string";
 #endif
-	int len = wcslen(strSource);
+	size_t len = wcslen(strSource);
 	LPCWSTR temp = (LPCWSTR)TP_CoTaskMemAlloc(sizeof(WCHAR)*(len+1));
 	if(temp != NULL)
 	{
@@ -418,7 +375,7 @@ void ChangeNumberSequential(NumberSequential* p)
 
 bool IsCorrectNumberSequential(NumberSequential* p)
 {
-	if(p->i32 != -0x80000000 || p->ui32 != 0xffffffff || p->s1 != -0x8000 || p->us1 != 0xffff || p->b != 0 || 
+	if(p->i32 != (-0x7fffffff - 1) || p->ui32 != 0xffffffff || p->s1 != -0x8000 || p->us1 != 0xffff || p->b != 0 || 
 		p->sb != 0x7f ||p->i16 != -0x8000 || p->ui16 != 0xffff || p->i64 != -1234567890 ||
 		p->ui64 != 1234567890 || (p->sgl) != 32.0 || p->d != 3.2)
 	{
@@ -448,17 +405,10 @@ void ChangeS3(S3* p)
 {
 	p->flag = false;
 
-	char const * strSource = "change string";
-	int len = strlen(strSource);
-	
-	LPCSTR temp = (LPCSTR)TP_CoTaskMemAlloc((sizeof(char)*len) + 1);
-	if(temp != NULL)
-	{
-		/*TP_CoTaskMemFree((void *)p->str);*/
-		strcpy((char*)temp,strSource);		
-		p->str = temp;
-	}
-	for(int i = 1;i<257;i++)
+	/*TP_CoTaskMemFree((void *)p->str);*/
+	p->str = CoStrDup("change string");
+
+    for(int i = 1;i<257;i++)
 	{
 		p->vals[i-1] = i;
 	}
@@ -468,12 +418,7 @@ bool IsCorrectS3(S3* p)
 {
 	int iflag = 0;
 
-	char const * lpstr = "some string";
-	size_t size = sizeof(char) * (strlen(lpstr) + 1);
-	LPSTR temp = (LPSTR)TP_CoTaskMemAlloc( size );
-	memset(temp, 0, size);
-
-	if(!p->flag || strcmp((char*)p->str, temp) != 0)
+	if (!p->flag || strcmp(p->str, "") != 0)
 		return false;
     for (int i = 0; i < 256; i++)
     {
@@ -514,33 +459,16 @@ void PrintS5(S5* str, char const * name)
 }
 void ChangeS5(S5* str)
 {
-	Enum1 eInstance = e2;
-	char const * strSource = "change string";	
-	int len = strlen(strSource);
-	LPCSTR temp = (LPCSTR)TP_CoTaskMemAlloc(sizeof(char)*(len+1));
-	if(temp != NULL)
-	{
-		strcpy((char*)temp,strSource);
-		str->s4.name = temp;
-	}
+	str->s4.name = CoStrDup("change string");
 	str->s4.age = 64;
-	str->ef = eInstance;
+	str->ef = e2;
 }
 bool IsCorrectS5(S5* str)
 {
-	Enum1 eInstance = e1;
-
-	char const * lpstr = "some string";
-	size_t size = sizeof(char) * (strlen(lpstr) + 1);
-	LPSTR temp = (LPSTR)TP_CoTaskMemAlloc( size );
-	memset(temp, 0, size);
-
-	if(str->s4.age != 32 || strcmp((char*)str->s4.name, temp) != 0)
+	if(str->s4.age != 32 || strcmp(str->s4.name, "") != 0)
 		return false;
-	if(str->ef != eInstance)
-	{
+	if(str->ef != e1)
 		return false;
-	}
 	return true;
 }
 
@@ -599,8 +527,13 @@ struct StringStructSequentialUnicode // size = 8 bytes
 
 void PrintStringStructSequentialUnicode(StringStructSequentialUnicode* str, char const * name)
 {
+#ifdef _WIN32
+	wprintf(L"\t%S.first = %s\n", name, str->first);
+	wprintf(L"\t%S.last = %s\n", name, str->last);
+#else
 	wprintf(L"\t%s.first = %s\n", name, str->first);
 	wprintf(L"\t%s.last = %s\n", name, str->last);
+#endif
 }
 
 bool IsCorrectStringStructSequentialUnicode(StringStructSequentialUnicode* str)
@@ -674,19 +607,7 @@ bool IsCorrectS8(S8* str)
 
 void ChangeS8(S8* str)
 {
-	char const * lpstr = "world";
-	size_t size = sizeof(char) * (strlen(lpstr) + 1);
-	LPSTR temp = (LPSTR)TP_CoTaskMemAlloc( size );
-	memset(temp, 0, size);
-	if(temp)
-	{
-		strcpy( (char*)temp, lpstr );
-		str->name = temp;
-	}
-	else
-	{
-		printf("Memory Allocated Failed!");
-	}
+	str->name = CoStrDup("world");
 	str->gender = false;
 	str->jobNum = 1;
 	str->i32 = 256;
@@ -787,7 +708,7 @@ void ChangeU(U* p)
 	p->uiPtr = (LPVOID)(64);
 	p->s = 32767;
 	p->us = 0;
-	p->b = -1;
+	p->b = 255;
 	p->sb = -128;
 	p->l = -1234567890;
 	p->ul = 0;


### PR DESCRIPTION
This fixes all but 4 warnings in the native test code. The remaining 4 warnings are all like `lptstrtestnative.cpp(107): warning C4905: wide string literal cast to 'LPTSTR'`, that code does something weird with Unicode and ANSI strings. I don't know what it is trying to do so I left it alone.