### PR TITLE
Introduce CORINFO_EH_CLAUSE_SAMETRY flag for CoreRT ABI

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -911,10 +911,12 @@ enum CORINFO_ACCESS_FLAGS
 // These are the flags set on an CORINFO_EH_CLAUSE
 enum CORINFO_EH_CLAUSE_FLAGS
 {
-    CORINFO_EH_CLAUSE_NONE    = 0,
-    CORINFO_EH_CLAUSE_FILTER  = 0x0001, // If this bit is on, then this EH entry is for a filter
-    CORINFO_EH_CLAUSE_FINALLY = 0x0002, // This clause is a finally clause
-    CORINFO_EH_CLAUSE_FAULT   = 0x0004, // This clause is a fault   clause
+    CORINFO_EH_CLAUSE_NONE      = 0,
+    CORINFO_EH_CLAUSE_FILTER    = 0x0001, // If this bit is on, then this EH entry is for a filter
+    CORINFO_EH_CLAUSE_FINALLY   = 0x0002, // This clause is a finally clause
+    CORINFO_EH_CLAUSE_FAULT     = 0x0004, // This clause is a fault clause
+    CORINFO_EH_CLAUSE_DUPLICATE = 0x0008, // Duplicated clause. This clause was duplicated to a funclet which was pulled out of line
+    CORINFO_EH_CLAUSE_SAMETRY   = 0x0010, // This clause covers same try block as the previous one. (Used by CoreRT ABI.)
 };
 
 // This enumeration is passed to InternalThrow

--- a/src/jit/jiteh.cpp
+++ b/src/jit/jiteh.cpp
@@ -2979,7 +2979,7 @@ void Compiler::dispOutgoingEHClause(unsigned num, const CORINFO_EH_CLAUSE& claus
     // Note: the flags field is kind of weird. It should be compared for equality
     // to determine the type of clause, even though it looks like a bitfield. In
     // Particular, CORINFO_EH_CLAUSE_NONE is zero, so you can "&" to check it.
-    // You do need to mask off the bits, though, because COR_ILEXCEPTION_CLAUSE_DUPLICATED
+    // You do need to mask off the bits, though, because CORINFO_EH_CLAUSE_DUPLICATE
     // is and'ed in.
     const DWORD CORINFO_EH_CLAUSE_TYPE_MASK = 0x7;
     switch (clause.Flags & CORINFO_EH_CLAUSE_TYPE_MASK)
@@ -3013,14 +3013,18 @@ void Compiler::dispOutgoingEHClause(unsigned num, const CORINFO_EH_CLAUSE& claus
     }
 
     if ((clause.TryOffset == clause.TryLength) && (clause.TryOffset == clause.HandlerOffset) &&
-        ((clause.Flags & (COR_ILEXCEPTION_CLAUSE_DUPLICATED | COR_ILEXCEPTION_CLAUSE_FINALLY)) ==
-         (COR_ILEXCEPTION_CLAUSE_DUPLICATED | COR_ILEXCEPTION_CLAUSE_FINALLY)))
+        ((clause.Flags & (CORINFO_EH_CLAUSE_DUPLICATE | CORINFO_EH_CLAUSE_FINALLY)) ==
+         (CORINFO_EH_CLAUSE_DUPLICATE | CORINFO_EH_CLAUSE_FINALLY)))
     {
         printf(" cloned finally");
     }
-    else if (clause.Flags & COR_ILEXCEPTION_CLAUSE_DUPLICATED)
+    else if (clause.Flags & CORINFO_EH_CLAUSE_DUPLICATE)
     {
         printf(" duplicated");
+    }
+    else if (clause.Flags & CORINFO_EH_CLAUSE_SAMETRY)
+    {
+        printf(" same try");
     }
     printf("\n");
 }


### PR DESCRIPTION
CORINFO_EH_CLAUSE_SAMEBLOCK flag is returned on mutually protecting EH clauses for CoreRT ABI. It is set on EH clauses that cover same try block as the previous one. The runtime cannot reliably infer this information from native code offsets without full description of duplicate clauses because of different try blocks can have same offsets. Alternative solution to this problem would be inserting extra nops to ensure that different try blocks have different offsets.