### PR TITLE
Span api update

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -12397,6 +12397,7 @@
     </Type>
     <Type Name="System.Span&lt;T&gt;" Condition="FEATURE_SPAN_OF_T">
       <Member Name="#ctor(T[])" />
+      <Member Name="#ctor(T[],System.Int32)" />
       <Member Name="#ctor(T[],System.Int32,System.Int32)" />
       <Member Name="#ctor(System.Void*,System.Int32)" />
       <Member Name="op_Implicit(T[])" ReturnType="System.Span&lt;T&gt;" />
@@ -12415,6 +12416,7 @@
     </Type>
     <Type Name="System.ReadOnlySpan&lt;T&gt;" Condition="FEATURE_SPAN_OF_T">
       <Member Name="#ctor(T[])" />
+      <Member Name="#ctor(T[],System.Int32)" />
       <Member Name="#ctor(T[],System.Int32,System.Int32)" />
       <Member Name="#ctor(System.Void*,System.Int32)" />
       <Member Name="op_Implicit(System.Span&lt;T&gt;)" ReturnType="System.ReadOnlySpan&lt;T&gt;" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -12402,6 +12402,8 @@
       <Member Name="#ctor(System.Void*,System.Int32)" />
       <Member Name="op_Implicit(T[])" ReturnType="System.Span&lt;T&gt;" />
       <Member Name="op_Implicit(System.ArraySegment&lt;T&gt;)" ReturnType="System.Span&lt;T&gt;" />
+      <Member Name="op_Equality(System.Span&lt;T&gt;,System.Span&lt;T&gt;)" />
+      <Member Name="op_Inequality(System.Span&lt;T&gt;,System.Span&lt;T&gt;)" />
       <Member Name="get_Length" />
       <Member Name="get_Empty" />
       <Member Name="get_IsEmpty" />
@@ -12411,8 +12413,10 @@
       <Member Name="Slice(System.Int32)" />
       <Member Name="Slice(System.Int32,System.Int32)" />
       <Member Name="Equals(System.Span&lt;T&gt;)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="GetHashCode" />
+      <Member Name="CopyTo(System.Span&lt;T&gt;)" />
       <Member Name="TryCopyTo(System.Span&lt;T&gt;)" />
-      <Member Name="Set(System.ReadOnlySpan&lt;T&gt;)" />
     </Type>
     <Type Name="System.ReadOnlySpan&lt;T&gt;" Condition="FEATURE_SPAN_OF_T">
       <Member Name="#ctor(T[])" />

--- a/src/mscorlib/src/System.Private.CoreLib.txt
+++ b/src/mscorlib/src/System.Private.CoreLib.txt
@@ -637,6 +637,7 @@ Argument_NativeOverlappedAlreadyFree = 'overlapped' has already been freed.
 Argument_AlreadyBoundOrSyncHandle = 'handle' has already been bound to the thread pool, or was not opened for asynchronous I/O.
 #if FEATURE_SPAN_OF_T
 Argument_InvalidTypeWithPointersNotSupported = Cannot use type '{0}'. Only value types without pointers or references are supported.
+Argument_DestinationTooShort = Destination is too short.
 #endif // FEATURE_SPAN_OF_T
 
 ;
@@ -1456,7 +1457,10 @@ NotSupported_NonStaticMethod = Non-static methods with NativeCallableAttribute a
 NotSupported_NativeCallableTarget = Methods with NativeCallableAttribute cannot be used as delegate target.
 NotSupported_GenericMethod = Generic methods with NativeCallableAttribute are not supported.
 NotSupported_NonBlittableTypes = Non-blittable parameter types are not supported for NativeCallable methods.
-
+#if FEATURE_SPAN_OF_T
+NotSupported_CannotCallEqualsOnSpan = Equals() on Span and ReadOnlySpan is not supported. Use operator== instead.
+NotSupported_CannotCallGetHashCodeOnSpan = GetHashCode() on Span and ReadOnlySpan is not supported.
+#endif // FEATURE_SPAN_OF_T
 #if FEATURE_WINDOWSPHONE
 NotSupported_UserDllImport = DllImport cannot be used on user-defined methods.
 NotSupported_UserCOM = COM Interop is not supported for user-defined types.

