### PR TITLE
Fix to issue 8286.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7191,59 +7191,44 @@ void LinearScan::allocateRegisters()
                 assert(currentInterval != nullptr);
 
                 // It's already in a register, but not one we need.
-                // If it is a fixed use that is not marked "delayRegFree", there is already a FixedReg to ensure that
-                // the needed reg is not otherwise in use, so we can simply ignore it and codegen will do the copy.
-                // The reason we need special handling for the "delayRegFree" case is that we need to mark the
-                // fixed-reg as in-use and delayed (the FixedReg RefPosition doesn't handle the delay requirement).
-                // Otherwise, if this is a pure use localVar or tree temp, we assign a copyReg, but must free both regs
-                // if it is a last use.
-                if (!currentRefPosition->isFixedRegRef || currentRefPosition->delayRegFree)
+                if (!RefTypeIsDef(currentRefPosition->refType))
                 {
-                    if (!RefTypeIsDef(currentRefPosition->refType))
+                    regNumber copyReg = assignCopyReg(currentRefPosition);
+                    assert(copyReg != REG_NA);
+                    INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_COPY_REG, currentInterval, copyReg));
+                    lastAllocatedRefPosition = currentRefPosition;
+                    if (currentRefPosition->lastUse)
                     {
-                        regNumber copyReg = assignCopyReg(currentRefPosition);
-                        assert(copyReg != REG_NA);
-                        INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_COPY_REG, currentInterval, copyReg));
-                        lastAllocatedRefPosition = currentRefPosition;
-                        if (currentRefPosition->lastUse)
+                        if (currentRefPosition->delayRegFree)
                         {
-                            if (currentRefPosition->delayRegFree)
-                            {
-                                INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_LAST_USE_DELAYED, currentInterval,
-                                                                assignedRegister));
-                                delayRegsToFree |=
-                                    (genRegMask(assignedRegister) | currentRefPosition->registerAssignment);
-                            }
-                            else
-                            {
-                                INDEBUG(
-                                    dumpLsraAllocationEvent(LSRA_EVENT_LAST_USE, currentInterval, assignedRegister));
-                                regsToFree |= (genRegMask(assignedRegister) | currentRefPosition->registerAssignment);
-                            }
+                            INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_LAST_USE_DELAYED, currentInterval,
+                                                            assignedRegister));
+                            delayRegsToFree |= (genRegMask(assignedRegister) | currentRefPosition->registerAssignment);
                         }
-                        // If this is a tree temp (non-localVar) interval, we will need an explicit move.
-                        if (!currentInterval->isLocalVar)
+                        else
                         {
-                            currentRefPosition->moveReg = true;
-                            currentRefPosition->copyReg = false;
-                        }
-                        continue;
-                    }
-                    else
-                    {
-                        INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NEEDS_NEW_REG, nullptr, assignedRegister));
-                        regsToFree |= genRegMask(assignedRegister);
-                        // We want a new register, but we don't want this to be considered a spill.
-                        assignedRegister = REG_NA;
-                        if (physRegRecord->assignedInterval == currentInterval)
-                        {
-                            unassignPhysRegNoSpill(physRegRecord);
+                            INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_LAST_USE, currentInterval, assignedRegister));
+                            regsToFree |= (genRegMask(assignedRegister) | currentRefPosition->registerAssignment);
                         }
                     }
+                    // If this is a tree temp (non-localVar) interval, we will need an explicit move.
+                    if (!currentInterval->isLocalVar)
+                    {
+                        currentRefPosition->moveReg = true;
+                        currentRefPosition->copyReg = false;
+                    }
+                    continue;
                 }
                 else
                 {
-                    INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_KEPT_ALLOCATION, nullptr, assignedRegister));
+                    INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NEEDS_NEW_REG, nullptr, assignedRegister));
+                    regsToFree |= genRegMask(assignedRegister);
+                    // We want a new register, but we don't want this to be considered a spill.
+                    assignedRegister = REG_NA;
+                    if (physRegRecord->assignedInterval == currentInterval)
+                    {
+                        unassignPhysRegNoSpill(physRegRecord);
+                    }
                 }
             }
         }
