### PR TITLE
[x86/Linux] Do not assume 16-byte stack alignment

### DIFF
--- a/cross/x86/toolchain.cmake
+++ b/cross/x86/toolchain.cmake
@@ -7,6 +7,7 @@ set(CMAKE_SYSTEM_PROCESSOR i686)
 add_compile_options("-m32")
 add_compile_options("--sysroot=${CROSS_ROOTFS}")
 add_compile_options("-Wno-error=unused-command-line-argument")
+add_compile_options("-mstack-alignment=4")
 
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} --sysroot=${CROSS_ROOTFS}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/i686-linux-gnu")


### PR DESCRIPTION
This commit enforces clang to assume 4-byte stack alignment instead of 16-byte.