### PR TITLE
Fix archiving for jitdiff windows build only jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1960,8 +1960,10 @@ combinedScenarios.each { scenario ->
 
                                         if (scenario == 'jitdiff') {
                                             // retrive jit-dasm output for base commit, and run jit-diff
-
-                                            Utilities.addArchival(newJob, "bin/tests/${osGroup}.${arch}.${configuration}/dasm/**")
+                                            if (!isBuildOnly) {
+                                                // if this is a build only job, we want to keep the default (build) artifacts for the flow job
+                                                Utilities.addArchival(newJob, "bin/tests/${osGroup}.${arch}.${configuration}/dasm/**")
+                                            }
                                         }
                                         
                                         if (!isBuildOnly) {


### PR DESCRIPTION
The dasm archiving was enabled for all jitdiff scenarios, including the
build set up for the ubuntu/osx flow jobs. The dasm artifacts don't
exist in build-only scenarios, and this was preventing archiving of
the build.         