### PR TITLE
Fix "method has no body, 'ret' emitted" warning

### DIFF
--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase0.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase0.il
@@ -36,7 +36,10 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -59,12 +62,20 @@
     .maxstack  8
     ldstr      "B::Bar2"
     ret
-  }  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  }
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase1.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase1.il
@@ -24,7 +24,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -43,12 +46,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase2.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase2.il
@@ -24,7 +24,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -43,12 +46,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase3.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase3.il
@@ -19,7 +19,10 @@
   .class interface nested family abstract auto ansi I`1<T>
   { .method public hidebysig newslot abstract virtual instance string  Foo() cil managed {} }
   
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -43,12 +46,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase4.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase4.il
@@ -18,8 +18,11 @@
 {
   .class interface nested family abstract auto ansi I`1<T>
   { .method public hidebysig newslot abstract virtual instance string  Foo() cil managed {} }
-  
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -43,12 +46,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase5.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase5.il
@@ -36,19 +36,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class A`1/I`1<!W>, J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase6.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I/TestCase6.il
@@ -36,19 +36,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class A`1/I`1<!W>, J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase0.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase0.il
@@ -36,7 +36,10 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -59,12 +62,20 @@
     .maxstack  8
     ldstr      "B::Bar2"
     ret
-  }  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  }
+  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed
+  {
+    ret
+  } 
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase1.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase1.il
@@ -24,7 +24,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -43,12 +46,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase2.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase2.il
@@ -24,7 +24,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -43,12 +46,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase3.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase3.il
@@ -19,7 +19,10 @@
 	    .method public hidebysig newslot abstract virtual instance string  Bar2() cil managed {}
 	  }
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -43,12 +46,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase4.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase4.il
@@ -19,7 +19,10 @@
 	    .method public hidebysig newslot abstract virtual instance string  Bar2() cil managed {}
 	  }
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -43,12 +46,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase5.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase5.il
@@ -36,18 +36,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class A`1/I`1<!W>, A`1/I`1/J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase6.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_I_Nested_J/TestCase6.il
@@ -36,19 +36,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class A`1/I`1<!W>, A`1/I`1/J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase0.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase0.il
@@ -36,7 +36,10 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -59,12 +62,20 @@
     .maxstack  8
     ldstr      "B::Bar2"
     ret
-  }  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  }
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase1.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase1.il
@@ -23,7 +23,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -42,12 +45,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase2.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase2.il
@@ -23,7 +23,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -42,12 +45,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase3.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase3.il
@@ -18,7 +18,10 @@
     .method public hidebysig newslot abstract virtual instance string  Bar1() cil managed {}
     .method public hidebysig newslot abstract virtual instance string  Bar2() cil managed {}
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -42,12 +45,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase4.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase4.il
@@ -18,7 +18,10 @@
     .method public hidebysig newslot abstract virtual instance string  Bar1() cil managed {}
     .method public hidebysig newslot abstract virtual instance string  Bar2() cil managed {}
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -42,12 +45,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase5.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase5.il
@@ -35,19 +35,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class I`1<!W>, A`1/J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase6.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J/TestCase6.il
@@ -35,19 +35,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class I`1<!W>, A`1/J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase0.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase0.il
@@ -34,7 +34,10 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -57,12 +60,20 @@
     .maxstack  8
     ldstr      "B::Bar2"
     ret
-  }  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  }
+  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{ 
+  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase1.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase1.il
@@ -22,7 +22,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -41,12 +44,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{ 
+  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase2.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase2.il
@@ -22,7 +22,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -41,12 +44,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase3.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase3.il
@@ -17,7 +17,10 @@
     .method public hidebysig newslot abstract virtual instance string  Bar1() cil managed {}
     .method public hidebysig newslot abstract virtual instance string  Bar2() cil managed {}
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -41,12 +44,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed
+  {
+    ret
+  } 
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase4.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase4.il
@@ -17,7 +17,10 @@
     .method public hidebysig newslot abstract virtual instance string  Bar1() cil managed {}
     .method public hidebysig newslot abstract virtual instance string  Bar2() cil managed {}
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -41,12 +44,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{ 
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase5.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase5.il
@@ -34,19 +34,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class A`1/J/I`1<!W>, A`1/J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase6.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/Nested_J_Nested_I/TestCase6.il
@@ -34,19 +34,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class A`1/J/I`1<!W>, A`1/J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/TestCase0.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/TestCase0.il
@@ -37,7 +37,10 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -60,12 +63,16 @@
     .maxstack  8
     ldstr      "B::Bar2"
     ret
-  }  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  }  
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{ 
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/TestCase1.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/TestCase1.il
@@ -25,7 +25,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -44,12 +47,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/TestCase2.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/TestCase2.il
@@ -25,7 +25,10 @@
     ldstr      "A::Foo"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -44,12 +47,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/TestCase3.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/TestCase3.il
@@ -20,7 +20,10 @@
 .class private abstract auto ansi beforefieldinit A`1<U> 
 		implements class I`1<!U>
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -44,12 +47,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/TestCase4.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/TestCase4.il
@@ -20,7 +20,10 @@
 .class private abstract auto ansi beforefieldinit A`1<U> 
 		implements class I`1<!U>
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
@@ -44,12 +47,19 @@
     ldstr      "B::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/TestCase5.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/TestCase5.il
@@ -37,19 +37,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class I`1<!W>, J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/TestCase6.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/TestCase6.il
@@ -37,19 +37,29 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private abstract auto ansi beforefieldinit B`2<V,W>
        extends class A`1<!V>
        implements class I`1<!W>, J
 {
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/InterfaceFolding/TestCase7.il
+++ b/tests/src/Loader/classloader/InterfaceFolding/TestCase7.il
@@ -37,7 +37,10 @@
     ldstr      "A::Bar2"
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit B`2<V,W>
@@ -61,12 +64,20 @@
     .maxstack  8
     ldstr      "B::Bar2"
     ret
-  }  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {}
+  }
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 .class private auto ansi beforefieldinit C extends class B`2<class C,class C>
-{ .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed {} }
-
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
+}
 
 .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
 {

--- a/tests/src/Loader/classloader/regressions/dev10_710121/dev10_710121.il
+++ b/tests/src/Loader/classloader/regressions/dev10_710121/dev10_710121.il
@@ -21,12 +21,18 @@ The bug related to populating MethodDesc slots in generic dictionaries at runtim
 .class public DerivedDerived
 		extends class Derived`2<string,string>
 {
-  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { }
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 .class public Derived`2<T0, T1> 
 		extends class Base`2<int32,!T1>
 {
-  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { }
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 .class public Base`2<T0, T1> 
 {
@@ -40,7 +46,10 @@ The bug related to populating MethodDesc slots in generic dictionaries at runtim
     call string [mscorlib]System.String::Concat(object,object)
     ret
   }
-  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { }
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ret
+  }
 }
 
 


### PR DESCRIPTION
Many class loader tests had empty constructor bodies, added `ret` to silence the ILASM warning.