### PR TITLE
Adding ValueTuple and ITuple to corlib in CoreCLR

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -170,6 +170,9 @@
     <!-- We want the sources to show up nicely in VS-->
     <Compile Include="@(MscorlibSources)">
     </Compile>
+    <Compile Include="src\System\Runtime\CompilerServices\TupleElementNamesAttribute.cs" />
+    <Compile Include="src\System\TupleExtensions.cs" />
+    <Compile Include="src\System\ValueTuple.cs" />
   </ItemGroup>
   
   <!-- Resources -->

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -170,6 +170,7 @@
     <!-- We want the sources to show up nicely in VS-->
     <Compile Include="@(MscorlibSources)">
     </Compile>
+    <Compile Include="src\System\Runtime\CompilerServices\ITuple.cs" />
     <Compile Include="src\System\Runtime\CompilerServices\TupleElementNamesAttribute.cs" />
     <Compile Include="src\System\TupleExtensions.cs" />
     <Compile Include="src\System\ValueTuple.cs" />

--- a/src/mscorlib/corefx/SR.cs
+++ b/src/mscorlib/corefx/SR.cs
@@ -585,4 +585,14 @@ internal static class SR
     {
         return string.Format(CultureInfo.CurrentCulture, formatString, args);
     }
+
+    internal static string ArgumentException_ValueTupleIncorrectType
+    {
+        get { return Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType"); }
+    }
+
+    internal static string ArgumentException_ValueTupleLastArgumentNotATuple
+    {
+        get { return Environment.GetResourceString("ArgumentException_ValueTupleLastArgumentNotATuple"); }
+    }
 }

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -8608,6 +8608,14 @@
       <Member Name="GetHashCode" />
       <Member Name="ToString" />
       <Member MemberType="Property" Name="Item1" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
     </Type>
     <Type Name="System.Tuple&lt;T1,T2&gt;">
       <Member Name="#ctor(T1,T2)" />
@@ -8618,6 +8626,14 @@
       <Member Name="ToString" />
       <Member MemberType="Property" Name="Item1" />
       <Member MemberType="Property" Name="Item2" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
     </Type>
     <Type Name="System.Tuple&lt;T1,T2,T3&gt;">
       <Member Name="#ctor(T1,T2,T3)" />
@@ -8630,6 +8646,14 @@
       <Member MemberType="Property" Name="Item1" />
       <Member MemberType="Property" Name="Item2" />
       <Member MemberType="Property" Name="Item3" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
     </Type>
     <Type Name="System.Tuple&lt;T1,T2,T3,T4&gt;">
       <Member Name="#ctor(T1,T2,T3,T4)" />
@@ -8644,6 +8668,14 @@
       <Member MemberType="Property" Name="Item2" />
       <Member MemberType="Property" Name="Item3" />
       <Member MemberType="Property" Name="Item4" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
     </Type>
     <Type Name="System.Tuple&lt;T1,T2,T3,T4,T5&gt;">
       <Member Name="#ctor(T1,T2,T3,T4,T5)" />
@@ -8660,6 +8692,14 @@
       <Member MemberType="Property" Name="Item3" />
       <Member MemberType="Property" Name="Item4" />
       <Member MemberType="Property" Name="Item5" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
     </Type>
     <Type Name="System.Tuple&lt;T1,T2,T3,T4,T5,T6&gt;">
       <Member Name="#ctor(T1,T2,T3,T4,T5,T6)" />
@@ -8678,6 +8718,14 @@
       <Member MemberType="Property" Name="Item4" />
       <Member MemberType="Property" Name="Item5" />
       <Member MemberType="Property" Name="Item6" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
     </Type>
     <Type Name="System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7&gt;">
       <Member Name="#ctor(T1,T2,T3,T4,T5,T6,T7)" />
@@ -8698,6 +8746,14 @@
       <Member MemberType="Property" Name="Item5" />
       <Member MemberType="Property" Name="Item6" />
       <Member MemberType="Property" Name="Item7" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
     </Type>
     <Type Name="System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,TRest&gt;">
       <Member Name="#ctor(T1,T2,T3,T4,T5,T6,T7,TRest)" />
