### PR TITLE
Fix longname DAC/SOS package path to enable arm/arm64 symbol packages

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -84,13 +84,13 @@
     <CrossArchitectureSpecificNativeSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" 
                                            Include="@(LongNameFiles -> '$(BinDir)$(CrossTargetComponentFolder)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')" />
     <AdditionalLibPackageExcludes Condition="'$(HasCrossTargetComponents)' == 'true'" 
-                                  Include="@(LongNameFiles -> 'runtimes\$(PackageTargetRuntime)\native\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')" />
+                                  Include="@(LongNameFiles -> 'tools\$(CrossTargetComponentFolder)_$(PackagePlatform)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')" />
     <File Include="@(ArchitectureSpecificNativeSymbol)">
       <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath> 
       <IsSymbolFile>true</IsSymbolFile>
     </File>
     <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeSymbol)">
-      <TargetPath>tools/$(CrossTargetComponentFolder)_$(PackagePlatform)</TargetPath>
+      <TargetPath>tools\$(CrossTargetComponentFolder)_$(PackagePlatform)</TargetPath>
       <IsSymbolFile>true</IsSymbolFile>
     </File>
   </ItemGroup>


### PR DESCRIPTION
The arm and arm64 builds aren't producing symbol packages because the logic in package creation skips creating the symbol package if a pattern in `AdditionalLibPackageExcludes` doesn't match something. For x86 and x64 build,s the long-name DAC/SOS aren't cross target, so this code path isn't normally exercised. (I looked at the x64 symbol package in https://github.com/dotnet/coreclr/pull/7265, but not arm/arm64 which don't have symbol packages.)

Making the exclude path and cross-target long-name DAC/SOS paths match will let the build make symbol packages.

I tested this on my machine by copying an arm build into my bin directory and creating packages based on it, because my machine wasn't able to compile arm builds (many errors) and I don't know the prereqs.

@gkhanna79 @mikem8361