### PR TITLE
[x86/Linux] Use portable JIT helpers

### DIFF
--- a/src/vm/i386/cgencpu.h
+++ b/src/vm/i386/cgencpu.h
@@ -562,6 +562,7 @@ inline BOOL ClrFlushInstructionCache(LPCVOID pCodeAddr, size_t sizeOfCode)
 // #define JIT_GetSharedGCStaticBaseNoCtor
 // #define JIT_GetSharedNonGCStaticBaseNoCtor
 
+#ifndef FEATURE_PAL
 #define JIT_ChkCastClass            JIT_ChkCastClass
 #define JIT_ChkCastClassSpecial     JIT_ChkCastClassSpecial
 #define JIT_IsInstanceOfClass       JIT_IsInstanceOfClass
@@ -570,4 +571,14 @@ inline BOOL ClrFlushInstructionCache(LPCVOID pCodeAddr, size_t sizeOfCode)
 #define JIT_NewCrossContext         JIT_NewCrossContext
 #define JIT_Stelem_Ref              JIT_Stelem_Ref
 
+#else // FEATURE_PAL
+#define JIT_ChkCastClass            JIT_ChkCastClass_Portable
+#define JIT_ChkCastClassSpecial     JIT_ChkCastClassSpecial_Portable
+#define JIT_IsInstanceOfClass       JIT_IsInstanceOfClass_Portable
+#define JIT_ChkCastInterface        JIT_ChkCastInterface_Portable
+#define JIT_IsInstanceOfInterface   JIT_IsInstanceOfInterface_Portable
+#define JIT_NewCrossContext         JIT_NewCrossContext_Portable
+#define JIT_Stelem_Ref              JIT_Stelem_Ref_Portable
+
+#endif // FEATURE_PAL
 #endif // __cgenx86_h__

--- a/src/vm/i386/cgencpu.h
+++ b/src/vm/i386/cgencpu.h
@@ -570,15 +570,5 @@ inline BOOL ClrFlushInstructionCache(LPCVOID pCodeAddr, size_t sizeOfCode)
 #define JIT_IsInstanceOfInterface   JIT_IsInstanceOfInterface
 #define JIT_NewCrossContext         JIT_NewCrossContext
 #define JIT_Stelem_Ref              JIT_Stelem_Ref
-
-#else // FEATURE_PAL
-#define JIT_ChkCastClass            JIT_ChkCastClass_Portable
-#define JIT_ChkCastClassSpecial     JIT_ChkCastClassSpecial_Portable
-#define JIT_IsInstanceOfClass       JIT_IsInstanceOfClass_Portable
-#define JIT_ChkCastInterface        JIT_ChkCastInterface_Portable
-#define JIT_IsInstanceOfInterface   JIT_IsInstanceOfInterface_Portable
-#define JIT_NewCrossContext         JIT_NewCrossContext_Portable
-#define JIT_Stelem_Ref              JIT_Stelem_Ref_Portable
-
 #endif // FEATURE_PAL
 #endif // __cgenx86_h__

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -72,37 +72,14 @@ extern "C" void STDCALL WriteBarrierAssert(BYTE* ptr, Object* obj)
 
 #endif // _DEBUG
 
-#ifdef FEATURE_PAL
-FCDECL3(void, JIT_Stelem_Ref, PtrArray* array, unsigned idx, Object* val)
-{
-    PORTABILITY_ASSERT("JIT_Stelem_Ref");
-}
-
-FCDECL2(Object*, JIT_IsInstanceOfClass, MethodTable *pMT, Object *pObject)
-{
-    PORTABILITY_ASSERT("JIT_IsInstanceOfClass");
-    return NULL;
-}
-
-FCDECL2(Object*, JIT_ChkCastClass, MethodTable *pMT, Object *pObject)
-{
-    PORTABILITY_ASSERT("JIT_ChkCastClass");
-    return NULL;
-}
-
-FCDECL2(Object*, JIT_ChkCastClassSpecial, MethodTable *pMT, Object *pObject)
-{
-    PORTABILITY_ASSERT("JIT_ChkCastClassSpecial");
-    return NULL;
-}
-#else  // FEATURE_PAL
+#ifdef _MSCVER
 /****************************************************************************/
 /* assigns 'val to 'array[idx], after doing all the proper checks */
 
 /* note that we can do almost as well in portable code, but this
    squezes the last little bit of perf out */
 
