### PR TITLE
Ensure MSBuild properties get persisted to child MSBuild tasks for GC ReliabilityFramework

### DIFF
--- a/tests/src/GC/Stress/Framework/ReliabilityFramework.csproj
+++ b/tests/src/GC/Stress/Framework/ReliabilityFramework.csproj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <BuildingForReliabilityFramework>true</BuildingForReliabilityFramework>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyName>ReliabilityFramework</AssemblyName>
     <SchemaVersion>2.0</SchemaVersion>
@@ -53,6 +52,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   
   <Target Name="AfterBuild">
-    <MSBuild Projects="@(StressTests)" Properties="OutputPath=$(OutDir)\Tests" />
+    <MSBuild Projects="@(StressTests)" Properties="OutputPath=$(OutDir)\Tests;BuildingForReliabilityFramework=true" />
   </Target>
 </Project>

--- a/tests/src/GC/Stress/Tests/dir.targets
+++ b/tests/src/GC/Stress/Tests/dir.targets
@@ -1,6 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<DisableProjectBuild Condition="'$(BuildingForReliabilityFramework)' == 'true'">true</DisableProjectBuild>
+		<DisableProjectBuild Condition="'$(BuildingForReliabilityFramework)' != 'true'">true</DisableProjectBuild>
 	</PropertyGroup>
 	<Import Project="..\..\..\dir.targets" />
 </Project>


### PR DESCRIPTION
This fixes another race condition in the build - it seems that this particular invocation of the MSBuild task wasn't inheriting the properties of the parent task because the "Properties" option was provided.

This PR also reverses the build condition in `dir.targets`, so the stress tests build as children of the ReliabilityFramework build instead of with the rest of the test build. This is more in-line with developer expectations when they build ReliabilityFramework.csproj and also ensure that the test binaries are in the location that ReliabilityFramework.csproj expects. Fixes #7762