### PR TITLE
TimeZoneInfo: Use string.Concat instead of string.Format

### DIFF
--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -2990,8 +2990,7 @@ namespace System {
 
             try {
                 using (RegistryKey dynamicKey = Registry.LocalMachine.OpenSubKey(
-                                   String.Format(CultureInfo.InvariantCulture, "{0}\\{1}\\Dynamic DST",
-                                       c_timeZonesRegistryHive, id),
+                                   c_timeZonesRegistryHive + "\\" + id + "\\Dynamic DST",
 #if FEATURE_MACL
                                    RegistryKeyPermissionCheck.Default,
                                    System.Security.AccessControl.RegistryRights.ReadKey
@@ -3160,8 +3159,7 @@ namespace System {
                 permSet.Assert();
 
                 using (RegistryKey key = Registry.LocalMachine.OpenSubKey(
-                                  String.Format(CultureInfo.InvariantCulture, "{0}\\{1}",
-                                      c_timeZonesRegistryHive, id),
+                                  c_timeZonesRegistryHive + "\\" + id,
 #if FEATURE_MACL
                                   RegistryKeyPermissionCheck.Default,
                                   System.Security.AccessControl.RegistryRights.ReadKey
@@ -3430,8 +3428,7 @@ namespace System {
                 permSet.Assert();
 
                 using (RegistryKey key = Registry.LocalMachine.OpenSubKey(
-                                  String.Format(CultureInfo.InvariantCulture, "{0}\\{1}",
-                                      c_timeZonesRegistryHive, id),
+                                  c_timeZonesRegistryHive + "\\" + id,
 #if FEATURE_MACL
                                   RegistryKeyPermissionCheck.Default,
                                   System.Security.AccessControl.RegistryRights.ReadKey


### PR DESCRIPTION
It's more efficient to concatenate the strings.