### PR TITLE
GcInfoEncoder: Initialize the BitArrays tracking liveness

### DIFF
--- a/src/gcinfo/gcinfoencoder.cpp
+++ b/src/gcinfo/gcinfoencoder.cpp
@@ -1163,7 +1163,8 @@ void GcInfoEncoder::Build()
     int size_tCount = (m_NumSlots + BITS_PER_SIZE_T - 1) / BITS_PER_SIZE_T;
     BitArray liveState(m_pAllocator, size_tCount);
     BitArray couldBeLive(m_pAllocator, size_tCount);
-
+    liveState.ClearAll();
+    couldBeLive.ClearAll();
 
 #ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
     _ASSERTE(m_NumCallSites == 0 || m_pCallSites != NULL);


### PR DESCRIPTION
The non-X86 GcInfoEncoder library uses two bit-arrays to keep track
of pointer-liveness. The BitArrays are allocated using the arena allocator
which doesn't zero-initialize them. This was causing non-deterministic
redundant allocation of unused slots. This change fixes the problem.