### PR TITLE
Local GC: Decouple write barrier operations between the GC and EE

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -65,6 +65,9 @@ public:
     static void DiagWalkSurvivors(void* gcContext);
     static void DiagWalkLOHSurvivors(void* gcContext);
     static void DiagWalkBGCSurvivors(void* gcContext);
+    static void StompWriteBarrierResize(WriteBarrierResizeArgs args);
+    static void StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args);
+    static void StompWriteBarrierInitialize(WriteBarrierResizeArgs args);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -65,7 +65,7 @@ public:
     static void DiagWalkSurvivors(void* gcContext);
     static void DiagWalkLOHSurvivors(void* gcContext);
     static void DiagWalkBGCSurvivors(void* gcContext);
-    static void StompWriteBarrier(WriteBarrierArgs* args);
+    static void StompWriteBarrier(WriteBarrierParameters* args);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -65,9 +65,7 @@ public:
     static void DiagWalkSurvivors(void* gcContext);
     static void DiagWalkLOHSurvivors(void* gcContext);
     static void DiagWalkBGCSurvivors(void* gcContext);
-    static void StompWriteBarrierResize(WriteBarrierResizeArgs args);
-    static void StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args);
-    static void StompWriteBarrierInitialize(WriteBarrierResizeArgs args);
+    static void StompWriteBarrier(WriteBarrierArgs* args);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -333,8 +333,8 @@ void gc_heap::add_to_history_per_heap()
 #endif //BACKGROUND_GC
     current_hist->fgc_lowest = lowest_address;
     current_hist->fgc_highest = highest_address;
-    current_hist->g_lowest = g_lowest_address;
-    current_hist->g_highest = g_highest_address;
+    current_hist->g_lowest = g_gc_lowest_address;
+    current_hist->g_highest = g_gc_highest_address;
 
     gchist_index_per_heap++;
     if (gchist_index_per_heap == max_history_count)
@@ -1402,8 +1402,8 @@ int mark_time, plan_time, sweep_time, reloc_time, compact_time;
 
 #ifndef MULTIPLE_HEAPS
 
-#define ephemeral_low           g_ephemeral_low
-#define ephemeral_high          g_ephemeral_high
+#define ephemeral_low           g_gc_ephemeral_low
+#define ephemeral_high          g_gc_ephemeral_high
 
 #endif // MULTIPLE_HEAPS
 
@@ -2175,6 +2175,40 @@ int log2(unsigned int n)
     if (n >= 1<< 1) {           pos +=  1; }
     return pos;
 }
+
+#ifndef DACCESS_COMPILE
+void stomp_write_barrier_resize(bool is_runtime_suspended, bool requires_upper_bounds_check)
+{
+    WriteBarrierResizeArgs args;
+    args.is_runtime_suspended = is_runtime_suspended;
+    args.requires_upper_bounds_check = requires_upper_bounds_check;
+    args.new_card_table = g_gc_card_table;
+    args.new_lowest_address = g_gc_lowest_address;
+    args.new_highest_address = g_gc_highest_address;
+    GCToEEInterface::StompWriteBarrierResize(args);
+}
+
+void stomp_write_barrier_ephemeral(bool is_runtime_suspended, uint8_t* ephemeral_lo, uint8_t* ephemeral_hi)
+{
+    WriteBarrierEphemeralArgs args;
+    args.is_runtime_suspended = is_runtime_suspended;
+    args.new_ephemeral_low = ephemeral_lo;
+    args.new_ephemeral_high = ephemeral_hi;
+    GCToEEInterface::StompWriteBarrierEphemeral(args);
+}
+
+void stomp_write_barrier_initialize()
+{
+    WriteBarrierResizeArgs args;
+    args.is_runtime_suspended = true;
+    args.requires_upper_bounds_check = false;
+    args.new_card_table = g_gc_card_table;
+    args.new_lowest_address = g_gc_lowest_address;
+    args.new_highest_address = g_gc_highest_address;
+    GCToEEInterface::StompWriteBarrierInitialize(args);
+}
+
+#endif // DACCESS_COMPILE
 
 //extract the low bits [0,low[ of a uint32_t
 #define lowbits(wrd, bits) ((wrd) & ((1 << (bits))-1))
@@ -3406,7 +3440,7 @@ inline
 size_t ro_seg_begin_index (heap_segment* seg)
 {
     size_t begin_index = (size_t)seg / gc_heap::min_segment_size;
-    begin_index = max (begin_index, (size_t)g_lowest_address / gc_heap::min_segment_size);
+    begin_index = max (begin_index, (size_t)g_gc_lowest_address / gc_heap::min_segment_size);
     return begin_index;
 }
 
