### PR TITLE
[x86/Linux] Fix dangling ClrCaptureContext

### DIFF
--- a/src/inc/stacktrace.h
+++ b/src/inc/stacktrace.h
@@ -74,7 +74,7 @@ void GetStringFromStackLevels(UINT ifrStart, UINT cfrTotal, __out_ecount(cchMaxA
 ******************************************************************** robch */
 void GetStringFromAddr(DWORD_PTR dwAddr, __out_ecount(cchMaxAssertStackLevelStringLen) LPSTR szString);
 
-#if defined(_TARGET_X86_) && defined(FEATURE_CORECLR)
+#if defined(_TARGET_X86_) && defined(FEATURE_CORECLR) && !defined(FEATURE_PAL)
 /****************************************************************************
 * ClrCaptureContext *
 *-------------------*
@@ -83,9 +83,9 @@ void GetStringFromAddr(DWORD_PTR dwAddr, __out_ecount(cchMaxAssertStackLevelStri
 *       support this, so we need it for CoreCLR 4, if we require Win2K support
 ****************************************************************************/
 extern "C" void __stdcall ClrCaptureContext(__out PCONTEXT ctx);
-#else // _TARGET_X86_ && FEATURE_CORECLR
+#else // _TARGET_X86_ && FEATURE_CORECLR && !FEATURE_PAL
 #define ClrCaptureContext RtlCaptureContext
-#endif // _X86 && FEATURE_CORECLR else
+#endif // _TARGET_X86_ && FEATURE_CORECLR && !FEATURE_PAL
 
 
 #endif


### PR DESCRIPTION
Use RtlCaptureContext instead of ClrCaptureContext for x86/Linux