### PR TITLE
Fix some problems with the ubuntu dasm output

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1877,7 +1877,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         }
                         if (scenario == 'gcstress15_pri1r2r')
                         {
-                           gcstressStr = 'gcstresslevel 0xF'
+                            gcstressStr = 'gcstresslevel 0xF'
                         }
 
                         if (scenario == 'jitdiff')
@@ -1934,7 +1934,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         // 10s of thousands of files around.
                         buildCommands += "powershell -Command \"Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('.\\bin\\tests\\${osGroup}.${arch}.${configuration}', '.\\bin\\tests\\tests.zip')\"";
 
-                        if (!Constants.jitStressModeScenarios.containsKey(scenario) && scenario != 'jitdiff') {
+                        if (!Constants.jitStressModeScenarios.containsKey(scenario)) {
                             // For windows, pull full test results and test drops for x86/x64.
                             // No need to pull for stress mode scenarios (downstream builds use the default scenario)
                             Utilities.addArchival(newJob, "bin/Product/**,bin/tests/tests.zip")

--- a/tests/src/CLRTest.Jit.targets
+++ b/tests/src/CLRTest.Jit.targets
@@ -25,17 +25,18 @@ WARNING:   When setting properties based on their current state (for example:
     <PropertyGroup>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <JitDisasmOut>$(BaseOutputPathWithConfig.Replace("\","/"))dasm/$(BuildProjectRelativeDir.Replace("\","/"))</JitDisasmOut>
+      <JitDisasmOut>$([MSBuild]::MakeRelative($(OutputPath), $(BaseOutputPathWithConfig)dasm\$(BuildProjectRelativeDir)).Replace("\","/"))</JitDisasmOut>
       <JitDisasmBashScript>
 <![CDATA[
 # JitDisasm Script
 if [ ! -z $RunningJitDisasm ]
 then
-    echo $CORE_ROOT/corerun "$CORE_ROOT/jit-dasm.dll" --crossgen $CORE_ROOT/crossgen.exe --platform $CORE_ROOT --output $(JitDisasmOut) $(InputAssemblyName)
-    "$CORE_ROOT/corerun" "$CORE_ROOT/jit-dasm" --crossgen $CORE_ROOT/crossgen.exe --platform $CORE_ROOT --output $(JitDisasmOut) $(InputAssemblyName)
-    if [ $ERRORLEVEL -ne 0 ]
+    echo $CORE_ROOT/corerun "$CORE_ROOT/jit-dasm.dll" --crossgen $CORE_ROOT/crossgen --platform $CORE_ROOT --output $(JitDisasmOut) $(InputAssemblyName)
+    "$CORE_ROOT/corerun" "$CORE_ROOT/jit-dasm.dll" --crossgen $CORE_ROOT/crossgen --platform $CORE_ROOT --output $(JitDisasmOut) $(InputAssemblyName)
+    _jdExitCode=$?
+    if [ $_jdExitCode -ne 0 ]
     then
-        echo EXECUTION OF JIT-DASM - FAILED $ERRORLEVEL
+        echo EXECUTION OF JIT-DASM - FAILED $_jdExitCode
         exit 1
     fi
 fi
@@ -49,7 +50,7 @@ fi
     <PropertyGroup>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <JitDisasmOut>$(BaseOutputPathWithConfig)dasm\$(BuildProjectRelativeDir)</JitDisasmOut>
+      <JitDisasmOut>$([MSBuild]::MakeRelative($(OutputPath), $(BaseOutputPathWithConfig)dasm\$(BuildProjectRelativeDir)))</JitDisasmOut>
       <JitDisasmBatchScript>
 <![CDATA[
 REM JitDisasm Script

--- a/tests/src/Common/test_runtime/project.json
+++ b/tests/src/Common/test_runtime/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "Microsoft.DotNet.CoreCLR.TestDependencies": "1.0.0-prerelease",
-    "jit-dasm": "0.0.1.1",
+    "jit-dasm": "0.0.1.4",
     "cijobs": "0.0.1.2",
-    "jit-analyze": "0.0.1.0"
+    "jit-analyze": "0.0.1.1"
   },
   "frameworks": {
     "netcoreapp1.1": {


### PR DESCRIPTION
- Re-enable the default build archiving in jitdiff scenarios so that the
  windows _bld job will publish correct build artifacts for the
  ubuntu_jitdiff_tst job to consume.
- Use relative paths in the generated scripts to avoid drive letters in
  bash scripts.
- Fix exit code reporting in bash wrapper scripts.
- Upgrade jit-dasm version to use version with improved error handling
- Upgrade jit-analyze version to use same dependencies as jit-dasm