@@ -8720,6 +8776,79 @@
       <Member MemberType="Property" Name="Item6" />
       <Member MemberType="Property" Name="Item7" />
       <Member MemberType="Property" Name="Rest" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <Type Name="System.TupleExtensions">
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17,T18,T19,T20,T21&gt;&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@,T13@,T14@,T15@,T16@,T17@,T18@,T19@,T20@,T21@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17,T18,T19,T20&gt;&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@,T13@,T14@,T15@,T16@,T17@,T18@,T19@,T20@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17,T18,T19&gt;&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@,T13@,T14@,T15@,T16@,T17@,T18@,T19@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17,T18&gt;&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@,T13@,T14@,T15@,T16@,T17@,T18@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17&gt;&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@,T13@,T14@,T15@,T16@,T17@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16&gt;&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@,T13@,T14@,T15@,T16@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15&gt;&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@,T13@,T14@,T15@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@,T13@,T14@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@,T13@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@,T12@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@,T11@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@,T10@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@,T9@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7,T8&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8&gt;&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@,T8@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6,T7&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7&gt;,T1@,T2@,T3@,T4@,T5@,T6@,T7@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5,T6&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6&gt;,T1@,T2@,T3@,T4@,T5@,T6@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4,T5&gt;(System.Tuple&lt;T1,T2,T3,T4,T5&gt;,T1@,T2@,T3@,T4@,T5@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3,T4&gt;(System.Tuple&lt;T1,T2,T3,T4&gt;,T1@,T2@,T3@,T4@)" />
+      <Member Name="Deconstruct&lt;T1,T2,T3&gt;(System.Tuple&lt;T1,T2,T3&gt;,T1@,T2@,T3@)" />
+      <Member Name="Deconstruct&lt;T1,T2&gt;(System.Tuple&lt;T1,T2&gt;,T1@,T2@)" />
+      <Member Name="Deconstruct&lt;T1&gt;(System.Tuple&lt;T1&gt;,T1@)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12,T13,T14,System.ValueTuple&lt;T15,T16,T17,T18,T19,T20,T21&gt;&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12,T13,T14,System.ValueTuple&lt;T15,T16,T17,T18,T19,T20&gt;&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12,T13,T14,System.ValueTuple&lt;T15,T16,T17,T18,T19&gt;&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12,T13,T14,System.ValueTuple&lt;T15,T16,T17,T18&gt;&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12,T13,T14,System.ValueTuple&lt;T15,T16,T17&gt;&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12,T13,T14,System.ValueTuple&lt;T15,T16&gt;&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12,T13,T14,System.ValueTuple&lt;T15&gt;&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12,T13,T14&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12,T13&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11,T12&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10,T11&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9,T10&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8,T9&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,System.ValueTuple&lt;T8&gt;&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6,T7&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5,T6&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4,T5&gt;(System.ValueTuple&lt;T1,T2,T3,T4,T5&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3,T4&gt;(System.ValueTuple&lt;T1,T2,T3,T4&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2,T3&gt;(System.ValueTuple&lt;T1,T2,T3&gt;)" />
+      <Member Name="ToTuple&lt;T1,T2&gt;(System.ValueTuple&lt;T1,T2&gt;)" />
+      <Member Name="ToTuple&lt;T1&gt;(System.ValueTuple&lt;T1&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17,T18,T19,T20,T21&gt;&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17,T18,T19,T20&gt;&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17,T18,T19&gt;&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17,T18&gt;&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16,T17&gt;&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15,T16&gt;&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14,System.Tuple&lt;T15&gt;&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13,T14&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12,T13&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11,T12&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10,T11&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9,T10&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9,T10&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8,T9&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8,T9&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,T8&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7,System.Tuple&lt;T8&gt;&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6,T7&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6,T7&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5,T6&gt;(System.Tuple&lt;T1,T2,T3,T4,T5,T6&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4,T5&gt;(System.Tuple&lt;T1,T2,T3,T4,T5&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3,T4&gt;(System.Tuple&lt;T1,T2,T3,T4&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2,T3&gt;(System.Tuple&lt;T1,T2,T3&gt;)" />
+      <Member Name="ToValueTuple&lt;T1,T2&gt;(System.Tuple&lt;T1,T2&gt;)" />
+      <Member Name="ToValueTuple&lt;T1&gt;(System.Tuple&lt;T1&gt;)" />
     </Type>
     <Type Name="System.Type">
       <Member Name="#ctor" />
@@ -9218,7 +9347,207 @@
     <Type Name="System.Runtime.CompilerServices.CompilerGlobalScopeAttribute">
       <Member Name="#ctor" />
     </Type>
-<!-- SMOSIER ADDED API ROOTS FOR our build process -->
+<!-- JCOUV ADDED API ROOTS FOR C# -->
+    <Type Name="System.Runtime.CompilerServices.ITuple">
+      <Member Name="get_Item(System.Int32)" />
+      <Member Name="get_Length" />
+      <Member MemberType="Property" Name="Item(System.Int32)" />
+      <Member MemberType="Property" Name="Length" />
+    </Type>
+    <Type Name="System.Runtime.CompilerServices.TupleElementNamesAttribute">
+      <Member Name="#ctor(System.String[])" />
+      <Member Name="get_TransformNames" />
+      <Member MemberType="Property" Name="TransformNames" />
+    </Type>
+    <Type Name="System.ValueTuple">
+      <Member Name="CompareTo(System.ValueTuple)" />
+      <Member Name="Create" />
+      <Member Name="Create&lt;T1,T2,T3,T4,T5,T6,T7,T8&gt;(T1,T2,T3,T4,T5,T6,T7,T8)" />
+      <Member Name="Create&lt;T1,T2,T3,T4,T5,T6,T7&gt;(T1,T2,T3,T4,T5,T6,T7)" />
+      <Member Name="Create&lt;T1,T2,T3,T4,T5,T6&gt;(T1,T2,T3,T4,T5,T6)" />
+      <Member Name="Create&lt;T1,T2,T3,T4,T5&gt;(T1,T2,T3,T4,T5)" />
+      <Member Name="Create&lt;T1,T2,T3,T4&gt;(T1,T2,T3,T4)" />
+      <Member Name="Create&lt;T1,T2,T3&gt;(T1,T2,T3)" />
+      <Member Name="Create&lt;T1,T2&gt;(T1,T2)" />
+      <Member Name="Create&lt;T1&gt;(T1)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ValueTuple)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <Type Name="System.ValueTuple&lt;T1&gt;">
+      <Member MemberType="Field" Name="Item1" />
+      <Member Name="#ctor(T1)" />
+      <Member Name="CompareTo(System.ValueTuple&lt;T1&gt;)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ValueTuple&lt;T1&gt;)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <Type Name="System.ValueTuple&lt;T1,T2&gt;">
+      <Member MemberType="Field" Name="Item1" />
+      <Member MemberType="Field" Name="Item2" />
+      <Member Name="#ctor(T1,T2)" />
+      <Member Name="CompareTo(System.ValueTuple&lt;T1,T2&gt;)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ValueTuple&lt;T1,T2&gt;)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <Type Name="System.ValueTuple&lt;T1,T2,T3&gt;">
+      <Member MemberType="Field" Name="Item1" />
+      <Member MemberType="Field" Name="Item2" />
+      <Member MemberType="Field" Name="Item3" />
+      <Member Name="#ctor(T1,T2,T3)" />
+      <Member Name="CompareTo(System.ValueTuple&lt;T1,T2,T3&gt;)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ValueTuple&lt;T1,T2,T3&gt;)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <Type Name="System.ValueTuple&lt;T1,T2,T3,T4&gt;">
+      <Member MemberType="Field" Name="Item1" />
+      <Member MemberType="Field" Name="Item2" />
+      <Member MemberType="Field" Name="Item3" />
+      <Member MemberType="Field" Name="Item4" />
+      <Member Name="#ctor(T1,T2,T3,T4)" />
+      <Member Name="CompareTo(System.ValueTuple&lt;T1,T2,T3,T4&gt;)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ValueTuple&lt;T1,T2,T3,T4&gt;)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <Type Name="System.ValueTuple&lt;T1,T2,T3,T4,T5&gt;">
+      <Member MemberType="Field" Name="Item1" />
+      <Member MemberType="Field" Name="Item2" />
+      <Member MemberType="Field" Name="Item3" />
+      <Member MemberType="Field" Name="Item4" />
+      <Member MemberType="Field" Name="Item5" />
+      <Member Name="#ctor(T1,T2,T3,T4,T5)" />
+      <Member Name="CompareTo(System.ValueTuple&lt;T1,T2,T3,T4,T5&gt;)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ValueTuple&lt;T1,T2,T3,T4,T5&gt;)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <Type Name="System.ValueTuple&lt;T1,T2,T3,T4,T5,T6&gt;">
+      <Member MemberType="Field" Name="Item1" />
+      <Member MemberType="Field" Name="Item2" />
+      <Member MemberType="Field" Name="Item3" />
+      <Member MemberType="Field" Name="Item4" />
+      <Member MemberType="Field" Name="Item5" />
+      <Member MemberType="Field" Name="Item6" />
+      <Member Name="#ctor(T1,T2,T3,T4,T5,T6)" />
+      <Member Name="CompareTo(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6&gt;)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6&gt;)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <Type Name="System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7&gt;">
+      <Member MemberType="Field" Name="Item1" />
+      <Member MemberType="Field" Name="Item2" />
+      <Member MemberType="Field" Name="Item3" />
+      <Member MemberType="Field" Name="Item4" />
+      <Member MemberType="Field" Name="Item5" />
+      <Member MemberType="Field" Name="Item6" />
+      <Member MemberType="Field" Name="Item7" />
+      <Member Name="#ctor(T1,T2,T3,T4,T5,T6,T7)" />
+      <Member Name="CompareTo(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7&gt;)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7&gt;)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <Type Name="System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,TRest&gt;">
+      <Member MemberType="Field" Name="Item1" />
+      <Member MemberType="Field" Name="Item2" />
+      <Member MemberType="Field" Name="Item3" />
+      <Member MemberType="Field" Name="Item4" />
+      <Member MemberType="Field" Name="Item5" />
+      <Member MemberType="Field" Name="Item6" />
+      <Member MemberType="Field" Name="Item7" />
+      <Member MemberType="Field" Name="Rest" />
+      <Member Name="#ctor(T1,T2,T3,T4,T5,T6,T7,TRest)" />
+      <Member Name="CompareTo(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,TRest&gt;)" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="Equals(System.ValueTuple&lt;T1,T2,T3,T4,T5,T6,T7,TRest&gt;)" />
+      <Member Name="GetHashCode" />
+      <Member Name="ToString" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralComparable.CompareTo(System.Object,System.Collections.IComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.Equals(System.Object,System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer)" />
+      <Member Status="ImplRoot" Name="System.IComparable.CompareTo(System.Object)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Item(System.Int32)" />
+      <Member Status="ImplRoot" Name="System.Runtime.CompilerServices.ITuple.get_Length" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Item(System.Int32)" />
+      <Member Status="ImplRoot" MemberType="Property" Name="System.Runtime.CompilerServices.ITuple.Length" />
+    </Type>
+    <!-- SMOSIER ADDED API ROOTS FOR our build process -->
     <Type Name="System.Runtime.InteropServices.ComVisibleAttribute">
       <Member Name="#ctor(System.Boolean)" />
       <Member Name="get_Value" />

--- a/src/mscorlib/src/System.Private.CoreLib.txt
+++ b/src/mscorlib/src/System.Private.CoreLib.txt
@@ -2282,3 +2282,6 @@ Globalization.cp_57011 = ISCII Punjabi
 
 ;------------------
 
+; ValueTuple
+ArgumentException_ValueTupleIncorrectType=Argument must be of type {0}.
+ArgumentException_ValueTupleLastArgumentNotAValueTuple=The last element of an eight element ValueTuple must be a ValueTuple.

--- a/src/mscorlib/src/System/Numerics/Hashing/HashHelpers.cs
+++ b/src/mscorlib/src/System/Numerics/Hashing/HashHelpers.cs
@@ -8,7 +8,7 @@ namespace System.Numerics.Hashing
 
     internal static class HashHelpers
     {
-        public static readonly int RandomSeed = Guid.NewGuid().GetHashCode();
+        public static readonly int RandomSeed = new Random().Next(Int32.MinValue, Int32.MaxValue);
 
         public static int Combine(int h1, int h2)
         {

--- a/src/mscorlib/src/System/Numerics/Hashing/HashHelpers.cs
+++ b/src/mscorlib/src/System/Numerics/Hashing/HashHelpers.cs
@@ -8,12 +8,14 @@ namespace System.Numerics.Hashing
 
     internal static class HashHelpers
     {
+        public static readonly int RandomSeed = Guid.NewGuid().GetHashCode();
+
         public static int Combine(int h1, int h2)
         {
-            // The jit optimizes this to use the ROL instruction on x86
+            // RyuJIT optimizes this to use the ROL instruction
             // Related GitHub pull request: dotnet/coreclr#1830
-            uint shift5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
-            return ((int)shift5 + h1) ^ h2;
+            uint rol5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
+            return ((int)rol5 + h1) ^ h2;
         }
     }
 }

--- a/src/mscorlib/src/System/Runtime/CompilerServices/ITuple.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/ITuple.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// This interface is required for types that want to be indexed into by dynamic patterns.
+    /// </summary>
+    public interface ITuple
+    {
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int Length { get; }
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object this[int index] { get; }
+    }
+}

--- a/src/mscorlib/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/TupleElementNamesAttribute.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that the use of <see cref="System.ValueTuple"/> on a member is meant to be treated as a tuple with element names.
+    /// </summary>
+    [CLSCompliant(false)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Event)]
+    public sealed class TupleElementNamesAttribute : Attribute
+    {
+        private readonly string[] _transformNames;
+
+        /// <summary>
+        /// Initializes a new instance of the <see
+        /// cref="TupleElementNamesAttribute"/> class.
+        /// </summary>
+        /// <param name="transformNames">
+        /// Specifies, in a pre-order depth-first traversal of a type's
+        /// construction, which <see cref="System.ValueType"/> occurrences are
+        /// meant to carry element names.
+        /// </param>
+        /// <remarks>
+        /// This constructor is meant to be used on types that contain an
+        /// instantiation of <see cref="System.ValueType"/> that contains
+        /// element names.  For instance, if <c>C</c> is a generic type with
+        /// two type parameters, then a use of the constructed type <c>C{<see
+        /// cref="System.ValueTuple{T1, T2}"/>, <see
+        /// cref="System.ValueTuple{T1, T2, T3}"/></c> might be intended to
+        /// treat the first type argument as a tuple with element names and the
+        /// second as a tuple without element names. In which case, the
+        /// appropriate attribute specification should use a
+        /// <c>transformNames</c> value of <c>{ "name1", "name2", null, null,
+        /// null }</c>.
+        /// </remarks>
+        public TupleElementNamesAttribute(string[] transformNames)
+        {
+            if (transformNames == null)
+            {
+                throw new ArgumentNullException(nameof(transformNames));
+            }
+
+            _transformNames = transformNames;
+        }
+
+        /// <summary>
+        /// Specifies, in a pre-order depth-first traversal of a type's
+        /// construction, which <see cref="System.ValueTuple"/> elements are
+        /// meant to carry element names.
+        /// </summary>
+        public IList<string> TransformNames => _transformNames;
+    }
+}

--- a/src/mscorlib/src/System/Tuple.cs
+++ b/src/mscorlib/src/System/Tuple.cs
@@ -7,161 +7,206 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
 
 //
 // Note: F# compiler depends on the exact tuple hashing algorithm. Do not ever change it.
 //
 
-namespace System {
+namespace System
+{
 
     /// <summary>
     /// Helper so we can call some tuple methods recursively without knowing the underlying types.
     /// </summary>
-    internal interface ITuple {
+    internal interface ITupleInternal : ITuple
+    {
         string ToString(StringBuilder sb);
         int GetHashCode(IEqualityComparer comparer);
-        int Size { get; }
-
     }
 
-    public static class Tuple {
-        public static Tuple<T1> Create<T1>(T1 item1) {
+    public static class Tuple
+    {
+        public static Tuple<T1> Create<T1>(T1 item1)
+        {
             return new Tuple<T1>(item1);
         }
 
-        public static Tuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2) {
+        public static Tuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2)
+        {
             return new Tuple<T1, T2>(item1, item2);
         }
 
-        public static Tuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3) {
+        public static Tuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
+        {
             return new Tuple<T1, T2, T3>(item1, item2, item3);
         }
 
-        public static Tuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4) {
+        public static Tuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
+        {
             return new Tuple<T1, T2, T3, T4>(item1, item2, item3, item4);
         }
 
-        public static Tuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) {
+        public static Tuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+        {
             return new Tuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
         }
 
-        public static Tuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) {
+        public static Tuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
+        {
             return new Tuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
         }
 
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7> Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) {
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7> Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
+        {
             return new Tuple<T1, T2, T3, T4, T5, T6, T7>(item1, item2, item3, item4, item5, item6, item7);
         }
 
-        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8) {
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8)
+        {
             return new Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>>(item1, item2, item3, item4, item5, item6, item7, new Tuple<T8>(item8));
         }
 
         // From System.Web.Util.HashCodeCombiner
-        internal static int CombineHashCodes(int h1, int h2) {
+        internal static int CombineHashCodes(int h1, int h2)
+        {
             return (((h1 << 5) + h1) ^ h2);
         }
 
-        internal static int CombineHashCodes(int h1, int h2, int h3) {
+        internal static int CombineHashCodes(int h1, int h2, int h3)
+        {
             return CombineHashCodes(CombineHashCodes(h1, h2), h3);
         }
 
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4) {
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
+        {
             return CombineHashCodes(CombineHashCodes(h1, h2), CombineHashCodes(h3, h4));
         }
 
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5) {
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
+        {
             return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
         }
 
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6) {
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
+        {
             return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6));
         }
 
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7) {
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
+        {
             return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7));
         }
 
-        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8) {
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
+        {
             return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), CombineHashCodes(h5, h6, h7, h8));
         }
     }
 
     [Serializable]
