### PR TITLE
Remove dead parameter in value-numbering

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3780,13 +3780,8 @@ public:
 
     // Utility functions for fgValueNumber.
 
-    // Perform value-numbering for the trees in "blk".  When giving VN's to the SSA
-    // names defined by phi definitions at the start of "blk", "newVNsForPhis" indicates
-    // that these should be given new VN's, irrespective of the values of the LHS.
-    // If "false", then we may assume that all inputs to phi RHS's of such definitions
-    // have already been assigned value numbers; if they are all assigned the *same* value
-    // number, then the LHS SSA name gets the same VN.
-    void fgValueNumberBlock(BasicBlock* blk, bool newVNsForPhis);
+    // Perform value-numbering for the trees in "blk".
+    void fgValueNumberBlock(BasicBlock* blk);
 
     // Requires that "entryBlock" is the entry block of loop "loopNum", and that "loopNum" is the
     // innermost loop of which "entryBlock" is the entry.  Returns the value number that should be

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -4329,7 +4329,7 @@ void Compiler::fgValueNumber()
         while (vs.m_toDoAllPredsDone.Size() > 0)
         {
             BasicBlock* toDo = vs.m_toDoAllPredsDone.Pop();
-            fgValueNumberBlock(toDo, /*newVNsForPhis*/ false);
+            fgValueNumberBlock(toDo);
             // Record that we've visited "toDo", and add successors to the right sets.
             vs.FinishVisit(toDo);
         }
@@ -4344,7 +4344,7 @@ void Compiler::fgValueNumber()
                 continue; // We may have run out, because of completed blocks on the not-all-preds done list.
             }
 
-            fgValueNumberBlock(toDo, /*newVNsForPhis*/ true);
+            fgValueNumberBlock(toDo);
             // Record that we've visited "toDo", and add successors to the right sest.
             vs.FinishVisit(toDo);
         }
@@ -4357,7 +4357,7 @@ void Compiler::fgValueNumber()
     fgVNPassesCompleted++;
 }
 
-void Compiler::fgValueNumberBlock(BasicBlock* blk, bool newVNsForPhis)
+void Compiler::fgValueNumberBlock(BasicBlock* blk)
 {
     compCurBB = blk;
 


### PR DESCRIPTION
Parameter `newVNsForPhis` of method `fgValueNumberBasicBlocks` is unused;
its presence and comment are confusing/misleading.  What actually happens
is that `fgValueNumberBlock` itself checks whether the value numbers for
incoming Phi args' SSA defs are defined yet or not.