### PR TITLE
x86: Deactivate P/Invoke frames after a native call.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2975,6 +2975,9 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
 #else
     const CORINFO_EE_INFO::InlinedCallFrameInfo& callFrameInfo = comp->eeGetEEInfo()->inlinedCallFrameInfo;
 
+    // ----------------------------------------------------------------------------------
+    // InlinedCallFrame.m_pCallerReturnAddress = nullptr
+
     GenTreeLclFld* const storeCallSiteTracker =
         new (comp, GT_STORE_LCL_FLD) GenTreeLclFld(GT_STORE_LCL_FLD, TYP_I_IMPL, comp->lvaInlinedPInvokeFrameVar,
                                                    callFrameInfo.offsetOfReturnAddress);


### PR DESCRIPTION
Although this does not appear to be strictly necessary, this matches
JIT32's behavior. With this change, the stack walker will ignore the
P/Invoke frame even while it is still present on its thread's frame
list.

Fixes VSO 297109.