### PR TITLE
Enable SIMD for RyuJIT/x86

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -562,13 +562,13 @@ CONFIG_DWORD_INFO_EX(INTERNAL_JitLoopHoistStats, W("JitLoopHoistStats"), 0, "Dis
 CONFIG_DWORD_INFO_EX(INTERNAL_JitDebugLogLoopCloning, W("JitDebugLogLoopCloning"), 0, "In debug builds log places where loop cloning optimizations are performed on the fast path.", CLRConfig::REGUTIL_default);
 CONFIG_DWORD_INFO_EX(INTERNAL_JitVNMapSelLimit, W("JitVNMapSelLimit"), 0, "If non-zero, assert if # of VNF_MapSelect applications considered reaches this", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_JitVNMapSelBudget, W("JitVNMapSelBudget"), 100, "Max # of MapSelect's considered for a particular top-level invocation.")
-#if defined(_TARGET_AMD64_)
+#if defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
 #define EXTERNAL_FeatureSIMD_Default 1
 #define EXTERNAL_JitEnableAVX_Default 1
-#else // !defined(_TARGET_AMD64_)
+#else // !defined(_TARGET_AMD64_) && !defined(_TARGET_X86_)
 #define EXTERNAL_FeatureSIMD_Default 0
 #define EXTERNAL_JitEnableAVX_Default 0
-#endif // !defined(_TARGET_AMD64_)
+#endif // !defined(_TARGET_AMD64_) && !defined(_TARGET_X86_)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_FeatureSIMD, W("FeatureSIMD"), EXTERNAL_FeatureSIMD_Default, "Enable SIMD support with companion SIMDVector.dll", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_EnableAVX, W("EnableAVX"), EXTERNAL_JitEnableAVX_Default, "Enable AVX instruction set for wide operations as default", CLRConfig::REGUTIL_default)
 

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -93,10 +93,11 @@ void genSIMDCheck(GenTree* treeNode);
 // their size rounded to TARGET_POINTER_SIZE (which is 8 bytes on 64-bit targets) and hence
 // Vector3 locals could be treated as TYP_SIMD16 while reading/writing.
 void genStoreIndTypeSIMD12(GenTree* treeNode);
-void genStoreLclFldTypeSIMD12(GenTree* treeNode);
 void genLoadIndTypeSIMD12(GenTree* treeNode);
+void genStoreLclTypeSIMD12(GenTree* treeNode);
 void genLoadLclTypeSIMD12(GenTree* treeNode);
 #ifdef _TARGET_X86_
+void genStoreSIMD12ToStack(regNumber operandReg, regNumber tmpReg);
 void genPutArgStkSIMD12(GenTree* treeNode);
 #endif // _TARGET_X86_
 #endif // FEATURE_SIMD

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1491,10 +1491,11 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             // storing of TYP_SIMD12 (i.e. Vector3) field
             if (treeNode->TypeGet() == TYP_SIMD12)
             {
-                genStoreLclFldTypeSIMD12(treeNode);
+                genStoreLclTypeSIMD12(treeNode);
                 break;
             }
-#endif
+#endif // FEATURE_SIMD
+
             GenTreePtr op1 = treeNode->gtGetOp1();
             genConsumeRegs(op1);
             emit->emitInsBinary(ins_Store(targetType), emitTypeSize(treeNode), treeNode, op1);
@@ -1531,6 +1532,13 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 #endif // !defined(_TARGET_64BIT_)
 
 #ifdef FEATURE_SIMD
+                // storing of TYP_SIMD12 (i.e. Vector3) field
+                if (treeNode->TypeGet() == TYP_SIMD12)
+                {
+                    genStoreLclTypeSIMD12(treeNode);
+                    break;
+                }
+
                 if (varTypeIsSIMD(targetType) && (targetReg != REG_NA) && op1->IsCnsIntOrI())
                 {
                     // This is only possible for a zero-init.
@@ -7450,13 +7458,19 @@ unsigned CodeGen::getBaseVarForPutArgStk(GenTreePtr treeNode)
 
 #ifdef _TARGET_X86_
 //---------------------------------------------------------------------
-// adjustStackForPutArgStk:
+// genAdjustStackForPutArgStk:
 //    adjust the stack pointer for a putArgStk node if necessary.
 //
 // Arguments:
 //    putArgStk - the putArgStk node.
 //
 // Returns: true if the stack pointer was adjusted; false otherwise.
+//
+// Notes:
+//    Sets `m_pushStkArg` to true if the stack arg needs to be pushed,
+//    false if the stack arg needs to be stored at the current stack
+//    pointer address. This is exactly the opposite of the return value
+//    of this function.
 //
 bool CodeGen::genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk)
 {
@@ -7515,11 +7529,10 @@ bool CodeGen::genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk)
 }
 
 //---------------------------------------------------------------------
