### PR TITLE
Add Tizen rootfs for armel

### DIFF
--- a/cross/armel/tizen-build-rootfs.sh
+++ b/cross/armel/tizen-build-rootfs.sh
@@ -17,64 +17,15 @@ if [ -d "$ROOTFS_DIR" ]; then
 fi
 
 TIZEN_TMP_DIR=$ROOTFS_DIR/tizen_tmp
-TIZEN_TMP_DOWNLOAD_DIR=$TIZEN_TMP_DIR/download
-TIZEN_TMP_UNZIP_DIR=$TIZEN_TMP_DIR/unzip
-mkdir -p $TIZEN_TMP_DOWNLOAD_DIR
-mkdir -p $TIZEN_TMP_UNZIP_DIR
-
-download_files()
-{
-    # TODO: There will be a stable Tizen rootfs available later.
-    # Now we temporarily use live repo for developing dotnet for Tizen
-
-    TIZEN_DOWNLOAD_OPTIONS="-P $TIZEN_TMP_DOWNLOAD_DIR"
-    TIZEN_DOWNLOAD_CMD="wget $TIZEN_DOWNLOAD_OPTIONS"
-
-    TIZEN_BASE_ARM="http://download.tizen.org/releases/weekly/tizen/base/latest/repos/arm/packages/armv7l"
-    TIZEN_BASE_NOARCH="http://download.tizen.org/releases/weekly/tizen/base/latest/repos/arm/packages/noarch"
-    TIZEN_MOBILE_ARM="http://download.tizen.org/releases/weekly/tizen/mobile/latest/repos/arm-wayland/packages/armv7l"
-
-    # 1. basse packages
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/gcc-4.9.2-15.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/glibc-2.20-12.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/glibc-devel-2.20-12.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_NOARCH/linux-glibc-devel-3.10-1.3.noarch.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libicu-devel-57.1-14.2.armv7l.rpm"
-
-    # 2. download rpms
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/lldb-3.8.1-2.7.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/lldb-devel-3.8.1-2.7.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libuuid-2.28-8.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libuuid-devel-2.28-8.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libgcc-4.9.2-15.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libstdc++-4.9.2-15.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libstdc++-devel-4.9.2-15.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libunwind-1.1-7.22.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libunwind-devel-1.1-7.22.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/tizen-release-3.0.0-10.31.armv7l.rpm"
-
-    # 3. for corefx
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libcom_err-1.42.13-2.8.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libcom_err-devel-1.42.13-2.8.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/zlib-1.2.8-1.17.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/zlib-devel-1.2.8-1.17.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libopenssl-1.0.2j-10.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libopenssl-devel-1.0.2j-10.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/gssdp-0.14.4-4.2.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/gssdp-devel-0.14.4-4.2.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/krb5-1.10.2-3.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/krb5-devel-1.10.2-3.1.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libcurl-7.50.2-17.2.armv7l.rpm"
-    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libcurl-devel-7.50.2-17.2.armv7l.rpm"
-}
+mkdir -p $TIZEN_TMP_DIR
 
 # Download files
 echo ">>Start downloading files"
-download_files
+VERBOSE=1 $__ARM_SOFTFP_CrossDir/tizen-fetch.sh $TIZEN_TMP_DIR
 echo "<<Finish downloading files"
 
 echo ">>Start constructing Tizen rootfs"
-TIZEN_RPM_FILES=`ls $TIZEN_TMP_DOWNLOAD_DIR/*.rpm`
+TIZEN_RPM_FILES=`ls $TIZEN_TMP_DIR/*.rpm`
 cd $ROOTFS_DIR
 for f in $TIZEN_RPM_FILES; do
     rpm2cpio $f  | cpio -idm --quiet

