### PR TITLE
Pass '(null)' when string is NULL

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -10694,7 +10694,8 @@ void Compiler::gtDispConst(GenTree* tree)
         case GT_CNS_INT:
             if (tree->IsIconHandle(GTF_ICON_STR_HDL))
             {
-                printf(" 0x%X \"%S\"", dspPtr(tree->gtIntCon.gtIconVal), eeGetCPString(tree->gtIntCon.gtIconVal));
+                const wchar_t *value = eeGetCPString(tree->gtIntCon.gtIconVal);
+                printf(" 0x%X \"%S\"", dspPtr(tree->gtIntCon.gtIconVal), value ? value : W("(null)"));
             }
             else
             {

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -10694,7 +10694,7 @@ void Compiler::gtDispConst(GenTree* tree)
         case GT_CNS_INT:
             if (tree->IsIconHandle(GTF_ICON_STR_HDL))
             {
-                const wchar_t *value = eeGetCPString(tree->gtIntCon.gtIconVal);
+                const wchar_t* value = eeGetCPString(tree->gtIntCon.gtIconVal);
                 printf(" 0x%X \"%S\"", dspPtr(tree->gtIntCon.gtIconVal), value ? value : W("(null)"));
             }
             else


### PR DESCRIPTION
WideCharToMultiByte in PAL failed with error code 87 when the argument is NULL (which causes #8797).

This commit passes explicit "(null)" to printf in order to fix #8797.