### PR TITLE
[x86/Linux] Revert UMThkCallFrame-related changes

### DIFF
--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -569,12 +569,12 @@ private:
     AppDomain *m_pDomain;
 };
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifdef _TARGET_X86_
 //-------------------------------------------------------------------------
 // One-time creation of special prestub to initialize UMEntryThunks.
 //-------------------------------------------------------------------------
 Stub *GenerateUMThunkPrestub();
-#endif
+#endif // _TARGET_X86_
 
 //-------------------------------------------------------------------------
 // NExport stub

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -74,7 +74,7 @@ void Frame::Log() {
 
     MethodDesc* method = GetFunction();
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifdef _TARGET_X86_
     if (GetVTablePtr() == UMThkCallFrame::GetMethodFrameVPtr())
         method = ((UMThkCallFrame*) this)->GetUMEntryThunk()->GetMethod();
 #endif
@@ -85,7 +85,7 @@ void Frame::Log() {
     const char* frameType;
     if (GetVTablePtr() == PrestubMethodFrame::GetMethodFrameVPtr())
         frameType = "PreStub";
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifdef _TARGET_X86_
     else if (GetVTablePtr() == UMThkCallFrame::GetMethodFrameVPtr())
         frameType = "UMThkCallFrame";
 #endif
@@ -1671,7 +1671,7 @@ void ComMethodFrame::DoSecondPassHandlerCleanup(Frame * pCurFrame)
 #endif // FEATURE_COMINTEROP
 
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifdef _TARGET_X86_
 
 PTR_UMEntryThunk UMThkCallFrame::GetUMEntryThunk()
 {
@@ -1694,7 +1694,7 @@ void UMThkCallFrame::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 }
 #endif
 
-#endif // _TARGET_X86_ && !FEATURE_PAL
+#endif // _TARGET_X86_
 
 #ifndef DACCESS_COMPILE
 

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -113,7 +113,7 @@
 //    |   +-ComPrestubMethodFrame - prestub frame for calls from COM to CLR
 //    |
 #endif //FEATURE_COMINTEROP
-#if defined(_TARGET_X86_)
+#ifdef _TARGET_X86_
 //    | +-UMThkCallFrame        - this frame represents an unmanaged->managed
 //    |                           transition through N/Direct
 #endif
@@ -268,7 +268,7 @@ FRAME_TYPE_NAME(DebuggerClassInitMarkFrame)
 FRAME_TYPE_NAME(DebuggerSecurityCodeMarkFrame)
 FRAME_TYPE_NAME(DebuggerExitFrame)
 FRAME_TYPE_NAME(DebuggerU2MCatchHandlerFrame)
-#if defined(_TARGET_X86_)
+#ifdef _TARGET_X86_
 FRAME_TYPE_NAME(UMThkCallFrame)
 #endif
 #if defined(FEATURE_INCLUDE_ALL_INTERFACES) && defined(_TARGET_X86_)

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -760,7 +760,6 @@ WORD GetUnpatchedCodeData(LPCBYTE pAddr)
 
 #ifndef DACCESS_COMPILE
 
-#if !defined(FEATURE_PAL)
 //-------------------------------------------------------------------------
 // One-time creation of special prestub to initialize UMEntryThunks.
 //-------------------------------------------------------------------------
@@ -810,7 +809,6 @@ Stub *GenerateUMThunkPrestub()
 
     RETURN psl->Link(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
 }
-#endif // !FEATURE_PAL
 
 Stub *GenerateInitPInvokeFrameHelper()
 {

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -2535,7 +2535,7 @@ VOID StubLinkerCPU::X86EmitCurrentAppDomainFetch(X86Reg dstreg, unsigned preserv
 #endif // FEATURE_IMPLICIT_TLS
 }
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#if defined(_TARGET_X86_)
 
 #ifdef PROFILING_SUPPORTED
 VOID StubLinkerCPU::EmitProfilerComCallProlog(TADDR pFrameVptr, X86Reg regFrame)
@@ -2860,6 +2860,7 @@ VOID StubLinkerCPU::EmitSetup(CodeLabel *pForwardRef)
 {
     STANDARD_VM_CONTRACT;
 
+#ifndef FEATURE_PAL
 #ifdef FEATURE_IMPLICIT_TLS
     DWORD idx = 0;
     TLSACCESSMODE mode = TLSACCESS_GENERIC;
@@ -2920,6 +2921,9 @@ VOID StubLinkerCPU::EmitSetup(CodeLabel *pForwardRef)
     X86EmitDebugTrashReg(kEDX);
 #endif
 
+#else  // FEATURE_PAL
+    PORTABILITY_ASSERT("StubLinkerCPU::EmitSetup");
+#endif // FEATURE_PAL
 }
 
 VOID StubLinkerCPU::EmitRareSetup(CodeLabel *pRejoinPoint, BOOL fThrow)
@@ -2946,7 +2950,7 @@ VOID StubLinkerCPU::EmitRareSetup(CodeLabel *pRejoinPoint, BOOL fThrow)
 }
 
 //========================================================================
-#endif // _TARGET_X86_ && !FEATURE_PAL
+#endif // _TARGET_X86_
 //========================================================================
 #if defined(FEATURE_COMINTEROP) && defined(_TARGET_X86_)
 //========================================================================

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1647,9 +1647,9 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
 // use the prestub.
 //==========================================================================
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifdef _TARGET_X86_
 static PCODE g_UMThunkPreStub;
-#endif
+#endif // _TARGET_X86_
 
 #ifndef DACCESS_COMPILE 
 
@@ -1676,9 +1676,9 @@ void InitPreStubManager(void)
         return;
     }
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifdef _TARGET_X86_
     g_UMThunkPreStub = GenerateUMThunkPrestub()->GetEntryPoint();
-#endif
+#endif // _TARGET_X86_
 
     ThePreStubManager::Init();
 }
@@ -1687,11 +1687,11 @@ PCODE TheUMThunkPreStub()
 {
     LIMITED_METHOD_CONTRACT;
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifdef _TARGET_X86_
     return g_UMThunkPreStub;
-#else
+#else  // _TARGET_X86_
     return GetEEFuncEntryPoint(TheUMEntryPrestub);
-#endif
+#endif // _TARGET_X86_
 }
 
 PCODE TheVarargNDirectStub(BOOL hasRetBuffArg)


### PR DESCRIPTION
This commit reverts the changes made at 4fb0c3e3cff61c.