### PR TITLE
[x86/Linux] Use Portable Floating-point Arithmetic Helpers

### DIFF
--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -333,6 +333,7 @@ extern "C" __declspec(naked) Object* F_CALL_CONV JIT_ChkCastClassSpecial(MethodT
 }
 #endif // FEATURE_PAL
 
+#ifndef FEATURE_PAL
 HCIMPL1_V(INT32, JIT_Dbl2IntOvf, double val)
 {
     FCALL_CONTRACT;
@@ -348,6 +349,7 @@ THROW:
     FCThrow(kOverflowException);
 }
 HCIMPLEND
+#endif // FEATURE_PAL
 
 
 FCDECL1(Object*, JIT_New, CORINFO_CLASS_HANDLE typeHnd_);

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -654,7 +654,7 @@ HCIMPL1_V(UINT64, JIT_Dbl2ULngOvf, double val)
 HCIMPLEND
 
 
-#if !defined(_TARGET_X86_)
+#if !defined(_TARGET_X86_) || defined(FEATURE_PAL)
 
 HCIMPL1_V(INT64, JIT_Dbl2Lng, double val)
 {
@@ -755,7 +755,7 @@ HCIMPL2_VV(double, JIT_DblRem, double dividend, double divisor)
 }
 HCIMPLEND
 
-#endif // !defined(_TARGET_X86_)
+#endif // !_TARGET_X86_ || FEATURE_PAL
 
 #include <optdefault.h>
 


### PR DESCRIPTION
This commit enables portable floating-point arithmetic helpers for
x86/Linux build.