-// genPutArgStkFieldList - generate code for passing an arg on the stack.
+// genPutArgStkFieldList - generate code for passing a GT_FIELD_LIST arg on the stack.
 //
 // Arguments
-//    treeNode      - the GT_PUTARG_STK node
-//    targetType    - the type of the treeNode
+//    treeNode      - the GT_PUTARG_STK node whose op1 is a GT_FIELD_LIST
 //
 // Return value:
 //    None
@@ -7531,24 +7544,36 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
 
     // Set m_pushStkArg and pre-adjust the stack if necessary.
     const bool preAdjustedStack = genAdjustStackForPutArgStk(putArgStk);
+
     // For now, we only support the "push" case; we will push a full slot for the first field of each slot
     // within the struct.
     assert((putArgStk->isPushKind()) && !preAdjustedStack && m_pushStkArg);
 
-    // If we have pre-adjusted the stack and are simply storing the fields in order) set the offset to 0.
+    // If we have pre-adjusted the stack and are simply storing the fields in order, set the offset to 0.
     // (Note that this mode is not currently being used.)
     // If we are pushing the arguments (i.e. we have not pre-adjusted the stack), then we are pushing them
     // in reverse order, so we start with the current field offset at the size of the struct arg (which must be
     // a multiple of the target pointer size).
     unsigned  currentOffset   = (preAdjustedStack) ? 0 : putArgStk->getArgSize();
     unsigned  prevFieldOffset = currentOffset;
-    regNumber tmpReg          = REG_NA;
+    regNumber intTmpReg       = REG_NA;
+    regNumber simdTmpReg      = REG_NA;
     if (putArgStk->gtRsvdRegs != RBM_NONE)
     {
-        assert(genCountBits(putArgStk->gtRsvdRegs) == 1);
-        tmpReg = genRegNumFromMask(putArgStk->gtRsvdRegs);
-        assert(genIsValidIntReg(tmpReg));
+        regMaskTP rsvdRegs = putArgStk->gtRsvdRegs;
+        if ((rsvdRegs & RBM_ALLINT) != 0)
+        {
+            intTmpReg = genRegNumFromMask(rsvdRegs & RBM_ALLINT);
+            assert(genIsValidIntReg(intTmpReg));
+        }
+        if ((rsvdRegs & RBM_ALLFLOAT) != 0)
+        {
+            simdTmpReg = genRegNumFromMask(rsvdRegs & RBM_ALLFLOAT);
+            assert(genIsValidFloatReg(simdTmpReg));
+        }
+        assert(genCountBits(rsvdRegs) == ((intTmpReg == REG_NA) ? 0 : 1) + ((simdTmpReg == REG_NA) ? 0 : 1));
     }
