### PR TITLE
Fix DllImport of IdnToAscii & IdnToUnicode

### DIFF
--- a/src/mscorlib/src/System/Globalization/IdnMapping.cs
+++ b/src/mscorlib/src/System/Globalization/IdnMapping.cs
@@ -1158,7 +1158,7 @@ namespace System.Globalization
 
 
         [SuppressUnmanagedCodeSecurityAttribute()]
-        [DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)]
+        [DllImport("normaliz.dll", CharSet=CharSet.Unicode, SetLastError=true)]
         private static extern int IdnToAscii(
                                         uint    dwFlags, 
                                         [InAttribute()]
@@ -1171,7 +1171,7 @@ namespace System.Globalization
                                         int     cchASCIIChar);
 
         [SuppressUnmanagedCodeSecurityAttribute()]
-        [DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)]
+        [DllImport("normaliz.dll", CharSet=CharSet.Unicode, SetLastError=true)]
         private static extern int IdnToUnicode(
                                         uint    dwFlags, 
                                         [InAttribute()]


### PR DESCRIPTION
Fix an issue found in OneCoreUAP testing. According to MSDN,
the official exporting DLL for IdnToAccii and IdnToUnicode
is normaliz.dll, not kernel32.dll. While most Windows SKUs
export these functions from both normaliz.dll and kernel32.dll,
recent tests revealed that some Windows SKUs export them from
normaliz.dll only.