@@ -3414,14 +3448,14 @@ inline
 size_t ro_seg_end_index (heap_segment* seg)
 {
     size_t end_index = (size_t)(heap_segment_reserved (seg) - 1) / gc_heap::min_segment_size;
-    end_index = min (end_index, (size_t)g_highest_address / gc_heap::min_segment_size);
+    end_index = min (end_index, (size_t)g_gc_highest_address / gc_heap::min_segment_size);
     return end_index;
 }
 
 void seg_mapping_table_add_ro_segment (heap_segment* seg)
 {
 #ifdef GROWABLE_SEG_MAPPING_TABLE
-    if ((heap_segment_reserved (seg) <= g_lowest_address) || (heap_segment_mem (seg) >= g_highest_address))
+    if ((heap_segment_reserved (seg) <= g_gc_lowest_address) || (heap_segment_mem (seg) >= g_gc_highest_address))
         return;
 #endif //GROWABLE_SEG_MAPPING_TABLE
 
@@ -3605,7 +3639,7 @@ gc_heap* seg_mapping_table_heap_of_worker (uint8_t* o)
 gc_heap* seg_mapping_table_heap_of (uint8_t* o)
 {
 #ifdef GROWABLE_SEG_MAPPING_TABLE
-    if ((o < g_lowest_address) || (o >= g_highest_address))
+    if ((o < g_gc_lowest_address) || (o >= g_gc_highest_address))
         return 0;
 #endif //GROWABLE_SEG_MAPPING_TABLE
 
@@ -3615,7 +3649,7 @@ gc_heap* seg_mapping_table_heap_of (uint8_t* o)
 gc_heap* seg_mapping_table_heap_of_gc (uint8_t* o)
 {
 #if defined(FEATURE_BASICFREEZE) && defined(GROWABLE_SEG_MAPPING_TABLE)
-    if ((o < g_lowest_address) || (o >= g_highest_address))
+    if ((o < g_gc_lowest_address) || (o >= g_gc_highest_address))
         return 0;
 #endif //FEATURE_BASICFREEZE || GROWABLE_SEG_MAPPING_TABLE
 
@@ -3627,7 +3661,7 @@ gc_heap* seg_mapping_table_heap_of_gc (uint8_t* o)
 heap_segment* seg_mapping_table_segment_of (uint8_t* o)
 {
 #if defined(FEATURE_BASICFREEZE) && defined(GROWABLE_SEG_MAPPING_TABLE)
-    if ((o < g_lowest_address) || (o >= g_highest_address))
+    if ((o < g_gc_lowest_address) || (o >= g_gc_highest_address))
 #ifdef FEATURE_BASICFREEZE
         return ro_segment_lookup (o);
 #else
@@ -3670,7 +3704,7 @@ heap_segment* seg_mapping_table_segment_of (uint8_t* o)
 
 #ifdef FEATURE_BASICFREEZE
     // TODO: This was originally written assuming that the seg_mapping_table would always contain entries for ro 
-    // segments whenever the ro segment falls into the [g_lowest_address,g_highest_address) range.  I.e., it had an 
+    // segments whenever the ro segment falls into the [g_gc_lowest_address,g_gc_highest_address) range.  I.e., it had an 
     // extra "&& (size_t)(entry->seg1) & ro_in_entry" expression.  However, at the moment, grow_brick_card_table does 
     // not correctly go through the ro segments and add them back to the seg_mapping_table when the [lowest,highest) 
     // range changes.  We should probably go ahead and modify grow_brick_card_table and put back the 
@@ -4070,8 +4104,8 @@ BOOL reserve_initial_memory (size_t normal_size, size_t large_size, size_t num_h
     memory_details.current_block_normal = 0;
     memory_details.current_block_large = 0;
 
-    g_lowest_address = MAX_PTR;
-    g_highest_address = 0;
+    g_gc_lowest_address = MAX_PTR;
+    g_gc_highest_address = 0;
 
     if (((size_t)MAX_PTR - large_size) < normal_size)
     {
@@ -4091,8 +4125,8 @@ BOOL reserve_initial_memory (size_t normal_size, size_t large_size, size_t num_h
     uint8_t* allatonce_block = (uint8_t*)virtual_alloc (requestedMemory);
     if (allatonce_block)
     {
-        g_lowest_address =  allatonce_block;
-        g_highest_address = allatonce_block + (memory_details.block_count * (large_size + normal_size));
+        g_gc_lowest_address =  allatonce_block;
+        g_gc_highest_address = allatonce_block + (memory_details.block_count * (large_size + normal_size));
         memory_details.allocation_pattern = initial_memory_details::ALLATONCE;
 
         for(size_t i = 0; i < memory_details.block_count; i++)
@@ -4115,8 +4149,8 @@ BOOL reserve_initial_memory (size_t normal_size, size_t large_size, size_t num_h
             if (b2)
             {
                 memory_details.allocation_pattern = initial_memory_details::TWO_STAGE;
-                g_lowest_address = min(b1,b2);
-                g_highest_address = max(b1 + memory_details.block_count*normal_size,
+                g_gc_lowest_address = min(b1,b2);
+                g_gc_highest_address = max(b1 + memory_details.block_count*normal_size,
                                         b2 + memory_details.block_count*large_size);
                 for(size_t i = 0; i < memory_details.block_count; i++)
                 {
@@ -4162,10 +4196,10 @@ BOOL reserve_initial_memory (size_t normal_size, size_t large_size, size_t num_h
                 }
                 else
                 {
-                    if (current_block->memory_base < g_lowest_address)
-                        g_lowest_address =  current_block->memory_base;
-                    if (((uint8_t *) current_block->memory_base + block_size) > g_highest_address)
-                        g_highest_address = (current_block->memory_base + block_size);
+                    if (current_block->memory_base < g_gc_lowest_address)
+                        g_gc_lowest_address =  current_block->memory_base;
+                    if (((uint8_t *) current_block->memory_base + block_size) > g_gc_highest_address)
+                        g_gc_highest_address = (current_block->memory_base + block_size);
                 }
                 reserve_success = TRUE;
             }
@@ -4607,22 +4641,22 @@ gc_heap::get_segment (size_t size, BOOL loh_p)
         {
             uint8_t* start;
             uint8_t* end;
-            if (mem < g_lowest_address)
+            if (mem < g_gc_lowest_address)
             {
                 start =  (uint8_t*)mem;
             }
             else
             {
-                start = (uint8_t*)g_lowest_address;
+                start = (uint8_t*)g_gc_lowest_address;
             }
 
-            if (((uint8_t*)mem + size) > g_highest_address)
+            if (((uint8_t*)mem + size) > g_gc_highest_address)
             {
                 end = (uint8_t*)mem + size;
             }
             else
             {
-                end = (uint8_t*)g_highest_address;
+                end = (uint8_t*)g_gc_highest_address;
             }
 
             if (gc_heap::grow_brick_card_tables (start, end, size, result, __this, loh_p) != 0)
@@ -5321,7 +5355,7 @@ heap_segment* gc_heap::segment_of (uint8_t* add, ptrdiff_t& delta, BOOL verify_p
     uint8_t* sadd = add;
     heap_segment* hs = 0;
     heap_segment* hs1 = 0;
-    if (!((add >= g_lowest_address) && (add < g_highest_address)))
+    if (!((add >= g_gc_lowest_address) && (add < g_gc_highest_address)))
     {
         delta = 0;
         return 0;
@@ -6378,7 +6412,7 @@ void gc_heap::set_card (size_t card)
 inline
 void gset_card (size_t card)
 {
-    g_card_table [card_word (card)] |= (1 << card_bit (card));
+    g_gc_card_table [card_word (card)] |= (1 << card_bit (card));
 }
 
 inline
@@ -6489,7 +6523,7 @@ size_t size_card_bundle_of (uint8_t* from, uint8_t* end)
 
 uint32_t* translate_card_bundle_table (uint32_t* cb)
 {
-    return (uint32_t*)((uint8_t*)cb - ((((size_t)g_lowest_address) / (card_size*card_word_width*card_bundle_size*card_bundle_word_width)) * sizeof (uint32_t)));
+    return (uint32_t*)((uint8_t*)cb - ((((size_t)g_gc_lowest_address) / (card_size*card_word_width*card_bundle_size*card_bundle_word_width)) * sizeof (uint32_t)));
 }
 
 void gc_heap::enable_card_bundles ()
@@ -6701,7 +6735,7 @@ size_t size_mark_array_of (uint8_t* from, uint8_t* end)
 // according to the lowest_address.
 uint32_t* translate_mark_array (uint32_t* ma)
 {
-    return (uint32_t*)((uint8_t*)ma - size_mark_array_of (0, g_lowest_address));
+    return (uint32_t*)((uint8_t*)ma - size_mark_array_of (0, g_gc_lowest_address));
 }
 
 // from and end must be page aligned addresses. 
@@ -6829,16 +6863,16 @@ void release_card_table (uint32_t* c_table)
         {
             destroy_card_table (c_table);
             // sever the link from the parent
-            if (&g_card_table[card_word (gcard_of(g_lowest_address))] == c_table)
+            if (&g_gc_card_table[card_word (gcard_of(g_gc_lowest_address))] == c_table)
             {
-                g_card_table = 0;
+                g_gc_card_table = 0;
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
                 SoftwareWriteWatch::StaticClose();
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
             }
             else
             {
-                uint32_t* p_table = &g_card_table[card_word (gcard_of(g_lowest_address))];
+                uint32_t* p_table = &g_gc_card_table[card_word (gcard_of(g_gc_lowest_address))];
                 if (p_table)
                 {
                     while (p_table && (card_table_next (p_table) != c_table))
@@ -6860,8 +6894,8 @@ void destroy_card_table (uint32_t* c_table)
 
 uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
 {
-    assert (g_lowest_address == start);
-    assert (g_highest_address == end);
+    assert (g_gc_lowest_address == start);
+    assert (g_gc_highest_address == end);
 
     uint32_t virtual_reserve_flags = VirtualReserveFlags::None;
 
@@ -6881,7 +6915,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
     if (can_use_write_watch_for_card_table())
     {
         virtual_reserve_flags |= VirtualReserveFlags::WriteWatch;
-        cb = size_card_bundle_of (g_lowest_address, g_highest_address);
+        cb = size_card_bundle_of (g_gc_lowest_address, g_gc_highest_address);
     }
 #endif //CARD_BUNDLE
 
@@ -6897,7 +6931,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
 #ifdef GROWABLE_SEG_MAPPING_TABLE
-    size_t st = size_seg_mapping_table_of (g_lowest_address, g_highest_address);
+    size_t st = size_seg_mapping_table_of (g_gc_lowest_address, g_gc_highest_address);
     size_t st_table_offset = sizeof(card_table_info) + cs + bs + cb + wws;
     size_t st_table_offset_aligned = align_for_seg_mapping_table (st_table_offset);
 
@@ -6952,7 +6986,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
 #ifdef GROWABLE_SEG_MAPPING_TABLE
     seg_mapping_table = (seg_mapping*)(mem + st_table_offset_aligned);
     seg_mapping_table = (seg_mapping*)((uint8_t*)seg_mapping_table - 
-                                        size_seg_mapping_table_of (0, (align_lower_segment (g_lowest_address))));
+                                        size_seg_mapping_table_of (0, (align_lower_segment (g_gc_lowest_address))));
 #endif //GROWABLE_SEG_MAPPING_TABLE
 
 #ifdef MARK_ARRAY
@@ -6991,10 +7025,10 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
                                      gc_heap* hp, 
                                      BOOL loh_p)
 {
-    uint8_t* la = g_lowest_address;
-    uint8_t* ha = g_highest_address;
-    uint8_t* saved_g_lowest_address = min (start, g_lowest_address);
-    uint8_t* saved_g_highest_address = max (end, g_highest_address);
+    uint8_t* la = g_gc_lowest_address;
+    uint8_t* ha = g_gc_highest_address;
+    uint8_t* saved_g_lowest_address = min (start, g_gc_lowest_address);
+    uint8_t* saved_g_highest_address = max (end, g_gc_highest_address);
 #ifdef BACKGROUND_GC
     // This value is only for logging purpose - it's not necessarily exactly what we 
     // would commit for mark array but close enough for diagnostics purpose.
@@ -7024,18 +7058,18 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
 #endif // BIT64
                 ps *= 2;
 
-            if (saved_g_lowest_address < g_lowest_address)
+            if (saved_g_lowest_address < g_gc_lowest_address)
             {
-                if (ps > (size_t)g_lowest_address)
+                if (ps > (size_t)g_gc_lowest_address)
                     saved_g_lowest_address = (uint8_t*)OS_PAGE_SIZE;
                 else
                 {
-                    assert (((size_t)g_lowest_address - ps) >= OS_PAGE_SIZE);
-                    saved_g_lowest_address = min (saved_g_lowest_address, (g_lowest_address - ps));
+                    assert (((size_t)g_gc_lowest_address - ps) >= OS_PAGE_SIZE);
+                    saved_g_lowest_address = min (saved_g_lowest_address, (g_gc_lowest_address - ps));
                 }
             }
 
-            if (saved_g_highest_address > g_highest_address)
+            if (saved_g_highest_address > g_gc_highest_address)
             {
                 saved_g_highest_address = max ((saved_g_lowest_address + ps), saved_g_highest_address);
                 if (saved_g_highest_address > top)
@@ -7048,7 +7082,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
 
         bool write_barrier_updated = false;
         uint32_t virtual_reserve_flags = VirtualReserveFlags::None;
-        uint32_t* saved_g_card_table = g_card_table;
+        uint32_t* saved_g_card_table = g_gc_card_table;
         uint32_t* ct = 0;
         uint32_t* translated_ct = 0;
         short* bt = 0;
@@ -7131,7 +7165,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         card_table_refcount (ct) = 0;
         card_table_lowest_address (ct) = saved_g_lowest_address;
         card_table_highest_address (ct) = saved_g_highest_address;
-        card_table_next (ct) = &g_card_table[card_word (gcard_of (la))];
+        card_table_next (ct) = &g_gc_card_table[card_word (gcard_of (la))];
 
         //clear the card table
 /*
@@ -7158,9 +7192,9 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
             seg_mapping* new_seg_mapping_table = (seg_mapping*)(mem + st_table_offset_aligned);
             new_seg_mapping_table = (seg_mapping*)((uint8_t*)new_seg_mapping_table -
                                               size_seg_mapping_table_of (0, (align_lower_segment (saved_g_lowest_address))));
-            memcpy(&new_seg_mapping_table[seg_mapping_word_of(g_lowest_address)],
-                &seg_mapping_table[seg_mapping_word_of(g_lowest_address)],
-                size_seg_mapping_table_of(g_lowest_address, g_highest_address));
+            memcpy(&new_seg_mapping_table[seg_mapping_word_of(g_gc_lowest_address)],
+                &seg_mapping_table[seg_mapping_word_of(g_gc_lowest_address)],
+                size_seg_mapping_table_of(g_gc_lowest_address, g_gc_highest_address));
 
             seg_mapping_table = new_seg_mapping_table;
         }
@@ -7222,12 +7256,14 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
                 // Note on points where the runtime is suspended anywhere in this function. Upon an attempt to suspend the
                 // runtime, a different thread may suspend first, causing this thread to block at the point of the suspend call.
                 // So, at any suspend point, externally visible state needs to be consistent, as code that depends on that state
-                // may run while this thread is blocked. This includes updates to g_card_table, g_lowest_address, and
-                // g_highest_address.
+                // may run while this thread is blocked. This includes updates to g_gc_card_table, g_gc_lowest_address, and
+                // g_gc_highest_address.
                 suspend_EE();
             }
 
-            g_card_table = translated_ct;
+            g_gc_card_table = translated_ct;
+            g_gc_lowest_address = saved_g_lowest_address;
+            g_gc_highest_address = saved_g_highest_address;
 
             SoftwareWriteWatch::SetResizedUntranslatedTable(
                 mem + sw_ww_table_offset,
@@ -7239,7 +7275,7 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
             // grow version of the write barrier.  This test tells us if the new
             // segment was allocated at a lower address than the old, requiring
             // that we start doing an upper bounds check in the write barrier.
-            StompWriteBarrierResize(true, la != saved_g_lowest_address);
+            stomp_write_barrier_resize(true, la != saved_g_lowest_address);
             write_barrier_updated = true;
 
             if (!is_runtime_suspended)
@@ -7250,8 +7286,11 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         else
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         {
-            g_card_table = translated_ct;
+            g_gc_card_table = translated_ct;
         }
+
+        g_gc_lowest_address = saved_g_lowest_address;
+        g_gc_highest_address = saved_g_highest_address;
 
         if (!write_barrier_updated)
         {
@@ -7263,19 +7302,9 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
             // to be changed, so we are doing this after all global state has
             // been updated. See the comment above suspend_EE() above for more
             // info.
-            StompWriteBarrierResize(!!IsGCThread(), la != saved_g_lowest_address);
+            stomp_write_barrier_resize(!!IsGCThread(), la != saved_g_lowest_address);
         }
 
-        // We need to make sure that other threads executing checked write barriers
-        // will see the g_card_table update before g_lowest/highest_address updates.
-        // Otherwise, the checked write barrier may AV accessing the old card table
-        // with address that it does not cover. Write barriers access card table 
-        // without memory barriers for performance reasons, so we need to flush 
-        // the store buffers here.
-        GCToOSInterface::FlushProcessWriteBuffers();
-
-        g_lowest_address = saved_g_lowest_address;
-        VolatileStore(&g_highest_address, saved_g_highest_address);
 
         return 0;
         
@@ -7284,7 +7313,7 @@ fail:
 
         if (mem)
         {
-            assert(g_card_table == saved_g_card_table);
+            assert(g_gc_card_table == saved_g_card_table);
 
             //delete (uint32_t*)((uint8_t*)ct - sizeof(card_table_info));
             if (!GCToOSInterface::VirtualRelease (mem, alloc_size_aligned))
@@ -7442,7 +7471,7 @@ void gc_heap::copy_brick_card_table()
     assert (ha == card_table_highest_address (&old_card_table[card_word (card_of (la))]));
 
     /* todo: Need a global lock for this */
-    uint32_t* ct = &g_card_table[card_word (gcard_of (g_lowest_address))];
+    uint32_t* ct = &g_gc_card_table[card_word (gcard_of (g_gc_lowest_address))];
     own_card_table (ct);
     card_table = translate_card_table (ct);
     /* End of global lock */
@@ -7455,8 +7484,8 @@ void gc_heap::copy_brick_card_table()
     if (gc_can_use_concurrent)
     {
         mark_array = translate_mark_array (card_table_mark_array (ct));
-        assert (mark_word_of (g_highest_address) ==
-            mark_word_of (align_on_mark_word (g_highest_address)));
+        assert (mark_word_of (g_gc_highest_address) ==
+            mark_word_of (align_on_mark_word (g_gc_highest_address)));
     }
     else
         mark_array = NULL;
@@ -7465,13 +7494,13 @@ void gc_heap::copy_brick_card_table()
 #ifdef CARD_BUNDLE
 #if defined(MARK_ARRAY) && defined(_DEBUG)
 #ifdef GROWABLE_SEG_MAPPING_TABLE
-    size_t st = size_seg_mapping_table_of (g_lowest_address, g_highest_address);
+    size_t st = size_seg_mapping_table_of (g_gc_lowest_address, g_gc_highest_address);
 #else  //GROWABLE_SEG_MAPPING_TABLE
     size_t st = 0;
 #endif //GROWABLE_SEG_MAPPING_TABLE
 #endif //MARK_ARRAY && _DEBUG
     card_bundle_table = translate_card_bundle_table (card_table_card_bundle_table (ct));
-    assert (&card_bundle_table [card_bundle_word (cardw_card_bundle (card_word (card_of (g_lowest_address))))] ==
+    assert (&card_bundle_table [card_bundle_word (cardw_card_bundle (card_word (card_of (g_gc_lowest_address))))] ==
             card_table_card_bundle_table (ct));
 
     //set the card table if we are in a heap growth scenario
@@ -9315,7 +9344,7 @@ void gc_heap::update_card_table_bundle()
             {
                 size_t bcardw = (uint32_t*)(max(g_addresses[i],base_address)) - &card_table[0];
                 size_t ecardw = (uint32_t*)(min(g_addresses[i]+OS_PAGE_SIZE, high_address)) - &card_table[0];
-                assert (bcardw >= card_word (card_of (g_lowest_address)));
+                assert (bcardw >= card_word (card_of (g_gc_lowest_address)));
 
                 card_bundles_set (cardw_card_bundle (bcardw),
                                   cardw_card_bundle (align_cardw_on_bundle (ecardw)));
@@ -9627,7 +9656,7 @@ void gc_heap::adjust_ephemeral_limits (bool is_runtime_suspended)
                  (size_t)ephemeral_low, (size_t)ephemeral_high))
 
     // This updates the write barrier helpers with the new info.
-    StompWriteBarrierEphemeral(is_runtime_suspended);
+    stomp_write_barrier_ephemeral(is_runtime_suspended, ephemeral_low, ephemeral_high);
 }
 
 #if defined(TRACE_GC) || defined(GC_CONFIG_DRIVEN)
@@ -9800,9 +9829,9 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 
     settings.first_init();
 
-    g_card_table = make_card_table (g_lowest_address, g_highest_address);
+    g_gc_card_table = make_card_table (g_gc_lowest_address, g_gc_highest_address);
 
-    if (!g_card_table)
+    if (!g_gc_card_table)
         return E_OUTOFMEMORY;
 
     gc_started = FALSE;
@@ -10285,7 +10314,7 @@ gc_heap::init_gc_heap (int  h_number)
 #endif //MULTIPLE_HEAPS
 
     /* todo: Need a global lock for this */
-    uint32_t* ct = &g_card_table [card_word (card_of (g_lowest_address))];
+    uint32_t* ct = &g_gc_card_table [card_word (card_of (g_gc_lowest_address))];
     own_card_table (ct);
     card_table = translate_card_table (ct);
     /* End of global lock */
@@ -10296,13 +10325,13 @@ gc_heap::init_gc_heap (int  h_number)
 
 #ifdef CARD_BUNDLE
     card_bundle_table = translate_card_bundle_table (card_table_card_bundle_table (ct));
-    assert (&card_bundle_table [card_bundle_word (cardw_card_bundle (card_word (card_of (g_lowest_address))))] ==
+    assert (&card_bundle_table [card_bundle_word (cardw_card_bundle (card_word (card_of (g_gc_lowest_address))))] ==
             card_table_card_bundle_table (ct));
 #endif //CARD_BUNDLE
 
 #ifdef MARK_ARRAY
     if (gc_can_use_concurrent)
-        mark_array = translate_mark_array (card_table_mark_array (&g_card_table[card_word (card_of (g_lowest_address))]));
+        mark_array = translate_mark_array (card_table_mark_array (&g_gc_card_table[card_word (card_of (g_gc_lowest_address))]));
     else
         mark_array = NULL;
 #endif //MARK_ARRAY
@@ -15166,7 +15195,7 @@ void gc_heap::gc1()
 
     vm_heap->GcCondemnedGeneration = settings.condemned_generation;
 
-    assert (g_card_table == card_table);
+    assert (g_gc_card_table == card_table);
 
     {
         if (n == max_generation)
@@ -16373,7 +16402,7 @@ int gc_heap::garbage_collect (int n)
         for (int i = 0; i < n_heaps; i++)
         {
             //copy the card and brick tables
-            if (g_card_table != g_heaps[i]->card_table)
+            if (g_gc_card_table != g_heaps[i]->card_table)
             {
                 g_heaps[i]->copy_brick_card_table();
             }
@@ -16397,7 +16426,7 @@ int gc_heap::garbage_collect (int n)
             }
 #endif //BACKGROUND_GC
         // check for card table growth
-        if (g_card_table != card_table)
+        if (g_gc_card_table != card_table)
             copy_brick_card_table();
 
 #endif //MULTIPLE_HEAPS
@@ -22373,7 +22402,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
         for (i = 0; i < n_heaps; i++)
         {
             //copy the card and brick tables
-            if (g_card_table!= g_heaps[i]->card_table)
+            if (g_gc_card_table!= g_heaps[i]->card_table)
             {
                 g_heaps[i]->copy_brick_card_table();
             }
@@ -25079,14 +25108,14 @@ BOOL gc_heap::commit_mark_array_new_seg (gc_heap* hp,
 
         if (new_card_table == 0)
         {
-            new_card_table = g_card_table;
+            new_card_table = g_gc_card_table;
         }
 
         if (hp->card_table != new_card_table)
         {
             if (new_lowest_address == 0)
             {
-                new_lowest_address = g_lowest_address;
+                new_lowest_address = g_gc_lowest_address;
             }
 
             uint32_t* ct = &new_card_table[card_word (gcard_of (new_lowest_address))];
@@ -29076,7 +29105,7 @@ generation* gc_heap::expand_heap (int condemned_generation,
         return consing_gen;
 
     //copy the card and brick tables
-    if (g_card_table!= card_table)
+    if (g_gc_card_table!= card_table)
         copy_brick_card_table();
 
     BOOL new_segment_p = (heap_segment_next (new_seg) == 0);
@@ -32386,7 +32415,7 @@ void gc_heap::clear_all_mark_array()
 void gc_heap::verify_mark_array_cleared (heap_segment* seg)
 {
 #if defined (VERIFY_HEAP) && defined (MARK_ARRAY)
-    assert (card_table == g_card_table);
+    assert (card_table == g_gc_card_table);
     size_t  markw = mark_word_of (heap_segment_mem (seg));
     size_t  markw_end = mark_word_of (heap_segment_reserved (seg));
 
@@ -32734,8 +32763,8 @@ gc_heap::verify_heap (BOOL begin_gc_p)
 #endif //BACKGROUND_GC 
 
 #ifndef MULTIPLE_HEAPS
-    if ((g_ephemeral_low != generation_allocation_start (generation_of (max_generation - 1))) ||
-        (g_ephemeral_high != heap_segment_reserved (ephemeral_heap_segment)))
+    if ((g_gc_ephemeral_low != generation_allocation_start (generation_of (max_generation - 1))) ||
+        (g_gc_ephemeral_high != heap_segment_reserved (ephemeral_heap_segment)))
     {
         FATAL_GC_ERROR();
     }
@@ -32794,7 +32823,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
         for (int i = 0; i < n_heaps; i++)
         {
             //copy the card and brick tables
-            if (g_card_table != g_heaps[i]->card_table)
+            if (g_gc_card_table != g_heaps[i]->card_table)
             {
                 g_heaps[i]->copy_brick_card_table();
             }
@@ -32803,7 +32832,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
         current_join->restart();
     }
 #else
-        if (g_card_table != card_table)
+        if (g_gc_card_table != card_table)
             copy_brick_card_table();
 #endif //MULTIPLE_HEAPS
 
@@ -33228,11 +33257,11 @@ HRESULT GCHeap::Shutdown ()
     //CloseHandle (WaitForGCEvent);
 
     //find out if the global card table hasn't been used yet
-    uint32_t* ct = &g_card_table[card_word (gcard_of (g_lowest_address))];
+    uint32_t* ct = &g_gc_card_table[card_word (gcard_of (g_gc_lowest_address))];
     if (card_table_refcount (ct) == 0)
     {
         destroy_card_table (ct);
-        g_card_table = 0;
+        g_gc_card_table = 0;
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         SoftwareWriteWatch::StaticClose();
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
@@ -33392,7 +33421,7 @@ HRESULT GCHeap::Initialize ()
         return E_FAIL;
     }
 
-    StompWriteBarrierResize(true, false);
+    stomp_write_barrier_initialize();
 
 #ifndef FEATURE_REDHAWK // Redhawk forces relocation a different way
 #if defined (STRESS_HEAP) && !defined (MULTIPLE_HEAPS)
@@ -33513,7 +33542,7 @@ Object * GCHeap::NextObj (Object * object)
     uint8_t* o = (uint8_t*)object;
 
 #ifndef FEATURE_BASICFREEZE
-    if (!((o < g_highest_address) && (o >= g_lowest_address)))
+    if (!((o < g_gc_highest_address) && (o >= g_gc_lowest_address)))
     {
         return NULL;
     }
@@ -33584,7 +33613,7 @@ BOOL GCHeap::IsHeapPointer (void* vpObject, BOOL small_heap_only)
 
     uint8_t* object = (uint8_t*) vpObject;
 #ifndef FEATURE_BASICFREEZE
-    if (!((object < g_highest_address) && (object >= g_lowest_address)))
+    if (!((object < g_gc_highest_address) && (object >= g_gc_lowest_address)))
         return FALSE;
 #endif //!FEATURE_BASICFREEZE
 
@@ -35695,12 +35724,12 @@ GCHeap::SetCardsAfterBulkCopy( Object **StartPoint, size_t len )
     end = StartPoint + (len/sizeof(Object*));
     while (rover < end)
     {
-        if ( (((uint8_t*)*rover) >= g_ephemeral_low) && (((uint8_t*)*rover) < g_ephemeral_high) )
+        if ( (((uint8_t*)*rover) >= g_gc_ephemeral_low) && (((uint8_t*)*rover) < g_gc_ephemeral_high) )
         {
             // Set Bit For Card and advance to next card
             size_t card = gcard_of ((uint8_t*)rover);
 
-            Interlocked::Or (&g_card_table[card/card_word_width], (1U << (card % card_word_width)));
+            Interlocked::Or (&g_gc_card_table[card/card_word_width], (1U << (card % card_word_width)));
             // Skip to next card for the object
             rover = (Object**)align_on_card ((uint8_t*)(rover+1));
         }
@@ -36568,7 +36597,7 @@ void initGCShadow()
     if (!(g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_BARRIERCHECK))
         return;
 
-    size_t len = g_highest_address - g_lowest_address;
+    size_t len = g_gc_highest_address - g_gc_lowest_address;
     if (len > (size_t)(g_GCShadowEnd - g_GCShadow)) 
     {
         deleteGCShadow();
@@ -36587,10 +36616,10 @@ void initGCShadow()
         g_GCShadowEnd += len;
     }
 
-    // save the value of g_lowest_address at this time.  If this value changes before
+    // save the value of g_gc_lowest_address at this time.  If this value changes before
     // the next call to checkGCWriteBarrier() it means we extended the heap (with a
     // large object segment most probably), and the whole shadow segment is inconsistent.
-    g_shadow_lowest_address = g_lowest_address;
+    g_shadow_lowest_address = g_gc_lowest_address;
 
         //****** Copy the whole GC heap ******
     //
@@ -36600,7 +36629,7 @@ void initGCShadow()
     generation* gen = gc_heap::generation_of (max_generation);
     heap_segment* seg = heap_segment_rw (generation_start_segment (gen));
 
-    ptrdiff_t delta = g_GCShadow - g_lowest_address;
+    ptrdiff_t delta = g_GCShadow - g_gc_lowest_address;
     BOOL small_object_segments = TRUE;
     while(1)
     {
@@ -36628,7 +36657,7 @@ void initGCShadow()
     // test to see if 'ptr' was only updated via the write barrier.
 inline void testGCShadow(Object** ptr)
 {
-    Object** shadow = (Object**) &g_GCShadow[((uint8_t*) ptr - g_lowest_address)];
+    Object** shadow = (Object**) &g_GCShadow[((uint8_t*) ptr - g_gc_lowest_address)];
     if (*ptr != 0 && (uint8_t*) shadow < g_GCShadowEnd && *ptr != *shadow)
     {
 
@@ -36687,9 +36716,9 @@ void testGCShadowHelper (uint8_t* x)
     // Walk the whole heap, looking for pointers that were not updated with the write barrier.
 void checkGCWriteBarrier()
 {
-    // g_shadow_lowest_address != g_lowest_address means the GC heap was extended by a segment
+    // g_shadow_lowest_address != g_gc_lowest_address means the GC heap was extended by a segment
     // and the GC shadow segment did not track that change!
-    if (g_GCShadowEnd <= g_GCShadow || g_shadow_lowest_address != g_lowest_address)
+    if (g_GCShadowEnd <= g_GCShadow || g_shadow_lowest_address != g_gc_lowest_address)
     {
         // No shadow stack, nothing to check.
         return;

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -2180,23 +2180,23 @@ int log2(unsigned int n)
 
 void stomp_write_barrier_resize(bool is_runtime_suspended, bool requires_upper_bounds_check)
 {
-    WriteBarrierArgs args = {};
+    WriteBarrierParameters args = {};
     args.operation = WriteBarrierOp::StompResize;
     args.is_runtime_suspended = is_runtime_suspended;
     args.requires_upper_bounds_check = requires_upper_bounds_check;
-    args.new_card_table = g_gc_card_table;
-    args.new_lowest_address = g_gc_lowest_address;
-    args.new_highest_address = g_gc_highest_address;
+    args.card_table = g_gc_card_table;
+    args.lowest_address = g_gc_lowest_address;
+    args.highest_address = g_gc_highest_address;
     GCToEEInterface::StompWriteBarrier(&args);
 }
 
 void stomp_write_barrier_ephemeral(bool is_runtime_suspended, uint8_t* ephemeral_lo, uint8_t* ephemeral_hi)
 {
-    WriteBarrierArgs args = {};
+    WriteBarrierParameters args = {};
     args.operation = WriteBarrierOp::StompEphemeral;
     args.is_runtime_suspended = is_runtime_suspended;
-    args.new_ephemeral_low = g_gc_ephemeral_low;
-    args.new_ephemeral_high = g_gc_ephemeral_high;
+    args.ephemeral_lo = g_gc_ephemeral_low;
+    args.ephemeral_hi = g_gc_ephemeral_high;
 #ifdef MULTIPLE_HEAPS
     // It is not correct to update the EE's g_ephemeral_low and g_ephemeral_high
     // to anything other than their default values when using Server GC, since
@@ -2205,21 +2205,21 @@ void stomp_write_barrier_ephemeral(bool is_runtime_suspended, uint8_t* ephemeral
     //
     // When MULTIPLE_HEAPS is defined, g_gc_ephemeral_low and g_gc_ephemeral_high should
     // always have their default values.
-    assert(args.new_ephemeral_low == (uint8_t*)1);
-    assert(args.new_ephemeral_high == (uint8_t*)~0);
+    assert(args.ephemeral_lo == (uint8_t*)1);
+    assert(args.ephemeral_hi == (uint8_t*)~0);
 #endif // MULTIPLE_HEAPS
     GCToEEInterface::StompWriteBarrier(&args);
 }
 
 void stomp_write_barrier_initialize()
 {
-    WriteBarrierArgs args = {};
+    WriteBarrierParameters args = {};
     args.operation = WriteBarrierOp::Initialize;
     args.is_runtime_suspended = true;
     args.requires_upper_bounds_check = false;
-    args.new_card_table = g_gc_card_table;
-    args.new_lowest_address = g_gc_lowest_address;
-    args.new_highest_address = g_gc_highest_address;
+    args.card_table = g_gc_card_table;
+    args.lowest_address = g_gc_lowest_address;
+    args.highest_address = g_gc_highest_address;
     GCToEEInterface::StompWriteBarrier(&args);
 }
 

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -137,6 +137,12 @@ class DacHeapWalker;
 
 #define MP_LOCKS
 
+extern "C" uint32_t* g_gc_card_table;
+extern "C" uint8_t* g_gc_lowest_address;
+extern "C" uint8_t* g_gc_highest_address;
+extern "C" uint8_t* g_gc_ephemeral_low;
+extern "C" uint8_t* g_gc_ephemeral_high;
+
 namespace WKS {
     ::IGCHeapInternal* CreateGCHeap();
     class GCHeap;

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -26,27 +26,23 @@ IGCHeapInternal* g_theGCHeap;
 IGCToCLR* g_theGCToCLR;
 #endif // FEATURE_STANDALONE_GC
 
-/* global versions of the card table and brick table */ 
-GPTR_IMPL(uint32_t,g_card_table);
-
-/* absolute bounds of the GC memory */
-GPTR_IMPL_INIT(uint8_t,g_lowest_address,0);
-GPTR_IMPL_INIT(uint8_t,g_highest_address,0);
-
 #ifdef GC_CONFIG_DRIVEN
 GARY_IMPL(size_t, gc_global_mechanisms, MAX_GLOBAL_GC_MECHANISMS_COUNT);
 #endif //GC_CONFIG_DRIVEN
 
 #ifndef DACCESS_COMPILE
 
-uint8_t* g_ephemeral_low = (uint8_t*)1;
-uint8_t* g_ephemeral_high = (uint8_t*)~0;
-
 #ifdef WRITE_BARRIER_CHECK
 uint8_t* g_GCShadow;
 uint8_t* g_GCShadowEnd;
 uint8_t* g_shadow_lowest_address = NULL;
 #endif
+
+uint32_t* g_gc_card_table;
+uint8_t* g_gc_lowest_address  = 0;
+uint8_t* g_gc_highest_address = 0;
+uint8_t* g_gc_ephemeral_low   = (uint8_t*)1;
+uint8_t* g_gc_ephemeral_high  = (uint8_t*)~0;
 
 VOLATILE(int32_t) m_GCLock = -1;
 

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -167,7 +167,7 @@ inline void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
     return g_theGCToCLR->DiagWalkBGCSurvivors(gcContext);
 }
 
-inline void GCToEEInterface::StompWriteBarrier(WriteBarrierArgs* args)
+inline void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
 {
     assert(g_theGCToCLR != nullptr);
     g_theGCToCLR->StompWriteBarrier(args);

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -166,4 +166,23 @@ inline void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
     assert(g_theGCToCLR != nullptr);
     return g_theGCToCLR->DiagWalkBGCSurvivors(gcContext);
 }
+
+inline void GCToEEInterface::StompWriteBarrierResize(WriteBarrierResizeArgs args)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->StompWriteBarrierResize(args);
+}
+
+inline void GCToEEInterface::StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->StompWriteBarrierEphemeral(args);
+}
+
+inline void GCToEEInterface::StompWriteBarrierInitialize(WriteBarrierResizeArgs args)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->StompWriteBarrierInitialize(args);
+}
+
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -167,22 +167,10 @@ inline void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
     return g_theGCToCLR->DiagWalkBGCSurvivors(gcContext);
 }
 
-inline void GCToEEInterface::StompWriteBarrierResize(WriteBarrierResizeArgs args)
+inline void GCToEEInterface::StompWriteBarrier(WriteBarrierArgs* args)
 {
     assert(g_theGCToCLR != nullptr);
-    g_theGCToCLR->StompWriteBarrierResize(args);
-}
-
-inline void GCToEEInterface::StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args)
-{
-    assert(g_theGCToCLR != nullptr);
-    g_theGCToCLR->StompWriteBarrierEphemeral(args);
-}
-
-inline void GCToEEInterface::StompWriteBarrierInitialize(WriteBarrierResizeArgs args)
-{
-    assert(g_theGCToCLR != nullptr);
-    g_theGCToCLR->StompWriteBarrierInitialize(args);
+    g_theGCToCLR->StompWriteBarrier(args);
 }
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -127,17 +127,7 @@ public:
     // Informs the EE of changes to the location of the card table, potentially updating the write
     // barrier if it needs to be updated.
     virtual
-    void StompWriteBarrierResize(WriteBarrierResizeArgs args) = 0;
-
-    // Informs the EE of changes to the bounds of the ephemeral generation, potentially
-    // updating the write barrier if it needs to be updated.
-    virtual
-    void StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args) = 0;
-
-    // Informs the EE of the initial configuration of the heap upon startup, potentially
-    // initializing the write barrier.
-    virtual
-    void StompWriteBarrierInitialize(WriteBarrierResizeArgs args) = 0;
+    void StompWriteBarrier(WriteBarrierArgs* args) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -123,6 +123,21 @@ public:
     // At the end of a background GC, gives the diagnostics code a chance to run.
     virtual
     void DiagWalkBGCSurvivors(void* gcContext) = 0;
+
+    // Informs the EE of changes to the location of the card table, potentially updating the write
+    // barrier if it needs to be updated.
+    virtual
+    void StompWriteBarrierResize(WriteBarrierResizeArgs args) = 0;
+
+    // Informs the EE of changes to the bounds of the ephemeral generation, potentially
+    // updating the write barrier if it needs to be updated.
+    virtual
+    void StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args) = 0;
+
+    // Informs the EE of the initial configuration of the heap upon startup, potentially
+    // initializing the write barrier.
+    virtual
+    void StompWriteBarrierInitialize(WriteBarrierResizeArgs args) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -127,7 +127,7 @@ public:
     // Informs the EE of changes to the location of the card table, potentially updating the write
     // barrier if it needs to be updated.
     virtual
-    void StompWriteBarrier(WriteBarrierArgs* args) = 0;
+    void StompWriteBarrier(WriteBarrierParameters* args) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -41,12 +41,23 @@ typedef enum
     walk_for_loh = 3
 } walk_surv_type;
 
-// Arguments to GCToEEInterface::StompWriteBarrierResize and
-// GCToEEInterface::StompWriteBarrierInitialize. 
-struct WriteBarrierResizeArgs 
+// Different operations that can be done by GCToEEInterface::StompWriteBarrier
+enum class WriteBarrierOp
 {
+    StompResize,
+    StompEphemeral,
+    Initialize
+};
+
+// Arguments to GCToEEInterface::StompWriteBarrier
+struct WriteBarrierArgs
+{
+    // The operation that StompWriteBarrier will perform.
+    WriteBarrierOp operation;
+
     // Whether or not the runtime is currently suspended. If it is not,
     // the EE will need to suspend it before bashing the write barrier.
+    // Used for all operations.
     bool is_runtime_suspended;
 
     // Whether or not the GC has moved the ephemeral generation to no longer
@@ -57,32 +68,27 @@ struct WriteBarrierResizeArgs
     // generation. When this is not the case, however, the GC must inform the EE
     // so that the EE can switch to a write barrier that checks that a pointer
     // is both greater than g_ephemeral_low and less than g_ephemeral_high.
+    // Used for WriteBarrierOp::StompResize.
     bool requires_upper_bounds_check;
 
     // The new card table location. May or may not be the same as the previous
-    // card table.
+    // card table. Used for WriteBarrierOp::Initialize and WriteBarrierOp::StompResize.
     uint32_t* new_card_table;
 
     // The heap's new low boundary. May or may not be the same as the previous
-    // value.
+    // value. Used for WriteBarrierOp::Initialize and WriteBarrierOp::StompResize.
     uint8_t* new_lowest_address;
 
     // The heap's new high boundary. May or may not be the same as the previous
-    // value.
+    // value. Used for WriteBarrierOp::Initialize and WriteBarrierOp::StompResize.
     uint8_t* new_highest_address;
-};
-
-// Arguments to GCToEEInterface::StompWriteBarrierEphemeral.
-struct WriteBarrierEphemeralArgs 
-{
-    // Whether or not the runtime is currently suspended. If it is not,
-    // the EE will need to suspend it before bashing the write barrier.
-    bool is_runtime_suspended;
 
     // The new start of the ephemeral generation. 
+    // Used for WriteBarrierOp::StompEphemeral.
     uint8_t* new_ephemeral_low;
 
     // The new end of the ephemeral generation.
+    // Used for WriteBarrierOp::StompEphemeral.
     uint8_t* new_ephemeral_high;
 };
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -50,7 +50,7 @@ enum class WriteBarrierOp
 };
 
 // Arguments to GCToEEInterface::StompWriteBarrier
-struct WriteBarrierArgs
+struct WriteBarrierParameters
 {
     // The operation that StompWriteBarrier will perform.
     WriteBarrierOp operation;
@@ -73,23 +73,23 @@ struct WriteBarrierArgs
 
     // The new card table location. May or may not be the same as the previous
     // card table. Used for WriteBarrierOp::Initialize and WriteBarrierOp::StompResize.
-    uint32_t* new_card_table;
+    uint32_t* card_table;
 
     // The heap's new low boundary. May or may not be the same as the previous
     // value. Used for WriteBarrierOp::Initialize and WriteBarrierOp::StompResize.
-    uint8_t* new_lowest_address;
+    uint8_t* lowest_address;
 
     // The heap's new high boundary. May or may not be the same as the previous
     // value. Used for WriteBarrierOp::Initialize and WriteBarrierOp::StompResize.
-    uint8_t* new_highest_address;
+    uint8_t* highest_address;
 
     // The new start of the ephemeral generation. 
     // Used for WriteBarrierOp::StompEphemeral.
-    uint8_t* new_ephemeral_low;
+    uint8_t* ephemeral_lo;
 
     // The new end of the ephemeral generation.
     // Used for WriteBarrierOp::StompEphemeral.
-    uint8_t* new_ephemeral_high;
+    uint8_t* ephemeral_hi;
 };
 
 #include "gcinterface.ee.h"

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -4319,9 +4319,6 @@ dynamic_data* gc_heap::dynamic_data_of (int gen_number)
     return &dynamic_data_table [ gen_number ];
 }
 
-extern "C" uint8_t* g_ephemeral_low;
-extern "C" uint8_t* g_ephemeral_high;
-
 #define card_word_width ((size_t)32)
 
 //

--- a/src/gc/sample/GCSample.cpp
+++ b/src/gc/sample/GCSample.cpp
@@ -91,14 +91,14 @@ inline void ErectWriteBarrier(Object ** dst, Object * ref)
 {
     // if the dst is outside of the heap (unboxed value classes) then we
     //      simply exit
-    if (((uint8_t*)dst < g_lowest_address) || ((uint8_t*)dst >= g_highest_address))
+    if (((uint8_t*)dst < g_gc_lowest_address) || ((uint8_t*)dst >= g_gc_highest_address))
         return;
         
-    if((uint8_t*)ref >= g_ephemeral_low && (uint8_t*)ref < g_ephemeral_high)
+    if((uint8_t*)ref >= g_gc_ephemeral_low && (uint8_t*)ref < g_gc_ephemeral_high)
     {
         // volatile is used here to prevent fetch of g_card_table from being reordered 
         // with g_lowest/highest_address check above. See comment in code:gc_heap::grow_brick_card_tables.
-        uint8_t* pCardByte = (uint8_t *)*(volatile uint8_t **)(&g_card_table) + card_byte((uint8_t *)dst);
+        uint8_t* pCardByte = (uint8_t *)*(volatile uint8_t **)(&g_gc_card_table) + card_byte((uint8_t *)dst);
         if(*pCardByte != 0xFF)
             *pCardByte = 0xFF;
     }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -249,7 +249,7 @@ void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
 {
 }
 
-void GCToEEInterface::StompWriteBarrier(WriteBarrierArgs* args)
+void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
 {
 }
 

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -249,6 +249,18 @@ void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
 {
 }
 
+void GCToEEInterface::StompWriteBarrierResize(WriteBarrierResizeArgs args)
+{
+}
+
+void GCToEEInterface::StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args)
+{
+}
+
+void GCToEEInterface::StompWriteBarrierInitialize(WriteBarrierResizeArgs args)
+{
+}
+
 void FinalizerThread::EnableFinalization()
 {
     // Signal to finalizer thread that there are objects to finalize
@@ -264,14 +276,6 @@ bool IsGCSpecialThread()
 {
     // TODO: Implement for background GC
     return false;
-}
-
-void StompWriteBarrierEphemeral(bool /* isRuntimeSuspended */)
-{
-}
-
-void StompWriteBarrierResize(bool /* isRuntimeSuspended */, bool /*bReqUpperBoundsCheck*/)
-{
 }
 
 bool IsGCThread()

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -249,15 +249,7 @@ void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
 {
 }
 
-void GCToEEInterface::StompWriteBarrierResize(WriteBarrierResizeArgs args)
-{
-}
-
-void GCToEEInterface::StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args)
-{
-}
-
-void GCToEEInterface::StompWriteBarrierInitialize(WriteBarrierResizeArgs args)
+void GCToEEInterface::StompWriteBarrier(WriteBarrierArgs* args)
 {
 }
 

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1214,51 +1214,57 @@ void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
 #endif //GC_PROFILING || FEATURE_EVENT_TRACE
 }
 
-void GCToEEInterface::StompWriteBarrierResize(WriteBarrierResizeArgs args)
+void GCToEEInterface::StompWriteBarrier(WriteBarrierArgs* args)
 {
-    g_card_table = args.new_card_table;
-    ::StompWriteBarrierResize(args.is_runtime_suspended, args.requires_upper_bounds_check);
-
-    // We need to make sure that other threads executing checked write barriers
-    // will see the g_card_table update before g_lowest/highest_address updates.
-    // Otherwise, the checked write barrier may AV accessing the old card table
-    // with address that it does not cover. Write barriers access card table 
-    // without memory barriers for performance reasons, so we need to flush 
-    // the store buffers here.
-    FlushProcessWriteBuffers();
-
-    g_lowest_address = args.new_lowest_address;
-    VolatileStore(&g_highest_address, args.new_highest_address);
-}
-
-void GCToEEInterface::StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args)
-{
-    // It is not correct to update g_ephemeral_low and g_ephemeral_high when
-    // using Server GC, since there is no single ephemeral generation across
-    // all of the heaps. Server GC write barriers do not reference these two
-    // globals, but ErectWriteBarrier does.
-    if (!GCHeapUtilities::IsServerHeap())
+    assert(args != nullptr);
+    switch (args->operation)
     {
-        g_ephemeral_low = args.new_ephemeral_low;
-        g_ephemeral_high = args.new_ephemeral_high;
+    case WriteBarrierOp::StompResize:
+        // StompResize requires a new card table, a new lowest address, and
+        // a new highest address
+        assert(args->new_card_table != nullptr);
+        assert(args->new_lowest_address != nullptr);
+        assert(args->new_highest_address != nullptr);
+        g_card_table = args->new_card_table;
+        ::StompWriteBarrierResize(args->is_runtime_suspended, args->requires_upper_bounds_check);
+
+        // We need to make sure that other threads executing checked write barriers
+        // will see the g_card_table update before g_lowest/highest_address updates.
+        // Otherwise, the checked write barrier may AV accessing the old card table
+        // with address that it does not cover. Write barriers access card table
+        // without memory barriers for performance reasons, so we need to flush
+        // the store buffers here.
+        FlushProcessWriteBuffers();
+
+        g_lowest_address = args->new_lowest_address;
+        VolatileStore(&g_highest_address, args->new_highest_address);
+        return;
+    case WriteBarrierOp::StompEphemeral:
+        // StompEphemeral requires a new ephemeral low and a new ephemeral high
+        assert(args->new_ephemeral_low != nullptr);
+        assert(args->new_ephemeral_high != nullptr);
+        g_ephemeral_low = args->new_ephemeral_low;
+        g_ephemeral_high = args->new_ephemeral_high;
+        ::StompWriteBarrierEphemeral(args->is_runtime_suspended);
+        return;
+    case WriteBarrierOp::Initialize:
+        // This operation should only be invoked once, upon initialization.
+        assert(g_card_table == nullptr);
+        assert(g_lowest_address == nullptr);
+        assert(g_highest_address == nullptr);
+        assert(args->new_card_table != nullptr);
+        assert(args->new_lowest_address != nullptr);
+        assert(args->new_highest_address != nullptr);
+        assert(args->is_runtime_suspended && "the runtime must be suspended here!");
+        assert(!args->requires_upper_bounds_check && "the ephemeral generation must be at the top of the heap!");
+
+        g_card_table = args->new_card_table;
+        FlushProcessWriteBuffers();
+        g_lowest_address = args->new_lowest_address;
+        VolatileStore(&g_highest_address, args->new_highest_address);
+        ::StompWriteBarrierResize(true, false);
+        return;
+    default:
+        assert(!"unknown WriteBarrierOp enum");
     }
-    
-    ::StompWriteBarrierEphemeral(args.is_runtime_suspended);
 }
-
-void GCToEEInterface::StompWriteBarrierInitialize(WriteBarrierResizeArgs args)
-{
-    // This method should only be called once, upon initialization.
-    assert(g_card_table == nullptr);
-    assert(g_lowest_address == nullptr);
-    assert(g_highest_address == nullptr);
-    assert(args.is_runtime_suspended && "the runtime must be suspended here!");
-    assert(!args.requires_upper_bounds_check && "the ephemeral generation must be at the top of the heap!");
-
-    g_card_table = args.new_card_table;
-    FlushProcessWriteBuffers();
-    g_lowest_address = args.new_lowest_address;
-    VolatileStore(&g_highest_address, args.new_highest_address);
-    ::StompWriteBarrierResize(true, false);
-}
-

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -41,6 +41,9 @@ public:
     void DiagWalkSurvivors(void* gcContext);
     void DiagWalkLOHSurvivors(void* gcContext);
     void DiagWalkBGCSurvivors(void* gcContext);
+    void StompWriteBarrierResize(WriteBarrierResizeArgs args);
+    void StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args);
+    void StompWriteBarrierInitialize(WriteBarrierEphemeralArgs args);
 };
 
 #endif // FEATURE_STANDALONE_GC

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -41,7 +41,7 @@ public:
     void DiagWalkSurvivors(void* gcContext);
     void DiagWalkLOHSurvivors(void* gcContext);
     void DiagWalkBGCSurvivors(void* gcContext);
-    void StompWriteBarrier(WriteBarrierArgs* args);
+    void StompWriteBarrier(WriteBarrierParameters* args);
 };
 
 #endif // FEATURE_STANDALONE_GC

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -41,9 +41,7 @@ public:
     void DiagWalkSurvivors(void* gcContext);
     void DiagWalkLOHSurvivors(void* gcContext);
     void DiagWalkBGCSurvivors(void* gcContext);
-    void StompWriteBarrierResize(WriteBarrierResizeArgs args);
-    void StompWriteBarrierEphemeral(WriteBarrierEphemeralArgs args);
-    void StompWriteBarrierInitialize(WriteBarrierEphemeralArgs args);
+    void StompWriteBarrier(WriteBarrierArgs* args);
 };
 
 #endif // FEATURE_STANDALONE_GC

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -5,5 +5,15 @@
 #include "common.h"
 #include "gcheaputilities.h"
 
+// These globals are variables used within the GC and maintained
+// by the EE for use in write barriers. It is the responsibility
+// of the GC to communicate updates to these globals to the EE through
+// GCToEEInterface::StompWriteBarrierResize and GCToEEInterface::StompWriteBarrierEphemeral.
+GPTR_IMPL_INIT(uint32_t, g_card_table,      nullptr);
+GPTR_IMPL_INIT(uint8_t,  g_lowest_address,  nullptr);
+GPTR_IMPL_INIT(uint8_t,  g_highest_address, nullptr);
+uint8_t* g_ephemeral_low  = (uint8_t*)1;
+uint8_t* g_ephemeral_high = (uint8_t*)~0;
+
 // This is the global GC heap, maintained by the VM.
 GPTR_IMPL(IGCHeap, g_pGCHeap);

--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -113,4 +113,17 @@ private:
     GCHeapUtilities() = delete;
 };
 
+#ifndef DACCESS_COMPILE
+extern "C" {
+#endif // !DACCESS_COMPILE
+GPTR_DECL(uint8_t,g_lowest_address);
+GPTR_DECL(uint8_t,g_highest_address);
+GPTR_DECL(uint32_t,g_card_table);
+#ifndef DACCESS_COMPILE
+} 
+#endif // !DACCESS_COMPILE
+
+extern "C" uint8_t* g_ephemeral_low;
+extern "C" uint8_t* g_ephemeral_high;
+
 #endif // _GCHEAPUTILITIES_H_


### PR DESCRIPTION
This PR decouples the GC and EE's write barrier logic by removing the GC and EE's shared globals and moving the functionality to `GCToEEInterface`.

There are two main parts of this PR:

1. `g_card_table`, `g_lowest_address`, `g_highest_address`, `g_ephemeral_low`, and `g_ephemeral_high` are all used by the EE in write barrier related code. In order to fully decouple the GC and the EE, we should remove this shared global state.
2. The GC communicates the timing of write barrier updates to the EE using the `StompWriteBarrierResize` and `StompWriteBarrierEphemeral` functions. These must go through the EE interface for a standalone GC.

This PR ensures that the GC and the EE both maintain copies of the five global variables named above, without sharing them. `StompWriteBarrierResize` and `StompWriteBarrierEphemeral` are moved to `GCToEEInterface`, and all changes to the GC's global variables that need to be synchronized with the EE are passed as arguments. In the implementation of GCToEEInterface in `gcenv.ee.cpp`, the VM updates its global variables and potentially changes the write barrier, based on the information it receives from the GC.

This plan is essentially the same as the one outlined in https://github.com/dotnet/coreclr/issues/8359, with the following slight deviation: A third function, `StompWriteBarrierInitialize`, is added to `GCToEEInterface` to handle the special case of the GC informing the EE of its initial heap topology upon startup.

This PR also doesn't decouple the global variables used by software write watch, although I'll be tackling that immediately after this in much the same way and I don't anticipate it will take very long.