### PR TITLE
Fix ThreadPool.SetMaxThreads to not allow having zero available threads

### DIFF
--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -532,7 +532,9 @@ BOOL ThreadpoolMgr::SetMaxThreadsHelper(DWORD MaxWorkerThreads,
     CrstHolder csh(&WorkerCriticalSection);
 
     if (MaxWorkerThreads >= (DWORD)MinLimitTotalWorkerThreads &&
-       MaxIOCompletionThreads >= (DWORD)MinLimitTotalCPThreads)
+        MaxIOCompletionThreads >= (DWORD)MinLimitTotalCPThreads &&
+        MaxWorkerThreads != 0 &&
+        MaxIOCompletionThreads != 0)
     {
         BEGIN_SO_INTOLERANT_CODE(GetThread());
 


### PR DESCRIPTION
There is an assertion checking for this, so allowing zero is probably not intentional.

Related to #8236