+
     for (GenTreeFieldList* current = fieldList; current != nullptr; current = current->Rest())
     {
         GenTree* const fieldNode   = current->Current();
@@ -7576,7 +7601,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
         // able to detect stores into the outgoing argument area of the stack on x86.
         const bool fieldIsSlot = ((fieldOffset % 4) == 0) && ((prevFieldOffset - fieldOffset) >= 4);
         int        adjustment  = roundUp(currentOffset - fieldOffset, 4);
-        if (fieldIsSlot)
+        if (fieldIsSlot && !varTypeIsSIMD(fieldType))
         {
             fieldType         = genActualType(fieldType);
             unsigned pushSize = genTypeSize(fieldType);
@@ -7594,12 +7619,13 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
         else
         {
             m_pushStkArg = false;
+
             // We always "push" floating point fields (i.e. they are full slot values that don't
             // require special handling).
-            assert(varTypeIsIntegralOrI(fieldNode));
+            assert(varTypeIsIntegralOrI(fieldNode) || varTypeIsSIMD(fieldNode));
+
             // If we can't push this field, it needs to be in a register so that we can store
             // it to the stack location.
-            assert(tmpReg != REG_NA);
             if (adjustment != 0)
             {
                 // This moves the stack pointer to fieldOffset.
@@ -7611,15 +7637,16 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
             }
 
             // Does it need to be in a byte register?
-            // If so, we'll use tmpReg, which must have been allocated as a byte register.
+            // If so, we'll use intTmpReg, which must have been allocated as a byte register.
             // If it's already in a register, but not a byteable one, then move it.
             if (varTypeIsByte(fieldType) && ((argReg == REG_NA) || ((genRegMask(argReg) & RBM_BYTE_REGS) == 0)))
             {
-                noway_assert((genRegMask(tmpReg) & RBM_BYTE_REGS) != 0);
+                assert(intTmpReg != REG_NA);
+                noway_assert((genRegMask(intTmpReg) & RBM_BYTE_REGS) != 0);
                 if (argReg != REG_NA)
                 {
-                    inst_RV_RV(INS_mov, tmpReg, argReg, fieldType);
-                    argReg = tmpReg;
+                    inst_RV_RV(INS_mov, intTmpReg, argReg, fieldType);
+                    argReg = intTmpReg;
                 }
             }
         }
@@ -7630,6 +7657,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
             {
                 if (fieldNode->isUsedFromSpillTemp())
                 {
+                    assert(!varTypeIsSIMD(fieldType)); // Q: can we get here with SIMD?
                     assert(fieldNode->IsRegOptional());
                     TempDsc* tmp = getSpillTempDsc(fieldNode);
                     getEmitter()->emitIns_S(INS_push, emitActualTypeSize(fieldNode->TypeGet()), tmp->tdTempNum(), 0);
@@ -7662,25 +7690,35 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
             }
             else
             {
-                // The stack has been adjusted and we will load the field to tmpReg and then store it on the stack.
+                // The stack has been adjusted and we will load the field to intTmpReg and then store it on the stack.
                 assert(varTypeIsIntegralOrI(fieldNode));
                 switch (fieldNode->OperGet())
                 {
                     case GT_LCL_VAR:
-                        inst_RV_TT(INS_mov, tmpReg, fieldNode);
+                        inst_RV_TT(INS_mov, intTmpReg, fieldNode);
                         break;
                     case GT_CNS_INT:
-                        genSetRegToConst(tmpReg, fieldNode->TypeGet(), fieldNode);
+                        genSetRegToConst(intTmpReg, fieldNode->TypeGet(), fieldNode);
                         break;
                     default:
                         unreached();
                 }
-                genStoreRegToStackArg(fieldType, tmpReg, fieldOffset - currentOffset);
+                genStoreRegToStackArg(fieldType, intTmpReg, fieldOffset - currentOffset);
             }
         }
         else
         {
-            genStoreRegToStackArg(fieldType, argReg, fieldOffset - currentOffset);
+#if defined(_TARGET_X86_) && defined(FEATURE_SIMD)
+            if (fieldType == TYP_SIMD12)
+            {
+                assert(genIsValidFloatReg(simdTmpReg));
+                genStoreSIMD12ToStack(argReg, simdTmpReg);
+            }
+            else
+#endif // defined(_TARGET_X86_) && defined(FEATURE_SIMD)
+            {
+                genStoreRegToStackArg(fieldType, argReg, fieldOffset - currentOffset);
+            }
             if (m_pushStkArg)
             {
                 // We always push a slot-rounded size
@@ -7714,14 +7752,6 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
     var_types targetType = putArgStk->TypeGet();
 
 #ifdef _TARGET_X86_
-
-#ifdef FEATURE_SIMD
-    if (targetType == TYP_SIMD12)
-    {
-        genPutArgStkSIMD12(putArgStk);
-        return;
-    }
-#endif // FEATURE_SIMD
 
     if (varTypeIsStruct(targetType))
     {
@@ -7949,6 +7979,14 @@ void CodeGen::genStoreRegToStackArg(var_types type, regNumber srcReg, int offset
 void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
 {
     var_types targetType = putArgStk->TypeGet();
+
+#if defined(_TARGET_X86_) && defined(FEATURE_SIMD)
+    if (targetType == TYP_SIMD12)
+    {
+        genPutArgStkSIMD12(putArgStk);
+        return;
+    }
+#endif // defined(_TARGET_X86_) && defined(FEATURE_SIMD)
 
     if (varTypeIsSIMD(targetType))
     {

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -249,6 +249,12 @@ GenTree* DecomposeLongs::DecomposeNode(GenTree* tree)
             nextNode = DecomposeRotate(use);
             break;
 
+#ifdef FEATURE_SIMD
+        case GT_SIMD:
+            nextNode = DecomposeSimd(use);
+            break;
+#endif // FEATURE_SIMD
+
         case GT_LOCKADD:
         case GT_XADD:
         case GT_XCHG:
@@ -1561,6 +1567,129 @@ GenTree* DecomposeLongs::DecomposeUMod(LIR::Use& use)
 
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);
 }
+
+#ifdef FEATURE_SIMD
+
+//------------------------------------------------------------------------
+// DecomposeSimd: Decompose GT_SIMD.
+//
+// Arguments:
+//    use - the LIR::Use object for the def that needs to be decomposed.
+//
+// Return Value:
+//    The next node to process.
+//
+GenTree* DecomposeLongs::DecomposeSimd(LIR::Use& use)
+{
+    GenTree*   tree = use.Def();
+    genTreeOps oper = tree->OperGet();
+
+    assert(oper == GT_SIMD);
+
+    GenTreeSIMD* simdTree = tree->AsSIMD();
+
+    switch (simdTree->gtSIMDIntrinsicID)
+    {
+        case SIMDIntrinsicGetItem:
+            return DecomposeSimdGetItem(use);
+
+        default:
+            noway_assert(!"unexpected GT_SIMD node in long decomposition");
+            break;
+    }
+
+    return nullptr;
+}
+
+//------------------------------------------------------------------------
+// DecomposeSimdGetItem: Decompose GT_SIMD -- SIMDIntrinsicGetItem.
+//
+// Decompose a get[i] node on Vector<long>. For:
+//
+// GT_SIMD{get_item}[long](simd_var, index)
+//
+// create:
+//
+// tmp_simd_var = simd_var
+// tmp_index = index
+// loResult = GT_SIMD{get_item}[int](tmp_simd_var, tmp_index * 2)
+// hiResult = GT_SIMD{get_item}[int](tmp_simd_var, tmp_index * 2 + 1)
+// return: GT_LONG(loResult, hiResult)
+//
+// This isn't optimal codegen, since SIMDIntrinsicGetItem sometimes requires
+// temps that could be shared, for example.
+//
+// Arguments:
+//    use - the LIR::Use object for the def that needs to be decomposed.
+//
+// Return Value:
+//    The next node to process.
+//
+GenTree* DecomposeLongs::DecomposeSimdGetItem(LIR::Use& use)
+{
+    GenTree*   tree = use.Def();
+    genTreeOps oper = tree->OperGet();
+
+    assert(oper == GT_SIMD);
+
+    GenTreeSIMD* simdTree = tree->AsSIMD();
+    var_types    baseType = simdTree->gtSIMDBaseType;
+    unsigned     simdSize = simdTree->gtSIMDSize;
+
+    assert(simdTree->gtSIMDIntrinsicID == SIMDIntrinsicGetItem);
+    assert(varTypeIsLong(baseType));
+    assert(varTypeIsLong(simdTree));
+    assert(varTypeIsSIMD(simdTree->gtOp.gtOp1->gtType));
+    assert(simdTree->gtOp.gtOp2->gtType == TYP_INT);
+
+    LIR::Use op1(Range(), &simdTree->gtOp.gtOp1, simdTree);
+    unsigned simdTmpVarNum = op1.ReplaceWithLclVar(m_compiler, m_blockWeight);
+    JITDUMP("[DecomposeSimdGetItem]: Saving op1 tree to a temp var:\n");
+    DISPTREERANGE(Range(), op1.Def());
+
+    LIR::Use op2(Range(), &simdTree->gtOp.gtOp2, simdTree);
+    unsigned indexTmpVarNum = op2.ReplaceWithLclVar(m_compiler, m_blockWeight);
+    JITDUMP("[DecomposeSimdGetItem]: Saving op2 tree to a temp var:\n");
+    DISPTREERANGE(Range(), op2.Def());
+
+    // TODO-CQ: if the index is constant, we don't need to do the computation dynamically.
+
+    // Create:
+    //      loResult = GT_SIMD{get_item}[int](tmp_simd_var, tmp_index * 2)
+
+    GenTree* simdTmpVar1    = m_compiler->gtNewLclLNode(simdTmpVarNum, simdTree->gtOp.gtOp1->gtType);
+    GenTree* indexTmpVar1   = m_compiler->gtNewLclLNode(indexTmpVarNum, TYP_INT);
+    GenTree* two1           = m_compiler->gtNewIconNode(2, TYP_INT);
+    GenTree* indexTimesTwo1 = m_compiler->gtNewOperNode(GT_MUL, TYP_INT, indexTmpVar1, two1);
+
+    GenTree* loResult =
+        m_compiler->gtNewSIMDNode(TYP_INT, simdTmpVar1, indexTimesTwo1, SIMDIntrinsicGetItem, TYP_INT, simdSize);
+
+    // Create:
+    //      hiResult = GT_SIMD{get_item}[int](tmp_simd_var, tmp_index * 2 + 1)
+
+    GenTree* simdTmpVar2          = m_compiler->gtNewLclLNode(simdTmpVarNum, simdTree->gtOp.gtOp1->gtType);
+    GenTree* indexTmpVar2         = m_compiler->gtNewLclLNode(indexTmpVarNum, TYP_INT);
+    GenTree* two2                 = m_compiler->gtNewIconNode(2, TYP_INT);
+    GenTree* indexTimesTwo2       = m_compiler->gtNewOperNode(GT_MUL, TYP_INT, indexTmpVar2, two2);
+    GenTree* one                  = m_compiler->gtNewIconNode(1, TYP_INT);
+    GenTree* indexTimesTwoPlusOne = m_compiler->gtNewOperNode(GT_ADD, TYP_INT, indexTimesTwo2, one);
+
+    GenTree* hiResult =
+        m_compiler->gtNewSIMDNode(TYP_INT, simdTmpVar2, indexTimesTwoPlusOne, SIMDIntrinsicGetItem, TYP_INT, simdSize);
+
+    // Put all the new nodes in execution order.
+
+    Range().InsertBefore(tree, simdTmpVar1, indexTmpVar1, two1, indexTimesTwo1);
+    Range().InsertBefore(tree, loResult, simdTmpVar2, indexTmpVar2, two2);
+    Range().InsertBefore(tree, indexTimesTwo2, one, indexTimesTwoPlusOne, hiResult);
+
+    Range().Remove(tree);
+
+    return FinalizeDecomposition(use, loResult, hiResult, hiResult);
+}
+
+#endif // FEATURE_SIMD
 
 //------------------------------------------------------------------------
 // StoreNodeToVar: Check if the user is a STORE_LCL_VAR, and if it isn't,

--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -55,6 +55,8 @@ private:
     GenTree* DecomposeRotate(LIR::Use& use);
     GenTree* DecomposeMul(LIR::Use& use);
     GenTree* DecomposeUMod(LIR::Use& use);
+    GenTree* DecomposeSimd(LIR::Use& use);
+    GenTree* DecomposeSimdGetItem(LIR::Use& use);
 
     // Helper functions
     GenTree* FinalizeDecomposition(LIR::Use& use, GenTree* loResult, GenTree* hiResult, GenTree* insertResultAfter);

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -409,13 +409,16 @@ unsigned CILJit::getMaxIntrinsicSIMDVectorLength(DWORD cpuCompileFlags)
     {
         if (JitConfig.EnableAVX() != 0)
         {
+            JITDUMP("getMaxIntrinsicSIMDVectorLength: returning 32\n");
             return 32;
         }
     }
 #endif // FEATURE_AVX_SUPPORT
+    JITDUMP("getMaxIntrinsicSIMDVectorLength: returning 16\n");
     return 16;
 #endif // _TARGET_XARCH_
 #else  // !FEATURE_SIMD
+    JITDUMP("getMaxIntrinsicSIMDVectorLength: returning 0\n");
     return 0;
 #endif // !FEATURE_SIMD
 }

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -109,6 +109,16 @@ void SetUseSSE3_4(bool value)
 }
 bool Is4ByteSSE4Instruction(instruction ins);
 
+bool hasRexPrefix(code_t code)
+{
+#ifdef _TARGET_AMD64_
+    const code_t REX_PREFIX_MASK = 0xFF00000000LL;
+    return (code & REX_PREFIX_MASK) != 0;
+#else  // !_TARGET_AMD64_
+    return false;
+#endif // !_TARGET_AMD64_
+}
+
 #ifdef FEATURE_AVX_SUPPORT
 
 // 3-byte VEX prefix starts with byte 0xC4
@@ -178,7 +188,7 @@ bool IsThreeOperandAVXInstruction(instruction ins)
 }
 bool Is4ByteAVXInstruction(instruction ins);
 #else  // !FEATURE_AVX_SUPPORT
-bool                     UseAVX()
+bool UseAVX()
 {
     return false;
 }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1514,10 +1514,8 @@ var_types Compiler::impNormStructType(CORINFO_CLASS_HANDLE structHnd,
                 {
                     *pSimdBaseType = simdBaseType;
                 }
-#ifdef _TARGET_AMD64_
-                // Amd64: also indicate that we use floating point registers
+                // Also indicate that we use floating point registers.
                 compFloatingPointUsed = true;
-#endif
             }
         }
     }

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -3513,6 +3513,12 @@ instruction CodeGen::ins_CopyIntToFloat(var_types srcType, var_types dstType)
 {
     // On SSE2/AVX - the same instruction is used for moving double/quad word to XMM/YMM register.
     assert((srcType == TYP_INT) || (srcType == TYP_UINT) || (srcType == TYP_LONG) || (srcType == TYP_ULONG));
+
+#if !defined(_TARGET_64BIT_)
+    // No 64-bit registers on x86.
+    assert((srcType != TYP_LONG) && (srcType != TYP_ULONG));
+#endif // !defined(_TARGET_64BIT_)
+
     return INS_mov_i2xmm;
 }
 
@@ -3520,6 +3526,12 @@ instruction CodeGen::ins_CopyFloatToInt(var_types srcType, var_types dstType)
 {
     // On SSE2/AVX - the same instruction is used for moving double/quad word of XMM/YMM to an integer register.
     assert((dstType == TYP_INT) || (dstType == TYP_UINT) || (dstType == TYP_LONG) || (dstType == TYP_ULONG));
+
+#if !defined(_TARGET_64BIT_)
+    // No 64-bit registers on x86.
+    assert((dstType != TYP_LONG) && (dstType != TYP_ULONG));
+#endif // !defined(_TARGET_64BIT_)
+
     return INS_mov_xmm2i;
 }
 

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -204,13 +204,14 @@ CONFIG_INTEGER(AltJitAssertOnNYI, W("AltJitAssertOnNYI"), 1) // Controls the Alt
 CONFIG_INTEGER(EnableSSE3_4, W("EnableSSE3_4"), 1) // Enable SSE3, SSSE3, SSE 4.1 and 4.2 instruction set as default
 #endif
 
-#if defined(_TARGET_AMD64_)
-CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 1) // Enable AVX instruction set for wide operations as default.
-// When both AVX and SSE3_4 are set, we will use the most capable instruction set available
-// which will prefer AVX over SSE3/4.
-#else  // !defined(_TARGET_AMD64_)
-CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 0)                 // Enable AVX instruction set for wide operations as default
-#endif // defined(_TARGET_AMD64_)
+#if defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
+// Enable AVX instruction set for wide operations as default. When both AVX and SSE3_4 are set, we will use the most
+// capable instruction set available which will prefer AVX over SSE3/4.
+CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 1)
+#else  // !defined(_TARGET_AMD64_) && !defined(_TARGET_X86_)
+// Enable AVX instruction set for wide operations as default
+CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 0)
+#endif // !defined(_TARGET_AMD64_) && !defined(_TARGET_X86_)
 
 #if !defined(DEBUG) && !defined(_DEBUG)
 CONFIG_INTEGER(JitEnableNoWayAssert, W("JitEnableNoWayAssert"), 0)

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3417,7 +3417,7 @@ static int ComputeOperandDstCount(GenTree* operand)
 // ComputeAvailableSrcCount: computes the number of registers available as
 //                           sources for a node.
 //