--- a/cross/armel/tizen-build-rootfs.sh
+++ b/cross/armel/tizen-build-rootfs.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -e
+
+__ARM_SOFTFP_CrossDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+__TIZEN_CROSSDIR="$__ARM_SOFTFP_CrossDir/tizen"
+
+if [[ -z "$ROOTFS_DIR" ]]; then
+    echo "ROOTFS_DIR is not defined."
+    exit 1;
+fi
+
+# Clean-up (TODO-Cleanup: We may already delete  $ROOTFS_DIR at ./cross/build-rootfs.sh.)
+# hk0110
+if [ -d "$ROOTFS_DIR" ]; then
+    umount $ROOTFS_DIR/*
+    rm -rf $ROOTFS_DIR
+fi
+
+TIZEN_TMP_DIR=$ROOTFS_DIR/tizen_tmp
+TIZEN_TMP_DOWNLOAD_DIR=$TIZEN_TMP_DIR/download
+TIZEN_TMP_UNZIP_DIR=$TIZEN_TMP_DIR/unzip
+mkdir -p $TIZEN_TMP_DOWNLOAD_DIR
+mkdir -p $TIZEN_TMP_UNZIP_DIR
+
+download_files()
+{
+    # TODO: There will be a stable Tizen rootfs available later.
+    # Now we temporarily use live repo for developing dotnet for Tizen
+
+    TIZEN_DOWNLOAD_OPTIONS="-P $TIZEN_TMP_DOWNLOAD_DIR"
+    TIZEN_DOWNLOAD_CMD="wget $TIZEN_DOWNLOAD_OPTIONS"
+
+    TIZEN_BASE_ARM="http://download.tizen.org/releases/weekly/tizen/base/latest/repos/arm/packages/armv7l"
+    TIZEN_BASE_NOARCH="http://download.tizen.org/releases/weekly/tizen/base/latest/repos/arm/packages/noarch"
+    TIZEN_MOBILE_ARM="http://download.tizen.org/releases/weekly/tizen/mobile/latest/repos/arm-wayland/packages/armv7l"
+
+    # 1. basse packages
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/gcc-4.9.2-15.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/glibc-2.20-12.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/glibc-devel-2.20-12.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_NOARCH/linux-glibc-devel-3.10-1.3.noarch.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libicu-devel-57.1-14.2.armv7l.rpm"
+
+    # 2. download rpms
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/lldb-3.8.1-2.7.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/lldb-devel-3.8.1-2.7.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libuuid-2.28-8.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libuuid-devel-2.28-8.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libgcc-4.9.2-15.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libstdc++-4.9.2-15.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libstdc++-devel-4.9.2-15.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libunwind-1.1-7.22.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libunwind-devel-1.1-7.22.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/tizen-release-3.0.0-10.31.armv7l.rpm"
+
+    # 3. for corefx
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libcom_err-1.42.13-2.8.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libcom_err-devel-1.42.13-2.8.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/zlib-1.2.8-1.17.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/zlib-devel-1.2.8-1.17.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libopenssl-1.0.2j-10.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_BASE_ARM/libopenssl-devel-1.0.2j-10.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/gssdp-0.14.4-4.2.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/gssdp-devel-0.14.4-4.2.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/krb5-1.10.2-3.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/krb5-devel-1.10.2-3.1.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libcurl-7.50.2-17.2.armv7l.rpm"
+    $TIZEN_DOWNLOAD_CMD "$TIZEN_MOBILE_ARM/libcurl-devel-7.50.2-17.2.armv7l.rpm"
+}
+
+# Download files
+echo ">>Start downloading files"
+download_files
+echo "<<Finish downloading files"
+
+echo ">>Start constructing Tizen rootfs"
+TIZEN_RPM_FILES=`ls $TIZEN_TMP_DOWNLOAD_DIR/*.rpm`
+cd $ROOTFS_DIR
+for f in $TIZEN_RPM_FILES; do
+    rpm2cpio $f  | cpio -idm --quiet
+done
+echo "<<Finish constructing Tizen rootfs"
+
+# Cleanup tmp
+rm -rf $TIZEN_TMP_DIR
+
+# Configure Tizen rootfs
+echo ">>Start configuring Tizen rootfs"
+rm ./usr/lib/libunwind.so
+ln -s libunwind.so.8 ./usr/lib/libunwind.so
+ln -sfn asm-arm ./usr/include/asm
+patch -p1 < $__TIZEN_CROSSDIR/tizen.patch
+echo "<<Finish configuring Tizen rootfs"

--- a/cross/armel/tizen-fetch.sh
+++ b/cross/armel/tizen-fetch.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ -z "${VERBOSE// }" ]] || [ "$VERBOSE" -ne "$VERBOSE" ] 2>/dev/null; then
+	VERBOSE=0
+fi
+
+Log()
+{
+	if [ $VERBOSE -ge $1 ]; then
+		echo ${@:2}
+	fi
+}
+
+Inform()
+{
+	Log 1 -e "\x1B[0;34m$@\x1B[m"
+}
+
+Debug()
+{
+	Log 2 -e "\x1B[0;32m$@\x1B[m"
+}
+
+Error()
+{
+	>&2 Log 0 -e "\x1B[0;31m$@\x1B[m"
+}
+
+Fetch()
+{
+	URL=$1
+	FILE=$2
+	PROGRESS=$3
+	if [ $VERBOSE -ge 1 ] && [ $PROGRESS ]; then
+		CURL_OPT="--progress-bar"
+	else
+		CURL_OPT="--silent"
+	fi
+	curl $CURL_OPT $URL > $FILE
+}
+
+hash curl 2> /dev/null || { Error "Require 'curl' Aborting."; exit 1; }
+hash xmllint 2> /dev/null || { Error "Require 'xmllint' Aborting."; exit 1; }
+hash sha256sum 2> /dev/null || { Error "Require 'sha256sum' Aborting."; exit 1; }
+
+TMPDIR=$1
+if [ ! -d $TMPDIR ]; then
+	TMPDIR=./tizen_tmp
+	Debug "Create temporary directory : $TMPDIR"
+	mkdir -p $TMPDIR 
+fi
+
+TIZEN_URL=http://download.tizen.org/releases/weekly/tizen
+BUILD_XML=build.xml
+REPOMD_XML=repomd.xml
+PRIMARY_XML=primary.xml
+TARGET_URL="http://__not_initialized"
+
+Xpath_get()
+{
+	XPATH_RESULT=''
+	XPATH=$1
+	XML_FILE=$2
+	RESULT=$(xmllint --xpath $XPATH $XML_FILE)
+	if [[ -z ${RESULT// } ]]; then
+		Error "Can not find target from $XML_FILE"
+		Debug "Xpath = $XPATH"
+		exit 1
+	fi
+	XPATH_RESULT=$RESULT
+}
+
+fetch_tizen_pkgs_init()
+{
+	TARGET=$1
+	PROFILE=$2
+	Debug "Initialize TARGET=$TARGET, PROFILE=$PROFILE"
+
+	TMP_PKG_DIR=$TMPDIR/tizen_${PROFILE}_pkgs
+	if [ -d $TMP_PKG_DIR ]; then rm -rf $TMP_PKG_DIR; fi
+	mkdir -p $TMP_PKG_DIR
+
+	PKG_URL=$TIZEN_URL/$PROFILE/latest
+
+	BUILD_XML_URL=$PKG_URL/$BUILD_XML
+	TMP_BUILD=$TMP_PKG_DIR/$BUILD_XML
+	TMP_REPOMD=$TMP_PKG_DIR/$REPOMD_XML
+	TMP_PRIMARY=$TMP_PKG_DIR/$PRIMARY_XML
+	TMP_PRIMARYGZ=${TMP_PRIMARY}.gz
+
+	Fetch $BUILD_XML_URL $TMP_BUILD
+
+	Debug "fetch $BUILD_XML_URL to $TMP_BUILD"
+
+	TARGET_XPATH="//build/buildtargets/buildtarget[@name=\"$TARGET\"]/repo[@type=\"binary\"]/text()"
+	Xpath_get $TARGET_XPATH $TMP_BUILD
+	TARGET_PATH=$XPATH_RESULT
+	TARGET_URL=$PKG_URL/$TARGET_PATH
+
+	REPOMD_URL=$TARGET_URL/repodata/repomd.xml
+	PRIMARY_XPATH='string(//*[local-name()="data"][@type="primary"]/*[local-name()="location"]/@href)'
+
+	Fetch $REPOMD_URL $TMP_REPOMD
+
+	Debug "fetch $REPOMD_URL to $TMP_REPOMD"
+
+	Xpath_get $PRIMARY_XPATH $TMP_REPOMD
+	PRIMARY_XML_PATH=$XPATH_RESULT
+	PRIMARY_URL=$TARGET_URL/$PRIMARY_XML_PATH
+
+	Fetch $PRIMARY_URL $TMP_PRIMARYGZ
+
+	Debug "fetch $PRIMARY_URL to $TMP_PRIMARYGZ"
+
+	gunzip $TMP_PRIMARYGZ 
+
+	Debug "unzip $TMP_PRIMARYGZ to $TMP_PRIMARY" 
+}
+
+fetch_tizen_pkgs()
+{
+	PROFILE=$1
+	PACKAGE_XPATH_TPL='string(//*[local-name()="metadata"]/*[local-name()="package"][*[local-name()="name"][text()="_PKG_"]]/*[local-name()="location"]/@href)'
+
+	PACKAGE_CHECKSUM_XPATH_TPL='string(//*[local-name()="metadata"]/*[local-name()="package"][*[local-name()="name"][text()="_PKG_"]]/*[local-name()="checksum"]/text())'
+
+	for pkg in ${@:2}
+	do
+		Inform "Fetching... $pkg"
+		XPATH=${PACKAGE_XPATH_TPL/_PKG_/$pkg}
+		Xpath_get $XPATH $TMP_PRIMARY
+		PKG_PATH=$XPATH_RESULT
+
+		XPATH=${PACKAGE_CHECKSUM_XPATH_TPL/_PKG_/$pkg}
+		Xpath_get $XPATH $TMP_PRIMARY
+		CHECKSUM=$XPATH_RESULT
+
+		PKG_URL=$TARGET_URL/$PKG_PATH
+		PKG_FILE=$(basename $PKG_PATH)
+		PKG_PATH=$TMPDIR/$PKG_FILE
+
+		Debug "Download $PKG_URL to $PKG_PATH"
+		Fetch $PKG_URL $PKG_PATH true
+		
+		echo "$CHECKSUM $PKG_PATH" | sha256sum -c - > /dev/null
+		if [ $? -ne 0 ]; then
+			Error "Fail to fetch $PKG_URL to $PKG_PATH"
+			Debug "Checksum = $CHECKSUM"
+			exit 1
+		fi
+
+	done
+}
+
+Inform "Initialize arm base"
+fetch_tizen_pkgs_init arm base
+Inform "fetch base common packages"
+fetch_tizen_pkgs base gcc glibc glibc-devel linux-glibc-devel
+Inform "fetch base coreclr packages"
+fetch_tizen_pkgs base lldb lldb-devel libuuid libuuid-devel libgcc libstdc++ libstdc++-devel
+Inform "fetch base corefx packages"
+fetch_tizen_pkgs base libcom_err libcom_err-devel zlib zlib-devel libopenssl libopenssl-devel
+
+Inform "initialize arm mobile"
+fetch_tizen_pkgs_init arm-wayland mobile
+Inform "fetch mobile common packages"
+fetch_tizen_pkgs mobile libicu-devel
+Inform "fetch mobile coreclr packages"
+fetch_tizen_pkgs mobile libunwind libunwind-devel tizen-release
+Inform "fetch mobile corefx packages"
+fetch_tizen_pkgs mobile gssdp gssdp-devel krb5 krb5-devel libcurl libcurl-devel
+
+

--- a/cross/armel/tizen/tizen.patch
+++ b/cross/armel/tizen/tizen.patch
@@ -1,0 +1,33 @@
+diff -u -r a/usr/lib/libc.so b/usr/lib/libc.so
+--- a/usr/lib/libc.so	2016-12-30 23:00:08.284951863 +0900
++++ b/usr/lib/libc.so	2016-12-30 23:00:32.140951815 +0900
+@@ -2,4 +2,4 @@
+    Use the shared library, but some functions are only in
+    the static library, so try that secondarily.  */
+ OUTPUT_FORMAT(elf32-littlearm)
+-GROUP ( /lib/libc.so.6 /usr/lib/libc_nonshared.a  AS_NEEDED ( /lib/ld-linux.so.3 ) )
++GROUP ( libc.so.6 libc_nonshared.a  AS_NEEDED ( ld-linux.so.3 ) )
+diff -u -r a/usr/lib/libpthread.so b/usr/lib/libpthread.so
+--- a/usr/lib/libpthread.so	2016-12-30 23:00:19.408951841 +0900
++++ b/usr/lib/libpthread.so	2016-12-30 23:00:39.068951801 +0900
+@@ -2,4 +2,4 @@
+    Use the shared library, but some functions are only in
+    the static library, so try that secondarily.  */
+ OUTPUT_FORMAT(elf32-littlearm)
+-GROUP ( /lib/libpthread.so.0 /usr/lib/libpthread_nonshared.a )
++GROUP ( libpthread.so.0 libpthread_nonshared.a )
+diff -u -r a/usr/lib/libpthread.so b/usr/lib/libpthread.so
+--- a/etc/os-release  2016-10-17 23:39:36.000000000 +0900
++++ b/etc/os-release  2017-01-05 14:34:39.099867682 +0900
+@@ -1,7 +1,7 @@
+ NAME=Tizen
+-VERSION="3.0.0 (Tizen3/Mobile)"
++VERSION="4.0.0 (Tizen4/Mobile)"
+ ID=tizen
+-VERSION_ID=3.0.0
+-PRETTY_NAME="Tizen 3.0.0 (Tizen3/Mobile)"
++VERSION_ID=4.0.0
++PRETTY_NAME="Tizen 4.0.0 (Tizen4/Mobile)"
+ ANSI_COLOR="0;36"
+-CPE_NAME="cpe:/o:tizen:tizen:3.0.0"
++CPE_NAME="cpe:/o:tizen:tizen:4.0.0"

