### PR TITLE
Fix missing flags on GT_DYN_BLK node

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4258,6 +4258,8 @@ public:
     GenTreeDynBlk(GenTreePtr addr, GenTreePtr dynamicSize)
         : GenTreeBlk(GT_DYN_BLK, TYP_STRUCT, addr, 0), gtDynamicSize(dynamicSize), gtEvalSizeFirst(false)
     {
+        // Conservatively the 'addr' could be null or point into the global heap.
+        gtFlags |= GTF_EXCEPT | GTF_GLOB_REF;
         gtFlags |= (dynamicSize->gtFlags & GTF_ALL_EFFECT);
     }
 


### PR DESCRIPTION
The fix is to set the GTF_EXCEPT and GTF_GLOB_REF for every GT_DYN_BLK node that we create.
We typically don't have any information about the address supplied to a GT_DYN_BLK so we should
conservatively allow that it can either be a null pointer or could point into the GC heap.
