### PR TITLE
Simplify TimeZoneInfo.Equals(object)

### DIFF
--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -946,11 +946,7 @@ namespace System {
         }
 
         public override bool Equals(object obj) {
-            TimeZoneInfo tzi = obj as TimeZoneInfo;            
-            if (null == tzi) {
-                return false;
-            }            
-            return Equals(tzi);
+            return Equals(obj as TimeZoneInfo);
         }
 
         //    


### PR DESCRIPTION
`Equals(TimeZoneInfo)` already handles null.