### PR TITLE
[x86/Linux][SOS] Get correct stack pointer from DT_CONTEXT

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/services.cpp
+++ b/src/ToolBox/SOS/lldbplugin/services.cpp
@@ -167,6 +167,8 @@ LLDBServices::VirtualUnwind(
 
 #ifdef DBG_TARGET_AMD64
     DWORD64 spToFind = dtcontext->Rsp;
+#elif DBG_TARGET_X86
+    DWORD spToFind = dtcontext->Esp;
 #elif DBG_TARGET_ARM
     DWORD spToFind = dtcontext->Sp;
 #endif


### PR DESCRIPTION
This PR fixes getting stack pointer from DT_CONTEXT in lldbplugin.
These changes fix build issue below:
```
[100%] Built target sos
[100%] Building CXX object src/ToolBox/SOS/lldbplugin/CMakeFiles/sosplugin.dir/services.cpp.o
/home/epavlov/Git/coreclr/src/ToolBox/SOS/lldbplugin/services.cpp:193:21: error: use of undeclared identifier 'spToFind'
                if (spToFind >= sp && spToFind < spNext)
                    ^
/home/epavlov/Git/coreclr/src/ToolBox/SOS/lldbplugin/services.cpp:193:39: error: use of undeclared identifier 'spToFind'
                if (spToFind >= sp && spToFind < spNext)
                                      ^
```

