### PR TITLE
Enable use of SSE3_4 instruction set for SIMD codegen.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6881,6 +6881,11 @@ private:
             return InstructionSet_AVX;
         }
 
+        if (CanUseSSE3_4())
+        {
+            return InstructionSet_SSE3_4;
+        }
+
         // min bar is SSE2
         assert(canUseSSE2());
         return InstructionSet_SSE2;
@@ -7341,6 +7346,16 @@ private:
 #endif
     }
 
+    // Whether SSE3, SSE3, SSE4.1 and SSE4.2 is available
+    bool CanUseSSE3_4() const
+    {
+#ifdef _TARGET_XARCH_
+        return opts.compCanUseSSE3_4;
+#else
+        return false;
+#endif
+    }
+
     bool canUseAVX() const
     {
 #ifdef FEATURE_AVX_SUPPORT
@@ -7453,7 +7468,8 @@ public:
         bool compUseFCOMI;
         bool compUseCMOV;
 #ifdef _TARGET_XARCH_
-        bool compCanUseSSE2; // Allow CodeGen to use "movq XMM" instructions
+        bool compCanUseSSE2;   // Allow CodeGen to use "movq XMM" instructions
+        bool compCanUseSSE3_4; // Allow CodeGen to use SSE3, SSSE3, SSE4.1 and SSE4.2 instructions
 
 #ifdef FEATURE_AVX_SUPPORT
         bool compCanUseAVX; // Allow CodeGen to use AVX 256-bit vectors for SIMD operations

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -427,6 +427,11 @@ public:
         // There seem to be some cases where this is used without being initialized via CodeGen::inst_set_SV_var().
         emitVarRefOffs = 0;
 #endif // DEBUG
+
+#ifdef _TARGET_XARCH_
+        SetUseSSE3_4(false);
+#endif // _TARGET_XARCH_
+
 #ifdef FEATURE_AVX_SUPPORT
         SetUseAVX(false);
 #endif // FEATURE_AVX_SUPPORT

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -86,6 +86,17 @@ size_t AddRexXPrefix(instruction ins, size_t code);
 size_t AddRexBPrefix(instruction ins, size_t code);
 size_t AddRexPrefix(instruction ins, size_t code);
 
+bool useSSE3_4Encodings;
+bool UseSSE3_4()
+{
+    return useSSE3_4Encodings;
+}
+void SetUseSSE3_4(bool value)
+{
+    useSSE3_4Encodings = value;
+}
+bool Is4ByteSSE4Instruction(instruction ins);
+
 #ifdef FEATURE_AVX_SUPPORT
 // 3-byte VEX prefix starts with byte 0xC4
 #define VEX_PREFIX_MASK_3BYTE 0xC4000000000000LL
@@ -112,6 +123,7 @@ size_t AddVexPrefixIfNeededAndNotPresent(instruction ins, size_t code, emitAttr 
     }
     return code;
 }
