### PR TITLE
Ryujit/ARM32: Start implementing Lowering::TreeNodeInfoInit for ARM32

### DIFF
--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -136,9 +136,11 @@ private:
 
     void TreeNodeInfoInitCheckByteable(GenTree* tree);
 
-#if defined(_TARGET_XARCH_)
+#if defined(_TARGET_XARCH_) || defined(_TARGET_ARM_)
     void TreeNodeInfoInitSimple(GenTree* tree);
+#endif
 
+#if defined(_TARGET_XARCH_)
     //----------------------------------------------------------------------
     // SetRegOptional - sets a bit to indicate to LSRA that register
     // for a given tree node is optional for codegen purpose.  If no

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -128,32 +128,8 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         // TODO-ARM-Cleanup: These cases can be fit into "default" case after
         // other remaining types are implmented.
         case GT_IL_OFFSET:
-            info->srcCount = 0;
-            info->dstCount = 0;
-            break;
-        // TODO-ARM-Cleanup: These cases can be fit into "default" case after
-        // other remaining types are implmented.
         case GT_CNS_INT:
-            info->dstCount = (tree->TypeGet() == TYP_VOID) ? 0 : 1;
-            if (kind & (GTK_CONST | GTK_LEAF))
-            {
-                info->srcCount = 0;
-            }
-            else if (kind & (GTK_SMPOP))
-            {
-                if (tree->gtGetOp2() != nullptr)
-                {
-                    info->srcCount = 2;
-                }
-                else
-                {
-                    info->srcCount = 1;
-                }
-            }
-            else
-            {
-                unreached();
-            }
+            TreeNodeInfoInitSimple(tree);
             break;
 
         // TODO-ARM-Cleanup: Remove this "default" case, and replace above cases with
@@ -171,6 +147,44 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
     // We need to be sure that we've set info->srcCount and info->dstCount appropriately
     assert((info->dstCount < 2) || tree->IsMultiRegCall());
 }
+
+//------------------------------------------------------------------------
+// TreeNodeInfoInitSimple: Sets the srcCount and dstCount for all the trees
+// without special handling based on the tree node type.
+//
+// Arguments:
+//    tree      - The node of interest
+//
+// Return Value:
+//    None.
+//
+
+void Lowering::TreeNodeInfoInitSimple(GenTree* tree)
+{
+    TreeNodeInfo* info = &(tree->gtLsraInfo);
+    unsigned      kind = tree->OperKind();
+    info->dstCount     = (tree->TypeGet() == TYP_VOID) ? 0 : 1;
+    if (kind & (GTK_CONST | GTK_LEAF))
+    {
+        info->srcCount = 0;
+    }
+    else if (kind & (GTK_SMPOP))
+    {
+        if (tree->gtGetOp2() != nullptr)
+        {
+            info->srcCount = 2;
+        }
+        else
+        {
+            info->srcCount = 1;
+        }
+    }
+    else
+    {
+        unreached();
+    }
+}
+
 //------------------------------------------------------------------------
 // TreeNodeInfoInitReturn: Set the NodeInfo for a GT_RETURN.
 //

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -164,12 +164,61 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 
         // Please add new types below
         case GT_RETURN:
-            NYI("ARM TreeNodeInfoInit(GT_RETURN)");
+            TreeNodeInfoInitReturn(tree);
             break;
     } // end switch (tree->OperGet())
 
     // We need to be sure that we've set info->srcCount and info->dstCount appropriately
     assert((info->dstCount < 2) || tree->IsMultiRegCall());
+}
+//------------------------------------------------------------------------
+// TreeNodeInfoInitReturn: Set the NodeInfo for a GT_RETURN.
+//
+// Arguments:
+//    tree      - The node of interest
+//
+// Return Value:
+//    None.
+//
+void Lowering::TreeNodeInfoInitReturn(GenTree* tree)
+{
+    TreeNodeInfo* info     = &(tree->gtLsraInfo);
+    LinearScan*   l        = m_lsra;
+    Compiler*     compiler = comp;
+
+    GenTree*  op1           = tree->gtGetOp1();
+    regMaskTP useCandidates = RBM_NONE;
+
+    info->srcCount = (tree->TypeGet() == TYP_VOID) ? 0 : 1;
+    info->dstCount = 0;
+
+    if (varTypeIsStruct(tree))
+    {
+        NYI_ARM("ARM TreeNodeInfoInitReturn for struct");
+    }
+    else
+    {
+        // Non-struct type return - determine useCandidates
+        switch (tree->TypeGet())
+        {
+            case TYP_VOID:
+                useCandidates = RBM_NONE;
+                break;
+            case TYP_FLOAT:
+            case TYP_DOUBLE:
+            case TYP_LONG: // We should consider register layout for TYP_LONG
+                NYI_ARM("ARM TreeNodeInfoInitReturn for VOID, FLOAT, DOUBLE, LONG");
+                break;
+            default:
+                useCandidates = RBM_INTRET;
+                break;
+        }
+    }
+
+    if (useCandidates != RBM_NONE)
+    {
+        op1->gtLsraInfo.setSrcCandidates(l, useCandidates);
+    }
 }
 
 // returns true if the tree can use the read-modify-write memory instruction form

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -125,9 +125,14 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
     {
         // Please add new types below "default" case except cases which can be fit into "default" case.
 
-        // TODO-ARM-Cleanup: These cases should be replaced with "default" case after
+        // TODO-ARM-Cleanup: These cases can be fit into "default" case after
         // other remaining types are implmented.
         case GT_IL_OFFSET:
+            info->srcCount = 0;
+            info->dstCount = 0;
+            break;
+        // TODO-ARM-Cleanup: These cases can be fit into "default" case after
+        // other remaining types are implmented.
         case GT_CNS_INT:
             info->dstCount = (tree->TypeGet() == TYP_VOID) ? 0 : 1;
             if (kind & (GTK_CONST | GTK_LEAF))


### PR DESCRIPTION
Related issue: #8501 

- Implement simple cases which should be default case later.
- Add template for incremental implemenation.
- Also fix typo in NYI message. 


I've tested it with `System.IO.ConsoleStream:get_CanSeek():bool` method.

```
IL_0000  16                ldc.i4.0
IL_0001  2a                ret
```

```
LSRA Block Sequence: BB01(   1  )
TreeNodeInfoInit for: N003 (  2,  2) [000003] -------------             *  il_offset void   IL offset: 0 REG NA
TreeNodeInfoInit for: N005 (  1,  1) [000001] -------------             *  const     int    0 REG NA $40
TreeNodeInfoInit for: N007 (  2,  2) [000002] -------------             *  return    int    REG NA $c0
```

It now successfully lowers GT_IL_OFFSET and GT_CNG_INT which will become a default case later.
Still GT_RETURN is not implemented yet.

I hope we can start implementing together after this commit.

Signed-off-by: Hyung-Kyu Choi <hk0110.choi@samsung.com>