### PR TITLE
Fix Typo in Unix Lock/Unlock PAL

### DIFF
--- a/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Fcntl.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Native/Interop.Fcntl.cs
@@ -11,8 +11,8 @@ internal static partial class Interop
     {
         internal enum LockType : short
         {
-            F_UNLCK = 2,    // unlock
-            F_WRLCK = 3     // exclusive or write lock
+            F_WRLCK = 1,    // exclusive or write lock
+            F_UNLCK = 2     // unlock
         }
         
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LockFileRegion", SetLastError=true)]


### PR DESCRIPTION
I got these variables mixed up in the PR feedback for https://github.com/dotnet/coreclr/pull/8233/files where I changed how they were being passed.

I verified these are the correct values. I couldn't find fcntl.h so I just did this:
```
#include <fcntl.h>
#include <stdio.h>

void main(char** args)
{
	printf("WriteLock: %d\n", F_WRLCK);
	printf("Unlock: %d\n", F_UNLCK);
	printf("Readlock: %d\n", F_RDLCK);
}
```

```
WriteLock: 1
Unlock: 2
Readlock: 0
```

@JeremyKuhne 