### PR TITLE
Admit block nodes in `GenTree::AsOp`.

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -267,7 +267,7 @@ struct GenTree
 #define GTSTRUCT_0(fn, en)                                                                                             \
     GenTree##fn* As##fn()                                                                                              \
     {                                                                                                                  \
-        assert(this->OperIsSimple());                                                                                  \
+        assert(this->OperIsSimple() || this->OperIsBlk());                                                             \
         return reinterpret_cast<GenTree##fn*>(this);                                                                   \
     }                                                                                                                  \
     GenTree##fn& As##fn##Ref()                                                                                         \


### PR DESCRIPTION
All block nodes are subtypes of `GenTreeOp`, but not all block nodes are
simple nodes: in particular, DYN_BLK and STORE_DYN_BLK are special
nodes. Because these nodes are not considered "simple", `GenTree::AsOp`
currently asserts when called on such a node. This change relaxes the
assertion to admit block nodes as well as simple nodes.

Fixes VSO 289704.