### PR TITLE
[x86/Linux] Emit compile error on porting issue when PORTABILITY_CHECK is set

### DIFF
--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1177,7 +1177,7 @@ typedef VOID (__stdcall *WAITORTIMERCALLBACK)(PVOID, BOOLEAN);
 // The message in these two macros should not contain any keywords like TODO
 // or NYI. It should be just the brief description of the problem.
 
-#if defined(_TARGET_X86_)
+#ifdef PORTABILITY_CHECK
 // Finished ports - compile-time errors
 #define PORTABILITY_WARNING(message)    NEED_TO_PORT_THIS_ONE(NEED_TO_PORT_THIS_ONE)
 #define PORTABILITY_ASSERT(message)     NEED_TO_PORT_THIS_ONE(NEED_TO_PORT_THIS_ONE)


### PR DESCRIPTION
The current implementation of ``PORTABILITY_WARNING`` and ``PORTABILITY_ASSERT`` emits compile error when  _TARGET_X86_ is defined.

This commit revises this implementation to emit compile error when PORTABILITY_CHECK is defined.