-    public class Tuple<T1> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple {
+    public class Tuple<T1> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
+    {
 
         private readonly T1 m_Item1;
 
         public T1 Item1 { get { return m_Item1; } }
 
-        public Tuple(T1 item1) {
+        public Tuple(T1 item1)
+        {
             m_Item1 = item1;
         }
 
-        public override Boolean Equals(Object obj) {
-            return ((IStructuralEquatable) this).Equals(obj, EqualityComparer<Object>.Default);
+        public override Boolean Equals(Object obj)
+        {
+            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<Object>.Default);
         }
 
-        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer) {
+        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer)
+        {
             if (other == null) return false;
 
             Tuple<T1> objTuple = other as Tuple<T1>;
 
-            if (objTuple == null) {
+            if (objTuple == null)
+            {
                 return false;
             }
 
             return comparer.Equals(m_Item1, objTuple.m_Item1);
         }
 
-        Int32 IComparable.CompareTo(Object obj) {
-            return ((IStructuralComparable) this).CompareTo(obj, Comparer<Object>.Default);
+        Int32 IComparable.CompareTo(Object obj)
+        {
+            return ((IStructuralComparable)this).CompareTo(obj, Comparer<Object>.Default);
         }
 
-        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer) {
+        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer)
+        {
             if (other == null) return 1;
 
             Tuple<T1> objTuple = other as Tuple<T1>;
 
-            if (objTuple == null) {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), nameof(other));
+            if (objTuple == null)
+            {
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), "other");
             }
 
             return comparer.Compare(m_Item1, objTuple.m_Item1);
         }
 
-        public override int GetHashCode() {
-            return ((IStructuralEquatable) this).GetHashCode(EqualityComparer<Object>.Default);
+        public override int GetHashCode()
+        {
+            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<Object>.Default);
         }
 
