### PR TITLE
[x86/linux] Fix redefined DISPATCHER_CONTEXT compile error

### DIFF
--- a/src/inc/clrnt.h
+++ b/src/inc/clrnt.h
@@ -835,18 +835,13 @@ RtlVirtualUnwind_Unsafe(
 //  X86
 //
 
-#if defined(_TARGET_X86_)
-
-#pragma warning(push)
-#pragma warning (disable:4035)        // disable 4035 (function must return something)
-#define PcTeb 0x18
-#pragma warning(pop)
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 
 typedef struct _DISPATCHER_CONTEXT {
     _EXCEPTION_REGISTRATION_RECORD* RegistrationPointer;
 } DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
 
-#endif // _TARGET_X86_
+#endif // _TARGET_X86_ && !FEATURE_PAL
 
 #ifdef _TARGET_ARM_
 #include "daccess.h"

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1516,7 +1516,7 @@ typedef struct _DISPATCHER_CONTEXT {
     ULONG64 Reserved;
 } DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
 
-#else
+#elif defined(_AMD64_)
 
 typedef struct _DISPATCHER_CONTEXT {
     ULONG64 ControlPc;
@@ -1529,6 +1529,24 @@ typedef struct _DISPATCHER_CONTEXT {
     PVOID HandlerData;
     PUNWIND_HISTORY_TABLE HistoryTable;
 } DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
+
+#elif defined(_X86_)
+
+typedef struct _DISPATCHER_CONTEXT {
+    DWORD ControlPc;
+    DWORD ImageBase;
+    PRUNTIME_FUNCTION FunctionEntry;
+    DWORD EstablisherFrame;
+    DWORD TargetIp;
+    PCONTEXT ContextRecord;
+    PEXCEPTION_ROUTINE LanguageHandler;
+    PVOID HandlerData;
+    PUNWIND_HISTORY_TABLE HistoryTable;
+} DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
+
+#else
+
+#error Unknown architecture for defining DISPATCHER_CONTEXT.
 
 #endif
 


### PR DESCRIPTION
WIP, fix compile error for x86/Linux
- add directive !FEATURE_PAL to current DISPATCHER_CONTEXT in clrnt.h
- add DISPATCHER_CONTEXT for x86 in palrt.h