### PR TITLE
Better bulk adds for List.

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -1041,21 +1041,29 @@ namespace System.Collections.Generic {
                 // Read in items from the enumerator, only updating fields
                 // when we run out of space.
 
-                while (en.MoveNext())
+                try
                 {
-                    if (size == items.Length)
+                    while (en.MoveNext())
                     {
-                        _size = size;
-                        EnsureCapacity(size + 1);
-                        items = _items;
-                    }
+                        if (size == items.Length)
+                        {
+                            _size = size;
+                            EnsureCapacity(size + 1);
+                            items = _items;
+                        }
 
-                    items[size++] = en.Current;
+                        // Note: It's important we increment size after Current is called.
+                        // If that throws an exception we don't want to to the increment.
+                        items[size] = en.Current;
+                        size++;
+                    }
                 }
-                
-                // Make a final update to _size and _version after we've finished adding.
-                _size = size;
-                _version++;
+                finally
+                {
+                    // Make a final update to _size and _version after we've finished adding.
+                    _size = size;
+                    _version++;
+                }
             }
         }
 

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -1036,32 +1036,19 @@ namespace System.Collections.Generic {
             using (IEnumerator<T> en = enumerable.GetEnumerator())
             {
                 T[] items = _items;
-                int size = _size;
 
-                // Read in items from the enumerator, only updating fields
-                // when we run out of space.
-
-                try
+                while (en.MoveNext())
                 {
-                    while (en.MoveNext())
+                    if (_size == items.Length)
                     {
-                        if (size == items.Length)
-                        {
-                            _size = size;
-                            EnsureCapacity(size + 1);
-                            items = _items;
-                        }
-
-                        // Note: It's important we increment size after Current is called.
-                        // If that throws an exception we don't want to do the increment.
-                        items[size] = en.Current;
-                        size++;
+                        EnsureCapacity(_size + 1);
+                        items = _items;
                     }
-                }
-                finally
-                {
-                    // Make a final update to _size and _version after we've finished adding.
-                    _size = size;
+
+                    // Note: It's important we increment size after Current is called.
+                    // If that throws an exception we don't want to do the increment.
+                    items[_size] = en.Current;
+                    _size++;
                     _version++;
                 }
             }

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -1053,7 +1053,7 @@ namespace System.Collections.Generic {
                         }
 
                         // Note: It's important we increment size after Current is called.
-                        // If that throws an exception we don't want to to the increment.
+                        // If that throws an exception we don't want to do the increment.
                         items[size] = en.Current;
                         size++;
                     }

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -1035,6 +1035,8 @@ namespace System.Collections.Generic {
 
             using (IEnumerator<T> en = enumerable.GetEnumerator())
             {
+                _version++; // Even if the enumerable has no items, we can update _version.
+
                 T[] items = _items;
 
                 while (en.MoveNext())
@@ -1049,7 +1051,6 @@ namespace System.Collections.Generic {
                     // If that throws an exception we don't want to do the increment.
                     items[_size] = en.Current;
                     _size++;
-                    _version++;
                 }
             }
         }

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -386,7 +386,7 @@ namespace System.Collections.Generic {
         }
 
         // Ensures that the capacity of this list is at least the given minimum
-        // value. If the currect capacity of the list is less than min, the
+        // value. If the current capacity of the list is less than min, the
         // capacity is increased to twice the current capacity or to min,
         // whichever is larger.
         private void EnsureCapacity(int min) {
@@ -1037,20 +1037,18 @@ namespace System.Collections.Generic {
             {
                 _version++; // Even if the enumerable has no items, we can update _version.
 
-                T[] items = _items;
-
                 while (en.MoveNext())
                 {
-                    if (_size == items.Length)
+                    // Capture Current before doing anything else. If this throws
+                    // an exception, we want to make a clean break.
+                    T current = en.Current;
+
+                    if (_size == _items.Length)
                     {
                         EnsureCapacity(_size + 1);
-                        items = _items;
                     }
 
-                    // Note: It's important we increment size after Current is called.
-                    // If that throws an exception we don't want to do the increment.
-                    items[_size] = en.Current;
-                    _size++;
+                    _items[_size++] = current;
                 }
             }
         }


### PR DESCRIPTION
This PR optimizes the `List(IEnumerable<T>)` .ctor and `AddRange` method for lazy enumerables.

- For the constructor, we were previously looping through the sequence and calling `Add` on each item. This is not very efficient since `Add` is not inlined. Instead, we can have a tighter loop where we essentially write `Add` inline and only update fields when we run out of space.

- For `InsertRange`, we check if we are adding at the end of the list first. This is a common case, since `AddRange` just forwards to `InsertRange`. If we are, then we call `AddEnumerable` instead of `Insert` in a loop.

I ran tests on corefx's System.Collections and everything passes.

Note: I can't test the perf impact these changes have at the moment because of #8266. If/when I am able to, however, I will update this PR.

cc @stephentoub @jkotas 

Related: https://github.com/dotnet/corefx/pull/13942#issuecomment-262844479