### PR TITLE
FreeBSD-11.0 build fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,11 +44,11 @@ usage()
     echo "skipnuget - skip building nuget packages."
     echo "verbose - optional argument to enable verbose build output."
     echo "-skiprestore: skip restoring packages ^(default: packages are restored during build^)."
-	echo "-disableoss: Disable Open Source Signing for System.Private.CoreLib."
-	echo "-sequential: force a non-parallel build ^(default is to build in parallel"
-	echo "   using all processors^)."
-	echo "-officialbuildid=^<ID^>: specify the official build ID to be used by this build."
-	echo "-Rebuild: passes /t:rebuild to the build projects."
+    echo "-disableoss: Disable Open Source Signing for System.Private.CoreLib."
+    echo "-sequential: force a non-parallel build ^(default is to build in parallel"
+    echo "   using all processors^)."
+    echo "-officialbuildid=^<ID^>: specify the official build ID to be used by this build."
+    echo "-Rebuild: passes /t:rebuild to the build projects."
     echo "skipgenerateversion - disable version generation even if MSBuild is supported."
     echo "cmakeargs - user-settable additional arguments passed to CMake."
     echo "bindir - output directory (defaults to $__ProjectRoot/bin)"
@@ -176,7 +176,7 @@ build_coreclr()
             echo $__versionSourceLine > $__versionSourceFile
         fi
 
-		pushd "$__IntermediatesDir"
+        pushd "$__IntermediatesDir"
         # Regenerate the CMake solution
         __ExtraCmakeArgs="-DCLR_CMAKE_TARGET_OS=$__BuildOS -DCLR_CMAKE_PACKAGES_DIR=$__PackagesDir -DCLR_CMAKE_PGO_INSTRUMENT=$__PgoInstrument"
         echo "Invoking \"$__ProjectRoot/src/pal/tools/gen-buildsys-clang.sh\" \"$__ProjectRoot\" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__BuildType $__CodeCoverage $__IncludeTests $generator $__ExtraCmakeArgs $__cmakeargs"
@@ -226,7 +226,7 @@ build_coreclr()
         exit 1
     fi
 
-	popd
+    popd
 }
 
 isMSBuildOnNETCoreSupported()
@@ -540,7 +540,7 @@ while :; do
             __CrossBuild=1
             ;;
 
-		verbose)
+        verbose)
         __VerboseBuild=1
         ;;
 
@@ -656,7 +656,7 @@ __RunArgs="-BuildArch=$__BuildArch -BuildType=$__BuildType -BuildOS=$__BuildOS"
 # Configure environment if we are doing a verbose build
 if [ $__VerboseBuild == 1 ]; then
     export VERBOSE=1
-	__RunArgs="$__RunArgs -verbose"
+    __RunArgs="$__RunArgs -verbose"
 fi
 
 # Set default clang version

--- a/build.sh
+++ b/build.sh
@@ -395,7 +395,7 @@ case $CPUName in
         __HostArch=x86
         ;;
 
-    x86_64)
+    amd64|x86_64)
         __BuildArch=x64
         __HostArch=x64
         ;;

--- a/src/corefx/System.Globalization.Native/configure.cmake
+++ b/src/corefx/System.Globalization.Native/configure.cmake
@@ -14,10 +14,18 @@ else()
     set(CMAKE_REQUIRED_LIBRARIES ${ICUCORE})
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+    # Somehow check_symbol_exists() failed to link to the required icu libraries
+    # and hence failed the test and cause problem about using deprecated function
+    # later on. With icu58 (lastest from ports as of today), this can be forced
+    # and at least everything get built.
+    set(HAVE_SET_MAX_VARIABLE 1)
+else()
 check_symbol_exists(
     ucol_setMaxVariable
     "unicode/ucol.h"
     HAVE_SET_MAX_VARIABLE)
+endif()
 
 unset(CMAKE_REQUIRED_LIBRARIES)
 unset(CMAKE_REQUIRED_INCLUDES)

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -839,7 +839,14 @@ SIZE_T DacDbiInterfaceImpl::GetArgCount(MethodDesc * pMD)
 // Allocator to pass to DebugInfoStores, allocating forDBI
 BYTE* InfoStoreForDbiNew(void * pData, size_t cBytes)
 {
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#endif
     return new(forDbi) BYTE[cBytes];
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
 }
 
 // Allocator to pass to the debug-info-stores...

--- a/src/debug/ee/controller.cpp
+++ b/src/debug/ee/controller.cpp
@@ -24,6 +24,12 @@
 
 #include "../../vm/methoditer.h"
 
+#ifdef __clang__
+// Needed for using interopsafe and interopsafeEXEC.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#endif
+
 const char *GetTType( TraceType tt);
 
 #define IsSingleStep(exception) (exception == EXCEPTION_SINGLE_STEP)
@@ -8890,3 +8896,7 @@ bool DebuggerContinuableExceptionBreakpoint::SendEvent(Thread *thread, bool fIpC
     return true;
 }
 #endif // !DACCESS_COMPILE
