### PR TITLE
[x86/Linux] Declare GetCallerSp when WIN64EXCEPTION (not _TARGET_X86_) is defined

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -602,7 +602,7 @@ HRESULT FixContextForEnC(PCONTEXT        pCtx,
 
 #endif // #ifndef DACCESS_COMPILE
 
-#ifndef _TARGET_X86_
+#ifdef WIN64EXCEPTIONS
     static void EnsureCallerContextIsValid( PREGDISPLAY pRD, StackwalkCacheEntry* pCacheEntry, EECodeInfo * pCodeInfo = NULL );
     static size_t GetCallerSp( PREGDISPLAY  pRD );
 #endif


### PR DESCRIPTION
GetExactGenericsToken in eetwain.cpp (enclosed by WIN64EXCEPTION) calls
GetCallerSp, but eetwain.h declares GetCallerSp only when _TARGET_X86_
is defined.

This results in compile error for x86/Linux build.

This commit revises eetwain.h to declare GetCallerSp when WIN64EXCEPTION
is defined.