### PR TITLE
Update PATENTS.TXT

### DIFF
--- a/PATENTS.TXT
+++ b/PATENTS.TXT
@@ -2,8 +2,8 @@
 
 Microsoft Corporation and its affiliates ("Microsoft") promise not to assert 
 any .NET Patents against you for making, using, selling, offering for sale, 
-importing, or distributing Covered Code, as part of either a .NET Runtime or 
-as part of any application designed to run on a .NET Runtime. 
+importing, or distributing Covered Code, a portion thereof, or a 
+derivative work thereof.
 
 If you file, maintain, or voluntarily participate in any claim in a lawsuit 
 alleging direct or contributory patent infringement by any Covered Code, or 
@@ -32,14 +32,6 @@ Patents do not include any patent claims that are infringed by any Enabling
 Technology, that are infringed only as a consequence of modification of 
 Covered Code, or that are infringed only by the combination of Covered Code 
 with third party code. 
-
-".NET Runtime" means any compliant implementation in software of (a) all of 
-the required parts of the mandatory provisions of Standard ECMA-335 – Common 
-Language Infrastructure (CLI); and (b) if implemented, any additional 
-functionality in Microsoft's .NET Framework, as described in Microsoft's API 
-documentation on its MSDN website. For example, .NET Runtimes include 
-Microsoft's .NET Framework and those portions of the Mono Project compliant 
-with (a) and (b). 
 
 "Enabling Technology" means underlying or enabling technology that may be 
 used, combined, or distributed in connection with Microsoft's .NET Framework 


### PR DESCRIPTION
Rationale: The "as part of" conditions don't make sense, rely on an **impossible-to-evaluate ".NET Runtime" definition**, and — I'm told by people who should know — were not *intended* to limit the scope of the license. More info at #375

Based on that information, I suggest the removal of any mention of the .NET Runtime, and the replacement of these unintentional conditions with an an unambiguous **"Covered Code, a portion thereof, or a derivative work thereof."**, which should cover all use cases that the original version intended (but failed) to include with the "as  part of" phrasing. 

Fixes #375

There is also a nitpick in the definition of ".NET Patents", as it unconditionally excludes from this promise any patent claims infringed by "Enabling Technology", which would be alright — except the definition thereof includes "applications that run on the .NET Framework". It's unlikely that the intent here could be misconstrued, but there is shorter, simpler and clearly way to say this: 

**".NET Patents" are those patent claims, both currently owned by Microsoft and 
acquired in the future, that are necessarily infringed by Covered Code.**

This is a *non-assertion promise* and not a *patent license*, there's no need for so many conditions. If a present or future Microsoft patent claim is *necessarily* infringed by Covered Code, then it's relevant to our concerns as an open-source community - full stop. Or can someone provide a counterexample?