### PR TITLE
Use JitHelpers.UnsafeCast in ConditionalWeakTable

### DIFF
--- a/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -473,7 +473,7 @@ namespace System.Runtime.CompilerServices
             {
                 object secondary;
                 int entryIndex = FindEntry(key, out secondary);
-                value = (TValue)secondary;
+                value = JitHelpers.UnsafeCast<TValue>(secondary);
                 return entryIndex != -1;
             }
 
@@ -649,7 +649,7 @@ namespace System.Runtime.CompilerServices
                     {
                         for (int entriesIndex = _buckets[bucket]; entriesIndex != -1; entriesIndex = _entries[entriesIndex].Next)
                         {
-                            TKey thisKey = (TKey)_entries[entriesIndex].depHnd.GetPrimary();
+                            TKey thisKey = JitHelpers.UnsafeCast<TKey>(_entries[entriesIndex].depHnd.GetPrimary());
                             if (thisKey != null)
                             {
                                 list.Add(thisKey);
@@ -680,7 +680,7 @@ namespace System.Runtime.CompilerServices
                             // expired key as a live key with a null value.)
                             if (primary != null)
                             {
-                                list.Add((TValue)secondary);
+                                list.Add(JitHelpers.UnsafeCast<TValue>(secondary));
                             }
                         }
                     }
@@ -706,8 +706,8 @@ namespace System.Runtime.CompilerServices
                         if (Equals(thisKey, key))
                         {
                             GC.KeepAlive(this); // ensure we don't get finalized while accessing DependentHandles.
-                            value = (TValue)thisValue;
-                            return (TKey)thisKey;
+                            value = JitHelpers.UnsafeCast<TValue>(thisValue);
+                            return JitHelpers.UnsafeCast<TKey>(thisKey);
                         }
                     }
                 }


### PR DESCRIPTION
We know the types and can use UnsafeCast when reading out the objects as TKey and TValue.  This improves reading speed by ~30%.

cc: @jkotas 