### PR TITLE
[x86/Linux][SOS] Fix DataTarget::GetPointerSize for x86

### DIFF
--- a/src/ToolBox/SOS/Strike/datatarget.cpp
+++ b/src/ToolBox/SOS/Strike/datatarget.cpp
@@ -83,7 +83,7 @@ DataTarget::GetPointerSize(
 {
 #if defined(SOS_TARGET_AMD64) || defined(SOS_TARGET_ARM64)
     *size = 8;
-#elif defined(SOS_TARGET_ARM)
+#elif defined(SOS_TARGET_ARM) || defined(SOS_TARGET_X86)
     *size = 4;
 #else
   #error Unsupported architecture


### PR DESCRIPTION
This PR fixes `Unsupported architecture` error in DataTarget::GetPointerSize method.