### PR TITLE
[x86/Linux][SOS] Disable ARM target support for xplat

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -24,7 +24,9 @@ elseif(CLR_CMAKE_PLATFORM_ARCH_I386)
   add_definitions(-DSOS_TARGET_X86=1)
   add_definitions(-D_TARGET_X86_=1)
   add_definitions(-DDBG_TARGET_32BIT)
-  add_definitions(-DSOS_TARGET_ARM=1)
+  if(WIN32)
+    add_definitions(-DSOS_TARGET_ARM=1)
+  endif(WIN32)
 elseif(CLR_CMAKE_PLATFORM_ARCH_ARM)
   add_definitions(-DSOS_TARGET_ARM=1)
   add_definitions(-D_TARGET_WIN32_=1)
@@ -155,8 +157,13 @@ if(CLR_CMAKE_PLATFORM_ARCH_AMD64)
 elseif(CLR_CMAKE_PLATFORM_ARCH_I386)
   set(SOS_SOURCES_ARCH 
     disasmX86.cpp
-    disasmARM.cpp
   )
+  if(WIN32)
+    list(APPEND
+      SOS_SOURCES_ARCH
+      disasmARM.cpp
+    )
+  endif(WIN32)
 elseif(CLR_CMAKE_PLATFORM_ARCH_ARM)
   set(SOS_SOURCES_ARCH
     disasmARM.cpp


### PR DESCRIPTION
This PR disables SOS ARM target for xplat and exclude `disasmARM.cpp` file 