-        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
+        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
             return comparer.GetHashCode(m_Item1);
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer) {
-            return ((IStructuralEquatable) this).GetHashCode(comparer);
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
-        public override string ToString() {
+        public override string ToString()
+        {
             StringBuilder sb = new StringBuilder();
             sb.Append("(");
-            return ((ITuple)this).ToString(sb);
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb) {
+        string ITupleInternal.ToString(StringBuilder sb)
+        {
             sb.Append(m_Item1);
             sb.Append(")");
             return sb.ToString();
         }
 
-        int ITuple.Size {
-            get {
-                return 1;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 1;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                if (index != 0)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+                return Item1;
             }
         }
     }
 
     [Serializable]
-    public class Tuple<T1, T2> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple {
+    public class Tuple<T1, T2> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
+    {
 
         private readonly T1 m_Item1;
         private readonly T2 m_Item2;
@@ -169,38 +214,45 @@ namespace System {
         public T1 Item1 { get { return m_Item1; } }
         public T2 Item2 { get { return m_Item2; } }
 
-        public Tuple(T1 item1, T2 item2) {
+        public Tuple(T1 item1, T2 item2)
+        {
             m_Item1 = item1;
             m_Item2 = item2;
         }
 
-        public override Boolean Equals(Object obj) {
-            return ((IStructuralEquatable) this).Equals(obj, EqualityComparer<Object>.Default);;
+        public override Boolean Equals(Object obj)
+        {
+            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<Object>.Default); ;
         }
 
-        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer) {
+        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer)
+        {
             if (other == null) return false;
 
             Tuple<T1, T2> objTuple = other as Tuple<T1, T2>;
 
-            if (objTuple == null) {
+            if (objTuple == null)
+            {
                 return false;
             }
 
             return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, objTuple.m_Item2);
         }
 
-        Int32 IComparable.CompareTo(Object obj) {
-            return ((IStructuralComparable) this).CompareTo(obj, Comparer<Object>.Default);
+        Int32 IComparable.CompareTo(Object obj)
+        {
+            return ((IStructuralComparable)this).CompareTo(obj, Comparer<Object>.Default);
         }
 
-        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer) {
+        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer)
+        {
             if (other == null) return 1;
 
             Tuple<T1, T2> objTuple = other as Tuple<T1, T2>;
 
-            if (objTuple == null) {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), nameof(other));
+            if (objTuple == null)
+            {
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), "other");
             }
 
             int c = 0;
@@ -212,24 +264,29 @@ namespace System {
             return comparer.Compare(m_Item2, objTuple.m_Item2);
         }
 
-        public override int GetHashCode() {
-            return ((IStructuralEquatable) this).GetHashCode(EqualityComparer<Object>.Default);
+        public override int GetHashCode()
+        {
+            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<Object>.Default);
         }
 
-        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
+        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer) {
-            return ((IStructuralEquatable) this).GetHashCode(comparer);
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
-        public override string ToString() {
+        public override string ToString()
+        {
             StringBuilder sb = new StringBuilder();
             sb.Append("(");
-            return ((ITuple)this).ToString(sb);
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb) {
+        string ITupleInternal.ToString(StringBuilder sb)
+        {
             sb.Append(m_Item1);
             sb.Append(", ");
             sb.Append(m_Item2);
@@ -237,15 +294,34 @@ namespace System {
             return sb.ToString();
         }
 
-        int ITuple.Size {
-            get {
-                return 2;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 2;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
     [Serializable]
-    public class Tuple<T1, T2, T3> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple {
+    public class Tuple<T1, T2, T3> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
+    {
 
         private readonly T1 m_Item1;
         private readonly T2 m_Item2;
@@ -255,39 +331,46 @@ namespace System {
         public T2 Item2 { get { return m_Item2; } }
         public T3 Item3 { get { return m_Item3; } }
 
-        public Tuple(T1 item1, T2 item2, T3 item3) {
+        public Tuple(T1 item1, T2 item2, T3 item3)
+        {
             m_Item1 = item1;
             m_Item2 = item2;
             m_Item3 = item3;
         }
 
-        public override Boolean Equals(Object obj) {
-            return ((IStructuralEquatable) this).Equals(obj, EqualityComparer<Object>.Default);;
+        public override Boolean Equals(Object obj)
+        {
+            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<Object>.Default); ;
         }
 
-        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer) {
+        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer)
+        {
             if (other == null) return false;
 
             Tuple<T1, T2, T3> objTuple = other as Tuple<T1, T2, T3>;
 
-            if (objTuple == null) {
+            if (objTuple == null)
+            {
                 return false;
             }
 
             return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, objTuple.m_Item2) && comparer.Equals(m_Item3, objTuple.m_Item3);
         }
 
-        Int32 IComparable.CompareTo(Object obj) {
-            return ((IStructuralComparable) this).CompareTo(obj, Comparer<Object>.Default);
+        Int32 IComparable.CompareTo(Object obj)
+        {
+            return ((IStructuralComparable)this).CompareTo(obj, Comparer<Object>.Default);
         }
 
-        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer) {
+        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer)
+        {
             if (other == null) return 1;
 
             Tuple<T1, T2, T3> objTuple = other as Tuple<T1, T2, T3>;
 
-            if (objTuple == null) {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), nameof(other));
+            if (objTuple == null)
+            {
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), "other");
             }
 
             int c = 0;
@@ -303,24 +386,29 @@ namespace System {
             return comparer.Compare(m_Item3, objTuple.m_Item3);
         }
 
-        public override int GetHashCode() {
-            return ((IStructuralEquatable) this).GetHashCode(EqualityComparer<Object>.Default);
+        public override int GetHashCode()
+        {
+            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<Object>.Default);
         }
 
-        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
+        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer) {
-            return ((IStructuralEquatable) this).GetHashCode(comparer);
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
-        public override string ToString() {
+        public override string ToString()
+        {
             StringBuilder sb = new StringBuilder();
             sb.Append("(");
-            return ((ITuple)this).ToString(sb);
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb) {
+        string ITupleInternal.ToString(StringBuilder sb)
+        {
             sb.Append(m_Item1);
             sb.Append(", ");
             sb.Append(m_Item2);
@@ -330,15 +418,36 @@ namespace System {
             return sb.ToString();
         }
 
-        int ITuple.Size {
-            get {
-                return 3;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 3;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
     [Serializable]
-    public class Tuple<T1, T2, T3, T4> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple {
+    public class Tuple<T1, T2, T3, T4> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
+    {
 
         private readonly T1 m_Item1;
         private readonly T2 m_Item2;
@@ -350,40 +459,47 @@ namespace System {
         public T3 Item3 { get { return m_Item3; } }
         public T4 Item4 { get { return m_Item4; } }
 
-        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4) {
+        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4)
+        {
             m_Item1 = item1;
             m_Item2 = item2;
             m_Item3 = item3;
             m_Item4 = item4;
         }
 
-        public override Boolean Equals(Object obj) {
-            return ((IStructuralEquatable) this).Equals(obj, EqualityComparer<Object>.Default);;
+        public override Boolean Equals(Object obj)
+        {
+            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<Object>.Default); ;
         }
 
-        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer) {
+        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer)
+        {
             if (other == null) return false;
 
             Tuple<T1, T2, T3, T4> objTuple = other as Tuple<T1, T2, T3, T4>;
 
-            if (objTuple == null) {
+            if (objTuple == null)
+            {
                 return false;
             }
 
             return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, objTuple.m_Item2) && comparer.Equals(m_Item3, objTuple.m_Item3) && comparer.Equals(m_Item4, objTuple.m_Item4);
         }
 
-        Int32 IComparable.CompareTo(Object obj) {
-            return ((IStructuralComparable) this).CompareTo(obj, Comparer<Object>.Default);
+        Int32 IComparable.CompareTo(Object obj)
+        {
+            return ((IStructuralComparable)this).CompareTo(obj, Comparer<Object>.Default);
         }
 
-        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer) {
+        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer)
+        {
             if (other == null) return 1;
 
             Tuple<T1, T2, T3, T4> objTuple = other as Tuple<T1, T2, T3, T4>;
 
-            if (objTuple == null) {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), nameof(other));
+            if (objTuple == null)
+            {
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), "other");
             }
 
             int c = 0;
@@ -403,24 +519,29 @@ namespace System {
             return comparer.Compare(m_Item4, objTuple.m_Item4);
         }
 
-        public override int GetHashCode() {
-            return ((IStructuralEquatable) this).GetHashCode(EqualityComparer<Object>.Default);
+        public override int GetHashCode()
+        {
+            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<Object>.Default);
         }
 
-        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
+        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer) {
-            return ((IStructuralEquatable) this).GetHashCode(comparer);
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
-        public override string ToString() {
+        public override string ToString()
+        {
             StringBuilder sb = new StringBuilder();
             sb.Append("(");
-            return ((ITuple)this).ToString(sb);
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb) {
+        string ITupleInternal.ToString(StringBuilder sb)
+        {
             sb.Append(m_Item1);
             sb.Append(", ");
             sb.Append(m_Item2);
@@ -432,15 +553,38 @@ namespace System {
             return sb.ToString();
         }
 
-        int ITuple.Size {
-            get {
-                return 4;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 4;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
     [Serializable]
-    public class Tuple<T1, T2, T3, T4, T5> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple {
+    public class Tuple<T1, T2, T3, T4, T5> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
+    {
 
         private readonly T1 m_Item1;
         private readonly T2 m_Item2;
@@ -454,7 +598,8 @@ namespace System {
         public T4 Item4 { get { return m_Item4; } }
         public T5 Item5 { get { return m_Item5; } }
 
-        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) {
+        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+        {
             m_Item1 = item1;
             m_Item2 = item2;
             m_Item3 = item3;
@@ -462,33 +607,39 @@ namespace System {
             m_Item5 = item5;
         }
 
-        public override Boolean Equals(Object obj) {
-            return ((IStructuralEquatable) this).Equals(obj, EqualityComparer<Object>.Default);;
+        public override Boolean Equals(Object obj)
+        {
+            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<Object>.Default); ;
         }
 
-        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer) {
+        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer)
+        {
             if (other == null) return false;
 
             Tuple<T1, T2, T3, T4, T5> objTuple = other as Tuple<T1, T2, T3, T4, T5>;
 
-            if (objTuple == null) {
+            if (objTuple == null)
+            {
                 return false;
             }
 
             return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, objTuple.m_Item2) && comparer.Equals(m_Item3, objTuple.m_Item3) && comparer.Equals(m_Item4, objTuple.m_Item4) && comparer.Equals(m_Item5, objTuple.m_Item5);
         }
 
-        Int32 IComparable.CompareTo(Object obj) {
-            return ((IStructuralComparable) this).CompareTo(obj, Comparer<Object>.Default);
+        Int32 IComparable.CompareTo(Object obj)
+        {
+            return ((IStructuralComparable)this).CompareTo(obj, Comparer<Object>.Default);
         }
 
-        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer) {
+        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer)
+        {
             if (other == null) return 1;
 
             Tuple<T1, T2, T3, T4, T5> objTuple = other as Tuple<T1, T2, T3, T4, T5>;
 
-            if (objTuple == null) {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), nameof(other));
+            if (objTuple == null)
+            {
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), "other");
             }
 
             int c = 0;
@@ -512,24 +663,29 @@ namespace System {
             return comparer.Compare(m_Item5, objTuple.m_Item5);
         }
 
-        public override int GetHashCode() {
-            return ((IStructuralEquatable) this).GetHashCode(EqualityComparer<Object>.Default);
+        public override int GetHashCode()
+        {
+            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<Object>.Default);
         }
 
-        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
+        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer) {
-            return ((IStructuralEquatable) this).GetHashCode(comparer);
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
-        public override string ToString() {
+        public override string ToString()
+        {
             StringBuilder sb = new StringBuilder();
             sb.Append("(");
-            return ((ITuple)this).ToString(sb);
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb) {
+        string ITupleInternal.ToString(StringBuilder sb)
+        {
             sb.Append(m_Item1);
             sb.Append(", ");
             sb.Append(m_Item2);
@@ -543,15 +699,40 @@ namespace System {
             return sb.ToString();
         }
 
-        int ITuple.Size {
-            get {
-                return 5;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 5;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
     [Serializable]
-    public class Tuple<T1, T2, T3, T4, T5, T6> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple {
+    public class Tuple<T1, T2, T3, T4, T5, T6> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
+    {
 
         private readonly T1 m_Item1;
         private readonly T2 m_Item2;
@@ -567,7 +748,8 @@ namespace System {
         public T5 Item5 { get { return m_Item5; } }
         public T6 Item6 { get { return m_Item6; } }
 
-        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) {
+        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
+        {
             m_Item1 = item1;
             m_Item2 = item2;
             m_Item3 = item3;
@@ -576,33 +758,39 @@ namespace System {
             m_Item6 = item6;
         }
 
-        public override Boolean Equals(Object obj) {
-            return ((IStructuralEquatable) this).Equals(obj, EqualityComparer<Object>.Default);;
+        public override Boolean Equals(Object obj)
+        {
+            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<Object>.Default); ;
         }
 
-        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer) {
+        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer)
+        {
             if (other == null) return false;
 
             Tuple<T1, T2, T3, T4, T5, T6> objTuple = other as Tuple<T1, T2, T3, T4, T5, T6>;
 
-            if (objTuple == null) {
+            if (objTuple == null)
+            {
                 return false;
             }
 
             return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, objTuple.m_Item2) && comparer.Equals(m_Item3, objTuple.m_Item3) && comparer.Equals(m_Item4, objTuple.m_Item4) && comparer.Equals(m_Item5, objTuple.m_Item5) && comparer.Equals(m_Item6, objTuple.m_Item6);
         }
 
-        Int32 IComparable.CompareTo(Object obj) {
-            return ((IStructuralComparable) this).CompareTo(obj, Comparer<Object>.Default);
+        Int32 IComparable.CompareTo(Object obj)
+        {
+            return ((IStructuralComparable)this).CompareTo(obj, Comparer<Object>.Default);
         }
 
-        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer) {
+        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer)
+        {
             if (other == null) return 1;
 
             Tuple<T1, T2, T3, T4, T5, T6> objTuple = other as Tuple<T1, T2, T3, T4, T5, T6>;
 
-            if (objTuple == null) {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), nameof(other));
+            if (objTuple == null)
+            {
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), "other");
             }
 
             int c = 0;
@@ -630,24 +818,29 @@ namespace System {
             return comparer.Compare(m_Item6, objTuple.m_Item6);
         }
 
-        public override int GetHashCode() {
-            return ((IStructuralEquatable) this).GetHashCode(EqualityComparer<Object>.Default);
+        public override int GetHashCode()
+        {
+            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<Object>.Default);
         }
 
-        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
+        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer) {
-            return ((IStructuralEquatable) this).GetHashCode(comparer);
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
-        public override string ToString() {
+        public override string ToString()
+        {
             StringBuilder sb = new StringBuilder();
             sb.Append("(");
-            return ((ITuple)this).ToString(sb);
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb) {
+        string ITupleInternal.ToString(StringBuilder sb)
+        {
             sb.Append(m_Item1);
             sb.Append(", ");
             sb.Append(m_Item2);
@@ -663,15 +856,42 @@ namespace System {
             return sb.ToString();
         }
 
-        int ITuple.Size {
-            get {
-                return 6;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 6;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
     [Serializable]
-    public class Tuple<T1, T2, T3, T4, T5, T6, T7> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple {
+    public class Tuple<T1, T2, T3, T4, T5, T6, T7> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
+    {
 
         private readonly T1 m_Item1;
         private readonly T2 m_Item2;
@@ -689,7 +909,8 @@ namespace System {
         public T6 Item6 { get { return m_Item6; } }
         public T7 Item7 { get { return m_Item7; } }
 
-        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) {
+        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
+        {
             m_Item1 = item1;
             m_Item2 = item2;
             m_Item3 = item3;
@@ -699,33 +920,39 @@ namespace System {
             m_Item7 = item7;
         }
 
-        public override Boolean Equals(Object obj) {
-            return ((IStructuralEquatable) this).Equals(obj, EqualityComparer<Object>.Default);;
+        public override Boolean Equals(Object obj)
+        {
+            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<Object>.Default); ;
         }
 
-        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer) {
+        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer)
+        {
             if (other == null) return false;
 
             Tuple<T1, T2, T3, T4, T5, T6, T7> objTuple = other as Tuple<T1, T2, T3, T4, T5, T6, T7>;
 
-            if (objTuple == null) {
+            if (objTuple == null)
+            {
                 return false;
             }
 
             return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, objTuple.m_Item2) && comparer.Equals(m_Item3, objTuple.m_Item3) && comparer.Equals(m_Item4, objTuple.m_Item4) && comparer.Equals(m_Item5, objTuple.m_Item5) && comparer.Equals(m_Item6, objTuple.m_Item6) && comparer.Equals(m_Item7, objTuple.m_Item7);
         }
 
-        Int32 IComparable.CompareTo(Object obj) {
-            return ((IStructuralComparable) this).CompareTo(obj, Comparer<Object>.Default);
+        Int32 IComparable.CompareTo(Object obj)
+        {
+            return ((IStructuralComparable)this).CompareTo(obj, Comparer<Object>.Default);
         }
 
-        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer) {
+        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer)
+        {
             if (other == null) return 1;
 
             Tuple<T1, T2, T3, T4, T5, T6, T7> objTuple = other as Tuple<T1, T2, T3, T4, T5, T6, T7>;
 
-            if (objTuple == null) {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), nameof(other));
+            if (objTuple == null)
+            {
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), "other");
             }
 
             int c = 0;
@@ -757,24 +984,29 @@ namespace System {
             return comparer.Compare(m_Item7, objTuple.m_Item7);
         }
 
-        public override int GetHashCode() {
-            return ((IStructuralEquatable) this).GetHashCode(EqualityComparer<Object>.Default);
+        public override int GetHashCode()
+        {
+            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<Object>.Default);
         }
 
-        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
+        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
             return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7));
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer) {
-            return ((IStructuralEquatable) this).GetHashCode(comparer);
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
-        public override string ToString() {
+        public override string ToString()
+        {
             StringBuilder sb = new StringBuilder();
             sb.Append("(");
-            return ((ITuple)this).ToString(sb);
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb) {
+        string ITupleInternal.ToString(StringBuilder sb)
+        {
             sb.Append(m_Item1);
             sb.Append(", ");
             sb.Append(m_Item2);
@@ -792,15 +1024,44 @@ namespace System {
             return sb.ToString();
         }
 
-        int ITuple.Size {
-            get {
-                return 7;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length => 7;
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    case 6:
+                        return Item7;
+                    default:
+                        throw new IndexOutOfRangeException();
+                }
             }
         }
     }
 
     [Serializable]
-    public class Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> : IStructuralEquatable, IStructuralComparable, IComparable, ITuple {
+    public class Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> : IStructuralEquatable, IStructuralComparable, IComparable, ITupleInternal, ITuple
+    {
 
         private readonly T1 m_Item1;
         private readonly T2 m_Item2;
@@ -820,8 +1081,10 @@ namespace System {
         public T7 Item7 { get { return m_Item7; } }
         public TRest Rest { get { return m_Rest; } }
 
-        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) {
-            if (!(rest is ITuple)) {
+        public Tuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
+        {
+            if (!(rest is ITupleInternal))
+            {
                 throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleLastArgumentNotATuple"));
             }
 
@@ -835,33 +1098,39 @@ namespace System {
             m_Rest = rest;
         }
 
-        public override Boolean Equals(Object obj) {
-            return ((IStructuralEquatable) this).Equals(obj, EqualityComparer<Object>.Default);;
+        public override Boolean Equals(Object obj)
+        {
+            return ((IStructuralEquatable)this).Equals(obj, EqualityComparer<Object>.Default); ;
         }
 
-        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer) {
+        Boolean IStructuralEquatable.Equals(Object other, IEqualityComparer comparer)
+        {
             if (other == null) return false;
 
             Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> objTuple = other as Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>;
 
-            if (objTuple == null) {
+            if (objTuple == null)
+            {
                 return false;
             }
 
             return comparer.Equals(m_Item1, objTuple.m_Item1) && comparer.Equals(m_Item2, objTuple.m_Item2) && comparer.Equals(m_Item3, objTuple.m_Item3) && comparer.Equals(m_Item4, objTuple.m_Item4) && comparer.Equals(m_Item5, objTuple.m_Item5) && comparer.Equals(m_Item6, objTuple.m_Item6) && comparer.Equals(m_Item7, objTuple.m_Item7) && comparer.Equals(m_Rest, objTuple.m_Rest);
         }
 
-        Int32 IComparable.CompareTo(Object obj) {
-            return ((IStructuralComparable) this).CompareTo(obj, Comparer<Object>.Default);
+        Int32 IComparable.CompareTo(Object obj)
+        {
+            return ((IStructuralComparable)this).CompareTo(obj, Comparer<Object>.Default);
         }
 
-        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer) {
+        Int32 IStructuralComparable.CompareTo(Object other, IComparer comparer)
+        {
             if (other == null) return 1;
 
             Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> objTuple = other as Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>;
 
-            if (objTuple == null) {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), nameof(other));
+            if (objTuple == null)
+            {
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_TupleIncorrectType", this.GetType().ToString()), "other");
             }
 
             int c = 0;
@@ -897,47 +1166,53 @@ namespace System {
             return comparer.Compare(m_Rest, objTuple.m_Rest);
         }
 
-        public override int GetHashCode() {
-            return ((IStructuralEquatable) this).GetHashCode(EqualityComparer<Object>.Default);
+        public override int GetHashCode()
+        {
+            return ((IStructuralEquatable)this).GetHashCode(EqualityComparer<Object>.Default);
         }
 
-        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer) {
+        Int32 IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
             // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
-            ITuple t = (ITuple) m_Rest;
-            if(t.Size >= 8) { return t.GetHashCode(comparer); }
-            
+            ITupleInternal t = (ITupleInternal)m_Rest;
+            if (t.Length >= 8) { return t.GetHashCode(comparer); }
+
             // In this case, the rest memeber has less than 8 elements so we need to combine some our elements with the elements in rest
-            int k = 8 - t.Size;
-            switch(k) {
+            int k = 8 - t.Length;
+            switch (k)
+            {
                 case 1:
-                return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
+                    return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
                 case 2:
-                return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
+                    return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
                 case 3:
-                return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
+                    return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
                 case 4:
-                return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
+                    return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
                 case 5:
-                return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
+                    return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
                 case 6:
-                return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
+                    return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
                 case 7:
-                return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
+                    return Tuple.CombineHashCodes(comparer.GetHashCode(m_Item1), comparer.GetHashCode(m_Item2), comparer.GetHashCode(m_Item3), comparer.GetHashCode(m_Item4), comparer.GetHashCode(m_Item5), comparer.GetHashCode(m_Item6), comparer.GetHashCode(m_Item7), t.GetHashCode(comparer));
             }
             Debug.Assert(false, "Missed all cases for computing Tuple hash code");
             return -1;
         }
 
-        Int32 ITuple.GetHashCode(IEqualityComparer comparer) {
-            return ((IStructuralEquatable) this).GetHashCode(comparer);
+        Int32 ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return ((IStructuralEquatable)this).GetHashCode(comparer);
         }
-        public override string ToString() {
+        public override string ToString()
+        {
             StringBuilder sb = new StringBuilder();
             sb.Append("(");
-            return ((ITuple)this).ToString(sb);
+            return ((ITupleInternal)this).ToString(sb);
         }
 
-        string ITuple.ToString(StringBuilder sb) {
+        string ITupleInternal.ToString(StringBuilder sb)
+        {
             sb.Append(m_Item1);
             sb.Append(", ");
             sb.Append(m_Item2);
@@ -952,12 +1227,46 @@ namespace System {
             sb.Append(", ");
             sb.Append(m_Item7);
             sb.Append(", ");
-            return ((ITuple)m_Rest).ToString(sb);
+            return ((ITupleInternal)m_Rest).ToString(sb);
         }
 
-        int ITuple.Size {
-            get {
-                return 7 + ((ITuple)m_Rest).Size;
+        /// <summary>
+        /// The number of positions in this data structure.
+        /// </summary>
+        int ITuple.Length
+        {
+            get
+            {
+                return 7 + ((ITupleInternal)Rest).Length;
+            }
+        }
+
+        /// <summary>
+        /// Get the element at position <param name="index"/>.
+        /// </summary>
+        object ITuple.this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0:
+                        return Item1;
+                    case 1:
+                        return Item2;
+                    case 2:
+                        return Item3;
+                    case 3:
+                        return Item4;
+                    case 4:
+                        return Item5;
+                    case 5:
+                        return Item6;
+                    case 6:
+                        return Item7;
+                }
+
+                return ((ITupleInternal)Rest)[index - 7];
             }
         }
     }

--- a/src/mscorlib/src/System/TupleExtensions.cs
+++ b/src/mscorlib/src/System/TupleExtensions.cs
@@ -1,0 +1,929 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace System
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="Tuple"/> instances to interop with C# tuples features (deconstruction syntax, converting from and to <see cref="ValueTuple"/>).
+    /// </summary>
+    public static class TupleExtensions
+    {
+        #region Deconstruct
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 1 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1>(
+            this Tuple<T1> value,
+            out T1 item1)
+        {
+            item1 = value.Item1;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 2 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2>(
+            this Tuple<T1, T2> value,
+            out T1 item1, out T2 item2)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 3 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3>(
+            this Tuple<T1, T2, T3> value,
+            out T1 item1, out T2 item2, out T3 item3)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 4 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4>(
+            this Tuple<T1, T2, T3, T4> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 5 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5>(
+            this Tuple<T1, T2, T3, T4, T5> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 6 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6>(
+            this Tuple<T1, T2, T3, T4, T5, T6> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 7 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 8 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 9 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 10 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 11 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 12 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 13 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 14 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 15 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 16 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 17 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 18 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 19 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+            item19 = value.Rest.Rest.Item5;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 20 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+            item19 = value.Rest.Rest.Item5;
+            item20 = value.Rest.Rest.Item6;
+        }
+
+        /// <summary>
+        /// Deconstruct a properly nested <see cref="Tuple"/> with 21 elements.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Deconstruct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+            this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value,
+            out T1 item1, out T2 item2, out T3 item3, out T4 item4, out T5 item5, out T6 item6, out T7 item7, out T8 item8, out T9 item9, out T10 item10, out T11 item11, out T12 item12, out T13 item13, out T14 item14, out T15 item15, out T16 item16, out T17 item17, out T18 item18, out T19 item19, out T20 item20, out T21 item21)
+        {
+            item1 = value.Item1;
+            item2 = value.Item2;
+            item3 = value.Item3;
+            item4 = value.Item4;
+            item5 = value.Item5;
+            item6 = value.Item6;
+            item7 = value.Item7;
+            item8 = value.Rest.Item1;
+            item9 = value.Rest.Item2;
+            item10 = value.Rest.Item3;
+            item11 = value.Rest.Item4;
+            item12 = value.Rest.Item5;
+            item13 = value.Rest.Item6;
+            item14 = value.Rest.Item7;
+            item15 = value.Rest.Rest.Item1;
+            item16 = value.Rest.Rest.Item2;
+            item17 = value.Rest.Rest.Item3;
+            item18 = value.Rest.Rest.Item4;
+            item19 = value.Rest.Rest.Item5;
+            item20 = value.Rest.Rest.Item6;
+            item21 = value.Rest.Rest.Item7;
+        }
+        #endregion
+
+        #region ToValueTuple
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 1 element.
+        /// </summary>
+        public static ValueTuple<T1>
+            ToValueTuple<T1>(
+                this Tuple<T1> value)
+        {
+            return ValueTuple.Create(value.Item1);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 2 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2>
+            ToValueTuple<T1, T2>(
+                this Tuple<T1, T2> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 3 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3>
+            ToValueTuple<T1, T2, T3>(
+                this Tuple<T1, T2, T3> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 4 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4>
+            ToValueTuple<T1, T2, T3, T4>(
+                this Tuple<T1, T2, T3, T4> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 5 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5>
+            ToValueTuple<T1, T2, T3, T4, T5>(
+                this Tuple<T1, T2, T3, T4, T5> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 6 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6>
+            ToValueTuple<T1, T2, T3, T4, T5, T6>(
+                this Tuple<T1, T2, T3, T4, T5, T6> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 7 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7> value)
+        {
+            return ValueTuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 8 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 9 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 10 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 11 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 12 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 13 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 14 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        ValueTuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 15 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 16 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 17 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 18 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 19 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 20 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="ValueTuple"/> from a properly nested <see cref="Tuple"/> with 21 elements.
+        /// </summary>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20, T21>>>
+            ToValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+                this Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>> value)
+        {
+            return CreateLong(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLong(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            ValueTuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6, value.Rest.Rest.Item7)));
+        }
+        #endregion
+
+        #region ToTuple
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 1 element.
+        /// </summary>
+        public static Tuple<T1>
+            ToTuple<T1>(
+                this ValueTuple<T1> value)
+        {
+            return Tuple.Create(value.Item1);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 2 elements.
+        /// </summary>
+        public static Tuple<T1, T2>
+            ToTuple<T1, T2>(
+                this ValueTuple<T1, T2> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 3 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3>
+            ToTuple<T1, T2, T3>(
+                this ValueTuple<T1, T2, T3> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 4 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4>
+            ToTuple<T1, T2, T3, T4>(
+                this ValueTuple<T1, T2, T3, T4> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 5 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5>
+            ToTuple<T1, T2, T3, T4, T5>(
+                this ValueTuple<T1, T2, T3, T4, T5> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 6 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6>
+            ToTuple<T1, T2, T3, T4, T5, T6>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 7 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7> value)
+        {
+            return Tuple.Create(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7);
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 8 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 9 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 10 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 11 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 12 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 13 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 14 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        Tuple.Create(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 15 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 16 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 17 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 18 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 19 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 20 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6)));
+        }
+
+        /// <summary>
+        /// Make a properly nested <see cref="Tuple"/> from a properly nested <see cref="ValueTuple"/> with 21 elements.
+        /// </summary>
+        public static Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10, T11, T12, T13, T14, Tuple<T15, T16, T17, T18, T19, T20, T21>>>
+            ToTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(
+                this ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8, T9, T10, T11, T12, T13, T14, ValueTuple<T15, T16, T17, T18, T19, T20, T21>>> value)
+        {
+            return CreateLongRef(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5, value.Item6, value.Item7,
+                        CreateLongRef(value.Rest.Item1, value.Rest.Item2, value.Rest.Item3, value.Rest.Item4, value.Rest.Item5, value.Rest.Item6, value.Rest.Item7,
+                            Tuple.Create(value.Rest.Rest.Item1, value.Rest.Rest.Item2, value.Rest.Rest.Item3, value.Rest.Rest.Item4, value.Rest.Rest.Item5, value.Rest.Rest.Item6, value.Rest.Rest.Item7)));
+        }
+        #endregion
+
+        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
+
+        private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) =>
+            new Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
+    }
+}

--- a/src/mscorlib/src/System/TupleExtensions.cs
+++ b/src/mscorlib/src/System/TupleExtensions.cs
@@ -4,6 +4,8 @@
 
 using System.ComponentModel;
 
+using System.Runtime.CompilerServices;
+
 namespace System
 {
     /// <summary>
@@ -920,10 +922,10 @@ namespace System
         }
         #endregion
 
-        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct =>
+        private static ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLong<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : struct, ITuple =>
             new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
 
-        private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) =>
+        private static Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> CreateLongRef<T1, T2, T3, T4, T5, T6, T7, TRest>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) where TRest : ITuple =>
             new Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, rest);
     }
 }

--- a/src/mscorlib/src/System/ValueTuple.cs
+++ b/src/mscorlib/src/System/ValueTuple.cs
@@ -1,0 +1,2080 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Numerics.Hashing;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    /// <summary>
+    /// Helper so we can call some tuple methods recursively without knowing the underlying types.
+    /// </summary>
+    internal interface ITupleInternal
+    {
+        int GetHashCode(IEqualityComparer comparer);
+        int Size { get; }
+        string ToStringEnd();
+    }
+
+    /// <summary>
+    /// The ValueTuple types (from arity 0 to 8) comprise the runtime implementation that underlies tuples in C# and struct tuples in F#.
+    /// Aside from created via language syntax, they are most easily created via the ValueTuple.Create factory methods.
+    /// The System.ValueTuple types differ from the System.Tuple types in that:
+    /// - they are structs rather than classes,
+    /// - they are mutable rather than readonly, and
+    /// - their members (such as Item1, Item2, etc) are fields rather than properties.
+    /// </summary>
+    public struct ValueTuple
+        : IEquatable<ValueTuple>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple>, ITupleInternal
+    {
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if <paramref name="obj"/> is a <see cref="ValueTuple"/>.</returns>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple;
+        }
+
+        /// <summary>Returns a value indicating whether this instance is equal to a specified value.</summary>
+        /// <param name="other">An instance to compare to this instance.</param>
+        /// <returns>true if <paramref name="other"/> has the same value as this instance; otherwise, false.</returns>
+        public bool Equals(ValueTuple other)
+        {
+            return true;
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            return other is ValueTuple;
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return 0;
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple other)
+        {
+            return 0;
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return 0;
+        }
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return 0;
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return 0;
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return 0;
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>()</c>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "()";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return ")";
+        }
+
+        int ITupleInternal.Size => 0;
+
+        /// <summary>Creates a new struct 0-tuple.</summary>
+        /// <returns>A 0-tuple.</returns>
+        public static ValueTuple Create() =>
+            new ValueTuple();
+
+        /// <summary>Creates a new struct 1-tuple, or singleton.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <returns>A 1-tuple (singleton) whose value is (item1).</returns>
+        public static ValueTuple<T1> Create<T1>(T1 item1) =>
+            new ValueTuple<T1>(item1);
+
+        /// <summary>Creates a new struct 2-tuple, or pair.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <returns>A 2-tuple (pair) whose value is (item1, item2).</returns>
+        public static ValueTuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2) =>
+            new ValueTuple<T1, T2>(item1, item2);
+
+        /// <summary>Creates a new struct 3-tuple, or triple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <returns>A 3-tuple (triple) whose value is (item1, item2, item3).</returns>
+        public static ValueTuple<T1, T2, T3> Create<T1, T2, T3>(T1 item1, T2 item2, T3 item3) =>
+            new ValueTuple<T1, T2, T3>(item1, item2, item3);
+
+        /// <summary>Creates a new struct 4-tuple, or quadruple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <returns>A 4-tuple (quadruple) whose value is (item1, item2, item3, item4).</returns>
+        public static ValueTuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4) =>
+            new ValueTuple<T1, T2, T3, T4>(item1, item2, item3, item4);
+
+        /// <summary>Creates a new struct 5-tuple, or quintuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <returns>A 5-tuple (quintuple) whose value is (item1, item2, item3, item4, item5).</returns>
+        public static ValueTuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5) =>
+            new ValueTuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
+
+        /// <summary>Creates a new struct 6-tuple, or sextuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <typeparam name="T6">The type of the sixth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <param name="item6">The value of the sixth component of the tuple.</param>
+        /// <returns>A 6-tuple (sextuple) whose value is (item1, item2, item3, item4, item5, item6).</returns>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6> Create<T1, T2, T3, T4, T5, T6>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6) =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
+
+        /// <summary>Creates a new struct 7-tuple, or septuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <typeparam name="T6">The type of the sixth component of the tuple.</typeparam>
+        /// <typeparam name="T7">The type of the seventh component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <param name="item6">The value of the sixth component of the tuple.</param>
+        /// <param name="item7">The value of the seventh component of the tuple.</param>
+        /// <returns>A 7-tuple (septuple) whose value is (item1, item2, item3, item4, item5, item6, item7).</returns>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7> Create<T1, T2, T3, T4, T5, T6, T7>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7) =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6, T7>(item1, item2, item3, item4, item5, item6, item7);
+
+        /// <summary>Creates a new struct 8-tuple, or octuple.</summary>
+        /// <typeparam name="T1">The type of the first component of the tuple.</typeparam>
+        /// <typeparam name="T2">The type of the second component of the tuple.</typeparam>
+        /// <typeparam name="T3">The type of the third component of the tuple.</typeparam>
+        /// <typeparam name="T4">The type of the fourth component of the tuple.</typeparam>
+        /// <typeparam name="T5">The type of the fifth component of the tuple.</typeparam>
+        /// <typeparam name="T6">The type of the sixth component of the tuple.</typeparam>
+        /// <typeparam name="T7">The type of the seventh component of the tuple.</typeparam>
+        /// <typeparam name="T8">The type of the eighth component of the tuple.</typeparam>
+        /// <param name="item1">The value of the first component of the tuple.</param>
+        /// <param name="item2">The value of the second component of the tuple.</param>
+        /// <param name="item3">The value of the third component of the tuple.</param>
+        /// <param name="item4">The value of the fourth component of the tuple.</param>
+        /// <param name="item5">The value of the fifth component of the tuple.</param>
+        /// <param name="item6">The value of the sixth component of the tuple.</param>
+        /// <param name="item7">The value of the seventh component of the tuple.</param>
+        /// <param name="item8">The value of the eighth component of the tuple.</param>
+        /// <returns>An 8-tuple (octuple) whose value is (item1, item2, item3, item4, item5, item6, item7, item8).</returns>
+        public static ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>> Create<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8) =>
+            new ValueTuple<T1, T2, T3, T4, T5, T6, T7, ValueTuple<T8>>(item1, item2, item3, item4, item5, item6, item7, ValueTuple.Create(item8));
+
+        internal static int CombineHashCodes(int h1, int h2)
+        {
+            return HashHelpers.Combine(HashHelpers.Combine(HashHelpers.RandomSeed, h1), h2);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2), h3);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3), h4);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4), h5);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5), h6);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
+        }
+
+        internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
+        {
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
+        }
+    }
+
+    /// <summary>Represents a 1-tuple, or singleton, as a value type.</summary>
+    /// <typeparam name="T1">The type of the tuple's only component.</typeparam>
+    public struct ValueTuple<T1>
+        : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        public ValueTuple(T1 item1)
+        {
+            Item1 = item1;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1> && Equals((ValueTuple<T1>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its field
+        /// is equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1>)) return false;
+
+            var objTuple = (ValueTuple<T1>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1>)other;
+
+            return Comparer<T1>.Default.Compare(Item1, objTuple.Item1);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1> other)
+        {
+            return Comparer<T1>.Default.Compare(Item1, other.Item1);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1>)other;
+
+            return comparer.Compare(Item1, objTuple.Item1);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return EqualityComparer<T1>.Default.GetHashCode(Item1);
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return comparer.GetHashCode(Item1);
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return comparer.GetHashCode(Item1);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1)</c>,
+        /// where <c>Item1</c> represents the value of <see cref="Item1"/>. If the field is <see langword="null"/>,
+        /// it is represented as <see cref="string.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 1;
+    }
+
+    /// <summary>
+    /// Represents a 2-tuple, or pair, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2>
+        : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
+        /// </summary>
+        public T2 Item2;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            Item1 = item1;
+            Item2 = item2;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        ///
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2> && Equals((ValueTuple<T1, T2>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2}"/> instance is equal to a specified <see cref="ValueTuple{T1, T2}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2}"/> instance is equal to a specified object based on a specified comparison method.
+        /// </summary>
+        /// <param name="other">The object to compare with this instance.</param>
+        /// <param name="comparer">An object that defines the method to use to evaluate whether the two objects are equal.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        ///
+        /// <remarks>
+        /// This member is an explicit interface member implementation. It can be used only when the
+        ///  <see cref="ValueTuple{T1, T2}"/> instance is cast to an <see cref="IStructuralEquatable"/> interface.
+        ///
+        /// The <see cref="IEqualityComparer.Equals"/> implementation is called only if <c>other</c> is not <see langword="null"/>,
+        ///  and if it can be successfully cast (in C#) or converted (in Visual Basic) to a <see cref="ValueTuple{T1, T2}"/>
+        ///  whose components are of the same types as those of the current instance. The IStructuralEquatable.Equals(Object, IEqualityComparer) method
+        ///  first passes the <see cref="Item1"/> values of the <see cref="ValueTuple{T1, T2}"/> objects to be compared to the
+        ///  <see cref="IEqualityComparer.Equals"/> implementation. If this method call returns <see langword="true"/>, the method is
+        ///  called again and passed the <see cref="Item2"/> values of the two <see cref="ValueTuple{T1, T2}"/> instances.
+        /// </remarks>
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            return Comparer<T2>.Default.Compare(Item2, other.Item2);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item2, objTuple.Item2);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2)</c>,
+        /// where <c>Item1</c> and <c>Item2</c> represent the values of the <see cref="Item1"/>
+        /// and <see cref="Item2"/> fields. If either field value is <see langword="null"/>,
+        /// it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 2;
+    }
+
+    /// <summary>
+    /// Represents a 3-tuple, or triple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3>
+        : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3> && Equals((ValueTuple<T1, T2, T3>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            return Comparer<T3>.Default.Compare(Item3, other.Item3);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item3, objTuple.Item3);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 3;
+    }
+
+    /// <summary>
+    /// Represents a 4-tuple, or quadruple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4>
+        : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4> && Equals((ValueTuple<T1, T2, T3, T4>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            return Comparer<T4>.Default.Compare(Item4, other.Item4);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item4, objTuple.Item4);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 4;
+    }
+
+    /// <summary>
+    /// Represents a 5-tuple, or quintuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4, T5>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's fifth component.
+        /// </summary>
+        public T5 Item5;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5> && Equals((ValueTuple<T1, T2, T3, T4, T5>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            return Comparer<T5>.Default.Compare(Item5, other.Item5);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item5, objTuple.Item5);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4),
+                                               comparer.GetHashCode(Item5));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 5;
+    }
+
+    /// <summary>
+    /// Represents a 6-tuple, or sixtuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's fifth component.
+        /// </summary>
+        public T5 Item5;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's sixth component.
+        /// </summary>
+        public T6 Item6;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        /// <param name="item6">The value of the tuple's sixth component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5, T6> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5)
+                && EqualityComparer<T6>.Default.Equals(Item6, other.Item6);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5, T6>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5)
+                && comparer.Equals(Item6, objTuple.Item6);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            c = Comparer<T5>.Default.Compare(Item5, other.Item5);
+            if (c != 0) return c;
+
+            return Comparer<T6>.Default.Compare(Item6, other.Item6);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item5, objTuple.Item5);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item6, objTuple.Item6);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                               EqualityComparer<T6>.Default.GetHashCode(Item6));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4),
+                                               comparer.GetHashCode(Item5),
+                                               comparer.GetHashCode(Item6));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 6;
+    }
+
+    /// <summary>
+    /// Represents a 7-tuple, or sentuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
+    /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ITupleInternal
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's fifth component.
+        /// </summary>
+        public T5 Item5;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's sixth component.
+        /// </summary>
+        public T6 Item6;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's seventh component.
+        /// </summary>
+        public T7 Item7;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        /// <param name="item6">The value of the tuple's sixth component.</param>
+        /// <param name="item7">The value of the tuple's seventh component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+            Item7 = item7;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5)
+                && EqualityComparer<T6>.Default.Equals(Item6, other.Item6)
+                && EqualityComparer<T7>.Default.Equals(Item7, other.Item7);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5)
+                && comparer.Equals(Item6, objTuple.Item6)
+                && comparer.Equals(Item7, objTuple.Item7);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            c = Comparer<T5>.Default.Compare(Item5, other.Item5);
+            if (c != 0) return c;
+
+            c = Comparer<T6>.Default.Compare(Item6, other.Item6);
+            if (c != 0) return c;
+
+            return Comparer<T7>.Default.Compare(Item7, other.Item7);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item5, objTuple.Item5);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item6, objTuple.Item6);
+            if (c != 0) return c;
+
+            return comparer.Compare(Item7, objTuple.Item7);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                               EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                               EqualityComparer<T7>.Default.GetHashCode(Item7));
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1),
+                                               comparer.GetHashCode(Item2),
+                                               comparer.GetHashCode(Item3),
+                                               comparer.GetHashCode(Item4),
+                                               comparer.GetHashCode(Item5),
+                                               comparer.GetHashCode(Item6),
+                                               comparer.GetHashCode(Item7));
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6, Item7)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ")";
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ")";
+        }
+
+        int ITupleInternal.Size => 7;
+    }
+
+    /// <summary>
+    /// Represents an 8-tuple, or octuple, as a value type.
+    /// </summary>
+    /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
+    /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
+    /// <typeparam name="T3">The type of the tuple's third component.</typeparam>
+    /// <typeparam name="T4">The type of the tuple's fourth component.</typeparam>
+    /// <typeparam name="T5">The type of the tuple's fifth component.</typeparam>
+    /// <typeparam name="T6">The type of the tuple's sixth component.</typeparam>
+    /// <typeparam name="T7">The type of the tuple's seventh component.</typeparam>
+    /// <typeparam name="TRest">The type of the tuple's eighth component.</typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
+        : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, ITupleInternal
+        where TRest : struct
+    {
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's first component.
+        /// </summary>
+        public T1 Item1;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's second component.
+        /// </summary>
+        public T2 Item2;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's third component.
+        /// </summary>
+        public T3 Item3;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's fourth component.
+        /// </summary>
+        public T4 Item4;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's fifth component.
+        /// </summary>
+        public T5 Item5;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's sixth component.
+        /// </summary>
+        public T6 Item6;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's seventh component.
+        /// </summary>
+        public T7 Item7;
+        /// <summary>
+        /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's eighth component.
+        /// </summary>
+        public TRest Rest;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> value type.
+        /// </summary>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        /// <param name="item3">The value of the tuple's third component.</param>
+        /// <param name="item4">The value of the tuple's fourth component.</param>
+        /// <param name="item5">The value of the tuple's fifth component.</param>
+        /// <param name="item6">The value of the tuple's sixth component.</param>
+        /// <param name="item7">The value of the tuple's seventh component.</param>
+        /// <param name="rest">The value of the tuple's eight component.</param>
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
+        {
+            if (!(rest is ITupleInternal))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleLastArgumentNotAValueTuple);
+            }
+
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+            Item7 = item7;
+            Rest = rest;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified object; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="obj"/> parameter is considered to be equal to the current instance under the following conditions:
+        /// <list type="bullet">
+        ///     <item><description>It is a <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> value type.</description></item>
+        ///     <item><description>Its components are of the same types as those of the current instance.</description></item>
+        ///     <item><description>Its components are equal to those of the current instance. Equality is determined by the default object equality comparer for each component.</description></item>
+        /// </list>
+        /// </remarks>
+        public override bool Equals(object obj)
+        {
+            return obj is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> && Equals((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)obj);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/>
+        /// instance is equal to a specified <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/>.
+        /// </summary>
+        /// <param name="other">The tuple to compare with this instance.</param>
+        /// <returns><see langword="true"/> if the current instance is equal to the specified tuple; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The <paramref name="other"/> parameter is considered to be equal to the current instance if each of its fields
+        /// are equal to that of the current instance, using the default comparer for that field's type.
+        /// </remarks>
+        public bool Equals(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
+        {
+            return EqualityComparer<T1>.Default.Equals(Item1, other.Item1)
+                && EqualityComparer<T2>.Default.Equals(Item2, other.Item2)
+                && EqualityComparer<T3>.Default.Equals(Item3, other.Item3)
+                && EqualityComparer<T4>.Default.Equals(Item4, other.Item4)
+                && EqualityComparer<T5>.Default.Equals(Item5, other.Item5)
+                && EqualityComparer<T6>.Default.Equals(Item6, other.Item6)
+                && EqualityComparer<T7>.Default.Equals(Item7, other.Item7)
+                && EqualityComparer<TRest>.Default.Equals(Rest, other.Rest);
+        }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer)
+        {
+            if (other == null || !(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)) return false;
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;
+
+            return comparer.Equals(Item1, objTuple.Item1)
+                && comparer.Equals(Item2, objTuple.Item2)
+                && comparer.Equals(Item3, objTuple.Item3)
+                && comparer.Equals(Item4, objTuple.Item4)
+                && comparer.Equals(Item5, objTuple.Item5)
+                && comparer.Equals(Item6, objTuple.Item6)
+                && comparer.Equals(Item7, objTuple.Item7)
+                && comparer.Equals(Rest, objTuple.Rest);
+        }
+
+        int IComparable.CompareTo(object other)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other);
+        }
+
+        /// <summary>Compares this instance to a specified instance and returns an indication of their relative values.</summary>
+        /// <param name="other">An instance to compare.</param>
+        /// <returns>
+        /// A signed number indicating the relative values of this instance and <paramref name="other"/>.
+        /// Returns less than zero if this instance is less than <paramref name="other"/>, zero if this
+        /// instance is equal to <paramref name="other"/>, and greater than zero if this instance is greater 
+        /// than <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> other)
+        {
+            int c = Comparer<T1>.Default.Compare(Item1, other.Item1);
+            if (c != 0) return c;
+
+            c = Comparer<T2>.Default.Compare(Item2, other.Item2);
+            if (c != 0) return c;
+
+            c = Comparer<T3>.Default.Compare(Item3, other.Item3);
+            if (c != 0) return c;
+
+            c = Comparer<T4>.Default.Compare(Item4, other.Item4);
+            if (c != 0) return c;
+
+            c = Comparer<T5>.Default.Compare(Item5, other.Item5);
+            if (c != 0) return c;
+
+            c = Comparer<T6>.Default.Compare(Item6, other.Item6);
+            if (c != 0) return c;
+
+            c = Comparer<T7>.Default.Compare(Item7, other.Item7);
+            if (c != 0) return c;
+
+            return Comparer<TRest>.Default.Compare(Rest, other.Rest);
+        }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer)
+        {
+            if (other == null) return 1;
+
+            if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
+            {
+                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+            }
+
+            var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;
+
+            int c = comparer.Compare(Item1, objTuple.Item1);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item2, objTuple.Item2);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item3, objTuple.Item3);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item4, objTuple.Item4);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item5, objTuple.Item5);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item6, objTuple.Item6);
+            if (c != 0) return c;
+
+            c = comparer.Compare(Item7, objTuple.Item7);
+            if (c != 0) return c;
+
+            return comparer.Compare(Rest, objTuple.Rest);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                   EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                   EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                   EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                   EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                   EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                   EqualityComparer<T7>.Default.GetHashCode(Item7));
+            }
+
+            int size = rest.Size;
+            if (size >= 8) { return rest.GetHashCode(); }
+
+            // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
+            int k = 8 - size;
+            switch (k)
+            {
+                case 1:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 2:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 3:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 4:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 5:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 6:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+                case 7:
+                case 8:
+                    return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
+                                                       EqualityComparer<T2>.Default.GetHashCode(Item2),
+                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
+                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
+                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
+                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
+                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                                                       rest.GetHashCode());
+            }
+
+            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            return -1;
+        }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        private int GetHashCodeCore(IEqualityComparer comparer)
+        {
+            // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1), comparer.GetHashCode(Item2), comparer.GetHashCode(Item3),
+                                                   comparer.GetHashCode(Item4), comparer.GetHashCode(Item5), comparer.GetHashCode(Item6),
+                                                   comparer.GetHashCode(Item7));
+            }
+
+            int size = rest.Size;
+            if (size >= 8) { return rest.GetHashCode(comparer); }
+
+            // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
+            int k = 8 - size;
+            switch (k)
+            {
+                case 1:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 2:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item6), comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 3:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item5), comparer.GetHashCode(Item6), comparer.GetHashCode(Item7),
+                                                       rest.GetHashCode(comparer));
+                case 4:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item4), comparer.GetHashCode(Item5), comparer.GetHashCode(Item6),
+                                                       comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 5:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item3), comparer.GetHashCode(Item4), comparer.GetHashCode(Item5),
+                                                       comparer.GetHashCode(Item6), comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+                case 6:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item2), comparer.GetHashCode(Item3), comparer.GetHashCode(Item4),
+                                                       comparer.GetHashCode(Item5), comparer.GetHashCode(Item6), comparer.GetHashCode(Item7),
+                                                       rest.GetHashCode(comparer));
+                case 7:
+                case 8:
+                    return ValueTuple.CombineHashCodes(comparer.GetHashCode(Item1), comparer.GetHashCode(Item2), comparer.GetHashCode(Item3),
+                                                       comparer.GetHashCode(Item4), comparer.GetHashCode(Item5), comparer.GetHashCode(Item6),
+                                                       comparer.GetHashCode(Item7), rest.GetHashCode(comparer));
+            }
+
+            Debug.Assert(false, "Missed all cases for computing ValueTuple hash code");
+            return -1;
+        }
+
+        int ITupleInternal.GetHashCode(IEqualityComparer comparer)
+        {
+            return GetHashCodeCore(comparer);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the value of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.
+        /// </summary>
+        /// <returns>The string representation of this <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance.</returns>
+        /// <remarks>
+        /// The string returned by this method takes the form <c>(Item1, Item2, Item3, Item4, Item5, Item6, Item7, Rest)</c>.
+        /// If any field value is <see langword="null"/>, it is represented as <see cref="String.Empty"/>.
+        /// </remarks>
+        public override string ToString()
+        {
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
+            }
+            else
+            {
+                return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + rest.ToStringEnd();
+            }
+        }
+
+        string ITupleInternal.ToStringEnd()
+        {
+            ITupleInternal rest = Rest as ITupleInternal;
+            if (rest == null)
+            {
+                return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
+            }
+            else
+            {
+                return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + rest.ToStringEnd();
+            }
+        }
+
+        int ITupleInternal.Size
+        {
+            get
+            {
+                ITupleInternal rest = Rest as ITupleInternal;
+                return rest == null ? 8 : 7 + rest.Size;
+            }
+        }
+    }
+}

