### PR TITLE
Avoid allocating in TimeZoneInfo.GetHashCode()

### DIFF
--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -973,7 +973,7 @@ namespace System {
         // GetHashCode -
         //
         public override int GetHashCode() {
-            return m_id.ToUpper(CultureInfo.InvariantCulture).GetHashCode();
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(m_id);
         }
 
         //


### PR DESCRIPTION
Avoid the intermediate `ToUpper` `string` allocation.