### PR TITLE
Adding Microsoft.NETCore.Native package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+localpkg/
 msbuild.log
 
 # add back architecture directories ignored in 'Build results'

--- a/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.builds
+++ b/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.builds
@@ -11,6 +11,10 @@
   <ItemGroup>
     <Project Include="Microsoft.NETCore.Native.pkgproj">
     </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'linux-x64'" Include="linux/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.Native.pkgproj">
       <OSGroup>Linux</OSGroup>
       <Platform>amd64</Platform>

--- a/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.builds
+++ b/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.builds
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <!-- This property must be set to the same value as $(PackageOutputPath) for the nuspecs and nupkgs to be binplaced to the intended location. -->
+    <OutputPath>$(PackageOutputPath)</OutputPath>
+  </PropertyGroup>
+
+  <!-- We always build the identity/redirection package. However, the platform specific runtime-*.nupkg is built based upon the target OS we are building the product for. -->
+  <ItemGroup>
+    <Project Include="Microsoft.NETCore.Native.pkgproj">
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'debian.8-x64'" Include="debian/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.23-x64'" Include="fedora/23/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'fedora.24-x64'" Include="fedora/24/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.13.2-x64'" Include="opensuse/13.2/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'opensuse.42.1-x64'" Include="opensuse/42.1/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and $(DistroRid.StartsWith('rhel.7'))" Include="rhel/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.14.04-x64'" Include="ubuntu/14.04/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.04-x64'" Include="ubuntu/16.04/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'ubuntu.16.10-x64'" Include="ubuntu/16.10/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroRid)' == 'alpine.3.4.3-x64'" Include="alpine/3.4.3/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx/Microsoft.NETCore.Native.pkgproj">
+      <OSGroup>OSX</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <SkipValidatePackage>true</SkipValidatePackage>
+    <PackagePlatforms>x64;x86;arm64;arm;</PackagePlatforms>
+    <OutputPath>$(PackagesOutputPath)</OutputPath>
+    <IncludeRuntimeJson>true</IncludeRuntimeJson>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="debian\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="fedora\23\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="fedora\24\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="opensuse\13.2\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="opensuse\42.1\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="rhel\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\14.04\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.04\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\16.10\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="alpine\3.4.3\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="osx\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.pkgproj
@@ -9,6 +9,9 @@
     <IncludeRuntimeJson>true</IncludeRuntimeJson>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="linux\Microsoft.NETCore.Native.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
     <ProjectReference Include="debian\Microsoft.NETCore.Native.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.Native/alpine/3.4.3/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/alpine/3.4.3/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>alpine.3.4.3-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/debian/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/debian/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>debian.8-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/fedora/23/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/fedora/23/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.23-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/fedora/24/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/fedora/24/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>fedora.24-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/linux/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/linux/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>linux-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/opensuse/13.2/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/opensuse/13.2/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.13.2-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/opensuse/42.1/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/opensuse/42.1/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>opensuse.42.1-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/osx/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/osx/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/osx/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/osx/Microsoft.NETCore.Native.pkgproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
-    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.dylib" />
     <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
     <File Include="@(ArchitectureSpecificNativeFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>

--- a/src/.nuget/Microsoft.NETCore.Native/rhel/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/rhel/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>rhel.7-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/ubuntu/14.04/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/ubuntu/14.04/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/ubuntu/16.04/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/ubuntu/16.04/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Native/ubuntu/16.10/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/ubuntu/16.10/Microsoft.NETCore.Native.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <PackageTargetRuntime>ubuntu.16.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
+    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
+    <File Include="@(ArchitectureSpecificNativeFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
+    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
+    <File Include="@(ArchitectureSpecificNativeSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
+    </File>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/descriptions.json
+++ b/src/.nuget/descriptions.json
@@ -38,5 +38,10 @@
         "Name": "Microsoft.NETCore.TestHost",
         "Description": "CoreCLR application host for test applications",
         "CommonTypes": [ ]
+    },
+    {
+	"Name": "Microsoft.NETCore.Native",
+	"Description": "Native shims for .NET Core runtime",
+	"CommonTypes": [ ]
     }
 ]

--- a/src/.nuget/packages.builds
+++ b/src/.nuget/packages.builds
@@ -18,6 +18,7 @@
   <ItemGroup Condition="'$(__SkipNativeBuild)'==''">
     <Project Include="Microsoft.NETCore.Jit\Microsoft.NETCore.Jit.builds" />     
     <Project Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds" />     
+    <Project Include="Microsoft.NETCore.Native\Microsoft.NETCore.Native.builds" />     
   </ItemGroup>
 
   <ItemGroup>

--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -67,6 +67,14 @@ _add_library(System.Globalization.Native
     ${NATIVEGLOBALIZATION_SOURCES}
 )
 
+_add_library(System.Globalization.Native_Static
+    STATIC
+    ${NATIVEGLOBALIZATION_SOURCES}
+)
+
+# Remove the _Static postfix from the static library name
+set_target_properties(System.Globalization.Native_Static PROPERTIES OUTPUT_NAME System.Globalization.Native)
+
 # Disable the "lib" prefix.
 set_target_properties(System.Globalization.Native PROPERTIES PREFIX "")
 
@@ -80,8 +88,15 @@ if(NOT CLR_CMAKE_PLATFORM_DARWIN)
             ${ICUUC}
             ${ICUI18N}
         )
+        target_link_libraries(System.Globalization.Native_Static
+            ${ICUUC}
+            ${ICUI18N}
+        )
     elseif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
         target_link_libraries(System.Globalization.Native
+            dl
+        )
+        target_link_libraries(System.Globalization.Native_Static
             dl
         )
     endif()
@@ -100,4 +115,5 @@ verify_dependencies(
 
 # add the install targets
 install_clr(System.Globalization.Native)
+install_clr(System.Globalization.Native_Static)
 


### PR DESCRIPTION
Changes:
- updating makefile to produce the static lib for System.Globalization.Native
- add a new package for static and shared lib of System.Globalization.Native. Other native libs will follow.

@jkotas, could you please take a look at these changes
/cc @dotnet/corert-contrib 