### PR TITLE
Disable PSPSym and LocAllocSPvar for CoreRT

### DIFF
--- a/Documentation/botr/clr-abi.md
+++ b/Documentation/botr/clr-abi.md
@@ -6,6 +6,8 @@ It describes requirements that the Just-In-Time (JIT) compiler imposes on the VM
 
 A note on the JIT codebases: JIT32 refers to the original JIT codebase that originally generated x86 code and was later ported to generate ARM code. Later, it was ported and re-architected to generate AMD64 code (making its name something of a confusing misnomer). This work is referred to as RyuJIT. RyuJIT is being ported to generate ARM64 code. JIT64 refers to the legacy codebase that supports AMD64.
 
+CoreRT refers to https://github.com/dotnet/corert runtime that is optimized for AOT. The CoreRT ABI differs in a few details for simplicity and consistency accross platforms.
+
 # Getting started
 
 Read everything in the documented Windows ABI.
@@ -288,6 +290,8 @@ Using the establisher frame, the funclet wants to load the value of the PSPSym. 
 On ARM and ARM64, for all second pass funclets (finally, fault, catch, and filter-handler) the VM restores all non-volatile registers to their values within the parent frame. This includes the frame register (`R11`). Thus, the PSPSym is not used to recompute the frame pointer register in this case, though the PSPSym is copied to the funclet's frame, as for all funclets.
 
 Catch, Filter, and Filter-handlers also get an Exception object (GC ref) as an argument (`REG_EXCEPTION_OBJECT`). On AMD64 it is the second argument and thus passed in RDX. On ARM and ARM64 this is the first argument and passed in R0.
+
+CoreRT does not use PSPSym. For filter funclets the VM sets the frame register to be the same as the parent function. For second pass funclets the VM restores all non-volatile registers. The same convention is used accross all platforms.
 
 (Note that the JIT64 source code contains a comment that says, "The current CLR doesn't always pass the correct establisher frame to the funclet. Funclet may receive establisher frame of funclet when expecting that of original routine." It indicates this is the reason that a PSPSym is required in all funclets as well as the main function, whereas if the establisher frame was correctly reported, the PSPSym could be omitted in some cases.)
 

--- a/Documentation/botr/clr-abi.md
+++ b/Documentation/botr/clr-abi.md
@@ -6,7 +6,7 @@ It describes requirements that the Just-In-Time (JIT) compiler imposes on the VM
 
 A note on the JIT codebases: JIT32 refers to the original JIT codebase that originally generated x86 code and was later ported to generate ARM code. Later, it was ported and re-architected to generate AMD64 code (making its name something of a confusing misnomer). This work is referred to as RyuJIT. RyuJIT is being ported to generate ARM64 code. JIT64 refers to the legacy codebase that supports AMD64.
 
-CoreRT refers to https://github.com/dotnet/corert runtime that is optimized for AOT. The CoreRT ABI differs in a few details for simplicity and consistency accross platforms.
+CoreRT refers to https://github.com/dotnet/corert runtime that is optimized for AOT. The CoreRT ABI differs in a few details for simplicity and consistency across platforms.
 
 # Getting started
 
