### PR TITLE
[x86/Linux] Fix no matching function for call to 'InternalCreateThread'

### DIFF
--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -1648,7 +1648,7 @@ namespace CorUnix
     }
 
     // Entry point routine for the thread that initiates process termination.
-    DWORD TerminationRequestHandlingRoutine(LPVOID pArg)
+    DWORD PALAPI TerminationRequestHandlingRoutine(LPVOID pArg)
     {
         // Call the termination request handler if one is registered.
         if (g_terminationRequestHandler != NULL)


### PR DESCRIPTION
Fix compile error for x86/Linux
- fix calling convention by adding PALAPI to TerminationRequestHandlingRoutine

`InternalCreateThread` is using `TerminationRequestHandlingRoutine` like
```
                    palErr = InternalCreateThread(pthrWorker,
                                      NULL,
                                      0,
                                      &TerminationRequestHandlingRoutine,
                                      NULL,
```