-__declspec(naked) FCDECL3(void, JIT_Stelem_Ref, PtrArray* array, unsigned idx, Object* val)
+__declspec(naked) void F_CALL_CONV JIT_Stelem_Ref(PtrArray* array, unsigned idx, Object* val)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -222,7 +199,7 @@ Epilog:
     }
 }
 
-extern "C" __declspec(naked) FCDECL2(Object*, JIT_IsInstanceOfClass, MethodTable *pMT, Object *pObject)
+extern "C" __declspec(naked) Object* F_CALL_CONV JIT_IsInstanceOfClass(MethodTable *pMT, Object *pObject)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -281,7 +258,7 @@ extern "C" __declspec(naked) FCDECL2(Object*, JIT_IsInstanceOfClass, MethodTable
     }
 }
 
-extern "C" __declspec(naked) FCDECL2(Object*, JIT_ChkCastClass, MethodTable *pMT, Object *pObject)
+extern "C" __declspec(naked) Object* F_CALL_CONV JIT_ChkCastClass(MethodTable *pMT, Object *pObject)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -321,7 +298,7 @@ extern "C" __declspec(naked) FCDECL2(Object*, JIT_ChkCastClass, MethodTable *pMT
     }
 }
 
-extern "C" __declspec(naked) FCDECL2(Object*, JIT_ChkCastClassSpecial, MethodTable *pMT, Object *pObject)
+extern "C" __declspec(naked) Object* F_CALL_CONV JIT_ChkCastClassSpecial(MethodTable *pMT, Object *pObject)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -331,7 +331,7 @@ extern "C" __declspec(naked) Object* F_CALL_CONV JIT_ChkCastClassSpecial(MethodT
         jmp             JITutil_ChkCastAny
     }
 }
-#endif // FEATURE_PAL
+#endif // _MSCVER
 
 HCIMPL1_V(INT32, JIT_Dbl2IntOvf, double val)
 {

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -72,7 +72,7 @@ extern "C" void STDCALL WriteBarrierAssert(BYTE* ptr, Object* obj)
 
 #endif // _DEBUG
 
-#ifdef _MSCVER
+#ifndef FEATURE_PAL
 /****************************************************************************/
 /* assigns 'val to 'array[idx], after doing all the proper checks */
 
@@ -331,7 +331,7 @@ extern "C" __declspec(naked) Object* F_CALL_CONV JIT_ChkCastClassSpecial(MethodT
         jmp             JITutil_ChkCastAny
     }
 }
-#endif // _MSCVER
+#endif // FEATURE_PAL
 
 HCIMPL1_V(INT32, JIT_Dbl2IntOvf, double val)
 {

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -72,13 +72,37 @@ extern "C" void STDCALL WriteBarrierAssert(BYTE* ptr, Object* obj)
 
 #endif // _DEBUG
 
+#ifdef FEATURE_PAL
+FCDECL3(void, JIT_Stelem_Ref, PtrArray* array, unsigned idx, Object* val)
+{
+    PORTABILITY_ASSERT("JIT_Stelem_Ref");
+}
+
+FCDECL2(Object*, JIT_IsInstanceOfClass, MethodTable *pMT, Object *pObject)
+{
+    PORTABILITY_ASSERT("JIT_IsInstanceOfClass");
+    return NULL;
+}
+
+FCDECL2(Object*, JIT_ChkCastClass, MethodTable *pMT, Object *pObject)
+{
+    PORTABILITY_ASSERT("JIT_ChkCastClass");
+    return NULL;
+}
+
+FCDECL2(Object*, JIT_ChkCastClassSpecial, MethodTable *pMT, Object *pObject)
+{
+    PORTABILITY_ASSERT("JIT_ChkCastClassSpecial");
+    return NULL;
+}
+#else  // FEATURE_PAL
 /****************************************************************************/
 /* assigns 'val to 'array[idx], after doing all the proper checks */
 
 /* note that we can do almost as well in portable code, but this
    squezes the last little bit of perf out */
 
-__declspec(naked) void F_CALL_CONV JIT_Stelem_Ref(PtrArray* array, unsigned idx, Object* val)
+__declspec(naked) FCDECL3(void, JIT_Stelem_Ref, PtrArray* array, unsigned idx, Object* val)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -198,7 +222,7 @@ Epilog:
     }
 }
 
