### PR TITLE
Supporting C# 7 deconstruction of KeyValuePair and DictionaryEntry

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -632,6 +632,7 @@
       <Member Name="get_Value" />
       <Member Name="set_Key(System.Object)" />
       <Member Name="set_Value(System.Object)" />
+      <Member Name="Deconstruct(System.Object@,System.Object@)" />
       <Member MemberType="Property" Name="Key" />
       <Member MemberType="Property" Name="Value" />
     </Type>
@@ -787,6 +788,7 @@
       <Member Name="get_Key" />
       <Member Name="get_Value" />
       <Member Name="ToString" />
+      <Member Name="Deconstruct(TKey@,TValue@)" />
       <Member MemberType="Property" Name="Key" />
       <Member MemberType="Property" Name="Value" />
     </Type>

--- a/src/mscorlib/src/System/Collections/DictionaryEntry.cs
+++ b/src/mscorlib/src/System/Collections/DictionaryEntry.cs
@@ -52,7 +52,7 @@ namespace System.Collections {
             }
         }
 
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        // BLOCKED (do not add now): [EditorBrowsable(EditorBrowsableState.Never)]
         public void Deconstruct(out object key, out object value)
         {
             key = Key;

--- a/src/mscorlib/src/System/Collections/DictionaryEntry.cs
+++ b/src/mscorlib/src/System/Collections/DictionaryEntry.cs
@@ -51,5 +51,12 @@ namespace System.Collections {
                 _value = value;
             }
         }
+
+        //[EditorBrowsable(EditorBrowsableState.Never)]
+        public void Deconstruct(out object key, out object value)
+        {
+            key = Key;
+            value = Value;
+        }
     }
 }

--- a/src/mscorlib/src/System/Collections/Generic/KeyValuePair.cs
+++ b/src/mscorlib/src/System/Collections/Generic/KeyValuePair.cs
@@ -62,5 +62,12 @@ namespace System.Collections.Generic {
             s.Append(']');
             return StringBuilderCache.GetStringAndRelease(s);
         }
+
+        //[EditorBrowsable(EditorBrowsableState.Never)]
+        public void Deconstruct(out TKey key, out TValue value)
+        {
+            key = Key;
+            value = Value;
+        }
     }
 }

--- a/src/mscorlib/src/System/Collections/Generic/KeyValuePair.cs
+++ b/src/mscorlib/src/System/Collections/Generic/KeyValuePair.cs
@@ -63,7 +63,7 @@ namespace System.Collections.Generic {
             return StringBuilderCache.GetStringAndRelease(s);
         }
 
-        //[EditorBrowsable(EditorBrowsableState.Never)]
+        // BLOCKED (do not add now): [EditorBrowsable(EditorBrowsableState.Never)]
         public void Deconstruct(out TKey key, out TValue value)
         {
             key = Key;


### PR DESCRIPTION
C# 7 added support for deconstruction of user-defined types via a Deconstruct(out ...) method. It would make sense to be able to use this feature with tuple-like types such as KeyValuePair and DictionaryEntry.
See https://github.com/dotnet/corefx/issues/13746