### PR TITLE
Fix RyuJIT debug dump: print YMM register on 256 bit AVX instruction, print XMM register on 128 AVX instruction

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6818,11 +6818,11 @@ void emitter::emitDispIns(
         case IF_RRD_ARD:
         case IF_RWR_ARD:
         case IF_RRW_ARD:
-            if (IsAVXInstruction(ins))
+            if (IsAVXInstruction(ins) && attr == EA_32BYTE)
             {
                 printf("%s, %s", emitYMMregName((unsigned)id->idReg1()), sstr);
             }
-            else if (IsSSE2Instruction(ins))
+            else if (IsSSE2Instruction(ins) || IsAVXInstruction(ins))
             {
                 printf("%s, %s", emitXMMregName((unsigned)id->idReg1()), sstr);
             }
@@ -6851,11 +6851,11 @@ void emitter::emitDispIns(
 
             printf("%s", sstr);
             emitDispAddrMode(id);
-            if (IsAVXInstruction(ins))
+            if (IsAVXInstruction(ins) && attr == EA_32BYTE)
             {
                 printf(", %s", emitYMMregName((unsigned)id->idReg1()));
             }
-            else if (IsSSE2Instruction(ins))
+            else if (IsSSE2Instruction(ins) || IsAVXInstruction(ins))
             {
                 printf(", %s", emitXMMregName((unsigned)id->idReg1()));
             }
@@ -6940,11 +6940,11 @@ void emitter::emitDispIns(
             emitDispFrameRef(id->idAddr()->iiaLclVar.lvaVarNum(), id->idAddr()->iiaLclVar.lvaOffset(),
                              id->idDebugOnlyInfo()->idVarRefOffs, asmfm);
 
-            if (IsAVXInstruction(ins))
+            if (IsAVXInstruction(ins) && attr == EA_32BYTE)
             {
                 printf(", %s", emitYMMregName((unsigned)id->idReg1()));
             }
-            else if (IsSSE2Instruction(ins))
+            else if (IsSSE2Instruction(ins) || IsAVXInstruction(ins))
             {
                 printf(", %s", emitXMMregName((unsigned)id->idReg1()));
             }
@@ -6993,11 +6993,11 @@ void emitter::emitDispIns(
         case IF_RRD_SRD:
         case IF_RWR_SRD:
         case IF_RRW_SRD:
-            if (IsAVXInstruction(ins))
+            if (IsAVXInstruction(ins) && attr == EA_32BYTE)
             {
                 printf("%s, %s", emitYMMregName((unsigned)id->idReg1()), sstr);
             }
-            else if (IsSSE2Instruction(ins))
+            else if (IsSSE2Instruction(ins) || IsAVXInstruction(ins))
             {
                 printf("%s, %s", emitXMMregName((unsigned)id->idReg1()), sstr);
             }
@@ -7049,11 +7049,11 @@ void emitter::emitDispIns(
             {
                 printf(" %s, %s", emitRegName(id->idReg1(), attr), emitXMMregName((unsigned)id->idReg2()));
             }
-            else if (IsAVXInstruction(ins))
+            else if (IsAVXInstruction(ins) && attr == EA_32BYTE)
             {
                 printf("%s, %s", emitYMMregName((unsigned)id->idReg1()), emitYMMregName((unsigned)id->idReg2()));
             }
-            else if (IsSSE2Instruction(ins))
+            else if (IsSSE2Instruction(ins) || IsAVXInstruction(ins))
             {
                 printf("%s, %s", emitXMMregName((unsigned)id->idReg1()), emitXMMregName((unsigned)id->idReg2()));
             }
@@ -7089,7 +7089,7 @@ void emitter::emitDispIns(
             break;
 #endif
         case IF_RRW_RRW_CNS:
-            if (IsAVXInstruction(ins))
+            if (IsAVXInstruction(ins) && attr == EA_32BYTE)
             {
                 printf("%s,", emitYMMregName((unsigned)id->idReg1()), attr);
                 printf(" %s", emitYMMregName((unsigned)id->idReg2()), attr);
@@ -7143,11 +7143,11 @@ void emitter::emitDispIns(
                 attr = EA_PTRSIZE;
             }
 #endif
-            if (IsAVXInstruction(ins))
+            if (IsAVXInstruction(ins) && attr == EA_32BYTE)
             {
                 printf("%s, %s", emitYMMregName((unsigned)id->idReg1()), sstr);
             }
-            else if (IsSSE2Instruction(ins))
+            else if (IsSSE2Instruction(ins) || IsAVXInstruction(ins))
             {
                 printf("%s, %s", emitXMMregName((unsigned)id->idReg1()), sstr);
             }


### PR DESCRIPTION
RyuJIT debug dump for COMPlus_JitDump and COMPlus_JitDisasm should print YMM registers for 256 bit AVX instruction and print XMM registers for 128 bit AVX instruction, thus to avoid misleading and to be consistent with Intel Architecture Instruction Set Manual and Windbg/SOS output.

Fix issue #8300

@CarolEidt @russellhadley @sivarv 