### PR TITLE
Removes non-existent target files from override.targets

### DIFF
--- a/tests/override.targets
+++ b/tests/override.targets
@@ -3,8 +3,6 @@
     Overrides for all other targets (including build tools) can go in this file.
   -->
 
-  <Import Project="mono.targets" Condition="'$(OsEnvironment)'=='Unix'" />
-  <Import Project="roslyn.xplat.targets" Condition="'$(OsEnvironment)'=='Unix'" />
   <!-- Contains overrides for the nuget reference resolution.  The regular nuget reference resolution will not 
        copy references local, which we need in order to correctly execute the xunit project -->
   <Import Project="xunitwrapper.targets" Condition="'$(IsXunitWrapperProject)'=='true'" />


### PR DESCRIPTION
This commit revises override.targets not to import ``mono.targets`` and
``roslyn.xplat.targets`` which do not exist in Tools/

This is the first step to resolve #4437.