### PR TITLE
Allow creating SortKey with Upper case first sorting attribute

### DIFF
--- a/src/corefx/System.Globalization.Native/collation.cpp
+++ b/src/corefx/System.Globalization.Native/collation.cpp
@@ -18,6 +18,8 @@ const int32_t CompareOptionsIgnoreNonSpace = 0x2;
 const int32_t CompareOptionsIgnoreSymbols = 0x4;
 const int32_t CompareOptionsIgnoreKanaType = 0x8;
 const int32_t CompareOptionsIgnoreWidth = 0x10;
+const int32_t CompareOptionsUpperCaseFirst = 0x01000000;
+
 // const int32_t CompareOptionsStringSort = 0x20000000;
 // ICU's default is to use "StringSort", i.e. nonalphanumeric symbols come before alphanumeric.
 // When StringSort is not specified (.NET's default), the sort order will be different between
@@ -227,6 +229,7 @@ UCollator* CloneCollatorWithOptions(const UCollator* pCollator, int32_t options,
     bool isIgnoreCase = (options & CompareOptionsIgnoreCase) == CompareOptionsIgnoreCase;
     bool isIgnoreNonSpace = (options & CompareOptionsIgnoreNonSpace) == CompareOptionsIgnoreNonSpace;
     bool isIgnoreSymbols = (options & CompareOptionsIgnoreSymbols) == CompareOptionsIgnoreSymbols;
+    bool isUpperCaseFirst =  (options & CompareOptionsUpperCaseFirst) == CompareOptionsUpperCaseFirst;
 
     if (isIgnoreCase)
     {
@@ -288,6 +291,11 @@ UCollator* CloneCollatorWithOptions(const UCollator* pCollator, int32_t options,
     if (strength < UCOL_TERTIARY && !isIgnoreCase)
     {
         ucol_setAttribute(pClonedCollator, UCOL_CASE_LEVEL, UCOL_ON, pErr);
+    }
+    
+    if (isUpperCaseFirst)
+    {
+        ucol_setAttribute(pClonedCollator, UCOL_CASE_FIRST, UCOL_UPPER_FIRST, pErr);
     }
 
     return pClonedCollator;

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -252,8 +252,11 @@ namespace System.Globalization
         {
             if (source==null) { throw new ArgumentNullException(nameof(source)); }
             Contract.EndContractBlock();
+            
+            // Allow 0x01000000 with sortkey creation for handling uppercase first sorting case used in System.Xml.Xsl
+            CompareOptions co = ValidSortkeyCtorMaskOffFlags & (~ (CompareOptions) 0x01000000);
 
-            if ((options & ValidSortkeyCtorMaskOffFlags) != 0)
+            if ((options & co) != 0)
             {
                 throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
             }

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.cs
@@ -37,6 +37,10 @@ namespace System.Globalization
         OrdinalIgnoreCase = 0x10000000,   // This flag can not be used with other flags.
         StringSort = 0x20000000,   // use string sort method
         Ordinal = 0x40000000,   // This flag can not be used with other flags.
+        
+        // UpperCaseFirst = 0x01000000
+        // This can be useful to expose in the future but we reserve the spot here as we'll use it
+        // to perform sorting uppercase first in Linux whch is used by System.Xml.Xsl
     }
 
     [Serializable]


### PR DESCRIPTION
Currently we don't have a way to sort or creat sort keys with the option upper case first. System.Xml.Xsl support transforming Xml docs using Xslt template with the option
      <xsl:sort select = \"firstname\" case-order=\"upper-first\"/>
which is sorting elements with uppercase first.

On Windows, System.Xml.Xsl support this option by creating the sort key (without upper-case first as it is not supported) and then manually manipulate the sort key bytes to make the result look like it is sorted as upper-case first. this will not work nicely on Linux because the sortkeys there are different than the sortkeys generated on Windows and it is not right to manually manipulate the sort keys after creating it.

The solution here is to allow passing some flag to sort key creation when running on Linux and then use this flag to instruct ICU to generate the sort key with upper-case first option