### PR TITLE
[x86/Linux] Add parentheses aroung logical operations

### DIFF
--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -7313,8 +7313,8 @@ AdjustContextForWriteBarrier(
 
     void* f_IP = (void *)GetIP(pContext);
 
-    if (f_IP >= (void *) JIT_WriteBarrierStart && f_IP <= (void *) JIT_WriteBarrierLast ||
-        f_IP >= (void *) JIT_PatchedWriteBarrierStart && f_IP <= (void *) JIT_PatchedWriteBarrierLast)
+    if (((f_IP >= (void *) JIT_WriteBarrierStart) && (f_IP <= (void *) JIT_WriteBarrierLast)) ||
+        ((f_IP >= (void *) JIT_PatchedWriteBarrierStart) && (f_IP <= (void *) JIT_PatchedWriteBarrierLast)))
     {
         // set the exception IP to be the instruction that called the write barrier
         void* callsite = (void *)GetAdjustedCallAddress(*dac_cast<PTR_PCODE>(GetSP(pContext)));


### PR DESCRIPTION
This commit fixes logical-op-parentheses compile error for x86/Linux build.