### PR TITLE
[x86/Linux] Uses portable ROTATE_LEFT for x86/Linux

### DIFF
--- a/src/utilcode/md5.cpp
+++ b/src/utilcode/md5.cpp
@@ -132,7 +132,7 @@ void MD5::GetHashValue(MD5HASHDATA* phash)
     //
     // but our compiler has an intrinsic!
 
-    #if defined(_ARM_) && defined(PLATFORM_UNIX)
+    #if (defined(_X86_) || defined(_ARM_)) && defined(PLATFORM_UNIX)
     #define ROL(x, n)        (((x) << (n)) | ((x) >> (32-(n))))
     #define ROTATE_LEFT(x,n) (x) = ROL(x,n)
     #else


### PR DESCRIPTION
The current PAL implementation defines ``_lrotl`` only for 64-bit architecture, which results in x86/Linux build failure.

This commit revises md5.cpp to use portable ROTATE_LEFT which is already used for ARM.