### PR TITLE
Support filter and fault blocks in DynamicILGenerator

### DIFF
--- a/src/mscorlib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -382,16 +382,6 @@ namespace System.Reflection.Emit
         // Exception related generation
         //
         //
-        public override Label BeginExceptionBlock()
-        {
-            return base.BeginExceptionBlock();
-        }
-
-        public override void EndExceptionBlock()
-        {
-            base.EndExceptionBlock();
-        }
-
         public override void BeginExceptFilterBlock()
         {
             // Begins an exception filter block. Emits a branch instruction to the end of the current exception block.
@@ -451,11 +441,6 @@ namespace System.Reflection.Emit
                 // Need to have a more integreted story for exceptions
                 current.m_filterAddr[current.m_currentCatch - 1] = GetTokenFor(rtType);
             }
-        }
-
-        public override void BeginFinallyBlock()
-        {
-            base.BeginFinallyBlock();
         }
 
         //

--- a/src/mscorlib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -438,7 +438,7 @@ namespace System.Reflection.Emit
 
 
                 // this is relying on too much implementation details of the base and so it's highly breaking
-                // Need to have a more integreted story for exceptions
+                // Need to have a more integrated story for exceptions
                 current.m_filterAddr[current.m_currentCatch - 1] = GetTokenFor(rtType);
             }
         }


### PR DESCRIPTION
Fixes #1764
Fixes dotnet/corefx#5873
Unblocks dotnet/corefx#3838

Copying the build into the test folder for System.Linq.Expressions/tests and removing all of the ActiveIssue attributes for 3838 results in all of those tests passing.