### PR TITLE
[x86/Linux] Revises exception handling macros for x86/Linux

### DIFF
--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -227,7 +227,7 @@ VOID DECLSPEC_NORETURN RealCOMPlusThrowSO();
     UNINSTALL_EXCEPTION_HANDLING_RECORD(&(___pExRecord->m_ExReg));              \
 }                                                                               
 
-#if !defined(WIN64EXCEPTIONS)
+#if !defined(WIN64EXCEPTIONS) && !defined(FEATURE_PAL)
 
 #define INSTALL_NESTED_EXCEPTION_HANDLER(frame)                                                                       \
    NestedHandlerExRecord *__pNestedHandlerExRecord = (NestedHandlerExRecord*) _alloca(sizeof(NestedHandlerExRecord)); \

--- a/src/vm/i386/excepcpu.h
+++ b/src/vm/i386/excepcpu.h
@@ -28,6 +28,11 @@ class Thread;
                               // Actually, the handler getting set is properly registered
 #endif
 
+#ifdef FEATURE_PAL
+#define INSTALL_EXCEPTION_HANDLING_RECORD(record)
+#define UNINSTALL_EXCEPTION_HANDLING_RECORD(record)
+#define DECLARE_CPFH_EH_RECORD(pCurThread)
+#else // FEATURE_PAL
 #define INSTALL_EXCEPTION_HANDLING_RECORD(record)               \
     {                                                           \
         PEXCEPTION_REGISTRATION_RECORD __record = (record);     \
@@ -64,6 +69,7 @@ class Thread;
     ___pExRecord->m_pEntryFrame = (pCurThread)->GetFrame();
 
 #endif
+#endif // FEATURE_PAL
 
 //
 // Retrieves the redirected CONTEXT* from the stack frame of one of the


### PR DESCRIPTION
This commit revises exception handling macros similarly as amd64/Linux.