### PR TITLE
[x86/Linux] Disable PrintSEHChain for non-Windows platforms

### DIFF
--- a/src/vm/debughelp.cpp
+++ b/src/vm/debughelp.cpp
@@ -202,7 +202,7 @@ void *DumpEnvironmentBlock(void)
     return WszGetEnvironmentStrings();
 }
 
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 /*******************************************************************/
 // Dump the SEH chain to stderr
 void PrintSEHChain(void)


### PR DESCRIPTION
PrintSEHChain uses 'EXCEPTION_REGISTRATION_RECORD' which is not
available for non-Windows platforms.

This commit disables PrintSEHChain for non-Windows platforms to fix
build error in x86/Linux.