### PR TITLE
[x86/Linux] Fix prototype for GCThreadStub

### DIFF
--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -639,7 +639,7 @@ struct GCThreadStubParam
 };
 
 // GC thread stub to convert GC thread function to an OS specific thread function
-static DWORD GCThreadStub(void* param)
+static DWORD __stdcall GCThreadStub(void* param)
 {
     WRAPPER_NO_CONTRACT;
 

--- a/tests/src/Common/Platform/platformdefines.h
+++ b/tests/src/Common/Platform/platformdefines.h
@@ -72,7 +72,7 @@ LPWSTR HackyConvertToWSTR(char* pszInput);
 
 typedef pthread_t THREAD_ID;
 typedef void* (*MacWorker)(void*);
-typedef DWORD (*LPTHREAD_START_ROUTINE)(void*);
+typedef DWORD __stdcall (*LPTHREAD_START_ROUTINE)(void*);
 #ifdef UNICODE
 typedef WCHAR TCHAR;
 #else // ANSI


### PR DESCRIPTION
Fix compile error for x86/Linux
- fix "cannot initialize a parameter of type 'LPTHREAD_START_ROUTINE'"
- add __stdcall GCThreadStub as it's Windows/Linux common code