-// This is simply the sum of the number of registers prduced by each
+// This is simply the sum of the number of registers produced by each
 // operand to the node.
 //
 // Arguments:
@@ -3436,7 +3436,7 @@ static int ComputeAvailableSrcCount(GenTree* node)
 
     return numSources;
 }
-#endif
+#endif // DEBUG
 
 void LinearScan::buildRefPositionsForNode(GenTree*                  tree,
                                           BasicBlock*               block,

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16971,6 +16971,14 @@ void Compiler::fgPromoteStructs()
         return;
     }
 
+#ifdef DEBUG
+    if (verbose)
+    {
+        printf("\nlvaTable before fgPromoteStructs\n");
+        lvaTableDump();
+    }
+#endif // DEBUG
+
     // The lvaTable might grow as we grab temps. Make a local copy here.
 
     unsigned startLvaCount = lvaCount;
@@ -16988,17 +16996,13 @@ void Compiler::fgPromoteStructs()
         bool       promotedVar = false;
         LclVarDsc* varDsc      = &lvaTable[lclNum];
 
-#ifdef FEATURE_SIMD
-        if (varDsc->lvSIMDType && varDsc->lvUsedInSIMDIntrinsic)
+        if (varDsc->lvIsSIMDType() && varDsc->lvIsUsedInSIMDIntrinsic())
         {
             // If we have marked this as lvUsedInSIMDIntrinsic, then we do not want to promote
             // its fields.  Instead, we will attempt to enregister the entire struct.
             varDsc->lvRegStruct = true;
         }
