### PR TITLE
[x86/Linux] Add Portable PopSEHRecords as NYI

### DIFF
--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -1595,12 +1595,7 @@ extern "C" VOID STDCALL StubRareDisableTHROWWorker(Thread *pThread)
     pThread->HandleThreadAbort();
 }
 
-#ifdef FEATURE_PAL
-VOID __cdecl PopSEHRecords(LPVOID pTargetSP)
-{
-  _ASSERTE("NYI");
-}
-#else // FEATURE_PAL
+#ifndef FEATURE_PAL
 // Note that this logic is copied below, in PopSEHRecords
 __declspec(naked)
 VOID __cdecl PopSEHRecords(LPVOID pTargetSP)

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -1595,6 +1595,12 @@ extern "C" VOID STDCALL StubRareDisableTHROWWorker(Thread *pThread)
     pThread->HandleThreadAbort();
 }
 
+#ifdef FEATURE_PAL
+VOID __cdecl PopSEHRecords(LPVOID pTargetSP)
+{
+  _ASSERTE("NYI");
+}
+#else // FEATURE_PAL
 // Note that this logic is copied below, in PopSEHRecords
 __declspec(naked)
 VOID __cdecl PopSEHRecords(LPVOID pTargetSP)
@@ -1616,6 +1622,7 @@ VOID __cdecl PopSEHRecords(LPVOID pTargetSP)
         retn
     }
 }
+#endif // FEATURE_PAL
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -88,3 +88,8 @@ extern "C"
     {
     }
 };
+
+VOID __cdecl PopSEHRecords(LPVOID pTargetSP)
+{
+    PORTABILITY_ASSERT("Implement for PAL");
+}


### PR DESCRIPTION
PopSEHRecords currently uses __declspec(naked). 

This commit introduces portable PopSEHRecords as NYI to enable x86/Linux build.