### PR TITLE
[x86/Linux] Fix cannot initialize a variable of type 'CLRFLSGETBLOCK'

### DIFF
--- a/src/utilcode/clrhost_nodependencies.cpp
+++ b/src/utilcode/clrhost_nodependencies.cpp
@@ -745,12 +745,12 @@ void ClrFlsAssociateCallback(DWORD slot, PTLS_CALLBACK_FUNCTION callback)
     GetExecutionEngine()->TLS_AssociateCallback(slot, callback);
 }
 
-void ** __stdcall ClrFlsGetBlockGeneric()
+LPVOID * ClrFlsGetBlockGeneric()
 {
     WRAPPER_NO_CONTRACT;
     STATIC_CONTRACT_SO_TOLERANT;
 
-    return (void **) GetExecutionEngine()->TLS_GetDataBlock();
+    return (LPVOID *) GetExecutionEngine()->TLS_GetDataBlock();
 }
 
 CLRFLSGETBLOCK __ClrFlsGetBlock = ClrFlsGetBlockGeneric;


### PR DESCRIPTION
Fix compile error for x86/Linux
- remove `__stdcall` for `ClrFlsGetBlockGeneric()`
- fix "cannot initialize a variable of type 'CLRFLSGETBLOCK'"