### PR TITLE
[x86/Linux] Fix constructor missing in UnmanagedToManagedFrame

### DIFF
--- a/src/inc/vptr_list.h
+++ b/src/inc/vptr_list.h
@@ -126,7 +126,7 @@ VPTR_CLASS(StubHelperFrame)
 #ifdef FEATURE_REMOTING
 VPTR_CLASS(TPMethodFrame)
 #endif
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 VPTR_CLASS(UMThkCallFrame)
 #endif
 VPTR_CLASS(TailCallFrame)

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -569,7 +569,7 @@ private:
     AppDomain *m_pDomain;
 };
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 //-------------------------------------------------------------------------
 // One-time creation of special prestub to initialize UMEntryThunks.
 //-------------------------------------------------------------------------

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -74,7 +74,7 @@ void Frame::Log() {
 
     MethodDesc* method = GetFunction();
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
     if (GetVTablePtr() == UMThkCallFrame::GetMethodFrameVPtr())
         method = ((UMThkCallFrame*) this)->GetUMEntryThunk()->GetMethod();
 #endif
@@ -85,7 +85,7 @@ void Frame::Log() {
     const char* frameType;
     if (GetVTablePtr() == PrestubMethodFrame::GetMethodFrameVPtr())
         frameType = "PreStub";
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
     else if (GetVTablePtr() == UMThkCallFrame::GetMethodFrameVPtr())
         frameType = "UMThkCallFrame";
 #endif
@@ -1671,7 +1671,7 @@ void ComMethodFrame::DoSecondPassHandlerCleanup(Frame * pCurFrame)
 #endif // FEATURE_COMINTEROP
 
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 
 PTR_UMEntryThunk UMThkCallFrame::GetUMEntryThunk()
 {
@@ -1694,7 +1694,7 @@ void UMThkCallFrame::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 }
 #endif
 
-#endif // _TARGET_X86_
+#endif // _TARGET_X86_ && !FEATURE_PAL
 
 #ifndef DACCESS_COMPILE
 

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -113,8 +113,10 @@
 //    |   +-ComPrestubMethodFrame - prestub frame for calls from COM to CLR
 //    |
 #endif //FEATURE_COMINTEROP
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 //    | +-UMThkCallFrame        - this frame represents an unmanaged->managed
 //    |                           transition through N/Direct
+#endif
 //    |
 //    +-ContextTransitionFrame  - this frame is used to mark an appdomain transition
 //    |
@@ -266,7 +268,7 @@ FRAME_TYPE_NAME(DebuggerClassInitMarkFrame)
 FRAME_TYPE_NAME(DebuggerSecurityCodeMarkFrame)
 FRAME_TYPE_NAME(DebuggerExitFrame)
 FRAME_TYPE_NAME(DebuggerU2MCatchHandlerFrame)
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 FRAME_TYPE_NAME(UMThkCallFrame)
 #endif
 #if defined(FEATURE_INCLUDE_ALL_INTERFACES) && defined(_TARGET_X86_)
@@ -2897,7 +2899,7 @@ typedef DPTR(class UMThunkMarshInfo) PTR_UMThunkMarshInfo;
 class UMEntryThunk;
 typedef DPTR(class UMEntryThunk) PTR_UMEntryThunk;
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 //------------------------------------------------------------------------
 // This frame guards an unmanaged->managed transition thru a UMThk
 //------------------------------------------------------------------------
@@ -2925,9 +2927,9 @@ protected:
     // Keep as last entry in class
     DEFINE_VTABLE_GETTER_AND_CTOR_AND_DTOR(UMThkCallFrame)
 };
-#endif // _TARGET_X86_
+#endif // _TARGET_X86_ && !FEATURE_PAL
 
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 //-------------------------------------------------------------------------
 // Exception handler for COM to managed frame
 //  and the layout of the exception registration record structure in the stack
@@ -2947,7 +2949,7 @@ struct ComToManagedExRecord
         return &m_frame;
     }
 };
-#endif // _TARGET_X86_
+#endif // _TARGET_X86_ && !FEATURE_PAL
 
 #if defined(FEATURE_INCLUDE_ALL_INTERFACES) && defined(_TARGET_X86_)
 //-----------------------------------------------------------------------------

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -760,6 +760,7 @@ WORD GetUnpatchedCodeData(LPCBYTE pAddr)
 
 #ifndef DACCESS_COMPILE
 
+#if !defined(FEATURE_PAL)
 //-------------------------------------------------------------------------
 // One-time creation of special prestub to initialize UMEntryThunks.
 //-------------------------------------------------------------------------
@@ -809,6 +810,7 @@ Stub *GenerateUMThunkPrestub()
 
     RETURN psl->Link(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
 }
+#endif // !FEATURE_PAL
 
 Stub *GenerateInitPInvokeFrameHelper()
 {

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -2535,7 +2535,7 @@ VOID StubLinkerCPU::X86EmitCurrentAppDomainFetch(X86Reg dstreg, unsigned preserv
 #endif // FEATURE_IMPLICIT_TLS
 }
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 
 #ifdef PROFILING_SUPPORTED
 VOID StubLinkerCPU::EmitProfilerComCallProlog(TADDR pFrameVptr, X86Reg regFrame)
@@ -2946,7 +2946,7 @@ VOID StubLinkerCPU::EmitRareSetup(CodeLabel *pRejoinPoint, BOOL fThrow)
 }
 
 //========================================================================
-#endif // _TARGET_X86_
+#endif // _TARGET_X86_ && !FEATURE_PAL
 //========================================================================
 #if defined(FEATURE_COMINTEROP) && defined(_TARGET_X86_)
 //========================================================================

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1647,7 +1647,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
 // use the prestub.
 //==========================================================================
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 static PCODE g_UMThunkPreStub;
 #endif
 
@@ -1676,7 +1676,7 @@ void InitPreStubManager(void)
         return;
     }
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
     g_UMThunkPreStub = GenerateUMThunkPrestub()->GetEntryPoint();
 #endif
 
@@ -1687,7 +1687,7 @@ PCODE TheUMThunkPreStub()
 {
     LIMITED_METHOD_CONTRACT;
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
     return g_UMThunkPreStub;
 #else
     return GetEEFuncEntryPoint(TheUMEntryPrestub);


### PR DESCRIPTION
Fix compile error for x86/Linux
- full error string: constructor for 'UMThkCallFrame' must explicitly
  initialize the base class 'UnmanagedToManagedFrame' which does not
  have a default constructor
- wrap UMThkCallFrame with also !FEATURE_PAL