### PR TITLE
Script to run CoreFx tests against a private CoreCLR

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -248,6 +248,7 @@ def static genStressModeScriptStep(def os, def stressModeName, def stressModeVar
 
         // Set the Timeout
         stepScript += "set __TestTimeout=${timeout}\r\n"
+        stepScript += "echo. > ${stepScriptLocation}\r\n"
         stressModeVars.each{ k, v -> 
             // Write out what we are writing to the script file
             stepScript += "echo Setting ${k}=${v}\r\n"
@@ -323,6 +324,257 @@ def static getJobName(def configuration, def architecture, def os, def scenario,
     return baseName + suffix
 }
 
+def static addNonPRTriggers(def job, def branch, def isPR, def architecture, def os, def configuration, def scenario, def isFlowJob, def isWindowsBuildOnlyJob, def isLinuxEmulatorBuild, def bidailyCrossList) {
+    // Check scenario.
+    switch (scenario) {
+        case 'default':
+            switch (architecture) {
+                case 'x64':
+                case 'x86':
+                case 'x86compatjit':
+                case 'x86lb':
+                    if (isFlowJob || os == 'Windows_NT' || !(os in Constants.crossList)) {
+                        Utilities.addGithubPushTrigger(job)
+                    }
+                    break
+                case 'arm':
+                    Utilities.addGithubPushTrigger(job)
+                    break
+                case 'arm64':
+                    if (os == 'Windows_NT') {
+                        Utilities.addGithubPushTrigger(job)
+                        // TODO: Add once external email sending is available again
+                        // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
+                    }
+                    break
+                default:
+                    println("Unknown architecture: ${architecture}");
+                    assert false
+                    break
+            }
+            break
+        case 'pri1':
+            // Pri one gets a push trigger, and only for release
+            if (architecture == 'x64') {
+                if (configuration == 'Release') {
+                    // We expect release jobs to be Windows, or in the cross list
+                    assert (os == 'Windows_NT') || (os in Constants.crossList)
+                    if (!os in bidailyCrossList) {
+                        if (isFlowJob || os == 'Windows_NT') {
+                            Utilities.addGithubPushTrigger(job)
+                        }
+                    } 
+                    else {
+                        if (isFlowJob) {
+                            Utilities.addPeriodicTrigger(job, 'H H/12 * * *')
+                        }
+                    }
+                }
+            }
+            break
+        case 'r2r':
+            //r2r jobs that aren't pri1 can only be triggered by phrase
+            break
+        case 'pri1r2r':
+            assert !(os in bidailyCrossList)
+            //pri1 r2r gets a push trigger for checked/release
+            if (configuration == 'Checked' || configuration == 'Release') {
+                assert (os == 'Windows_NT') || (os in Constants.crossList)
+                if (architecture == 'x64' && os != 'OSX') {
+                    //Flow jobs should be Windows, Ubuntu, OSX, or CentOS
+                    if (isFlowJob || os == 'Windows_NT') {
+                        Utilities.addGithubPushTrigger(job)
+                    }
+                // OSX pri1r2r jobs should only run every 12 hours, not daily.
+                } else if (architecture == 'x64' && os == 'OSX'){
+                    if (isFlowJob) {
+                        Utilities.addPeriodicTrigger(job, 'H H/12 * * *')
+                    }
+                }
+                // For x86, only add per-commit jobs for Windows
+                else if (architecture == 'x86' || architecture == 'x86compatjit' || architecture == 'x86lb') {
+                    if (os == 'Windows_NT') {
+                        Utilities.addGithubPushTrigger(job)
+                    }
+                }
+                // arm64 pri1r2r jobs should only run every 12 hours.
+                else if (architecture == 'arm64') {
+                    if (os == 'Windows_NT') {
+                        Utilities.addPeriodicTrigger(job, 'H H/12 * * *')
+                        // TODO: Add once external email sending is available again
+                        // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
+                    }
+                }
+            }
+            break
+        case 'r2r_jitstress1':
+        case 'r2r_jitstress2':
+        case 'r2r_jitstressregs1':
+        case 'r2r_jitstressregs2':
+        case 'r2r_jitstressregs3':
+        case 'r2r_jitstressregs4':
+        case 'r2r_jitstressregs8':
+        case 'r2r_jitstressregsx10':
+        case 'r2r_jitstressregsx80':
+        case 'r2r_jitminopts':
+        case 'r2r_jitforcerelocs':
+        case 'gcstress15_pri1r2r':
+            assert !(os in bidailyCrossList)
+
+            // GCStress=C is currently not supported on OS X
+            if (os == 'OSX' && isGCStressRelatedTesting(scenario)) {
+                break
+            }
+
+            //GC Stress 15 pri1 r2r gets a push trigger for checked/release
+            if (configuration == 'Checked' || configuration == 'Release') {
+                assert (os == 'Windows_NT') || (os in Constants.crossList)
+                if (architecture == 'x64') {
+                    //Flow jobs should be Windows, Ubuntu, OSX, or CentOS
+                    if (isFlowJob || os == 'Windows_NT') {
+                        // Add a weekly periodic trigger
+                        Utilities.addPeriodicTrigger(job, 'H H * * 3,6') // some time every Wednesday and Saturday
+                    }
+                }
+                // For x86, only add per-commit jobs for Windows
+                else if (architecture == 'x86' || architecture == 'x86compatjit' || architecture == 'x86lb') {
+                    if (os == 'Windows_NT') {
+                        Utilities.addPeriodicTrigger(job, 'H H * * 3,6') // some time every Wednesday and Saturday
+                    }
+                }
+            }
+            break
+        case 'longgc':
+            assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX')
+            assert configuration == 'Release'
+            assert architecture == 'x64'
+            Utilities.addPeriodicTrigger(job, '@daily')
+            // TODO: Add once external email sending is available again
+            // addEmailPublisher(job, 'dotnetgctests@microsoft.com')
+            break
+        case 'gcsimulator':
+            assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX')
+            assert configuration == 'Release'
+            assert architecture == 'x64'
+            Utilities.addPeriodicTrigger(job, 'H H * * 3,6') // some time every Wednesday and Saturday
+            // TODO: Add once external email sending is available again
+            // addEmailPublisher(job, 'dotnetgctests@microsoft.com')
+            break
+        case 'standalone_gc':
+            assert (os == 'Windows_NT')
+            assert (configuration == 'Release' || configuration == 'Checked')
+            // TODO: Add once external email sending is available again
+            // addEmailPublisher(job, 'dotnetgctests@microsoft.com')
+            Utilities.addPeriodicTrigger(job, '@weekly')
+            break
+        case 'ilrt':
+            assert !(os in bidailyCrossList)
+            // ILASM/ILDASM roundtrip one gets a daily build, and only for release
+            if (architecture == 'x64' && configuration == 'Release') {
+                // We don't expect to see a job generated except in these scenarios
+                assert (os == 'Windows_NT') || (os in Constants.crossList)
+                if (isFlowJob || os == 'Windows_NT') {
+                    Utilities.addPeriodicTrigger(job, '@daily')
+                }
+            }
+            break
+        case 'jitdiff':
+            assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX')
+            assert configuration == 'Checked'
+            assert (architecture == 'x64' || architecture == 'x86') 
+            Utilities.addGithubPushTrigger(job)
+            break
+        case 'coverage':
+            assert (os == 'Ubuntu' || os == 'Windows_NT')
+            assert configuration == 'Release'
+            assert architecture == 'x64'
+            Utilities.addPeriodicTrigger(job, '@weekly')
+            break
+        case 'formatting':
+            assert (os == 'Windows_NT' || os == "Ubuntu")
+            assert architecture == 'x64'
+            Utilities.addGithubPushTrigger(job)
+            break
+        case 'jitstressregs1':
+        case 'jitstressregs2':
+        case 'jitstressregs3':
+        case 'jitstressregs4':
+        case 'jitstressregs8':
+        case 'jitstressregs0x10':
+        case 'jitstressregs0x80':
+        case 'minopts':
+        case 'forcerelocs':
+        case 'jitstress1':
+        case 'jitstress2':   
+        case 'jitstress2_jitstressregs1':
+        case 'jitstress2_jitstressregs2':
+        case 'jitstress2_jitstressregs3':
+        case 'jitstress2_jitstressregs4':
+        case 'jitstress2_jitstressregs8':
+        case 'jitstress2_jitstressregs0x10':
+        case 'jitstress2_jitstressregs0x80':
+        case 'corefx_baseline': 
+        case 'corefx_minopts':
+        case 'corefx_jitstress1':               
+        case 'corefx_jitstress2':
+        case 'corefx_jitstressregs1':
+        case 'corefx_jitstressregs2':
+        case 'corefx_jitstressregs3':
+        case 'corefx_jitstressregs4':
+        case 'corefx_jitstressregs8':
+        case 'corefx_jitstressregs0x10':
+        case 'corefx_jitstressregs0x80':
+        case 'zapdisable':           
+            if (os != 'CentOS7.1' && !(os in bidailyCrossList)) {
+            assert (os == 'Windows_NT') || (os in Constants.crossList)
+            Utilities.addPeriodicTrigger(job, '@daily')
+        }
+        break            
+        case 'heapverify1':
+        case 'gcstress0x3':            
+            if (os != 'CentOS7.1' && !(os in bidailyCrossList)) {
+                assert (os == 'Windows_NT') || (os in Constants.crossList)
+                if (architecture == 'arm64') {
+                    assert (os == 'Windows_NT')
+                    Utilities.addPeriodicTrigger(job, '@daily')
+                    // TODO: Add once external email sending is available again
+                    // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
+                }
+                else {
+                    Utilities.addPeriodicTrigger(job, '@weekly')
+                }
+            }
+            break
+        case 'gcstress0xc':
+        case 'gcstress0xc_zapdisable':
+        case 'gcstress0xc_zapdisable_jitstress2':
+        case 'gcstress0xc_zapdisable_heapverify1':
+        case 'gcstress0xc_jitstress1':
+        case 'gcstress0xc_jitstress2':
+        case 'gcstress0xc_minopts_heapverify1':
+            // GCStress=C is currently not supported on OS X
+            if (os != 'CentOS7.1' && os != 'OSX' && !(os in bidailyCrossList)) {
+                assert (os == 'Windows_NT') || (os in Constants.crossList)
+                if (architecture == 'arm64') {
+                    assert (os == 'Windows_NT')
+                    // TODO: Enable a periodic trigger after tests are updated.
+                    // Utilities.addPeriodicTrigger(job, '@daily')
+                    // TODO: Add once external email sending is available again
+                    // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
+                }
+                else {
+                    Utilities.addPeriodicTrigger(job, '@weekly')
+                }
+            }
+            break
+        default:
+            println("Unknown scenario: ${scenario}");
+            assert false
+            break
+    }
+    return
+}
+
 // **************************
 // Define the basic inner loop builds for PR and commit.  This is basically just the set
 // of coreclr builds over linux/osx/freebsd/windows and debug/release/checked.  In addition, the windows
@@ -341,253 +593,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
     def bidailyCrossList = ['RHEL7.2', 'Debian8.4', 'OpenSUSE13.2']
     // Non pull request builds.
     if (!isPR) {
-        // Check scenario.
-        switch (scenario) {
-            case 'default':
-                switch (architecture) {
-                    case 'x64':
-                    case 'x86':
-                    case 'x86compatjit':
-                    case 'x86lb':
-                        if (isFlowJob || os == 'Windows_NT' || !(os in Constants.crossList)) {
-                            Utilities.addGithubPushTrigger(job)
-                        }
-                        break
-                    case 'arm':
-                        Utilities.addGithubPushTrigger(job)
-                        break
-                    case 'arm64':
-                        if (os == 'Windows_NT') {
-                            Utilities.addGithubPushTrigger(job)
-                            // TODO: Add once external email sending is available again
-                            // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
-                        }
-                        break
-                    default:
-                        println("Unknown architecture: ${architecture}");
-                        assert false
-                        break
-                }
-                break
-            case 'pri1':
-                // Pri one gets a push trigger, and only for release
-                if (architecture == 'x64') {
-                    if (configuration == 'Release') {
-                        // We expect release jobs to be Windows, or in the cross list
-                        assert (os == 'Windows_NT') || (os in Constants.crossList)
-                        if (!os in bidailyCrossList) {
-                            if (isFlowJob || os == 'Windows_NT') {
-                                Utilities.addGithubPushTrigger(job)
-                            }
-                        } 
-                        else {
-                            if (isFlowJob) {
-                                Utilities.addPeriodicTrigger(job, 'H H/12 * * *')
-                            }
-                        }
-                    }
-                }
-                break
-            case 'r2r':
-                //r2r jobs that aren't pri1 can only be triggered by phrase
-                break
-            case 'pri1r2r':
-                assert !(os in bidailyCrossList)
-                //pri1 r2r gets a push trigger for checked/release
-                if (configuration == 'Checked' || configuration == 'Release') {
-                    assert (os == 'Windows_NT') || (os in Constants.crossList)
-                    if (architecture == 'x64' && os != 'OSX') {
-                        //Flow jobs should be Windows, Ubuntu, OSX, or CentOS
-                        if (isFlowJob || os == 'Windows_NT') {
-                            Utilities.addGithubPushTrigger(job)
-                        }
-                    // OSX pri1r2r jobs should only run every 12 hours, not daily.
-                    } else if (architecture == 'x64' && os == 'OSX'){
-                        if (isFlowJob) {
-                            Utilities.addPeriodicTrigger(job, 'H H/12 * * *')
-                        }
-                    }
-                    // For x86, only add per-commit jobs for Windows
-                    else if (architecture == 'x86' || architecture == 'x86compatjit' || architecture == 'x86lb') {
-                        if (os == 'Windows_NT') {
-                            Utilities.addGithubPushTrigger(job)
-                        }
-                    }
-                    // arm64 pri1r2r jobs should only run every 12 hours.
-                    else if (architecture == 'arm64') {
-                        if (os == 'Windows_NT') {
-                            Utilities.addPeriodicTrigger(job, 'H H/12 * * *')
-                            // TODO: Add once external email sending is available again
-                            // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
-                        }
-                    }
-                }
-                break
-            case 'r2r_jitstress1':
-            case 'r2r_jitstress2':
-            case 'r2r_jitstressregs1':
-            case 'r2r_jitstressregs2':
-            case 'r2r_jitstressregs3':
-            case 'r2r_jitstressregs4':
-            case 'r2r_jitstressregs8':
-            case 'r2r_jitstressregsx10':
-            case 'r2r_jitstressregsx80':
-            case 'r2r_jitminopts':
-            case 'r2r_jitforcerelocs':
-            case 'gcstress15_pri1r2r':
-                assert !(os in bidailyCrossList)
-
-                // GCStress=C is currently not supported on OS X
-                if (os == 'OSX' && isGCStressRelatedTesting(scenario)) {
-                    break
-                }
-
-                //GC Stress 15 pri1 r2r gets a push trigger for checked/release
-                if (configuration == 'Checked' || configuration == 'Release') {
-                    assert (os == 'Windows_NT') || (os in Constants.crossList)
-                    if (architecture == 'x64') {
-                        //Flow jobs should be Windows, Ubuntu, OSX, or CentOS
-                        if (isFlowJob || os == 'Windows_NT') {
-                            // Add a weekly periodic trigger
-                            Utilities.addPeriodicTrigger(job, 'H H * * 3,6') // some time every Wednesday and Saturday
-                        }
-                    }
-                    // For x86, only add per-commit jobs for Windows
-                    else if (architecture == 'x86' || architecture == 'x86compatjit' || architecture == 'x86lb') {
-                        if (os == 'Windows_NT') {
-                            Utilities.addPeriodicTrigger(job, 'H H * * 3,6') // some time every Wednesday and Saturday
-                        }
-                    }
-                }
-                break
-            case 'longgc':
-                assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX')
-                assert configuration == 'Release'
-                assert architecture == 'x64'
-                Utilities.addPeriodicTrigger(job, '@daily')
-                // TODO: Add once external email sending is available again
-                // addEmailPublisher(job, 'dotnetgctests@microsoft.com')
-                break
-            case 'gcsimulator':
-                assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX')
-                assert configuration == 'Release'
-                assert architecture == 'x64'
-                Utilities.addPeriodicTrigger(job, 'H H * * 3,6') // some time every Wednesday and Saturday
-                // TODO: Add once external email sending is available again
-                // addEmailPublisher(job, 'dotnetgctests@microsoft.com')
-                break
-            case 'standalone_gc':
-                assert (os == 'Windows_NT')
-                assert (configuration == 'Release' || configuration == 'Checked')
-                // TODO: Add once external email sending is available again
-                // addEmailPublisher(job, 'dotnetgctests@microsoft.com')
-                Utilities.addPeriodicTrigger(job, '@weekly')
-                break
-            case 'ilrt':
-                assert !(os in bidailyCrossList)
-                // ILASM/ILDASM roundtrip one gets a daily build, and only for release
-                if (architecture == 'x64' && configuration == 'Release') {
-                    // We don't expect to see a job generated except in these scenarios
-                    assert (os == 'Windows_NT') || (os in Constants.crossList)
-                    if (isFlowJob || os == 'Windows_NT') {
-                        Utilities.addPeriodicTrigger(job, '@daily')
-                    }
-                }
-                break
-            case 'jitdiff':
-                assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX')
-                assert configuration == 'Checked'
-                assert (architecture == 'x64' || architecture == 'x86') 
-                Utilities.addGithubPushTrigger(job)
-                break
-            case 'coverage':
-                assert (os == 'Ubuntu' || os == 'Windows_NT')
-                assert configuration == 'Release'
-                assert architecture == 'x64'
-                Utilities.addPeriodicTrigger(job, '@weekly')
-                break
-            case 'formatting':
-                assert (os == 'Windows_NT' || os == "Ubuntu")
-                assert architecture == 'x64'
-                Utilities.addGithubPushTrigger(job)
-                break
-            case 'jitstressregs1':
-            case 'jitstressregs2':
-            case 'jitstressregs3':
-            case 'jitstressregs4':
-            case 'jitstressregs8':
-            case 'jitstressregs0x10':
-            case 'jitstressregs0x80':
-            case 'minopts':
-            case 'forcerelocs':
-            case 'jitstress1':
-            case 'jitstress2':   
-            case 'jitstress2_jitstressregs1':
-            case 'jitstress2_jitstressregs2':
-            case 'jitstress2_jitstressregs3':
-            case 'jitstress2_jitstressregs4':
-            case 'jitstress2_jitstressregs8':
-            case 'jitstress2_jitstressregs0x10':
-            case 'jitstress2_jitstressregs0x80':
-            case 'corefx_baseline': 
-            case 'corefx_minopts':
-            case 'corefx_jitstress1':               
-            case 'corefx_jitstress2':
-            case 'corefx_jitstressregs1':
-            case 'corefx_jitstressregs2':
-            case 'corefx_jitstressregs3':
-            case 'corefx_jitstressregs4':
-            case 'corefx_jitstressregs8':
-            case 'corefx_jitstressregs0x10':
-            case 'corefx_jitstressregs0x80':
-            case 'zapdisable':           
-                if (os != 'CentOS7.1' && !(os in bidailyCrossList)) {
-                    assert (os == 'Windows_NT') || (os in Constants.crossList)
-                    Utilities.addPeriodicTrigger(job, '@daily')
-                }
-                break            
-            case 'heapverify1':
-            case 'gcstress0x3':            
-                if (os != 'CentOS7.1' && !(os in bidailyCrossList)) {
-                    assert (os == 'Windows_NT') || (os in Constants.crossList)
-                    if (architecture == 'arm64') {
-                        assert (os == 'Windows_NT')
-                        Utilities.addPeriodicTrigger(job, '@daily')
-                        // TODO: Add once external email sending is available again
-                        // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
-                    }
-                    else {
-                        Utilities.addPeriodicTrigger(job, '@weekly')
-                    }
-                }
-                break
-            case 'gcstress0xc':
-            case 'gcstress0xc_zapdisable':
-            case 'gcstress0xc_zapdisable_jitstress2':
-            case 'gcstress0xc_zapdisable_heapverify1':
-            case 'gcstress0xc_jitstress1':
-            case 'gcstress0xc_jitstress2':
-            case 'gcstress0xc_minopts_heapverify1':
-                // GCStress=C is currently not supported on OS X
-                if (os != 'CentOS7.1' && os != 'OSX' && !(os in bidailyCrossList)) {
-                    assert (os == 'Windows_NT') || (os in Constants.crossList)
-                    if (architecture == 'arm64') {
-                        assert (os == 'Windows_NT')
-                        // TODO: Enable a periodic trigger after tests are updated.
-                        // Utilities.addPeriodicTrigger(job, '@daily')
-                        // TODO: Add once external email sending is available again
-                        // addEmailPublisher(job, 'dotnetonarm64@microsoft.com')
-                    }
-                    else {
-                        Utilities.addPeriodicTrigger(job, '@weekly')
-                    }
-                }
-                break
-            default:
-                println("Unknown scenario: ${scenario}");
-                assert false
-                break
-        }
+        addNonPRTriggers(job, branch, isPR, architecture, os, configuration, scenario, isFlowJob, isWindowsBuildOnlyJob, isLinuxEmulatorBuild, bidailyCrossList)
         return
     }
     // Pull request builds.  Generally these fall into two categories: default triggers and on-demand triggers
@@ -1389,6 +1395,22 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                     Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayStr})",
                        "(?i).*test\\W+${os}\\W+${architecture}\\W+${configuration}\\W+${scenario}.*")
                     break                                   
