### PR TITLE
Fix formatting in files

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8253,8 +8253,8 @@ void Compiler::fgAddInternal()
         if (!varTypeIsFloating(info.compRetType))
         {
             lvaTable[genReturnLocal].setPrefReg(REG_INTRET, this);
-#ifdef REG_FLOATRET
         }
+#ifdef REG_FLOATRET
         else
         {
             lvaTable[genReturnLocal].setPrefReg(REG_FLOATRET, this);
@@ -8948,10 +8948,10 @@ void Compiler::fgSimpleLowering()
             for (GenTreePtr tree = stmt->gtStmtList; tree; tree = tree->gtNext)
             {
 #else
-            LIR::Range& range         = LIR::AsRange(block);
-            for (GenTree* tree : range)
+        LIR::Range& range             = LIR::AsRange(block);
+        for (GenTree* tree : range)
+        {
             {
-                {
 #endif
                 if (tree->gtOper == GT_ARR_LENGTH)
                 {
@@ -8999,7 +8999,7 @@ void Compiler::fgSimpleLowering()
                         add->gtNext  = tree;
                         tree->gtPrev = add;
 #else
-                            range.InsertAfter(arr, con, add);
+                        range.InsertAfter(arr, con, add);
 #endif
                     }
 
@@ -11031,10 +11031,10 @@ bool Compiler::fgExpandRarelyRunBlocks()
                             noway_assert(tmpbb->isBBCallAlwaysPair());
                             bPrevPrev = tmpbb;
 #else
-                                if (tmpbb->bbJumpKind == BBJ_CALLFINALLY)
-                                {
-                                    bPrevPrev = tmpbb;
-                                }
+                            if (tmpbb->bbJumpKind == BBJ_CALLFINALLY)
+                            {
+                                bPrevPrev = tmpbb;
+                            }
 #endif
                         }
 
@@ -11566,60 +11566,60 @@ BasicBlock* Compiler::fgRelocateEHRange(unsigned regionIndex, FG_RELOCATE_TYPE r
 
 #else // FEATURE_EH_FUNCLETS
 
-        for (XTnum = 0, HBtab = compHndBBtab; XTnum < compHndBBtabCount; XTnum++, HBtab++)
+    for (XTnum = 0, HBtab = compHndBBtab; XTnum < compHndBBtabCount; XTnum++, HBtab++)
+    {
+        if (XTnum == regionIndex)
         {
-            if (XTnum == regionIndex)
-            {
-                // Don't update our handler's Last info
-                continue;
-            }
+            // Don't update our handler's Last info
+            continue;
+        }
 
-            if (HBtab->ebdTryLast == bLast)
+        if (HBtab->ebdTryLast == bLast)
+        {
+            // If we moved a set of blocks that were at the end of
+            // a different try region then we may need to update ebdTryLast
+            for (block = HBtab->ebdTryBeg; block != NULL; block = block->bbNext)
             {
-                // If we moved a set of blocks that were at the end of
-                // a different try region then we may need to update ebdTryLast
-                for (block = HBtab->ebdTryBeg; block != NULL; block = block->bbNext)
+                if (block == bPrev)
                 {
-                    if (block == bPrev)
-                    {
-                        fgSetTryEnd(HBtab, bPrev);
-                        break;
-                    }
-                    else if (block == HBtab->ebdTryLast->bbNext)
-                    {
-                        // bPrev does not come after the TryBeg
-                        break;
-                    }
+                    fgSetTryEnd(HBtab, bPrev);
+                    break;
+                }
+                else if (block == HBtab->ebdTryLast->bbNext)
+                {
+                    // bPrev does not come after the TryBeg
+                    break;
                 }
             }
-            if (HBtab->ebdHndLast == bLast)
+        }
+        if (HBtab->ebdHndLast == bLast)
+        {
+            // If we moved a set of blocks that were at the end of
+            // a different handler region then we must update ebdHndLast
+            for (block = HBtab->ebdHndBeg; block != NULL; block = block->bbNext)
             {
-                // If we moved a set of blocks that were at the end of
-                // a different handler region then we must update ebdHndLast
-                for (block = HBtab->ebdHndBeg; block != NULL; block = block->bbNext)
+                if (block == bPrev)
                 {
-                    if (block == bPrev)
-                    {
-                        fgSetHndEnd(HBtab, bPrev);
-                        break;
-                    }
-                    else if (block == HBtab->ebdHndLast->bbNext)
-                    {
-                        // bPrev does not come after the HndBeg
-                        break;
-                    }
+                    fgSetHndEnd(HBtab, bPrev);
+                    break;
+                }
+                else if (block == HBtab->ebdHndLast->bbNext)
+                {
+                    // bPrev does not come after the HndBeg
+                    break;
                 }
             }
-        } // end exception table iteration
+        }
+    } // end exception table iteration
 
-        // We have decided to insert the block(s) after fgLastBlock
-        fgMoveBlocksAfter(bStart, bLast, insertAfterBlk);
+    // We have decided to insert the block(s) after fgLastBlock
+    fgMoveBlocksAfter(bStart, bLast, insertAfterBlk);
 
-        // If bPrev falls through, we will insert a jump to block
-        fgConnectFallThrough(bPrev, bStart);
+    // If bPrev falls through, we will insert a jump to block
+    fgConnectFallThrough(bPrev, bStart);
 
-        // If bLast falls through, we will insert a jump to bNext
-        fgConnectFallThrough(bLast, bNext);
+    // If bLast falls through, we will insert a jump to bNext
+    fgConnectFallThrough(bLast, bNext);
 
 #endif // FEATURE_EH_FUNCLETS
 
@@ -12060,70 +12060,70 @@ void Compiler::fgCreateFunclets()
 
 #else // !FEATURE_EH_FUNCLETS
 
-    /*****************************************************************************
-     *
-     *  Function called to relocate any and all EH regions.
-     *  Only entire consecutive EH regions will be moved and they will be kept together.
-     *  Except for the first block, the range can not have any blocks that jump into or out of the region.
-     */
+/*****************************************************************************
+ *
+ *  Function called to relocate any and all EH regions.
+ *  Only entire consecutive EH regions will be moved and they will be kept together.
+ *  Except for the first block, the range can not have any blocks that jump into or out of the region.
+ */
 
-    bool Compiler::fgRelocateEHRegions()
-    {
-        bool result = false; // Our return value
+bool Compiler::fgRelocateEHRegions()
+{
+    bool result = false; // Our return value
 
 #ifdef DEBUG
-        if (verbose)
-            printf("*************** In fgRelocateEHRegions()\n");
+    if (verbose)
+        printf("*************** In fgRelocateEHRegions()\n");
 #endif
 
-        if (fgCanRelocateEHRegions)
+    if (fgCanRelocateEHRegions)
+    {
+        unsigned  XTnum;
+        EHblkDsc* HBtab;
+
+        for (XTnum = 0, HBtab = compHndBBtab; XTnum < compHndBBtabCount; XTnum++, HBtab++)
         {
-            unsigned  XTnum;
-            EHblkDsc* HBtab;
-
-            for (XTnum = 0, HBtab = compHndBBtab; XTnum < compHndBBtabCount; XTnum++, HBtab++)
+            // Nested EH regions cannot be moved.
+            // Also we don't want to relocate an EH region that has a filter
+            if ((HBtab->ebdHandlerNestingLevel == 0) && !HBtab->HasFilter())
             {
-                // Nested EH regions cannot be moved.
-                // Also we don't want to relocate an EH region that has a filter
-                if ((HBtab->ebdHandlerNestingLevel == 0) && !HBtab->HasFilter())
+                bool movedTry = false;
+#if DEBUG
+                bool movedHnd = false;
+#endif // DEBUG
+
+                // Only try to move the outermost try region
+                if (HBtab->ebdEnclosingTryIndex == EHblkDsc::NO_ENCLOSING_INDEX)
                 {
-                    bool movedTry = false;
-#if DEBUG
-                    bool movedHnd = false;
-#endif // DEBUG
-
-                    // Only try to move the outermost try region
-                    if (HBtab->ebdEnclosingTryIndex == EHblkDsc::NO_ENCLOSING_INDEX)
+                    // Move the entire try region if it can be moved
+                    if (HBtab->ebdTryBeg->isRunRarely())
                     {
-                        // Move the entire try region if it can be moved
-                        if (HBtab->ebdTryBeg->isRunRarely())
+                        BasicBlock* bTryLastBB = fgRelocateEHRange(XTnum, FG_RELOCATE_TRY);
+                        if (bTryLastBB != NULL)
                         {
-                            BasicBlock* bTryLastBB = fgRelocateEHRange(XTnum, FG_RELOCATE_TRY);
-                            if (bTryLastBB != NULL)
-                            {
-                                result   = true;
-                                movedTry = true;
-                            }
+                            result   = true;
+                            movedTry = true;
                         }
-#if DEBUG
-                        if (verbose && movedTry)
-                        {
-                            printf("\nAfter relocating an EH try region");
-                            fgDispBasicBlocks();
-                            fgDispHandlerTab();
-
-                            // Make sure that the predecessor lists are accurate
-                            if (expensiveDebugCheckLevel >= 2)
-                            {
-                                fgDebugCheckBBlist();
-                            }
-                        }
-#endif // DEBUG
                     }
+#if DEBUG
+                    if (verbose && movedTry)
+                    {
+                        printf("\nAfter relocating an EH try region");
+                        fgDispBasicBlocks();
+                        fgDispHandlerTab();
 
-                    // Currently it is not good to move the rarely run handler regions to the end of the method
-                    // because fgDetermineFirstColdBlock() must put the start of any handler region in the hot section.
-                    CLANG_FORMAT_COMMENT_ANCHOR;
+                        // Make sure that the predecessor lists are accurate
+                        if (expensiveDebugCheckLevel >= 2)
+                        {
+                            fgDebugCheckBBlist();
+                        }
+                    }
+#endif // DEBUG
+                }
+
+                // Currently it is not good to move the rarely run handler regions to the end of the method
+                // because fgDetermineFirstColdBlock() must put the start of any handler region in the hot section.
+                CLANG_FORMAT_COMMENT_ANCHOR;
 
 #if 0
                 // Now try to move the entire handler region if it can be moved.
@@ -12142,38 +12142,38 @@ void Compiler::fgCreateFunclets()
 #endif // 0
 
 #if DEBUG
-                    if (verbose && movedHnd)
-                    {
-                        printf("\nAfter relocating an EH handler region");
-                        fgDispBasicBlocks();
-                        fgDispHandlerTab();
+                if (verbose && movedHnd)
+                {
+                    printf("\nAfter relocating an EH handler region");
+                    fgDispBasicBlocks();
+                    fgDispHandlerTab();
 
-                        // Make sure that the predecessor lists are accurate
-                        if (expensiveDebugCheckLevel >= 2)
-                        {
-                            fgDebugCheckBBlist();
-                        }
+                    // Make sure that the predecessor lists are accurate
+                    if (expensiveDebugCheckLevel >= 2)
+                    {
+                        fgDebugCheckBBlist();
                     }
-#endif // DEBUG
                 }
+#endif // DEBUG
             }
         }
+    }
 
 #if DEBUG
-        fgVerifyHandlerTab();
+    fgVerifyHandlerTab();
 
-        if (verbose && result)
-        {
-            printf("\nAfter fgRelocateEHRegions()");
-            fgDispBasicBlocks();
-            fgDispHandlerTab();
-            // Make sure that the predecessor lists are accurate
-            fgDebugCheckBBlist();
-        }
+    if (verbose && result)
+    {
+        printf("\nAfter fgRelocateEHRegions()");
+        fgDispBasicBlocks();
+        fgDispHandlerTab();
+        // Make sure that the predecessor lists are accurate
+        fgDebugCheckBBlist();
+    }
 #endif // DEBUG
 
-        return result;
-    }
+    return result;
+}
 
 #endif // !FEATURE_EH_FUNCLETS
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -10660,8 +10660,8 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
             case GT_COLON:
 #if LOCAL_ASSERTION_PROP
                 if (optLocalAssertionProp)
-                {
 #endif
+                {
                     isQmarkColon = true;
                 }
                 break;
@@ -10875,44 +10875,44 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
 // Note for _TARGET_ARMARCH_ we don't have  a remainder instruction, so we don't do this optimization
 //
 #else  // _TARGET_XARCH
-            /* If this is an unsigned long mod with op2 which is a cast to long from a
-               constant int, then don't morph to a call to the helper.  This can be done
-               faster inline using idiv.
-            */
+                /* If this is an unsigned long mod with op2 which is a cast to long from a
+                   constant int, then don't morph to a call to the helper.  This can be done
+                   faster inline using idiv.
+                */
 
-            noway_assert(op2);
-            if ((typ == TYP_LONG) && opts.OptEnabled(CLFLG_CONSTANTFOLD) &&
-                ((tree->gtFlags & GTF_UNSIGNED) == (op1->gtFlags & GTF_UNSIGNED)) &&
-                ((tree->gtFlags & GTF_UNSIGNED) == (op2->gtFlags & GTF_UNSIGNED)))
-            {
-                if (op2->gtOper == GT_CAST && op2->gtCast.CastOp()->gtOper == GT_CNS_INT &&
-                    op2->gtCast.CastOp()->gtIntCon.gtIconVal >= 2 &&
-                    op2->gtCast.CastOp()->gtIntCon.gtIconVal <= 0x3fffffff &&
-                    (tree->gtFlags & GTF_UNSIGNED) == (op2->gtCast.CastOp()->gtFlags & GTF_UNSIGNED))
+                noway_assert(op2);
+                if ((typ == TYP_LONG) && opts.OptEnabled(CLFLG_CONSTANTFOLD) &&
+                    ((tree->gtFlags & GTF_UNSIGNED) == (op1->gtFlags & GTF_UNSIGNED)) &&
+                    ((tree->gtFlags & GTF_UNSIGNED) == (op2->gtFlags & GTF_UNSIGNED)))
                 {
-                    tree->gtOp.gtOp2 = op2 = fgMorphCast(op2);
-                    noway_assert(op2->gtOper == GT_CNS_NATIVELONG);
-                }
-
-                if (op2->gtOper == GT_CNS_NATIVELONG && op2->gtIntConCommon.LngValue() >= 2 &&
-                    op2->gtIntConCommon.LngValue() <= 0x3fffffff)
-                {
-                    tree->gtOp.gtOp1 = op1 = fgMorphTree(op1);
-                    noway_assert(op1->TypeGet() == TYP_LONG);
-
-                    // Update flags for op1 morph
-                    tree->gtFlags &= ~GTF_ALL_EFFECT;
-
-                    tree->gtFlags |= (op1->gtFlags & GTF_ALL_EFFECT); // Only update with op1 as op2 is a constant
-
-                    // If op1 is a constant, then do constant folding of the division operator
-                    if (op1->gtOper == GT_CNS_NATIVELONG)
+                    if (op2->gtOper == GT_CAST && op2->gtCast.CastOp()->gtOper == GT_CNS_INT &&
+                        op2->gtCast.CastOp()->gtIntCon.gtIconVal >= 2 &&
+                        op2->gtCast.CastOp()->gtIntCon.gtIconVal <= 0x3fffffff &&
+                        (tree->gtFlags & GTF_UNSIGNED) == (op2->gtCast.CastOp()->gtFlags & GTF_UNSIGNED))
                     {
-                        tree = gtFoldExpr(tree);
+                        tree->gtOp.gtOp2 = op2 = fgMorphCast(op2);
+                        noway_assert(op2->gtOper == GT_CNS_NATIVELONG);
                     }
-                    return tree;
+
+                    if (op2->gtOper == GT_CNS_NATIVELONG && op2->gtIntConCommon.LngValue() >= 2 &&
+                        op2->gtIntConCommon.LngValue() <= 0x3fffffff)
+                    {
+                        tree->gtOp.gtOp1 = op1 = fgMorphTree(op1);
+                        noway_assert(op1->TypeGet() == TYP_LONG);
+
+                        // Update flags for op1 morph
+                        tree->gtFlags &= ~GTF_ALL_EFFECT;
+
+                        tree->gtFlags |= (op1->gtFlags & GTF_ALL_EFFECT); // Only update with op1 as op2 is a constant
+
+                        // If op1 is a constant, then do constant folding of the division operator
+                        if (op1->gtOper == GT_CNS_NATIVELONG)
+                        {
+                            tree = gtFoldExpr(tree);
+                        }
+                        return tree;
+                    }
                 }
-            }
 #endif // _TARGET_XARCH
 
             ASSIGN_HELPER_FOR_MOD:
@@ -11071,12 +11071,12 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                     ((op2->gtCall.gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC) ||
                      (op2->gtCall.gtCallType == CT_HELPER)))
 #else
-            if ((((op1->gtOper == GT_INTRINSIC) &&
-                  (op1->gtIntrinsic.gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType)) ||
-                 ((op1->gtOper == GT_CALL) && (op1->gtCall.gtCallType == CT_HELPER))) &&
-                (((op2->gtOper == GT_INTRINSIC) &&
-                  (op2->gtIntrinsic.gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType)) ||
-                 ((op2->gtOper == GT_CALL) && (op2->gtCall.gtCallType == CT_HELPER))))
+                if ((((op1->gtOper == GT_INTRINSIC) &&
+                      (op1->gtIntrinsic.gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType)) ||
+                     ((op1->gtOper == GT_CALL) && (op1->gtCall.gtCallType == CT_HELPER))) &&
+                    (((op2->gtOper == GT_INTRINSIC) &&
+                      (op2->gtIntrinsic.gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType)) ||
+                     ((op2->gtOper == GT_CALL) && (op2->gtCall.gtCallType == CT_HELPER))))
 #endif
                 {
                     GenTreePtr pGetClassFromHandle;
@@ -11086,8 +11086,8 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                     bool bOp1ClassFromHandle = gtIsTypeHandleToRuntimeTypeHelper(op1);
                     bool bOp2ClassFromHandle = gtIsTypeHandleToRuntimeTypeHelper(op2);
 #else
-                bool bOp1ClassFromHandle = op1->gtOper == GT_CALL ? gtIsTypeHandleToRuntimeTypeHelper(op1) : false;
-                bool bOp2ClassFromHandle = op2->gtOper == GT_CALL ? gtIsTypeHandleToRuntimeTypeHelper(op2) : false;
+                    bool bOp1ClassFromHandle = op1->gtOper == GT_CALL ? gtIsTypeHandleToRuntimeTypeHelper(op1) : false;
+                    bool bOp2ClassFromHandle = op2->gtOper == GT_CALL ? gtIsTypeHandleToRuntimeTypeHelper(op2) : false;
 #endif
 
                     // Optimize typeof(...) == typeof(...)
@@ -11143,8 +11143,8 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                             info.compCompHnd->getIntrinsicID(pGetType->gtCall.gtCallMethHnd) ==
                                 CORINFO_INTRINSIC_Object_GetType &&
 #else
-                    if ((pGetType->gtOper == GT_INTRINSIC) &&
-                        (pGetType->gtIntrinsic.gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType) &&
+                        if ((pGetType->gtOper == GT_INTRINSIC) &&
+                            (pGetType->gtIntrinsic.gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType) &&
 #endif
                             pConstLiteral->gtOper == GT_CNS_INT && pConstLiteral->gtType == TYP_I_IMPL)
                         {
@@ -11158,7 +11158,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
 #ifdef LEGACY_BACKEND
                                 GenTreePtr objMT = gtNewOperNode(GT_IND, TYP_I_IMPL, pGetType->gtCall.gtCallObjp);
 #else
-                            GenTreePtr objMT = gtNewOperNode(GT_IND, TYP_I_IMPL, pGetType->gtUnOp.gtOp1);
+                                GenTreePtr objMT = gtNewOperNode(GT_IND, TYP_I_IMPL, pGetType->gtUnOp.gtOp1);
 #endif
                                 objMT->gtFlags |= GTF_EXCEPT; // Null ref exception if object is null
                                 compCurBB->bbFlags |= BBF_HAS_VTABREF;
@@ -11746,7 +11746,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                 //
                 //                        EQ/NE
                 //                        /  \
-        //                      op1   CNS 0/1
+                //                      op1   CNS 0/1
                 //
                 ival2 = INT_MAX; // The value of INT_MAX for ival2 just means that the constant value is not 0 or 1
 
@@ -11771,11 +11771,11 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                         //
                         //                  EQ/NE                    Possible REVERSE(RELOP)
                         //                  /  \                           /      \
-                //               COMMA CNS 0/1             ->   COMMA   relop_op2
+                        //               COMMA CNS 0/1             ->   COMMA   relop_op2
                         //              /   \                          /    \
-                //             x  RELOP                       x     relop_op1
+                        //             x  RELOP                       x     relop_op1
                         //               /    \
-                //         relop_op1  relop_op2
+                        //         relop_op1  relop_op2
                         //
                         //
                         //
@@ -11814,13 +11814,13 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                         //
                         //                        EQ/NE                  EQ/NE
                         //                        /  \                   /  \
-                //                     COMMA  CNS 0/1  ->     RELOP CNS 0/1
+                        //                     COMMA  CNS 0/1  ->     RELOP CNS 0/1
                         //                     /   \                   / \
-                //                   ASG  LCL_VAR
+                        //                   ASG  LCL_VAR
                         //                  /  \
-                //           LCL_VAR   RELOP
+                        //           LCL_VAR   RELOP
                         //                      / \
-                //
+                        //
 
                         GenTreePtr asg = op1->gtOp.gtOp1;
                         GenTreePtr lcl = op1->gtOp.gtOp2;
@@ -11903,9 +11903,9 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                         //
                         //                        EQ/NE           ->      RELOP/!RELOP
                         //                        /  \                       /    \
-                //                     RELOP  CNS 0/1
+                        //                     RELOP  CNS 0/1
                         //                     /   \
-                //
+                        //
                         // Note that we will remove/destroy the EQ/NE node and move
                         // the RELOP up into it's location.
 
@@ -11935,11 +11935,11 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                     //
                     //                        EQ/NE                  EQ/NE
                     //                        /  \                   /  \
-            //                      AND   CNS 0/1  ->      AND   CNS 0
+                    //                      AND   CNS 0/1  ->      AND   CNS 0
                     //                     /   \                  /   \
-            //                RSZ/RSH   CNS 1            x     CNS (1 << y)
+                    //                RSZ/RSH   CNS 1            x     CNS (1 << y)
                     //                  /  \
-            //                 x   CNS_INT +y
+                    //                 x   CNS_INT +y
 
                     if (op1->gtOper == GT_AND)
                     {


### PR DESCRIPTION
In morph and flowgraph, we had an instance where an opening/closing
brace was inside a #if when it should not have been, which broke our
formatting on these files. This change fixes that error and reformats
the files.