@@ -291,7 +291,7 @@ On ARM and ARM64, for all second pass funclets (finally, fault, catch, and filte
 
 Catch, Filter, and Filter-handlers also get an Exception object (GC ref) as an argument (`REG_EXCEPTION_OBJECT`). On AMD64 it is the second argument and thus passed in RDX. On ARM and ARM64 this is the first argument and passed in R0.
 
-CoreRT does not use PSPSym. For filter funclets the VM sets the frame register to be the same as the parent function. For second pass funclets the VM restores all non-volatile registers. The same convention is used accross all platforms.
+CoreRT does not use PSPSym. For filter funclets the VM sets the frame register to be the same as the parent function. For second pass funclets the VM restores all non-volatile registers. The same convention is used across all platforms.
 
 (Note that the JIT64 source code contains a comment that says, "The current CLR doesn't always pass the correct establisher frame to the funclet. Funclet may receive establisher frame of funclet when expecting that of original routine." It indicates this is the reason that a PSPSym is required in all funclets as well as the main function, whereas if the establisher frame was correctly reported, the PSPSym could be omitted in some cases.)
 

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -747,7 +747,7 @@ void CodeGen::genRestoreCalleeSavedRegistersHelp(regMaskTP regsToRestoreMask, in
  *      +=======================+ <---- Caller's SP
  *      |Callee saved registers | // multiple of 8 bytes
  *      |-----------------------|
- *      |        PSP slot       | // 8 bytes
+ *      |        PSP slot       | // 8 bytes (omitted in CoreRT ABI)
  *      |-----------------------|
  *      ~  alignment padding    ~ // To make the whole frame 16 byte aligned.
  *      |-----------------------|
@@ -773,7 +773,7 @@ void CodeGen::genRestoreCalleeSavedRegistersHelp(regMaskTP regsToRestoreMask, in
  *      +=======================+ <---- Caller's SP
  *      |Callee saved registers | // multiple of 8 bytes
  *      |-----------------------|
- *      |        PSP slot       | // 8 bytes
+ *      |        PSP slot       | // 8 bytes (omitted in CoreRT ABI)
  *      |-----------------------|
  *      ~  alignment padding    ~ // To make the whole frame 16 byte aligned.
  *      |-----------------------|
@@ -801,7 +801,7 @@ void CodeGen::genRestoreCalleeSavedRegistersHelp(regMaskTP regsToRestoreMask, in
  *      +=======================+ <---- Caller's SP
  *      |Callee saved registers | // multiple of 8 bytes
  *      |-----------------------|
- *      |        PSP slot       | // 8 bytes
+ *      |        PSP slot       | // 8 bytes (omitted in CoreRT ABI)
  *      |-----------------------|
  *      ~  alignment padding    ~ // To make the first SP subtraction 16 byte aligned
  *      |-----------------------|
@@ -883,7 +883,7 @@ void CodeGen::genRestoreCalleeSavedRegistersHelp(regMaskTP regsToRestoreMask, in
  *      +=======================+ <---- Caller's SP
  *      |Callee saved registers | // multiple of 8 bytes
  *      |-----------------------|
- *      |        PSP slot       | // 8 bytes
+ *      |        PSP slot       | // 8 bytes (omitted in CoreRT ABI)
  *      |-----------------------|
  *      |      Saved FP, LR     | // 16 bytes
  *      |-----------------------|
@@ -988,7 +988,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
     // This is the end of the OS-reported prolog for purposes of unwinding
     compiler->unwindEndProlog();
 
-    // If there is no PSPSym (used by CoreRT ABI), we are done.
+    // If there is no PSPSym (CoreRT ABI), we are done.
     if (compiler->lvaPSPSym == BAD_VAR_NUM)
     {
         return;
@@ -1329,7 +1329,7 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
 BasicBlock* CodeGen::genCallFinally(BasicBlock* block, BasicBlock* lblk)
 {
     // Generate a call to the finally, like this:
-    //      mov         x0,qword ptr [fp + 10H]         // Load x0 with PSPSym
+    //      mov         x0,qword ptr [fp + 10H] / sp    // Load x0 with PSPSym, or sp if PSPSym is not used
     //      bl          finally-funclet
     //      b           finally-return                  // Only for non-retless finally calls
     // The 'b' can be a NOP if we're going to the next block.

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -8741,12 +8741,6 @@ void CodeGen::genFnProlog()
     // when compInitMem is true the genZeroInitFrame will zero out the shadow SP slots
     if (compiler->ehNeedsShadowSPslots() && !compiler->info.compInitMem)
     {
-        /*
-        // size/speed option?
-        getEmitter()->emitIns_I_ARR(INS_mov, EA_PTRSIZE, 0,
-                                REG_EBP, REG_NA, -compiler->lvaLocAllocSPvar);
-        */
-
         // The last slot is reserved for ICodeManager::FixContext(ppEndRegion)
         unsigned filterEndOffsetSlotOffs = compiler->lvaLclSize(compiler->lvaShadowSPslotsVar) - (sizeof(void*));
 
@@ -9711,7 +9705,7 @@ void CodeGen::genFnEpilog(BasicBlock* block)
  *      |Pre-spill regs space   |   // This is only necessary to keep the PSP slot at the same offset
  *      |                       |   // in function and funclet
  *      |-----------------------|
- *      |        PSP slot       |
+ *      |        PSP slot       |   // Omitted in CoreRT ABI
  *      |-----------------------|
  *      ~  possible 4 byte pad  ~
  *      ~     for alignment     ~
@@ -10010,7 +10004,7 @@ void CodeGen::genCaptureFuncletPrologEpilogInfo()
  *      ~  possible 8 byte pad  ~
  *      ~     for alignment     ~
  *      |-----------------------|
- *      |        PSP slot       |
+ *      |        PSP slot       | // Omitted in CoreRT ABI
  *      |-----------------------|
  *      |   Outgoing arg space  | // this only exists if the function makes a call
  *      |-----------------------| <---- Initial SP
@@ -10081,7 +10075,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
     // This is the end of the OS-reported prolog for purposes of unwinding
     compiler->unwindEndProlog();
 
-    // If there is no PSPSym (used by CoreRT ABI), we are done.
+    // If there is no PSPSym (CoreRT ABI), we are done.
     if (compiler->lvaPSPSym == BAD_VAR_NUM)
     {
         return;

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -20588,9 +20588,11 @@ DONE:
     }
 #endif
 
-    /* Write the lvaShadowSPfirst stack frame slot */
-    noway_assert(compiler->lvaLocAllocSPvar != BAD_VAR_NUM);
-    getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SPBASE, compiler->lvaLocAllocSPvar, 0);
+    /* Write the lvaLocAllocSPvar stack frame slot */
+    if (compiler->lvaLocAllocSPvar != BAD_VAR_NUM)
+    {
+        getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SPBASE, compiler->lvaLocAllocSPvar, 0);
+    }
 
 #if STACK_PROBES
     // Don't think it is worth it the codegen complexity to embed this

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -238,7 +238,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block, BasicBlock* lblk)
     // then RSP at this point is the same value as that stored in the PSPsym. So just copy RSP
     // instead of loading the PSPSym in this case.
 
-    if (!compiler->compLocallocUsed && (compiler->funCurrentFunc()->funKind == FUNC_ROOT))
+    if ((compiler->lvaPSPSym == BAD_VAR_NUM) ||
+        (!compiler->compLocallocUsed && (compiler->funCurrentFunc()->funKind == FUNC_ROOT)))
     {
         inst_RV_RV(INS_mov, REG_ARG_0, REG_SPBASE, TYP_I_IMPL);
     }
@@ -2718,8 +2719,10 @@ ALLOC_DONE:
 BAILOUT:
 
     // Write the lvaLocAllocSPvar stack frame slot
-    noway_assert(compiler->lvaLocAllocSPvar != BAD_VAR_NUM);
-    getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SPBASE, compiler->lvaLocAllocSPvar, 0);
+    if (compiler->lvaLocAllocSPvar != BAD_VAR_NUM)
+    {
+        getEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SPBASE, compiler->lvaLocAllocSPvar, 0);
+    }
 
 #if STACK_PROBES
     if (compiler->opts.compNeedStackProbes)

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -235,8 +235,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block, BasicBlock* lblk)
     //      jmp         finally-return                  // Only for non-retless finally calls
     // The jmp can be a NOP if we're going to the next block.
     // If we're generating code for the main function (not a funclet), and there is no localloc,
-    // then RSP at this point is the same value as that stored in the PSPsym. So just copy RSP
-    // instead of loading the PSPSym in this case.
+    // then RSP at this point is the same value as that stored in the PSPSym. So just copy RSP
+    // instead of loading the PSPSym in this case, or if PSPSym is not used (CoreRT ABI).
 
     if ((compiler->lvaPSPSym == BAD_VAR_NUM) ||
         (!compiler->compLocallocUsed && (compiler->funCurrentFunc()->funKind == FUNC_ROOT)))

--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -3761,10 +3761,8 @@ void GCInfo::gcInfoBlockHdrSave(GcInfoEncoder* gcInfoEncoder, unsigned methodSiz
     }
 
 #if FEATURE_EH_FUNCLETS
-    if (compiler->ehNeedsPSPSym())
+    if (compiler->lvaPSPSym != BAD_VAR_NUM)
     {
-        assert(compiler->lvaPSPSym != BAD_VAR_NUM);
-
 #ifdef _TARGET_AMD64_
         // The PSPSym is relative to InitialSP on X64 and CallerSP on other platforms.
         gcInfoEncoderWithLog->SetPSPSymStackSlot(compiler->lvaGetInitialSPRelativeOffset(compiler->lvaPSPSym));

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3400,6 +3400,8 @@ void Compiler::lvaMarkLocalVars()
         }
 #endif // FEATURE_EH_FUNCLETS
 
+        // TODO: LocAllocSPvar should be only required by the implicit frame layout expected by the VM on x86.
+        // It should be removed on other platforms once we check there are no other implicit dependencies.
         if (compLocallocUsed)
         {
             lvaLocAllocSPvar         = lvaGrabTempWithImplicitUse(false DEBUGARG("LocAllocSPvar"));

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3388,20 +3388,24 @@ void Compiler::lvaMarkLocalVars()
 
 #endif // !FEATURE_EH_FUNCLETS
 
-#if FEATURE_EH_FUNCLETS
-    if (ehNeedsPSPSym())
+    // PSPSym and LocAllocSPvar are not used by the CoreRT ABI
+    if (eeGetEEInfo()->targetAbi != CORINFO_CORERT_ABI)
     {
-        lvaPSPSym            = lvaGrabTempWithImplicitUse(false DEBUGARG("PSPSym"));
-        LclVarDsc* lclPSPSym = &lvaTable[lvaPSPSym];
-        lclPSPSym->lvType    = TYP_I_IMPL;
-    }
+#if FEATURE_EH_FUNCLETS
+        if (ehNeedsPSPSym())
+        {
+            lvaPSPSym            = lvaGrabTempWithImplicitUse(false DEBUGARG("PSPSym"));
+            LclVarDsc* lclPSPSym = &lvaTable[lvaPSPSym];
+            lclPSPSym->lvType    = TYP_I_IMPL;
+        }
 #endif // FEATURE_EH_FUNCLETS
 
-    if (compLocallocUsed)
-    {
-        lvaLocAllocSPvar         = lvaGrabTempWithImplicitUse(false DEBUGARG("LocAllocSPvar"));
-        LclVarDsc* locAllocSPvar = &lvaTable[lvaLocAllocSPvar];
-        locAllocSPvar->lvType    = TYP_I_IMPL;
+        if (compLocallocUsed)
+        {
+            lvaLocAllocSPvar         = lvaGrabTempWithImplicitUse(false DEBUGARG("LocAllocSPvar"));
+            LclVarDsc* locAllocSPvar = &lvaTable[lvaLocAllocSPvar];
+            locAllocSPvar->lvType    = TYP_I_IMPL;
+        }
     }
 
     BasicBlock* block;
@@ -4060,12 +4064,11 @@ void Compiler::lvaFixVirtualFrameOffsets()
     LclVarDsc* varDsc;
 
 #if FEATURE_EH_FUNCLETS && defined(_TARGET_AMD64_)
-    if (ehNeedsPSPSym())
+    if (lvaPSPSym != BAD_VAR_NUM)
     {
         // We need to fix the offset of the PSPSym so there is no padding between it and the outgoing argument space.
         // Without this code, lvaAlignFrame might have put the padding lower than the PSPSym, which would be between
         // the PSPSym and the outgoing argument space.
-        assert(lvaPSPSym != BAD_VAR_NUM);
         varDsc = &lvaTable[lvaPSPSym];
         assert(varDsc->lvFramePointerBased); // We always access it RBP-relative.
         assert(!varDsc->lvMustInit);         // It is never "must init".
@@ -4975,13 +4978,12 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
 #endif //_TARGET_AMD64_
 
 #if FEATURE_EH_FUNCLETS && defined(_TARGET_ARMARCH_)
-    if (ehNeedsPSPSym())
+    if (lvaPSPSym != BAD_VAR_NUM)
     {
         // On ARM/ARM64, if we need a PSPSym, allocate it first, before anything else, including
         // padding (so we can avoid computing the same padding in the funclet
         // frame). Note that there is no special padding requirement for the PSPSym.
         noway_assert(codeGen->isFramePointerUsed()); // We need an explicit frame pointer
-        assert(lvaPSPSym != BAD_VAR_NUM);            // We should have created the PSPSym variable
         stkOffs = lvaAllocLocalAndSetVirtualOffset(lvaPSPSym, TARGET_POINTER_SIZE, stkOffs);
     }
 #endif // FEATURE_EH_FUNCLETS && defined(_TARGET_ARMARCH_)
@@ -5035,7 +5037,7 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
         stkOffs = lvaAllocLocalAndSetVirtualOffset(lvaSecurityObject, TARGET_POINTER_SIZE, stkOffs);
     }
 
-    if (compLocallocUsed)
+    if (lvaLocAllocSPvar != BAD_VAR_NUM)
     {
 #ifdef JIT32_GCENCODER
         noway_assert(codeGen->isFramePointerUsed()); // else offsets of locals of frameless methods will be incorrect
@@ -5481,13 +5483,12 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
     }
 
 #if FEATURE_EH_FUNCLETS && defined(_TARGET_AMD64_)
-    if (ehNeedsPSPSym())
+    if (lvaPSPSym != BAD_VAR_NUM)
     {
         // On AMD64, if we need a PSPSym, allocate it last, immediately above the outgoing argument
         // space. Any padding will be higher on the stack than this
         // (including the padding added by lvaAlignFrame()).
         noway_assert(codeGen->isFramePointerUsed()); // We need an explicit frame pointer
-        assert(lvaPSPSym != BAD_VAR_NUM);            // We should have created the PSPSym variable
         stkOffs = lvaAllocLocalAndSetVirtualOffset(lvaPSPSym, TARGET_POINTER_SIZE, stkOffs);
     }
 #endif // FEATURE_EH_FUNCLETS && defined(_TARGET_AMD64_)


### PR DESCRIPTION
The establisher frame definition differs between CoreRT ABI and CoreCLR ABI. In CoreRT ABI created by @russellhadley and @smosier while back, the establisher frame is always the SP value at the point that control left the frame in which execution would resume after a catch handler completes. This mismatch leads to crashes when PSPSym is recomputed in funclets of methods with localloc.

Fixed by disabling PSPSym for CoreRT since it does not need it. Also disabled LocAllocSPvar while I was on it since it is not needed for CoreRT either.

Fixes https://github.com/dotnet/corert/issues/2255