-        else
-#endif // FEATURE_SIMD
-            // Don't promote if we have reached the tracking limit.
-            if (lvaHaveManyLocals())
+        else if (lvaHaveManyLocals()) // Don't promote if we have reached the tracking limit.
         {
             // Print the message first time when we detected this condition
             if (!tooManyLocals)
@@ -17029,7 +17033,6 @@ void Compiler::fgPromoteStructs()
 
             if (canPromote)
             {
-
                 // We *can* promote; *should* we promote?
                 // We should only do so if promotion has potential savings.  One source of savings
                 // is if a field of the struct is accessed, since this access will be turned into
@@ -17154,6 +17157,14 @@ void Compiler::fgPromoteStructs()
         }
 #endif // FEATURE_SIMD
     }
+
+#ifdef DEBUG
+    if (verbose)
+    {
+        printf("\nlvaTable after fgPromoteStructs\n");
+        lvaTableDump();
+    }
+#endif // DEBUG
 }
 
 Compiler::fgWalkResult Compiler::fgMorphStructField(GenTreePtr tree, fgWalkData* fgWalkPre)

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -427,16 +427,6 @@ const SIMDIntrinsicInfo* Compiler::getSIMDIntrinsicInfo(CORINFO_CLASS_HANDLE* in
         return nullptr;
     }
 
