### PR TITLE
[x86/Linux] Declare CtorFtnType only when it is used

### DIFF
--- a/src/classlibnative/bcltype/arraynative.cpp
+++ b/src/classlibnative/bcltype/arraynative.cpp
@@ -176,7 +176,6 @@ void ArrayInitializeWorker(ARRAYBASEREF * arrayRef,
 #ifdef _X86_
     BEGIN_CALL_TO_MANAGED();
 
-    typedef void (__fastcall * CtorFtnType)(BYTE*, BYTE*);
 
     for (SIZE_T i = 0; i < cElements; i++)
     {
@@ -197,6 +196,7 @@ void ArrayInitializeWorker(ARRAYBASEREF * arrayRef,
             nop                // Mark the fact that we can call managed code
         }
 #else // _DEBUG
+        typedef void (__fastcall * CtorFtnType)(BYTE*, BYTE*);
         (*(CtorFtnType)ctorFtn)(thisPtr, (BYTE*)pElemMT);
 #endif // _DEBUG
 


### PR DESCRIPTION
In x86, ``CtorFtnType`` is used only for release build, but is declared even for debug build (which results in unused-local-typedef error).