--- a/cross/armel/toolchain.cmake
+++ b/cross/armel/toolchain.cmake
@@ -22,7 +22,7 @@ add_compile_options(--sysroot=${CROSS_ROOTFS})
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target ${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} --sysroot=${CROSS_ROOTFS}")
 
-if("$ENV{__DistroRid}" STREQUAL "tizen.3.0.0-armel")
+if("$ENV{__DistroRid}" MATCHES "tizen.*")
     add_compile_options(-I$ENV{ROOTFS_DIR}/usr/lib/gcc/armv7l-tizen-linux-gnueabi/4.9.2/include/c++/)
     add_compile_options(-I$ENV{ROOTFS_DIR}/usr/lib/gcc/armv7l-tizen-linux-gnueabi/4.9.2/include/c++/armv7l-tizen-linux-gnueabi)
     add_compile_options(-Wno-deprecated-declarations) # compile-time option

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -4,7 +4,7 @@ usage()
 {
     echo "Usage: $0 [BuildArch] [UbuntuCodeName] [lldbx.y]"
     echo "BuildArch can be: arm(default), armel, arm64, x86"
-    echo "UbuntuCodeName - optional, Code name for Ubuntu, can be: trusty(default), vivid, wily, xenial. If BuildArch is armel, UbuntuCodeName is ignored."
+    echo "UbuntuCodeName - optional, Code name for Ubuntu, can be: trusty(default), vivid, wily, xenial. If BuildArch is armel, UbuntuCodeName is jessie(default) or tizen."
     echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8"
 
     exit 1
@@ -73,6 +73,16 @@ for i in "$@"
             __UbuntuCodeName=jessie
             __UbuntuRepo="http://ftp.debian.org/debian/"
             ;;
+        tizen)
+            if [ "$__BuildArch" != "armel" ]; then
+                echo "Tizen is available only for armel."
+                usage;
+                exit 1;
+            fi
+            __UbuntuCodeName=
+            __UbuntuRepo=
+            __Tizen=tizen
+            ;;
         *)
             __UnprocessedBuildArgs="$__UnprocessedBuildArgs $i"
             ;;
