### PR TITLE
[Wip] Inline+Unwrap String.Equals

### DIFF
--- a/src/mscorlib/src/System/Boolean.cs
+++ b/src/mscorlib/src/System/Boolean.cs
@@ -169,28 +169,23 @@ namespace System {
             if (value==null) {
                 return false;
             }
-            // For perf reasons, let's first see if they're equal, then do the
-            // trim to get rid of white space, and check again.
-            if (TrueLiteral.Equals(value, StringComparison.OrdinalIgnoreCase)) {
-                result = true;
-                return true;
-            }
-            if (FalseLiteral.Equals(value,StringComparison.OrdinalIgnoreCase)) {
-                result = false;
-                return true;
-            }
+            // For perf reasons, let's first see if they're equal, 
+            // repeat doing trim to get rid of white space, and check again.
+            for (var i = 0; i < 4; i++)
+            {
+                // This is done in a loop as String.Equals will partially inline; so this reduces the function size by 336 bytes of asm
+                if (((i & 1) == 0 ? TrueLiteral : FalseLiteral).Equals(value, StringComparison.OrdinalIgnoreCase))
+                {
+                    result = (i & 1) == 0;
+                    return true;
+                }
 
-            // Special case: Trim whitespace as well as null characters.
-            value = TrimWhiteSpaceAndNull(value);
-
-            if (TrueLiteral.Equals(value, StringComparison.OrdinalIgnoreCase)) {
-                result = true;
-                return true;
-            }
-            
-            if (FalseLiteral.Equals(value,StringComparison.OrdinalIgnoreCase)) {
-                result = false;
-                return true;
+                // Looped twice, not parsed true or false; trim input string and try again
+                if (i == 1)
+                {
+                    // Special case: Trim whitespace as well as null characters.
+                    value = TrimWhiteSpaceAndNull(value);
+                }
             }
             
             return false;

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -314,6 +314,17 @@ namespace System.Collections.Generic
         }
 
         [Pure]
+        public new bool Equals(object x, object y) {
+            if (!(x is string) || !(y is string)) ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArgumentForComparison);
+            return string.Equals((string)x, (string)y);
+        }
+
+        [Pure]
+        public override bool Equals(string x, string y) {
+            return string.Equals(x, y);
+        }
+
+        [Pure]
         public override int GetHashCode(string obj)  {
             if (obj == null) return 0;
             return obj.GetLegacyNonRandomizedHashCode();
@@ -530,21 +541,13 @@ namespace System.Collections.Generic
         }
 
         public new bool Equals(object x, object y) {
-            if (x == y) return true;
-            if (x == null || y == null) return false;
-            if ((x is string) && (y is string)) return Equals((string)x, (string)y);
-            ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArgumentForComparison);
-            return false;
+            if (!(x is string) || !(y is string)) ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidArgumentForComparison);
+            return string.Equals((string)x, (string)y);
         }
 
         [Pure]
         public bool Equals(string x, string y) {
-            if (x != null) {
-                if (y != null) return x.Equals(y);
-                return false;
-            }
-            if (y != null) return false;
-            return true;
+            return string.Equals(x, y);
         }
 
         [Pure]

