### PR TITLE
[x86/Linux] Disable windows-specific code

### DIFF
--- a/src/utilcode/stresslog.cpp
+++ b/src/utilcode/stresslog.cpp
@@ -51,7 +51,7 @@ unsigned __int64 getTimeStamp() {
 
 #endif // _TARGET_X86_ 
 
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 
 /*********************************************************************************/
 /* Get the the frequency cooresponding to 'getTimeStamp'.  For x86, this is the


### PR DESCRIPTION
getTimeStamp function in stresslog.cpp uses window-specific API even for x86/Linux. 

This commit disables the use of Window-specific API for x86/Linux build.