### PR TITLE
[x86/Linux][SOS] Don't include utilcode.h in gcdump(x86).cpp 

### DIFF
--- a/src/gcdump/gcdump.cpp
+++ b/src/gcdump/gcdump.cpp
@@ -11,7 +11,9 @@
  * to the standard code-manager spec.
  */
 
+#ifndef FEATURE_PAL
 #include "utilcode.h"           // For _ASSERTE()
+#endif //!FEATURE_PAL
 #include "gcdump.h"
 
 /*****************************************************************************/

--- a/src/gcdump/i386/gcdumpx86.cpp
+++ b/src/gcdump/i386/gcdumpx86.cpp
@@ -9,7 +9,9 @@
 #ifdef _TARGET_X86_
 /*****************************************************************************/
 
+#ifndef FEATURE_PAL
 #include "utilcode.h"           // For _ASSERTE()
+#endif //!FEATURE_PAL
 #include "gcdump.h"
 
 


### PR DESCRIPTION
This PR fixes build issues related to include utilcode.h in gcdump.cpp and gcdumpx86.cpp files.  According to comment utilcode.h is needed for _ASSERTE() only.  
```

[ 99%] Building CXX object src/ToolBox/SOS/Strike/CMakeFiles/sos.dir/datatarget.cpp.o
[ 99%] Building CXX object src/ToolBox/SOS/Strike/CMakeFiles/sos.dir/disasm.cpp.o
[ 99%] Building CXX object src/ToolBox/SOS/Strike/CMakeFiles/sos.dir/exts.cpp.o
[ 99%] Building CXX object src/ToolBox/SOS/Strike/CMakeFiles/sos.dir/eeheap.cpp.o
[ 99%] Building CXX object src/ToolBox/SOS/Strike/CMakeFiles/sos.dir/gchist.cpp.o
[ 99%] Building CXX object src/ToolBox/SOS/Strike/CMakeFiles/sos.dir/gcroot.cpp.o
[ 99%] Building CXX object src/ToolBox/SOS/Strike/CMakeFiles/sos.dir/metadata.cpp.o
In file included from /home/epavlov/Git/coreclr/src/ToolBox/SOS/Strike/disasm.cpp:41:
In file included from /home/epavlov/Git/coreclr/src/gcdump/gcdump.cpp:14:
In file included from /home/epavlov/Git/coreclr/src/inc/utilcode.h:15:
/home/epavlov/Git/coreclr/src/inc/winwrap.h:958:9: error: no matching function for call to 'fwprintf'
        fwprintf(stdout, W("%s"), wszBuffer);
        ^~~~~~~~
/home/epavlov/Git/coreclr/cross/rootfs/x86/usr/include/wchar.h:594:12: note: candidate function not viable: no known conversion from 'const char16_t [3]' to 'const wchar_t *__restrict' for 2nd argument
extern int fwprintf (__FILE *__restrict __stream,
           ^
In file included from /home/epavlov/Git/coreclr/src/ToolBox/SOS/Strike/disasm.cpp:41:
In file included from /home/epavlov/Git/coreclr/src/gcdump/gcdump.cpp:14:
In file included from /home/epavlov/Git/coreclr/src/inc/utilcode.h:26:
In file included from /home/epavlov/Git/coreclr/src/inc/clrhost.h:20:
/home/epavlov/Git/coreclr/src/inc/new.hpp:20:16: error: 'operator new' cannot be declared inside a namespace
void * __cdecl operator new(size_t n, const NoThrow&) NOEXCEPT;
               ^
/home/epavlov/Git/coreclr/src/inc/new.hpp:21:16: error: 'operator new[]' cannot be declared inside a namespace
void * __cdecl operator new[](size_t n, const NoThrow&) NOEXCEPT;
               ^
In file included from /home/epavlov/Git/coreclr/src/ToolBox/SOS/Strike/disasm.cpp:41:
In file included from /home/epavlov/Git/coreclr/src/gcdump/gcdump.cpp:14:
In file included from /home/epavlov/Git/coreclr/src/inc/utilcode.h:28:
In file included from /home/epavlov/Git/coreclr/src/inc/corhlprpriv.h:15:
/home/epavlov/Git/coreclr/src/inc/fstring.h:28:57: error: unknown type name '__out'
    HRESULT Unicode_Utf8_Length(__in_z LPCWSTR pString, __out bool * pAllAscii, __out DWORD * pLength);
                                                        ^
/home/epavlov/Git/coreclr/src/inc/fstring.h:28:63: error: expected ')'
    HRESULT Unicode_Utf8_Length(__in_z LPCWSTR pString, __out bool * pAllAscii, __out DWORD * pLength);
                                                              ^
/home/epavlov/Git/coreclr/src/inc/fstring.h:28:32: note: to match this '('
    HRESULT Unicode_Utf8_Length(__in_z LPCWSTR pString, __out bool * pAllAscii, __out DWORD * pLength);
                               ^
/home/epavlov/Git/coreclr/src/inc/fstring.h:34:56: error: unknown type name '__out'
    HRESULT Utf8_Unicode_Length(__in_z LPCSTR pString, __out bool * pAllAscii, __out DWORD * pLength);
                                                       ^
/home/epavlov/Git/coreclr/src/inc/fstring.h:34:62: error: expected ')'
    HRESULT Utf8_Unicode_Length(__in_z LPCSTR pString, __out bool * pAllAscii, __out DWORD * pLength);
                                                             ^
/home/epavlov/Git/coreclr/src/inc/fstring.h:34:32: note: to match this '('
    HRESULT Utf8_Unicode_Length(__in_z LPCSTR pString, __out bool * pAllAscii, __out DWORD * pLength);
                               ^
In file included from /home/epavlov/Git/coreclr/src/ToolBox/SOS/Strike/disasm.cpp:41:
In file included from /home/epavlov/Git/coreclr/src/gcdump/gcdump.cpp:14:
In file included from /home/epavlov/Git/coreclr/src/inc/utilcode.h:28:
/home/epavlov/Git/coreclr/src/inc/corhlprpriv.h:60:20: error: no matching function for call to 'operator new[]'
            return NEW_NOTHROW(iItems);
                   ^~~~~~~~~~~~~~~~~~~
/home/epavlov/Git/coreclr/src/inc/corhlpr.h:33:29: note: expanded from macro 'NEW_NOTHROW'
#define NEW_NOTHROW(_bytes) new (nothrow) BYTE[_bytes]
                            ^   ~~~~~~~~~
/home/epavlov/Git/coreclr/cross/rootfs/x86/usr/lib/gcc/i686-linux-gnu/4.8/../../../../include/c++/4.8/new:101:7: note: candidate function not viable: no known conversion from 'const X86GCDump::NoThrow' to
      'const std::nothrow_t' for 2nd argument
void* operator new[](std::size_t, const std::nothrow_t&) _GLIBCXX_USE_NOEXCEPT
      ^
/home/epavlov/Git/coreclr/cross/rootfs/x86/usr/lib/gcc/i686-linux-gnu/4.8/../../../../include/c++/4.8/new:111:14: note: candidate function not viable: no known conversion from 'const X86GCDump::NoThrow' to
      'void *' for 2nd argument
inline void* operator new[](std::size_t, void* __p) _GLIBCXX_USE_NOEXCEPT
             ^
/home/epavlov/Git/coreclr/cross/rootfs/x86/usr/lib/gcc/i686-linux-gnu/4.8/../../../../include/c++/4.8/new:93:7: note: candidate function not viable: requires 1 argument, but 2 were provided
void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      ^
In file included from /home/epavlov/Git/coreclr/src/ToolBox/SOS/Strike/disasm.cpp:41:
In file included from /home/epavlov/Git/coreclr/src/gcdump/gcdump.cpp:14:
In file included from /home/epavlov/Git/coreclr/src/inc/utilcode.h:28:
/home/epavlov/Git/coreclr/src/inc/corhlprpriv.h:288:40: error: cannot initialize a parameter of type 'LPCWSTR' (aka 'const char16_t *') with an lvalue of type 'const WCHAR *' (aka 'const wchar_t *')
            hr = FString::Unicode_Utf8(pString, allAscii, buffer, length);

```