+                case 'corefx_baseline':
+                        case 'corefx_minopts':
+                        case 'corefx_jitstress1':
+                        case 'corefx_jitstress2':
+                        case 'corefx_jitstressregs1':
+                        case 'corefx_jitstressregs2':
+                        case 'corefx_jitstressregs3':
+                        case 'corefx_jitstressregs4':
+                        case 'corefx_jitstressregs8':
+                        case 'corefx_jitstressregs0x10':
+                        case 'corefx_jitstressregs0x80':
+                            def displayName = 'CoreFx ' + getStressModeDisplayName(scenario)
+                            assert (os == 'Windows_NT') || (os in Constants.crossList)
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayName})",
+                               "(?i).*test\\W+${os}\\W+${scenario}.*")
+                            break                       
                 default:
                     println("Unknown scenario: ${os} ${architecture} ${scenario}");
                     assert false
@@ -1732,6 +1754,392 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
     }
 }
 
+def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR, def architecture, def configuration, def os, def enableCorefxTesting, def isBuildOnly, def isLinuxEmulatorBuild) {
+    def buildCommands = [];
+    def osGroup = getOSGroup(os)
+    def lowerConfiguration = configuration.toLowerCase()
+
+    // Calculate the build steps, archival, and xunit results
+    switch (os) {
+        case 'Windows_NT': // editor brace matching: {
+            switch (architecture) {
+                case 'x64':
+                case 'x86':
+                case 'x86compatjit':
+                case 'x86lb':
+                    def arch = architecture
+                    def buildOpts = ''
+                    if (architecture == 'x86compatjit') {
+                        arch = 'x86'
+                        buildOpts = 'compatjitcrossgen'
+                    }
+                    else if (architecture == 'x86lb') {
+                        arch = 'x86'
+                        buildOpts = 'legacyjitcrossgen'
+                    }
+                    
+                    if (Constants.jitStressModeScenarios.containsKey(scenario) ||
+                            scenario == 'default' ||
+                            scenario == 'r2r' ||
+                            scenario == 'jitdiff' ||
+                            Constants.r2rJitStressScenarios.indexOf(scenario) != -1) {
+                        buildOpts += enableCorefxTesting ? ' skiptests' : ''
+                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts}"
+                    }
+
+                    // For Pri 1 tests, we must shorten the output test binary path names.
+                    // if __TestIntermediateDir is already set, build-test.cmd will
+                    // output test binaries to that directory. If it is not set, the 
+                    // binaries are sent to a default directory whose name is about
+                    // 35 characters long.
+
+                    else if (scenario == 'pri1' || scenario == 'pri1r2r' || scenario == 'gcstress15_pri1r2r'|| scenario == 'coverage') {
+                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts} -priority=1"
+                    }
+                    else if (scenario == 'ilrt') {
+                        // First do the build with skiptests and then build the tests with ilasm roundtrip
+                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
+                        buildCommands += "set __TestIntermediateDir=int&&build-test.cmd ${lowerConfiguration} ${arch} -ilasmroundtrip"
+                    }
+                    else if (isLongGc(scenario)) {
+                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
+                        buildCommands += "set __TestIntermediateDir=int&&build-test.cmd ${lowerConfiguration} ${arch}"
+                    }
+                    else if (scenario == 'standalone_gc') {
+                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} buildstandalonegc"
+                    }
+                    else if (scenario == 'formatting') {
+                        buildCommands += "python -u tests\\scripts\\format.py -c %WORKSPACE% -o Windows_NT -a ${arch}"
+                        Utilities.addArchival(newJob, "format.patch", "", true, false)
+                        break
+                    }
+                    else {
+                        println("Unknown scenario: ${scenario}")
+                        assert false
+                    }
+                    
+                    // If we are running a stress mode, we should write out the set of key
+                    // value env pairs to a file at this point and then we'll pass that to runtest.cmd
+
+                    if (!isBuildOnly) {
+                        //If this is a crossgen build, pass 'crossgen' to runtest.cmd
+                        def crossgenStr = ''
+                        def runcrossgentestsStr = ''
+                        def runjitstressStr = ''
+                        def runjitstressregsStr = ''
+                        def runjitmioptsStr = ''
+                        def runjitforcerelocsStr = ''
+                        def runjitdisasmStr = ''
+                        def gcstressStr = ''
+                        def runtestArguments = ''
+                        def gcTestArguments = ''
+
+                        if (scenario == 'r2r' ||
+                            scenario == 'pri1r2r' ||
+                            scenario == 'gcstress15_pri1r2r' ||
+                            Constants.r2rJitStressScenarios.indexOf(scenario) != -1) {
+                                crossgenStr = 'crossgen'
+                                runcrossgentestsStr = 'runcrossgentests'
+                            
+                                if (scenario == 'r2r_jitstress1'){
+                                    runjitstressStr = 'jitstress 1'
+                                }
+                                else if (scenario == 'r2r_jitstress2') {
+                                    runjitstressStr = 'jitstress 2'
+                                }
+                                else if (scenario == 'r2r_jitstressregs1'){
+                                    runjitstressregsStr = 'jitstressregs 1'
+                                }
+                                else if (scenario == 'r2r_jitstressregs2') {
+                                    runjitstressregsStr = 'jitstressregs 2'
+                                }
+                                else if (scenario == 'r2r_jitstressregs3') {
+                                    runjitstressregsStr = 'jitstressregs 3'
+                                }
+                                else if (scenario == 'r2r_jitstressregs4') {
+                                    runjitstressregsStr = 'jitstressregs 4'
+                                }
+                                else if (scenario == 'r2r_jitstressregs8') {
+                                    runjitstressregsStr = 'jitstressregs 8'
+                                }
+                                else if (scenario == 'r2r_jitstressregsx10') {
+                                    runjitstressregsStr = 'jitstressregs x10'
+                                }
+                                else if (scenario == 'r2r_jitstressregsx80') {
+                                    runjitstressregsStr = 'jitstressregs x80'
+                                }
+                                else if (scenario == 'r2r_jitminopts') {
+                                    runjitmioptsStr = 'jitminopts'
+                                }
+                                else if (scenario == 'r2r_jitforcerelocs') {
+                                    runjitforcerelocsStr = 'jitforcerelocs'
+                                }
+                        }
+                        if (scenario == 'gcstress15_pri1r2r')
+                        {
+                           gcstressStr = 'gcstresslevel 0xF'
+                        }
+
+                        if (scenario == 'jitdiff')
+                        {
+                            runjitdisasmStr = 'jitdisasm crossgen'
+                        }
+
+                        if (isLongGc(scenario)) {
+                            gcTestArguments = "${scenario} sequential"
+                        }
+
+                        runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${gcTestArguments}"
+
+                        if (Constants.jitStressModeScenarios.containsKey(scenario)) {
+                            def stepScriptLocation = "%WORKSPACE%\\SetStressModes.bat"
+                            buildCommands += genStressModeScriptStep(os, scenario, Constants.jitStressModeScenarios[scenario], stepScriptLocation)
+
+                            if (enableCorefxTesting) {
+                                def fxRoot = "%WORKSPACE%\\_\\fx"
+                                buildCommands += "python %WORKSPACE%\\tests\\scripts\\run-corefx-tests.py -arch ${arch} -build_type ${configuration} -fx_root ${fxRoot} -fx_branch ${branch} -env_script ${stepScriptLocation}"
+
+                                // Archive only result xml files since corefx/bin/tests is very large around 10 GB.
+                                // For windows, pull full test results and test drops for x86/x64
+                                Utilities.addArchival(newJob, "${fxRoot}/bin/tests/**/testResults.xml")
+
+                                // Set timeout
+                                setTestJobTimeOut(newJob, scenario)
+
+                                if (architecture == 'x64' || !isPR) {
+                                    Utilities.addXUnitDotNETResults(newJob, "${fxRoot}/bin/tests/**/testResults.xml")
+                                }
+                            }
+                            else {
+                                buildCommands += "%WORKSPACE%\\tests\\runtest.cmd ${runtestArguments} TestEnv ${stepScriptLocation}"
+                            }
+                        }
+                        else if (architecture == 'x64' || architecture == 'x86') {
+                            buildCommands += "tests\\runtest.cmd ${runtestArguments}"
+                        }                                        
+                        else if (architecture == 'x86compatjit') {
+                            def testEnvLocation = "%WORKSPACE%\\tests\\x86\\compatjit_x86_testenv.cmd"
+                            buildCommands += "tests\\runtest.cmd ${runtestArguments} Exclude0 x86_legacy_backend_issues.targets TestEnv ${testEnvLocation}"
+                        }
+                        else if (architecture == 'x86lb') {
+                            def testEnvLocation = "%WORKSPACE%\\tests\\x86\\legacyjit_x86_testenv.cmd"
+                            buildCommands += "tests\\runtest.cmd ${runtestArguments} Exclude0 x86_legacy_backend_issues.targets TestEnv ${testEnvLocation}"
+                        }
+                    }
+
+                    if (!enableCorefxTesting) {
+                        // Run the rest of the build    
+                        // Build the mscorlib for the other OS's
+                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} linuxmscorlib"
+                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} freebsdmscorlib"
+                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} osxmscorlib"
+
+                        // Zip up the tests directory so that we don't use so much space/time copying
+                        // 10s of thousands of files around.
+                        buildCommands += "powershell -Command \"Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('.\\bin\\tests\\${osGroup}.${arch}.${configuration}', '.\\bin\\tests\\tests.zip')\"";
+
+                        if (!Constants.jitStressModeScenarios.containsKey(scenario) && scenario != 'jitdiff') {
+                            // For windows, pull full test results and test drops for x86/x64.
+                            // No need to pull for stress mode scenarios (downstream builds use the default scenario)
+                            Utilities.addArchival(newJob, "bin/Product/**,bin/tests/tests.zip")
+                        }
+
+                        if (scenario == 'jitdiff') {
+                            // retrive jit-dasm output for base commit, and run jit-diff
+                            if (!isBuildOnly) {
+                                // if this is a build only job, we want to keep the default (build) artifacts for the flow job
+                                Utilities.addArchival(newJob, "bin/tests/${osGroup}.${arch}.${configuration}/dasm/**")
+                            }
+                        }
+                        
+                        if (!isBuildOnly) {
+                            if (architecture == 'x64' || !isPR) {
+                                Utilities.addXUnitDotNETResults(newJob, 'bin/**/TestRun*.xml')
+                            }
+                            setTestJobTimeOut(newJob, scenario)
+                        }
+                    }
+                    break
+                case 'arm':
+                    assert (scenario == 'default')
+                    
+                    // Set time out
+                    setTestJobTimeOut(newJob, scenario)
+
+                    if ( lowerConfiguration == "debug" ) {
+                        // For Debug builds, we will do a P1 test build
+                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture} -priority=1"
+                    }
+                    else {
+                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture}"
+                    }
+                    // Add archival.
+                    Utilities.addArchival(newJob, "bin/Product/**")
+                    break
+                case 'arm64':
+                    assert (scenario == 'default') || (scenario == 'pri1r2r') || (scenario == 'gcstress0x3') || (scenario == 'gcstress0xc')
+                    // Set time out
+                    setTestJobTimeOut(newJob, scenario)
+
+                    // Debug runs take too long to run. So build job only.
+                    if (lowerConfiguration == "debug") {
+                       buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture} toolset_dir C:\\ats2"
+                    }
+                    else {
+                       buildCommands += "set __TestIntermediateDir=int&&build.cmd skiptests ${lowerConfiguration} ${architecture} toolset_dir C:\\ats2"
+                       // Test build and run are launched together.
+                       buildCommands += "python tests\\scripts\\arm64_post_build.py -repo_root %WORKSPACE% -arch ${architecture} -build_type ${lowerConfiguration} -scenario ${scenario} -key_location C:\\tools\\key.txt"
+                       //Utilities.addXUnitDotNETResults(newJob, 'bin/tests/testResults.xml')
+                    }
+
+                    // Add archival.
+                    Utilities.addArchival(newJob, "bin/Product/**")
+                    break
+                default:
+                    println("Unknown architecture: ${architecture}");
+                    assert false
+                    break
+            }
+            break
+        // editor brace matching: }
+        case 'Ubuntu':
+        case 'Ubuntu16.04':
+        case 'Ubuntu16.10':
+        case 'Debian8.4':
+        case 'OSX':
+        case 'FreeBSD':
+        case 'CentOS7.1':
+        case 'RHEL7.2':
+        case 'OpenSUSE13.2':
+        case 'OpenSUSE42.1':
+        case 'Fedora23': // editor brace matching: {
+            switch (architecture) {
+                case 'x64':
+                case 'x86':
+                case 'x86compatjit':
+                case 'x86lb':
+                    def arch = architecture
+                    if (architecture == 'x86compatjit' || architecture == 'x86lb') {
+                        arch = 'x86'
+                    }
+
+                    if (scenario == 'formatting') {
+                        buildCommands += "python tests/scripts/format.py -c \${WORKSPACE} -o Linux -a ${arch}"
+                        Utilities.addArchival(newJob, "format.patch", "", true, false)
+                        break
+                    }
+                
+                    if (!enableCorefxTesting) {
+                        // We run pal tests on all OS but generate mscorlib (and thus, nuget packages)
+                        // only on supported OS platforms.
+                        if ((os == 'FreeBSD') || (os == 'OpenSUSE13.2'))
+                        {
+                            buildCommands += "./build.sh skipmscorlib verbose ${lowerConfiguration} ${arch}"
+                        }
+                        else
+                        {
+                            def bootstrapRid = Utilities.getBoostrapPublishRid(os)
+                            def bootstrapRidEnv = bootstrapRid != null ? "__PUBLISH_RID=${bootstrapRid} " : ''
+                            buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${arch}"
+                        }
+                        buildCommands += "src/pal/tests/palsuite/runpaltests.sh \${WORKSPACE}/bin/obj/${osGroup}.${arch}.${configuration} \${WORKSPACE}/bin/paltestout"
+                    
+                        // Set time out
+                        setTestJobTimeOut(newJob, scenario)
+                        // Basic archiving of the build
+                        Utilities.addArchival(newJob, "bin/Product/**,bin/obj/*/tests/**/*.dylib,bin/obj/*/tests/**/*.so")
+                        // And pal tests
+                        Utilities.addXUnitDotNETResults(newJob, '**/pal_tests.xml')
+                    }
+                    else {
+                        // Corefx stress testing                                        
+                        assert os == 'Ubuntu'
+                        assert architecture == 'x64'
+                        assert lowerConfiguration == 'checked'
+                        assert Constants.jitStressModeScenarios.containsKey(scenario)
+                        
+                        // Build coreclr
+                        buildCommands += "./build.sh verbose ${lowerConfiguration} ${architecture}"
+                        
+                        def scriptFileName = "\$WORKSPACE/set_stress_test_env.sh"
+                        buildCommands += genStressModeScriptStep(os, scenario, Constants.jitStressModeScenarios[scenario], scriptFileName)
+
+                        // Build and text corefx
+                        def fxRoot = "\$WORKSPACE%/_/fx"
+                        buildCommands += "python \$WORKSPACE/tests/scripts/run-corefx-tests.py -arch ${arch} -build_type ${configuration} -fx_root ${fxRoot} -fx_branch ${branch} -env_script ${scriptFileName}"
+
+                        // Archive and process test result
+                        Utilities.addArchival(newJob, "${fxRoot}/bin/tests/**/testResults.xml")
+                        setTestJobTimeOut(newJob, scenario)
+                        Utilities.addXUnitDotNETResults(newJob, "${fxRoot}/bin/tests/**/testResults.xml")
+                    }
+                    break
+                case 'arm64':
+                    // We don't run the cross build except on Ubuntu
+                    assert os == 'Ubuntu'
+                    
+                    buildCommands += """echo \"Using rootfs in /opt/aarch64-linux-gnu-root\"
+                        ROOTFS_DIR=/opt/aarch64-linux-gnu-root ./build.sh skipmscorlib arm64 cross verbose ${lowerConfiguration}"""
+                    
+                    // Basic archiving of the build, no pal tests
+                    Utilities.addArchival(newJob, "bin/Product/**")
+                    break
+                case 'arm':
+                    // All builds for ARM architecture are run on Ubuntu currently
+                    assert os == 'Ubuntu'
+                    if (isLinuxEmulatorBuild == false) {
+                        buildCommands += """echo \"Using rootfs in /opt/arm-liux-genueabihf-root\"
+                            ROOTFS_DIR=/opt/arm-linux-genueabihf-root ./build.sh skipmscorlib arm cross verbose ${lowerConfiguration}"""
+                        
+                        // Basic archiving of the build, no pal tests
+                        Utilities.addArchival(newJob, "bin/Product/**")
+                        break
+                    }
+                    else {
+                        // Make sure the build configuration is either of debug or release
+                        assert ( lowerConfiguration == 'debug' ) || ( lowerConfiguration == 'release' )
+
+                        // Setup variables to hold emulator folder path and the rootfs mount path
+                        def armemul_path = '/opt/linux-arm-emulator'
+                        def armrootfs_mountpath = '/opt/linux-arm-emulator-root'
+
+                        // Unzip the Windows test binaries first. Exit with 0
+                        buildCommands += "unzip -q -o ./bin/tests/tests.zip -d ./bin/tests/Windows_NT.x64.${configuration} || exit 0"
+
+                        // Unpack the corefx binaries
+                        buildCommands += "tar -xf ./bin/build.tar.gz"
+
+                        // Call the ARM emulator build script to cross build and test using the ARM emulator rootfs
+                        buildCommands += """./tests/scripts/arm32_ci_script.sh \\
+                        --emulatorPath=${armemul_path} \\
+                        --mountPath=${armrootfs_mountpath} \\
+                        --buildConfig=${lowerConfiguration} \\
+                        --testRootDir=./bin/tests/Windows_NT.x64.${configuration} \\
+                        --coreFxNativeBinDir=./bin/Linux.arm-softfp.${configuration} \\
+                        --coreFxBinDir=\"./bin/Linux.AnyCPU.${configuration};./bin/Unix.AnyCPU.${configuration};./bin/AnyOS.AnyCPU.${configuration}\" \\
+                        --testDirFile=./tests/testsRunningInsideARM.txt"""
+
+
+                        // Basic archiving of the build
+                        Utilities.addArchival(newJob, "bin/Product/**")
+                        break
+                    }
+                default:
+                    println("Unknown architecture: ${architecture}");
+                    assert false
+                    break
+            }
+            break
+        // editor brace matching: }
+        default:
+            println("Unknown os: ${os}");
+            assert false
+            break
+    } // os
+
+    return buildCommands
+}
+
 // Additional scenario which can alter behavior
 
 def combinedScenarios = Constants.basicScenarios + Constants.jitStressModeScenarios.keySet()
