### PR TITLE
Move RUNTIME_FUNCTION__BeginAddress into clrnt.h

### DIFF
--- a/src/inc/clrnt.h
+++ b/src/inc/clrnt.h
@@ -835,13 +835,18 @@ RtlVirtualUnwind_Unsafe(
 //  X86
 //
 
-#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
+#ifdef _TARGET_X86_
+#ifndef FEATURE_PAL
 
 typedef struct _DISPATCHER_CONTEXT {
     _EXCEPTION_REGISTRATION_RECORD* RegistrationPointer;
 } DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
 
-#endif // _TARGET_X86_ && !FEATURE_PAL
+#endif // !FEATURE_PAL
+
+#define RUNTIME_FUNCTION__BeginAddress(prf)             (prf)->BeginAddress
+
+#endif // _TARGET_X86_
 
 #ifdef _TARGET_ARM_
 #include "daccess.h"

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -85,7 +85,6 @@ typedef struct _RUNTIME_FUNCTION {
 
 typedef DPTR(RUNTIME_FUNCTION) PTR_RUNTIME_FUNCTION;
 
-#define RUNTIME_FUNCTION__BeginAddress(prf)             (prf)->BeginAddress
 
 // Chained unwind info. Used for cold methods.
 #define RUNTIME_FUNCTION_INDIRECT 0x80000000


### PR DESCRIPTION
RUNTIME_FUNCTION__BeginAddress is defined in corcompile.h for x86, but
is defined in clrnt.h for all the other architectures.

This commit moves RUNTIME_FUNCTION__BeginAddress defines for x86 into
clrnt.h to make it consistent.