### PR TITLE
Fix subtle bug in new string.Join implementation.

### DIFF
--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -845,7 +845,9 @@ namespace System
             // something changed concurrently to mutate the input array: fall back to
             // doing the concatenation again, but this time with a defensive copy. This
             // fall back should be extremely rare.
-            return copiedLength == totalLength ? result : Concat((string[])value.Clone());
+            return copiedLength == totalLength ?
+                result :
+                JoinCore(separator, separatorLength, (string[])value.Clone(), startIndex, count);
         }
         
         //


### PR DESCRIPTION
I had copied the code straight from #4559 and neglected to edit the last part; sorry about that. This fixes the case where there is a concurrent write between the first/second read of the array, so we make a defensive copy.

cc @jkotas, @AlexGhiondea 