### PR TITLE
[x86/Linux] Disable Watson-related code for non-Windows platforms

### DIFF
--- a/src/vm/exinfo.cpp
+++ b/src/vm/exinfo.cpp
@@ -76,9 +76,11 @@ void ExInfo::CopyAndClearSource(ExInfo *from)
     // Finally, initialize the source ExInfo.
     from->Init();
 
+#ifndef FEATURE_PAL
     // Clear the Watson Bucketing information as well since they
     // have been transferred over by the "memcpy" above.
     from->GetWatsonBucketTracker()->Init();
+#endif // FEATURE_PAL
 }
 
 void ExInfo::Init()
@@ -136,8 +138,10 @@ ExInfo::ExInfo()
     m_hThrowable = NULL;
     Init();
 
+#ifndef FEATURE_PAL
     // Init the WatsonBucketTracker
     m_WatsonBucketTracker.Init();
+#endif // FEATURE_PAL
 }
 
 //*******************************************************************************
@@ -206,9 +210,11 @@ void ExInfo::UnwindExInfo(VOID* limit)
             pPrevNestedInfo->DestroyExceptionHandle();
         }
 
+        #ifndef FEATURE_PAL
         // Free the Watson bucket details when ExInfo
         // is being released
         pPrevNestedInfo->GetWatsonBucketTracker()->ClearWatsonBucketDetails();
+        #endif // FEATURE_PAL
 
         pPrevNestedInfo->m_StackTraceInfo.FreeStackTrace();
 
@@ -256,8 +262,10 @@ void ExInfo::UnwindExInfo(VOID* limit)
         // We just do a basic Init of the current top ExInfo here.
         Init();
 
+        #ifndef FEATURE_PAL
         // Init the Watson buckets as well
         GetWatsonBucketTracker()->ClearWatsonBucketDetails();
+        #endif // FEATURE_PAL
     }
 }
 #endif // DACCESS_COMPILE

--- a/src/vm/i386/excepx86.cpp
+++ b/src/vm/i386/excepx86.cpp
@@ -1153,6 +1153,7 @@ CPFH_RealFirstPassHandler(                  // ExceptionContinueSearch, etc.
 
     pExInfo->m_pExceptionPointers = &exceptionPointers;
 
+#ifndef FEATURE_PAL
     if (bRethrownException || bNestedException)
     {
         _ASSERTE(pExInfo->m_pPrevNestedInfo != NULL);
@@ -1161,6 +1162,7 @@ CPFH_RealFirstPassHandler(                  // ExceptionContinueSearch, etc.
         SetStateForWatsonBucketing(bRethrownException, pExInfo->GetPreviousExceptionTracker()->GetThrowableAsHandle());
         END_SO_INTOLERANT_CODE;
     }
+#endif
 
 #ifdef DEBUGGING_SUPPORTED
     //


### PR DESCRIPTION
This commit disables Watson-related code in order to fix x86/Linux build error.