### PR TITLE
Fix shared library dependencies verification on some platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -218,14 +218,6 @@ build_coreclr()
         exit 1
     fi
 
-    echo "Verifying System.Globalization.Native.so dependencies"
-
-    ldd -r $__BinDir/System.Globalization.Native.so | awk 'BEGIN {count=0} /undefined symbol:/ { if (count==0) {print "Undefined symbol(s) found:"} print " " $3; count++ } END {if (count>0) exit(1)}'
-    if [ $? != 0 ]; then
-        echo "Failed. System.Globalization.Native.so has undefined dependencies. These are likely ICU APIs that need to be added to icushim.h"
-        exit 1
-    fi
-
 	popd
 }
 

--- a/functions.cmake
+++ b/functions.cmake
@@ -216,3 +216,19 @@ function(_install)
       install(${ARGV})
     endif()
 endfunction()
+
+function(verify_dependencies targetName errorMessage)
+    # We don't need to verify dependencies on OSX, since missing dependencies
+    # result in link error over there.
+    if (NOT CLR_CMAKE_PLATFORM_DARWIN)
+        add_custom_command(
+            TARGET ${targetName}
+            POST_BUILD
+            VERBATIM
+            COMMAND ${CMAKE_SOURCE_DIR}/verify-so.sh 
+                $<TARGET_FILE:${targetName}> 
+                ${errorMessage}
+            COMMENT "Verifying ${targetName} dependencies"
+        )
+    endif()
+endfunction()

--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -93,5 +93,11 @@ else()
     add_definitions(-DU_DISABLE_RENAMING=1)
 endif()
 
+verify_dependencies(
+    System.Globalization.Native
+    "Verification failed. System.Globalization.Native.so has undefined dependencies. These are likely ICU APIs that need to be added to icushim.h."
+)
+
 # add the install targets
 install_clr(System.Globalization.Native)
+

--- a/verify-so.sh
+++ b/verify-so.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# $1 contains full path to the .so to verify
+# $2 contains message to print when the verification fails
+
+OSName=$(uname -s)
+case $OSName in
+    Linux)
+        source /etc/os-release
+        # TODO: add support for verification on Alpine Linux
+        if [ "$ID" != "alpine" ]; then
+            ldd -r $1 | awk 'BEGIN {count=0} /undefined symbol:/ { if (count==0) {print "Undefined symbol(s) found:"} print " " $3; count++ } END {if (count>0) exit(1)}'
+            if [ $? != 0 ]; then
+                echo "$2"
+                exit 1
+            fi
+        fi
+        ;;
+esac
+
+# TODO: add support for verification on non-Linux Unixes (except of OSX)


### PR DESCRIPTION
The existing way of verifying shared library dependencies, used for
System.Globalization.Native.so, doesn't work on platforms that don't
have `ldd` or where `ldd` doesn't support the `-r` option.
This change makes the check happen on non-Alpine Linux only for now.
It also refactors the way the check is performed. Instead of doing it
post build in the build.sh, it is now performed as a postbuild phase
of the System.Globalization.Native target and it is also generalized
so that we can easily add such verification to other build targets.