### PR TITLE
Adjust ref counts during EH normalization

### DIFF
--- a/src/jit/jiteh.cpp
+++ b/src/jit/jiteh.cpp
@@ -2426,6 +2426,11 @@ bool Compiler::fgNormalizeEHCase2()
                                 // this once per dup.
                                 fgReplaceJumpTarget(predBlock, newTryStart, insertBeforeBlk);
 
+                                // Need to adjust ref counts here since we're retargeting edges.
+                                newTryStart->bbRefs++;
+                                noway_assert(insertBeforeBlk->countOfInEdges() > 0);
+                                insertBeforeBlk->bbRefs--;
+
 #ifdef DEBUG
                                 if (verbose)
                                 {

--- a/src/jit/jiteh.cpp
+++ b/src/jit/jiteh.cpp
@@ -2428,7 +2428,7 @@ bool Compiler::fgNormalizeEHCase2()
 
                                 // Need to adjust ref counts here since we're retargeting edges.
                                 newTryStart->bbRefs++;
-                                noway_assert(insertBeforeBlk->countOfInEdges() > 0);
+                                assert(insertBeforeBlk->countOfInEdges() > 0);
                                 insertBeforeBlk->bbRefs--;
 
 #ifdef DEBUG


### PR DESCRIPTION
EH normalization can leave incorrect ref counts. This caused asserts in a few
cases with the forthcoming finally cloning, as these EH related blocks were
exposed to flow optimizations.