### PR TITLE
Current should throw InvalidOperationException after elements was added

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -1068,7 +1068,7 @@ namespace System.Collections.Generic {
                     ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
                 }
 
-                index = list._size + 1;
+                index = -1; // Current shoud throw InvalidOperationException even after new elements was added to list
                 current = default(T);
                 return false;                
             }
@@ -1081,7 +1081,8 @@ namespace System.Collections.Generic {
 
             Object System.Collections.IEnumerator.Current {
                 get {
-                    if( index == 0 || index == list._size + 1) {
+                    // Following trick can reduce the range check by one
+                    if (index <= 0) {
                          ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
                     }
                     return Current;


### PR DESCRIPTION
Enumerator.Current should throw InvalidOperationException even after new elements was added to list. See https://github.com/dotnet/corefx/pull/14150

Now next code does not throw InvalidOperationException
```cs
using (IEnumerator<T> enu = list.GetEnumerator())
{
    while (enu.MoveNext()) ; // Go to end of enumerator
    try {
        var item = enu.Current); // throw InvalidOperationException
    } catch() {};

    // But after list.Add the enu.Current return default value but should throw InvalidOperationException
    list.Add("Something");
    var item = enu.Current); // does not throw InvalidOperationException but return default value
}
```