### PR TITLE
[x86/Linux] Fix dangling TheUMEntryPrestub reference

### DIFF
--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -569,7 +569,7 @@ private:
     AppDomain *m_pDomain;
 };
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifndef WIN64EXCEPTIONS
 //-------------------------------------------------------------------------
 // One-time creation of special prestub to initialize UMEntryThunks.
 //-------------------------------------------------------------------------

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -569,12 +569,12 @@ private:
     AppDomain *m_pDomain;
 };
 
-#ifndef WIN64EXCEPTIONS
+#ifdef _TARGET_X86_
 //-------------------------------------------------------------------------
 // One-time creation of special prestub to initialize UMEntryThunks.
 //-------------------------------------------------------------------------
 Stub *GenerateUMThunkPrestub();
-#endif
+#endif // _TARGET_X86_
 
 //-------------------------------------------------------------------------
 // NExport stub

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -760,7 +760,7 @@ WORD GetUnpatchedCodeData(LPCBYTE pAddr)
 
 #ifndef DACCESS_COMPILE
 
-#if !defined(FEATURE_PAL)
+#ifndef WIN64EXCEPTIONS
 //-------------------------------------------------------------------------
 // One-time creation of special prestub to initialize UMEntryThunks.
 //-------------------------------------------------------------------------
@@ -810,7 +810,7 @@ Stub *GenerateUMThunkPrestub()
 
     RETURN psl->Link(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
 }
-#endif // !FEATURE_PAL
+#endif // WIN64EXCEPTIONS
 
 Stub *GenerateInitPInvokeFrameHelper()
 {

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -760,7 +760,7 @@ WORD GetUnpatchedCodeData(LPCBYTE pAddr)
 
 #ifndef DACCESS_COMPILE
 
-#ifndef WIN64EXCEPTIONS
+#ifdef _TARGET_X86_
 //-------------------------------------------------------------------------
 // One-time creation of special prestub to initialize UMEntryThunks.
 //-------------------------------------------------------------------------
@@ -810,7 +810,7 @@ Stub *GenerateUMThunkPrestub()
 
     RETURN psl->Link(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
 }
-#endif // WIN64EXCEPTIONS
+#endif // _TARGET_X86_
 
 Stub *GenerateInitPInvokeFrameHelper()
 {

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -760,7 +760,6 @@ WORD GetUnpatchedCodeData(LPCBYTE pAddr)
 
 #ifndef DACCESS_COMPILE
 
-#ifdef _TARGET_X86_
 //-------------------------------------------------------------------------
 // One-time creation of special prestub to initialize UMEntryThunks.
 //-------------------------------------------------------------------------
@@ -810,7 +809,6 @@ Stub *GenerateUMThunkPrestub()
 
     RETURN psl->Link(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
 }
-#endif // _TARGET_X86_
 
 Stub *GenerateInitPInvokeFrameHelper()
 {

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1647,9 +1647,9 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
 // use the prestub.
 //==========================================================================
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifndef WIN64EXCEPTIONS
 static PCODE g_UMThunkPreStub;
-#endif
+#endif // WIN64EXCEPTIONS
 
 #ifndef DACCESS_COMPILE 
 
@@ -1676,9 +1676,9 @@ void InitPreStubManager(void)
         return;
     }
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifndef WIN64EXCEPTIONS
     g_UMThunkPreStub = GenerateUMThunkPrestub()->GetEntryPoint();
-#endif
+#endif // WIN64EXCEPTIONS
 
     ThePreStubManager::Init();
 }
@@ -1687,11 +1687,11 @@ PCODE TheUMThunkPreStub()
 {
     LIMITED_METHOD_CONTRACT;
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifndef WIN64EXCEPTIONS
     return g_UMThunkPreStub;
-#else
+#else  // WIN64EXCEPTIONS
     return GetEEFuncEntryPoint(TheUMEntryPrestub);
-#endif
+#endif // WIN64EXCEPTIONS
 }
 
 PCODE TheVarargNDirectStub(BOOL hasRetBuffArg)

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1647,9 +1647,9 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
 // use the prestub.
 //==========================================================================
 
-#ifndef WIN64EXCEPTIONS
+#ifdef _TARGET_X86_
 static PCODE g_UMThunkPreStub;
-#endif // WIN64EXCEPTIONS
+#endif // _TARGET_X86_
 
 #ifndef DACCESS_COMPILE 
 
@@ -1676,9 +1676,9 @@ void InitPreStubManager(void)
         return;
     }
 
-#ifndef WIN64EXCEPTIONS
+#ifdef _TARGET_X86_
     g_UMThunkPreStub = GenerateUMThunkPrestub()->GetEntryPoint();
-#endif // WIN64EXCEPTIONS
+#endif // _TARGET_X86_
 
     ThePreStubManager::Init();
 }
@@ -1687,11 +1687,11 @@ PCODE TheUMThunkPreStub()
 {
     LIMITED_METHOD_CONTRACT;
 
-#ifndef WIN64EXCEPTIONS
+#ifdef _TARGET_X86_
     return g_UMThunkPreStub;
-#else  // WIN64EXCEPTIONS
+#else  // _TARGET_X86_
     return GetEEFuncEntryPoint(TheUMEntryPrestub);
-#endif // WIN64EXCEPTIONS
+#endif // _TARGET_X86_
 }
 
 PCODE TheVarargNDirectStub(BOOL hasRetBuffArg)


### PR DESCRIPTION
This commit re-enables GenerateUMThunkPrestub and its related code in
order to remove TheUMEntryPrestub reference.