### PR TITLE
[x86/Linux] Mark LeaveCatch as NYI

### DIFF
--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -1675,7 +1675,7 @@ bool FinallyIsUnwinding(EHRangeTreeNode *pNode,
         return false;
 }
 
-#ifndef WIN64EXCEPTIONS
+#if !defined(WIN64EXCEPTIONS) && !defined(FEATURE_PAL)
 BOOL LeaveCatch(ICodeManager* pEECM,
                 Thread *pThread,
                 CONTEXT *pCtx,
@@ -1865,7 +1865,7 @@ HRESULT IsLegalTransition(Thread *pThread,
                 case TCF_NONE:
                 case TCF_TRY:
                 {
-#if !defined(WIN64EXCEPTIONS)
+#if !defined(WIN64EXCEPTIONS) && !defined(FEATURE_PAL)
                     CONTEXT *pFilterCtx = pThread->GetFilterContext();
                     if (pFilterCtx == NULL)
                         return CORDBG_E_SET_IP_IMPOSSIBLE;

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -1675,7 +1675,7 @@ bool FinallyIsUnwinding(EHRangeTreeNode *pNode,
         return false;
 }
 
-#if !defined(WIN64EXCEPTIONS) && !defined(FEATURE_PAL)
+#if !defined(WIN64EXCEPTIONS)
 BOOL LeaveCatch(ICodeManager* pEECM,
                 Thread *pThread,
                 CONTEXT *pCtx,
@@ -1690,6 +1690,7 @@ BOOL LeaveCatch(ICodeManager* pEECM,
     }
     CONTRACTL_END;
 
+#ifndef FEATURE_PAL
     // We can assert these things here, and skip a call
     // to COMPlusCheckForAbort later.
 
@@ -1707,6 +1708,10 @@ BOOL LeaveCatch(ICodeManager* pEECM,
 
     SetSP(pCtx, (UINT_PTR)esp);
     return TRUE;
+#else // FEATURE_PAL
+    PORTABILITY_ASSERT("LeaveCatch");
+    return FALSE;
+#endif
 }
 #endif // WIN64EXCEPTIONS
 
@@ -1865,7 +1870,7 @@ HRESULT IsLegalTransition(Thread *pThread,
                 case TCF_NONE:
                 case TCF_TRY:
                 {
-#if !defined(WIN64EXCEPTIONS) && !defined(FEATURE_PAL)
+#if !defined(WIN64EXCEPTIONS)
                     CONTEXT *pFilterCtx = pThread->GetFilterContext();
                     if (pFilterCtx == NULL)
                         return CORDBG_E_SET_IP_IMPOSSIBLE;

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -1675,7 +1675,7 @@ bool FinallyIsUnwinding(EHRangeTreeNode *pNode,
         return false;
 }
 
-#if !defined(WIN64EXCEPTIONS)
+#ifndef WIN64EXCEPTIONS
 BOOL LeaveCatch(ICodeManager* pEECM,
                 Thread *pThread,
                 CONTEXT *pCtx,


### PR DESCRIPTION
LeaveCatch invokes GetExceptionListPtr method which is provided only when FEATURE_PAL is undefined,
which results in compile error during x86/Linux build.

This commit fixes it.