### PR TITLE
Enable field EndAddress only for AMD64 in PAL of RUNTIME_FUNCTION

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -4709,7 +4709,9 @@ enum {
 //
 typedef struct _RUNTIME_FUNCTION {
     DWORD BeginAddress;
+#ifdef _AMD64_
     DWORD EndAddress;
+#endif
     DWORD UnwindData;
 } RUNTIME_FUNCTION, *PRUNTIME_FUNCTION;
 


### PR DESCRIPTION
Enable field EndAddress only for AMD64 in PAL

As noted in https://github.com/dotnet/coreclr/pull/8272#discussion_r89505866