### PR TITLE
Do not rewrite `(t + cns_a) << cns_s)` during CSE.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13897,7 +13897,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
 
             /* Check for the case "(val + icon) << icon" */
 
-            if (op2->IsCnsIntOrI() && op1->gtOper == GT_ADD && !op1->gtOverflow())
+            if (!optValnumCSE_phase && op2->IsCnsIntOrI() && op1->gtOper == GT_ADD && !op1->gtOverflow())
             {
                 GenTreePtr cns = op1->gtOp.gtOp2;
 


### PR DESCRIPTION
Morph normally rewrites trees of the form `(t + cns_a) << cns_s` to
`(t << cns_s + cns_a << cns_s)`. This transformation is not safe to run
during CSE, as it may invalidate CSE candidates.

Fixes #8285.