### PR TITLE
[x86/Linux] Disable GetReturnAddressPtr for non-Windows platforms

### DIFF
--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -1135,11 +1135,13 @@ public:
     }
 #endif
 
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
     virtual TADDR GetReturnAddressPtr()
     {
         LIMITED_METHOD_DAC_CONTRACT;
         return PTR_HOST_MEMBER_TADDR(FaultingExceptionFrame, this, m_ReturnAddress);
     }
+#endif
 
     void Init(T_CONTEXT *pContext);
     void InitAndLink(T_CONTEXT *pContext);


### PR DESCRIPTION
GetReturnAddressPtr in FaultingExceptionFrame accesses m_ReturnAddress, which is available only for Windows platform.

This commit disables GetReturnAddressPtr for non-Windows platforms