### PR TITLE
[x86/Linux] Fix unknown type name 'ExInfo'

### DIFF
--- a/src/vm/stackwalk.h
+++ b/src/vm/stackwalk.h
@@ -36,14 +36,14 @@ class AppDomain;
 //  on the stack.  The FEF is used for unwinding.  If not defined, the unwinding
 //  uses the exception context.
 #define USE_FEF // to mark where code needs to be changed to eliminate the FEF
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
  #undef USE_FEF // Turn off the FEF use on x86.
  #define ELIMINATE_FEF
 #else
  #if defined(ELIMINATE_FEF)
   #undef ELIMINATE_FEF
  #endif 
-#endif // _86_
+#endif // _TARGET_X86_ && !FEATURE_PAL
 
 //************************************************************************
 // Enumerate all functions.


### PR DESCRIPTION
Fix compile error for x86/Linux
- need to undefine ELIMINATE_FEF by adding !defined(FEATURE_PAL)