### PR TITLE
Use field type value-numbering local field stores

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -5640,10 +5640,9 @@ void Compiler::fgValueNumberTree(GenTreePtr tree, bool evalAsgLhsInd)
                                 // (we looked in a side table above for its "def" identity).  Look up that value.
                                 ValueNumPair oldLhsVNPair =
                                     lvaTable[lclFld->GetLclNum()].GetPerSsaData(lclFld->GetSsaNum())->m_vnPair;
-                                newLhsVNPair =
-                                    vnStore->VNPairApplySelectorsAssign(oldLhsVNPair, lclFld->gtFieldSeq,
-                                                                        rhsVNPair, // Pre-value.
-                                                                        lvaGetActualType(lclFld->gtLclNum), compCurBB);
+                                newLhsVNPair = vnStore->VNPairApplySelectorsAssign(oldLhsVNPair, lclFld->gtFieldSeq,
+                                                                                   rhsVNPair, // Pre-value.
+                                                                                   lclFld->TypeGet(), compCurBB);
                             }
                         }
                         lvaTable[lclFld->GetLclNum()].GetPerSsaData(lclDefSsaNum)->m_vnPair = newLhsVNPair;


### PR DESCRIPTION
Method `VNPairApplySelectorsAssign` takes the type of the value being
assigned, so when processing a store to a field of a local struct, pass
the type of the field rather than the type of the local; failure to do so
was blocking propagation of the value number to subsequent loads of the
same field due to the type mismatch.