### PR TITLE
Remove AVX/SSE transition penalties

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -390,6 +390,8 @@ protected:
     // Save/Restore callee saved float regs to stack
     void genPreserveCalleeSavedFltRegs(unsigned lclFrameSize);
     void genRestoreCalleeSavedFltRegs(unsigned lclFrameSize);
+    // Generate VZeroupper instruction to avoid AVX/SSE transition penalty
+    bool genVzeroupperIfNeeded(bool check256bitOnly = true);
 
 #endif // _TARGET_XARCH_ && FEATURE_STACK_FP_X87
 

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -391,7 +391,7 @@ protected:
     void genPreserveCalleeSavedFltRegs(unsigned lclFrameSize);
     void genRestoreCalleeSavedFltRegs(unsigned lclFrameSize);
     // Generate VZeroupper instruction to avoid AVX/SSE transition penalty
-    bool genVzeroupperIfNeeded(bool check256bitOnly = true);
+    void genVzeroupperIfNeeded(bool check256bitOnly = true);
 
 #endif // _TARGET_XARCH_ && FEATURE_STACK_FP_X87
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10701,22 +10701,20 @@ void CodeGen::genRestoreCalleeSavedFltRegs(unsigned lclFrameSize)
 void CodeGen::genVzeroupperIfNeeded(bool check256bitOnly /* = true*/)
 {
 #ifdef FEATURE_AVX_SUPPORT
-    if (compiler->getSIMDInstructionSet() == InstructionSet_AVX)
+    bool emitVzeroUpper = false;
+    if (check256bitOnly)
     {
-        if (check256bitOnly)
-        {
-            if (getEmitter()->Contains256bitAVX())
-            {
-                instGen(INS_vzeroupper);
-            }
-        }
-        else
-        {
-            if (getEmitter()->ContainsAVX())
-            {
-                instGen(INS_vzeroupper);
-            }
-        }
+        emitVzeroUpper = getEmitter()->Contains256bitAVX();
+    }
+    else
+    {
+        emitVzeroUpper = getEmitter()->ContainsAVX();
+    }
+
+    if (emitVzeroUpper)
+    {
+        assert(compiler->getSIMDInstructionSet() == InstructionSet_AVX);
+        instGen(INS_vzeroupper);
     }
 #endif
 }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10692,12 +10692,12 @@ void CodeGen::genRestoreCalleeSavedFltRegs(unsigned lclFrameSize)
 }
 
 // Generate Vzeroupper instruction as needed to zero out upper 128b-bit of all YMM registers so that the
-// AVX/Legacy SSE transition penalties can be avoided. This function is been used in genPreserveCalleeSavedFltRegs 
-// (prolog) and genRestoreCalleeSavedFltRegs (epilog). Issue VZEROUPPER in Prolog if the method contains 
+// AVX/Legacy SSE transition penalties can be avoided. This function is been used in genPreserveCalleeSavedFltRegs
+// (prolog) and genRestoreCalleeSavedFltRegs (epilog). Issue VZEROUPPER in Prolog if the method contains
 // 128-bit or 256-bit AVX code, to avoid legacy SSE to AVX transition penalty, which could happen when native
 // code contains legacy SSE code calling into JIT AVX code (e.g. reverse pinvoke). Issue VZEROUPPER in Epilog
 // if the method contains 256-bit AVX code, to avoid AVX to legacy SSE transition penalty.
