### PR TITLE
Fix to issue 8287.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4854,11 +4854,11 @@ void LinearScan::setFrameType()
     compiler->rpFrameType = frameType;
 }
 
-// Is the copyReg given by this RefPosition still busy at the
+// Is the copyReg/moveReg given by this RefPosition still busy at the
 // given location?
-bool copyRegInUse(RefPosition* ref, LsraLocation loc)
+bool copyOrMoveRegInUse(RefPosition* ref, LsraLocation loc)
 {
-    assert(ref->copyReg);
+    assert(ref->copyReg || ref->moveReg);
     if (ref->getRefEndLocation() >= loc)
     {
         return true;
@@ -4918,14 +4918,15 @@ bool LinearScan::registerIsAvailable(RegRecord*    physRegRecord,
             return false;
         }
 
-        // Is this a copyReg?  It is if the register assignment doesn't match.
-        // (the recentReference may not be a copyReg, because we could have seen another
-        // reference since the copyReg)
+        // Is this a copyReg/moveReg?  It is if the register assignment doesn't match.
+        // (the recentReference may not be a copyReg/moveReg, because we could have seen another
+        // reference since the copyReg/moveReg)
 
         if (!assignedInterval->isAssignedTo(physRegRecord->regNum))
         {
             // Don't reassign it if it's still in use
-            if (recentReference->copyReg && copyRegInUse(recentReference, currentLoc))
+            if ((recentReference->copyReg || recentReference->moveReg) &&
+                copyOrMoveRegInUse(recentReference, currentLoc))
             {
                 return false;
             }


### PR DESCRIPTION
This issue repros under jitstressregs=8.
Repro is a big method in a CoreFx assemly and has the following IR somewhere in the middle of the method:

```
st.indir(byte, reverse-ops, addr, value)
value = SHIFT_RIGHT(V01, 8)
addr = V50

```
`V01` was allocated to esi.
Def of SHIFT_RIGHT was allocated esi.
Since st.indir is of byte type, value is constrained to a bytable reg at its use.
Therefore, Use of SHIFT_RIGHT is allocated ecx and marked as 'moveReg=true' since it is a non-LclVar.
V50 was on stack and was getting allocated ecx, by incorrectly considering as available for the reason 
`tryAllocateFreeReg()->registerIsAvailable()->CopyRegInUse()` is only handling copyReg case.

Fix: 
CopyRegInUse() is updated to also handle moveReg case.

Asm Diffs:
There were no SPMI diffs on desktop due to this fix.

Fixes #8287 