### PR TITLE
[x86/Linux] Adjust the definition of FnStaticBaseHelper for x86

### DIFF
--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -1134,6 +1134,7 @@ public:
 #define HCCALL5(funcname, a1, a2, a3, a4, a5)   funcname(0, a2, a1, a5, a4, a3)
 #define HCCALL1_PTR(rettype, funcptr, a1)        rettype (F_CALL_CONV * funcptr)(int /* EAX */, int /* EDX */, a1)
 #define HCCALL2_PTR(rettype, funcptr, a1, a2)    rettype (F_CALL_CONV * funcptr)(int /* EAX */, a2, a1)
+#define HCCALL2_TYPEDEF(rettype, ty, a1, a2)     typedef rettype (F_CALL_CONV * ty)(int /* EAX */, a2, a1)
 #else
 
 #define HCIMPL0(rettype, funcname) rettype F_CALL_CONV funcname() { HCIMPL_PROLOG(funcname) 
@@ -1157,6 +1158,7 @@ public:
 #define HCCALL5(funcname, a1, a2, a3, a4, a5)   funcname(a1, a2, a5, a4, a3)
 #define HCCALL1_PTR(rettype, funcptr, a1)        rettype (F_CALL_CONV * funcptr)(a1)
 #define HCCALL2_PTR(rettype, funcptr, a1, a2)    rettype (F_CALL_CONV * funcptr)(a1, a2)
+#define HCCALL2_TYPEDEF(rettype, ty, a1, a2)     typedef rettype (F_CALL_CONV * ty)(a1, a2)
 
 #endif
 
@@ -1186,6 +1188,7 @@ public:
 #define HCCALL5(funcname, a1, a2, a3, a4, a5)   funcname(a1, a2, a3, a4, a5)
 #define HCCALL1_PTR(rettype, funcptr, a1)        rettype (F_CALL_CONV * funcptr)(a1)
 #define HCCALL2_PTR(rettype, funcptr, a1, a2)    rettype (F_CALL_CONV * funcptr)(a1, a2)
+#define HCCALL2_TYPEDEF(rettype, ty, a1, a2)     typedef rettype (F_CALL_CONV * ty)(a1, a2)
 
 #endif
 

--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -1134,7 +1134,6 @@ public:
 #define HCCALL5(funcname, a1, a2, a3, a4, a5)   funcname(0, a2, a1, a5, a4, a3)
 #define HCCALL1_PTR(rettype, funcptr, a1)        rettype (F_CALL_CONV * funcptr)(int /* EAX */, int /* EDX */, a1)
 #define HCCALL2_PTR(rettype, funcptr, a1, a2)    rettype (F_CALL_CONV * funcptr)(int /* EAX */, a2, a1)
-#define HCCALL2_TYPEDEF(rettype, ty, a1, a2)     typedef rettype (F_CALL_CONV * ty)(int /* EAX */, a2, a1)
 #else
 
 #define HCIMPL0(rettype, funcname) rettype F_CALL_CONV funcname() { HCIMPL_PROLOG(funcname) 
@@ -1158,7 +1157,6 @@ public:
 #define HCCALL5(funcname, a1, a2, a3, a4, a5)   funcname(a1, a2, a5, a4, a3)
 #define HCCALL1_PTR(rettype, funcptr, a1)        rettype (F_CALL_CONV * funcptr)(a1)
 #define HCCALL2_PTR(rettype, funcptr, a1, a2)    rettype (F_CALL_CONV * funcptr)(a1, a2)
-#define HCCALL2_TYPEDEF(rettype, ty, a1, a2)     typedef rettype (F_CALL_CONV * ty)(a1, a2)
 
 #endif
 
@@ -1188,7 +1186,6 @@ public:
 #define HCCALL5(funcname, a1, a2, a3, a4, a5)   funcname(a1, a2, a3, a4, a5)
 #define HCCALL1_PTR(rettype, funcptr, a1)        rettype (F_CALL_CONV * funcptr)(a1)
 #define HCCALL2_PTR(rettype, funcptr, a1, a2)    rettype (F_CALL_CONV * funcptr)(a1, a2)
-#define HCCALL2_TYPEDEF(rettype, ty, a1, a2)     typedef rettype (F_CALL_CONV * ty)(a1, a2)
 
 #endif
 

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1655,7 +1655,7 @@ struct VirtualFunctionPointerArgs
 
 FCDECL2(CORINFO_MethodPtr, JIT_VirtualFunctionPointer_Dynamic, Object * objectUNSAFE, VirtualFunctionPointerArgs * pArgs);
 
-typedef TADDR (F_CALL_CONV * FnStaticBaseHelper)(TADDR arg0, TADDR arg1);
+HCCALL2_TYPEDEF(TADDR, FnStaticBaseHelper, TADDR arg0, TADDR arg1);
 
 struct StaticFieldAddressArgs
 {

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1655,7 +1655,7 @@ struct VirtualFunctionPointerArgs
 
 FCDECL2(CORINFO_MethodPtr, JIT_VirtualFunctionPointer_Dynamic, Object * objectUNSAFE, VirtualFunctionPointerArgs * pArgs);
 
-HCCALL2_TYPEDEF(TADDR, FnStaticBaseHelper, TADDR arg0, TADDR arg1);
+typedef HCCALL2_PTR(TADDR, FnStaticBaseHelper, TADDR arg0, TADDR arg1);
 
 struct StaticFieldAddressArgs
 {


### PR DESCRIPTION
The inconsistency between HCCALL2 and FnStaticBaseHelper results in 'too many arguments to function call' error during x86/Linux build.

This commit resolve the inconsistency between them. 