### PR TITLE
Correct an assertion in LSRA.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -11788,15 +11788,14 @@ void LinearScan::verifyFinalAllocation()
                     interval->physReg     = REG_NA;
                     interval->assignedReg = nullptr;
 
-                    // regRegcord could be null if RefPosition is to be allocated a
-                    // reg only if profitable.
+                    // regRegcord could be null if the RefPosition does not require a register.
                     if (regRecord != nullptr)
                     {
                         regRecord->assignedInterval = nullptr;
                     }
                     else
                     {
-                        assert(currentRefPosition->AllocateIfProfitable());
+                        assert(!currentRefPosition->RequiresRegister());
                     }
                 }
             }


### PR DESCRIPTION
`verifyFinalAllocation` asserts that if a non-BB interval RefPosition
that is either spilled or is the interval's last use does not have a
register, then that ref position must be marked `AllocateIfProfitable`.
However, this situation can also arise in at least one other situation:
an unused parameter will have at least one ref position that may not be
allocated to a register. This change corrects the assertion to check
`RefPosition::RequiresRegister` rather than
`RefPosition::AllocateIfProfitable`.

Fixes VSO 299207.