### PR TITLE
Fix heap live-in calculation

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4722,21 +4722,6 @@ void Compiler::ResetOptAnnotations()
                 tree->ClearVN();
                 tree->ClearAssertion();
                 tree->gtCSEnum = NO_CSE;
-
-                // Clear any *_ASG_LHS flags -- these are set during SSA construction,
-                // and the heap live-in calculation depends on them being unset coming
-                // into SSA construction (without clearing them, a block that has a
-                // heap def via one of these before any heap use is treated as not having
-                // an upwards-exposed heap use, even though subsequent heap uses may not
-                // be killed by the store; this seems to be a bug, worked around here).
-                if (tree->OperIsIndir())
-                {
-                    tree->gtFlags &= ~GTF_IND_ASG_LHS;
-                }
-                else if (tree->OperGet() == GT_CLS_VAR)
-                {
-                    tree->gtFlags &= ~GTF_CLS_VAR_ASG_LHS;
-                }
             }
         }
     }

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -328,7 +328,7 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree, GenTree* asgdLclVar)
             }
             // If the GT_CLS_VAR is the lhs of an assignment, we'll handle it as a heap def, when we get to assignment.
             // Otherwise, we treat it as a use here.
-            if (!fgCurHeapDef && (tree->gtFlags & GTF_CLS_VAR_ASG_LHS) == 0)
+            if ((tree->gtFlags & GTF_CLS_VAR_ASG_LHS) == 0)
             {
                 fgCurHeapUse = true;
             }
@@ -381,10 +381,7 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree, GenTree* asgdLclVar)
         case GT_XADD:
         case GT_XCHG:
         case GT_CMPXCHG:
-            if (!fgCurHeapDef)
-            {
-                fgCurHeapUse = true;
-            }
+            fgCurHeapUse   = true;
             fgCurHeapDef   = true;
             fgCurHeapHavoc = true;
             break;
@@ -410,10 +407,7 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree, GenTree* asgdLclVar)
             }
             if (modHeap)
             {
-                if (!fgCurHeapDef)
-                {
-                    fgCurHeapUse = true;
-                }
+                fgCurHeapUse   = true;
                 fgCurHeapDef   = true;
                 fgCurHeapHavoc = true;
             }


### PR DESCRIPTION
Update the code in liveness that sets the `fgCurHeapUse` flag (which needs
to identify whether the current block has an upwards-exposed use of the
heap) to set this unconditionally for opcodes that use the heap.
Previously, this code was avoiding setting the flag if the block has a
prior def of the heap, but in the absence of a guarantee to the contrary,
we must assume that the heap use may not alias the heap def, and so still
be upwards-exposed and cause the heap to be live-in to the block.

Also remove the OptRepeat workaround for the lack of this, in
`ResetOptAnnotations`.

Fixes #7846.