### PR TITLE
[x86/Linux] Fix indirection of non-volatile null pointer will be deleted

### DIFF
--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -1108,7 +1108,7 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
                     goto again;
                 }
 #ifndef _PREFIX_
-                *((int*) 0) = 1;        // If you get at this error, it is because yout
+                *((volatile int*) 0) = 1; // If you get at this error, it is because yout
                                         // set a breakpoint in a helpermethod frame epilog
                                         // you can't do that unfortunately.  Just move it
                                         // into the interior of the method to fix it  
@@ -1225,7 +1225,7 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
                 // FIX what to do here?
 #ifndef DACCESS_COMPILE
 #ifndef _PREFIX_
-                *((unsigned __int8**) 0) = ip;  // cause an access violation (Free Build assert)
+                *((volatile PTR_BYTE*) 0) = ip;  // cause an access violation (Free Build assert)
 #endif // !_PREFIX_                            
 #else
                 DacNotImpl();


### PR DESCRIPTION
Fix compile error for x86/Linux
- fix error "indirection of non-volatile null pointer will be deleted, not trap [-Werror,-Wnull-dereference]"
- using clang 3.8