### PR TITLE
Adding missing ctor - 'public Span(T[] array, int start)'

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -12397,6 +12397,7 @@
     </Type>
     <Type Name="System.Span&lt;T&gt;" Condition="FEATURE_SPAN_OF_T">
       <Member Name="#ctor(T[])" />
+      <Member Name="#ctor(T[],System.Int32)" />
       <Member Name="#ctor(T[],System.Int32,System.Int32)" />
       <Member Name="#ctor(System.Void*,System.Int32)" />
       <Member Name="op_Implicit(T[])" ReturnType="System.Span&lt;T&gt;" />
@@ -12415,6 +12416,7 @@
     </Type>
     <Type Name="System.ReadOnlySpan&lt;T&gt;" Condition="FEATURE_SPAN_OF_T">
       <Member Name="#ctor(T[])" />
+      <Member Name="#ctor(T[],System.Int32)" />
       <Member Name="#ctor(T[],System.Int32,System.Int32)" />
       <Member Name="#ctor(System.Void*,System.Int32)" />
       <Member Name="op_Implicit(System.Span&lt;T&gt;)" ReturnType="System.ReadOnlySpan&lt;T&gt;" />

--- a/src/mscorlib/src/System/ReadOnlySpan.cs
+++ b/src/mscorlib/src/System/ReadOnlySpan.cs
@@ -38,6 +38,29 @@ namespace System
 
         /// <summary>
         /// Creates a new span over the portion of the target array beginning