@@ -95,10 +105,18 @@ if [ -d "$__RootfsDir" ]; then
     rm -rf $__RootfsDir
 fi
 
-qemu-debootstrap --arch $__UbuntuArch $__UbuntuCodeName $__RootfsDir $__UbuntuRepo
-cp $__CrossDir/$__BuildArch/sources.list.$__UbuntuCodeName $__RootfsDir/etc/apt/sources.list
-chroot $__RootfsDir apt-get update
-chroot $__RootfsDir apt-get -f -y install
-chroot $__RootfsDir apt-get -y install $__UbuntuPackages
-chroot $__RootfsDir symlinks -cr /usr
-umount $__RootfsDir/*
+if [[ -n $__UbuntuCodeName ]]; then
+    qemu-debootstrap --arch $__UbuntuArch $__UbuntuCodeName $__RootfsDir $__UbuntuRepo
+    cp $__CrossDir/$__BuildArch/sources.list.$__UbuntuCodeName $__RootfsDir/etc/apt/sources.list
+    chroot $__RootfsDir apt-get update
+    chroot $__RootfsDir apt-get -f -y install
+    chroot $__RootfsDir apt-get -y install $__UbuntuPackages
+    chroot $__RootfsDir symlinks -cr /usr
+    umount $__RootfsDir/*
+elif [ "$__Tizen" == "tizen" ]; then
+    ROOTFS_DIR=$__RootfsDir $__CrossDir/$__BuildArch/tizen-build-rootfs.sh
+else
+    echo "Unsupported target platform."
+    usage;
+    exit 1
+fi


### PR DESCRIPTION
Add Tizen rootfs for arm-softfp which is also used for arm cross CI.

Update rootfs script for arm-softfp and cmake file.

Now we have two rootfs for arm-softfp, Debian 8 and Tizen and we can make rootfs as follows.

- Debian 8 "jessie" (default)
`$ sudo ./cross/build-rootfs.sh armel`

- Tizen (new)
`$ sudo ./cross/build-rootfs.sh armel tizen`

For more detail about rootfs,  see https://github.com/dotnet/coreclr/blob/master/Documentation/building/cross-building.md#generating-the-rootfs

BTW there are another issue and pr about chainging name of `arm-softfp` port to `armel`. (issue #8770, pr #8771). This PR and PR #8771 conflict each other and we will rebase one of two when either one is merged.