### PR TITLE
[x86/Linux] Fix SEH '__try' is not supported on this target

### DIFF
--- a/src/jit/error.h
+++ b/src/jit/error.h
@@ -239,7 +239,7 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 // limitations (that could be removed in the future)
 #define IMPL_LIMITATION(msg) NO_WAY(msg)
 
-#if defined(_HOST_X86_)
+#if defined(_HOST_X86_) && !defined(FEATURE_PAL)
 
 // While debugging in an Debugger, the "int 3" will cause the program to break
 // Outside, the exception handler will just filter out the "int 3".


### PR DESCRIPTION
Fix compile error for x86/Linux
- add check !FEATURE_PAL