### PR TITLE
ArrayPool fixes

### DIFF
--- a/src/mscorlib/corefx/System/Buffers/ArrayPool.cs
+++ b/src/mscorlib/corefx/System/Buffers/ArrayPool.cs
@@ -29,26 +29,13 @@ namespace System.Buffers
         /// array than was requested. Renting a buffer from it with <see cref="Rent"/> will result in an 
         /// existing buffer being taken from the pool if an appropriate buffer is available or in a new 
         /// buffer being allocated if one is not available.
+        /// byte[] and char[] are the most commonly pooled array types. For these we use a special pool type
+        /// optimized for very fast access speeds, at the expense of more memory consumption.
+        /// The shared pool instance is created lazily on first access.
         /// </remarks>
-        public static ArrayPool<T> Shared => SharedPool.Value;
-
-        /// <summary>Stores a cached pool instance for T[].</summary>
-        /// <remarks>
-        /// Separated out into a nested class to enable lazy-initialization of the pool provided by
-        /// the runtime, only forced when Shared is used (and not when Create is called or when
-        /// other non-Shared accesses happen).
-        /// </remarks>
-        private static class SharedPool
-        {
-            /// <summary>Per-type cached pool.</summary>
-            /// <remarks>
-            /// byte[] and char[] are the most commonly pooled array types. For these we use a special pool type
-            /// optimized for very fast access speeds, at the expense of more memory consumption.
-            /// </remarks>
-            internal readonly static ArrayPool<T> Value =
-                typeof(T) == typeof(byte) || typeof(T) == typeof(char) ? new TlsOverPerCoreLockedStacksArrayPool<T>() :
-                Create();
-        }
+        public static ArrayPool<T> Shared { get; } =
+            typeof(T) == typeof(byte) || typeof(T) == typeof(char) ? new TlsOverPerCoreLockedStacksArrayPool<T>() :
+            Create();
 
         /// <summary>
         /// Creates a new <see cref="ArrayPool{T}"/> instance using default configuration options.

--- a/src/mscorlib/corefx/System/Buffers/ConfigurableArrayPool.cs
+++ b/src/mscorlib/corefx/System/Buffers/ConfigurableArrayPool.cs
@@ -70,7 +70,7 @@ namespace System.Buffers
             {
                 // No need for events with the empty array.  Our pool is effectively infinite
                 // and we'll never allocate for rents and never store for returns.
-                return EmptyArray<T>.Value;
+                return Array.Empty<T>();
             }
 
             var log = ArrayPoolEventSource.Log;

--- a/src/mscorlib/corefx/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/mscorlib/corefx/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -80,7 +80,7 @@ namespace System.Buffers
             {
                 // No need to log the empty array.  Our pool is effectively infinite
                 // and we'll never allocate for rents and never store for returns.
-                return EmptyArray<T>.Value;
+                return Array.Empty<T>();
             }
 
             ArrayPoolEventSource log = ArrayPoolEventSource.Log;

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -1168,7 +1168,7 @@ namespace System {
             Debug.Assert(ExecutionIdRefreshRate <= ExecutionIdCacheCountDownMask);
 
             // Mask with Int32.MaxValue to ensure the execution Id is not negative
-            t_executionIdCache = ((executionId << ExecutionIdCacheShift) & Int32.MaxValue) + ExecutionIdRefreshRate;
+            t_executionIdCache = ((executionId << ExecutionIdCacheShift) & Int32.MaxValue) | ExecutionIdRefreshRate;
 
             return executionId;
         }


### PR DESCRIPTION
- Use Array.Empty<T>() to make the code identical to CoreRT copy
- Remove unnecessary helper type for lazy initialization
- Use | for clarity