### PR TITLE
[x86/Linux] Fix 'stdcall' here was previously declared without

### DIFF
--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1693,6 +1693,6 @@ public:
 
 CORJIT_FLAGS GetDebuggerCompileFlags(Module* pModule, CORJIT_FLAGS flags);
 
-bool TrackAllocationsEnabled();
+bool __stdcall TrackAllocationsEnabled();
 
 #endif // JITINTERFACE_H


### PR DESCRIPTION
Fix compile error for x86/Linux
- add __stdcall in header
- fix "function declared 'stdcall' here was previously declared without"