### PR TITLE
Fix phantom TEXTREL in libcoreclr.so

### DIFF
--- a/src/pal/inc/unixasmmacrosamd64.inc
+++ b/src/pal/inc/unixasmmacrosamd64.inc
@@ -8,7 +8,7 @@
 #if defined(__APPLE__)
         .cfi_personality 0x9b, C_FUNC(\Handler) // 0x9b == DW_EH_PE_indirect | DW_EH_PE_pcrel | DW_EH_PE_sdata4
 #else
-        .cfi_personality 0, C_FUNC(\Handler) // 0 == DW_EH_PE_absptr
+        .cfi_personality 0x1b, C_FUNC(\Handler) // 0x1b == DW_EH_PE_pcrel | DW_EH_PE_sdata4
 #endif
         .endif
 .endm

--- a/src/pal/inc/unixasmmacrosarm64.inc
+++ b/src/pal/inc/unixasmmacrosarm64.inc
@@ -5,7 +5,7 @@
 .macro NESTED_ENTRY Name, Section, Handler
         LEAF_ENTRY \Name, \Section
         .ifnc \Handler, NoHandler
-        .cfi_personality 0, C_FUNC(\Handler) // 0 == DW_EH_PE_absptr
+        .cfi_personality 0x1b, C_FUNC(\Handler) // 0x1b == DW_EH_PE_pcrel | DW_EH_PE_sdata4
         .endif
 .endm
 


### PR DESCRIPTION
This change fixes the problem where scanelf tool reported that libcoreclr.s
contains TEXTRELs, however it was unable to find any.
It turns out there actually were TEXTRELs, but not in the program code or
program data, but rather in the DWARF tables. The NESTED_ENTRY macro for
ARM64 and AMD64 uses .cfi_personality with encoding 0, which means
absolute address. This is the source of the TEXTREL.
Changing the encoding to 0x1b - DW_EH_PE_pcrel | DW_EH_PE_sdata4 fixes the
problem - the scanelf tool no longer reports any TEXTRELs in libcoreclr.so.