### PR TITLE
Fix rootfs script: lldb package

### DIFF
--- a/cross/arm-softfp/sources.list.jessie
+++ b/cross/arm-softfp/sources.list.jessie
@@ -1,6 +1,3 @@
-# Debian (sid)   # UNSTABLE
-deb http://ftp.debian.org/debian/ sid main contrib non-free
-deb-src http://ftp.debian.org/debian/ sid main contrib non-free
-
-deb http://ftp.debian.org/debian/ stable main contrib non-free
-deb-src http://ftp.debian.org/debian/ stable main contrib non-free
+# Debian (jessie)   # Stable
+deb http://ftp.debian.org/debian/ jessie main contrib non-free
+deb-src http://ftp.debian.org/debian/ jessie main contrib non-free

--- a/cross/arm-softfp/sources.list.jessie
+++ b/cross/arm-softfp/sources.list.jessie
@@ -1,3 +1,6 @@
 # Debian (sid)   # UNSTABLE
 deb http://ftp.debian.org/debian/ sid main contrib non-free
 deb-src http://ftp.debian.org/debian/ sid main contrib non-free
+
+deb http://ftp.debian.org/debian/ stable main contrib non-free
+deb-src http://ftp.debian.org/debian/ stable main contrib non-free

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -79,6 +79,10 @@ for i in "$@"
     esac
 done
 
+if [ "$__BuildArch" == "arm-softfp" ]; then
+     __LLDB_Package="lldb-3.5-dev"
+fi
+
 __RootfsDir="$__CrossDir/rootfs/$__BuildArch"
 __UbuntuPackages="$__UbuntuPackagesBase $__LLDB_Package"
 


### PR DESCRIPTION
lldb package only usable lldb-3.5-dev for jessie/arm-softfp
We cannot get lldb-3.6-dev or lldb-3.8-dev from jessie/arm-softfp repository

related issue: #8746