### PR TITLE
Fix ref count adjustment in `fgMorphBlockStmt`.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -15330,6 +15330,12 @@ bool Compiler::fgMorphBlockStmt(BasicBlock* block, GenTreeStmt* stmt DEBUGARG(co
 
     stmt->gtStmtExpr = morph;
 
+    if (lvaLocalVarRefCounted)
+    {
+        // fgMorphTree may have introduced new lclVar references. Bump the ref counts if requested.
+        lvaRecursiveIncRefCounts(stmt->gtStmtExpr);
+    }
+
     // Can the entire tree be removed?
     bool removedStmt = fgCheckRemoveStmt(block, stmt);
 
@@ -15347,12 +15353,6 @@ bool Compiler::fgMorphBlockStmt(BasicBlock* block, GenTreeStmt* stmt DEBUGARG(co
 
     if (!removedStmt)
     {
-        if (lvaLocalVarRefCounted)
-        {
-            // fgMorphTree may have introduced new lclVar references. Bump the ref counts if requested.
-            lvaRecursiveIncRefCounts(stmt->gtStmtExpr);
-        }
-
         // Have to re-do the evaluation order since for example some later code does not expect constants as op1
         gtSetStmtInfo(stmt);
 

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_359734/DevDiv_359734.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_359734/DevDiv_359734.il
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// The original bug for this test was an assertion after the following sequence of events:
+// - Assertion propagation constant propagated away the ldlocs, or, and shl in the IL at label "expr"
+// - After constant propagation, the resulting expression--`(mod tmp0 cns)`--was remorphed, which
+//   replaced the modulus with `(sub tmp0 (mul (div tmp0 cns) cns))` and unset the "exception" flag.
+//   Critically, this transformation added a new use of `tmp0` without updating the ref count for `tmp0`.
+// - After morphing, the resulting expression was both unsused and side-effect-free, and was removed
+// - While removing the lclVar ref count for `tmp0` fell to `0`
+// - Later, liveness found a reference to `tmp0` despite the `0` lclVar count and asserted.
+//
+// The fix was to bump lclVar ref counts after remorphing but before attempting to remove the expression.
+
+.assembly extern mscorlib{}
+.assembly ILGEN_MODULE{}
+.class ILGEN_CLASS
+{
+    .method static char ILGEN_METHOD(bool, char, int16, int32)
+    {
+        .maxstack  65535
+        .locals init (int32, int16, int64, int16, unsigned int8, float32, unsigned int8)
+
+        ldc.i8 0x80BBE1AB
+        ldc.i8 0x866D9EF3
+        or
+        ldarg 0x1
+        shl
+        ldc.i8 0xC09C2177
+        sub.ovf.un
+        conv.ovf.u8.un
+        ldc.i8 0x82B1C678
+        or
+        ldc.r8 -0.000000
+        ldloc 0x5
+        ckfinite
+        ldloc 0x5
+        neg
+        neg
+        add
+        add
+        ldc.r8 0.000000
+        clt
+        stloc.s 0x4
+        ldc.i8 0xACB4FC40
+
+    expr:
+        ldloc.s 0x3
+        ldloc.s 0x0
+        or
+        shl
+        rem
+
+        conv.ovf.i8
+        ldloc.s 0x4
+        conv.ovf.u
+        neg
+        brtrue IL_0089
+        ldarg 0x0
+        conv.ovf.i8
+        conv.i8
+        ldc.i8 0x2ECADED8
+        ldloc 0x2
+        shr
+        clt
+        pop
+        ldloc.s 0x1
+        conv.ovf.u1.un
+        conv.ovf.u.un
+        starg 0x0
+
+    IL_0089:
+        ldarg.s 0x3
+        conv.u8
+        bgt IL_0094
+        ldloc.s 0x5
+        pop
+
+    IL_0094:
+        ldc.r8 0.000000
+        neg
+        conv.i
+        ldloc 0x5
+        ckfinite
+        ldc.i8 0x8BD98F2C
+        conv.r4
+        ckfinite
+        clt
+        pop
+        neg
+        ret
+    }
+
+    .method static int32 Main()
+    {
+        .entrypoint
+
+        .try
+        {
+            ldc.i4 0
+            dup
+            dup
+            dup
+            call char ILGEN_CLASS::ILGEN_METHOD(bool, char, int16, int32)
+            pop
+            leave.s done
+        }
+        catch [mscorlib]System.Exception
+        {
+            leave.s done
+        }
+
+    done:
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_359734/DevDiv_359734.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_359734/DevDiv_359734.ilproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_359734.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
LclVar ref counts must be incremented before attempting to remove the
morphed statement, since doing so decrements ref counts (and thus
requires refcounts to be conservatively correct).

Fixes VSO 359734.