--- a/src/mscorlib/src/System/Double.cs
+++ b/src/mscorlib/src/System/Double.cs
@@ -261,14 +261,39 @@ namespace System {
             bool success = Number.TryParseDouble(s, style, info, out result);
             if (!success) {
                 String sTrim = s.Trim();
-                if (sTrim.Equals(info.PositiveInfinitySymbol)) {
-                    result = PositiveInfinity;
-                } else if (sTrim.Equals(info.NegativeInfinitySymbol)) {
-                    result = NegativeInfinity;
-                } else if (sTrim.Equals(info.NaNSymbol)) {
-                    result = NaN;
-                } else
-                    return false; // We really failed
+                for (var i = 0; i < 3; i++)
+                {
+                    string comparison;
+                    switch (i)
+                    {
+                        case 0:
+                            comparison = info.PositiveInfinitySymbol;
+                            break;
+                        case 1:
+                            comparison = info.NegativeInfinitySymbol;
+                            break;
+                        default:
+                            comparison = info.NaNSymbol;
+                            break;
+                    }
+                    // This is done in a loop as String.Equals will partially inline; so this reduces the function size by 21 bytes of asm
+                    if (!sTrim.Equals(comparison)) continue;
+                    switch (i)
+                    {
+                        case 0:
+                            result = PositiveInfinity;
+                            break;
+                        case 1:
+                            result = NegativeInfinity;
+                            break;
+                        default:
+                            result = NaN;
+                            break;
+                    }
+                    return true;
+                }
+
+                return false; // We really failed
             }
             return true;
         }

