### PR TITLE
[x86/Linux] Fix dangling CLR_ImpersonateLoggedOnUser reference

### DIFF
--- a/src/vm/i386/excepx86.cpp
+++ b/src/vm/i386/excepx86.cpp
@@ -2247,6 +2247,7 @@ int COMPlusThrowCallbackHelper(IJitManager *pJitManager,
     int iFilt = 0;
     BOOL impersonating = FALSE;
 
+#ifndef FEATURE_PAL
     EX_TRY
     {
         GCPROTECT_BEGIN (throwable);
@@ -2297,6 +2298,10 @@ int COMPlusThrowCallbackHelper(IJitManager *pJitManager,
     EX_END_CATCH(SwallowAllExceptions)
 
     return iFilt;
+#else   // FEATURE_PAL
+    PORTABILITY_ASSERT("COMPlusThrowCallbackHelper");
+    return EXCEPTION_CONTINUE_SEARCH;
+#endif  // FEATURE_PAL
 }
 
 //******************************************************************************

--- a/src/vm/securityprincipal.h
+++ b/src/vm/securityprincipal.h
@@ -11,9 +11,11 @@
 
 
 
+#ifndef FEATURE_PAL
 class COMPrincipal
 {
 public:
+#ifndef FEATURE_CORECLR
     static
     INT32 QCALLTYPE ImpersonateLoggedOnUser(HANDLE hToken);
 
@@ -24,6 +26,8 @@ public:
 
     static
     INT32 QCALLTYPE SetThreadToken(HANDLE hToken);
+#endif // !FEATURE_CORECLR
 
     static void CLR_ImpersonateLoggedOnUser(HANDLE hToken);
 };
+#endif // FEATURE_PAL


### PR DESCRIPTION
src/vm/securityprincipal.cpp is not included in x86/Linux build, and
thus all the reference to the functions in it will be dangling. (i.e.
COMPrincipal::CLR_ImpersonateLoggedOnUser).

This commit hides COMPrincipal for non-Windows platforms, and marks
COMPlusThrowCallbackHelper as NYI.