### PR TITLE
Add CORE_LIBRARIES to the TPA list if it's set in unixcoreruncommon

### DIFF
--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -321,7 +321,10 @@ int ExecuteManagedAssembly(
     {
         nativeDllSearchDirs.append(":");
         nativeDllSearchDirs.append(coreLibraries);
-        AddFilesFromDirectoryToTpaList(coreLibraries, tpaList);
+        if (std::strcmp(coreLibraries, clrFilesAbsolutePath) != 0)
+        {
+            AddFilesFromDirectoryToTpaList(coreLibraries, tpaList);
+        }
     }
     nativeDllSearchDirs.append(":");
     nativeDllSearchDirs.append(clrFilesAbsolutePath);

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -313,6 +313,7 @@ int ExecuteManagedAssembly(
     std::string appPath;
     GetDirectory(managedAssemblyAbsolutePath, appPath);
 
+    std::string tpaList;
     // Construct native search directory paths
     std::string nativeDllSearchDirs(appPath);
     char *coreLibraries = getenv("CORE_LIBRARIES");
@@ -320,11 +321,11 @@ int ExecuteManagedAssembly(
     {
         nativeDllSearchDirs.append(":");
         nativeDllSearchDirs.append(coreLibraries);
+        AddFilesFromDirectoryToTpaList(coreLibraries, tpaList);
     }
     nativeDllSearchDirs.append(":");
     nativeDllSearchDirs.append(clrFilesAbsolutePath);
 
-    std::string tpaList;
     AddFilesFromDirectoryToTpaList(clrFilesAbsolutePath, tpaList);
 
     void* coreclrLib = dlopen(coreClrDllPath.c_str(), RTLD_NOW | RTLD_LOCAL);


### PR DESCRIPTION
https://github.com/dotnet/coreclr/pull/5112 added basic support for the `CORE_LIBRARIES` environment variable in the Unix version of corerun, but unlike the Windows version of CoreRun, that environment variable is not added to the TPA list, so managed assemblies can't be loaded from the extra folder. This simple change synchronizes that behavior so that both platforms behave the same when that environment variable is set.

@adityamandaleeka @gkhanna79 @janvorli 

