### PR TITLE
[ARM32/Linux] Fix unpredictable sub.w sp, rN, #imm

### DIFF
--- a/src/pal/inc/unixasmmacrosarm.inc
+++ b/src/pal/inc/unixasmmacrosarm.inc
@@ -229,7 +229,8 @@ C_FUNC(\Name\()_End):
 .endm
 
 .macro EPILOG_STACK_RESTORE_OFFSET Register, Offset
-        sub sp, \Register, \Offset
+        sub \Register, \Offset
+        mov sp, \Register
 .endm
 
 .macro EPILOG_BRANCH Target


### PR DESCRIPTION
[unixasmmacrosarm.inc](https://github.com/dotnet/coreclr/blob/3a8ebe8cefd0e2e7e14c544bcce687bf87fc7de9/src/pal/inc/unixasmmacrosarm.inc#L231) defines the macro:
```
.macro EPILOG_STACK_RESTORE_OFFSET Register, Offset
        sub sp, \Register, \Offset
.endm
```
ARMv7 ISA manual (section A8.8.221) states this Thumb2 instruction is unpredictable:
```
Encoding T3   ARMv6T2, ARMv7
SUB{S}<c>.W <Rd>, <Rn>, #<const>

if Rd == ‘1111’ && S == ‘1’ then SEE CMP (immediate);
if Rn == ‘1101’ then SEE SUB (SP minus immediate);
d = UInt(Rd); n = UInt(Rn); setflags = (S == ‘1’); imm32 = ThumbExpandImm(i:imm3:imm8);
if d == 13 || (d == 15 && S == ‘0’) || n == 15 then UNPREDICTABLE;
```
The LLVM assembler silently accepts this instruction but GCC correctly gives the error message:
```
$ cat fail.c
int main()
{
    asm("mov r7, sp\n"
        "sub.w sp, r7, 0" : : : "r7");
    return 0;
}
$ gcc -march=armv7-a -mthumb -O1 -o fail fail.c 
/tmp/ccX51xFo.s: Assembler messages:
/tmp/ccX51xFo.s:29: Error: r13 not allowed here -- `sub.w sp,r7,0'
```
A relevant LLVM bug [exists](https://llvm.org/bugs/show_bug.cgi?id=25275) already.

Originally I stumbled upon this issue while running the VM under Valgrind:
```
==30819== Command: coreclr/corerun Tiny.exe
==30819== 
disInstr(thumb): unhandled instruction: 0xF1A7 0x0D08
==30819== valgrind: Unrecognised instruction at address 0x103c7.
```