+
 bool useAVXEncodings;
 bool UseAVX()
 {
@@ -121,12 +133,14 @@ void SetUseAVX(bool value)
 {
     useAVXEncodings = value;
 }
+
 bool IsThreeOperandBinaryAVXInstruction(instruction ins);
 bool IsThreeOperandMoveAVXInstruction(instruction ins);
 bool IsThreeOperandAVXInstruction(instruction ins)
 {
     return (IsThreeOperandBinaryAVXInstruction(ins) || IsThreeOperandMoveAVXInstruction(ins));
 }
+bool Is4ByteAVXInstruction(instruction ins);
 #else  // !FEATURE_AVX_SUPPORT
 bool UseAVX()
 {
@@ -145,6 +159,10 @@ bool IsThreeOperandMoveAVXInstruction(instruction ins)
     return false;
 }
 bool IsThreeOperandAVXInstruction(instruction ins)
+{
+    return false;
+}
+bool Is4ByteAVXInstruction(instruction ins)
 {
     return false;
 }

--- a/src/jit/instr.h
+++ b/src/jit/instr.h
@@ -284,15 +284,19 @@ END_DECLARE_TYPED_ENUM(emitAttr,unsigned)
 #define EmitSize(x)                 (EA_ATTR(genTypeSize(TypeGet(x))))
 
 // Enum specifying the instruction set for generating floating point or SIMD code.
+// These enums are ordered such that each one is inclusive of previous instruction sets
+// and the VM ensures this as well when setting the CONFIG flags.
 enum InstructionSet
 {
 #ifdef _TARGET_XARCH_
-    InstructionSet_SSE2,
-    InstructionSet_AVX,
+    InstructionSet_SSE2,      // SSE2 Instruction set
+    InstructionSet_SSE3_4,    // SSE3, SSSE3, SSE4.1 and SSE4.2 instruction set
+    InstructionSet_AVX,       // AVX2 instruction set
+                              // TODO-Cleaup - This should be named as InstructionSet_AVX2
 #elif defined(_TARGET_ARM_)
     InstructionSet_NEON,
 #endif
-    InstructionSet_NONE
+    InstructionSet_NONE       // No instruction set is available indicating an invalid value
 };
 // clang-format on
 

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -200,11 +200,17 @@ CONFIG_INTEGER(AltJitAssertOnNYI, W("AltJitAssertOnNYI"), 0) // Controls the Alt
 CONFIG_INTEGER(AltJitAssertOnNYI, W("AltJitAssertOnNYI"), 1) // Controls the AltJit behavior of NYI stuff
 #endif                                                       // defined(_TARGET_ARM64_) || defined(_TARGET_X86_)
 
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+CONFIG_INTEGER(EnableSSE3_4, W("EnableSSE3_4"), 1) // Enable SSE3, SSSE3, SSE 4.1 and 4.2 instruction set as default
+#endif
+
 #if defined(_TARGET_AMD64_)
-CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 1) // Enable AVX instruction set for wide operations as default
-#else                                        // !defined(_TARGET_AMD64_)
+CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 1) // Enable AVX instruction set for wide operations as default.
+// When both AVX and SSE3_4 are set, we will use the most capable instruction set available
+// which will prefer AVX over SSE3/4.
+#else  // !defined(_TARGET_AMD64_)
 CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 0)                 // Enable AVX instruction set for wide operations as default
-#endif                                       // defined(_TARGET_AMD64_)
+#endif // defined(_TARGET_AMD64_)
 
 #if !defined(DEBUG) && !defined(_DEBUG)
 CONFIG_INTEGER(JitEnableNoWayAssert, W("JitEnableNoWayAssert"), 0)

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -2391,8 +2391,9 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
         {
 #if defined(_TARGET_XARCH_)
             // Right now dot product is supported only for float/double vectors and
-            // int vectors on AVX.
-            if (!varTypeIsFloating(baseType) && !(baseType == TYP_INT && canUseAVX()))
+            // int vectors on SSE4/AVX.
+            if (!varTypeIsFloating(baseType) &&
+                !(baseType == TYP_INT && getSIMDInstructionSet() >= InstructionSet_SSE3_4))
             {
                 return nullptr;
             }


### PR DESCRIPTION
Right now RyuJIT supports SSE2 and AVX2 instruction set for SIMD codegen.  SSE3/SSSE3/SSE4.1/SSE4.2 instruction sets gets used only if the machine supports AVX2.  These code changes are meant to take advantage of SSE3_4 instruction set on a target that doesn't support AVX2 but supports SSE3_4.

Summary points:
Complus_EnableSSE3_4 - setting is added to disable use of SSE3_4.  By setting complus_EnableSSE3_4=0 and complus_EnableAVX=0, we can test SSE2 based SIMD codegen.  I will be filing a git work item to add such a test leg in OSS CI.

Code changes are mostly in simd.cpp/lowerxarch.cpp/simdcodegenxarch.cpp/emitxarch.cpp.  Right now SSE3_4 instructions are leveraged for dot product (horizontal add, packed multiply of 32-bit uint), ptest,  packed compare of long vectors and insertps.

Asm Diffs:
SuperPMI asm diffs show a 6K code size improvement across all SSE2 SPMI collection.

```
                                                       baseline        diff improvement  %improvement    #funcs
TOTAL                                                   217093      210676        6417          2.96       369
```

Kestrel and RavenDB would benefit from SSE3_4 support. 