### PR TITLE
Configures tests even when configureonly is provided

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -581,7 +581,6 @@ while :; do
             __ConfigureOnly=1
             __SkipMSCorLib=1
             __SkipNuget=1
-            __IncludeTests=
             ;;
 
         skipconfigure)


### PR DESCRIPTION
The current script does not configure tests when configureonly is
provided.

This commit revises 'build.sh' to configure tests even when configureonly
is provided.

This commit makes it possible to build tests (including related components)
via configuring the whole projects and running make inside that directory.