### PR TITLE
[Linux][GDB-JIT] Fix bugs in gdbjit that break lldb stepping

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1948,6 +1948,13 @@ bool NotifyGdb::BuildLineProg(MemBuf& buf, PCODE startAddr, TADDR codeSize, Symb
             prevFile = lines[i].fileIndex;
         }
 
+        // GCC don't use the is_prologue_end flag to mark the first instruction after the prologue.
+        // Instead of it it is issueing a line table entry for the first instruction of the prologue
+        // and one for the first instruction after the prologue.
+        // We do not want to confuse the debugger so we have to avoid adding a line in such case.
+        if (i > 0 && lines[i - 1].nativeOffset == lines[i].nativeOffset)
+            continue;
+
         IssueSetAddress(ptr, startAddr + lines[i].nativeOffset);
 
         if (lines[i].lineNumber != prevLine) {

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1894,10 +1894,7 @@ static void fixLineMapping(SymbolsInfo* lines, unsigned nlines)
         {
             if (lines[i].lineNumber == 0)
             {
-                if (prevLine != 0)
-                {
-                    lines[i].lineNumber = prevLine;
-                }
+                lines[i].lineNumber = prevLine;
             }
             else
             {

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1884,13 +1884,15 @@ static void fixLineMapping(SymbolsInfo* lines, unsigned nlines)
     int prevLine = 0;
     for (int i = 0; i < nlines; ++i)
     {
+        if (lines[i].lineNumber == HiddenLine)
+            continue;
         if (lines[i].ilOffset == ICorDebugInfo::PROLOG) // will be fixed in next step
         {
             prevLine = 0;
         }
         else
         {
-            if (lines[i].lineNumber == 0 || lines[i].lineNumber == HiddenLine)
+            if (lines[i].lineNumber == 0)
             {
                 if (prevLine != 0)
                 {
@@ -1907,10 +1909,22 @@ static void fixLineMapping(SymbolsInfo* lines, unsigned nlines)
     prevLine = lines[nlines - 1].lineNumber;
     for (int i = nlines - 1; i >= 0; --i)
     {
-        if (lines[i].lineNumber == 0 || lines[i].lineNumber == HiddenLine)
+        if (lines[i].lineNumber == HiddenLine)
+            continue;
+        if (lines[i].lineNumber == 0)
             lines[i].lineNumber = prevLine;
         else
             prevLine = lines[i].lineNumber;
+    }
+    // Skip HiddenLines
+    for (int i = 0; i < nlines; ++i)
+    {
+        if (lines[i].lineNumber == HiddenLine)
+        {
+            lines[i].lineNumber = 0;
+            if (i + 1 < nlines && lines[i + 1].ilOffset == ICorDebugInfo::NO_MAPPING)
+                lines[i + 1].lineNumber = 0;
+        }
     }
 }
 

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1432,13 +1432,11 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
     CodeHeader* pCH = (CodeHeader*)pCode - 1;
     CalledMethod* pCalledMethods = reinterpret_cast<CalledMethod*>(pCH->GetCalledMethods());
     /* Collect addresses of thunks called by method */
-    if (!CollectCalledMethods(pCalledMethods))
+    if (!CollectCalledMethods(pCalledMethods, (TADDR)MethodDescPtr->GetNativeCode()))
     {
         return;
     }
     pCH->SetCalledMethods(NULL);
-    if (!codeAddrs.Contains((TADDR)pCode))
-        codeAddrs.Add((TADDR)pCode);
 
     MetaSig sig(MethodDescPtr);
     int nArgsCount = sig.NumFixedArgs();
@@ -2139,9 +2137,12 @@ bool NotifyGdb::BuildDebugPub(MemBuf& buf, const char* name, uint32_t size, uint
 }
 
 /* Store addresses and names of the called methods into symbol table */
-bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods)
+bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods, TADDR nativeCode)
 {
     AddrSet tmpCodeAddrs;
+
+    if (!codeAddrs.Contains(nativeCode))
+        codeAddrs.Add(nativeCode);
 
     CalledMethod* pList = pCalledMethods;
 

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -2160,7 +2160,8 @@ bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods, TADDR nativeC
     SymbolNames = new (nothrow) Elf_Symbol[SymbolCount];
 
     pList = pCalledMethods;
-    for (int i = 1 + method.GetCount(); i < SymbolCount;)
+    int i = 1 + method.GetCount();
+    while (i < SymbolCount)
     {
         TADDR callAddr = (TADDR)pList->GetCallAddr();
         if (!codeAddrs.Contains(callAddr))
@@ -2179,7 +2180,7 @@ bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods, TADDR nativeC
         pList = pList->GetNext();
         delete ptr;
     }
-
+    SymbolCount = i;
     return true;
 }
 

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -2182,7 +2182,7 @@ bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods, TADDR nativeC
 
     pList = pCalledMethods;
     int i = 1 + method.GetCount();
-    while (i < SymbolCount)
+    while (i < SymbolCount && pList != NULL)
     {
         TADDR callAddr = (TADDR)pList->GetCallAddr();
         if (!codeAddrs.Contains(callAddr))

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -401,7 +401,7 @@ private:
     static void IssueSimpleCommand(char*& ptr, uint8_t command);
     static void IssueParamCommand(char*& ptr, uint8_t command, char* param, int param_len);
     static void SplitPathname(const char* path, const char*& pathName, const char*& fileName);
-    static bool CollectCalledMethods(CalledMethod* pCM);
+    static bool CollectCalledMethods(CalledMethod* pCM, TADDR nativeCode);
 #ifdef _DEBUG
     static void DumpElf(const char* methodName, const MemBuf& buf);
 #endif


### PR DESCRIPTION
This PR fixes a number of bugs in GDBJIT that sometimes break LLDB stepping:
* Overlapping symbols in .text and .thunk sections
  When current method calls itself, a __thunk* symbol might be generated with the same address as the method symbol in .text section. Avoid generating such __thunk* symbol.
* Symbols containing garbage in .thunk sections
  When __thunk* symbols of previously compiled methods cause generation of __thunk* symbols for currently compiled method without filling symbol info.
* Incorrect prologue_end detection by LLDB
  GCC don't use the is_prologue_end flag to mark the first instruction after the prologue. Instead of it it is issueing a line table entry for the first instruction of the prologue and one for the first instruction after the prologue.
* LLDB does not skip HiddenLines

@mikem8361, @janvorli PTAL

cc @Dmitri-Botcharnikov @chunseoklee @seanshpark @lucenticus