### PR TITLE
[Ryujit/ARM32] Implement const, comparion and intrinsic for floating-point

### DIFF
--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -611,7 +611,6 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
 
         var_types argType    = argNode->TypeGet();
         bool      argIsFloat = varTypeIsFloating(argType);
-        NYI_IF(argIsFloat, "float argument");
         callHasFloatRegArgs |= argIsFloat;
 
         regNumber argReg = curArgTabEntry->regNum;
@@ -874,6 +873,27 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             }
             break;
 
+        case GT_INTRINSIC:
+        {
+            // TODO-ARM: Implement other type of intrinsics (round, sqrt and etc.)
+            // Both operand and its result must be of the same floating point type.
+            op1 = tree->gtOp.gtOp1;
+            assert(varTypeIsFloating(op1));
+            assert(op1->TypeGet() == tree->TypeGet());
+
+            switch (tree->gtIntrinsic.gtIntrinsicId)
+            {
+                case CORINFO_INTRINSIC_Abs:
+                    info->srcCount = 1;
+                    info->dstCount = 1;
+                    break;
+                default:
+                    NYI_ARM("Lowering::TreeNodeInfoInit for GT_INRINSIC");
+                    break;
+            }
+        }
+        break;
+
         case GT_CAST:
         {
             info->srcCount = 1;
@@ -995,6 +1015,24 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_PROF_HOOK:
             info->srcCount = 0;
             info->dstCount = 0;
+            break;
+
+        case GT_CNS_DBL:
+            info->srcCount = 0;
+            info->dstCount = 1;
+            if (tree->TypeGet() == TYP_FLOAT)
+            {
+                // An int register for float constant
+                info->internalIntCount = 1;
+            }
+            else
+            {
+                // TYP_DOUBLE
+                assert(tree->TypeGet() == TYP_DOUBLE);
+
+                // Two int registers for double constant
+                info->internalIntCount = 2;
+            }
             break;
 
         case GT_RETURN:
@@ -1201,10 +1239,6 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
 {
     if (varTypeIsFloating(parentNode->TypeGet()))
     {
-        // TODO-ARM-Cleanup: not tested yet.
-        NYI_ARM("ARM IsContainableImmed for floating point type");
-
-        // We can contain a floating point 0.0 constant in a compare instruction
         switch (parentNode->OperGet())
         {
             default:
@@ -1217,7 +1251,12 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
             case GT_GE:
             case GT_GT:
                 if (childNode->IsIntegralConst(0))
+                {
+                    // TODO-ARM-Cleanup: not tested yet.
+                    NYI_ARM("ARM IsContainableImmed for floating point type");
+                    // We can contain a floating point 0.0 constant in a compare instruction
                     return true;
+                }
                 break;
         }
     }


### PR DESCRIPTION
Related issue: #8496

Implement const, comparion and intrinsic for floating-point

- Implement float/double const (`GT_CNS_DBL`) generation for ARM32 RyuJIT.
  GT_CNS_DBL in `CodeGen::genSetRegToConst`  is newly implemented, since ARM requires  temporary registers for conversion.

- Implement binary operators for floating point for ARM32 RyuJIT
  GT_ADD, GT_SUB, GT_MUL in `CodeGen::genCodeForTreeNode` is update to handle floating point types with new implementation.

- Implement of GT_INTRINSIC for ARM32 RyuJIT
  `Lowering::TreeNodeInfoInit(GenTree* tree)` in `lowerarm.cpp` is adopted from lowerarm64.cpp with modification.
  `CodeGen::genIntrinsic(GenTreePtr treeNode)` in `codegenarm.cpp` is adopted from codegenarm64.cpp with additional NYI assertions.

- Implement comparison (e.g. GT_GT and etc.) for floating-point
  GT_EQ, GT_NE, GT_LT, GT_LE, GT_GE, GT_GT in `CodeGen::genCodeForTreeNode (codegenarm.cpp)` is adopted from `codegenarm64.cpp`, but most of implementation are rewritten for floating point type, since we cannot use arm64 logic.

Now we can pass `FPAddConst.exe` and more tests from `JIT/CodeGenBringUpTests`  with RyuJIT/ARM32. (Total 15 more tests.)

# Example
## Before

```
$ COMPlus_JitDisasm=FPAddConst COMPlus_AltJit=FPAddConst ./corerun ../unittests/Windows_NT.x86.Release.161213.04d6bd10/JIT/CodeGenBringUpTests/FPAddConst/FPAddConst.exe
007 (  1,  1) [000002] -------------             *  dconst    float  1.0000000000000000 REG NA $100

Assert failure(PID 21053 [0x0000523d], Thread: 21053 [0x523d]): Assertion failed 'NYI_ARM: TreeNodeInfoInit default case' in 'BringUpTest:FPAddConst(float):float' (IL size 8)
```


## After
```
$ COMPlus_JitDisasm=BringUpTest:* COMPlus_AltJit=BringUpTest:* ../Windows_NT.x86.Release.161213.04d6bd10/JIT/CodeGenBringUpTests/FPAddConst/FPAddConst.exe
; Assembly listing for method BringUpTest:Main():int
; Emitting BLENDED_CODE for generic ARM CPU
; optimized code
; r11 based frame
; partially interruptible
; Final local variable assignments
;
;  V00 loc0         [V00,T00] (  3,   3  )   float  ->  [sp+0x04]  
;# V01 OutArgs      [V01    ] (  1,   1  )  lclBlk ( 0) [sp+0x00]  
;
; Lcl frame size = 8
G_M15680_IG01:
000000  E92D 480C      push    {r2,r3,r11,lr}
000004  F10D 0B08      add     r11, sp, 8
G_M15680_IG02:
000008  F04F 537E      mov     r3, 0x3f800000
00000C  EE00 3A10      vmov.i2f s0, r3
000010  F240 0339      movw    r3, 0x39
000014  F2C7 13BF      movt    r3, 0x71bf
000018  4798           blx     r3               // BringUpTest:FPAddConst(float):float
00001A  ED8D 0A01      vstr    s0, [sp+0x04]    // [V00 loc0]
00001E  F240 13F5      movw    r3, 0x1f5
000022  F2C7 13BF      movt    r3, 0x71bf
000026  4798           blx     r3               // System.Console:WriteLine(float)
000028  F04F 4080      mov     r0, 0x40000000
00002C  EE04 0A10      vmov.i2f s8, r0
000030  ED9D 0A01      vldr    s0, [sp+0x04]    // [V00 loc0]
000034  EE30 4A44      vsub    s8, s0, s8
000038  EEB0 4AC4      vabs    s8, s8
00003C  2001           movs    r0, 1
00003E  EE04 0A90      vmov.i2f s9, r0
000042  EEB4 4A64      vcmp    s8, s9
000046  EEF1 FA10      vmrs    APSR, FPSCR
00004A  D802           bhi     SHORT G_M15680_IG04
00004C  2064           movs    r0, 100
G_M15680_IG03:
00004E  E8BD 880C      pop     {r2,r3,r11,pc}
G_M15680_IG04:
000052  F04F 30FF      mov     r0, -1
G_M15680_IG05:
000056  E8BD 880C      pop     {r2,r3,r11,pc}

; Total bytes of code 90, prolog size 8 for method BringUpTest:Main():int
; ============================================================
; Assembly listing for method BringUpTest:FPAddConst(float):float
; Emitting BLENDED_CODE for generic ARM CPU
; optimized code
; r11 based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,   3  )   float  ->   f0        
;# V01 OutArgs      [V01    ] (  1,   1  )  lclBlk ( 0) [sp+0x00]  
;
; Lcl frame size = 0
G_M51289_IG01:
000000  E92D 4800      push    {r11,lr}
000004  46EB           mov     r11, sp
G_M51289_IG02:
000006  F04F 537E      mov     r3, 0x3f800000
00000A  EE04 3A10      vmov.i2f s8, r3
00000E  EE30 0A04      vadd    s0, s0, s8
G_M51289_IG03:
000012  E8BD 8800      pop     {r11,pc}
; Total bytes of code 22, prolog size 6 for method BringUpTest:FPAddConst(float):float
; ============================================================
2
```

# Status
Test result from 139 tests from `JIT/CodeGenBringUpTests`  with `COMPlus_JitDisasm=BringUpTest:* COMPlus_AltJit=BringUpTest:*`

## Before
```
=======================
     Test Results
=======================
# CoreCLR Bin Dir  : 
# Tests Discovered : 139
# Passed           : 61
# Failed           : 78
# Skipped          : 0
=======================
```
All 78 failures are `Assert failure` as follows.
- **60 of 'NYI_ARM: TreeNodeInfoInit default case' (GT_CNS_DBL is addressed by this PR)**
- 7 of 'NYI: genSetRegToCond'
- 6 of 'NYI: Lowering of long register argument'
- 2 of 'NYI_ARM: fgMorphMultiregStructArgs'
- 1 of 'NYI: Cast'
- 1 of 'NYI: ARM genCallFinally'
- 1 of '!isRegPairType(tree->TypeGet())'

## After : 15 more tests are PASSED.
```
=======================
Test Results
=======================
# CoreCLR Bin Dir : 
# Tests Discovered : 139
# Passed : 76
# Failed : 63
# Skipped : 0
=======================
```

All 63 failures are `Assert failure` as follows.
- 29 of 'assignedInterval != nullptr' (NEW)
- 7 of 'NYI: GT_DIV' (NEW)
- 4 of 'NYI_ARM: TreeNodeInfoInit default case' (NEW)
- 2 of '!"Unexpected instruction"' (NEW)
- 2 of 'NYI_ARM: Lowering for cast from float'  (NEW)
- 1 of 'NYI_ARM: GT_LEA: index and cns are not nil' (NEW)
- 7 of 'NYI: genSetRegToCond'  (no change)
- 6 of 'NYI: Lowering of long register argument' (no change)
- 2 of 'NYI_ARM: fgMorphMultiregStructArgs' (no change)
- 1 of 'NYI: Cast' (no change)
- 1 of 'NYI: ARM genCallFinally' (no change)
- 1 of '!isRegPairType(tree->TypeGet())' (no change) 