### PR TITLE
Remove one virtual call from StreamHelpers.ValidateCopyToArgs

### DIFF
--- a/src/mscorlib/src/System/IO/StreamHelpers.CopyValidation.cs
+++ b/src/mscorlib/src/System/IO/StreamHelpers.CopyValidation.cs
@@ -27,7 +27,7 @@ namespace System.IO
             }
 
             bool destinationCanWrite = destination.CanWrite;
-            if (!destination.CanRead && !destinationCanWrite)
+            if (!destinationCanWrite && !destination.CanRead)
             {
                 throw new ObjectDisposedException(nameof(destination), Environment.GetResourceString("ObjectDisposed_StreamClosed"));
             }


### PR DESCRIPTION
There's no need to call CanRead on the destination stream in the
common case; it's only needed in exceptional cases to refine the type
of exception being thrown.

Restructured the code so that the intent is a bit clearer.