### PR TITLE
[x86/Linux] Enclose stub-linking methods with FEATURE_STUBS_AS_IL

### DIFF
--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -773,6 +773,7 @@ Stub *GenerateUMThunkPrestub()
     }
     CONTRACT_END;
 
+#ifndef FEATURE_STUBS_AS_IL
     CPUSTUBLINKER sl;
     CPUSTUBLINKER *psl = &sl;
 
@@ -809,6 +810,10 @@ Stub *GenerateUMThunkPrestub()
     psl->EmitComMethodStubEpilog(UMThkCallFrame::GetMethodFrameVPtr(), rgRareLabels, rgRejoinLabels, FALSE /*Don't profile*/);
 
     RETURN psl->Link(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
+#else  // FEATURE_STUBS_AS_IL
+    PORTABILITY_ASSERT("GenerateUMThunkPrestub");
+    return NULL;
+#endif // FEATURE_STUBS_AS_IL
 }
 #endif // !FEATURE_PAL
 

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -2624,6 +2624,7 @@ VOID StubLinkerCPU::EmitProfilerComCallEpilog(TADDR pFrameVptr, X86Reg regFrame)
 #endif // PROFILING_SUPPORTED
 
 
+#ifndef FEATURE_STUBS_AS_IL
 //========================================================================
 //  Prolog for entering managed code from COM
 //  pushes the appropriate frame ptr
@@ -2850,6 +2851,7 @@ void StubLinkerCPU::EmitComMethodStubEpilog(TADDR pFrameVptr,
     EmitLabel(rgRareLabels[0]);  // label for rare setup thread
     EmitRareSetup(rgRejoinLabels[0], /*fThrow*/ TRUE); // emit rare setup thread
 }
+#endif // !FEATURE_STUBS_AS_IL
 
 //---------------------------------------------------------------
 // Emit code to store the setup current Thread structure in eax.

--- a/src/vm/i386/stublinkerx86.h
+++ b/src/vm/i386/stublinkerx86.h
@@ -345,6 +345,11 @@ class StubLinkerCPU : public StubLinker
 
         VOID EmitSetup(CodeLabel *pForwardRef);
         VOID EmitRareSetup(CodeLabel* pRejoinPoint, BOOL fThrow);
+
+#ifndef FEATURE_STUBS_AS_IL
+        VOID EmitMethodStubProlog(TADDR pFrameVptr, int transitionBlockOffset);
+        VOID EmitMethodStubEpilog(WORD numArgBytes, int transitionBlockOffset);
+
         VOID EmitCheckGSCookie(X86Reg frameReg, int gsCookieOffset);
 
 #ifdef _TARGET_X86_
@@ -353,10 +358,8 @@ class StubLinkerCPU : public StubLinker
 
         void EmitComMethodStubEpilog(TADDR pFrameVptr, CodeLabel** rgRareLabels, 
                                      CodeLabel** rgRejoinLabels, BOOL bShouldProfile);
-#endif
-
-        VOID EmitMethodStubProlog(TADDR pFrameVptr, int transitionBlockOffset);
-        VOID EmitMethodStubEpilog(WORD numArgBytes, int transitionBlockOffset);
+#endif // _TARGET_X86_
+#endif // !FEATURE_STUBS_AS_IL
 
         VOID EmitUnboxMethodStub(MethodDesc* pRealMD);
 #if defined(FEATURE_SHARE_GENERIC_CODE)  


### PR DESCRIPTION
EmitCheckGSCookie is available when FEATURE_STUBS_AS_IL is turned on, but its signature and other methods that depend on it are not enclosed with FEATURE_STUBS_AS_IL.

This commit encloses them with FEATURE_STUBS_AS_IL in order to fix dangling EmitCheckGSCookie reference.