### PR TITLE
[x86/Linux] Re-enable FrameHandlerExRecord for x86/Linux

### DIFF
--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -422,10 +422,11 @@ VOID DECLSPEC_NORETURN RealCOMPlusThrowInvalidCastException(TypeHandle thCastFro
 VOID DECLSPEC_NORETURN RealCOMPlusThrowInvalidCastException(OBJECTREF *pObj, TypeHandle thCastTo);
 
 
+#ifndef WIN64EXCEPTIONS
+
 #include "eexcp.h"
 #include "exinfo.h"
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
 struct FrameHandlerExRecord
 {
     EXCEPTION_REGISTRATION_RECORD   m_ExReg;
@@ -460,7 +461,7 @@ struct NestedHandlerExRecord : public FrameHandlerExRecord
     }
 };
 
-#endif // _TARGET_X86_ && !FEATURE_PAL
+#endif // WIN64EXCEPTIONS
 
 #if defined(ENABLE_CONTRACTS_IMPL)
 

--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -422,7 +422,7 @@ VOID DECLSPEC_NORETURN RealCOMPlusThrowInvalidCastException(TypeHandle thCastFro
 VOID DECLSPEC_NORETURN RealCOMPlusThrowInvalidCastException(OBJECTREF *pObj, TypeHandle thCastTo);
 
 
-#ifndef WIN64EXCEPTIONS
+#ifdef _TARGET_X86_
 
 #include "eexcp.h"
 #include "exinfo.h"
@@ -461,7 +461,7 @@ struct NestedHandlerExRecord : public FrameHandlerExRecord
     }
 };
 
-#endif // WIN64EXCEPTIONS
+#endif // _TARGET_X86_
 
 #if defined(ENABLE_CONTRACTS_IMPL)
 


### PR DESCRIPTION
FrameHandlerExRecord is disabled to fix build error in x86/Linux, but this workaround is no longer required as EXCEPTION_REGISTRATION_RECORD is introduced in #8408.

This commit re-enables FrameHandlerExRecord for x86/Linux.