### PR TITLE
[x86/Linux] Fix mismatch between signature and implementation of ActivationFunctions

### DIFF
--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -1072,7 +1072,7 @@ class Thread: public IUnknown
     friend DWORD MapWin32FaultToCOMPlusException(EXCEPTION_RECORD *pExceptionRecord);
     friend void STDCALL OnHijackWorker(HijackArgs * pArgs);
 #ifdef PLATFORM_UNIX
-    friend void PALAPI HandleGCSuspensionForInterruptedThread(CONTEXT *interruptedContext);
+    friend void HandleGCSuspensionForInterruptedThread(CONTEXT *interruptedContext);
 #endif // PLATFORM_UNIX
 
 #endif // FEATURE_HIJACK

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -8212,7 +8212,7 @@ retry_for_debugger:
 
 // This function is called by PAL to check if the specified instruction pointer
 // is in a function where we can safely inject activation. 
-BOOL PALAPI CheckActivationSafePoint(SIZE_T ip, BOOL checkingCurrentThread)
+BOOL CheckActivationSafePoint(SIZE_T ip, BOOL checkingCurrentThread)
 {
     Thread *pThread = GetThread();
     // It is safe to call the ExecutionManager::IsManagedCode only if we are making the check for
@@ -8239,7 +8239,7 @@ BOOL PALAPI CheckActivationSafePoint(SIZE_T ip, BOOL checkingCurrentThread)
 //       address to take the thread to the appropriate stub (based on the return 
 //       type of the method) which will then handle preparing the thread for GC.
 //
-void PALAPI HandleGCSuspensionForInterruptedThread(CONTEXT *interruptedContext)
+void HandleGCSuspensionForInterruptedThread(CONTEXT *interruptedContext)
 {
     Thread *pThread = GetThread();
 


### PR DESCRIPTION
PAL_ActivationFunction and PAL_SafeActivationCheckFunction types are defined without PALAPI attribute, but HandleGCSuspensionForInterruptedThread and CheckActivationSafePoint functions are implemented with PALAPI attribute.