### PR TITLE
[x86/Linux] Fix stdcall calling convention ignored on variadic function

### DIFF
--- a/src/pal/prebuilt/inc/xclrdata.h
+++ b/src/pal/prebuilt/inc/xclrdata.h
@@ -1017,7 +1017,7 @@ EXTERN_C const IID IID_IXCLRDataDisplay;
     IXCLRDataDisplay : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE ErrorPrintF( 
+        virtual HRESULT STDMETHODVCALLTYPE ErrorPrintF(
             const char *const fmt,
             ...) = 0;
         
@@ -1063,11 +1063,11 @@ EXTERN_C const IID IID_IXCLRDataDisplay;
         
         virtual HRESULT STDMETHODCALLTYPE EndTextElement( void) = 0;
         
-        virtual HRESULT STDMETHODCALLTYPE WriteXmlText( 
+        virtual HRESULT STDMETHODVCALLTYPE WriteXmlText(
             const char *const fmt,
             ...) = 0;
         
-        virtual HRESULT STDMETHODCALLTYPE WriteXmlTextBlock( 
+        virtual HRESULT STDMETHODVCALLTYPE WriteXmlTextBlock(
             const char *const fmt,
             ...) = 0;
         
@@ -1258,7 +1258,7 @@ EXTERN_C const IID IID_IXCLRDataDisplay;
         ULONG ( STDMETHODCALLTYPE *Release )( 
             IXCLRDataDisplay * This);
         
-        HRESULT ( STDMETHODCALLTYPE *ErrorPrintF )( 
+        HRESULT ( STDMETHODVCALLTYPE *ErrorPrintF )(
             IXCLRDataDisplay * This,
             const char *const fmt,
             ...);
@@ -1319,12 +1319,12 @@ EXTERN_C const IID IID_IXCLRDataDisplay;
         HRESULT ( STDMETHODCALLTYPE *EndTextElement )( 
             IXCLRDataDisplay * This);
         
-        HRESULT ( STDMETHODCALLTYPE *WriteXmlText )( 
+        HRESULT ( STDMETHODVCALLTYPE *WriteXmlText )(
             IXCLRDataDisplay * This,
             const char *const fmt,
             ...);
         
-        HRESULT ( STDMETHODCALLTYPE *WriteXmlTextBlock )( 
+        HRESULT ( STDMETHODVCALLTYPE *WriteXmlTextBlock )(
             IXCLRDataDisplay * This,
             const char *const fmt,
             ...);


### PR DESCRIPTION
Fix compile error for x86/Linux
- fix to use STDMETHODVCALLTYPE
- related issue: #8248