### PR TITLE
Make it easier to iterate through an ArraySegment

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -341,12 +341,20 @@
         <Member Name="get_Array" />
         <Member Name="get_Count" />
         <Member Name="get_Offset" />
+        <Member Name="GetEnumerator" />
         <Member Name="GetHashCode" />
         <Member Name="op_Equality(System.ArraySegment&lt;T&gt;,System.ArraySegment&lt;T&gt;)" />
         <Member Name="op_Inequality(System.ArraySegment&lt;T&gt;,System.ArraySegment&lt;T&gt;)" />
         <Member MemberType="Property" Name="Array" />
         <Member MemberType="Property" Name="Count" />
         <Member MemberType="Property" Name="Offset" />
+    </Type>
+    <Type Name="System.ArraySegment&lt;T&gt;+Enumerator">
+      <Member Name="Dispose" />
+      <Member Name="get_Current" />
+      <Member Name="MoveNext" />
+      <Member MemberType="Property" Name="Current" />
+      <Member Name="System.Collections.IEnumerator.Reset" />
     </Type>
     <Type Name="System.ArrayTypeMismatchException">
       <Member Name="#ctor" />

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -28,9 +28,9 @@ namespace System
     [Serializable]
     public struct ArraySegment<T> : IList<T>, IReadOnlyList<T>
     {
-        private T[] _array;
-        private int _offset;
-        private int _count;
+        private readonly T[] _array;
+        private readonly int _offset;
+        private readonly int _count;
 
         public ArraySegment(T[] array)
         {
@@ -290,9 +290,9 @@ namespace System
         [Serializable]
         public struct Enumerator : IEnumerator<T>
         {
-            private T[] array { get; }
-            private int offset { get; }
-            private int endIndex { get; } // cache Offset + Count, since it's a little slow
+            private readonly T[] array;
+            private readonly int offset;
+            private readonly int endIndex; // cache Offset + Count, since it's a little slow
             private int index;
 
             internal Enumerator(ArraySegment<T> arraySegment)

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -290,10 +290,10 @@ namespace System
         [Serializable]
         public struct Enumerator : IEnumerator<T>
         {
-            private readonly T[] array;
-            private readonly int offset;
-            private readonly int endIndex; // cache Offset + Count, since it's a little slow
-            private int index;
+            private readonly T[] _array;
+            private readonly int _offset;
+            private readonly int _endIndex; // cache Offset + Count, since it's a little slow
+            private int _index;
 
             internal Enumerator(ArraySegment<T> arraySegment)
             {
@@ -302,18 +302,18 @@ namespace System
                 Contract.Requires(arraySegment.Count >= 0);
                 Contract.Requires(arraySegment.Offset + arraySegment.Count <= arraySegment.Array.Length);
 
-                array = arraySegment.Array;
-                offset = arraySegment.Offset;
-                endIndex = arraySegment.Offset + arraySegment.Count;
-                index = arraySegment.Offset - 1;
+                _array = arraySegment.Array;
+                _offset = arraySegment.Offset;
+                _endIndex = arraySegment.Offset + arraySegment.Count;
+                _index = arraySegment.Offset - 1;
             }
 
             public bool MoveNext()
             {
-                if (index < endIndex)
+                if (_index < _endIndex)
                 {
-                    index++;
-                    return (index < endIndex);
+                    _index++;
+                    return (_index < _endIndex);
                 }
                 return false;
             }
@@ -322,11 +322,11 @@ namespace System
             {
                 get
                 {
-                    if (index < offset)
+                    if (_index < _offset)
                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
-                    if (index >= endIndex)
+                    if (_index >= _endIndex)
                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
-                    return array[index];
+                    return _array[_index];
                 }
             }
 
@@ -334,7 +334,7 @@ namespace System
 
             void IEnumerator.Reset()
             {
-                index = offset - 1;
+                _index = _offset - 1;
             }
 
             public void Dispose()

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -291,9 +291,9 @@ namespace System
         public struct Enumerator : IEnumerator<T>
         {
             private readonly T[] _array;
-            private readonly int _offset;
-            private readonly int _endIndex; // cache Offset + Count, since it's a little slow
-            private int _index;
+            private readonly int _start;
+            private readonly int _end; // cache Offset + Count, since it's a little slow
+            private int _current;
 
             internal Enumerator(ArraySegment<T> arraySegment)
             {
@@ -303,17 +303,17 @@ namespace System
                 Contract.Requires(arraySegment.Offset + arraySegment.Count <= arraySegment.Array.Length);
 
                 _array = arraySegment.Array;
-                _offset = arraySegment.Offset;
-                _endIndex = arraySegment.Offset + arraySegment.Count;
-                _index = arraySegment.Offset - 1;
+                _start = arraySegment.Offset;
+                _end = arraySegment.Offset + arraySegment.Count;
+                _current = arraySegment.Offset - 1;
             }
 
             public bool MoveNext()
             {
-                if (_index < _endIndex)
+                if (_current < _end)
                 {
-                    _index++;
-                    return (_index < _endIndex);
+                    _current++;
+                    return (_current < _end);
                 }
                 return false;
             }
@@ -322,11 +322,11 @@ namespace System
             {
                 get
                 {
-                    if (_index < _offset)
+                    if (_current < _start)
                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumNotStarted();
-                    if (_index >= _endIndex)
+                    if (_current >= _end)
                         ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumEnded();
-                    return _array[_index];
+                    return _array[_current];
                 }
             }
 
@@ -334,7 +334,7 @@ namespace System
 
             void IEnumerator.Reset()
             {
-                _index = _offset - 1;
+                _current = _start - 1;
             }
 
             public void Dispose()


### PR DESCRIPTION
Value: Saves 1 boxing per enumerator. See https://github.com/dotnet/corefx/issues/14170