### PR TITLE
TimeZoneInfo: Avoid cloning privately-created ArgumentRule[] arrays

### DIFF
--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -1266,16 +1266,13 @@ namespace System {
             Boolean adjustmentRulesSupportDst;
             ValidateTimeZoneInfo(id, baseUtcOffset, adjustmentRules, out adjustmentRulesSupportDst);
 
-            if (!disableDaylightSavingTime && adjustmentRules != null && adjustmentRules.Length > 0) {
-                m_adjustmentRules = (AdjustmentRule[])adjustmentRules.Clone();
-            }
-
             m_id = id;
             m_baseUtcOffset = baseUtcOffset;
             m_displayName = displayName;
             m_standardDisplayName = standardDisplayName;
             m_daylightDisplayName = (disableDaylightSavingTime ? null : daylightDisplayName);
             m_supportsDaylightSavingTime = adjustmentRulesSupportDst && !disableDaylightSavingTime;
+            m_adjustmentRules = adjustmentRules;
         }
 
         // -------- SECTION: factory methods -----------------*
@@ -1316,7 +1313,7 @@ namespace System {
                 String daylightDisplayName,
                 AdjustmentRule [] adjustmentRules) {
 
-            return new TimeZoneInfo(
+            return CreateCustomTimeZone(
                            id,
                            baseUtcOffset,
                            displayName,
@@ -1345,7 +1342,11 @@ namespace System {
                 AdjustmentRule [] adjustmentRules,
                 Boolean disableDaylightSavingTime) {
 
-           return new TimeZoneInfo(
+            if (!disableDaylightSavingTime && adjustmentRules?.Length > 0) {
+                adjustmentRules = (AdjustmentRule[])adjustmentRules.Clone();
+            }
+
+            return new TimeZoneInfo(
                            id,
                            baseUtcOffset,
                            displayName,
@@ -5086,7 +5087,7 @@ namespace System {
                 AdjustmentRule[] rules = s.GetNextAdjustmentRuleArrayValue(false);
 
                 try { 
-                    return TimeZoneInfo.CreateCustomTimeZone(id, baseUtcOffset, displayName, standardName, daylightName, rules);
+                    return new TimeZoneInfo(id, baseUtcOffset, displayName, standardName, daylightName, rules, disableDaylightSavingTime: false);
                 }
                 catch (ArgumentException ex) {
                     throw new SerializationException(Environment.GetResourceString("Serialization_InvalidData"), ex);


### PR DESCRIPTION
`TimeZoneInfo` currently always creates a defensive copy of the specified `ArgumentRule[]` array when created. This makes sense for the public static factory methods. However, there's no need to create a defensive copy of arrays created privately as part of its implementation (e.g. reading the rules from the registry/disk). This change avoids the unnecessary cloning in such cases.

On Mac OS X El Capitan, the largest array from the system time zones is 243 rules.
On Windows 10 it's 37 rules.