### PR TITLE
Remove private TimeZoneInfoComparer

### DIFF
--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -1010,7 +1010,12 @@ namespace System {
                     }
 
                     // sort and copy the TimeZoneInfo's into a ReadOnlyCollection for the user
-                    list.Sort(new TimeZoneInfoComparer());
+                    list.Sort((x, y) =>
+                    {
+                        // sort by BaseUtcOffset first and by DisplayName second - this is similar to the Windows Date/Time control panel
+                        int comparison = x.BaseUtcOffset.CompareTo(y.BaseUtcOffset);
+                        return comparison == 0 ? string.CompareOrdinal(x.DisplayName, y.DisplayName) : comparison;
+                    });
 
                     cachedData.m_readOnlySystemTimeZones = new ReadOnlyCollection<TimeZoneInfo>(list);
                 }          
@@ -5687,14 +5692,6 @@ namespace System {
                     m_state = State.StartOfToken;
                 }
                 return transition;
-            }
-        }
-
-        private class TimeZoneInfoComparer : System.Collections.Generic.IComparer<TimeZoneInfo> {
-            int System.Collections.Generic.IComparer<TimeZoneInfo>.Compare(TimeZoneInfo x, TimeZoneInfo y)  {
-                // sort by BaseUtcOffset first and by DisplayName second - this is similar to the Windows Date/Time control panel
-                int comparison = x.BaseUtcOffset.CompareTo(y.BaseUtcOffset);
-                return comparison == 0 ? String.Compare(x.DisplayName, y.DisplayName, StringComparison.Ordinal) : comparison;
             }
         }
 


### PR DESCRIPTION
Use `Comparison<T>` instead of `IComparer<T>` to sort the list of `TimeZoneInfo`s, which moves the comparison code to the sole place where it is used, and now that `Array.Sort` is implemented in terms of `Comparison<T>` instead of `IComparer<T>` (#8504), avoids some unnecessary intermediate allocations.