### PR TITLE
[x86/Linux] Fix dangling StubLinkerCPU::EmitDelegateInvoke in x86/Linux

### DIFF
--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -2395,7 +2395,7 @@ PCODE COMDelegate::TheDelegateInvokeStub()
     }
     CONTRACT_END;
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_STUBS_AS_IL)
     static PCODE s_pInvokeStub;
 
     if (s_pInvokeStub == NULL)
@@ -2415,7 +2415,7 @@ PCODE COMDelegate::TheDelegateInvokeStub()
     RETURN s_pInvokeStub;
 #else
     RETURN GetEEFuncEntryPoint(SinglecastDelegateInvokeStub);
-#endif // _TARGET_X86_
+#endif // _TARGET_X86_ && !FEATURE_STUBS_AS_IL
 }
 
 // Get the cpu stub for a delegate invoke.

--- a/src/vm/i386/cgencpu.h
+++ b/src/vm/i386/cgencpu.h
@@ -43,6 +43,10 @@ EXTERN_C void STDCALL PInvokeStackImbalanceHelper(void);
 EXTERN_C void STDCALL CopyCtorCallStub(void);
 #endif // !FEATURE_CORECLR
 
+#ifdef FEATURE_STUBS_AS_IL
+EXTERN_C void SinglecastDelegateInvokeStub();
+#endif // FEATURE_STUBS_AS_IL
+
 BOOL Runtime_Test_For_SSE2();
 
 #ifdef CROSSGEN_COMPILE

--- a/src/vm/i386/stublinkerx86.h
+++ b/src/vm/i386/stublinkerx86.h
@@ -374,13 +374,16 @@ class StubLinkerCPU : public StubLinker
                                            BOOL bShouldProfile);
 #endif // FEATURE_COMINTEROP && _TARGET_X86_
 
+#ifndef FEATURE_STUBS_AS_IL
         //===========================================================================
         // Computes hash code for MulticastDelegate.Invoke()
         static UINT_PTR HashMulticastInvoke(MetaSig* pSig);
 
+#ifdef _TARGET_X86_
         //===========================================================================
         // Emits code for Delegate.Invoke() any delegate type
         VOID EmitDelegateInvoke();
+#endif // _TARGET_X86_
 
         //===========================================================================
         // Emits code for MulticastDelegate.Invoke() - sig specific
@@ -389,6 +392,7 @@ class StubLinkerCPU : public StubLinker
         //===========================================================================
         // Emits code for Delegate.Invoke() on delegates that recorded creator assembly
         VOID EmitSecureDelegateInvoke(UINT_PTR hash);
+#endif // !FEATURE_STUBS_AS_IL
 
         //===========================================================================
         // Emits code to adjust for a static delegate target.
@@ -402,9 +406,11 @@ class StubLinkerCPU : public StubLinker
         //Worker function to emit throw helpers for array ops.
         VOID EmitArrayOpStubThrow(unsigned exConst, unsigned cbRetArg);
 
+#ifndef FEATURE_STUBS_AS_IL
         //===========================================================================
         // Emits code to break into debugger
         VOID EmitDebugBreak();
+#endif // !FEATURE_STUBS_AS_IL
 
 #if defined(_DEBUG) && (defined(_TARGET_AMD64_) || defined(_TARGET_X86_)) && !defined(FEATURE_PAL)
         //===========================================================================


### PR DESCRIPTION
Several methods in StublicLinkerCPU (including EmitDelegateInvoke) are
available only when FEATURE_STUBS_AS_IL is defined.

This commit encloses their declaration with appropriate macro
(FEATURE_STUBS_AS_IL), and fix related build erros.