### PR TITLE
[WIP] Removes unnecessary shift count masking

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4592,6 +4592,7 @@ private:
 
     GenTreePtr fgMorphToEmulatedFP(GenTreePtr tree);
     GenTreePtr fgMorphConst(GenTreePtr tree);
+    GenTree* fgMorphShiftCount(GenTreeOp* shift);
 
 public:
     GenTreePtr fgMorphTree(GenTreePtr tree, MorphAddrContext* mac = nullptr);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13919,7 +13919,13 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
 
             break;
 
+        case GT_RSH:
+        case GT_RSZ:
+            op2 = fgMorphShiftCount(tree);
+            break;
+
         case GT_LSH:
+            op2 = fgMorphShiftCount(tree);
 
             /* Check for the case "(val + icon) << icon" */
 
@@ -14326,6 +14332,42 @@ GenTreePtr Compiler::fgRecognizeAndMorphBitwiseRotation(GenTreePtr tree)
     }
 #endif // LEGACY_BACKEND
     return tree;
+}
+
+//------------------------------------------------------------------------------
+// fgMorphShiftCount : Removes unnecessary shift count masking on architectures
+//                     (x86, x64) which do masking in their shift instructions.
+//
+// Arguments:
+//    shift - Shift operator node
+//
+// Return Value:
+//    The updated shift count operand or the original operand if the optimization
+//    could not be performed.
+//
+// Assumption:
+//    The input node operator is a shift (GT_LSH, GT_RSH, GT_RSZ).
+//
+// Notes:
+//    The shift node count operand is updated if the optimization is performed.
+//    The shift node type is used to determine the appropiate mask.
+
+GenTree* Compiler::fgMorphShiftCount(GenTreeOp* shift)
+{
+    assert(shift->OperGet() == GT_LSH || shift->OperGet() == GT_RSH || shift->OperGet() == GT_RSZ);
+
+    GenTree* shiftCount = shift->gtGetOp2();
+    size_t   mask       = getShiftCountMask<size_t>(genTypeSize(shift));
+
+    while ((shiftCount->OperGet() == GT_AND) && shiftCount->gtGetOp2()->IsCnsIntOrI() &&
+           ((mask & static_cast<size_t>(shiftCount->gtGetOp2()->AsIntCon()->IconValue())) == mask))
+    {
+        shift->gtOp2 = shiftCount->gtGetOp1();
+        DEBUG_DESTROY_NODE(shiftCount);
+        shiftCount = shift->gtGetOp2();
+    }
+
+    return shiftCount;
 }
 
 #if !CPU_HAS_FP_SUPPORT

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -335,6 +335,8 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define ROUND_FLOAT              1       // round intermed float expression results
   #define CPU_HAS_BYTE_REGS        1
   #define CPU_USES_BLOCK_MOVE      1 
+  #define CPU_HAS_MASKED_SHIFT32   1
+  #define CPU_HAS_MASKED_SHIFT64   0       // x86's 64 bit shift helpers do not mask the shift count
 
 #ifndef LEGACY_BACKEND
   // TODO-CQ: Fine tune the following xxBlk threshold values:
@@ -706,6 +708,8 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define ROUND_FLOAT              0       // Do not round intermed float expression results
   #define CPU_HAS_BYTE_REGS        0
   #define CPU_USES_BLOCK_MOVE      1 
+  #define CPU_HAS_MASKED_SHIFT32   1
+  #define CPU_HAS_MASKED_SHIFT64   1
 
   #define CPBLK_MOVS_LIMIT         16      // When generating code for CpBlk, this is the buffer size 
                                            // threshold to stop generating rep movs and switch to the helper call.
@@ -1170,6 +1174,8 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define ROUND_FLOAT              0       // Do not round intermed float expression results
   #define CPU_HAS_BYTE_REGS        0
   #define CPU_USES_BLOCK_MOVE      0
+  #define CPU_HAS_MASKED_SHIFT32   0
+  #define CPU_HAS_MASKED_SHIFT64   0
   #define FEATURE_WRITE_BARRIER    1       // Generate the proper WriteBarrier calls for GC    
   #define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
   #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers
@@ -2319,6 +2325,26 @@ inline bool isFloatRegType(int /* s/b "var_types" */ type)
 #else
     return false;
 #endif
+}
+
+template <typename TSize>
+inline TSize getShiftCountMask(size_t operandByteSize)
+{
+    switch (operandByteSize)
+    {
+#if CPU_HAS_MASKED_SHIFT64
+        case 8:
+            return static_cast<TSize>(0x3f);
+#endif
+
+#if CPU_HAS_MASKED_SHIFT32
+        case 4:
+            return static_cast<TSize>(0x1f);
+#endif
+
+        default:
+            return static_cast<TSize>(-1);
+    }
 }
 
 // If the WINDOWS_AMD64_ABI is defined make sure that _TARGET_AMD64_ is also defined.

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -345,17 +345,17 @@ T ValueNumStore::EvalOpIntegral(VNFunc vnf, T v0, T v1, ValueNum* pExcSet)
         case GT_AND:
             return v0 & v1;
         case GT_LSH:
-            return v0 << v1;
+            return v0 << (v1 & getShiftCountMask<T>(sizeof(T)));
         case GT_RSH:
-            return v0 >> v1;
+            return v0 >> (v1 & getShiftCountMask<T>(sizeof(T)));
         case GT_RSZ:
             if (sizeof(T) == 8)
             {
-                return UINT64(v0) >> v1;
+                return UINT64(v0) >> (v1 & getShiftCountMask<T>(sizeof(T)));
             }
             else
             {
-                return UINT32(v0) >> v1;
+                return UINT32(v0) >> (v1 & getShiftCountMask<T>(sizeof(T)));
             }
         case GT_ROL:
             if (sizeof(T) == 8)


### PR DESCRIPTION
The C# compiler translates code like `x << y` to `x << (y & 31)` because the behavior of IL shift operations is unspecified if the shift count is greater than or equal to the bit width of the shifted value. However, x86/x64 shift instructions do mask the shift count so the `& 31` is redundant.

Contributes to #1741
