### PR TITLE
Widen basic block flag field to 64 bits

### DIFF
--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -554,7 +554,9 @@ void BasicBlock::dspBlockHeader(Compiler* compiler,
     }
     if (showFlags)
     {
-        printf(" flags=0x%08x: ", bbFlags);
+        const unsigned lowFlags  = (unsigned)bbFlags;
+        const unsigned highFlags = (unsigned)(bbFlags >> 32);
+        printf(" flags=0x%08x.%08x: ", highFlags, lowFlags);
         dspFlags();
     }
     printf("\n");

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -287,13 +287,13 @@ struct BasicBlock : private LIR::Range
         }
     }
 
+    unsigned __int64 bbFlags; // see BBF_xxxx below
+
     unsigned bbNum; // the block's number
 
     unsigned bbPostOrderNum; // the block's post order number in the graph.
     unsigned bbRefs; // number of blocks that can reach here, either by fall-through or a branch. If this falls to zero,
                      // the block is unreachable.
-
-    unsigned bbFlags; // see BBF_xxxx below
 
 #define BBF_VISITED 0x00000001 // BB visited during optimizations
 #define BBF_MARKED 0x00000002  // BB marked  during optimizations

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -3890,8 +3890,7 @@ bool Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
         BBjumpKinds oldJumpKind = top->bbJumpKind;
 
         // Update block flags
-        unsigned originalFlags;
-        originalFlags = top->bbFlags | BBF_GC_SAFE_POINT;
+        const unsigned __int64 originalFlags = top->bbFlags | BBF_GC_SAFE_POINT;
 
         // Unlike Fei's inliner from puclr, I'm allowed to split loops.
         // And we keep a few other flags...
@@ -19318,14 +19317,13 @@ void Compiler::fgDispDoms()
 
 void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 */)
 {
-    unsigned flags = block->bbFlags;
-
-    unsigned bbNumMax         = compIsForInlining() ? impInlineInfo->InlinerCompiler->fgBBNumMax : fgBBNumMax;
-    int      maxBlockNumWidth = CountDigits(bbNumMax);
-    maxBlockNumWidth          = max(maxBlockNumWidth, 2);
-    int blockNumWidth         = CountDigits(block->bbNum);
-    blockNumWidth             = max(blockNumWidth, 2);
-    int blockNumPadding       = maxBlockNumWidth - blockNumWidth;
+    const unsigned __int64 flags    = block->bbFlags;
+    unsigned               bbNumMax = compIsForInlining() ? impInlineInfo->InlinerCompiler->fgBBNumMax : fgBBNumMax;
+    int                    maxBlockNumWidth = CountDigits(bbNumMax);
+    maxBlockNumWidth                        = max(maxBlockNumWidth, 2);
+    int blockNumWidth                       = CountDigits(block->bbNum);
+    blockNumWidth                           = max(blockNumWidth, 2);
+    int blockNumPadding                     = maxBlockNumWidth - blockNumWidth;
 
     printf("BB%02u%*s [%08p] %2u", block->bbNum, blockNumPadding, "", dspPtr(block), block->bbRefs);
 
@@ -21746,7 +21744,7 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
                 stmtAfter = fgInsertStmtListAfter(iciBlock, stmtAfter, InlineeCompiler->fgFirstBB->bbTreeList);
 
                 // Copy inlinee bbFlags to caller bbFlags.
-                const unsigned int inlineeBlockFlags = InlineeCompiler->fgFirstBB->bbFlags;
+                const unsigned __int64 inlineeBlockFlags = InlineeCompiler->fgFirstBB->bbFlags;
                 noway_assert((inlineeBlockFlags & BBF_HAS_JMP) == 0);
                 noway_assert((inlineeBlockFlags & BBF_KEEP_BBJ_ALWAYS) == 0);
                 iciBlock->bbFlags |= inlineeBlockFlags;
@@ -21794,11 +21792,12 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
     topBlock->bbJumpKind = BBJ_NONE;
 
     // Update block flags
-    unsigned originalFlags;
-    originalFlags = topBlock->bbFlags;
-    noway_assert((originalFlags & BBF_SPLIT_NONEXIST) == 0);
-    topBlock->bbFlags &= ~(BBF_SPLIT_LOST);
-    bottomBlock->bbFlags |= originalFlags & BBF_SPLIT_GAINED;
+    {
+        const unsigned __int64 originalFlags = topBlock->bbFlags;
+        noway_assert((originalFlags & BBF_SPLIT_NONEXIST) == 0);
+        topBlock->bbFlags &= ~(BBF_SPLIT_LOST);
+        bottomBlock->bbFlags |= originalFlags & BBF_SPLIT_GAINED;
+    }
 
     //
     // Split statements between topBlock and bottomBlock

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2528,8 +2528,6 @@ void Compiler::optCleanupCSEs()
     //
     for (BasicBlock* block = fgFirstBB; block; block = block->bbNext)
     {
-        unsigned blkFlags = block->bbFlags;
-
         // And clear all the "visited" bits on the block
         //
         block->bbFlags &= ~(BBF_VISITED | BBF_MARKED);


### PR DESCRIPTION
Flag field is currently full, and I need at least one more bit to identify
the start of a cloned finally.

Widen to 64 bits and update a few uses. Also removed an unused copy.