@@ -11725,9 +11710,18 @@ void LinearScan::verifyFinalAllocation()
                     {
                         if (VERBOSE)
                         {
+                            // If refPos is marked as copyReg, then the reg that is spilled
+                            // is the homeReg of the interval not the reg currently assigned
+                            // to refPos.
+                            regNumber spillReg = regNum;
+                            if (currentRefPosition->copyReg)
+                            {
+                                assert(interval != nullptr);
+                                spillReg = interval->physReg;
+                            }
                             dumpRegRecords();
                             dumpEmptyRefPosition();
-                            printf("Spill %-4s ", getRegName(regNum));
+                            printf("Spill %-4s ", getRegName(spillReg));
                         }
                     }
                     else if (currentRefPosition->copyReg)
@@ -11902,6 +11896,8 @@ void LinearScan::verifyResolutionMove(GenTree* resolutionMove, LsraLocation curr
         assert(leftInterval->physReg == leftRegNum && rightInterval->physReg == rightRegNum);
         leftInterval->physReg                  = rightRegNum;
         rightInterval->physReg                 = leftRegNum;
+        leftInterval->assignedReg              = &physRegs[rightRegNum];
+        rightInterval->assignedReg             = &physRegs[leftRegNum];
         physRegs[rightRegNum].assignedInterval = leftInterval;
         physRegs[leftRegNum].assignedInterval  = rightInterval;
         if (VERBOSE)


### PR DESCRIPTION
Issue 1: the original issue uncovered by issue 8286.

This issue repros with JitStressRegs=4 against x86 RyuJIT.

The repro method has a InitBlock  with size specified by a variable i.e. StoreDynBlk(InitValue, DstAddr, Size).
Lower/Codegen decides to use rep.Stosb which requires InitValue=eax, DstAddr=edi, Size=ecx.  Rep.Stosb kill edi and ecx and leaves eax intact.  The kill set of StoreDynBlk is modeled accordingly.  That is at the point of Use of InitValue in StoreDynBlk, it has a fixedRef to eax.

 ```
--------------------------------+----+----+----+----+----+----+----+----+
Loc RP#  Name Type  Action Reg  |eax |ecx |edx |ebx |esp |ebp |esi |edi |
--------------------------------+----+----+----+----+----+----+----+----+
59.#39  eax  Fixd   Keep  eax  |V0 a|    |V11a|V6 a|----|----|    |V3 a|
 59.#40  V11  Use    Keep  edx  |V0 a|    |V11a|V6 a|----|----|    |V3 a|
59.#41  ecx  Fixd   Keep  ecx  |V0 a|    |V11a|V6 a|----|----|    |V3 a|
 59.#42  V6   Use *  Keep  ebx  |V0 a|    |V11a|V6 a|----|----|    |V3 a|
 60.#43  ecx  Kill   Keep  ecx  |V0 a|    |V11a|    |----|----|    |V3 a|
 60.#44  edi  Kill   Spill edi  |V0 a|    |V11a|    |----|----|    |    |
                     Keep  edi  |V0 a|    |V11a|    |----|----|    |    |
```

Above V11 corresponds to InitVal.  Note that prior to allocating Use of V11, we have the following reg allocation V11=edx, V3=eax.

Now refPos 40 is a fixedRegRef which is not a kill nor marked delayRegFree.  Further it is in a register (edx) which is not the one (eax) we want.  In this case we need eax to be spilled and assigned to refPos 40 with it marked as copyReg=true.  But that logic in allocateRegisters() gets triggered only `if (!fixedRegRef || refPos marked delayRegFree)`.   

Fix:
This if condition is removed to fix the above case.  Note that in resolveLocalRef, GT_COPY is inserted only `if (!fixedRegRef || moveReg)`

Issue2:
This lead to an assert in verifyFinalAllocation() for the case of RefTypeKill that was asserting that the RegRecord that is being killed is not assigned to any interval at the point of kill.  This assert is hit for CQPerf benchmark method PermuteArray on ubuntu.

```
--------------------------------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
Loc RP#  Name Type  Action Reg  |rax |rcx |rdx |rbx |rsp |rbp |rsi |rdi |r8  |r9  |r10 |r11 |r12 |r13 |r14 |r15 |
--------------------------------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
399.#168 BB13 PredBB3           |V5 a|    |    |V28a|----|----|    |    |    |    |    |    |V4 a|V30a|V27a|V31a|
399.#0   V5   Swap         r13  |V30a|    |    |V28a|----|----|    |    |    |    |    |    |V4 a|V5 a|V27a|V31a|
399.#0   V30  "            rax  |V30a|    |    |V28a|----|----|    |    |    |    |    |    |V4 a|V5 a|V27a|V31a|
407.#169 V27  Use    Keep  r14  |V30a|    |    |V28a|----|----|    |    |    |    |    |    |V4 a|V5 a|V27a|V31a|
408.#170 I57  Def    Alloc rsi  |V30a|    |    |V28a|----|----|I57a|    |    |    |    |    |V4 a|V5 a|V27a|V31a|
409.#171 I57  Use *  Keep  rsi  |V30a|    |    |V28a|----|----|I57i|    |    |    |    |    |V4 a|V5 a|V27a|V31a|
410.#172 V6   Def    Alloc rsi  |V30a|    |    |V28a|----|----|V6 a|    |    |    |    |    |V4 a|V5 a|V27a|V31a|
421.#173 V6   Use    Keep  rsi  |V30a|    |    |V28a|----|----|V6 a|    |    |    |    |    |V4 a|V5 a|V27a|V31a|
421.#174 V4   Use    Keep  r12  |V30a|    |    |V28a|----|----|V6 a|    |    |    |    |    |V4 a|V5 a|V27a|V31a|
427.#175 V4   Use    Keep  r12  |V30a|    |    |V28a|----|----|V6 a|    |    |    |    |    |V4 a|V5 a|V27a|V31a|
428.#176 I58  Def    Alloc rdi  |V30a|    |    |V28a|----|----|V6 a|I58a|    |    |    |    |V4 a|V5 a|V27a|V31a|
431.#177 V6   Use    Keep  rsi  |V30a|    |    |V28a|----|----|V6 a|I58a|    |    |    |    |V4 a|V5 a|V27a|V31a|
431.#178 I58  Use *  Keep  rdi  |V30a|    |    |V28a|----|----|V6 a|I58i|    |    |    |    |V4 a|V5 a|V27a|V31a|
432.#179 I59  Def    Alloc rdi  |V30a|    |    |V28a|----|----|V6 a|I59a|    |    |    |    |V4 a|V5 a|V27a|V31a|
433.#180 I59  Use *  Keep  rdi  |V30a|    |    |V28a|----|----|V6 a|I59i|    |    |    |    |V4 a|V5 a|V27a|V31a|
434.#181 V7   Def    Alloc rdi  |V30a|    |    |V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
445.#182 V6   Use    Keep  rsi  |V30a|    |    |V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
445.#183 V5   Use    Keep  r13  |V30a|    |    |V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
451.#184 V5   Use    Keep  r13  |V30a|    |    |V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
452.#185 I60  Def    Alloc rdx  |V30a|    |I60a|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
455.#186 V6   Use    Keep  rsi  |V30a|    |I60a|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
455.#187 I60  Use *  Keep  rdx  |V30a|    |I60i|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
456.#188 I61  Def    Alloc rdx  |V30a|    |I61a|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
457.#189 I61  Use *  Keep  rdx  |V30a|    |I61i|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
458.#190 V8   Def    Alloc rdx  |V30a|    |V8 a|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
465.#191 V4   Use    Keep  r12  |V30a|    |V8 a|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
466.#192 I62  Def    Alloc rcx  |V30a|I62a|V8 a|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
471.#193 V6   Use    Keep  rsi  |V30a|I62a|V8 a|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
471.#194 I62  Use *  Keep  rcx  |V30a|I62i|V8 a|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
471.#195 V8   Use *  Keep  rdx  |V30a|    |V8 i|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
479.#196 V5   Use    Keep  r13  |V30a|    |    |V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
480.#197 I63  Def    Alloc rdx  |V30a|    |I63a|V28a|----|----|V6 a|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
485.#198 V6   Use *  Keep  rsi  |V30a|    |I63a|V28a|----|----|V6 i|V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
485.#199 I63  Use *  Keep  rdx  |V30a|    |I63i|V28a|----|----|    |V7 a|    |    |    |    |V4 a|V5 a|V27a|V31a|
485.#200 V7   Use *  Keep  rdi  |V30a|    |    |V28a|----|----|    |V7 i|    |    |    |    |V4 a|V5 a|V27a|V31a|
491.#201 rsi  Fixd   Keep  rsi  |V30a|    |    |V28a|----|----|    |    |    |    |    |    |V4 a|V5 a|V27a|V31a|
491.#202 V30  Use    Copy  rsi  |V30i|    |    |V28a|----|----|    |    |    |    |    |    |V4 a|V5 a|V27a|V31a|
                     Spill rsi  |V30i|    |    |V28a|----|----|    |    |    |    |    |    |V4 a|V5 a|V27a|V31a|
492.#203 rsi  Fixd   Keep  rsi  |V30i|    |    |V28a|----|----|    |    |    |    |    |    |V4 a|    |V27a|V31a|
492.#204 I64  Def    Alloc rsi  |V30i|    |    |V28a|----|----|I64a|    |    |    |    |    |V4 a|    |V27a|V31a|
495.#205 rdi  Fixd   Keep  rdi  |V30i|    |    |V28a|----|----|I64a|    |    |    |    |    |V4 a|    |V27a|V31a|
495.#206 V27  Use    Copy  rdi  |V30i|    |    |V28a|----|----|I64a|V27a|    |    |    |    |V4 a|    |V27a|V31a|
496.#207 rdi  Fixd   Keep  rdi  |V30i|    |    |V28a|----|----|I64a|    |    |    |    |    |V4 a|    |V27a|V31a|
496.#208 I65  Def    Alloc rdi  |V30i|    |    |V28a|----|----|I64a|I65a|    |    |    |    |V4 a|    |V27a|V31a|
497.#209 rsi  Fixd   Keep  rsi  |V30i|    |    |V28a|----|----|I64a|I65a|    |    |    |    |V4 a|    |V27a|V31a|
497.#210 I64  Use *  Keep  rsi  |V30i|    |    |V28a|----|----|I64i|I65a|    |    |    |    |V4 a|    |V27a|V31a|
497.#211 rdi  Fixd   Keep  rdi  |V30i|    |    |V28a|----|----|    |I65a|    |    |    |    |V4 a|    |V27a|V31a|
497.#212 I65  Use *  Keep  rdi  |V30i|    |    |V28a|----|----|    |I65i|    |    |    |    |V4 a|    |V27a|V31a|
498.#213 rax  Kill   
```

Above the refPos of interest are 202 and 213.  in verifyFinalAllocation(),  while processing RefPos 213 (i.e. kill eax) finds eax RegRecord's assignedInterval is non-null and set to Interval of refPos 202 (i.e. V30).  At the beginning of this basic block at location 399, LSRA inserted resolution move to swap V30 and V5 so that V30 will be eax.  Prior to resolution move V30 came into basic block in reg R13.  verifyResolutionMove() logic didn't set V30's interval->assignedReg to eax' RegRecord as result it remained pointing to R13.  As a result verifyFinalAllocation() while processing refPos 202, has cleared assignedInterval field on R13 instead of on eax's RegRecord.  And when refKill pos 213 is processed it finds eax's regRecord->assignedInterval is not cleared.

Fix:
verifyResolutionMove() is fixed to update interval->assignedReg field of both leftInterval and rightInterval in case of a swap.

Issue3:
Ref pos 202 is isFixedReg=true, copyReg=true and spillAfter=true.  verifyFinalAllocation() is printing assigned reg as the register (esi) spilled in the dump.  In case of copyreg=true and spillAfter=true, the register that is being is spilled is homeReg given by interval->physReg.  Corrected dump to handle to this case.

AsmDiffs:
SPMI asm diffs on amd64 desktop indicate minor code size regression.  These are due to a different register allocated or in some cases additional mov instruction or an additional resolution mov generated.

```
00.63:         <filename>                                            baseline        diff improvement  %improvement    #funcs
00.63:         CQ_PERF_Clean_Thin_Unique_all.dasm                      202227      203763       -1536         -0.76       154
00.68:         mscorlib_Clean_Thin_Unique_all.dasm                     165042      166991       -1949         -1.18       178
```

For example in case of mscorlib
```
20 functions improved (105 total bytes improvement)
110 functions regressed (2054 total bytes regression)

```
Throughput:
Throughput measured on desktop shows that the regression is within noise limit

```
Mscorlib:  Before 13200  and After the fix 13237
System.Windows.Forms:   Before 9245 and After the fix 9295
```

Fixes #8286