### PR TITLE
Change ConditionalWeakTable.Clear

### DIFF
--- a/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -281,7 +281,7 @@ namespace System.Runtime.CompilerServices
         {
             lock (_lock)
             {
-                _container.Clear();
+                _container = new Container(this);
             }
         }
 
@@ -493,16 +493,6 @@ namespace System.Runtime.CompilerServices
                 }
 
                 return false;
-            }
-
-            internal void Clear()
-            {
-                // Remove all handles (as in Remove, just by setting the hashcode and leaving
-                // actual removal up to the finalizer).
-                for (int i = 0; i < _firstFreeEntry; i++)
-                {
-                    Volatile.Write(ref _entries[i].HashCode, -1);
-                }
             }
 
             //----------------------------------------------------------------------------------------


### PR DESCRIPTION
The original CoreRT implementation just dropped the current table and replaced it with a new one.  In the process of porting the CoreRT implementation to CoreCLR, I'd changed it to instead remove each item from the table (by setting its hashcode to -1, as does Remove), in order to work around some code in the finalizer that would null out te parent's reference to the container, and that would cause problems with dropping this table... but that code in the finalizer changed before it got merged, and in its current form, the old CoreRT clear implementation was fine.  It's also likely better, as it'll let the handles be cleaned up earlier, and it's simple.  So reverting back to it.

cc: @jkotas 