### PR TITLE
Avoid storing successfully completed tasks in Task.WhenAll

### DIFF
--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -5994,7 +5994,10 @@ namespace System.Threading.Tasks
             foreach (Task task in tasks)
             {
                 if (task == null) ThrowHelper.ThrowArgumentException(ExceptionResource.Task_MultiTaskContinuation_NullTask, ExceptionArgument.tasks);
-                taskList.Add(task);
+                if (!task.IsRanToCompletion) // no need to wait on the task if it's already successfully completed
+                {
+                    taskList.Add(task);
+                }
             }
 
             // Delegate the rest to InternalWhenAll()


### PR DESCRIPTION
When WhenAll is used with an enumerable, such as in:
```C#
await Task.WhenAll(inputs.Select(async input =>
{
    ...
}));
```
it's not uncommon for some of the tasks to already be completed by the time WhenAll sees them.  Currently all of the tasks are stored and counted in the countdown list that tracks which tasks remain.  We can instead easily filter those tasks out before they're added to the list, avoiding those overheads (e.g. interlocked operations), the extra array size, unnecessarily keeping those objects alive, etc.

(Note that there are some more impactful changes that could be made in this area, such as getting rid of the ```List<T>```, just using an array, and avoiding the second array from ToArray, but that's a larger change, and this one was trivial to get in.)

cc: @kouvel, @mellinoe 