--- a/src/mscorlib/src/System/Single.cs
+++ b/src/mscorlib/src/System/Single.cs
@@ -235,14 +235,39 @@ namespace System {
             bool success = Number.TryParseSingle(s, style, info, out result);
             if (!success) {
                 String sTrim = s.Trim();
-                if (sTrim.Equals(info.PositiveInfinitySymbol)) {
-                    result = PositiveInfinity;
-                } else if (sTrim.Equals(info.NegativeInfinitySymbol)) {
-                    result = NegativeInfinity;
-                } else if (sTrim.Equals(info.NaNSymbol)) {
-                    result = NaN;
-                } else
-                    return false; // We really failed
+                for (var i = 0; i < 3; i++)
+                {
+                    string comparison;
+                    switch (i)
+                    {
+                        case 0:
+                            comparison = info.PositiveInfinitySymbol;
+                            break;
+                        case 1:
+                            comparison = info.NegativeInfinitySymbol;
+                            break;
+                        default:
+                            comparison = info.NaNSymbol;
+                            break;
+                    }
+                    // This is done in a loop as String.Equals will partially inline; so this reduces the function size by 21 bytes of asm
+                    if (!sTrim.Equals(comparison)) continue;
+                    switch (i)
+                    {
+                        case 0:
+                            result = PositiveInfinity;
+                            break;
+                        case 1:
+                            result = NegativeInfinity;
+                            break;
+                        default:
+                            result = NaN;
+                            break;
+                    }
+                    return true;
+                }
+
+                return false; // We really failed
             }
             return true;
 

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -865,7 +865,9 @@ namespace System
             if (ReferenceEquals(a, b)) return true;
             if (NotPossiblyEquals(a, b)) return false;
 
-            if (a.IsAscii() && b.IsAscii())
+            var isAscii = a.IsAscii();
+            if (isAscii != b.IsAscii()) return false;
+            if (isAscii)
             {
                 return (CompareOrdinalIgnoreCaseHelper(a, b) == 0);
             }

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -796,7 +796,7 @@ namespace System
         public override bool Equals(Object obj)
         {
             if (this == null)                        // this is necessary to guard against reverse-pinvokes and
-                throw new NullReferenceException();  // other callers who do not use the callvirt instruction
+                ThrowHelper.ThrowNullReferenceException();  // other callers who do not use the callvirt instruction
 
             if (object.ReferenceEquals(this, obj))
                 return true;
@@ -817,153 +817,104 @@ namespace System
         public bool Equals(String value)
         {
             if (this == null)                        // this is necessary to guard against reverse-pinvokes and
-                throw new NullReferenceException();  // other callers who do not use the callvirt instruction
+                ThrowHelper.ThrowNullReferenceException();  // other callers who do not use the callvirt instruction
 
-            if (object.ReferenceEquals(this, value))
-                return true;
-
-            // NOTE: No need to worry about casting to object here.
-            // If either side of an == comparison between strings
-            // is null, Roslyn generates a simple ceq instruction
-            // instead of calling string.op_Equality.
-            if (value == null)
-                return false;
-            
-            if (this.Length != value.Length)
-                return false;
-
-            return EqualsHelper(this, value);
+            return EqualsOrdinalCaseSensitive(this, value);
         }
-
-        [Pure]
-        public bool Equals(String value, StringComparison comparisonType) {
-            if (comparisonType < StringComparison.CurrentCulture || comparisonType > StringComparison.OrdinalIgnoreCase)
-                throw new ArgumentException(Environment.GetResourceString("NotSupported_StringComparison"), nameof(comparisonType));
-            Contract.EndContractBlock();
-
-            if ((Object)this == (Object)value) {
-                return true;
-            }
-
-            if ((Object)value == null) {
-                return false;
-            }
-
-            switch (comparisonType) {
-                case StringComparison.CurrentCulture:
-                    return (CultureInfo.CurrentCulture.CompareInfo.Compare(this, value, CompareOptions.None) == 0);
-
-                case StringComparison.CurrentCultureIgnoreCase:
-                    return (CultureInfo.CurrentCulture.CompareInfo.Compare(this, value, CompareOptions.IgnoreCase) == 0);
-
-                case StringComparison.InvariantCulture:
-                    return (CultureInfo.InvariantCulture.CompareInfo.Compare(this, value, CompareOptions.None) == 0);
-
-                case StringComparison.InvariantCultureIgnoreCase:
-                    return (CultureInfo.InvariantCulture.CompareInfo.Compare(this, value, CompareOptions.IgnoreCase) == 0);
-
-                case StringComparison.Ordinal:
-                    if (this.Length != value.Length)
-                        return false;
-                    return EqualsHelper(this, value);
-
-                case StringComparison.OrdinalIgnoreCase:
-                    if (this.Length != value.Length)
-                        return false;
-
-                    // If both strings are ASCII strings, we can take the fast path.
-                    if (this.IsAscii() && value.IsAscii()) {
-                        return (CompareOrdinalIgnoreCaseHelper(this, value) == 0);
-                    }
-
-#if FEATURE_COREFX_GLOBALIZATION
-                    return (CompareInfo.CompareOrdinalIgnoreCase(this, 0, this.Length, value, 0, value.Length) == 0);
-#else
-                    // Take the slow path.
-                    return (TextInfo.CompareOrdinalIgnoreCase(this, value) == 0);
-#endif
-
-                default:
-                    throw new ArgumentException(Environment.GetResourceString("NotSupported_StringComparison"), nameof(comparisonType));
-            }
-        }
-
 
         // Determines whether two Strings match.
         [Pure]
         public static bool Equals(String a, String b) {
-            if ((Object)a==(Object)b) {
-                return true;
-            }
+            return EqualsOrdinalCaseSensitive(a, b);
+        }
 
-            if ((Object)a == null || (Object)b == null || a.Length != b.Length) {
-                return false;
-            }
-
-            return EqualsHelper(a, b);
+        [Pure]
+        public bool Equals(String value, StringComparison comparisonType) {
+            return EqualsHelperComparison(this, value, comparisonType);
         }
 
         [Pure]
         public static bool Equals(String a, String b, StringComparison comparisonType) {
-            if (comparisonType < StringComparison.CurrentCulture || comparisonType > StringComparison.OrdinalIgnoreCase)
-                throw new ArgumentException(Environment.GetResourceString("NotSupported_StringComparison"), nameof(comparisonType));
-            Contract.EndContractBlock();
+            return EqualsHelperComparison(a, b, comparisonType);
+        }
 
-            if ((Object)a==(Object)b) {
-                return true;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool EqualsHelperComparison(String a, String b, StringComparison comparisonType)
+        {
+            if (comparisonType == StringComparison.Ordinal) { 
+                return EqualsOrdinalCaseSensitive(a, b);
             }
-    
-            if ((Object)a==null || (Object)b==null) {
-                return false;
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase) {
+                return EqualsOrdinalIgnoreCase(a, b);
             }
+            else {
+                return EqualsCulture(a, b, comparisonType);
+            }
+        }
 
-            switch (comparisonType) {
-                case StringComparison.CurrentCulture:
-                    return (CultureInfo.CurrentCulture.CompareInfo.Compare(a, b, CompareOptions.None) == 0);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool EqualsOrdinalCaseSensitive(String a, String b) {
+            if (ReferenceEquals(a, b)) return true;
+            if (NotPossiblyEquals(a, b)) return false;
 
-                case StringComparison.CurrentCultureIgnoreCase:
-                    return (CultureInfo.CurrentCulture.CompareInfo.Compare(a, b, CompareOptions.IgnoreCase) == 0);
+            return EqualsHelper(a, b);
+        }
 
-                case StringComparison.InvariantCulture:
-                    return (CultureInfo.InvariantCulture.CompareInfo.Compare(a, b, CompareOptions.None) == 0);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool EqualsOrdinalIgnoreCase(String a, String b) {
+            if (ReferenceEquals(a, b)) return true;
+            if (NotPossiblyEquals(a, b)) return false;
 
-                case StringComparison.InvariantCultureIgnoreCase:
-                    return (CultureInfo.InvariantCulture.CompareInfo.Compare(a, b, CompareOptions.IgnoreCase) == 0);
-
-                case StringComparison.Ordinal:
-                    if (a.Length != b.Length)
-                        return false;
-
-                    return EqualsHelper(a, b);
-
-                case StringComparison.OrdinalIgnoreCase:
-                    if (a.Length != b.Length)
-                        return false;
-                    else {
-                        // If both strings are ASCII strings, we can take the fast path.
-                        if (a.IsAscii() && b.IsAscii()) {
-                            return (CompareOrdinalIgnoreCaseHelper(a, b) == 0);
-                        }
-                        // Take the slow path.
+            if (a.IsAscii() && b.IsAscii())
+            {
+                return (CompareOrdinalIgnoreCaseHelper(a, b) == 0);
+            }
+            // Take the slow path.
 
 #if FEATURE_COREFX_GLOBALIZATION
-                        return (CompareInfo.CompareOrdinalIgnoreCase(a, 0, a.Length, b, 0, b.Length) == 0);
+            return (CompareInfo.CompareOrdinalIgnoreCase(a, 0, a.Length, b, 0, b.Length) == 0);
 #else
-                        return (TextInfo.CompareOrdinalIgnoreCase(a, b) == 0);
+            return (TextInfo.CompareOrdinalIgnoreCase(a, b) == 0);
 #endif
-                    }
+        }
 
-                default:
-                    throw new ArgumentException(Environment.GetResourceString("NotSupported_StringComparison"), nameof(comparisonType));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool EqualsCulture(String a, String b, StringComparison comparisonType) {
+            if (comparisonType < StringComparison.CurrentCulture || comparisonType > StringComparison.InvariantCultureIgnoreCase)
+                ThrowHelper.ThrowArgumentException_NotSupported_StringComparison();
+
+            if (ReferenceEquals(a, b)) return true;
+            if (NotPossiblyEquals(a, b)) return false;
+
+            if (comparisonType == StringComparison.CurrentCulture)
+            {
+                return (CultureInfo.CurrentCulture.CompareInfo.Compare(a, b, CompareOptions.None) == 0);
             }
+            else if (comparisonType == StringComparison.CurrentCultureIgnoreCase)
+            {
+                return (CultureInfo.CurrentCulture.CompareInfo.Compare(a, b, CompareOptions.IgnoreCase) == 0);
+            }
+            else if (comparisonType == StringComparison.InvariantCulture)
+            {
+                return (CultureInfo.InvariantCulture.CompareInfo.Compare(a, b, CompareOptions.None) == 0);
+            }
+            else // comparisonType == StringComparison.InvariantCultureIgnoreCase
+            {
+                return (CultureInfo.InvariantCulture.CompareInfo.Compare(a, b, CompareOptions.IgnoreCase) == 0);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool NotPossiblyEquals(string a, string b) {
+            return a == null || b == null || a.Length != b.Length;
         }
 
         public static bool operator == (String a, String b) {
-           return String.Equals(a, b);
+           return EqualsOrdinalCaseSensitive(a, b);
         }
 
         public static bool operator != (String a, String b) {
-           return !String.Equals(a, b);
+           return !EqualsOrdinalCaseSensitive(a, b);
         }
 
 #if FEATURE_RANDOMIZED_STRING_HASHING

--- a/src/mscorlib/src/System/StringComparer.cs
+++ b/src/mscorlib/src/System/StringComparer.cs
@@ -95,17 +95,7 @@ namespace System {
 
        
         public new bool Equals(Object x, Object y) {
-            if (x == y) return true;
-            if (x == null || y == null) return false;
-            
-            String sa = x as String;
-            if (sa != null) {
-                String sb = y as String;                
-                if( sb != null) {
-                    return Equals(sa, sb);
-                }
-            }
-            return x.Equals(y);                        
+            return string.Equals(x, y);                        
         }
         
         public int GetHashCode(object obj) {
@@ -297,16 +287,7 @@ namespace System {
         }
                 
         public override bool Equals(string x, string y) {
-            if (Object.ReferenceEquals(x ,y)) return true;
-            if (x == null || y == null) return false;
-
-            if( _ignoreCase) {
-                if( x.Length != y.Length) {
-                    return false;
-                }
-                return (String.Compare(x, y, StringComparison.OrdinalIgnoreCase) == 0);                                            
-            }
-            return x.Equals(y);
+            return string.Equals(x, y);
         }               
                 
         public override int GetHashCode(string obj) {
@@ -373,16 +354,7 @@ namespace System {
         }
                 
         public override bool Equals(string x, string y) {
-            if (Object.ReferenceEquals(x ,y)) return true;
-            if (x == null || y == null) return false;
-
-            if( _ignoreCase) {
-                if( x.Length != y.Length) {
-                    return false;
-                }
-                return (String.Compare(x, y, StringComparison.OrdinalIgnoreCase) == 0);                                            
-            }
-            return x.Equals(y);
+            return string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
         }               
 
         public override int GetHashCode(string obj) {

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -113,6 +113,10 @@ namespace System {
             throw GetArgumentException(resource);
         }
 
+        internal static void ThrowArgumentException_NotSupported_StringComparison() {
+            throw GetArgumentException(ExceptionResource.NotSupported_StringComparison, ExceptionArgument.comparisonType);
+        }
+
         internal static void ThrowArgumentException(ExceptionResource resource, ExceptionArgument argument) {
             throw GetArgumentException(resource, argument);
         }
@@ -276,6 +280,11 @@ namespace System {
 
             return Environment.GetResourceString(resource.ToString());
         }
+
+        internal static void ThrowNullReferenceException()
+        {
+            throw new NullReferenceException();
+        }
     }
 
     //
@@ -353,6 +362,7 @@ namespace System {
         updateValueFactory,
         concurrencyLevel,
         text,
+        comparisonType,
 
     }
 
@@ -458,6 +468,7 @@ namespace System {
         ConcurrentDictionary_ArrayNotLargeEnough,
         ConcurrentDictionary_ArrayIncorrectType,
         ConcurrentCollection_SyncRoot_NotSupported,
+        NotSupported_StringComparison,
 
     }
 }


### PR DESCRIPTION
Currently
* String.Equals currently never inlines
* String.Equals(String value, StringComparison comparisonType) never inlines
* They both then call other non-inlining methods

`[FAILED: noinline per IL/cached result] String:Equals(ref):bool:this`
`[FAILED: noinline per IL/cached result] String:Equals(ref,int):bool:this`

This change allows the forms of String.Equals to inline for reference equality and length differences; and call the final non-inlining method directly (e.g. `EqualsHelper`, `CompareOrdinalIgnoreCaseHelper`, `CultureInfo.XXXCulture.CompareInfo.Compare`)

As the comparisonType is generally a constant e.g `StringComparison.OrdinalIgnoreCase` the inlining also means the jit branch eliminates all the other references to the other comparison types.

So for example a call to 
```csharp
value1.Equals(value2, StringComparison.InvariantCultureIgnoreCase)
```
Only pulls in the Invariant Culture Ignore Case Branch
```
[3 IL=0036 TR=000055 060004A8] [below ALWAYS_INLINE size] String:Equals(ref,int):bool:this
  [4 IL=0003 TR=000106 060004AA] [aggressive inline attribute] String:EqualsHelperComparison(ref,ref,int):bool
    [5 IL=0027 TR=000127 060004AD] [aggressive inline attribute] String:EqualsCulture(ref,ref,int):bool
      [6 IL=0021 TR=000154 060004AE] [aggressive inline attribute] String:NotPossiblyEquals(ref,ref):bool
      [7 IL=0107 TR=000176 06001AC6] [below ALWAYS_INLINE size] CultureInfo:get_InvariantCulture():ref
      [0 IL=0120 TR=000183 06001A73] [FAILED: target not direct] CompareInfo:Compare(ref,ref,int):int:this
      [0 IL=0112 TR=000179 06001AD4] [FAILED: target not direct] CultureInfo:get_CompareInfo():ref:this
```

A call to 
```csharp
value1.Equals(value2, StringComparison.OrdinalIgnoreCase)
```
Only pulls in the Ordinal Ignore Case branch
```
  [8 IL=0140 TR=000157 060004A8] [below ALWAYS_INLINE size] String:Equals(ref,int):bool:this
    [9 IL=0003 TR=000460 060004AA] [aggressive inline attribute] String:EqualsHelperComparison(ref,ref,int):bool
      [10 IL=0018 TR=000481 060004AC] [aggressive inline attribute] String:EqualsOrdinalIgnoreCase(ref,ref):bool
        [11 IL=0008 TR=000500 060004AE] [aggressive inline attribute] String:NotPossiblyEquals(ref,ref):bool
        [0 IL=0018 TR=000511 06000485] [FAILED: cannot get method info] String:IsAscii():bool:this
        [0 IL=0026 TR=000532 06000485] [FAILED: noinline per IL/cached result] String:IsAscii():bool:this
        [0 IL=0035 TR=000540 0600048D] [FAILED: too many il bytes] String:CompareOrdinalIgnoreCaseHelper(ref,ref):int
        [12 IL=0046 TR=000519 06001D44] [profitable inline] TextInfo:CompareOrdinalIgnoreCase(ref,ref):int
```
`TextInfo:CompareOrdinalIgnoreCase` inline is a simple unwrap to `InternalCompareStringOrdinalIgnoreCase`

Ordinal `String:Equals` is unwrapped down to the non-inlining `String:EqualsHelper`
```
  [11 IL=0097 TR=000071 060004A6] [below ALWAYS_INLINE size] String:Equals(ref):bool:this
    [0 IL=0003 TR=000333 060003BD] [FAILED: does not return] ThrowHelper:ThrowNullReferenceException()
    [12 IL=0010 TR=000326 060004AB] [aggressive inline attribute] String:EqualsOrdinalCaseSensitive(ref,ref):bool
      [13 IL=0008 TR=000349 060004AE] [aggressive inline attribute] String:NotPossiblyEquals(ref,ref):bool
      [0 IL=0019 TR=000361 06000490] [FAILED: noinline per IL/cached result] String:EqualsHelper(ref,ref):bool
```
etc