### PR TITLE
[x86/Linux] Add missing files in x86/Linux PAL

### DIFF
--- a/cross/x86/toolchain.cmake
+++ b/cross/x86/toolchain.cmake
@@ -7,7 +7,6 @@ set(CMAKE_SYSTEM_PROCESSOR i686)
 add_compile_options("-m32")
 add_compile_options("--sysroot=${CROSS_ROOTFS}")
 add_compile_options("-Wno-error=unused-command-line-argument")
-add_compile_options("-Wno-missing-prototype-for-cc")
 
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} --sysroot=${CROSS_ROOTFS}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/i686-linux-gnu")

--- a/cross/x86/toolchain.cmake
+++ b/cross/x86/toolchain.cmake
@@ -7,6 +7,7 @@ set(CMAKE_SYSTEM_PROCESSOR i686)
 add_compile_options("-m32")
 add_compile_options("--sysroot=${CROSS_ROOTFS}")
 add_compile_options("-Wno-error=unused-command-line-argument")
+add_compile_options("-Wno-missing-prototype-for-cc")
 
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} --sysroot=${CROSS_ROOTFS}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/i686-linux-gnu")

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -331,7 +331,7 @@ typedef char * va_list;
 PALIMPORT
 BOOL
 PALAPI
-PAL_IsDebuggerPresent();
+PAL_IsDebuggerPresent(VOID);
  
 #define MAXIMUM_SUSPEND_COUNT  MAXCHAR
 