+        /// at 'start' index and covering the remainder of the array.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> is not in the range (&lt;0 or &gt;&eq;Length).
+        /// </exception>
+        public ReadOnlySpan(T[] array, int start)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if ((uint)start > (uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+
+            // TODO-SPAN: This has GC hole. It needs to be JIT intrinsic instead
+            _rawPointer = (IntPtr)Unsafe.AsPointer(ref Unsafe.Add(ref JitHelpers.GetArrayData(array), start));
+            _length = array.Length - start;
+        }
+
+        /// <summary>
+        /// Creates a new span over the portion of the target array beginning
         /// at 'start' index and ending at 'end' index (exclusive).
         /// </summary>
         /// <param name="array">The target array.</param>
@@ -46,7 +69,7 @@ namespace System
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
         /// reference (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">
-        /// Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;&eq;Length).
+        /// Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;&eq;Length).
         /// </exception>
         public ReadOnlySpan(T[] array, int start, int length)
         {

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -43,6 +43,34 @@ namespace System
 
         /// <summary>
         /// Creates a new span over the portion of the target array beginning
+        /// at 'start' index and covering the remainder of the array.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> is not in the range (&lt;0 or &gt;=Length).
+        /// </exception>
+        public Span(T[] array, int start)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null) { // Arrays of valuetypes are never covariant
+                if (array.GetType() != typeof(T[]))
+                    ThrowHelper.ThrowArrayTypeMismatchException();
+            }
+            if ((uint)start > (uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+
+            // TODO-SPAN: This has GC hole. It needs to be JIT intrinsic instead
+            _rawPointer = (IntPtr)Unsafe.AsPointer(ref Unsafe.Add(ref JitHelpers.GetArrayData(array), start));
+            _length = array.Length - start;
+        }
+
+        /// <summary>
+        /// Creates a new span over the portion of the target array beginning
         /// at 'start' index and ending at 'end' index (exclusive).
         /// </summary>
         /// <param name="array">The target array.</param>
@@ -52,7 +80,7 @@ namespace System
         /// reference (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">
-        /// Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;&eq;Length).
+        /// Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
         /// </exception>
         public Span(T[] array, int start, int length)
         {

--- a/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
+++ b/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
@@ -41,8 +41,11 @@ class My
         int failedTestsCount = 0;
 
         Test(CanAccessItemsViaIndexer, "CanAccessItemsViaIndexer", ref failedTestsCount);
+        Test(CanAccessItemsViaIndexerStartCtor, "CanAccessItemsViaIndexerStartCtor", ref failedTestsCount);
+        Test(CanAccessItemsViaIndexerStartLengthCtor, "CanAccessItemsViaIndexerStartLengthCtor", ref failedTestsCount);
 
-        Test(TestBoundaryEmptySpan, "TestBoundaryEmptySpan", ref failedTestsCount);
+        Test(TestBoundaryEmptySpanStartCtor, "TestBoundaryEmptySpanStartCtor", ref failedTestsCount);
+        Test(TestBoundaryEmptySpanStartLengthCtor, "TestBoundaryEmptySpanStartLengthCtor", ref failedTestsCount);
 
         Test(ReferenceTypesAreSupported, "ReferenceTypesAreSupported", ref failedTestsCount);
 
@@ -51,6 +54,9 @@ class My
         Test(MustNotMoveGcTypesToUnmanagedMemory, "MustNotMoveGcTypesToUnmanagedMemory", ref failedTestsCount);
 
         Test(TestArrayCoVariance, "TestArrayCoVariance", ref failedTestsCount);
+        Test(TestArrayCoVarianceStartCtor, "TestArrayCoVarianceStartCtor", ref failedTestsCount);
+        Test(TestArrayCoVarianceStartLengthCtor, "TestArrayCoVarianceStartLengthCtor", ref failedTestsCount);
+
         Test(TestArrayCoVarianceReadOnly, "TestArrayCoVarianceReadOnly", ref failedTestsCount);
 
         Test(CanCopyValueTypesWithoutPointersToSlice, "CanCopyValueTypesWithoutPointersToSlice", ref failedTestsCount);
@@ -74,8 +80,12 @@ class My
         Test(SourceTypeLargerThanTargetOneCorrectlyCalcsTargetsLength, "SourceTypeLargerThanTargetOneCorrectlyCalcsTargetsLength", ref failedTestsCount);
         Test(WhenSourceDoesntFitIntoTargetLengthIsZero, "WhenSourceDoesntFitIntoTargetLengthIsZero", ref failedTestsCount);
         Test(WhenSourceFitsIntoTargetOnceLengthIsOne, "WhenSourceFitsIntoTargetOnceLengthIsOne", ref failedTestsCount);
-        Test(WhenSourceTypeLargerThaTargetAndOverflowsInt32ThrowsException, "WhenSourceTypeLargerThaTargetAndOverflowsInt32ThrowsException", ref failedTestsCount);
+        Test(WhenSourceTypeLargerThanTargetAndOverflowsInt32ThrowsException, "WhenSourceTypeLargerThanTargetAndOverflowsInt32ThrowsException", ref failedTestsCount);
         Test(CanCreateSpanFromString, "CanCreateSpanFromString", ref failedTestsCount);
+
+        Test(WhenStartLargerThanLengthThrowsExceptionStartCtor, "WhenStartLargerThanLengthThrowsExceptionStartCtor", ref failedTestsCount);
+        Test(WhenStartLargerThanLengthThrowsExceptionStartLengthCtor, "WhenStartLargerThanLengthThrowsExceptionStartLengthCtor", ref failedTestsCount);
+        Test(WhenStartAndLengthLargerThanLengthThrowsExceptionStartLengthCtor, "WhenStartAndLengthLargerThanLengthThrowsExceptionStartLengthCtor", ref failedTestsCount);
 
         Console.WriteLine(string.Format("{0} tests has failed", failedTestsCount));
         Environment.Exit(failedTestsCount);
@@ -91,9 +101,31 @@ class My
         AssertTrue(Sum(subslice) == 5, "Failed to sum subslice");
     }
 
-    static TestBoundaryEmptySpan()
+    static void CanAccessItemsViaIndexerStartCtor()
     {
-        int[] a = new byte[5];
+        int[] a = new int[] { 1, 2, 3 };
+        Span<int> slice = new Span<int>(a, start: 1);
+        AssertTrue(Sum(slice) == 5, "Failed to sum slice");
+    }
+
+    static void CanAccessItemsViaIndexerStartLengthCtor()
+    {
+        int[] a = new int[] { 1, 2, 3 };
+        Span<int> slice = new Span<int>(a, start: 1, length: 1);
+        AssertTrue(Sum(slice) == 2, "Failed to sum slice");
+    }
+
+    static void TestBoundaryEmptySpanStartCtor()
+    {
+        int[] a = new int[5];
+
+        Span<int> slice = new Span<int>(a, start: a.Length);
+        AssertEqual(slice.Length, 0);
+    }
+
+    static void TestBoundaryEmptySpanStartLengthCtor()
+    {
+        int[] a = new int[5];
 
         Span<int> slice = new Span<int>(a, a.Length, 0);
         AssertEqual(slice.Length, 0);
@@ -158,6 +190,54 @@ class My
         try
         {
             new Span<object>(objEmptyArray);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+    }
+
+    static void TestArrayCoVarianceStartCtor()
+    {
+        var array = new ReferenceType[1];
+        var objArray = (object[])array;
+        try
+        {
+            new Span<object>(objArray, start: 0);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+
+        var objEmptyArray = Array.Empty<ReferenceType>();
+        try
+        {
+            new Span<object>(objEmptyArray, start: 0);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+    }
+
+    static void TestArrayCoVarianceStartLengthCtor()
+    {
+        var array = new ReferenceType[1];
+        var objArray = (object[])array;
+        try
+        {
+            new Span<object>(objArray, start: 0, length: 1);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+
+        var objEmptyArray = Array.Empty<ReferenceType>();
+        try
+        {
+            new Span<object>(objEmptyArray, start: 0, length: 1);
             AssertTrue(false, "Expected exception not thrown");
         }
         catch (ArrayTypeMismatchException)
@@ -603,7 +683,7 @@ class My
         }
     }
 
-    static void WhenSourceTypeLargerThaTargetAndOverflowsInt32ThrowsException()
+    static void WhenSourceTypeLargerThanTargetAndOverflowsInt32ThrowsException()
     {
         unsafe
         {
@@ -635,6 +715,45 @@ class My
         string secondHalfOfString = fullText.Substring(fullText.Length / 2);
         var spanFromSecondHalf = fullText.Slice(fullText.Length / 2);
         AssertEqualContent(secondHalfOfString, spanFromSecondHalf);
+    }
+
+    static void WhenStartLargerThanLengthThrowsExceptionStartCtor()
+    {
+        try
+        {
+            var data = new byte[10];
+            var slice = new Span<byte>(data, start: 11);
+            AssertTrue(false, "Expected exception for Argument Out of Range not thrown");
+        }
+        catch (System.ArgumentOutOfRangeException)
+        {
+        }
+    }
+    
+    static void WhenStartLargerThanLengthThrowsExceptionStartLengthCtor()
+    {
+        try
+        {
+            var data = new byte[10];
+            var slice = new Span<byte>(data, start: 11, length: 0);
+            AssertTrue(false, "Expected exception for Argument Out of Range not thrown");
+        }
+        catch (System.ArgumentOutOfRangeException)
+        {
+        }
+    }
+
+    static void WhenStartAndLengthLargerThanLengthThrowsExceptionStartLengthCtor()
+    {
+        try
+        {
+            var data = new byte[10];
+            var slice = new Span<byte>(data, start: 1, length: 10);
+            AssertTrue(false, "Expected exception for Argument Out of Range not thrown");
+        }
+        catch (System.ArgumentOutOfRangeException)
+        {
+        }
     }
 
     static void Test(Action test, string testName, ref int failedTestsCount)


### PR DESCRIPTION
Initial work as per the comment from @jkotas, https://github.com/dotnet/coreclr/issues/5851#issuecomment-263037098. I wanted to make a start and have it checked, before I do anymore work

Here are the other missing functions (compared to the [Span<T> API Review](https://github.com/dotnet/apireviews/tree/master/2016/11-04-SpanOfT#api-review-for-spant)), can you confirm if they **all** need to be added or not?

``` csharp
public void CopyTo(Span<T> destination);

[Obsolete("This operation is not supported.", IsError=True)]
[EditorBrowsable(EditorBrowsableState.Never)]
public override int GetHashCode();

[EditorBrowsable(EditorBrowsableState.Never)]
public ref T DangerousGetPinnableReference();

public static Span<T> DangerousCreate(object obj, ref T rawPointer, int length); 

public static bool operator ==(Span<T> left, Span<T> right);

public static bool operator !=(Span<T> left, Span<T> right);`
```

The [`Equals` method is there](https://github.com/dotnet/coreclr/blob/9059610008205ac6c7c88e2a2651f61b94558ffc/src/mscorlib/src/System/Span.cs#L234), but not the same signature and not marked as `[Obsolete]`, does it need to be?

``` csharp
[Obsolete("This operation is not supported.", IsError=True)]
[EditorBrowsable(EditorBrowsableState.Never)]
public override bool Equals(object obj);
```