### PR TITLE
Fix order of raising AssemblyLoadContext.Unloading and AppDomain.Proc…

### DIFF
--- a/src/mscorlib/src/System/AppContext/AppContext.cs
+++ b/src/mscorlib/src/System/AppContext/AppContext.cs
@@ -19,6 +19,16 @@ namespace System
         }
         private static readonly Dictionary<string, SwitchValueState> s_switchMap = new Dictionary<string, SwitchValueState>();
 
+        static AppContext()
+        {
+            // Unloading event must happen before ProcessExit event
+            AppDomain.CurrentDomain.ProcessExit += OnUnloading;
+            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+
+            // populate the AppContext with the default set of values
+            AppContextDefaultValues.PopulateDefaultValues();
+        }
+
         public static string BaseDirectory
         {
             get
@@ -73,25 +83,28 @@ namespace System
             }  
         }  
 
-        public static event System.EventHandler ProcessExit
-        {  
-            add  
-            {  
-                AppDomain.CurrentDomain.ProcessExit += value;  
-            }  
-            remove  
-            {  
-                AppDomain.CurrentDomain.ProcessExit -= value;  
-            }  
+        public static event System.EventHandler ProcessExit;
+        public static event System.EventHandler Unloading;
+
+        private static void OnProcessExit(object sender, EventArgs e)
+        {
+            var processExit = ProcessExit;
+            if (processExit != null)
+            {
+                processExit(null, EventArgs.Empty);
+            }
+        }
+
+        private static void OnUnloading(object sender, EventArgs e)
+        {
+            var unloading = Unloading;
+            if (unloading != null)
+            {
+                unloading(null, EventArgs.Empty);
+            }
         }
 
         #region Switch APIs
-        static AppContext()
-        {
-            // populate the AppContext with the default set of values
-            AppContextDefaultValues.PopulateDefaultValues();
-        }
-
         /// <summary>
         /// Try to get the value of the switch.
         /// </summary>

--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -75,7 +75,7 @@ namespace System.Runtime.Loader
             // Since unloading an AssemblyLoadContext is not yet implemented, this is a temporary solution to raise the
             // Unloading event on process exit. Register for the current AppDomain's ProcessExit event, and the handler will in
             // turn raise the Unloading event.
-            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+            AppContext.Unloading += OnAppContextUnloading;
         }
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -446,7 +446,7 @@ namespace System.Runtime.Loader
 #endif // FEATURE_MULTICOREJI
         }
 
-        private void OnProcessExit(object sender, EventArgs e)
+        private void OnAppContextUnloading(object sender, EventArgs e)
         {
             var unloading = Unloading;
             if (unloading != null)


### PR DESCRIPTION
…essExit

The AssemblyLoadContext.Unloading event must be raised before the AppDomain.ProcessExit event.
AssemblyLoadContext.OnUnloading now subscribes to AppContext.Unloading.
Then AppContext.OnAppContextUnloading and AppContext.OnProcessExit, in that order, subscribe to AppDomain.ProcessExit.
Fixes dotnet/corefx#14566