### PR TITLE
Fix the byref/gcref kill set for ASSIGN_BYREF.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -710,10 +710,15 @@ regMaskTP Compiler::compNoGCHelperCallKillSet(CorInfoHelpFunc helper)
             return RBM_PROFILER_TAILCALL_TRASH;
 #endif // defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
 
-#if defined(_TARGET_AMD64_)
         case CORINFO_HELP_ASSIGN_BYREF:
+#if defined(_TARGET_AMD64_)
             // this helper doesn't trash RSI and RDI
             return RBM_CALLEE_TRASH_NOGC & ~(RBM_RSI | RBM_RDI);
+#elif defined(_TARGET_X86_)
+            // This helper only trashes ECX.
+            return RBM_ECX;
+#else
+            return RBM_CALLEE_TRASH_NOGC;
 #endif // defined(_TARGET_AMD64_)
 
         default:


### PR DESCRIPTION
CORINFO_HELP_ASSIGN_BYREF has an odd calling convention: it kills a
smaller set of registers than a typical call and produces values in
RDI/EDI and RSI/ESI. This convention was not accurately modeled for the
emitter, which was causing assertions later on in the pipeline.