+
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -51,6 +51,12 @@
 
 #include "threadsuspend.h"
 
+#ifdef __clang__
+// Needed for using interopsafe and interopsafeEXEC.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#endif
+
 class CCLRSecurityAttributeManager;
 extern CCLRSecurityAttributeManager s_CLRSecurityAttributeManager;
 
@@ -17071,3 +17077,7 @@ void Debugger::StartCanaryThread()
 #endif // DACCESS_COMPILE
 
 #endif //DEBUGGING_SUPPORTED
+
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif

--- a/src/debug/ee/funceval.cpp
+++ b/src/debug/ee/funceval.cpp
@@ -32,6 +32,12 @@
 #include <limits.h>
 #include "ilformatter.h"
 
+#ifdef __clang__
+// Needed for using interopsafe.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#endif
+
 #ifndef DACCESS_COMPILE
 
 //
@@ -3982,3 +3988,7 @@ FuncEvalHijackPersonalityRoutine(IN     PEXCEPTION_RECORD   pExceptionRecord
 #endif // WIN64EXCEPTIONS && !FEATURE_PAL
 
 #endif // ifndef DACCESS_COMPILE
+
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif

--- a/src/debug/ee/functioninfo.cpp
+++ b/src/debug/ee/functioninfo.cpp
@@ -20,6 +20,12 @@
 #include "debuginfostore.h"
 #include "../../vm/methoditer.h"
 
+#ifdef __clang__
+// Needed for using interopsafe.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#endif
+
 #ifndef DACCESS_COMPILE
 
 bool DbgIsSpecialILOffset(DWORD offset)
@@ -2473,3 +2479,7 @@ void DebuggerMethodInfoTable::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     }
 }
 #endif // #ifdef DACCESS_COMPILE
+
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif

--- a/src/debug/ildbsymlib/symwrite.h
+++ b/src/debug/ildbsymlib/symwrite.h
@@ -839,7 +839,14 @@ public:
         {
             // Help mitigate the impact of buffer overflow
             // Fail fast with a null-reference AV
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#endif
             return *(static_cast<T*>(0)) ;
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
         }
         return m_array[ i ];
     }

--- a/src/debug/inc/dacdbistructures.inl
+++ b/src/debug/inc/dacdbistructures.inl
@@ -101,7 +101,14 @@ void DacDbiArrayList<T>::Alloc(int nElements)
     Dealloc();
     if (nElements > 0)
     {
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#endif
         m_pList = new(forDbi) T[(size_t)nElements];
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
         m_nEntries = nElements;
     }
 }

--- a/src/pal/src/debug/debug.cpp
+++ b/src/pal/src/debug/debug.cpp
@@ -76,6 +76,10 @@ extern "C" void DBG_DebugBreak_End();
 #define CTL_WAIT        "wait"
 #endif   // HAVE_PROCFS_CTL
 
+#ifndef PROCFS_MEM_NAME
+#define PROCFS_MEM_NAME "mem"
+#endif
+
 /* ------------------- Constant definitions ----------------------------------*/
 
 #if !HAVE_VM_READ && !HAVE_PROCFS_CTL

--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -22,10 +22,16 @@ if which "clang-$2.$3" > /dev/null 2>&1
     then
         export CC="$(which clang-$2.$3)"
         export CXX="$(which clang++-$2.$3)"
+        if [ `uname` = "FreeBSD" ]; then
+            export LLVM_HOME=${LLVM_HOME:-/usr/local/llvm$2$3}
+        fi
 elif which "clang$2$3" > /dev/null 2>&1
     then
         export CC="$(which clang$2$3)"
         export CXX="$(which clang++$2$3)"
+        if [ `uname` = "FreeBSD" ]; then
+            export LLVM_HOME=${LLVM_HOME:-/usr/local/llvm$2$3}
+        fi
 elif which clang > /dev/null 2>&1
     then
         export CC="$(which clang)"

--- a/tests/src/Common/Platform/platformdefines.h
+++ b/tests/src/Common/Platform/platformdefines.h
@@ -87,7 +87,7 @@ typedef void* HMODULE;
 typedef void* ULONG_PTR;
 typedef unsigned error_t;
 typedef void* LPVOID;
-typedef char BYTE;
+typedef unsigned char BYTE;
 typedef WCHAR OLECHAR;
 #endif
 

--- a/tests/src/Interop/common/types.h
+++ b/tests/src/Interop/common/types.h
@@ -28,7 +28,7 @@ typedef void* HMODULE;
 typedef void* ULONG_PTR;
 typedef unsigned error_t;
 typedef void* LPVOID;
-typedef char BYTE;
+typedef unsigned char BYTE;
 typedef WCHAR OLECHAR;
 
 typedef unsigned int UINT_PTR;


### PR DESCRIPTION
Various little fixes to build on FreeBSD-11.0 with clang3.9.

Just to get binaries built. Output binaries are not known if fully functional.
The bunch of command line programs do run without obvious crashing though.