### PR TITLE
Don't change a GT_DYN_BLK into a GT_BLK when the size is zero

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -9874,7 +9874,7 @@ void Compiler::gtDispNodeName(GenTree* tree)
     {
         sprintf_s(bufp, sizeof(buf), " %s_ovfl%c", name, 0);
     }
-    else if (tree->OperIsBlk() && (tree->AsBlk()->gtBlkSize != 0))
+    else if (tree->OperIsBlk() && !tree->OperIsDynBlk())
     {
         sprintf_s(bufp, sizeof(buf), " %s(%d)", name, tree->AsBlk()->gtBlkSize);
     }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1171,6 +1171,16 @@ public:
         return OperIsBlk(OperGet());
     }
 
+    static bool OperIsDynBlk(genTreeOps gtOper)
+    {
+        return ((gtOper == GT_DYN_BLK) || (gtOper == GT_STORE_DYN_BLK));
+    }
+
+    bool OperIsDynBlk() const
+    {
+        return OperIsDynBlk(OperGet());
+    }
+
     static bool OperIsStoreBlk(genTreeOps gtOper)
     {
         return ((gtOper == GT_STORE_BLK) || (gtOper == GT_STORE_OBJ) || (gtOper == GT_STORE_DYN_BLK));

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -9217,9 +9217,18 @@ GenTree* Compiler::fgMorphBlkNode(GenTreePtr tree, bool isDest)
         if (blkNode->AsDynBlk()->gtDynamicSize->IsCnsIntOrI())
         {
             unsigned size = (unsigned)blkNode->AsDynBlk()->gtDynamicSize->AsIntConCommon()->IconValue();
-            blkNode->AsDynBlk()->gtDynamicSize = nullptr;
-            blkNode->ChangeOper(GT_BLK);
-            blkNode->gtBlkSize = size;
+            // A GT_BLK with size of zero is not supported,
+            // so if we encounter such a thing we just leave it as a GT_DYN_BLK
+            if (size != 0)
+            {
+                blkNode->AsDynBlk()->gtDynamicSize = nullptr;
+                blkNode->ChangeOper(GT_BLK);
+                blkNode->gtBlkSize = size;
+            }
+            else
+            {
+                return tree;
+            }
         }
         else
         {


### PR DESCRIPTION
We should not transform a GT_DYN_BLK with a constant zero size into a… GT_BLK as we do not support a GT_BLK of size zero.

Fixes VSO 287663