### PR TITLE
[x86/Linux] Revise COMPlusThrowCallback

### DIFF
--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -88,9 +88,11 @@ struct ThrowCallbackType
     MethodDesc * pProfilerNotify;   // Context for profiler callbacks -- see COMPlusFrameHandler().
     BOOL    bReplaceStack;  // Used to pass info to SaveStackTrace call
     BOOL    bSkipLastElement;// Used to pass info to SaveStackTrace call
+#ifndef FEATURE_PAL
     HANDLE hCallerToken;
     HANDLE hImpersonationToken;
     BOOL bImpersonationTokenSet;
+#endif // !FEATURE_PAL
 #ifdef _DEBUG
     void * pCurrentExceptionRecord;
     void * pPrevExceptionRecord;
@@ -114,9 +116,11 @@ struct ThrowCallbackType
         pProfilerNotify = NULL;
         bReplaceStack = FALSE;
         bSkipLastElement = FALSE;
+#ifndef FEATURE_PAL
         hCallerToken = NULL;
         hImpersonationToken = NULL;
         bImpersonationTokenSet = FALSE;
+#endif // !FEATURE_PAL
         
 #ifdef _DEBUG
         pCurrentExceptionRecord = 0;

--- a/src/vm/i386/excepx86.cpp
+++ b/src/vm/i386/excepx86.cpp
@@ -2316,6 +2316,7 @@ StackWalkAction COMPlusThrowCallback(       // SWA value
     STATIC_CONTRACT_GC_TRIGGERS;
     STATIC_CONTRACT_MODE_COOPERATIVE;
 
+#ifndef FEATURE_PAL
     Frame *pFrame = pCf->GetFrame();
     MethodDesc *pFunc = pCf->GetFunction();
 
@@ -2762,6 +2763,10 @@ StackWalkAction COMPlusThrowCallback(       // SWA value
     if (fGiveDebuggerAndProfilerNotification)
         EEToProfilerExceptionInterfaceWrapper::ExceptionSearchFunctionLeave(pFunc);
     return SWA_CONTINUE;
+#else  // FEATURE_PAL
+    PORTABILITY_ASSERT("COMPlusThrowCallback");
+    return SWA_ABORT;
+#endif // FEATURE_PAL
 } // StackWalkAction COMPlusThrowCallback()
 
 

--- a/src/vm/i386/excepx86.cpp
+++ b/src/vm/i386/excepx86.cpp
@@ -2316,7 +2316,6 @@ StackWalkAction COMPlusThrowCallback(       // SWA value
     STATIC_CONTRACT_GC_TRIGGERS;
     STATIC_CONTRACT_MODE_COOPERATIVE;
 
-#ifndef FEATURE_PAL
     Frame *pFrame = pCf->GetFrame();
     MethodDesc *pFunc = pCf->GetFunction();
 
@@ -2412,6 +2411,7 @@ StackWalkAction COMPlusThrowCallback(       // SWA value
         pData->bSkipLastElement = FALSE;
     }
 
+#ifndef FEATURE_PAL
     // Check for any impersonation on the frame and save that for use during EH filter callbacks
     OBJECTREF* pRefSecDesc = pCf->GetAddrOfSecurityObject();
     if (pRefSecDesc != NULL && *pRefSecDesc != NULL)
@@ -2430,6 +2430,7 @@ StackWalkAction COMPlusThrowCallback(       // SWA value
             }
         }
     }
+#endif // !FEATURE_PAL
 
     // now we've got the stack trace, if we aren't allowed to catch this and we're first pass, return
     if (pData->bDontCatch)
@@ -2763,10 +2764,6 @@ StackWalkAction COMPlusThrowCallback(       // SWA value
     if (fGiveDebuggerAndProfilerNotification)
         EEToProfilerExceptionInterfaceWrapper::ExceptionSearchFunctionLeave(pFunc);
     return SWA_CONTINUE;
-#else  // FEATURE_PAL
-    PORTABILITY_ASSERT("COMPlusThrowCallback");
-    return SWA_ABORT;
-#endif // FEATURE_PAL
 } // StackWalkAction COMPlusThrowCallback()
 
 

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -2880,8 +2880,10 @@ class FrameSecurityDescriptorBaseObject : public Object
         LIMITED_METHOD_CONTRACT;
         m_declSecComputed = !!declSec;
     }
+#ifndef FEATURE_PAL
     LPVOID GetCallerToken();
     LPVOID GetImpersonationToken();
+#endif  // FEATURE_PAL
 };
 
 #ifdef FEATURE_COMPRESSEDSTACK


### PR DESCRIPTION
GetCallerToken and GetImpersonationToken methods in FrameSecurityDescriptorBaseObject
are implemented only for Windows-platform.

This commit revises COMPlusThrowCallback not to use these methods for non-Windows-platform.