@@ -2005,386 +2413,8 @@ combinedScenarios.each { scenario ->
                     Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
                     addTriggers(newJob, branch, isPR, architecture, os, configuration, scenario, false, isBuildOnly, isLinuxEmulatorBuild)
                 
-                    def buildCommands = [];
+                    def buildCommands = calculateBuildCommands(newJob, scenario, branch, isPR, architecture, configuration, os, enableCorefxTesting, isBuildOnly, isLinuxEmulatorBuild)
                     def osGroup = getOSGroup(os)
-                
-                    // Calculate the build steps, archival, and xunit results
-                    switch (os) {
-                        case 'Windows_NT': // editor brace matching: {
-                            switch (architecture) {
-                                case 'x64':
-                                case 'x86':
-                                case 'x86compatjit':
-                                case 'x86lb':
-                                    def arch = architecture
-                                    def buildOpts = ''
-                                    if (architecture == 'x86compatjit') {
-                                        arch = 'x86'
-                                        buildOpts = 'compatjitcrossgen'
-                                    }
-                                    else if (architecture == 'x86lb') {
-                                        arch = 'x86'
-                                        buildOpts = 'legacyjitcrossgen'
-                                    }
-                                    
-                                    if (Constants.jitStressModeScenarios.containsKey(scenario) ||
-                                            scenario == 'default' ||
-                                            scenario == 'r2r' ||
-                                            scenario == 'jitdiff' ||
-                                            Constants.r2rJitStressScenarios.indexOf(scenario) != -1) {
-                                        buildOpts += enableCorefxTesting ? ' skiptests' : ''
-                                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts}"
-                                    }
-
-                                    // For Pri 1 tests, we must shorten the output test binary path names.
-                                    // if __TestIntermediateDir is already set, build-test.cmd will
-                                    // output test binaries to that directory. If it is not set, the 
-                                    // binaries are sent to a default directory whose name is about
-                                    // 35 characters long.
-
-                                    else if (scenario == 'pri1' || scenario == 'pri1r2r' || scenario == 'gcstress15_pri1r2r'|| scenario == 'coverage') {
-                                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts} -priority=1"
-                                    }
-                                    else if (scenario == 'ilrt') {
-                                        // First do the build with skiptests and then build the tests with ilasm roundtrip
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
-                                        buildCommands += "set __TestIntermediateDir=int&&build-test.cmd ${lowerConfiguration} ${arch} -ilasmroundtrip"
-                                    }
-                                    else if (isLongGc(scenario)) {
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
-                                        buildCommands += "set __TestIntermediateDir=int&&build-test.cmd ${lowerConfiguration} ${arch}"
-                                    }
-                                    else if (scenario == 'standalone_gc') {
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} buildstandalonegc"
-                                    }
-                                    else if (scenario == 'formatting') {
-                                        buildCommands += "python -u tests\\scripts\\format.py -c %WORKSPACE% -o Windows_NT -a ${arch}"
-                                        Utilities.addArchival(newJob, "format.patch", "", true, false)
-                                        break
-                                    }
-                                    else {
-                                        println("Unknown scenario: ${scenario}")
-                                        assert false
-                                    }
-                                    
-                                    // If we are running a stress mode, we should write out the set of key
-                                    // value env pairs to a file at this point and then we'll pass that to runtest.cmd
-
-                                    if (!isBuildOnly) {
-                                        //If this is a crossgen build, pass 'crossgen' to runtest.cmd
-                                        def crossgenStr = ''
-                                        def runcrossgentestsStr = ''
-                                        def runjitstressStr = ''
-                                        def runjitstressregsStr = ''
-                                        def runjitmioptsStr = ''
-                                        def runjitforcerelocsStr = ''
-                                        def runjitdisasmStr = ''
-                                        def gcstressStr = ''
-                                        def runtestArguments = ''
-                                        def gcTestArguments = ''
-
-                                        if (scenario == 'r2r' ||
-                                            scenario == 'pri1r2r' ||
-                                            scenario == 'gcstress15_pri1r2r' ||
-                                            Constants.r2rJitStressScenarios.indexOf(scenario) != -1) {
-                                                crossgenStr = 'crossgen'
-                                                runcrossgentestsStr = 'runcrossgentests'
-                                            
-                                                if (scenario == 'r2r_jitstress1'){
-                                                    runjitstressStr = 'jitstress 1'
-                                                }
-                                                else if (scenario == 'r2r_jitstress2') {
-                                                    runjitstressStr = 'jitstress 2'
-                                                }
-                                                else if (scenario == 'r2r_jitstressregs1'){
-                                                    runjitstressregsStr = 'jitstressregs 1'
-                                                }
-                                                else if (scenario == 'r2r_jitstressregs2') {
-                                                    runjitstressregsStr = 'jitstressregs 2'
-                                                }
-                                                else if (scenario == 'r2r_jitstressregs3') {
-                                                    runjitstressregsStr = 'jitstressregs 3'
-                                                }
-                                                else if (scenario == 'r2r_jitstressregs4') {
-                                                    runjitstressregsStr = 'jitstressregs 4'
-                                                }
-                                                else if (scenario == 'r2r_jitstressregs8') {
-                                                    runjitstressregsStr = 'jitstressregs 8'
-                                                }
-                                                else if (scenario == 'r2r_jitstressregsx10') {
-                                                    runjitstressregsStr = 'jitstressregs x10'
-                                                }
-                                                else if (scenario == 'r2r_jitstressregsx80') {
-                                                    runjitstressregsStr = 'jitstressregs x80'
-                                                }
-                                                else if (scenario == 'r2r_jitminopts') {
-                                                    runjitmioptsStr = 'jitminopts'
-                                                }
-                                                else if (scenario == 'r2r_jitforcerelocs') {
-                                                    runjitforcerelocsStr = 'jitforcerelocs'
-                                                }
-                                        }
-                                        if (scenario == 'gcstress15_pri1r2r')
-                                        {
-                                           gcstressStr = 'gcstresslevel 0xF'
-                                        }
-
-                                        if (scenario == 'jitdiff')
-                                        {
-                                            runjitdisasmStr = 'jitdisasm crossgen'
-                                        }
-
-                                        if (isLongGc(scenario)) {
-                                            gcTestArguments = "${scenario} sequential"
-                                        }
-
-                                        runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${gcTestArguments}"
-
-                                        if (Constants.jitStressModeScenarios.containsKey(scenario)) {
-                                            def stepScriptLocation = "%WORKSPACE%\\SetStressModes.bat"
-                                            buildCommands += genStressModeScriptStep(os, scenario, Constants.jitStressModeScenarios[scenario], stepScriptLocation)
-
-                                            if (enableCorefxTesting) {
-                                                def fxRoot = "%WORKSPACE%\\_\\fx"
-                                                buildCommands += "python %WORKSPACE%\\tests\\scripts\\run-corefx-tests.cmd -arch ${arch} -build_type ${configuration} -fx_root ${fxRoot} -fx_branch ${branch} -env_script ${stepScriptLocation}"
-
-                                                // Archive only result xml files since corefx/bin/tests is very large around 10 GB.
-                                                // For windows, pull full test results and test drops for x86/x64
-                                                Utilities.addArchival(newJob, "${fxRoot}/bin/tests/**/testResults.xml")
-
-                                                // Set timeout
-                                                setTestJobTimeOut(newJob, scenario)
-
-                                                if (architecture == 'x64' || !isPR) {
-                                                    Utilities.addXUnitDotNETResults(newJob, "${fxRoot}/bin/tests/**/testResults.xml")
-                                                }
-                                            }
-                                            else {
-                                                buildCommands += "%WORKSPACE%\\tests\\runtest.cmd ${runtestArguments} TestEnv ${stepScriptLocation}"
-                                            }
-                                        }
-                                        else if (architecture == 'x64' || architecture == 'x86') {
-                                            buildCommands += "tests\\runtest.cmd ${runtestArguments}"
-                                        }                                        
-                                        else if (architecture == 'x86compatjit') {
-                                            def testEnvLocation = "%WORKSPACE%\\tests\\x86\\compatjit_x86_testenv.cmd"
-                                            buildCommands += "tests\\runtest.cmd ${runtestArguments} Exclude0 x86_legacy_backend_issues.targets TestEnv ${testEnvLocation}"
-                                        }
-                                        else if (architecture == 'x86lb') {
-                                            def testEnvLocation = "%WORKSPACE%\\tests\\x86\\legacyjit_x86_testenv.cmd"
-                                            buildCommands += "tests\\runtest.cmd ${runtestArguments} Exclude0 x86_legacy_backend_issues.targets TestEnv ${testEnvLocation}"
-                                        }
-                                    }
-
-                                    if (!enableCorefxTesting) {
-                                        // Run the rest of the build    
-                                        // Build the mscorlib for the other OS's
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} linuxmscorlib"
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} freebsdmscorlib"
-                                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} osxmscorlib"
-
-                                        // Zip up the tests directory so that we don't use so much space/time copying
-                                        // 10s of thousands of files around.
-                                        buildCommands += "powershell -Command \"Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('.\\bin\\tests\\${osGroup}.${arch}.${configuration}', '.\\bin\\tests\\tests.zip')\"";
-
-                                        if (!Constants.jitStressModeScenarios.containsKey(scenario) && scenario != 'jitdiff') {
-                                            // For windows, pull full test results and test drops for x86/x64.
-                                            // No need to pull for stress mode scenarios (downstream builds use the default scenario)
-                                            Utilities.addArchival(newJob, "bin/Product/**,bin/tests/tests.zip")
-                                        }
-
-                                        if (scenario == 'jitdiff') {
-                                            // retrive jit-dasm output for base commit, and run jit-diff
-                                            if (!isBuildOnly) {
-                                                // if this is a build only job, we want to keep the default (build) artifacts for the flow job
-                                                Utilities.addArchival(newJob, "bin/tests/${osGroup}.${arch}.${configuration}/dasm/**")
-                                            }
-                                        }
-                                        
-                                        if (!isBuildOnly) {
-                                            if (architecture == 'x64' || !isPR) {
-                                                Utilities.addXUnitDotNETResults(newJob, 'bin/**/TestRun*.xml')
-                                            }
-                                            setTestJobTimeOut(newJob, scenario)
-                                        }
-                                    }
-                                    break
-                                case 'arm':
-                                    assert (scenario == 'default')
-                                    
-                                    // Set time out
-                                    setTestJobTimeOut(newJob, scenario)
-
-                                    if ( lowerConfiguration == "debug" ) {
-                                        // For Debug builds, we will do a P1 test build
-                                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture} -priority=1"
-                                    }
-                                    else {
-                                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture}"
-                                    }
-                                    // Add archival.
-                                    Utilities.addArchival(newJob, "bin/Product/**")
-                                    break
-                                case 'arm64':
-                                    assert (scenario == 'default') || (scenario == 'pri1r2r') || (scenario == 'gcstress0x3') || (scenario == 'gcstress0xc')
-                                    // Set time out
-                                    setTestJobTimeOut(newJob, scenario)
-
-                                    // Debug runs take too long to run. So build job only.
-                                    if (lowerConfiguration == "debug") {
-                                       buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture} toolset_dir C:\\ats2"
-                                    }
-                                    else {
-                                       buildCommands += "set __TestIntermediateDir=int&&build.cmd skiptests ${lowerConfiguration} ${architecture} toolset_dir C:\\ats2"
-                                       // Test build and run are launched together.
-                                       buildCommands += "python tests\\scripts\\arm64_post_build.py -repo_root %WORKSPACE% -arch ${architecture} -build_type ${lowerConfiguration} -scenario ${scenario} -key_location C:\\tools\\key.txt"
-                                       //Utilities.addXUnitDotNETResults(newJob, 'bin/tests/testResults.xml')
-                                    }
-
-                                    // Add archival.
-                                    Utilities.addArchival(newJob, "bin/Product/**")
-                                    break
-                                default:
-                                    println("Unknown architecture: ${architecture}");
-                                    assert false
-                                    break
-                            }
-                            break
-                        // editor brace matching: }
-                        case 'Ubuntu':
-                        case 'Ubuntu16.04':
-                        case 'Ubuntu16.10':
-                        case 'Debian8.4':
-                        case 'OSX':
-                        case 'FreeBSD':
-                        case 'CentOS7.1':
-                        case 'RHEL7.2':
-                        case 'OpenSUSE13.2':
-                        case 'OpenSUSE42.1':
-                        case 'Fedora23': // editor brace matching: {
-                            switch (architecture) {
-                                case 'x64':
-                                case 'x86':
-                                case 'x86compatjit':
-                                case 'x86lb':
-                                    def arch = architecture
-                                    if (architecture == 'x86compatjit' || architecture == 'x86lb') {
-                                        arch = 'x86'
-                                    }
-
-                                    if (scenario == 'formatting') {
-                                        buildCommands += "python tests/scripts/format.py -c \${WORKSPACE} -o Linux -a ${arch}"
-                                        Utilities.addArchival(newJob, "format.patch", "", true, false)
-                                        break
-                                    }
-                                
-                                    if (!enableCorefxTesting) {
-                                        // We run pal tests on all OS but generate mscorlib (and thus, nuget packages)
-                                        // only on supported OS platforms.
-                                        if ((os == 'FreeBSD') || (os == 'OpenSUSE13.2'))
-                                        {
-                                            buildCommands += "./build.sh skipmscorlib verbose ${lowerConfiguration} ${arch}"
-                                        }
-                                        else
-                                        {
-                                            def bootstrapRid = Utilities.getBoostrapPublishRid(os)
-                                            def bootstrapRidEnv = bootstrapRid != null ? "__PUBLISH_RID=${bootstrapRid} " : ''
-                                            buildCommands += "${bootstrapRidEnv}./build.sh verbose ${lowerConfiguration} ${arch}"
-                                        }
-                                        buildCommands += "src/pal/tests/palsuite/runpaltests.sh \${WORKSPACE}/bin/obj/${osGroup}.${arch}.${configuration} \${WORKSPACE}/bin/paltestout"
-                                    
-                                        // Set time out
-                                        setTestJobTimeOut(newJob, scenario)
-                                        // Basic archiving of the build
-                                        Utilities.addArchival(newJob, "bin/Product/**,bin/obj/*/tests/**/*.dylib,bin/obj/*/tests/**/*.so")
-                                        // And pal tests
-                                        Utilities.addXUnitDotNETResults(newJob, '**/pal_tests.xml')
-                                    }
-                                    else {
-                                        // Corefx stress testing                                        
-                                        assert os == 'Ubuntu'
-                                        assert architecture == 'x64'
-                                        assert lowerConfiguration == 'checked'
-                                        assert Constants.jitStressModeScenarios.containsKey(scenario)
-                                        
-                                        // Build coreclr
-                                        buildCommands += "./build.sh verbose ${lowerConfiguration} ${architecture}"
-                                        
-                                        def scriptFileName = "\$WORKSPACE/set_stress_test_env.sh"
-                                        buildCommands += genStressModeScriptStep(os, scenario, Constants.jitStressModeScenarios[scenario], scriptFileName)
-
-                                        // Build and text corefx
-                                        def fxRoot = "\$WORKSPACE%/_/fx"
-                                        buildCommands += "python \$WORKSPACE/tests/scripts/run-corefx-tests.cmd -arch ${arch} -build_type ${configuration} -fx_root ${fxRoot} -fx_branch ${branch} -env_script ${scriptFileName}"
-
-                                        // Archive and process test result
-                                        Utilities.addArchival(newJob, "${fxRoot}/bin/tests/**/testResults.xml")
-                                        setTestJobTimeOut(newJob, scenario)
-                                        Utilities.addXUnitDotNETResults(newJob, "${fxRoot}/bin/tests/**/testResults.xml")
-                                    }
-                                    break
-                                case 'arm64':
-                                    // We don't run the cross build except on Ubuntu
-                                    assert os == 'Ubuntu'
-                                    
-                                    buildCommands += """echo \"Using rootfs in /opt/aarch64-linux-gnu-root\"
-                                        ROOTFS_DIR=/opt/aarch64-linux-gnu-root ./build.sh skipmscorlib arm64 cross verbose ${lowerConfiguration}"""
-                                    
-                                    // Basic archiving of the build, no pal tests
-                                    Utilities.addArchival(newJob, "bin/Product/**")
-                                    break
-                                case 'arm':
-                                    // All builds for ARM architecture are run on Ubuntu currently
-                                    assert os == 'Ubuntu'
-                                    if (isLinuxEmulatorBuild == false) {
-                                        buildCommands += """echo \"Using rootfs in /opt/arm-liux-genueabihf-root\"
-                                            ROOTFS_DIR=/opt/arm-linux-genueabihf-root ./build.sh skipmscorlib arm cross verbose ${lowerConfiguration}"""
-                                        
-                                        // Basic archiving of the build, no pal tests
-                                        Utilities.addArchival(newJob, "bin/Product/**")
-                                        break
-                                    }
-                                    else {
-                                        // Make sure the build configuration is either of debug or release
-                                        assert ( lowerConfiguration == 'debug' ) || ( lowerConfiguration == 'release' )
-
-                                        // Setup variables to hold emulator folder path and the rootfs mount path
-                                        def armemul_path = '/opt/linux-arm-emulator'
-                                        def armrootfs_mountpath = '/opt/linux-arm-emulator-root'
-
-                                        // Unzip the Windows test binaries first. Exit with 0
-                                        buildCommands += "unzip -q -o ./bin/tests/tests.zip -d ./bin/tests/Windows_NT.x64.${configuration} || exit 0"
-
-                                        // Unpack the corefx binaries
-                                        buildCommands += "tar -xf ./bin/build.tar.gz"
-
-                                        // Call the ARM emulator build script to cross build and test using the ARM emulator rootfs
-                                        buildCommands += """./tests/scripts/arm32_ci_script.sh \\
-                                        --emulatorPath=${armemul_path} \\
-                                        --mountPath=${armrootfs_mountpath} \\
-                                        --buildConfig=${lowerConfiguration} \\
-                                        --testRootDir=./bin/tests/Windows_NT.x64.${configuration} \\
-                                        --coreFxNativeBinDir=./bin/Linux.arm-softfp.${configuration} \\
-                                        --coreFxBinDir=\"./bin/Linux.AnyCPU.${configuration};./bin/Unix.AnyCPU.${configuration};./bin/AnyOS.AnyCPU.${configuration}\" \\
-                                        --testDirFile=./tests/testsRunningInsideARM.txt"""
-
-
-                                        // Basic archiving of the build
-                                        Utilities.addArchival(newJob, "bin/Product/**")
-                                        break
-                                    }
-                                default:
-                                    println("Unknown architecture: ${architecture}");
-                                    assert false
-                                    break
-                            }
-                            break
-                        // editor brace matching: }
-                        default:
-                            println("Unknown os: ${os}");
-                            assert false
-                            break
-                    } // os
 
                     newJob.with {
                         steps {

--- a/tests/scripts/run-corefx-tests.py
+++ b/tests/scripts/run-corefx-tests.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python
+#
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+#
+##########################################################################
+##########################################################################
+#
+# Module: run-corefx-tests.py
+#
+# Notes:
+#
+# Script to clone the CoreFx repo, build, and run its tests.
+#
+##########################################################################
+##########################################################################
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+
+##########################################################################
+# Globals
+##########################################################################
+
+Corefx_url = 'https://github.com/dotnet/corefx.git'
+
+# This should be factored out of build.sh
+Unix_name_map = {
+    'Linux': 'Linux',
+    'Darwin': 'OSX',
+    'FreeBSD': 'FreeBSD',
+    'OpenBSD': 'OpenBSD',
+    'NetBSD': 'NetBSD',
+    'SunOS': 'SunOS'
+}
+
+Is_windows = (os.name == 'nt')
+
+##########################################################################
+# Delete protocol
+##########################################################################
+
+def del_rw(action, name, exc):
+    os.chmod(name, 0651)
+    os.remove(name)
+
+##########################################################################
+# Argument Parser
+##########################################################################
+
+description = 'Tool to facilitate running CoreFx tests from the CoreCLR repo'
+
+parser = argparse.ArgumentParser(description=description)
+
+parser.add_argument('-arch', dest='arch', default='x64')
+parser.add_argument('-build_type', dest='build_type', default='Debug')
+parser.add_argument('-clr_root', dest='clr_root', default=None)
+parser.add_argument('-fx_root', dest='fx_root', default=None)
+parser.add_argument('-fx_branch', dest='fx_branch', default='master')
+parser.add_argument('-env_script', dest='env_script', default=None)
+
+
+##########################################################################
+# Helper Functions
+##########################################################################
+
+def validate_args(args):
+    """ Validate all of the arguments parsed.
+    Args:
+        args (argparser.ArgumentParser): Args parsed by the argument parser.
+    Returns:
+        (arch, build_type, clr_root, fx_root, fx_branch, env_script)
+            (str, str, str, str, str, str)
+    Notes:
+    If the arguments are valid then return them all in a tuple. If not, raise
+    an exception stating x argument is incorrect.
+    """
+
+    arch = args.arch
+    build_type = args.build_type
+    clr_root = args.clr_root
+    fx_root = args.fx_root
+    fx_branch = args.fx_branch
+    env_script = args.env_script
+
+    def validate_arg(arg, check):
+        """ Validate an individual arg
+        Args:
+           arg (str|bool): argument to be validated
+           check (lambda: x-> bool): test that returns either True or False
+                                   : based on whether the check passes.
+
+        Returns:
+           is_valid (bool): Is the argument valid?
+        """
+
+        helper = lambda item: item is not None and check(item)
+
+        if not helper(arg):
+            raise Exception('Argument: %s is not valid.' % (arg))
+
+    valid_archs = ['x86', 'x64', 'arm', 'arm64']
+    valid_build_types = ['Debug', 'Checked', 'Release']
+
+    arch = next((a for a in valid_archs if a.lower() == arch.lower()), arch)
+    build_type = next((b for b in valid_build_types if b.lower() == build_type.lower()), build_type)
+
+    validate_arg(arch, lambda item: item in valid_archs)
+    validate_arg(build_type, lambda item: item in valid_build_types)
+    validate_arg(fx_branch, lambda item: True)
+
+    if clr_root is None:
+        clr_root = nth_dirname(os.path.abspath(sys.argv[0]), 3)
+    else:
+        clr_root = os.path.normpath(clr_root)
+        validate_arg(clr_root, lambda item: os.path.isdir(clr_root))
+
+    if fx_root is None:
+        fx_root = os.path.join(clr_root, '_', 'fx')
+    else:
+        fx_root = os.path.normpath(fx_root)
+        validate_arg(fx_root, lambda item: os.path.isdir(
+            os.path.dirname(fx_root)))
+
+    if env_script is not None:
+        validate_arg(env_script, lambda item: os.path.isfile(env_script))
+        env_script = os.path.abspath(env_script)
+
+    args = (arch, build_type, clr_root, fx_root, fx_branch, env_script)
+
+    log('Configuration:')
+    log(' arch: %s' % arch)
+    log(' build_type: %s' % build_type)
+    log(' clr_root: %s' % clr_root)
+    log(' fx_root: %s' % fx_root)
+    log(' fx_branch: %s' % fx_branch)
+    log(' env_script: %s' % env_script)
+
+    return args
+
+
+def nth_dirname(path, n):
+    """ Find the Nth parent directory of the given path
+    Args:
+        path (str): path name containing at least N components
+        n (int): num of basenames to remove
+    Returns:
+        outpath (str): path with the last n components removed
+    Notes:
+        If n is 0, path is returned unmodified
+    """
+
+    assert n >= 0
+
+    for i in range(0, n):
+        path = os.path.dirname(path)
+
+    return path
+
+
+def dotnet_rid_os(dotnet_path):
+    """ Determine the OS identifier from the RID as reported by dotnet
+    Args:
+        dotnet_path (str): path to folder containing dotnet(.exe)
+    Returns:
+        rid_os (str): OS component of RID as reported by dotnet
+    """
+    dotnet_info = subprocess.check_output([os.path.join(dotnet_path, 'dotnet'), '--info'])
+    m = re.search('^\s*RID:\s+([^-]*)-(\S*)\s*$', dotnet_info, re.MULTILINE)
+    return m.group(1)
+
+
+def log(message):
+    """ Print logging information
+    Args:
+        message (str): message to be printed
+    """
+
+    print '[%s]: %s' % (sys.argv[0], message)
+
+
+##########################################################################
+# Main
+##########################################################################
+
+def main(args):
+    global Corefx_url
+    global Unix_name_map
+
+    arch, build_type, clr_root, fx_root, fx_branch, env_script = validate_args(
+        args)
+
+    clr_os = 'Windows_NT' if Is_windows else Unix_name_map[os.uname()[0]]
+
+    core_root = os.path.join(clr_root,
+                             'bin',
+                             'Product',
+                             '%s.%s.%s' % (clr_os, arch, build_type))
+
+    # corefx creates both files that are read-only and files that include non-ascii
+    # characters. Using onerror=del_rw allows us to delete all of the read-only files.
+    # To delete the files with non-ascii characters, when rmtree fails due to those
+    # files, we then will call rd on Windows.
+
+    if os.path.exists(fx_root):
+        if Is_windows:
+            vbcscompiler_running = True
+            while vbcscompiler_running:
+                res = subprocess.check_output(['tasklist'])
+                if not 'VBCSCompiler.exe' in res:
+                    vbcscompiler_running = False
+        os.chdir(fx_root)
+        os.system('git clean -fxd')
+        os.chdir(clr_root)
+        shutil.rmtree(fx_root, onerror=del_rw)
+
+    command = 'git clone -b %s --single-branch %s %s' % (
+        fx_branch, Corefx_url, fx_root)
+
+    log(command)
+
+    testing = False
+
+    if testing:
+        os.makedirs(fx_root)
+        returncode = 0
+    else:
+        returncode = os.system(command)
+
+    if returncode != 0:
+        sys.exit(returncode)
+
+    cwd = os.getcwd()
+    log('cd ' + fx_root)
+    os.chdir(fx_root)
+
+    if Is_windows:
+        command = '.\\build.cmd'
+        if env_script is not None:
+            command = ('cmd /c %s&&' % env_script) + command
+    else:
+        # CoreFx build.sh requires HOME to be set, and it isn't by default
+        # under our CI.
+        fx_home = os.path.join(fx_root, 'tempHome')
+        if not os.path.exists(fx_home):
+            os.makedirs(fx_home)
+        os.putenv('HOME', fx_home)
+        log('HOME=' + fx_home)
+
+        command = './build.sh'
+        if env_script is not None:
+            command = ('. %s;' % env_script) + command
+
+    if testing:
+        rid_os = dotnet_rid_os('')
+    else:
+        if clr_os == "Windows_NT":
+            rid_os = "win7"
+        else:
+            rid_os = dotnet_rid_os(os.path.join(clr_root, 'Tools', 'dotnetcli'))
+
+    command = ' '.join((
+        command,
+        '-Release',
+        '-TestNugetRuntimeId=%s-%s' % (rid_os, arch),
+        '--',
+        '/p:BUILDTOOLS_OVERRIDE_RUNTIME="%s"' % core_root,
+        '/p:WithoutCategories=IgnoreForCI'
+    ))
+
+    if not Is_windows:
+        command += ' /p:TestWithLocalNativeLibraries=true'
+
+    log(command)
+
+    if testing:
+        returncode = 0
+    else:
+        returncode = os.system(command)
+
+    sys.exit(returncode)
+
+
+##########################################################################
+# setup for Main
+##########################################################################
+
+if __name__ == '__main__':
+    Args = parser.parse_args(sys.argv[1:])
+
+    main(Args)


### PR DESCRIPTION
Move the increasingly complex logic required for the CI to run CoreFx
tests from the CoreCLR repo into a separate script.

Also enable automated CoreFx jitstress testing for x86.