### PR TITLE
[x86/Linux] Port PATCH_LABEL macro

### DIFF
--- a/src/pal/inc/unixasmmacrosx86.inc
+++ b/src/pal/inc/unixasmmacrosx86.inc
@@ -20,6 +20,11 @@ C_FUNC(\Name):
         .cfi_startproc
 .endm
 
+.macro PATCH_LABEL Name
+        .global C_FUNC(\Name)
+C_FUNC(\Name):
+.endm
+
 .macro LEAF_END Name, Section
         .size \Name, .-\Name
         .cfi_endproc


### PR DESCRIPTION
This commit ports PATCH_LABEL as the first step to port various assembies to x86/Linux