### PR TITLE
Disable GetGenerationWR2 for GCStress on x86

### DIFF
--- a/tests/src/GC/API/GC/GetGenerationWR2.csproj
+++ b/tests/src/GC/API/GC/GetGenerationWR2.csproj
@@ -13,6 +13,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
     
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <CLRTestExecutionArguments></CLRTestExecutionArguments>


### PR DESCRIPTION
Disable this test for GCStress on x86 until the cause for its failure
can be investigated.