### PR TITLE
Add handling of multiple CMake installations in probe-win.ps1

### DIFF
--- a/src/pal/tools/probe-win.ps1
+++ b/src/pal/tools/probe-win.ps1
@@ -28,7 +28,15 @@ function GetCMakeInfo($regKey)
 function LocateCMake
 {
   $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from http://www.cmake.org/download/ and ensure it is on your path."
-  $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue).Path
+  $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue)
+  
+  if ($inPathPath.Length -gt 1) {
+	[System.Console]::WriteLine("echo Multiple CMake versions found. Using $($inPathPath[0].Definition)")
+	$inPathPath = $inPathPath[0].Path
+  } else {
+	$inPathPath = $inPathPathPath
+  }
+  
   if ($inPathPath -ne $null) {
     return $inPathPath
   }


### PR DESCRIPTION
Check if multiple CMake versions are installed, and use by default the first path available

Fixes #8221