### PR TITLE
[x86/Linux] Port Several Stubs as NYI

### DIFF
--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -112,3 +112,23 @@ VOID __cdecl PopSEHRecords(LPVOID pTargetSP)
 {
     PORTABILITY_ASSERT("Implement for PAL");
 }
+
+EXTERN_C VOID SinglecastDelegateInvokeStub()
+{
+    PORTABILITY_ASSERT("SinglecastDelegateInvokeStub");
+}
+
+EXTERN_C VOID ResolveWorkerChainLookupAsmStub()
+{
+    PORTABILITY_ASSERT("ResolveWorkerChainLookupAsmStub");
+}
+
+EXTERN_C VOID ResolveWorkerAsmStub()
+{
+    PORTABILITY_ASSERT("ResolveWorkerAsmStub");
+}
+
+EXTERN_C VOID BackPatchWorkerAsmStub()
+{
+    PORTABILITY_ASSERT("BackPatchWorkerAsmStub");
+}


### PR DESCRIPTION
This commit adds SinglecastDelegateInvokeStub and VSD-related Stubs as NYI.