-HCIMPL2(Object*, JIT_IsInstanceOfClass, MethodTable *pMT, Object *pObject)
+extern "C" __declspec(naked) FCDECL2(Object*, JIT_IsInstanceOfClass, MethodTable *pMT, Object *pObject)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -256,9 +280,8 @@ HCIMPL2(Object*, JIT_IsInstanceOfClass, MethodTable *pMT, Object *pObject)
 #endif            
     }
 }
-HCIMPLEND
 
-HCIMPL2(Object*, JIT_ChkCastClass, MethodTable *pMT, Object *pObject)
+extern "C" __declspec(naked) FCDECL2(Object*, JIT_ChkCastClass, MethodTable *pMT, Object *pObject)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -297,9 +320,8 @@ HCIMPL2(Object*, JIT_ChkCastClass, MethodTable *pMT, Object *pObject)
         jmp             JITutil_ChkCastAny
     }
 }
-HCIMPLEND
 
-HCIMPL2(Object*, JIT_ChkCastClassSpecial, MethodTable *pMT, Object *pObject)
+extern "C" __declspec(naked) FCDECL2(Object*, JIT_ChkCastClassSpecial, MethodTable *pMT, Object *pObject)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -332,7 +354,7 @@ HCIMPL2(Object*, JIT_ChkCastClassSpecial, MethodTable *pMT, Object *pObject)
         jmp             JITutil_ChkCastAny
     }
 }
-HCIMPLEND
+#endif // FEATURE_PAL
 
 HCIMPL1_V(INT32, JIT_Dbl2IntOvf, double val)
 {

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -198,7 +198,7 @@ Epilog:
     }
 }
 
-extern "C" __declspec(naked) Object* F_CALL_CONV JIT_IsInstanceOfClass(MethodTable *pMT, Object *pObject)
+HCIMPL2(Object*, JIT_IsInstanceOfClass, MethodTable *pMT, Object *pObject)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -256,8 +256,9 @@ extern "C" __declspec(naked) Object* F_CALL_CONV JIT_IsInstanceOfClass(MethodTab
 #endif            
     }
 }
+HCIMPLEND
 
-extern "C" __declspec(naked) Object* F_CALL_CONV JIT_ChkCastClass(MethodTable *pMT, Object *pObject)
+HCIMPL2(Object*, JIT_ChkCastClass, MethodTable *pMT, Object *pObject)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -296,8 +297,9 @@ extern "C" __declspec(naked) Object* F_CALL_CONV JIT_ChkCastClass(MethodTable *p
         jmp             JITutil_ChkCastAny
     }
 }
+HCIMPLEND
 
-extern "C" __declspec(naked) Object* F_CALL_CONV JIT_ChkCastClassSpecial(MethodTable *pMT, Object *pObject)
+HCIMPL2(Object*, JIT_ChkCastClassSpecial, MethodTable *pMT, Object *pObject)
 {
     STATIC_CONTRACT_SO_TOLERANT;
     STATIC_CONTRACT_THROWS;
@@ -330,6 +332,7 @@ extern "C" __declspec(naked) Object* F_CALL_CONV JIT_ChkCastClassSpecial(MethodT
         jmp             JITutil_ChkCastAny
     }
 }
+HCIMPLEND
 
 HCIMPL1_V(INT32, JIT_Dbl2IntOvf, double val)
 {


### PR DESCRIPTION
This commit enforces the use of portable JIT helpers (instead of platform-specific helpers) for x86/Linux.