-// 
+//
 // Params
 //   check256bitOnly  - true to check if the function contains 256-bit AVX instruction and generate Vzeroupper
 //      instruction, false to check if the function contains AVX instruciton (either 128-bit or 256-bit).

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10584,7 +10584,7 @@ GenTreePtr CodeGen::genMakeConst(const void* cnsAddr, var_types cnsType, GenTree
 void CodeGen::genPreserveCalleeSavedFltRegs(unsigned lclFrameSize)
 {
     genVzeroupperIfNeeded(false);
-    regMaskTP regMask           = compiler->compCalleeFPRegsSavedMask;
+    regMaskTP regMask = compiler->compCalleeFPRegsSavedMask;
 
     // Only callee saved floating point registers should be in regMask
     assert((regMask & RBM_FLT_CALLEE_SAVED) == regMask);

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10692,8 +10692,12 @@ void CodeGen::genRestoreCalleeSavedFltRegs(unsigned lclFrameSize)
 }
 
 // Generate Vzeroupper instruction as needed to zero out upper 128b-bit of all YMM registers so that the
-// AVX/Legacy SSE transition penalties can be avoided
-//
+// AVX/Legacy SSE transition penalties can be avoided. This function is been used in genPreserveCalleeSavedFltRegs 
+// (prolog) and genRestoreCalleeSavedFltRegs (epilog). Issue VZEROUPPER in Prolog if the method contains 
+// 128-bit or 256-bit AVX code, to avoid legacy SSE to AVX transition penalty, which could happen when native
+// code contains legacy SSE code calling into JIT AVX code (e.g. reverse pinvoke). Issue VZEROUPPER in Epilog
+// if the method contains 256-bit AVX code, to avoid AVX to legacy SSE transition penalty.
+// 
 // Params
 //   check256bitOnly  - true to check if the function contains 256-bit AVX instruction and generate Vzeroupper
 //      instruction, false to check if the function contains AVX instruciton (either 128-bit or 256-bit).

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10701,7 +10701,7 @@ void CodeGen::genRestoreCalleeSavedFltRegs(unsigned lclFrameSize)
 void CodeGen::genVzeroupperIfNeeded(bool check256bitOnly /* = true*/)
 {
 #ifdef FEATURE_AVX_SUPPORT
-    if (compiler->getFloatingPointInstructionSet() == InstructionSet_AVX)
+    if (compiler->getSIMDInstructionSet() == InstructionSet_AVX)
     {
         if (check256bitOnly)
         {

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5004,7 +5004,10 @@ void CodeGen::genCallInstruction(GenTreePtr node)
 #ifdef FEATURE_AVX_SUPPORT
     // When it's a PInvoke call and the call type is USER function, we issue VZEROUPPER here
     // if the function contains 256bit AVX instructions, this is to avoid AVX-256 to Legacy SSE
-    // transition penalty, assuming the user function contains legacy SSE instruction
+    // transition penalty, assuming the user function contains legacy SSE instruction. 
+    // To limit code size increase impact: we only issue VZEROUPPER before PInvoke call, not issue 
+    // VZEROUPPER after PInvoke call because transition penalty from legacy SSE to AVX only happens  
+    // when there's preceding 256-bit AVX to legacy SSE transition penalty.  
     if (call->IsPInvoke() && (call->gtCallType == CT_USER_FUNC) && getEmitter()->Contains256bitAVX())
     {
         assert(compiler->getSIMDInstructionSet() == InstructionSet_AVX);

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5004,10 +5004,10 @@ void CodeGen::genCallInstruction(GenTreePtr node)
 #ifdef FEATURE_AVX_SUPPORT
     // When it's a PInvoke call and the call type is USER function, we issue VZEROUPPER here
     // if the function contains 256bit AVX instructions, this is to avoid AVX-256 to Legacy SSE
-    // transition penalty, assuming the user function contains legacy SSE instruction. 
-    // To limit code size increase impact: we only issue VZEROUPPER before PInvoke call, not issue 
-    // VZEROUPPER after PInvoke call because transition penalty from legacy SSE to AVX only happens  
-    // when there's preceding 256-bit AVX to legacy SSE transition penalty.  
+    // transition penalty, assuming the user function contains legacy SSE instruction.
+    // To limit code size increase impact: we only issue VZEROUPPER before PInvoke call, not issue
+    // VZEROUPPER after PInvoke call because transition penalty from legacy SSE to AVX only happens
+    // when there's preceding 256-bit AVX to legacy SSE transition penalty.
     if (call->IsPInvoke() && (call->gtCallType == CT_USER_FUNC) && getEmitter()->Contains256bitAVX())
     {
         assert(compiler->getSIMDInstructionSet() == InstructionSet_AVX);

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5005,13 +5005,10 @@ void CodeGen::genCallInstruction(GenTreePtr node)
     // When it's a PInvoke call and the call type is USER function, we issue VZEROUPPER here
     // if the function contains 256bit AVX instructions, this is to avoid AVX-256 to Legacy SSE
     // transition penalty, assuming the user function contains legacy SSE instruction
-    if (call->IsPInvoke() && call->gtCallType == CT_USER_FUNC &&
-        compiler->getFloatingPointInstructionSet() == InstructionSet_AVX)
+    if (call->IsPInvoke() && (call->gtCallType == CT_USER_FUNC) && getEmitter()->Contains256bitAVX())
     {
-        if (getEmitter()->Contains256bitAVX())
-        {
-            instGen(INS_vzeroupper);
-        }
+        assert(compiler->getSIMDInstructionSet() == InstructionSet_AVX);
+        instGen(INS_vzeroupper);
     }
 #endif
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5001,6 +5001,20 @@ void CodeGen::genCallInstruction(GenTreePtr node)
 
 #endif // defined(_TARGET_X86_)
 
+#ifdef FEATURE_AVX_SUPPORT
+    // When it's a PInvoke call and the call type is USER function, we issue VZEROUPPER here
+    // if the function contains 256bit AVX instructions, this is to avoid AVX-256 to Legacy SSE
+    // transition penalty, assuming the user function contains legacy SSE instruction
+    if (call->IsPInvoke() && call->gtCallType == CT_USER_FUNC &&
+        compiler->getFloatingPointInstructionSet() == InstructionSet_AVX)
+    {
+        if (getEmitter()->Contains256bitAVX())
+        {
+            instGen(INS_vzeroupper);
+        }
+    }
+#endif
+
     if (target != nullptr)
     {
 #ifdef _TARGET_X86_

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2310,6 +2310,9 @@ void Compiler::compSetProcessor()
         if (opts.compCanUseAVX)
         {
             codeGen->getEmitter()->SetUseAVX(true);
+            // Assume each JITted method does not contain AVX instruction at first
+            codeGen->getEmitter()->SetContainsAVX(false);
+            codeGen->getEmitter()->SetContains256bitAVX(false);
         }
         else
 #endif // FEATURE_AVX_SUPPORT

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -150,7 +150,7 @@ void SetUseAVX(bool value)
     useAVXEncodings = value;
 }
 
-bool containsAVXInstruction;
+bool containsAVXInstruction = false;
 bool ContainsAVX()
 {
     return containsAVXInstruction;
@@ -160,7 +160,7 @@ void SetContainsAVX(bool value)
     containsAVXInstruction = value;
 }
 
-bool contains256bitAVXInstruction;
+bool contains256bitAVXInstruction = false;
 bool Contains256bitAVX()
 {
     return contains256bitAVXInstruction;

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -150,6 +150,26 @@ void SetUseAVX(bool value)
     useAVXEncodings = value;
 }
 
+bool containsAVXInstruction;
+bool ContainsAVX()
+{
+    return containsAVXInstruction;
+}
+void SetContainsAVX(bool value)
+{
+    containsAVXInstruction = value;
+}
+
+bool contains256bitAVXInstruction;
+bool Contains256bitAVX()
+{
+    return contains256bitAVXInstruction;
+}
+void SetContains256bitAVX(bool value)
+{
+    contains256bitAVXInstruction = value;
+}
+
 bool IsThreeOperandBinaryAVXInstruction(instruction ins);
 bool IsThreeOperandMoveAVXInstruction(instruction ins);
 bool IsThreeOperandAVXInstruction(instruction ins)
@@ -159,6 +179,14 @@ bool IsThreeOperandAVXInstruction(instruction ins)
 bool Is4ByteAVXInstruction(instruction ins);
 #else  // !FEATURE_AVX_SUPPORT
 bool                     UseAVX()
+{
+    return false;
+}
+bool ContainsAVX()
+{
+    return false;
+}
+bool Contains256bitAVX()
 {
     return false;
 }

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -235,7 +235,7 @@ private:
 
 #if defined(_TARGET_XARCH_)
     void SetMulOpCounts(GenTreePtr tree);
-    void SetContainsAVXFlags(bool isFloatingType = true, unsigned sizeOfSIMDVector = 0);
+    void SetContainsAVXFlags(bool isFloatingPointType = true, unsigned sizeOfSIMDVector = 0);
 #endif // defined(_TARGET_XARCH_)
 
 #if !CPU_LOAD_STORE_ARCH

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -235,6 +235,7 @@ private:
 
 #if defined(_TARGET_XARCH_)
     void SetMulOpCounts(GenTreePtr tree);
+    void SetContainsAVXFlags(bool isFloatingType = true, unsigned sizeOfSIMDVector = 0);
 #endif // defined(_TARGET_XARCH_)
 
 #if !CPU_LOAD_STORE_ARCH

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1957,7 +1957,7 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
                     // series of 16-byte loads and stores.
                     blkNode->gtLsraInfo.internalFloatCount = 1;
                     blkNode->gtLsraInfo.addInternalCandidates(l, l->internalFloatRegCandidates());
-                    // use XMM register for load and store, need set the flag for AVX instruction
+                    // Uses XMM reg for load and store and hence check to see whether AVX instructions are used for codegen
                     SetContainsAVXFlags();
                 }
 
@@ -4579,15 +4579,14 @@ void Lowering::SetMulOpCounts(GenTreePtr tree)
 }
 
 //------------------------------------------------------------------------------
-// SetContainsAVXFlags: default value of isFloatingType is true, we set the
-// ContainsAVX flag when floating type value is true, when SIMD vector size is
-// 32 bytes, it is 256bit AVX instruction and we set Contains256bitAVX flag too
+// SetContainsAVXFlags: Set ContainsAVX flag when it is floating type, set 
+// Contains256bitAVX flag when SIMD vector size is 32 bytes
 //
 // Arguments:
-//    isFloatingType    - is floating type
+//    isFloatingType    - true if it is floating type
 //    sizeOfSIMDVector  - SIMD Vector size
 //
-void Lowering::SetContainsAVXFlags(bool isFloatingType, unsigned sizeOfSIMDVector)
+void Lowering::SetContainsAVXFlags(bool isFloatingType /* = true */, unsigned sizeOfSIMDVector /* = 0*/)
 {
 #ifdef FEATURE_AVX_SUPPORT
     if (comp->getSIMDInstructionSet() == InstructionSet_AVX)

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -4584,21 +4584,21 @@ void Lowering::SetMulOpCounts(GenTreePtr tree)
 // Contains256bitAVX flag when SIMD vector size is 32 bytes
 //
 // Arguments:
-//    isFloatingType    - true if it is floating type
-//    sizeOfSIMDVector  - SIMD Vector size
+//    isFloatingPointType   - true if it is floating point type
+//    sizeOfSIMDVector      - SIMD Vector size
 //
-void Lowering::SetContainsAVXFlags(bool isFloatingType /* = true */, unsigned sizeOfSIMDVector /* = 0*/)
+void Lowering::SetContainsAVXFlags(bool isFloatingPointType /* = true */, unsigned sizeOfSIMDVector /* = 0*/)
 {
 #ifdef FEATURE_AVX_SUPPORT
-    if (comp->getSIMDInstructionSet() == InstructionSet_AVX)
+    if (isFloatingPointType)
     {
-        if (isFloatingType)
+        if (comp->getFloatingPointInstructionSet() == InstructionSet_AVX)
         {
             comp->getEmitter()->SetContainsAVX(true);
-            if (sizeOfSIMDVector == 32)
-            {
-                comp->codeGen->getEmitter()->SetContains256bitAVX(true);
-            }
+        }
+        if (sizeOfSIMDVector == 32 && comp->getSIMDInstructionSet() == InstructionSet_AVX)
+        {
+            comp->getEmitter()->SetContains256bitAVX(true);
         }
     }
 #endif

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1957,7 +1957,7 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
                     // series of 16-byte loads and stores.
                     blkNode->gtLsraInfo.internalFloatCount = 1;
                     blkNode->gtLsraInfo.addInternalCandidates(l, l->internalFloatRegCandidates());
-                    // Uses XMM reg for load and store and hence check to see whether AVX instructions 
+                    // Uses XMM reg for load and store and hence check to see whether AVX instructions
                     // are used for codegen, set ContainsAVX flag
                     SetContainsAVXFlags();
                 }

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1957,7 +1957,8 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
                     // series of 16-byte loads and stores.
                     blkNode->gtLsraInfo.internalFloatCount = 1;
                     blkNode->gtLsraInfo.addInternalCandidates(l, l->internalFloatRegCandidates());
-                    // Uses XMM reg for load and store and hence check to see whether AVX instructions are used for codegen
+                    // Uses XMM reg for load and store and hence check to see whether AVX instructions are used for
+                    // codegen
                     SetContainsAVXFlags();
                 }
 
@@ -4579,7 +4580,7 @@ void Lowering::SetMulOpCounts(GenTreePtr tree)
 }
 
 //------------------------------------------------------------------------------
-// SetContainsAVXFlags: Set ContainsAVX flag when it is floating type, set 
+// SetContainsAVXFlags: Set ContainsAVX flag when it is floating type, set
 // Contains256bitAVX flag when SIMD vector size is 32 bytes
 //
 // Arguments:

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1957,8 +1957,8 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
                     // series of 16-byte loads and stores.
                     blkNode->gtLsraInfo.internalFloatCount = 1;
                     blkNode->gtLsraInfo.addInternalCandidates(l, l->internalFloatRegCandidates());
-                    // Uses XMM reg for load and store and hence check to see whether AVX instructions are used for
-                    // codegen
+                    // Uses XMM reg for load and store and hence check to see whether AVX instructions 
+                    // are used for codegen, set ContainsAVX flag
                     SetContainsAVXFlags();
                 }
 


### PR DESCRIPTION
There are two two kinds of transition penalties:
1.Transition from 256-bit AVX code to 128-bit legacy SSE code.
2.Transition from 128-bit legacy SSE code to either 128 or 256-bit AVX code. This only happens if there was a preceding AVX256->legacy SSE transition penalty.

The primary goal is to remove the AVX to SSE transition penalty. 

Added two emitter flags: contains256bitAVXInstruction indicates that if the JIT method contains 256-bit AVX code, containsAVXInstruction indicates that if the method contains 128-bit or 256-bit AVX code.

Issue VZEROUPPER in Prolog if the method contains 128-bit or 256-bit AVX code, to avoid legacy SSE to AVX transition penalty, this could happen for reverse pinvoke situation. Issue VZEROUPPER in Epilog
if the method contains 256-bit AVX code, to avoid AVX to legacy SSE transition penalty.

To limit code size increase impact, we only issue VZEROUPPER before PInvoke call on user defined function if the JIT method contains 256-bit AVX code, assuming user defined function contains legacy
SSE code. No need to issue VZEROUPPER after PInvoke call because SSE to AVX transition penalty won't happen since AVX to SSE transition has been taken care of before the PInvoke call.

We measured ~3% to 1% performance gain on TechEmPower plaintext and verified those VTune AVX/SSE events: OTHER_ASSISTS.AVX_TO_SSE and OTHER_ASSISTS.SSE_TO_AVE have been reduced to 0.

[JITUtils](https://github.com/dotnet/jitutils/blob/master/doc/getstarted.md) reports no code size increase on Linux Scenario 1 (Running the mscorlib and frameworks diffs using just the assemblies made available by jitutils) and Scenario 2 (Running mscorlib, frameworks, and test assets diffs using the resources generated for a CoreCLR test run), further analysis on the dasm code appears verified the report, since no AVX instruction are present on the dasm code, thus no additional VZEROUPPER instruction are inserted. 

Fix #7240