### PR TITLE
[x86/Linux] Fix error variable 'td' is uninitialized

### DIFF
--- a/src/debug/di/rsthread.cpp
+++ b/src/debug/di/rsthread.cpp
@@ -1493,7 +1493,7 @@ void CordbThread::Get32bitFPRegisters(CONTEXT * pContext)
 
     for (i = 0; i <= floatStackTop; i++)
     {
-        long double td;
+        double td = 0.0;
         __asm fstp td // copy out the double
         m_floatValues[i] = td;
     }


### PR DESCRIPTION
Fix compile error for x86/Linux
- make compiler happy with initialize variable 'td' with 0.0