### PR TITLE
[x86/Linux] Fix mismatch over LPOVERLAPPED_COMPLETION_ROUTINE

### DIFF
--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -520,7 +520,7 @@ public:
         LPOVERLAPPED lpOverlapped
     );
 
-    static VOID CallbackForContinueDrainageOfCompletionPortQueue(
+    static VOID WINAPI CallbackForContinueDrainageOfCompletionPortQueue(
         DWORD dwErrorCode,
         DWORD dwNumberOfBytesTransfered,
         LPOVERLAPPED lpOverlapped

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -505,16 +505,16 @@ public:
     static BOOL UnregisterWaitEx(HANDLE hWaitObject,HANDLE CompletionEvent);
     static void WaitHandleCleanup(HANDLE hWaitObject);
 
-    static BOOL BindIoCompletionCallback(HANDLE FileHandle,
+    static BOOL WINAPI BindIoCompletionCallback(HANDLE FileHandle,
                                             LPOVERLAPPED_COMPLETION_ROUTINE Function,
                                             ULONG Flags,
                                             DWORD& errorCode);
 
-    static void WaitIOCompletionCallback(DWORD dwErrorCode,
+    static void WINAPI WaitIOCompletionCallback(DWORD dwErrorCode,
                                             DWORD numBytesTransferred,
                                             LPOVERLAPPED lpOverlapped);
 
-    static VOID CallbackForInitiateDrainageOfCompletionPortQueue(
+    static VOID WINAPI CallbackForInitiateDrainageOfCompletionPortQueue(
         DWORD dwErrorCode,
         DWORD dwNumberOfBytesTransfered,
         LPOVERLAPPED lpOverlapped


### PR DESCRIPTION
Those functions are compared with Function variable of
LPOVERLAPPED_COMPLETION_ROUTINE type, but has inconsistent type,
 - WaitIOCompletionCallback,
 - CallbackForInitiateDrainageOfCompletionPortQueue
 - CallbackForContinueDrainageOfCompletionPortQueue
This inconsistency results in compile error for x86/Linux build.

This commit fixes such inconsistency.