### PR TITLE
[x86/Linux] Enclose ArrayOpStub Exceptions with FEATURE_ARRAYSTUB_AS_IL

### DIFF
--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -82,9 +82,10 @@ EXCEPTION_HELPERS(ArrayOpStubTypeMismatchException);
 #endif // !_TARGET_AMD64_
 #endif // !FEATURE_ARRAYSTUB_AS_IL
 
-#if defined(_DEBUG) 
+#if defined(_TARGET_AMD64_)
+#if defined(_DEBUG)
 extern "C" VOID __cdecl DebugCheckStubUnwindInfo();
-#endif
+#endif // _DEBUG
 #endif // _TARGET_AMD64_
 
 // Presumably this code knows what it is doing with TLS.  If we are hiding these

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -64,6 +64,7 @@ extern "C" HRESULT __cdecl StubRareDisableHR(Thread *pThread);
 #endif // FEATURE_COMINTEROP
 extern "C" VOID __cdecl StubRareDisableTHROW(Thread *pThread, Frame *pFrame);
 
+#ifndef FEATURE_ARRAYSTUB_AS_IL
 extern "C" VOID __cdecl ArrayOpStubNullException(void);
 extern "C" VOID __cdecl ArrayOpStubRangeException(void);
 extern "C" VOID __cdecl ArrayOpStubTypeMismatchException(void);
@@ -78,6 +79,7 @@ EXCEPTION_HELPERS(ArrayOpStubNullException);
 EXCEPTION_HELPERS(ArrayOpStubRangeException);
 EXCEPTION_HELPERS(ArrayOpStubTypeMismatchException);
 #undef EXCEPTION_HELPERS
+#endif // !FEATURE_ARRAYSTUB_AS_IL
 
 #if defined(_DEBUG) 
 extern "C" VOID __cdecl DebugCheckStubUnwindInfo();

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -79,6 +79,7 @@ EXCEPTION_HELPERS(ArrayOpStubNullException);
 EXCEPTION_HELPERS(ArrayOpStubRangeException);
 EXCEPTION_HELPERS(ArrayOpStubTypeMismatchException);
 #undef EXCEPTION_HELPERS
+#endif // !_TARGET_AMD64_
 #endif // !FEATURE_ARRAYSTUB_AS_IL
 
 #if defined(_DEBUG) 


### PR DESCRIPTION
The following functions are used only when FEATURE_ARRAYSTUB_AS_IL is undefined:
 - ArrayOpStubNullException
 - ArrayOpStubRangeException
 - ArrayOpStubTypeMismatchException

This commit encloses their declaration with FEATURE_ARRAYSTUB_AS_IL macro.