### PR TITLE
[x86/Linux] Fix PAL unit test paltest_pal_sxs_test1

### DIFF
--- a/src/pal/src/arch/i386/context2.S
+++ b/src/pal/src/arch/i386/context2.S
@@ -82,7 +82,7 @@ LOCAL_LABEL(Done_CONTEXT_EXTENDED_REGISTERS):
     // Restore
     pop   ebx
     pop   eax
-    ret
+    ret   4
 LEAF_END CONTEXT_CaptureContext, _TEXT
 
 LEAF_ENTRY RtlCaptureContext, _TEXT
@@ -91,7 +91,6 @@ LEAF_ENTRY RtlCaptureContext, _TEXT
     mov     DWORD PTR [eax + CONTEXT_ContextFlags], (CONTEXT_FLOATING_POINT)
     pop     eax
     jmp     C_FUNC(CONTEXT_CaptureContext)
-    ret
 LEAF_END RtlCaptureContext, _TEXT
 
 LEAF_ENTRY RtlRestoreContext, _TEXT
@@ -147,6 +146,6 @@ LOCAL_LABEL(Done_Restore_CONTEXT_EXTENDED_REGISTERS):
     pop   esi
     pop   edi
 
-    ret
+    ret   8
 LEAF_END RtlRestoreContext, _TEXT
 

--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -504,6 +504,7 @@ Parameters :
 
 --*/
 void
+PALAPI
 CONTEXT_CaptureContext(
     LPCONTEXT lpContext
     );

--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -33,9 +33,6 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 
 extern PGET_GCMARKER_EXCEPTION_CODE g_getGcMarkerExceptionCode;
 
-// in context2.S
-extern void CONTEXT_CaptureContext(LPCONTEXT lpContext);
-
 #define CONTEXT_AREA_MASK 0xffff
 #ifdef _X86_
 #define CONTEXT_ALL_FLOATING (CONTEXT_FLOATING_POINT | CONTEXT_EXTENDED_REGISTERS)


### PR DESCRIPTION
Fix unit test error for x86/Linux
- fix fail of exception_handling/pal_sxs/test1/paltest_pal_sxs_test1

For issue #8487.
As `RtlCaptureContext` and `CONTEXT_CaptureContext` has different calling convention copied the function body code. If there is a better way, it can be done. Or if it is better to change `CONTEXT_CaptureContext` to `PALAPI` I'll do the change.