### PR TITLE
[x86/Linux] Fix ignored attribute warning for x86/Linux build

### DIFF
--- a/src/vm/i386/cgencpu.h
+++ b/src/vm/i386/cgencpu.h
@@ -476,7 +476,7 @@ inline BOOL IsUnmanagedValueTypeReturnedByRef(UINT sizeofvaluetype)
 }
 
 #include <pshpack1.h>
-DECLSPEC_ALIGN(4) struct UMEntryThunkCode
+struct DECLSPEC_ALIGN(4) UMEntryThunkCode
 {
     BYTE            m_alignpad[2];  // used to guarantee alignment of backpactched portion
     BYTE            m_movEAX;   //MOV EAX,imm32


### PR DESCRIPTION
This commit fixes the following warning during x86/Linux build:
```
src/vm/i386/cgencpu.h:479:1: error: attribute 'align' is ignored, place it after "struct" to apply attribute to type declaration [-Werror,-Wignored-attributes]
DECLSPEC_ALIGN(4) struct UMEntryThunkCode
^
```