### PR TITLE
[x86/Linux] Do not invoke VerifyValidTransitionFromManagedCode for ...

### DIFF
--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -2677,7 +2677,7 @@ StackWalkAction StackFrameIterator::NextRaw(void)
 
                 // We are transitioning from unmanaged code to managed code... lets do some validation of our
                 // EH mechanism on platforms that we can.
-#if defined(_DEBUG)  && !defined(DACCESS_COMPILE) && defined(_TARGET_X86_)
+#if defined(_DEBUG)  && !defined(DACCESS_COMPILE) && (defined(_TARGET_X86_) && !defined(FEATURE_PAL))
                 VerifyValidTransitionFromManagedCode(m_crawl.pThread, &m_crawl);
 #endif // _DEBUG && !DACCESS_COMPILE && _TARGET_X86_
             }


### PR DESCRIPTION
non-Windows platforms.

VerifyValidTransitionFromManagedCode is valid only when FEATURE_PAL is not defined (for Windows platform), but called even when FEATURE_PAL is defined.

This commit comments out VerifyValidTransitionFromManagedCode call when FEATURE_PAL is defined.