--- a/src/mscorlib/src/System/ValueTuple.cs
+++ b/src/mscorlib/src/System/ValueTuple.cs
@@ -404,7 +404,7 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return EqualityComparer<T1>.Default.GetHashCode(Item1);
+            return Item1?.GetHashCode() ?? 0;
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -600,8 +600,8 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -804,9 +804,9 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0,
+                                               Item3?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1025,10 +1025,10 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                               EqualityComparer<T4>.Default.GetHashCode(Item4));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0,
+                                               Item3?.GetHashCode() ?? 0,
+                                               Item4?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1265,11 +1265,11 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                               EqualityComparer<T5>.Default.GetHashCode(Item5));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0,
+                                               Item3?.GetHashCode() ?? 0,
+                                               Item4?.GetHashCode() ?? 0,
+                                               Item5?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1524,12 +1524,12 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                               EqualityComparer<T6>.Default.GetHashCode(Item6));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                               Item2?.GetHashCode() ?? 0,
+                                               Item3?.GetHashCode() ?? 0,
+                                               Item4?.GetHashCode() ?? 0,
+                                               Item5?.GetHashCode() ?? 0,
+                                               Item6?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -1802,13 +1802,13 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                               EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                               EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                               EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                               EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                               EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                               EqualityComparer<T7>.Default.GetHashCode(Item7));
+            return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                Item2?.GetHashCode() ?? 0,
+                                                Item3?.GetHashCode() ?? 0,
+                                                Item4?.GetHashCode() ?? 0,
+                                                Item5?.GetHashCode() ?? 0,
+                                                Item6?.GetHashCode() ?? 0,
+                                                Item7?.GetHashCode() ?? 0);
         }
 
         int IStructuralEquatable.GetHashCode(IEqualityComparer comparer)
