### PR TITLE
[x86/Linux] Add Dummy Exception Handler

### DIFF
--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -296,7 +296,7 @@ VOID DECLSPEC_NORETURN RaiseTheExceptionInternalOnly(OBJECTREF throwable, BOOL r
 void UnwindAndContinueRethrowHelperInsideCatch(Frame* pEntryFrame, Exception* pException);
 VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFrame, Exception* pException);
 
-#if defined(FEATURE_PAL) && defined(WIN64EXCEPTIONS)
+#ifdef FEATURE_PAL
 VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHardwareException);
 
 #define INSTALL_MANAGED_EXCEPTION_DISPATCHER        \
@@ -334,14 +334,14 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
             UNREACHABLE();                                                                          \
         }
 
-#else // FEATURE_PAL && WIN64EXCEPTIONS
+#else // FEATURE_PAL
 
 #define INSTALL_MANAGED_EXCEPTION_DISPATCHER
 #define UNINSTALL_MANAGED_EXCEPTION_DISPATCHER
 #define INSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP
 #define UNINSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP
 
-#endif // FEATURE_PAL && WIN64EXCEPTIONS
+#endif // FEATURE_PAL
 
 #define INSTALL_UNWIND_AND_CONTINUE_HANDLER_NO_PROBE                                        \
     {                                                                                       \


### PR DESCRIPTION
This commit adds a dummy exception handler to enable x86/Linux build.

This commit also reverts 7b92136d5ee (introduced in #8433) to make it easy to enable WIN64EXCEPTIONS in x86/Linux.