-#ifdef _TARGET_X86_
-    // NYI: support LONG type SIMD intrinsics. Need support in long decomposition.
-    // (Don't use NYI fallback mechanism; just call the function.)
-    if ((*baseType == TYP_LONG) || (*baseType == TYP_ULONG))
-    {
-        JITDUMP("NYI: x86 long base type SIMD intrinsics\n");
-        return nullptr;
-    }
-#endif // _TARGET_X86_
-
     // account for implicit "this" arg
     *argCount = sig->numArgs;
     if (sig->hasThis())

--- a/tests/src/JIT/SIMD/VectorUtil.cs
+++ b/tests/src/JIT/SIMD/VectorUtil.cs
@@ -26,7 +26,7 @@ internal partial class VectorTest
         }
         if (returnVal == false)
         {
-            Console.WriteLine("CheckValue failed for " + expectedValue + " of type " + typeof(T).ToString());
+            Console.WriteLine("CheckValue failed for type " + typeof(T).ToString() + ". Expected: {0} (0x{0:X}), Got: {1} (0x{1:X})", expectedValue, value);
         }
         return returnVal;
     }


### PR DESCRIPTION
This change implements support for `Vector<long>`, handling
SIMDIntrinsicInit, which takes a LONG, and decomposition of
SIMDIntrinsicGetItem, which produces a LONG.

It also enables SIMD, including AVX, by default for RyuJIT/x86.