### PR TITLE
Fix gtDispLIRNode space alignment.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11955,6 +11955,10 @@ void Compiler::gtDispLIRNode(GenTree* node)
 
         // 49 spaces for alignment
         printf("%-49s", "");
+#ifdef FEATURE_SET_FLAGS
+        // additional flag enlarges the flag field by one character
+        printf(" ");
+#endif
 
         indentStack.Push(operandArc);
         indentStack.print();


### PR DESCRIPTION
JIT dumps on Linux/ARM currently look like this (note the operands are off by one character to the left):
```
                                                 ┌──▌  t4     int    
                                                 ├──▌  t33    int    
               [000034] -------------       t34 = ▌  gt_long   long  
```
The cause is [Compiler::gtDispLIRNode::displayOperand](https://github.com/dotnet/coreclr/blob/94502643d53d5ded7542d9ed883a45be06fdf6e7/src/jit/gentree.cpp#L11956-L11957) has a hardcoded value for the number of spaces to display:
```c++
        // 49 spaces for alignment
        printf("%-49s", "");
```
`TARGET_ARM` and `TARGET_ARM64` have `FEATURE_SET_FLAGS` turned on, which enlarges the flags field by one char and breaks the alignment. The PR being proposed fixes that:
```
                                                  ┌──▌  t4     int    
                                                  ├──▌  t33    int    
               [000034] -------------       t34 = ▌  gt_long   long  
```