### PR TITLE
Set the size of SIMD this pointer

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -385,8 +385,9 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
                 if (simdBaseType != TYP_UNKNOWN)
                 {
                     assert(varTypeIsSIMD(type));
-                    varDsc->lvSIMDType = true;
-                    varDsc->lvBaseType = simdBaseType;
+                    varDsc->lvSIMDType  = true;
+                    varDsc->lvBaseType  = simdBaseType;
+                    varDsc->lvExactSize = genTypeSize(type);
                 }
             }
 #endif // FEATURE_SIMD

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_288222/DevDiv_288222.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_288222/DevDiv_288222.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+
+// This test is a repro case for DevDiv VSO bug 288222.
+// The failure mode is that the size was not being set for a "this" pointer
+// with SIMD type.
+
+internal class Program
+{
+    // Declare a delegate type for calling the Vector2.CopyTo method.
+    public delegate void CopyToDelegate(float[] array, int start);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void MyCopyTo(CopyToDelegate doCopy, float[] array, int start)
+    {
+        doCopy(array, start);
+    }
+
+    private static int Main(string[] args)
+    {
+        try
+        {
+            float x = 1.0F;
+            float y = 2.0F;
+            Vector2 v = new Vector2(x, y);
+            float[] array = new float[4];
+            MyCopyTo(new CopyToDelegate(v.CopyTo), array, 2);
+            
+            if ((array[2] != x) || (array[3] != y))
+            {
+                Console.WriteLine("Failed with wrong values");
+                return -1;
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Failed with exception: " + e.Message);
+            return -1;   
+        }
+
+        Console.WriteLine("Pass");
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_288222/DevDiv_288222.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_288222/DevDiv_288222.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_288222.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)threading+thread\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)threading+thread\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
When setting the SIMD type of a "this" pointer,
we need to capture the size of the SIMD type.
This was previously being set in a method in simd.cpp,
but when the SIMD type recognition was moved
earlier in the JIT, it was omitted.
This caused an assert in the case where a fixed-size
SIMD type is handled by `fgMorphCombineSIMDFieldAssignments()`.

Fixes bug 288222