### PR TITLE
[x86/Linux] Port EXCEPTION_REGISTRATION_RECORD

### DIFF
--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1532,6 +1532,11 @@ typedef struct _DISPATCHER_CONTEXT {
 
 #elif defined(_X86_)
 
+typedef struct _EXCEPTION_REGISTRATION_RECORD {
+    struct _EXCEPTION_REGISTRATION_RECORD *Next;
+    PEXCEPTION_ROUTINE Handler;
+} EXCEPTION_REGISTRATION_RECORD;
+
 typedef struct _DISPATCHER_CONTEXT {
     DWORD ControlPc;
     DWORD ImageBase;


### PR DESCRIPTION
Port EXCEPTION_REGISTRATION_RECORD for x86/Linux build.