### PR TITLE
Use only lower floats for Vector3 dot and equality

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -955,6 +955,9 @@ public:
                                        //                  struct fields constituting a single call argument.
 
 //----------------------------------------------------------------
+#define GTF_SIMD12_OP 0x80000000 // GT_SIMD -- Indicates that the operands need to be handled as SIMD12
+                                 //            even if they have been retyped as SIMD16.
+//----------------------------------------------------------------
 
 #define GTF_STMT_CMPADD 0x80000000  // GT_STMT    -- added by compiler
 #define GTF_STMT_HAS_CSE 0x40000000 // GT_STMT    -- CSE def or use was subsituted

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -754,7 +754,7 @@ SIMDIntrinsicID Compiler::impSIMDLongRelOpEqual(CORINFO_CLASS_HANDLE typeHnd,
     //
     // Equality(v1, v2):
     // tmp = (v1 == v2) i.e. compare for equality as if v1 and v2 are vector<int>
-    // result = BitwiseAnd(t, shuffle(t, (2, 3, 1 0)))
+    // result = BitwiseAnd(t, shuffle(t, (2, 3, 0, 1)))
     // Shuffle is meant to swap the comparison results of low-32-bits and high 32-bits of respective long elements.
 
     // Compare vector<long> as if they were vector<int> and assign the result to a temp
@@ -768,7 +768,7 @@ SIMDIntrinsicID Compiler::impSIMDLongRelOpEqual(CORINFO_CLASS_HANDLE typeHnd,
     // op2 = Shuffle(tmp, 0xB1)
     // IntrinsicId = BitwiseAnd
     *pOp1 = gtNewOperNode(GT_COMMA, simdType, asg, tmp);
-    *pOp2 = gtNewSIMDNode(simdType, gtNewLclvNode(lclNum, simdType), gtNewIconNode(SHUFFLE_ZWYX, TYP_INT),
+    *pOp2 = gtNewSIMDNode(simdType, gtNewLclvNode(lclNum, simdType), gtNewIconNode(SHUFFLE_ZWXY, TYP_INT),
                           SIMDIntrinsicShuffleSSE2, TYP_INT, size);
     return SIMDIntrinsicBitwiseAnd;
 }
@@ -2248,7 +2248,11 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
             assert(op2->TypeGet() == simdType);
 
             simdTree = gtNewSIMDNode(genActualType(callType), op1, op2, SIMDIntrinsicOpEquality, baseType, size);
-            retVal   = simdTree;
+            if (simdType == TYP_SIMD12)
+            {
+                simdTree->gtFlags |= GTF_SIMD12_OP;
+            }
+            retVal = simdTree;
         }
         break;
 
@@ -2259,7 +2263,11 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
             op2      = impSIMDPopStack(simdType);
             op1      = impSIMDPopStack(simdType, instMethod);
             simdTree = gtNewSIMDNode(genActualType(callType), op1, op2, SIMDIntrinsicOpInEquality, baseType, size);
-            retVal   = simdTree;
+            if (simdType == TYP_SIMD12)
+            {
+                simdTree->gtFlags |= GTF_SIMD12_OP;
+            }
+            retVal = simdTree;
         }
         break;
 
@@ -2407,7 +2415,11 @@ GenTreePtr Compiler::impSIMDIntrinsic(OPCODE                opcode,
             op1 = impSIMDPopStack(simdType, instMethod);
 
             simdTree = gtNewSIMDNode(baseType, op1, op2, simdIntrinsicID, baseType, size);
-            retVal   = simdTree;
+            if (simdType == TYP_SIMD12)
+            {
+                simdTree->gtFlags |= GTF_SIMD12_OP;
+            }
+            retVal = simdTree;
         }
         break;
 

--- a/src/jit/simd.h
+++ b/src/jit/simd.h
@@ -32,11 +32,16 @@ struct SIMDIntrinsicInfo
 #ifdef _TARGET_XARCH_
 // SSE2 Shuffle control byte to shuffle vector <W, Z, Y, X>
 // These correspond to shuffle immediate byte in shufps SSE2 instruction.
