### PR TITLE
[x86/Linux] add a stub for THROW_CONTROL_FOR_THREAD_FUNCTION

### DIFF
--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -6,7 +6,7 @@
 
 extern "C"
 {
-    void RedirectForThrowControl()
+    void ThrowControlForThread()
     {
         PORTABILITY_ASSERT("Implement for PAL");
     }


### PR DESCRIPTION
THROW_CONTROL_FOR_THREAD_FUNCTION is defined as ThrowControlForThread
for x86/Linux, but unixstubs implements RedirectForThrowControl (which
corresponds to x64/Linux).

This commit renames RedirectForThrowControl as ThrowControlForThread to
fix dangling ThrowControlForThread reference in x86/Linux.