### PR TITLE
[x86/Linux] Fix inconsistency between the declarations of GetAppDomain

### DIFF
--- a/src/strongname/api/common.h
+++ b/src/strongname/api/common.h
@@ -192,7 +192,7 @@ Thread * const CURRENT_THREAD = NULL;
     (void)CURRENT_THREAD_AVAILABLE; /* silence "local variable initialized but not used" warning */ \
 
 #ifndef DACCESS_COMPILE
-EXTERN_C AppDomain* GetAppDomain();
+EXTERN_C AppDomain* STDCALL GetAppDomain();
 #endif //!DACCESS_COMPILE
 
 inline void RetailBreak()  


### PR DESCRIPTION
GetAppDomain is declared with STDCALL in vm/threads.inl, but without STDCALL in strongname/api/common.h

This commit fixes the inconsistency between these declarations.