### PR TITLE
[x86/Linux] Disable WIN64EXECPTION and fix related changes

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -22,11 +22,11 @@
 #error FEATURE_PREJIT is required for this file
 #endif // FEATURE_PREJIT
 
-#if !defined(_TARGET_X86_) || defined(FEATURE_PAL)
+#if !defined(_TARGET_X86_)
 #ifndef WIN64EXCEPTIONS
 #define WIN64EXCEPTIONS
 #endif
-#endif  // !_TARGET_X86_ || FEATURE_PAL
+#endif  // !_TARGET_X86_
 
 #include <cor.h>
 #include <corhdr.h>

--- a/src/inc/switches.h
+++ b/src/inc/switches.h
@@ -37,7 +37,7 @@
     #define LOGGING
 #endif
 
-#if !defined(_TARGET_X86_) || defined(FEATURE_PAL)
+#if !defined(_TARGET_X86_)
 #define WIN64EXCEPTIONS
 #endif
 

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -1114,7 +1114,7 @@ class FaultingExceptionFrame : public Frame
 {
     friend class CheckAsmOffsets;
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#if defined(_TARGET_X86_)
     DWORD                   m_Esp;
     CalleeSavedRegisters    m_regs;
     TADDR                   m_ReturnAddress;
@@ -1156,7 +1156,7 @@ public:
         return FRAME_ATTR_EXCEPTION | FRAME_ATTR_FAULTED;
     }
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#if defined(_TARGET_X86_)
     CalleeSavedRegisters *GetCalleeSavedRegisters()
     {
         LIMITED_METHOD_DAC_CONTRACT;

--- a/src/zap/common.h
+++ b/src/zap/common.h
@@ -21,11 +21,11 @@
 #include <float.h>
 #include <limits.h>
 
-#if !defined(_TARGET_X86_) || defined(FEATURE_PAL)
+#if !defined(_TARGET_X86_)
 #ifndef WIN64EXCEPTIONS
 #define WIN64EXCEPTIONS
 #endif
-#endif // !_TARGET_X86_ || FEATURE_PAL
+#endif // !_TARGET_X86_
 
 #include "utilcode.h"
 #include "corjit.h"


### PR DESCRIPTION
Fix compile error for x86/Linux
- undo some changes to disable WIN64EXCEPTION so the x86/Linux builds