### PR TITLE
[x86/Linux] Fix extraneous parentheses

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6970,7 +6970,7 @@ void emitter::emitDispIns(
 #ifndef LEGACY_BACKEND
                      || (ins == INS_cvtss2si) || (ins == INS_cvtsd2si) || (ins == INS_cvttss2si)
 #endif
-                         )
+                     || 0)
             {
                 printf(" %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), EA_16BYTE));
             }


### PR DESCRIPTION
Fix compile error for x86/Linux
- fix "equality comparison with extraneous parentheses" for LEGACY_BACKEND