### PR TITLE
Fix a typo that caused AVX2 flag to be unset

### DIFF
--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -1227,7 +1227,7 @@ bool DoesOSSupportAVX()
     PGETENABLEDXSTATEFEATURES pfnGetEnabledXStateFeatures = NULL;
     
     HMODULE hMod = WszLoadLibraryEx(WINDOWS_KERNEL32_DLLNAME_W, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    if(hMod = NULL)
+    if(hMod == NULL)
         return FALSE;
         
     pfnGetEnabledXStateFeatures = (PGETENABLEDXSTATEFEATURES)GetProcAddress(hMod, "GetEnabledXStateFeatures");


### PR DESCRIPTION
Fix issue #8736, a regression caused by PR #8624. A typo in
the code causes the AVX2 flag to be always unset.