### PR TITLE
[x86/Linux] Remove __fastcall related defines

### DIFF
--- a/src/pal/inc/pal_mstypes.h
+++ b/src/pal/inc/pal_mstypes.h
@@ -56,12 +56,6 @@ extern "C" {
 #define CDECL          __cdecl
 #endif
 
-#ifndef PAL_STDCPP_COMPAT
-#undef __fastcall
-#define __fastcall      __stdcall
-#undef _fastcall
-#define _fastcall       __fastcall
-#endif // PAL_STDCPP_COMPAT
 
 #else   // !defined(__i386__)
 


### PR DESCRIPTION
In x86/Linux, __fastcall is defined as __stdcall which causes stack corruption issue 
for the following functions:
 - HelperMethodFrameRestoreState
 - LazyMachStateCaptureState

This commit removes __fastcall definition as clang recognize __fastcall.
