### PR TITLE
Forbid the inclusion of gcscan.h and softwarewritewatch.h from within the VM

### DIFF
--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -26,6 +26,7 @@ Module Name:
 #endif // Sleep
 
 #include "gcinterface.h"
+#include "softwarewritewatch.h"
 #include "env/gcenv.os.h"
 #include "env/gcenv.ee.h"
 

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -884,6 +884,29 @@ void GCHeap::UnregisterFrozenSegment(segment_handle seg)
 #endif // FEATURE_BASICFREEZE
 }
 
+void GCHeap::SetDirty(void* address, size_t size)
+{
+#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+    if (SoftwareWriteWatch::IsEnabledForGCHeap())
+    {
+        SoftwareWriteWatch::SetDirty(address, size);
+    }
+#endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+}
+
+void* GCHeap::GetTable()
+{
+#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+    return SoftwareWriteWatch::GetTable();
+#endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+    assert(!"Should not call GCHeap::GetTable called without FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP defined!");
+    return nullptr;
+}
+
+bool GCHeap::GetGcRuntimeStructuresValid()
+{
+    return GCScan::GetGcRuntimeStructuresValid();
+}
 
 #endif // !DACCESS_COMPILE
 

--- a/src/gc/gcimpl.h
+++ b/src/gc/gcimpl.h
@@ -274,6 +274,13 @@ protected:
 
     virtual void DescrGenerationsToProfiler (gen_walk_fn fn, void *context);
 
+    virtual void SetDirty(void* address, size_t size);
+
+    virtual void* GetTable();
+
+    virtual bool GetGcRuntimeStructuresValid();
+
+
 public:
     Object * NextObj (Object * object);
 #if defined (FEATURE_BASICFREEZE) && defined (VERIFY_HEAP)

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -479,6 +479,30 @@ public:
     // Unregisters a frozen segment.
     virtual void UnregisterFrozenSegment(segment_handle seg) = 0;
 
+    /*
+    ===========================================================================
+    Routines used by the write barrier to coordinate a non-OS WriteWatch
+    implementation with the GC.
+    ===========================================================================
+    */
+    
+    // Marks the given address (representing an object with the given size) as
+    // dirty.
+    virtual void SetDirty(void* address, size_t size) = 0;
+
+    // Gets a pointer to the implementation-defined WriteWatch table.
+    virtual void* GetTable() = 0;
+
+    /*
+    ===========================================================================
+    Routines useful when traversing the managed heap.
+    ===========================================================================
+    */
+
+    // Returns true if the GC structures are in a valid state.
+    virtual bool GetGcRuntimeStructuresValid() = 0;
+
+
     IGCHeap() {}
     virtual ~IGCHeap() {}
 

--- a/src/vm/amd64/jitinterfaceamd64.cpp
+++ b/src/vm/amd64/jitinterfaceamd64.cpp
@@ -16,7 +16,6 @@
 #include "eeconfig.h"
 #include "excep.h"
 #include "threadsuspend.h"
-#include "../../gc/softwarewritewatch.h"
 
 extern uint8_t* g_ephemeral_low;
 extern uint8_t* g_ephemeral_high;
@@ -525,6 +524,7 @@ void WriteBarrierManager::UpdateWriteWatchAndCardTableLocations(bool isRuntimeSu
     bool fFlushCache = false;
     
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+    size_t swwTable = 0;
     switch (m_currentWriteBarrier)
     {
         case WRITE_BARRIER_WRITE_WATCH_PREGROW64:
@@ -532,9 +532,11 @@ void WriteBarrierManager::UpdateWriteWatchAndCardTableLocations(bool isRuntimeSu
 #ifdef FEATURE_SVR_GC
         case WRITE_BARRIER_WRITE_WATCH_SVR64:
 #endif // FEATURE_SVR_GC
-            if (*(UINT64*)m_pWriteWatchTableImmediate != (size_t)SoftwareWriteWatch::GetTable())
+            swwTable = (size_t)GCHeapUtilities::GetGCHeap()->GetTable();
+            _ASSERTE(swwTable != 0);
+            if (*(UINT64*)m_pWriteWatchTableImmediate != swwTable)
             {
-                *(UINT64*)m_pWriteWatchTableImmediate = (size_t)SoftwareWriteWatch::GetTable();
+                *(UINT64*)m_pWriteWatchTableImmediate = swwTable;
                 fFlushCache = true;
             }
             break;

--- a/src/vm/gcenv.h
+++ b/src/vm/gcenv.h
@@ -51,8 +51,6 @@
 #include "gcenv.interlocked.h"
 #include "gcenv.interlocked.inl"
 
-#include "../gc/softwarewritewatch.h"
-
 namespace ETW
 {
     typedef  enum _GC_ROOT_KIND {

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -35,7 +35,7 @@
 #endif // FEATURE_COMINTEROP
 
 #include "rcwwalker.h"
-#include "../gc/softwarewritewatch.h"
+#include "gcheaputilities.h"
 
 //========================================================================
 //
@@ -1239,10 +1239,7 @@ extern "C" HCIMPL2_RAW(VOID, JIT_CheckedWriteBarrier, Object **dst, Object *ref)
 #endif
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    if (SoftwareWriteWatch::IsEnabledForGCHeap())
-    {
-        SoftwareWriteWatch::SetDirty(dst, sizeof(*dst));
-    }
+    GCHeapUtilities::GetGCHeap()->SetDirty(dst, sizeof(*dst));
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
 #ifdef FEATURE_COUNT_GC_WRITE_BARRIERS
@@ -1296,10 +1293,7 @@ extern "C" HCIMPL2_RAW(VOID, JIT_WriteBarrier, Object **dst, Object *ref)
 #endif
     
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    if (SoftwareWriteWatch::IsEnabledForGCHeap())
-    {
-        SoftwareWriteWatch::SetDirty(dst, sizeof(*dst));
-    }
+    GCHeapUtilities::GetGCHeap()->SetDirty(dst, sizeof(*dst));
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
 #ifdef FEATURE_COUNT_GC_WRITE_BARRIERS
@@ -1364,10 +1358,7 @@ void ErectWriteBarrier(OBJECTREF *dst, OBJECTREF ref)
 #endif
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    if (SoftwareWriteWatch::IsEnabledForGCHeap())
-    {
-        SoftwareWriteWatch::SetDirty(dst, sizeof(*dst));
-    }
+    GCHeapUtilities::GetGCHeap()->SetDirty(dst, sizeof(*dst));
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
     if((BYTE*) OBJECTREFToObject(ref) >= g_ephemeral_low && (BYTE*) OBJECTREFToObject(ref) < g_ephemeral_high)
@@ -1397,10 +1388,7 @@ void ErectWriteBarrierForMT(MethodTable **dst, MethodTable *ref)
     if (ref->Collectible())
     {
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-        if (SoftwareWriteWatch::IsEnabledForGCHeap())
-        {
-            SoftwareWriteWatch::SetDirty(dst, sizeof(*dst));
-        }
+        GCHeapUtilities::GetGCHeap()->SetDirty(dst, sizeof(*dst));
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
         BYTE *refObject = *(BYTE **)((MethodTable*)ref)->GetLoaderAllocatorObjectHandle();

--- a/src/vm/gcscan.h
+++ b/src/vm/gcscan.h
@@ -1,5 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-#include "../gc/gcscan.h"

--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -22,7 +22,6 @@
 #include "remoting.h"
 #endif
 #include "field.h"
-#include "gcscan.h"
 #include "argdestination.h"
 
 #ifdef FEATURE_COMPRESSEDSTACK
@@ -1813,9 +1812,10 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
         // try to validate next object's header
         if (bDeep 
             && bVerifyNextHeader 
-            && GCScan::GetGcRuntimeStructuresValid ()
+            && GCHeapUtilities::IsGCHeapInitialized()
+            && GCHeapUtilities::GetGCHeap()->GetGcRuntimeStructuresValid()
             //NextObj could be very slow if concurrent GC is going on
-            && !(GCHeapUtilities::IsGCHeapInitialized() && GCHeapUtilities::GetGCHeap ()->IsConcurrentGCInProgress ()))
+            && !GCHeapUtilities::GetGCHeap ()->IsConcurrentGCInProgress ())
         {
             Object * nextObj = GCHeapUtilities::GetGCHeap ()->NextObj (this);
             if ((nextObj != NULL) &&

--- a/src/vm/stubhelpers.cpp
+++ b/src/vm/stubhelpers.cpp
@@ -21,7 +21,7 @@
 #include "comdatetime.h"
 #include "gcheaputilities.h"
 #include "interoputil.h"
-#include "gcscan.h"
+#include "gcheaputilities.h"
 #ifdef FEATURE_REMOTING
 #include "remoting.h"
 #endif
@@ -61,7 +61,7 @@ void StubHelpers::ValidateObjectInternal(Object *pObjUNSAFE, BOOL fValidateNextO
 }
 	CONTRACTL_END;
 
-	_ASSERTE(GCScan::GetGcRuntimeStructuresValid());
+	_ASSERTE(GCHeapUtilities::GetGCHeap()->GetGcRuntimeStructuresValid());
 
 	// validate the object - there's no need to validate next object's
 	// header since we validate the next object explicitly below

--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -30,7 +30,7 @@
 #include "corhost.h"
 #include "comdelegate.h"
 #include "finalizerthread.h"
-#include "gcscan.h"
+#include "gcheaputilities.h"
 
 #ifdef FEATURE_COMINTEROP
 #include "runtimecallablewrapper.h"
@@ -2518,7 +2518,7 @@ BOOL ObjHeader::Validate (BOOL bVerifySyncBlkIndex)
         //rest of the DWORD is SyncBlk Index
         if (!(bits & BIT_SBLK_IS_HASHCODE))
         {
-            if (bVerifySyncBlkIndex  && GCScan::GetGcRuntimeStructuresValid ())
+            if (bVerifySyncBlkIndex  && GCHeapUtilities::GetGCHeap()->GetGcRuntimeStructuresValid ())
             {
                 DWORD sbIndex = bits & MASK_SYNCBLOCKINDEX;
                 ASSERT_AND_CHECK(SyncTableEntry::GetSyncTableEntry()[sbIndex].m_Object == obj);             


### PR DESCRIPTION
This PR removes `gcscan.h` and `softwarewritewatch.h` from the set of GC headers that can be included by the VM by exposing their functionality as part of the GC interface. 

This PR also adds one indirection in `WriteBarrierManager::UpdateWriteWatchAndCardTableLocations` and one indirection in each of the non-assembly write barriers that interact with `SoftwareWriteWatch`. 

This PR does not attempt to prevent the DAC from including `gcscan.h` - that can be done later as a part of #8268