### PR TITLE
[x86/Linux] Add virtual dtor for ArrayStubCache class

### DIFF
--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -3400,7 +3400,7 @@ public:
         m_iSize = iBuckets + 7;
     }
 
-    ~CClosedHashBase()
+    virtual ~CClosedHashBase()
     {
         WRAPPER_NO_CONTRACT;
         Clear();

--- a/src/vm/array.cpp
+++ b/src/vm/array.cpp
@@ -1252,8 +1252,6 @@ class ArrayStubCache : public StubCacheBase
                              StubLinker *psl);
     virtual UINT Length(const BYTE *pRawStub);
 
-    virtual ~ArrayStubCache() = default;
-
 public:
     static ArrayStubCache * GetArrayStubCache()
     {

--- a/src/vm/array.cpp
+++ b/src/vm/array.cpp
@@ -1252,6 +1252,8 @@ class ArrayStubCache : public StubCacheBase
                              StubLinker *psl);
     virtual UINT Length(const BYTE *pRawStub);
 
+    virtual ~ArrayStubCache() = default;
+
 public:
     static ArrayStubCache * GetArrayStubCache()
     {

--- a/src/vm/stubcache.h
+++ b/src/vm/stubcache.h
@@ -50,7 +50,7 @@ public:
     //---------------------------------------------------------
     // Destructor
     //---------------------------------------------------------
-    ~StubCacheBase();
+    virtual ~StubCacheBase();
 
     //---------------------------------------------------------
     // Returns the equivalent hashed Stub, creating a new hash


### PR DESCRIPTION
Adds virtual destructor for ArrayStubCache class (and its super classes) to fix the following warning during x86/Linux build:
```
src/vm/array.cpp:1266:17: error: delete called on 'ArrayStubCache' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
                delete pArrayStubCache;
                ^
```