### PR TITLE
Fix building CoreCLR with Clang 3.9

### DIFF
--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -90,6 +90,7 @@ IDacDbiInterface::IAllocator * g_pAllocator = NULL;
 //
 
 // Need a class to serve as a tag that we can use to overload New/Delete.
+forDbiWorker forDbi;
 
 void * operator new(size_t lenBytes, const forDbiWorker &)
 {

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -90,7 +90,6 @@ IDacDbiInterface::IAllocator * g_pAllocator = NULL;
 //
 
 // Need a class to serve as a tag that we can use to overload New/Delete.
-#define forDbi (*(forDbiWorker *)NULL)
 
 void * operator new(size_t lenBytes, const forDbiWorker &)
 {

--- a/src/debug/di/rsmain.cpp
+++ b/src/debug/di/rsmain.cpp
@@ -40,6 +40,8 @@
 RSDebuggingInfo g_RSDebuggingInfo_OutOfProc = {0 }; // set to NULL
 RSDebuggingInfo * g_pRSDebuggingInfo = &g_RSDebuggingInfo_OutOfProc;
 
+// The following instances are used for invoking overloaded new/delete
+forDbiWorker forDbi;
 
 #ifdef _DEBUG
 // For logs, we can print the string name for the debug codes.

--- a/src/debug/di/rspriv.h
+++ b/src/debug/di/rspriv.h
@@ -177,7 +177,7 @@ private:
     USHORT m_usPort;
 };
 
-#define forDbi (*(forDbiWorker *)NULL)
+extern forDbiWorker forDbi;
 
 // for dbi we just default to new, but we need to have these defined for both dac and dbi
 inline void * operator new(size_t lenBytes, const forDbiWorker &)

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -75,6 +75,9 @@ SVAL_IMPL_INIT(BOOL, Debugger, s_fCanChangeNgenFlags, TRUE);
 
 bool g_EnableSIS = false;
 
+// The following instances are used for invoking overloaded new/delete
+InteropSafe interopsafe;
+InteropSafeExecutable interopsafeEXEC;
 
 #ifndef DACCESS_COMPILE
 

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -3512,10 +3512,10 @@ public:
  * ------------------------------------------------------------------------ */
 
 class InteropSafe {};
-SELECTANY InteropSafe interopsafe;
+extern InteropSafe interopsafe;
 
 class InteropSafeExecutable {};
-SELECTANY InteropSafeExecutable interopsafeEXEC;
+extern InteropSafeExecutable interopsafeEXEC;
 
 #ifndef DACCESS_COMPILE
 inline void * __cdecl operator new(size_t n, const InteropSafe&)

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -3512,10 +3512,10 @@ public:
  * ------------------------------------------------------------------------ */
 
 class InteropSafe {};
-#define interopsafe (*(InteropSafe*)NULL)
+SELECTANY InteropSafe interopsafe;
 
 class InteropSafeExecutable {};
-#define interopsafeEXEC (*(InteropSafeExecutable*)NULL)
+SELECTANY InteropSafeExecutable interopsafeEXEC;
 
 #ifndef DACCESS_COMPILE
 inline void * __cdecl operator new(size_t n, const InteropSafe&)

--- a/src/debug/ildbsymlib/symwrite.h
+++ b/src/debug/ildbsymlib/symwrite.h
@@ -839,7 +839,8 @@ public:
         {
             // Help mitigate the impact of buffer overflow
             // Fail fast with a null-reference AV
-            return *(static_cast<T*>(0)) ;
+            volatile char* nullPointer = nullptr;
+            *nullPointer;
         }
         return m_array[ i ];
     }

--- a/src/debug/inc/dacdbiinterface.h
+++ b/src/debug/inc/dacdbiinterface.h
@@ -32,7 +32,7 @@
 template<class T> void DeleteDbiMemory(T *p);
 // Need a class to serve as a tag that we can use to overload New/Delete.
 class forDbiWorker {};
-SELECTANY forDbiWorker forDbi;
+extern forDbiWorker forDbi;
 extern void * operator new(size_t lenBytes, const forDbiWorker &);
 extern void * operator new[](size_t lenBytes, const forDbiWorker &);
 extern void operator delete(void *p, const forDbiWorker &);

--- a/src/debug/inc/dacdbiinterface.h
+++ b/src/debug/inc/dacdbiinterface.h
@@ -32,7 +32,7 @@
 template<class T> void DeleteDbiMemory(T *p);
 // Need a class to serve as a tag that we can use to overload New/Delete.
 class forDbiWorker {};
-#define forDbi (*(forDbiWorker *)NULL)
+SELECTANY forDbiWorker forDbi;
 extern void * operator new(size_t lenBytes, const forDbiWorker &);
 extern void * operator new[](size_t lenBytes, const forDbiWorker &);
 extern void operator delete(void *p, const forDbiWorker &);

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -274,7 +274,7 @@ SEHProcessException(PAL_SEHException* exception)
                     {
                         // The exception happened in the page right below the stack limit,
                         // so it is a stack overflow
-                        write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
+                        (void)write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
                         PROCAbort();
                     }
                 }

--- a/tests/src/Common/Platform/platformdefines.cpp
+++ b/tests/src/Common/Platform/platformdefines.cpp
@@ -277,7 +277,7 @@ DWORD TP_GetFullPathName(LPWSTR fileName, DWORD nBufferLength, LPWSTR lpBuffer)
 	return GetFullPathNameW(fileName, nBufferLength, lpBuffer, NULL);
 #else
 	char nativeFullPath[MAX_PATH];
-	realpath(HackyConvertToSTR(fileName), nativeFullPath);
+	(void)realpath(HackyConvertToSTR(fileName), nativeFullPath);
 	LPWSTR fullPathForCLR = HackyConvertToWSTR(nativeFullPath);
 	wcscpy_s(lpBuffer, MAX_PATH, fullPathForCLR);
 	return wcslen(lpBuffer);

--- a/tests/src/Common/Platform/platformdefines.h
+++ b/tests/src/Common/Platform/platformdefines.h
@@ -87,7 +87,7 @@ typedef void* HMODULE;
 typedef void* ULONG_PTR;
 typedef unsigned error_t;
 typedef void* LPVOID;
-typedef char BYTE;
+typedef unsigned char BYTE;
 typedef WCHAR OLECHAR;
 #endif
 

--- a/tests/src/Interop/common/types.h
+++ b/tests/src/Interop/common/types.h
@@ -28,7 +28,7 @@ typedef void* HMODULE;
 typedef void* ULONG_PTR;
 typedef unsigned error_t;
 typedef void* LPVOID;
-typedef char BYTE;
+typedef unsigned char BYTE;
 typedef WCHAR OLECHAR;
 
 typedef unsigned int UINT_PTR;


### PR DESCRIPTION
There were few constructs that Clang 3.9 didn't like due to its strict
C++ standard conformance rules.