@@ -2109,13 +2109,13 @@ namespace System
             IValueTupleInternal rest = Rest as IValueTupleInternal;
             if (rest == null)
             {
-                return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                   EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                   EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                   EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                   EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                   EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                   EqualityComparer<T7>.Default.GetHashCode(Item7));
+                return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                 Item2?.GetHashCode() ?? 0,
+                                                 Item3?.GetHashCode() ?? 0,
+                                                 Item4?.GetHashCode() ?? 0,
+                                                 Item5?.GetHashCode() ?? 0,
+                                                 Item6?.GetHashCode() ?? 0,
+                                                 Item7?.GetHashCode() ?? 0);
             }
 
             int size = rest.Length;
@@ -2126,47 +2126,47 @@ namespace System
             switch (k)
             {
                 case 1:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 2:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 3:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 4:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 5:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item3?.GetHashCode() ?? 0,
+                                                       Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 6:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item2?.GetHashCode() ?? 0,
+                                                       Item3?.GetHashCode() ?? 0,
+                                                       Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
                 case 7:
                 case 8:
-                    return ValueTuple.CombineHashCodes(EqualityComparer<T1>.Default.GetHashCode(Item1),
-                                                       EqualityComparer<T2>.Default.GetHashCode(Item2),
-                                                       EqualityComparer<T3>.Default.GetHashCode(Item3),
-                                                       EqualityComparer<T4>.Default.GetHashCode(Item4),
-                                                       EqualityComparer<T5>.Default.GetHashCode(Item5),
-                                                       EqualityComparer<T6>.Default.GetHashCode(Item6),
-                                                       EqualityComparer<T7>.Default.GetHashCode(Item7),
+                    return ValueTuple.CombineHashCodes(Item1?.GetHashCode() ?? 0,
+                                                       Item2?.GetHashCode() ?? 0,
+                                                       Item3?.GetHashCode() ?? 0,
+                                                       Item4?.GetHashCode() ?? 0,
+                                                       Item5?.GetHashCode() ?? 0,
+                                                       Item6?.GetHashCode() ?? 0,
+                                                       Item7?.GetHashCode() ?? 0,
                                                        rest.GetHashCode());
             }
 

--- a/src/mscorlib/src/System/ValueTuple.cs
+++ b/src/mscorlib/src/System/ValueTuple.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using HashHelpers = System.Numerics.Hashing.HashHelpers;
 
 namespace System
 {
@@ -59,7 +60,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return 0;
@@ -84,7 +85,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return 0;
@@ -259,40 +260,37 @@ namespace System
 
         internal static int CombineHashCodes(int h1, int h2)
         {
-            // Forward to helper class in Common for this
-            // We keep the actual hashing logic there, so
-            // other classes can use it for hashing
-            return System.Numerics.Hashing.HashHelpers.Combine(h1, h2);
+            return HashHelpers.Combine(HashHelpers.Combine(HashHelpers.RandomSeed, h1), h2);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2), h3);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3), h4);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3), h4);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4), h5);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4), h5);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5), h6);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5), h6);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6), h7);
         }
 
         internal static int CombineHashCodes(int h1, int h2, int h3, int h4, int h5, int h6, int h7, int h8)
         {
-            return CombineHashCodes(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
+            return HashHelpers.Combine(CombineHashCodes(h1, h2, h3, h4, h5, h6, h7), h8);
         }
     }
 
