### PR TITLE
Allow remorph of SIMD assignment

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -10579,7 +10579,7 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                 {
                     // We should check whether op2 should be assigned to a SIMD field or not.
                     // If it is, we should tranlate the tree to simd intrinsic.
-                    assert((tree->gtDebugFlags & GTF_DEBUG_NODE_MORPHED) == 0);
+                    assert(!fgGlobalMorph || ((tree->gtDebugFlags & GTF_DEBUG_NODE_MORPHED) == 0));
                     GenTreePtr newTree = fgMorphFieldAssignToSIMDIntrinsicSet(tree);
                     typ                = tree->TypeGet();
                     op1                = tree->gtGetOp1();


### PR DESCRIPTION
This fixes an assert exposed by JitStress=1.