### PR TITLE
[x86/Linux] Fix "Bad opcode" assert in unwindLazyState

### DIFF
--- a/compileoptions.cmake
+++ b/compileoptions.cmake
@@ -17,6 +17,7 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   else()
     if(NOT CLR_CMAKE_PLATFORM_ARCH_I386)
       # x86 unwinder cannot handle stack protection code, yet
+      # see https://github.com/dotnet/coreclr/issues/8625 for details
       add_compile_options(-fstack-protector-strong)
     endif(NOT CLR_CMAKE_PLATFORM_ARCH_I386)
   endif(CLR_CMAKE_PLATFORM_DARWIN)

--- a/compileoptions.cmake
+++ b/compileoptions.cmake
@@ -15,7 +15,10 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     # We cannot enable "stack-protector-strong" on OS X due to a bug in clang compiler (current version 7.0.2)
     add_compile_options(-fstack-protector)
   else()
-    add_compile_options(-fstack-protector-strong)
+    if(NOT CLR_CMAKE_PLATFORM_ARCH_I386)
+      # x86 unwinder cannot handle stack protection code, yet
+      add_compile_options(-fstack-protector-strong)
+    endif(NOT CLR_CMAKE_PLATFORM_ARCH_I386)
   endif(CLR_CMAKE_PLATFORM_DARWIN)
 
   add_definitions(-DDISABLE_CONTRACTS)

--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -683,6 +683,10 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
                 ip += 2;
                 break;
 
+            case 0x34:                            // XOR AL, imm8
+                ip += 2;
+                break;
+
             case 0x31:
             case 0x32:
             case 0x33:
@@ -878,6 +882,10 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
 
                 datasize = b16bit?2:4;
                 goto decodeRM;
+
+            case 0x24:                           // AND AL, imm8
+                ip += 2;
+                break;
 
             case 0x01:                           // ADD mod/rm
             case 0x03:

--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -683,9 +683,11 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
                 ip += 2;
                 break;
 
+#ifdef FEATURE_PAL
             case 0x34:                            // XOR AL, imm8
                 ip += 2;
                 break;
+#endif // FEATURE_PAL
 
             case 0x31:
             case 0x32:
@@ -883,9 +885,11 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
                 datasize = b16bit?2:4;
                 goto decodeRM;
 
+#ifdef FEATURE_PAL
             case 0x24:                           // AND AL, imm8
                 ip += 2;
                 break;
+#endif // FEATURE_PAL
 
             case 0x01:                           // ADD mod/rm
             case 0x03:

--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -683,11 +683,9 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
                 ip += 2;
                 break;
 
-#ifdef FEATURE_PAL
             case 0x34:                            // XOR AL, imm8
                 ip += 2;
                 break;
-#endif // FEATURE_PAL
 
             case 0x31:
             case 0x32:
@@ -885,11 +883,9 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
                 datasize = b16bit?2:4;
                 goto decodeRM;
 
-#ifdef FEATURE_PAL
             case 0x24:                           // AND AL, imm8
                 ip += 2;
                 break;
-#endif // FEATURE_PAL
 
             case 0x01:                           // ADD mod/rm
             case 0x03:


### PR DESCRIPTION
This commit suppresses "Bad opcode" assert to enable "Hello, World" example.

This commit addresses the following three code patterns discovered while
digging the assert failure:
 - and $0x1, %al
 - xor $0xff, %al
 - stack protector (discussed in #8625)
   mov %gs:<off>, <reg>
   cmp <off>(%esp), <reg>
   mov <reg>, <off>($esp)
   jne <disp32>

This commit revises LazyMachState::unwindLazyState to handle the first two patterns,
and revises compile options not to emit the third pattern.