### PR TITLE
[x86/Linux] Exclude jithelp.asm for x86/Linux

### DIFF
--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -423,7 +423,6 @@ elseif(CLR_CMAKE_TARGET_ARCH_I386)
     )
     
     set(VM_SOURCES_WKS_ARCH
-        ${ARCH_SOURCES_DIR}/jithelp.asm
         ${ARCH_SOURCES_DIR}/jitinterfacex86.cpp
         ${ARCH_SOURCES_DIR}/profiler.cpp
     )


### PR DESCRIPTION
jithelp.asm is included in x86/Linux build.

This commit exclude it from the build.