### PR TITLE
RyuJIT/ARM32: float/double const for RyuJIT/ARM32

### DIFF
--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -976,6 +976,24 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             info->dstCount = 0;
             break;
 
+        case GT_CNS_DBL:
+            info->srcCount = 0;
+            info->dstCount = 1;
+            if (tree->TypeGet() == TYP_FLOAT)
+            {
+                // An int register for float constant
+                info->internalIntCount = 1;
+            }
+            else
+            {
+                // TYP_DOUBLE
+                noway_assert(tree->TypeGet() == TYP_DOUBLE);
+
+                // Two int registers for double constant
+                info->internalIntCount = 2;
+            }
+            break;
+
         case GT_RETURN:
             TreeNodeInfoInitReturn(tree);
             break;


### PR DESCRIPTION
Related issue: #8496 

Implement float/double const (`GT_CNS_DBL`) generation for ARM32 RyuJIT.


# Example 
Exmple code with `JIT/CodeGenBringUpTests/FPAddConst/FPAddConst.exe`.
I've also tested it with double const value in `JIT/CodeGenBringUpTests/DblAddConst/DblAddConst.exe`.

## Before

```
$ COMPlus_JitDisasm=FPAddConst COMPlus_AltJit=FPAddConst ./corerun ../unittests/Windows_NT.x86.Release.161213.04d6bd10/JIT/CodeGenBringUpTests/FPAddConst/FPAddConst.exe
007 (  1,  1) [000002] -------------             *  dconst    float  1.0000000000000000 REG NA $100

Assert failure(PID 21053 [0x0000523d], Thread: 21053 [0x523d]): Assertion failed 'NYI_ARM: TreeNodeInfoInit default case' in 'BringUpTest:FPAddConst(float):float' (IL size 8)
```

## After
```
$ COMPlus_JitDisasm=FPAddConst COMPlus_AltJit=FPAddConst ./corerun ../unittests/Windows_NT.x86.Release.161213.04d6bd10/JIT/CodeGenBringUpTests/FPAddConst/FPAddConst.exe
; Assembly listing for method BringUpTest:FPAddConst(float):float
; Emitting BLENDED_CODE for generic ARM CPU
; optimized code
; r11 based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,   3  )   float  ->   f0        
;# V01 OutArgs      [V01    ] (  1,   1  )  lclBlk ( 0) [sp+0x00]  
;
; Lcl frame size = 0

G_M51289_IG01:
000000  E92D 4800      push    {r11,lr}
000004  46EB           mov     r11, sp

G_M51289_IG02:
000006  F04F 537E      mov     r3, 0x3f800000
00000A  EE04 3A10      vmov.i2f s8, r3
00000E  EE30 0A04      vadd    s0, s0, s8

G_M51289_IG03:
000012  E8BD 8800      pop     {r11,pc}

; Total bytes of code 22, prolog size 6 for method BringUpTest:FPAddConst(float):float
; ============================================================
2
```

## Legacy JIT
```
$ COMPlus_JitDisasm=FPAddConst ./corerun ../unittests/Windows_NT.x86.Release.161213.04d6bd10/JIT/CodeGenBringUpTests/FPAddConst/FPAddConst.exe
; Assembly listing for method BringUpTest:FPAddConst(float):float
; Emitting BLENDED_CODE for generic ARM CPU
; optimized code
; r11 based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,   3  )   float  ->   f0        
;# V01 OutArgs      [V01    ] (  1,   1  )  lclBlk ( 0) [sp+0x00]  
;
; Lcl frame size = 0

G_M51289_IG01:
000000  E92D 4800      push    {r11,lr}
000004  46EB           mov     r11, sp

G_M51289_IG02:
000006  F04F 537E      mov     r3, 0x3f800000
00000A  EE07 3A90      vmov.i2f s15, r3
00000E  EE30 0A27      vadd    s0, s0, s15

G_M51289_IG03:
000012  E8BD 8800      pop     {r11,pc}

; Total bytes of code 22, prolog size 6 for method BringUpTest:FPAddConst(float):float
; ============================================================
2
```




# Status 
Ran 139 tests of JIT/CodeGenBringUpTests with `COMPlus_JitDump=BringUpTest:* COMPlus_AltJit=BringUpTest:*`.
```
=======================
     Test Results
=======================
# CoreCLR Bin Dir  : 
# Tests Discovered : 139
# Passed           : 61
# Failed           : 78
# Skipped          : 0
=======================
```

## Before : Total 78  assertions,
- **60 of 'NYI_ARM: TreeNodeInfoInit default case' (GT_CNS_DBL is addressed by this PR)**
- 7 of 'NYI: genSetRegToCond'
- 6 of 'NYI: Lowering of long register argument'
- 2 of 'NYI_ARM: fgMorphMultiregStructArgs'
- 1 of 'NYI: Cast'
- 1 of 'NYI: ARM genCallFinally'
- 1 of '!isRegPairType(tree->TypeGet())'

## After: Total 78 assertions.
- **54 of 'NYI: float argument' (NEW)**
- 7 of 'NYI: genSetRegToCond'
- 6 of 'NYI: Lowering of long register argument'
- **4 of 'NYI_ARM: TreeNodeInfoInit default case' (reduced)**
- **2 of 'NYI_ARM: ARM IsContainableImmed for floating point type' (NEW)**
- 2 of 'NYI_ARM: fgMorphMultiregStructArgs'
- 1 of 'NYI: Cast'
- 1 of 'NYI: ARM genCallFinally'
- 1 of '!isRegPairType(tree->TypeGet())'