### PR TITLE
[x86/Linux] Fix exception handling routine

### DIFF
--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -296,7 +296,7 @@ VOID DECLSPEC_NORETURN RaiseTheExceptionInternalOnly(OBJECTREF throwable, BOOL r
 void UnwindAndContinueRethrowHelperInsideCatch(Frame* pEntryFrame, Exception* pException);
 VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFrame, Exception* pException);
 
-#ifdef FEATURE_PAL
+#if defined(FEATURE_PAL) && defined(WIN64EXCEPTIONS)
 VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHardwareException);
 
 #define INSTALL_MANAGED_EXCEPTION_DISPATCHER        \
@@ -334,14 +334,14 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
             UNREACHABLE();                                                                          \
         }
 
-#else
+#else // defined(FEATURE_PAL) && defined(WIN64EXCEPTIONS)
 
 #define INSTALL_MANAGED_EXCEPTION_DISPATCHER
 #define UNINSTALL_MANAGED_EXCEPTION_DISPATCHER
 #define INSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP
 #define UNINSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP
 
-#endif // FEATURE_PAL
+#endif // defined(FEATURE_PAL) && defined(WIN64EXCEPTIONS)
 
 #define INSTALL_UNWIND_AND_CONTINUE_HANDLER_NO_PROBE                                        \
     {                                                                                       \

--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -334,14 +334,14 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
             UNREACHABLE();                                                                          \
         }
 
-#else // defined(FEATURE_PAL) && defined(WIN64EXCEPTIONS)
+#else // FEATURE_PAL && WIN64EXCEPTIONS
 
 #define INSTALL_MANAGED_EXCEPTION_DISPATCHER
 #define UNINSTALL_MANAGED_EXCEPTION_DISPATCHER
 #define INSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP
 #define UNINSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP
 
-#endif // defined(FEATURE_PAL) && defined(WIN64EXCEPTIONS)
+#endif // FEATURE_PAL && WIN64EXCEPTIONS
 
 #define INSTALL_UNWIND_AND_CONTINUE_HANDLER_NO_PROBE                                        \
     {                                                                                       \


### PR DESCRIPTION
WIN64EXCEPTIONS is required to use DispatchManagedException, but is not defined for x86/Linux.