### PR TITLE
[x86/Linux] Mark several Windows-specific functions in excepx86.cpp as NYI 

### DIFF
--- a/src/vm/i386/excepx86.cpp
+++ b/src/vm/i386/excepx86.cpp
@@ -371,6 +371,7 @@ CPFH_AdjustContextForThreadSuspensionRace(CONTEXT *pContext, Thread *pThread)
 {
     WRAPPER_NO_CONTRACT;
 
+#ifndef FEATURE_PAL
     PCODE f_IP = GetIP(pContext);
     if (Thread::IsAddrOfRedirectFunc((PVOID)f_IP)) {
 
@@ -427,6 +428,9 @@ CPFH_AdjustContextForThreadSuspensionRace(CONTEXT *pContext, Thread *pThread)
         SetIP(pContext, GetIP(pThread->m_OSContext) - 1);
         STRESS_LOG1(LF_EH, LL_INFO100, "CPFH_AdjustContextForThreadSuspensionRace: Case 4 setting IP = %x\n", pContext->Eip);
     }
+#else
+    PORTABILITY_ASSERT("CPFH_AdjustContextForThreadSuspensionRace");
+#endif
 }
 #endif // FEATURE_HIJACK
 
@@ -2017,12 +2021,17 @@ PEXCEPTION_REGISTRATION_RECORD GetCurrentSEHRecord()
 
 PEXCEPTION_REGISTRATION_RECORD GetFirstCOMPlusSEHRecord(Thread *pThread) {
     WRAPPER_NO_CONTRACT;
+#ifndef FEATURE_PAL
     EXCEPTION_REGISTRATION_RECORD *pEHR = *(pThread->GetExceptionListPtr());
     if (pEHR == EXCEPTION_CHAIN_END || IsUnmanagedToManagedSEHHandler(pEHR)) {
         return pEHR;
     } else {
         return GetNextCOMPlusSEHRecord(pEHR);
     }
+#else   // FEATURE_PAL
+    PORTABILITY_ASSERT("GetFirstCOMPlusSEHRecord");
+    return NULL;
+#endif  // FEATURE_PAL
 }
 
 
@@ -2048,7 +2057,11 @@ PEXCEPTION_REGISTRATION_RECORD GetPrevSEHRecord(EXCEPTION_REGISTRATION_RECORD *n
 VOID SetCurrentSEHRecord(EXCEPTION_REGISTRATION_RECORD *pSEH)
 {
     WRAPPER_NO_CONTRACT;
+#ifndef FEATURE_PAL
     *GetThread()->GetExceptionListPtr() = pSEH;
+#else  // FEATURE_PAL
+    _ASSERTE("NYI");
+#endif // FEATURE_PAL
 }
 
 
@@ -2085,6 +2098,7 @@ BOOL PopNestedExceptionRecords(LPVOID pTargetSP, BOOL bCheckForUnknownHandlers)
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_SO_TOLERANT;
 
+#ifndef FEATURE_PAL
     PEXCEPTION_REGISTRATION_RECORD pEHR = GetCurrentSEHRecord();
 
     while ((LPVOID)pEHR < pTargetSP)
@@ -2140,6 +2154,10 @@ BOOL PopNestedExceptionRecords(LPVOID pTargetSP, BOOL bCheckForUnknownHandlers)
         SetCurrentSEHRecord(pEHR);
     }
     return FALSE;
+#else   // FEATURE_PAL
+    PORTABILITY_ASSERT("PopNestedExceptionRecords");
+    return FALSE;
+#endif  // FEATURE_PAL
 }
 
 //

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -3721,7 +3721,7 @@ private:
     ARG_SLOT CallPropertyGet(BinderMethodID id, OBJECTREF pObject);
     ARG_SLOT CallPropertySet(BinderMethodID id, OBJECTREF pObject, OBJECTREF pValue);
 
-#if defined(FEATURE_HIJACK) && !defined(PLATFORM_UNIX)
+#if defined(FEATURE_HIJACK) && !defined(FEATURE_PAL)
     // Used in suspension code to redirect a thread at a HandledJITCase
     BOOL RedirectThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt);
     BOOL RedirectCurrentThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt, T_CONTEXT *pCurrentThreadCtx);
@@ -3743,7 +3743,7 @@ public:
 private:
     bool        m_fPreemptiveGCDisabledForGCStress;
 #endif // HAVE_GCCOVER && USE_REDIRECT_FOR_GCSTRESS
-#endif // FEATURE_HIJACK && !PLATFORM_UNIX
+#endif // FEATURE_HIJACK && !FEATURE_PAL
 
 public:
 

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -3721,7 +3721,7 @@ private:
     ARG_SLOT CallPropertyGet(BinderMethodID id, OBJECTREF pObject);
     ARG_SLOT CallPropertySet(BinderMethodID id, OBJECTREF pObject, OBJECTREF pValue);
 
-#if defined(FEATURE_HIJACK) && !defined(FEATURE_PAL)
+#if defined(FEATURE_HIJACK) && !defined(PLATFORM_UNIX)
     // Used in suspension code to redirect a thread at a HandledJITCase
     BOOL RedirectThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt);
     BOOL RedirectCurrentThreadAtHandledJITCase(PFN_REDIRECTTARGET pTgt, T_CONTEXT *pCurrentThreadCtx);
@@ -3743,7 +3743,7 @@ public:
 private:
     bool        m_fPreemptiveGCDisabledForGCStress;
 #endif // HAVE_GCCOVER && USE_REDIRECT_FOR_GCSTRESS
-#endif // FEATURE_HIJACK && !FEATURE_PAL
+#endif // FEATURE_HIJACK && !PLATFORM_UNIX
 
 public:
 


### PR DESCRIPTION
This commit mark several Windows-specific functions in excepx86.cpp as NYI (To be specific, GetExceptionListPtr and Thread::IsAddrOfRedirectFunc are not available for x86/Linux).

In addition, this commit encloses IsAddrOfRedirectFunc by FEATURE_PAL (instead of PLATFORM_UNIX) to prevent future conflicts between defines.