### PR TITLE
Make it easier to use StringComparison & StringComparer with GetHashCode

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -7393,6 +7393,7 @@
       <Member Name="get_Length" />
       <Member Name="GetEnumerator" />
       <Member Name="GetHashCode" />
+      <Member Name="GetHashCode(System.StringComparison)" />
       <Member Name="GetTypeCode" />
       <Member Name="IndexOf(System.Char)" />
       <Member Name="IndexOf(System.Char,System.Int32)" />
@@ -7500,6 +7501,7 @@
       <Member Name="Create(System.Globalization.CultureInfo,System.Boolean)" />
       <Member Name="Equals(System.Object,System.Object)" />
       <Member Name="Equals(System.String,System.String)" />
+      <Member Name="FromComparison(System.StringComparison)" />
       <Member Name="get_CurrentCulture" />
       <Member Name="get_CurrentCultureIgnoreCase" />
       <Member Name="get_InvariantCulture" />

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -997,6 +997,11 @@ namespace System
             return GetLegacyNonRandomizedHashCode();
         }
 
+        // Gets a hash code for this string and this comparison. If strings A and B and comparition C are such
+        // that String.Equals(A, B, C), then they will return the same hash code with this comparison C.
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        public int GetHashCode(StringComparison comparisonType) => StringComparer.FromComparison(comparisonType).GetHashCode(this);
+
         // Use this if and only if you need the hashcode to not change across app domains (e.g. you have an app domain agile
         // hash table).
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]

--- a/src/mscorlib/src/System/StringComparer.cs
+++ b/src/mscorlib/src/System/StringComparer.cs
@@ -62,6 +62,28 @@ namespace System {
             }
         }
 
+        // Convert a StringComparison to a StringComparer
+        public static StringComparer FromComparison(StringComparison comparisonType)
+        {
+            switch (comparisonType)
+            {
+                case StringComparison.CurrentCulture:
+                    return CurrentCulture;
+                case StringComparison.CurrentCultureIgnoreCase:
+                    return CurrentCultureIgnoreCase;
+                case StringComparison.InvariantCulture:
+                    return InvariantCulture;
+                case StringComparison.InvariantCultureIgnoreCase:
+                    return InvariantCultureIgnoreCase;
+                case StringComparison.Ordinal:
+                    return Ordinal;
+                case StringComparison.OrdinalIgnoreCase:
+                    return OrdinalIgnoreCase;
+                default:
+                    throw new ArgumentException(Environment.GetResourceString("NotSupported_StringComparison"), nameof(comparisonType));
+            }
+        }
+
         public static StringComparer Create(CultureInfo culture, bool ignoreCase) {
             if( culture == null) {
                 throw new ArgumentNullException(nameof(culture));


### PR DESCRIPTION
Add API to convert a StringComparison to a StringComparer.
Add string.GetHashCode(StringComparison) API.
Close https://github.com/dotnet/corefx/issues/13800
