### PR TITLE
[x86/Linux] Fix the mistmatch between gc_thread_stub and GCThreadFunction

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -24711,7 +24711,7 @@ void gc_heap::compact_phase (int condemned_gen_number,
 #pragma warning(push)
 #pragma warning(disable:4702) // C4702: unreachable code: gc_thread_function may not return
 #endif //_MSC_VER
-void __stdcall gc_heap::gc_thread_stub (void* arg)
+void gc_heap::gc_thread_stub (void* arg)
 {
     ClrFlsSetThreadType (ThreadType_GC);
     STRESS_LOG_RESERVE_MEM (GC_STRESSLOG_MULTIPLY);

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -1224,7 +1224,7 @@ public:
     static 
     gc_heap* balance_heaps_loh (alloc_context* acontext, size_t size);
     static
-    void __stdcall gc_thread_stub (void* arg);
+    void gc_thread_stub (void* arg);
 #endif //MULTIPLE_HEAPS
 
     CObjectHeader* try_fast_alloc (size_t jsize);


### PR DESCRIPTION
This commit fixes the following warning during x86/Linux build:
```
/home/parjong/projects/dotnet/coreclr/src/gc/gc.cpp:5192:42: error: cannot initialize a parameter of type 'GCThreadFunction' (aka 'void (*)(void *)') with an lvalue of type 'void (void *) __attribute__((stdcall))'
    return GCToOSInterface::CreateThread(gc_thread_stub, this, &affinity);
                                         ^~~~~~~~~~~~~~
/home/parjong/projects/dotnet/coreclr/src/gc/env/gcenv.os.h:153:47: note: passing argument to parameter 'function' here
    static bool CreateThread(GCThreadFunction function, void* param, GCThreadAffinity* affinity);
                                                                           ^
```