### PR TITLE
[x86/Linux] Fix comparison of two values with different enumeration types

### DIFF
--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -1303,7 +1303,7 @@ size_t GCInfo::gcInfoBlockHdrSave(
         ReturnKind returnKind = getReturnKind();
         _ASSERTE(IsValidReturnKind(returnKind) && "Return Kind must be valid");
         _ASSERTE(!IsStructReturnKind(returnKind) && "Struct Return Kinds Unexpected for JIT32");
-        _ASSERTE((returnKind < SET_RET_KIND_MAX) && "ReturnKind has no legal encoding");
+        _ASSERTE(((int)returnKind < (int)SET_RET_KIND_MAX) && "ReturnKind has no legal encoding");
         header->returnKind = returnKind;
     }
 


### PR DESCRIPTION
Fix compile error for x86/Linux
- convert to int type for 'ReturnKind' and 'infoHdrAdjustConstants'