### PR TITLE
[x86/Linux] Fix compile error in zapcode

### DIFF
--- a/src/zap/zapcode.cpp
+++ b/src/zap/zapcode.cpp
@@ -1130,7 +1130,7 @@ void ZapUnwindInfo::Save(ZapWriter * pZapWriter)
     pZapWriter->Write(&runtimeFunction, sizeof(runtimeFunction));
 }
 
-#ifdef WIN64EXCEPTIONS
+#if defined(WIN64EXCEPTIONS) && !defined(_TARGET_X86_)
 // Compare the unwind infos by their offset
 int __cdecl ZapUnwindInfo::CompareUnwindInfo(const void* a_, const void* b_)
 {


### PR DESCRIPTION
Fix compile error for x86/Linux
- Remove ZapUnwindInfo WIN64EXCEPTIONS codes for x86/Linux
- fix "use of undeclared identifier 'NEED_TO_PORT_THIS_ONE'"
- fix "unknown type name 'UNWIND_INFO'"
- fix "use of undeclared identifier 'READYTORUN_HELPER_PersonalityRoutineFilterFunclet'"