### PR TITLE
[x86/Linux] Fix all paths through this function will call itself

### DIFF
--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -49,9 +49,18 @@ static int __stdcall zeroFtn() {
     return 0;
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winfinite-recursion"
+#endif
+
 static int __stdcall recursiveFtn() {
     return recursiveFtn()+1;
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #pragma optimize("", on )
 


### PR DESCRIPTION
Fix compile error for x86/Linux
- disable "infinite-recursion" for "recursiveFtn" function
- only for clang