### PR TITLE
Change CWT use of GetPrimaryAndSecondary to GetPrimary

### DIFF
--- a/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -568,9 +568,7 @@ namespace System.Runtime.CompilerServices
                     DependentHandle depHnd = _entries[entriesIndex].depHnd;
                     if (hashCode != -1 && depHnd.IsAllocated)
                     {
-                        object primary, secondary;
-                        depHnd.GetPrimaryAndSecondary(out primary, out secondary);
-                        if (primary != null)
+                        if (depHnd.GetPrimary() != null)
                         {
                             // Entry is used and has not expired. Link it into the appropriate bucket list.
                             newEntries[newEntriesIndex].HashCode = hashCode;


### PR DESCRIPTION
This snuck in as part of my previous ConditionalWeakTable changes.  We don't need the secondary here, and it's more expensive to get than just the primary.

cc: @jkotas 