@@ -363,7 +361,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -390,7 +388,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -555,7 +553,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2>)other);
@@ -583,7 +581,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2>)other;
@@ -753,7 +751,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3>)other);
@@ -784,7 +782,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3>)other;
@@ -968,7 +966,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4>)other);
@@ -1002,7 +1000,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
@@ -1202,7 +1200,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5>)other);
@@ -1239,7 +1237,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
@@ -1455,7 +1453,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6>)other);
@@ -1495,7 +1493,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
@@ -1727,7 +1725,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other);
@@ -1770,7 +1768,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
@@ -1949,7 +1947,7 @@ namespace System
         {
             if (!(rest is IValueTupleInternal))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleLastArgumentNotAValueTuple"));
+                throw new ArgumentException(SR.ArgumentException_ValueTupleLastArgumentNotATuple);
             }
 
             Item1 = item1;
@@ -2024,7 +2022,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other);
@@ -2070,7 +2068,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;

--- a/src/mscorlib/src/System/ValueTuple.cs
+++ b/src/mscorlib/src/System/ValueTuple.cs
@@ -4,9 +4,8 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Numerics.Hashing;
 using System.Runtime.InteropServices;
+using HashHelpers = System.Numerics.Hashing.HashHelpers;
 
 namespace System
 {
@@ -60,7 +59,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return 0;
@@ -85,7 +84,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return 0;
@@ -347,7 +346,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -374,7 +373,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -521,7 +520,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2>)other);
@@ -549,7 +548,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2>)other;
@@ -697,7 +696,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3>)other);
@@ -728,7 +727,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3>)other;
@@ -888,7 +887,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4>)other);
@@ -922,7 +921,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
@@ -1096,7 +1095,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5>)other);
@@ -1133,7 +1132,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
@@ -1321,7 +1320,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6>)other);
@@ -1361,7 +1360,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
@@ -1563,7 +1562,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other);
@@ -1606,7 +1605,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
@@ -1753,7 +1752,7 @@ namespace System
         {
             if (!(rest is ITupleInternal))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleLastArgumentNotAValueTuple);
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleLastArgumentNotAValueTuple"));
             }
 
             Item1 = item1;
@@ -1828,7 +1827,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other);
@@ -1874,7 +1873,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(SR.ArgumentException_ValueTupleIncorrectType, nameof(other));
+                throw new ArgumentException(Environment.GetResourceString("ArgumentException_ValueTupleIncorrectType", this.GetType().ToString()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;


### PR DESCRIPTION
ValueTuple types are supporting the C#7.0 tuples feature. They have been implemented as a standalone CoreFx package, but should be moved down into the various corlibs (mscorlib/desktop and mscorlib/mono are already done) to be consistent with `System.Tuple` and can be used by other APIs.

This PR does not contain `ITuple` yet, but I will push it shortly into this same PR. 
It is an interface in `CompilerServices` namespace used for dynamic pattern matching (in a future version of C#). It applies to `System.Tuple` and `System.ValueTuple` types. It was implemented in mscorlib/desktop, and I'm in the process of implementing it in other corlibs.

The main purpose for opening this PR at this point is to raise two questions: 
1. where should test code for `ValueTuple` go?
2. where is the existing test code for `System.Tuple`? I could not find it.

FYI @tarekgh @VSadov 