### PR TITLE
Compare opt against zero involving a shift oper.

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1174,13 +1174,17 @@ void Lowering::TreeNodeInfoInitShiftRotate(GenTree* tree)
     else
     {
         MakeSrcContained(tree, shiftBy);
-    }
 
-    // Codegen of shift oper sets ZF and SF flags.
-    // Note that Rotate Left/Right instructions don't set ZF and SF flags.
-    if (tree->OperIsShift())
-    {
-        tree->gtFlags |= GTF_ZSF_SET;
+        // Note that Rotate Left/Right instructions don't set ZF and SF flags.
+        //
+        // If the operand being shifted is 32-bits then upper three bits are masked
+        // by hardware to get actual shift count.  Similarly for 64-bit operands
+        // shift count is narrowed to [0..63].  If the resulting shift count is zero,
+        // then shift operation won't modify flags.
+        //
+        // TODO-CQ-XARCH: We can optimize generating 'test' instruction for GT_EQ/NE(shift, 0)
+        // if the shift count is known to be non-zero and in the range depending on the
+        // operand size.
     }
 }
 

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8460/GitHub_8460.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8460/GitHub_8460.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace bug
+{
+    class Program
+    {
+        static int Pass = 100;
+        static int Fail = -1;
+
+        // This test is meant to check that in case of
+        // GT_EQ/NE(shift, 0), JIT doesn't optimize out
+        // 'test' instruction incorrectly, because shift
+        // operations on xarch don't modify flags if the
+        // shift count is zero.
+        static int Main(string[] args)
+        {
+            // Absolute bits
+            int bitCount = 0;
+            while ((0 != (100 >> bitCount)) && (31 > bitCount))
+            {
+                bitCount++;
+            }
+            // Sign bit
+            bitCount++;
+
+            if (bitCount != 8)
+            {
+                return Fail;
+            }
+
+            return Pass;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8460/GitHub_8460.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8460/GitHub_8460.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
This is a regression introduced by PR https://github.com/dotnet/coreclr/pull/7787
That PR meant to optimize test instruction in case of GT_EQ/NE comparison against zero.

On xarch shift instructions (SAL/SAR/SHR/SHL) modify SF/ZF flags provided shift count is not zero.  The following is a repro case whose very first iteration through the loop involves shift-right by zero shift count and hence the loop will not be executed since 'test' instruction is incorrectly optimized out.

```
           // Absolute bits
            int bitCount = 0;
            while ((0 != (100 >> bitCount)) && (31 > bitCount))
            {
                bitCount++;
            }
            // Sign bit
            bitCount++;
```

On xarch depending on the operand size, hardware narrows down shift count by masking upper bits.   Flags are not modified if the resulting shift count is zero.

Fix: For now disabling compare opt peep for GT_EQ/NE(shift, 0).

Filed issue https://github.com/dotnet/coreclr/issues/8462 to track re-doing this optimization correctly.

Fixes #8460
