### PR TITLE
[x86/Linux] Disables FrameHandlerExRecordWithBarrier for non-Windows platforms

### DIFF
--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -566,7 +566,7 @@ VOID SetCurrentSEHRecord(EXCEPTION_REGISTRATION_RECORD *pSEH);
 #define STACK_OVERWRITE_BARRIER_VALUE 0xabcdefab
 
 #ifdef _DEBUG
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 struct FrameHandlerExRecordWithBarrier {
     DWORD m_StackOverwriteBarrier[STACK_OVERWRITE_BARRIER_SIZE];
     FrameHandlerExRecord m_ExRecord;


### PR DESCRIPTION
Currently, FrameHandlerExRecord is available only for Windows platform.

This commit disables FrameHandlerExRecordWithBarrier (which depends on FrameHandlerExRecord) for non-Windows platforms.