--- a/src/mscorlib/src/System/ReadOnlySpan.cs
+++ b/src/mscorlib/src/System/ReadOnlySpan.cs
@@ -38,6 +38,29 @@ namespace System
 
         /// <summary>
         /// Creates a new span over the portion of the target array beginning
+        /// at 'start' index and covering the remainder of the array.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> is not in the range (&lt;0 or &gt;&eq;Length).
+        /// </exception>
+        public ReadOnlySpan(T[] array, int start)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if ((uint)start > (uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+
+            // TODO-SPAN: This has GC hole. It needs to be JIT intrinsic instead
+            _rawPointer = (IntPtr)Unsafe.AsPointer(ref Unsafe.Add(ref JitHelpers.GetArrayData(array), start));
+            _length = array.Length - start;
+        }
+
+        /// <summary>
+        /// Creates a new span over the portion of the target array beginning
         /// at 'start' index and ending at 'end' index (exclusive).
         /// </summary>
         /// <param name="array">The target array.</param>
@@ -46,7 +69,7 @@ namespace System
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
         /// reference (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">
-        /// Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;&eq;Length).
+        /// Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;&eq;Length).
         /// </exception>
         public ReadOnlySpan(T[] array, int start, int length)
         {

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -43,6 +43,34 @@ namespace System
 
         /// <summary>
         /// Creates a new span over the portion of the target array beginning
+        /// at 'start' index and covering the remainder of the array.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="array"/> is a null
+        /// reference (Nothing in Visual Basic).</exception>
+        /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> is not in the range (&lt;0 or &gt;=Length).
+        /// </exception>
+        public Span(T[] array, int start)
+        {
+            if (array == null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null) { // Arrays of valuetypes are never covariant
+                if (array.GetType() != typeof(T[]))
+                    ThrowHelper.ThrowArrayTypeMismatchException();
+            }
+            if ((uint)start > (uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+
+            // TODO-SPAN: This has GC hole. It needs to be JIT intrinsic instead
+            _rawPointer = (IntPtr)Unsafe.AsPointer(ref Unsafe.Add(ref JitHelpers.GetArrayData(array), start));
+            _length = array.Length - start;
+        }
+
+        /// <summary>
+        /// Creates a new span over the portion of the target array beginning
         /// at 'start' index and ending at 'end' index (exclusive).
         /// </summary>
         /// <param name="array">The target array.</param>
@@ -52,7 +80,7 @@ namespace System
         /// reference (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">
-        /// Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;&eq;Length).
+        /// Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
         /// </exception>
         public Span(T[] array, int start, int length)
         {

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -59,6 +59,18 @@ namespace System {
         internal static void ThrowArgumentOutOfRangeException() {
             throw new ArgumentOutOfRangeException();
         }
+
+        internal static void ThrowArgumentException_DestinationTooShort() {
+            throw new ArgumentException(Environment.GetResourceString("Argument_DestinationTooShort"));
+        }
+
+        internal static void ThrowNotSupportedException_CannotCallEqualsOnSpan() {
+            throw new NotSupportedException(Environment.GetResourceString("NotSupported_CannotCallEqualsOnSpan"));
+        }
+
+        internal static void ThrowNotSupportedException_CannotCallGetHashCodeOnSpan() {
+            throw new NotSupportedException(Environment.GetResourceString("NotSupported_CannotCallGetHashCodeOnSpan"));
+        }
 #endif
 
         internal static void ThrowArgumentOutOfRange_IndexException() {

--- a/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
+++ b/tests/src/CoreMangLib/system/span/BasicSpanTest.cs
@@ -41,8 +41,11 @@ class My
         int failedTestsCount = 0;
 
         Test(CanAccessItemsViaIndexer, "CanAccessItemsViaIndexer", ref failedTestsCount);
+        Test(CanAccessItemsViaIndexerStartCtor, "CanAccessItemsViaIndexerStartCtor", ref failedTestsCount);
+        Test(CanAccessItemsViaIndexerStartLengthCtor, "CanAccessItemsViaIndexerStartLengthCtor", ref failedTestsCount);
 
-        Test(TestBoundaryEmptySpan, "TestBoundaryEmptySpan", ref failedTestsCount);
+        Test(TestBoundaryEmptySpanStartCtor, "TestBoundaryEmptySpanStartCtor", ref failedTestsCount);
+        Test(TestBoundaryEmptySpanStartLengthCtor, "TestBoundaryEmptySpanStartLengthCtor", ref failedTestsCount);
 
         Test(ReferenceTypesAreSupported, "ReferenceTypesAreSupported", ref failedTestsCount);
 
@@ -51,6 +54,9 @@ class My
         Test(MustNotMoveGcTypesToUnmanagedMemory, "MustNotMoveGcTypesToUnmanagedMemory", ref failedTestsCount);
 
         Test(TestArrayCoVariance, "TestArrayCoVariance", ref failedTestsCount);
+        Test(TestArrayCoVarianceStartCtor, "TestArrayCoVarianceStartCtor", ref failedTestsCount);
+        Test(TestArrayCoVarianceStartLengthCtor, "TestArrayCoVarianceStartLengthCtor", ref failedTestsCount);
+
         Test(TestArrayCoVarianceReadOnly, "TestArrayCoVarianceReadOnly", ref failedTestsCount);
 
         Test(CanCopyValueTypesWithoutPointersToSlice, "CanCopyValueTypesWithoutPointersToSlice", ref failedTestsCount);
@@ -74,8 +80,12 @@ class My
         Test(SourceTypeLargerThanTargetOneCorrectlyCalcsTargetsLength, "SourceTypeLargerThanTargetOneCorrectlyCalcsTargetsLength", ref failedTestsCount);
         Test(WhenSourceDoesntFitIntoTargetLengthIsZero, "WhenSourceDoesntFitIntoTargetLengthIsZero", ref failedTestsCount);
         Test(WhenSourceFitsIntoTargetOnceLengthIsOne, "WhenSourceFitsIntoTargetOnceLengthIsOne", ref failedTestsCount);
-        Test(WhenSourceTypeLargerThaTargetAndOverflowsInt32ThrowsException, "WhenSourceTypeLargerThaTargetAndOverflowsInt32ThrowsException", ref failedTestsCount);
+        Test(WhenSourceTypeLargerThanTargetAndOverflowsInt32ThrowsException, "WhenSourceTypeLargerThanTargetAndOverflowsInt32ThrowsException", ref failedTestsCount);
         Test(CanCreateSpanFromString, "CanCreateSpanFromString", ref failedTestsCount);
+
+        Test(WhenStartLargerThanLengthThrowsExceptionStartCtor, "WhenStartLargerThanLengthThrowsExceptionStartCtor", ref failedTestsCount);
+        Test(WhenStartLargerThanLengthThrowsExceptionStartLengthCtor, "WhenStartLargerThanLengthThrowsExceptionStartLengthCtor", ref failedTestsCount);
+        Test(WhenStartAndLengthLargerThanLengthThrowsExceptionStartLengthCtor, "WhenStartAndLengthLargerThanLengthThrowsExceptionStartLengthCtor", ref failedTestsCount);
 
         Console.WriteLine(string.Format("{0} tests has failed", failedTestsCount));
         Environment.Exit(failedTestsCount);
@@ -91,9 +101,31 @@ class My
         AssertTrue(Sum(subslice) == 5, "Failed to sum subslice");
     }
 
-    static TestBoundaryEmptySpan()
+    static void CanAccessItemsViaIndexerStartCtor()
     {
-        int[] a = new byte[5];
+        int[] a = new int[] { 1, 2, 3 };
+        Span<int> slice = new Span<int>(a, start: 1);
+        AssertTrue(Sum(slice) == 5, "Failed to sum slice");
+    }
+
+    static void CanAccessItemsViaIndexerStartLengthCtor()
+    {
+        int[] a = new int[] { 1, 2, 3 };
+        Span<int> slice = new Span<int>(a, start: 1, length: 1);
+        AssertTrue(Sum(slice) == 2, "Failed to sum slice");
+    }
+
+    static void TestBoundaryEmptySpanStartCtor()
+    {
+        int[] a = new int[5];
+
+        Span<int> slice = new Span<int>(a, start: a.Length);
+        AssertEqual(slice.Length, 0);
+    }
+
+    static void TestBoundaryEmptySpanStartLengthCtor()
+    {
+        int[] a = new int[5];
 
         Span<int> slice = new Span<int>(a, a.Length, 0);
         AssertEqual(slice.Length, 0);
@@ -158,6 +190,54 @@ class My
         try
         {
             new Span<object>(objEmptyArray);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+    }
+
+    static void TestArrayCoVarianceStartCtor()
+    {
+        var array = new ReferenceType[1];
+        var objArray = (object[])array;
+        try
+        {
+            new Span<object>(objArray, start: 0);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+
+        var objEmptyArray = Array.Empty<ReferenceType>();
+        try
+        {
+            new Span<object>(objEmptyArray, start: 0);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+    }
+
+    static void TestArrayCoVarianceStartLengthCtor()
+    {
+        var array = new ReferenceType[1];
+        var objArray = (object[])array;
+        try
+        {
+            new Span<object>(objArray, start: 0, length: 1);
+            AssertTrue(false, "Expected exception not thrown");
+        }
+        catch (ArrayTypeMismatchException)
+        {
+        }
+
+        var objEmptyArray = Array.Empty<ReferenceType>();
+        try
+        {
+            new Span<object>(objEmptyArray, start: 0, length: 1);
             AssertTrue(false, "Expected exception not thrown");
         }
         catch (ArrayTypeMismatchException)
@@ -603,7 +683,7 @@ class My
         }
     }
 
-    static void WhenSourceTypeLargerThaTargetAndOverflowsInt32ThrowsException()
+    static void WhenSourceTypeLargerThanTargetAndOverflowsInt32ThrowsException()
     {
         unsafe
         {
@@ -635,6 +715,45 @@ class My
         string secondHalfOfString = fullText.Substring(fullText.Length / 2);
         var spanFromSecondHalf = fullText.Slice(fullText.Length / 2);
         AssertEqualContent(secondHalfOfString, spanFromSecondHalf);
+    }
+
+    static void WhenStartLargerThanLengthThrowsExceptionStartCtor()
+    {
+        try
+        {
+            var data = new byte[10];
+            var slice = new Span<byte>(data, start: 11);
+            AssertTrue(false, "Expected exception for Argument Out of Range not thrown");
+        }
+        catch (System.ArgumentOutOfRangeException)
+        {
+        }
+    }
+    
+    static void WhenStartLargerThanLengthThrowsExceptionStartLengthCtor()
+    {
+        try
+        {
+            var data = new byte[10];
+            var slice = new Span<byte>(data, start: 11, length: 0);
+            AssertTrue(false, "Expected exception for Argument Out of Range not thrown");
+        }
+        catch (System.ArgumentOutOfRangeException)
+        {
+        }
+    }
+
+    static void WhenStartAndLengthLargerThanLengthThrowsExceptionStartLengthCtor()
+    {
+        try
+        {
+            var data = new byte[10];
+            var slice = new Span<byte>(data, start: 1, length: 10);
+            AssertTrue(false, "Expected exception for Argument Out of Range not thrown");
+        }
+        catch (System.ArgumentOutOfRangeException)
+        {
+        }
     }
 
     static void Test(Action test, string testName, ref int failedTestsCount)


### PR DESCRIPTION
Changing method/property order to match CoreFX impl (to make diffs easier)

Added other missing methods (to match CoreFX impl):
- `public void CopyTo(Span<T> destination)`
- `public static bool operator ==(Span<T> left, Span<T> right)`
- `public static bool operator !=(Span<T> left, Span<T> right)`
- `public override bool Equals(object obj)`
- `public override int GetHashCode()`

Also removed `public void Set(ReadOnlySpan<T> values)` as it's no
longer part of the [Span<T> public API](https://github.com/dotnet/apireviews/tree/master/2016/11-04-SpanOfT#spantset)