-#define SHUFFLE_XXXX 0x00
-#define SHUFFLE_ZWYX 0xB1
-#define SHUFFLE_WWYY 0xF5
-#define SHUFFLE_ZZXX 0xA0
-#endif // _TARGET_XARCH_
+#define SHUFFLE_XXXX 0x00 // 00 00 00 00
+#define SHUFFLE_XXWW 0x0F // 00 00 11 11
+#define SHUFFLE_XYZW 0x1B // 00 01 10 11
+#define SHUFFLE_YXYX 0x44 // 01 00 01 00
+#define SHUFFLE_YYZZ 0x5A // 01 01 10 10
+#define SHUFFLE_ZXXY 0x81 // 10 00 00 01
+#define SHUFFLE_ZWXY 0xB1 // 10 11 00 01
+#define SHUFFLE_WWYY 0xF5 // 11 11 01 01
+#define SHUFFLE_ZZXX 0xA0 // 10 10 00 00
+#endif
 
 #endif // FEATURE_SIMD
 

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8220/GitHub_8220.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8220/GitHub_8220.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Regression test for Vector3 intrinsics using upper non-zero'd bits from
+// a byref return.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+
+namespace Test
+{
+
+    public class Program
+    {
+        static Random random;
+
+        static Program()
+        {
+            random = new Random(1);
+        }
+
+        [MethodImpl( MethodImplOptions.NoInlining )]
+        public static double StackScribble()
+        {
+            double d1 = random.NextDouble();
+            double d2 = random.NextDouble();
+            double d3 = random.NextDouble();
+            double d4 = random.NextDouble();
+            double d5 = random.NextDouble();
+            double d6 = random.NextDouble();
+            double d7 = random.NextDouble();
+            double d8 = random.NextDouble();
+            double d9 = random.NextDouble();
+            double d10 = random.NextDouble();
+            double d11 = random.NextDouble();
+            double d12 = random.NextDouble();
+            double d13 = random.NextDouble();
+            double d14 = random.NextDouble();
+            double d15 = random.NextDouble();
+            double d16 = random.NextDouble();
+            double d17 = random.NextDouble();
+            double d18 = random.NextDouble();
+            double d19 = random.NextDouble();
+            double d20 = random.NextDouble();
+            double d21 = random.NextDouble();
+            double d22 = random.NextDouble();
+            double d23 = random.NextDouble();
+            double d24 = random.NextDouble();
+            double d25 = random.NextDouble();
+            double d26 = random.NextDouble();
+            double d27 = random.NextDouble();
+            double d28 = random.NextDouble();
+            double d29 = random.NextDouble();
+            double d30 = random.NextDouble();
+            double d31 = random.NextDouble();
+            double d32 = random.NextDouble();
+            double d33 = random.NextDouble();
+            double d34 = random.NextDouble();
+            double d35 = random.NextDouble();
+            double d36 = random.NextDouble();
+            double d37 = random.NextDouble();
+            double d38 = random.NextDouble();
+            double d39 = random.NextDouble();
+            double d40 = random.NextDouble();
+            return d1 + d2 + d3 + d4 + d5 + d6 + d7 + d8 + d9 + d10 +
+                   d11 + d12 + d13 + d14 + d15 + d16 + d17 + d18 + d19 + d20 +
+                   d21 + d22 + d23 + d24 + d25 + d26 + d27 + d28 + d29 + d20 +
+                   d31 + d32 + d33 + d34 + d35 + d36 + d37 + d38 + d39 + d40;
+        }
+
+        [MethodImpl( MethodImplOptions.NoInlining )]
+        public static Vector3 getTestValue(float f1, float f2, float f3)
+        {
+            return new Vector3(f1, f2, f3);
+        }
+
+        public static bool Check(float value, float expectedValue)
+        {
+            // These may differ in the last place.
+            float expectedValueLow;
+            float expectedValueHigh;
+
+            unsafe
+            {
+                UInt32 expectedValueUInt = *(UInt32*)&expectedValue;
+                UInt32 expectedValueUIntLow = (expectedValueUInt == 0) ? 0 : expectedValueUInt - 1;
+                UInt32 expectedValueUIntHigh = (expectedValueUInt == 0xffffffff) ? 0xffffffff : expectedValueUInt + 1;
+                expectedValueLow = *(float*)&expectedValueUIntLow;
+                expectedValueHigh = *(float*)&expectedValueUIntHigh;
+            }
+            float errorMargin = Math.Abs(expectedValueHigh - expectedValueLow);
+            if (Math.Abs(value - expectedValue) > errorMargin)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static int testDotProduct(Vector3 v0)
+        {
+            float f1 = (float)random.NextDouble();
+            float f2 = (float)random.NextDouble();
+            float f3 = (float)random.NextDouble();
+
+            Vector3 v1 = Vector3.Normalize(getTestValue(f1, f2, f3) - v0);
+            Vector3 v2 = new Vector3(f1, f2, f3) - v0;
+            v2 = v2 / v2.Length();
+
+            if (!Check(v1.X, v2.X) || !Check(v1.Y, v2.Y) || !Check(v1.Z, v2.Z))
+            {
+                Console.WriteLine("Vectors do not match " + v1 + v2);
+                return -1;
+            }
+
+            return 100;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static int testEquals(Vector3 v0)
+        {
+            float f1 = (float)random.NextDouble();
+            float f2 = (float)random.NextDouble();
+            float f3 = (float)random.NextDouble();
+
+            Vector3 v1 = new Vector3(f1, f2, f3) - v0;
+            bool result = v1.Equals(getTestValue(f1, f2, f3) - v0);
+
+            if ((result == false) || !v1.Equals(getTestValue(f1, f2, f3) - v0))
+            {
+                Console.WriteLine("Equals returns wrong value " + v1);
+                return -1;
+            }
+
+            return 100;
+        }
+
+        public static int Main()
+        {
+            int returnValue = 100;
+            Console.WriteLine("Testing Dot Product");
+            for (int i = 0; i < 10; i++)
+            {
+                StackScribble();
+                if (testDotProduct(new Vector3(1.0F, 2.0F, 3.0F)) != 100)
+                {
+                    Console.WriteLine("Failed on iteration " + i);
+                    returnValue = -1;
+                    break;
+                }
+            }
+            Console.WriteLine("Testing Equals");
+            for (int i = 0; i < 10; i++)
+            {
+                StackScribble();
+                if (testEquals(new Vector3(1.0F, 2.0F, 3.0F)) != 100)
+                {
+                    Console.WriteLine("Failed on iteration " + i);
+                    returnValue = -1;
+                    break;
+                }
+            }
+            return returnValue;
+        }
+    }
+}
+

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8220/GitHub_8220.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8220/GitHub_8220.csproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{76E69AA0-8C5A-4F76-8561-B8089FFA8D79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)benchmark\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)benchmark\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
For both dot product and comparisons that produce a boolean result, we need to use only the lower 3 floats. The bug was exposed by a case where the result of a call was being used in one of these operations without being stored to a local (which would have caused the upper bits to be cleared).

Fix #8220