### PR TITLE
[x86/Linux] Add UnhandledExceptionHandlerUnix Stub

### DIFF
--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -87,6 +87,19 @@ extern "C"
     void STDCALL JIT_ProfilerEnterLeaveTailcallStub(UINT_PTR ProfilerHandle)
     {
     }
+
+    _Unwind_Reason_Code
+    UnhandledExceptionHandlerUnix(
+                IN int version,
+                IN _Unwind_Action action,
+                IN uint64_t exceptionClass,
+                IN struct _Unwind_Exception *exception,
+                IN struct _Unwind_Context *context
+              )
+    {
+        PORTABILITY_ASSERT("UnhandledExceptionHandlerUnix");
+        return _URC_FATAL_PHASE1_ERROR;
+    }
 };
 
 VOID __cdecl PopSEHRecords(LPVOID pTargetSP)


### PR DESCRIPTION
FuncEvalHijack in dbghelpers.S uses UnhandledExceptionHandlerUnix as a
personality routine, but UnhandledExceptionHandlerUnix is not avaiable
for x86 (UnhandledExceptionHandlerUnix is available only when
WIN64EXCEPTIONS which is not defined for x86).

This commit adds UnhandledExceptionHandlerUnix to fix dangling
reference.