@@ -507,7 +507,7 @@ PAL_Initialize(
 PALIMPORT
 int
 PALAPI
-PAL_InitializeDLL();
+PAL_InitializeDLL(VOID);
 
 PALIMPORT
 DWORD
@@ -581,7 +581,7 @@ PAL_UnregisterForRuntimeStartup(
 PALIMPORT
 BOOL
 PALAPI
-PAL_NotifyRuntimeStarted();
+PAL_NotifyRuntimeStarted(VOID);
 
 static const int MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH = 64;
 
@@ -3251,22 +3251,22 @@ TlsFree(
 PALIMPORT
 void *
 PALAPI
-PAL_GetStackBase();
+PAL_GetStackBase(VOID);
 
 PALIMPORT
 void *
 PALAPI
-PAL_GetStackLimit();
+PAL_GetStackLimit(VOID);
 
 PALIMPORT
 DWORD
 PALAPI
-PAL_GetLogicalCpuCountFromOS();
+PAL_GetLogicalCpuCountFromOS(VOID);
 
 PALIMPORT
 size_t
 PALAPI
-PAL_GetLogicalProcessorCacheSizeFromOS();
+PAL_GetLogicalProcessorCacheSizeFromOS(VOID);
 
 typedef BOOL (*ReadMemoryWordCallback)(SIZE_T address, SIZE_T *value);
 
@@ -4901,7 +4901,7 @@ GetTickCount(
 PALIMPORT
 ULONGLONG
 PALAPI
-GetTickCount64();
+GetTickCount64(VOID);
 
 PALIMPORT
 BOOL
@@ -5341,7 +5341,7 @@ YieldProcessor(
 PALIMPORT
 DWORD
 PALAPI
-GetCurrentProcessorNumber();
+GetCurrentProcessorNumber(VOID);
 
 /*++
 Function:
@@ -5353,7 +5353,7 @@ Checks if GetCurrentProcessorNumber is available in the current environment
 PALIMPORT
 BOOL
 PALAPI
-PAL_HasGetCurrentProcessorNumber();
+PAL_HasGetCurrentProcessorNumber(VOID);
     
 #define FORMAT_MESSAGE_ALLOCATE_BUFFER 0x00000100
 #define FORMAT_MESSAGE_IGNORE_INSERTS  0x00000200
@@ -5439,7 +5439,7 @@ ResetWriteWatch(
 PALIMPORT
 VOID 
 PALAPI 
-FlushProcessWriteBuffers();
+FlushProcessWriteBuffers(VOID);
 
 typedef void (*PAL_ActivationFunction)(CONTEXT *context);
 typedef BOOL (*PAL_SafeActivationCheckFunction)(SIZE_T ip, BOOL checkingCurrentThread);
@@ -6302,14 +6302,14 @@ PAL_Enter(PAL_Boundary boundary);
 PALIMPORT
 BOOL
 PALAPI
-PAL_HasEntered();
+PAL_HasEntered(VOID);
 
 // Equivalent to PAL_Enter(PAL_BoundaryTop) and is for stub
 // code generation use.
 PALIMPORT
 DWORD
 PALAPI
-PAL_EnterTop();
+PAL_EnterTop(VOID);
 
 // This function needs to be called on a thread when it enters
 // a region of code that depends on this instance of the PAL
@@ -6344,14 +6344,14 @@ PAL_Leave(PAL_Boundary boundary);
 PALIMPORT
 VOID
 PALAPI
-PAL_LeaveBottom();
+PAL_LeaveBottom(VOID);
 
 // This function is equivalent to PAL_Leave(PAL_BoundaryTop)
 // and is available to limit the creation of stub code.
 PALIMPORT
 VOID
 PALAPI
-PAL_LeaveTop();
+PAL_LeaveTop(VOID);
 
 #ifdef  __cplusplus
 //

--- a/src/pal/inc/unixasmmacros.inc
+++ b/src/pal/inc/unixasmmacros.inc
@@ -28,7 +28,9 @@
         .equiv \New, \Old
 .endm
 
-#if defined(_AMD64_)
+#if defined(_X86_)
+#include "unixasmmacrosx86.inc"
+#elif defined(_AMD64_)
 #include "unixasmmacrosamd64.inc"
 #elif defined(_ARM_)
 #include "unixasmmacrosarm.inc"

--- a/src/pal/inc/unixasmmacrosx86.inc
+++ b/src/pal/inc/unixasmmacrosx86.inc
@@ -5,7 +5,7 @@
 .macro NESTED_ENTRY Name, Section, Handler
         LEAF_ENTRY \Name, \Section
         .ifnc \Handler, NoHandler
-        .cfi_personality 0, C_FUNC(\Handler) // 0 == DW_EH_PE_absptr
+        .cfi_personality 0x1b, C_FUNC(\Handler) // 0x1b == DW_EH_PE_pcrel | DW_EH_PE_sdata4
         .endif
 .endm
 

--- a/src/pal/inc/unixasmmacrosx86.inc
+++ b/src/pal/inc/unixasmmacrosx86.inc
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.macro NESTED_ENTRY Name, Section, Handler
+        LEAF_ENTRY \Name, \Section
+        .ifnc \Handler, NoHandler
+        .cfi_personality 0, C_FUNC(\Handler) // 0 == DW_EH_PE_absptr
+        .endif
+.endm
+
+.macro NESTED_END Name, Section
+        LEAF_END \Name, \Section
+.endm
+
+.macro LEAF_ENTRY Name, Section
+        .global C_FUNC(\Name)
+        .type \Name, %function
+C_FUNC(\Name):
+        .cfi_startproc
+.endm
+
+.macro LEAF_END Name, Section
+        .size \Name, .-\Name
+        .cfi_endproc
+.endm
+
+.macro LEAF_END_MARKED Name, Section
+C_FUNC(\Name\()_End):
+        .global C_FUNC(\Name\()_End)
+        LEAF_END \Name, \Section
+.endm

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -106,10 +106,10 @@ elseif(PAL_CMAKE_PLATFORM_ARCH_ARM64)
   )
 elseif(CLR_CMAKE_PLATFORM_ARCH_I386)
   set(ARCH_SOURCES
-    #arch/i386/context2.S
-    #arch/i386/debugbreak.S
-    #arch/i386/exceptionhelper.S
-    arch/amd64/processor.cpp
+    arch/i386/context2.S
+    arch/i386/debugbreak.S
+    arch/i386/exceptionhelper.S
+    arch/i386/processor.cpp
   )
 endif()
 

--- a/src/pal/src/arch/i386/asmconstants.h
+++ b/src/pal/src/arch/i386/asmconstants.h
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#define CONTEXT_ContextFlags 0
+#define CONTEXT_FLOATING_POINT 8
+#define CONTEXT_FloatSave 7*4
+#define FLOATING_SAVE_AREA_SIZE 8*4+80
+#define CONTEXT_Edi CONTEXT_FloatSave + FLOATING_SAVE_AREA_SIZE + 4*4
+#define CONTEXT_Esi CONTEXT_Edi+4
+#define CONTEXT_Ebx CONTEXT_Esi+4
+#define CONTEXT_Edx CONTEXT_Ebx+4
+#define CONTEXT_Ecx CONTEXT_Edx+4
+#define CONTEXT_Eax CONTEXT_Ecx+4
+#define CONTEXT_Ebp CONTEXT_Eax+4
+#define CONTEXT_Eip CONTEXT_Ebp+4
+#define CONTEXT_SegCs CONTEXT_Eip+4
+#define CONTEXT_EFlags CONTEXT_SegCs+4
+#define CONTEXT_Esp CONTEXT_EFlags+4
+#define CONTEXT_SegSs CONTEXT_Esp+4
+#define CONTEXT_EXTENDED_REGISTERS 32
+#define CONTEXT_ExtendedRegisters CONTEXT_SegSs+4
+#define CONTEXT_Xmm0 CONTEXT_ExtendedRegisters+160
+#define CONTEXT_Xmm1 CONTEXT_Xmm0+16
+#define CONTEXT_Xmm2 CONTEXT_Xmm1+16
+#define CONTEXT_Xmm3 CONTEXT_Xmm2+16
+#define CONTEXT_Xmm4 CONTEXT_Xmm3+16
+#define CONTEXT_Xmm5 CONTEXT_Xmm4+16
+#define CONTEXT_Xmm6 CONTEXT_Xmm5+16
+#define CONTEXT_Xmm7 CONTEXT_Xmm6+16

--- a/src/pal/src/arch/i386/context2.S
+++ b/src/pal/src/arch/i386/context2.S
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.intel_syntax noprefix
+#include "unixasmmacros.inc"
+#include "asmconstants.h"
+
+//
+// Implementation of CONTEXT_CaptureContext for the Intel x86 platform.
+//
+//  extern void CONTEXT_CaptureContext(LPCONTEXT lpContext);
+//
+// This function is processor-dependent. It is used by exception handling,
+// and is always apply to the current thread.
+//
+LEAF_ENTRY CONTEXT_CaptureContext, _TEXT
+    // Store
+    push  eax
+    push  ebx
+
+    // The stack will contain the following elements on the top of
+    // the caller's stack
+    //  [ebx]             / esp + 00
+    //  [eax]             / esp + 04
+    //  [ret]             / esp + 08
+    //  [arg0: lpContext] / esp + 12
+
+    mov   eax, [esp + 12] // eax will point to lpContext
+
+    // Capture INTEGER registers
+    mov   ebx, [esp + 4]
+    mov   [eax + CONTEXT_Eax], ebx
+    mov   ebx, [esp]
+    mov   [eax + CONTEXT_Ebx], ebx
+    mov   [eax + CONTEXT_Ecx], ecx
+    mov   [eax + CONTEXT_Edx], edx
+    mov   [eax + CONTEXT_Esi], esi
+    mov   [eax + CONTEXT_Edi], edi
+
+    // Capture CONTROL registers
+    mov   [eax + CONTEXT_Ebp], ebp
+    lea   ebx, [esp + 12]
+    mov   [eax + CONTEXT_Esp], ebx
+    mov   ebx, [esp + 8]
+    mov   [eax + CONTEXT_Eip], ebx
+
+    push  cs
+    xor   ebx, ebx
+    pop   bx
+    mov   [eax + CONTEXT_SegCs], ebx
+
+    push  ss
+    xor   ebx, ebx
+    pop   bx
+    mov   [eax + CONTEXT_SegSs], ebx
+
+    pushf
+    xor   ebx, ebx
+    pop   bx
+    mov   [eax + CONTEXT_EFlags], ebx
+
+    test   BYTE PTR [eax + CONTEXT_ContextFlags], CONTEXT_FLOATING_POINT
+    je      LOCAL_LABEL(Done_CONTEXT_FLOATING_POINT)
+    // Capture FPU status
+    fnsave [eax + CONTEXT_FloatSave]
+    frstor [eax + CONTEXT_FloatSave]
+LOCAL_LABEL(Done_CONTEXT_FLOATING_POINT):
+
+    test   BYTE PTR [eax + CONTEXT_ContextFlags], CONTEXT_EXTENDED_REGISTERS
+    je     LOCAL_LABEL(Done_CONTEXT_EXTENDED_REGISTERS)
+    movdqu [eax + CONTEXT_Xmm0], xmm0
+    movdqu [eax + CONTEXT_Xmm1], xmm1
+    movdqu [eax + CONTEXT_Xmm2], xmm2
+    movdqu [eax + CONTEXT_Xmm3], xmm3
+    movdqu [eax + CONTEXT_Xmm4], xmm4
+    movdqu [eax + CONTEXT_Xmm5], xmm5
+    movdqu [eax + CONTEXT_Xmm6], xmm6
+    movdqu [eax + CONTEXT_Xmm7], xmm7
+LOCAL_LABEL(Done_CONTEXT_EXTENDED_REGISTERS):
+
+    // Restore
+    pop   ebx
+    pop   eax
+    ret
+LEAF_END CONTEXT_CaptureContext, _TEXT
+
+LEAF_ENTRY RtlCaptureContext, _TEXT
+    push    eax
+    mov     eax, [esp + 8]
+    mov     DWORD PTR [eax + CONTEXT_ContextFlags], (CONTEXT_FLOATING_POINT)
+    pop     eax
+    jmp     C_FUNC(CONTEXT_CaptureContext)
+    ret
+LEAF_END RtlCaptureContext, _TEXT
+
+LEAF_ENTRY RtlRestoreContext, _TEXT
+    mov   eax, [esp + 4]
+
+    test    BYTE PTR [eax + CONTEXT_ContextFlags], CONTEXT_FLOATING_POINT
+    je      LOCAL_LABEL(Done_Restore_CONTEXT_FLOATING_POINT)
+    frstor  [eax + CONTEXT_FloatSave]
+LOCAL_LABEL(Done_Restore_CONTEXT_FLOATING_POINT):
+
+    test   BYTE PTR [eax + CONTEXT_ContextFlags], CONTEXT_EXTENDED_REGISTERS
+    je     LOCAL_LABEL(Done_Restore_CONTEXT_EXTENDED_REGISTERS)
+    movdqu xmm0, [eax + CONTEXT_Xmm0]
+    movdqu xmm1, [eax + CONTEXT_Xmm1]
+    movdqu xmm2, [eax + CONTEXT_Xmm2]
+    movdqu xmm3, [eax + CONTEXT_Xmm3]
+    movdqu xmm4, [eax + CONTEXT_Xmm4]
+    movdqu xmm5, [eax + CONTEXT_Xmm5]
+    movdqu xmm6, [eax + CONTEXT_Xmm6]
+    movdqu xmm7, [eax + CONTEXT_Xmm7]
+LOCAL_LABEL(Done_Restore_CONTEXT_EXTENDED_REGISTERS):
+
+    // Restore CONTROL register(s)
+    mov   ecx, [eax + CONTEXT_Eip]
+    mov   [esp], ecx
+
+    mov   ecx, [eax + CONTEXT_Esp]
+    push  ecx
+    mov   ecx, [eax + CONTEXT_Ebp]
+    push  ecx
+
+    pop   ebp
+    pop   esp
+
+    // Restore INTEGER register(s)
+    mov   ecx, [eax + CONTEXT_Edi]
+    push  ecx
+    mov   ecx, [eax + CONTEXT_Esi]
+    push  ecx
+    mov   ecx, [eax + CONTEXT_Edx]
+    push  ecx
+    mov   ecx, [eax + CONTEXT_Ecx]
+    push  ecx
+    mov   ecx, [eax + CONTEXT_Ebx]
+    push  ecx
+    mov   ecx, [eax + CONTEXT_Eax]
+    push  ecx
+
+    pop   eax
+    pop   ebx
+    pop   ecx
+    pop   edx
+    pop   esi
+    pop   edi
+
+    ret
+LEAF_END RtlRestoreContext, _TEXT
+

--- a/src/pal/src/arch/i386/debugbreak.S
+++ b/src/pal/src/arch/i386/debugbreak.S
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.intel_syntax noprefix
+#include "unixasmmacros.inc"
+
+LEAF_ENTRY DBG_DebugBreak, _TEXT
+        int3
+        ret
+LEAF_END_MARKED DBG_DebugBreak, _TEXT
+

--- a/src/pal/src/arch/i386/exceptionhelper.S
+++ b/src/pal/src/arch/i386/exceptionhelper.S
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.intel_syntax noprefix
+#include "unixasmmacros.inc"
+#include "asmconstants.h"
+
+//////////////////////////////////////////////////////////////////////////
+//
+// EXTERN_C void ThrowExceptionFromContextInternal(CONTEXT* context, PAL_SEHException* ex);
+//
+// This function creates a stack frame right below the target frame, restores all callee
+// saved registers from the passed in context, sets the SP to that frame and sets the
+// return address to the target frame's IP.
+// Then it uses the ThrowExceptionHelper to throw the passed in exception from that context.
+//
+//////////////////////////////////////////////////////////////////////////
+
+LEAF_ENTRY ThrowExceptionFromContextInternal, _TEXT
+        push  ebp
+        mov   eax, [esp + 12] // ebx: PAL_SEHException *
+        mov   ebx, [esp + 8]  // eax: CONTEXT *
+
+        mov   ebp, [ebx + CONTEXT_Ebp]
+        mov   esp, [ebx + CONTEXT_Esp]
+
+        // The ESP is re-initialized as the target frame's value, so the current function's
+        // CFA is now right at the ESP.
+        .cfi_def_cfa_offset 0
+
+        // Indicate that now that we have moved the RSP to the target address,
+        // the EBP is no longer saved in the current stack frame.
+        .cfi_restore ebp
+
+        // Store PAL_SEHException as the first argument
+        push    eax
+
+        // Store return address to the stack
+        mov     ebx, [ebx + CONTEXT_Eip]
+        push    ebx
+        jmp     EXTERNAL_C_FUNC(ThrowExceptionHelper)
+LEAF_END ThrowExceptionFromContextInternal, _TEXT

--- a/src/pal/src/arch/i386/processor.cpp
+++ b/src/pal/src/arch/i386/processor.cpp
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*++
+
+
+
+Module Name:
+
+    processor.cpp
+
+Abstract:
+
+    Implementation of processor related functions for the Intel x86/x64
+    platforms. These functions are processor dependent.
+
+
+
+--*/
+
+#include "pal/palinternal.h"
+
+/*++
+Function:
+YieldProcessor
+
+The YieldProcessor function signals to the processor to give resources
+to threads that are waiting for them. This macro is only effective on
+processors that support technology allowing multiple threads running
+on a single processor, such as Intel's Hyper-Threading technology.
+
+--*/
+void
+PALAPI
+YieldProcessor(
+    VOID)
+{
+    __asm__ __volatile__ (
+        "rep\n"
+        "nop"
+    );
+}
+

--- a/src/pal/tests/palsuite/threading/NamedMutex/test1/namedmutex.cpp
+++ b/src/pal/tests/palsuite/threading/NamedMutex/test1/namedmutex.cpp
@@ -520,7 +520,7 @@ bool MutualExclusionTests_Parent()
     return true;
 }
 
-DWORD MutualExclusionTests_Child(void *arg = nullptr)
+DWORD PALAPI MutualExclusionTests_Child(void *arg = nullptr)
 {
     const char *testName = "MutualExclusionTests";
 
@@ -626,7 +626,7 @@ bool LifetimeTests_Parent()
     return true;
 }
 
-DWORD LifetimeTests_Child(void *arg = nullptr)
+DWORD PALAPI LifetimeTests_Child(void *arg = nullptr)
 {
     const char *testName = "LifetimeTests";
 
@@ -682,7 +682,7 @@ bool LifetimeTests()
     return true;
 }
 
-DWORD AbandonTests_Child_TryLock(void *arg = nullptr);
+DWORD PALAPI AbandonTests_Child_TryLock(void *arg = nullptr);
 
 bool AbandonTests_Parent()
 {
@@ -751,7 +751,7 @@ bool AbandonTests_Parent()
     return true;
 }
 
-DWORD AbandonTests_Child_GracefulExit_Close(void *arg = nullptr)
+DWORD PALAPI AbandonTests_Child_GracefulExit_Close(void *arg = nullptr)
 {
     const char *testName = "AbandonTests";
 
@@ -837,7 +837,7 @@ DWORD AbandonTests_Child_AbruptExit(void *arg = nullptr)
     return 0;
 }
 
-DWORD AbandonTests_Child_TryLock(void *arg)
+DWORD PALAPI AbandonTests_Child_TryLock(void *arg)
 {
     const char *testName = "AbandonTests";
 
@@ -910,7 +910,7 @@ DWORD g_stressDurationMilliseconds = 0;
 LONG g_stressTestCounts[_countof(TestList)] = {0};
 LONG g_stressResult = true;
 
-DWORD StressTest(void *arg)
+DWORD PALAPI StressTest(void *arg)
 {
     // Run the specified test continuously for the stress duration
     SIZE_T testIndex = reinterpret_cast<SIZE_T>(arg);

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOMutexTest/WFSOMutexTest.cpp
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOMutexTest/WFSOMutexTest.cpp
@@ -30,7 +30,7 @@ unsigned int globalcounter =0;
 int testReturnCode = PASS;
 
 //Declaring Function Prototypes
-DWORD WFSOMutexTest(LPVOID params);
+DWORD PALAPI WFSOMutexTest(LPVOID params);
 void incrementCounter(void);
 
 
@@ -131,7 +131,7 @@ void incrementCounter(void)
 }
 
 
-DWORD WFSOMutexTest(LPVOID params)
+DWORD PALAPI WFSOMutexTest(LPVOID params)
 {
 
      DWORD dwWaitResult; 

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOSemaphoreTest/WFSOSemaphoreTest.cpp
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOSemaphoreTest/WFSOSemaphoreTest.cpp
@@ -31,7 +31,7 @@ unsigned int globalcounter =0;
 int testReturnCode = PASS;
 
 //Declaring Function Prototypes
-DWORD WFSOSemaphoreTest(LPVOID params);
+DWORD PALAPI WFSOSemaphoreTest(LPVOID params);
 void incrementCounter(void);
 
 int __cdecl main(int argc, char **argv)
@@ -134,7 +134,7 @@ void incrementCounter(void)
 }
 
 
-DWORD WFSOSemaphoreTest(LPVOID params)
+DWORD PALAPI WFSOSemaphoreTest(LPVOID params)
 {
 
      DWORD dwWaitResult; 

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOThreadTest/WFSOThreadTest.cpp
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOThreadTest/WFSOThreadTest.cpp
@@ -28,7 +28,7 @@ HANDLE hEvent = NULL;
 unsigned int globalcounter =0;
 
 //Declaring Function Prototypes
-DWORD incrementCounter(LPVOID params);
+DWORD PALAPI incrementCounter(LPVOID params);
 
 int __cdecl main(int argc, char **argv)
 {
@@ -154,7 +154,7 @@ return ( PASS );
 
 }
 
-DWORD incrementCounter(LPVOID params)
+DWORD PALAPI incrementCounter(LPVOID params)
 {
 
 	//Signal Event so that main thread can start to wait for thread object

--- a/src/utilcode/clrhost_nodependencies.cpp
+++ b/src/utilcode/clrhost_nodependencies.cpp
@@ -745,12 +745,12 @@ void ClrFlsAssociateCallback(DWORD slot, PTLS_CALLBACK_FUNCTION callback)
     GetExecutionEngine()->TLS_AssociateCallback(slot, callback);
 }
 
-void ** __stdcall ClrFlsGetBlockGeneric()
+LPVOID *ClrFlsGetBlockGeneric()
 {
     WRAPPER_NO_CONTRACT;
     STATIC_CONTRACT_SO_TOLERANT;
 
-    return (void **) GetExecutionEngine()->TLS_GetDataBlock();
+    return (LPVOID *) GetExecutionEngine()->TLS_GetDataBlock();
 }
 
 CLRFLSGETBLOCK __ClrFlsGetBlock = ClrFlsGetBlockGeneric;


### PR DESCRIPTION
This commit attempts to (partially) enable x86/Linux PAL Layer.

Currently, only ``exception_handling.pal_sxs.test1.paltest_pal_sxs_test1`` fails with this commit.