### PR TITLE
Fix SIMD Scalar Move Encoding: VEX.L should be 0

### DIFF
--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -68,7 +68,8 @@ enum SIMDScalarMoveType
 };
 
 instruction getOpForSIMDIntrinsic(SIMDIntrinsicID intrinsicId, var_types baseType, unsigned* ival = nullptr);
-void genSIMDScalarMove(var_types type, regNumber target, regNumber src, SIMDScalarMoveType moveType);
+void genSIMDScalarMove(
+    var_types targetType, var_types type, regNumber target, regNumber src, SIMDScalarMoveType moveType);
 void genSIMDZero(var_types targetType, var_types baseType, regNumber targetReg);
 void genSIMDIntrinsicInit(GenTreeSIMD* simdNode);
 void genSIMDIntrinsicInitN(GenTreeSIMD* simdNode);


### PR DESCRIPTION
For SIMD Scalar Move instructions such as vmovlpd, vmovlps, vmovhps,
vmovhps and vmovss on AVX system, JIT should ensure that those
instructions are encoded with VEX.L=0, because encoding them with
VEX.L=1 may encounter unpredictable behavior across different
processor generations. The reason of VEX.L is encoded with 1 is
because JIT calls compiler->getSIMDVectorType() which returns
EA_32BYTE, and it is been passed into emitter AddVexPrefix() which
ends up encoded VEX.L=1, the fix is to pass EA_16BYTE for those
instructions to ensure that VEX.L=0 at emitter AddVexPrefix()

Fix #8328