### PR TITLE
[x86/Linux] Use Portable SHIFT JIT Helpers

### DIFF
--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -460,7 +460,7 @@ HCIMPL2_VV(UINT64, JIT_ULMod, UINT64 dividend, UINT64 divisor)
 }
 HCIMPLEND
 
-#if !defined(_TARGET_X86_) | defined(FEATURE_PAL)
+#if !defined(_TARGET_X86_) || defined(FEATURE_PAL)
 /*********************************************************************/
 HCIMPL2_VV(UINT64, JIT_LLsh, UINT64 num, int shift)
 {

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -460,7 +460,7 @@ HCIMPL2_VV(UINT64, JIT_ULMod, UINT64 dividend, UINT64 divisor)
 }
 HCIMPLEND
 
-#if !defined(_WIN64) && !defined(_TARGET_X86_)
+#if !defined(_TARGET_X86_) | defined(FEATURE_PAL)
 /*********************************************************************/
 HCIMPL2_VV(UINT64, JIT_LLsh, UINT64 num, int shift)
 {
@@ -485,7 +485,7 @@ HCIMPL2_VV(UINT64, JIT_LRsz, UINT64 num, int shift)
 }
 HCIMPLEND
 
-#endif
+#endif // !_TARGET_X86_ || FEATURE_PAL
 
 #include <optdefault.h>
 

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -343,20 +343,23 @@ EXTERN_C FCDECL1_V(INT32, JIT_Dbl2IntOvf, double val);
 EXTERN_C FCDECL2_VV(float, JIT_FltRem, float dividend, float divisor);
 EXTERN_C FCDECL2_VV(double, JIT_DblRem, double dividend, double divisor);
 
-#if !defined(_WIN64) && !defined(_TARGET_X86_)
-EXTERN_C FCDECL2_VV(UINT64, JIT_LLsh, UINT64 num, int shift);
-EXTERN_C FCDECL2_VV(INT64, JIT_LRsh, INT64 num, int shift);
-EXTERN_C FCDECL2_VV(UINT64, JIT_LRsz, UINT64 num, int shift);
-#endif
+extern "C"
+{
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+    void STDCALL JIT_LLsh();                      // JIThelp.asm
+    void STDCALL JIT_LRsh();                      // JIThelp.asm
+    void STDCALL JIT_LRsz();                      // JIThelp.asm
+#else   // _TARGET_X86_ && !FEATURE_PAL
+    FCDECL2_VV(UINT64, JIT_LLsh, UINT64 num, int shift);
+    FCDECL2_VV(INT64, JIT_LRsh, INT64 num, int shift);
+    FCDECL2_VV(UINT64, JIT_LRsz, UINT64 num, int shift);
+#endif  // _TARGET_X86_ && !FEATURE_PAL
+}
 
 #ifdef _TARGET_X86_
 
 extern "C"
 {
-    void STDCALL JIT_LLsh();                      // JIThelp.asm
-    void STDCALL JIT_LRsh();                      // JIThelp.asm
-    void STDCALL JIT_LRsz();                      // JIThelp.asm
-
     void STDCALL JIT_CheckedWriteBarrierEAX(); // JIThelp.asm/JIThelp.s
     void STDCALL JIT_CheckedWriteBarrierEBX(); // JIThelp.asm/JIThelp.s
     void STDCALL JIT_CheckedWriteBarrierECX(); // JIThelp.asm/JIThelp.s


### PR DESCRIPTION
This commit enables portable SHFIT JIT Helpers for x86/Linux.