### PR TITLE
Increment lclVar refCounts in fgMorphBlockStmt.

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4683,9 +4683,8 @@ GenTreePtr Compiler::optVNConstantPropOnJTrue(BasicBlock* block, GenTreePtr stmt
             newStmt     = fgInsertStmtNearEnd(block, sideEffList);
             sideEffList = nullptr;
         }
-        fgMorphBlockStmt(block, newStmt DEBUGARG(__FUNCTION__));
-        gtSetStmtInfo(newStmt);
-        fgSetStmtSeq(newStmt);
+
+        fgMorphBlockStmt(block, newStmt->AsStmt() DEBUGARG(__FUNCTION__));
     }
 
     // Transform the relop's operands to be both zeroes.
@@ -4909,9 +4908,7 @@ GenTreePtr Compiler::optVNAssertionPropCurStmt(BasicBlock* block, GenTreePtr stm
 
     if (optAssertionPropagatedCurrentStmt)
     {
-        fgMorphBlockStmt(block, stmt DEBUGARG("optVNAssertionPropCurStmt"));
-        gtSetStmtInfo(stmt);
-        fgSetStmtSeq(stmt);
+        fgMorphBlockStmt(block, stmt->AsStmt() DEBUGARG("optVNAssertionPropCurStmt"));
     }
 
     // Check if propagation removed statements starting from current stmt.
@@ -5108,13 +5105,7 @@ void Compiler::optAssertionPropMain()
                 }
 #endif
                 // Re-morph the statement.
-                fgMorphBlockStmt(block, stmt DEBUGARG("optAssertionPropMain"));
-
-                // Recalculate the gtCostSz, etc...
-                gtSetStmtInfo(stmt);
-
-                // Re-thread the nodes
-                fgSetStmtSeq(stmt);
+                fgMorphBlockStmt(block, stmt->AsStmt() DEBUGARG("optAssertionPropMain"));
             }
 
             // Check if propagation removed statements starting from current stmt.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3511,7 +3511,7 @@ public:
     void fgMorphStmts(BasicBlock* block, bool* mult, bool* lnot, bool* loadw);
     void fgMorphBlocks();
 
-    bool fgMorphBlockStmt(BasicBlock* block, GenTreePtr stmt DEBUGARG(const char* msg));
+    bool fgMorphBlockStmt(BasicBlock* block, GenTreeStmt* stmt DEBUGARG(const char* msg));
 
     void fgCheckArgCnt();
     void fgSetOptions();

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -612,13 +612,7 @@ void Compiler::optFoldNullCheck(GenTreePtr tree)
                                                         additionNode->gtFlags & (GTF_EXCEPT | GTF_DONT_CSE);
 
                                                     // Re-morph the statement.
-                                                    fgMorphBlockStmt(compCurBB, curStmt DEBUGARG("optFoldNullCheck"));
-
-                                                    // Recalculate the gtCostSz, etc...
-                                                    gtSetStmtInfo(curStmt);
-
-                                                    // Re-thread the nodes
-                                                    fgSetStmtSeq(curStmt);
+                                                    fgMorphBlockStmt(compCurBB, curStmt->AsStmt() DEBUGARG("optFoldNullCheck"));
                                                 }
                                             }
                                         }

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -612,7 +612,8 @@ void Compiler::optFoldNullCheck(GenTreePtr tree)
                                                         additionNode->gtFlags & (GTF_EXCEPT | GTF_DONT_CSE);
 
                                                     // Re-morph the statement.
-                                                    fgMorphBlockStmt(compCurBB, curStmt->AsStmt() DEBUGARG("optFoldNullCheck"));
+                                                    fgMorphBlockStmt(compCurBB,
+                                                                     curStmt->AsStmt() DEBUGARG("optFoldNullCheck"));
                                                 }
                                             }
                                         }

--- a/src/jit/loopcloning.cpp
+++ b/src/jit/loopcloning.cpp
@@ -698,7 +698,7 @@ void LoopCloneContext::CondToStmtInBlock(Compiler*                       comp,
     comp->fgInsertStmtAtEnd(block, stmt);
 
     // Remorph.
-    comp->fgMorphBlockStmt(block, stmt DEBUGARG("Loop cloning condition"));
+    comp->fgMorphBlockStmt(block, stmt->AsStmt() DEBUGARG("Loop cloning condition"));
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2050,7 +2050,7 @@ public:
             assert(m_pCompiler->fgRemoveRestOfBlock == false);
 
             /* re-morph the statement */
-            m_pCompiler->fgMorphBlockStmt(blk, stm DEBUGARG("optValnumCSE"));
+            m_pCompiler->fgMorphBlockStmt(blk, stm->AsStmt() DEBUGARG("optValnumCSE"));
 
         } while (lst != nullptr);
     }

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -4242,7 +4242,7 @@ void Compiler::optDebugLogLoopCloning(BasicBlock* block, GenTreePtr insertBefore
     GenTreePtr logCall = gtNewHelperCallNode(CORINFO_HELP_DEBUG_LOG_LOOP_CLONING, TYP_VOID);
     GenTreePtr stmt    = fgNewStmtFromTree(logCall);
     fgInsertStmtBefore(block, insertBefore, stmt);
-    fgMorphBlockStmt(block, stmt DEBUGARG("Debug log loop cloning"));
+    fgMorphBlockStmt(block, stmt->AsStmt() DEBUGARG("Debug log loop cloning"));
 }
 #endif
 


### PR DESCRIPTION
`fgMorphTree` may introduce additional lclVar references. Call
`lvaRecursiveIncRefCounts` in `fgMorphBlockStmt` to ensure that ref
counts are conservatively correct.

Fixes #8258.