### PR TITLE
[x86/Linux] Disable CheckStackBarrier for non-Windows platforms

### DIFF
--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -3541,7 +3541,7 @@ DWORD MapWin32FaultToCOMPlusException(EXCEPTION_RECORD *pExceptionRecord)
 }
 
 #ifdef _DEBUG
-#ifndef WIN64EXCEPTIONS
+#if !defined(WIN64EXCEPTIONS) && !defined(FEATURE_PAL)
 // check if anyone has written to the stack above the handler which would wipe out the EH registration
 void CheckStackBarrier(EXCEPTION_REGISTRATION_RECORD *exRecord)
 {
@@ -3558,7 +3558,7 @@ void CheckStackBarrier(EXCEPTION_REGISTRATION_RECORD *exRecord)
         }
     }
 }
-#endif // WIN64EXCEPTIONS
+#endif // !defined(WIN64EXCEPTIONS) && !defined(FEATURE_PAL)
 #endif // _DEBUG
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
CheckStackBarrier uses 'EXCEPTION_REGISTRATION_RECORD' which is not
available for non-Windows platforms.

This commit disables CheckStackBarrier for non-Windows platforms to fix
build error in x86/Linux.