### PR TITLE
Fast path ExecutionContext.Default for AsyncLocal

### DIFF
--- a/src/mscorlib/src/System/Threading/AsyncLocal.cs
+++ b/src/mscorlib/src/System/Threading/AsyncLocal.cs
@@ -123,6 +123,7 @@ namespace System.Threading
     {
         bool TryGetValue(IAsyncLocal key, out object value);
         IAsyncLocalValueMap Set(IAsyncLocal key, object value);
+        int Count { get; }
     }
 
     //
@@ -151,6 +152,8 @@ namespace System.Threading
                 value = null;
                 return false;
             }
+
+            public int Count => 0;
         }
 
         // Instance with one key/value pair.
@@ -198,6 +201,8 @@ namespace System.Threading
                     return false;
                 }
             }
+
+            public int Count => 1;
         }
 
         // Instance with two key/value pairs.
@@ -253,6 +258,8 @@ namespace System.Threading
                     return false;
                 }
             }
+
+            public int Count => 2;
         }
 
         // Instance with three key/value pairs.
@@ -322,6 +329,8 @@ namespace System.Threading
                     return false;
                 }
             }
+
+            public int Count => 3;
         }
 
         // Instance with up to 16 key/value pairs.
@@ -421,6 +430,8 @@ namespace System.Threading
                 value = null;
                 return false;
             }
+
+            public int Count => _keyValues.Length;
         }
 
         // Instance with any number of key/value pairs.


### PR DESCRIPTION
Move back to Default ExecutionContext when AsyncLocals are cleared

Early exit if setting value to null on DefaultContext

Return `null` for get if context is default without checking.

/cc @stephentoub @jkotas 