### PR TITLE
[x86/Linux] Fix inconsistent GetCLRFunction definitions

### DIFF
--- a/src/dlls/mscoree/mscoree.cpp
+++ b/src/dlls/mscoree/mscoree.cpp
@@ -75,8 +75,6 @@ HINSTANCE g_hThisInst;  // This library.
 
 #include <process.h> // for __security_init_cookie()
 
-#include <utilcode.h>
-
 extern "C" IExecutionEngine* __stdcall IEE();
 
 #ifdef NO_CRT_INIT

--- a/src/dlls/mscoree/mscoree.cpp
+++ b/src/dlls/mscoree/mscoree.cpp
@@ -75,7 +75,7 @@ HINSTANCE g_hThisInst;  // This library.
 
 #include <process.h> // for __security_init_cookie()
 
-void* __stdcall GetCLRFunction(LPCSTR FunctionName);
+#include <utilcode.h>
 
 extern "C" IExecutionEngine* __stdcall IEE();
 

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -5766,4 +5766,6 @@ extern SpinConstants g_SpinConstants;
 
 // ======================================================================================
 
+void* __stdcall GetCLRFunction(LPCSTR FunctionName);
+
 #endif // __UtilCode_h__

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -306,7 +306,6 @@ extern "C" HRESULT __cdecl CorDBGetInterface(DebugInterface** rcInterface);
 
 
 #if !defined(FEATURE_CORECLR) && !defined(CROSSGEN_COMPILE)
-#include <utilcode.h>
 
 // Pointer to the activated CLR interface provided by the shim.
 ICLRRuntimeInfo *g_pCLRRuntime = NULL;

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -306,7 +306,7 @@ extern "C" HRESULT __cdecl CorDBGetInterface(DebugInterface** rcInterface);
 
 
 #if !defined(FEATURE_CORECLR) && !defined(CROSSGEN_COMPILE)
-void* __stdcall GetCLRFunction(LPCSTR FunctionName);
+#include <utilcode.h>
 
 // Pointer to the activated CLR interface provided by the shim.
 ICLRRuntimeInfo *g_pCLRRuntime = NULL;

--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -15,6 +15,7 @@
 #include "posterror.h"
 #include "eemessagebox.h"
 #include "newapis.h"
+#include "utilcode.h"
 
 #include <shlobj.h>
 
@@ -2551,7 +2552,7 @@ extern BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
 extern void ShutdownRuntimeWithoutExiting(int exitCode);
 extern BOOL IsRuntimeStarted(DWORD *pdwStartupFlags);
 
-void * GetCLRFunction(LPCSTR FunctionName)
+void * __stdcall GetCLRFunction(LPCSTR FunctionName)
 {
 
     void* func = NULL;

--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -15,7 +15,6 @@
 #include "posterror.h"
 #include "eemessagebox.h"
 #include "newapis.h"
-#include "utilcode.h"
 
 #include <shlobj.h>
 


### PR DESCRIPTION
GetCLRFunction is treated as pfnGetCLRFunction_t which has __stdcall
convention, but is  implemented without __stdcall.

This inconsistency causes segmentaion fault while initializing CoreCLR
for x86/Linux.

This commit fixes such inconsistency via adding __stdcall to
GetCLRFunction implementation.

In addition, this commit introduces 'callback.h' which declares GetCLRFunction,
and revises .cpp files to include 'callback.h' instead of declaring
'GetCLRFunction'.