### PR TITLE
Include system native as coreclr dependency

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -14,6 +14,7 @@
   <PropertyGroup>
     <CoreClrPackageVersion>1.2.0-beta-24709-03</CoreClrPackageVersion>
     <XunitPackageVersion>2.2.0-beta2-build3300</XunitPackageVersion>
+    <SystemNativePackageVersion>4.4.0-beta-24710-01</SystemNativePackageVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->
@@ -46,6 +47,11 @@
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>CoreClrPackageVersion</ElementName>
       <PackageId>Microsoft.NETCore.Runtime.CoreCLR</PackageId>
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="SystemNative">
+      <Path>$(MSBuildThisFileFullPath)</Path>
+      <ElementName>SystemNativePackageVersion</ElementName>
+      <PackageId>runtime.native.System</PackageId>
     </XmlUpdateStep>
   </ItemGroup>
 

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -14,6 +14,9 @@
     <Dependency Include="Microsoft.NETCore.Windows.ApiSets">
       <Version>$(WindowsAPISetPackageVersion)</Version>
     </Dependency>
+    <Dependency Include="runtime.native.System">
+      <Version>$(SystemNativePackageVersion)</Version>
+    </Dependency>
     <ProjectReference Include="..\Microsoft.NETCore.Jit\Microsoft.NETCore.Jit.pkgproj" />
     <ProjectReference Include="win\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>


### PR DESCRIPTION
@gkhanna79 PTAL

@dagood the version string would need to be updated periodically by dotnet-bot.

Cc @JohnChen0 investigated the failure in https://github.com/dotnet/core-setup/pull/702 due to https://github.com/dotnet/coreclr/commit/233c58ca964e15e6ce1e756940ec59819d797edf
