### PR TITLE
Fix NULL string printing in printf

### DIFF
--- a/src/pal/tests/palsuite/c_runtime/_snprintf_s/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_snprintf_s/test2/test2.cpp
@@ -38,6 +38,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest("foo %5.2s", "bar", "foo    ba");
     DoStrTest("foo %-5s", "bar", "foo bar  ");
     DoStrTest("foo %05s", "bar", "foo 00bar");   
+    DoStrTest("foo %s", NULL, "foo (null)");
+    DoStrTest("foo %hs", NULL, "foo (null)");
+    DoWStrTest("foo %ls", NULL, "foo (null)");
+    DoWStrTest("foo %ws", NULL, "foo (null)");
+    DoStrTest("foo %Ls", NULL, "foo (null)");
+    DoStrTest("foo %I64s", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/_snprintf_s/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_snprintf_s/test3/test3.cpp
@@ -39,6 +39,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest("foo %5.2S", convert("bar"), "foo    ba");
     DoWStrTest("foo %-5S", convert("bar"), "foo bar  ");
     DoWStrTest("foo %05S", convert("bar"), "foo 00bar");
+    DoWStrTest("foo %S", NULL, "foo (null)");
+    DoStrTest("foo %hS", NULL, "foo (null)");
+    DoWStrTest("foo %lS", NULL, "foo (null)");
+    DoWStrTest("foo %wS", NULL, "foo (null)");
+    DoWStrTest("foo %LS", NULL, "foo (null)");
+    DoWStrTest("foo %I64S", NULL, "foo (null)");
     
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/_snwprintf_s/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_snwprintf_s/test2/test2.cpp
@@ -38,6 +38,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest(convert("foo %5.2s"), convert("bar"), convert("foo    ba"));
     DoWStrTest(convert("foo %-5s"), convert("bar"), convert("foo bar  "));
     DoWStrTest(convert("foo %05s"), convert("bar"), convert("foo 00bar"));
+    DoWStrTest(convert("foo %s"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %hs"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %ls"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %ws"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %Ls"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %I64s"), NULL, convert("foo (null)"));
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/_snwprintf_s/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_snwprintf_s/test3/test3.cpp
@@ -38,6 +38,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest(convert("foo %5.2S"), "bar", convert("foo    ba"));
     DoStrTest(convert("foo %-5S"), "bar", convert("foo bar  "));
     DoStrTest(convert("foo %05S"), "bar", convert("foo 00bar"));
+    DoStrTest(convert("foo %S"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %hS"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %lS"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %wS"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %LS"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %I64S"), NULL, convert("foo (null)"));
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/_vsnprintf_s/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_vsnprintf_s/test2/test2.cpp
@@ -37,6 +37,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest("foo %5.2s", "bar", "foo    ba");
     DoStrTest("foo %-5s", "bar", "foo bar  ");
     DoStrTest("foo %05s", "bar", "foo 00bar");   
+    DoStrTest("foo %s", NULL, "foo (null)");
+    DoStrTest("foo %hs", NULL, "foo (null)");
+    DoWStrTest("foo %ls", NULL, "foo (null)");
+    DoWStrTest("foo %ws", NULL, "foo (null)");
+    DoStrTest("foo %Ls", NULL, "foo (null)");
+    DoStrTest("foo %I64s", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/_vsnprintf_s/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_vsnprintf_s/test3/test3.cpp
@@ -37,6 +37,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest("foo %5.2S", convert("bar"), "foo    ba");
     DoWStrTest("foo %-5S", convert("bar"), "foo bar  ");
     DoWStrTest("foo %05S", convert("bar"), "foo 00bar");
+    DoWStrTest("foo %S", NULL, "foo (null)");
+    DoStrTest("foo %hS", NULL, "foo (null)");
+    DoWStrTest("foo %lS", NULL, "foo (null)");
+    DoWStrTest("foo %wS", NULL, "foo (null)");
+    DoWStrTest("foo %LS", NULL, "foo (null)");
+    DoWStrTest("foo %I64S", NULL, "foo (null)");
     
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/_vsnwprintf_s/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_vsnwprintf_s/test2/test2.cpp
@@ -34,6 +34,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest(convert("foo %5.2s"), convert("bar"), convert("foo    ba"));
     DoWStrTest(convert("foo %-5s"), convert("bar"), convert("foo bar  "));
     DoWStrTest(convert("foo %05s"), convert("bar"), convert("foo 00bar"));
+    DoWStrTest(convert("foo %s"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %hs"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %ls"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %ws"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %Ls"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %I64s"), NULL, convert("foo (null)"));
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/_vsnwprintf_s/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_vsnwprintf_s/test3/test3.cpp
@@ -34,6 +34,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest(convert("foo %5.2S"), "bar", convert("foo    ba"));
     DoStrTest(convert("foo %-5S"), "bar", convert("foo bar  "));
     DoStrTest(convert("foo %05S"), "bar", convert("foo 00bar"));
+    DoStrTest(convert("foo %S"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %hS"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %lS"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %wS"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %LS"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %I64S"), NULL, convert("foo (null)"));
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/fprintf/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/fprintf/test2/test2.cpp
@@ -36,6 +36,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest("foo %5.2s", "bar", "foo    ba");
     DoStrTest("foo %-5s", "bar", "foo bar  ");
     DoStrTest("foo %05s", "bar", "foo 00bar");
+    DoStrTest("foo %s", NULL, "foo (null)");
+    DoStrTest("foo %hs", NULL, "foo (null)");
+    DoWStrTest("foo %ls", NULL, "foo (null)");
+    DoWStrTest("foo %ws", NULL, "foo (null)");
+    DoStrTest("foo %Ls", NULL, "foo (null)");
+    DoStrTest("foo %I64s", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;    

--- a/src/pal/tests/palsuite/c_runtime/fprintf/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/fprintf/test3/test3.cpp
@@ -35,6 +35,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest("foo %5.2S", convert("bar"), "foo    ba");
     DoWStrTest("foo %-5S", convert("bar"), "foo bar  ");
     DoWStrTest("foo %05S", convert("bar"), "foo 00bar");
+    DoWStrTest("foo %S", NULL, "foo (null)");
+    DoStrTest("foo %hS", NULL, "foo (null)");
+    DoWStrTest("foo %lS", NULL, "foo (null)");
+    DoWStrTest("foo %wS", NULL, "foo (null)");
+    DoWStrTest("foo %LS", NULL, "foo (null)");
+    DoWStrTest("foo %I64S", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/fwprintf/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/fwprintf/test2/test2.cpp
@@ -38,6 +38,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest(convert("foo %5.2s"), convert("bar"), "foo    ba");
     DoWStrTest(convert("foo %-5s"), convert("bar"), "foo bar  ");
     DoWStrTest(convert("foo %05s"), convert("bar"), "foo 00bar");
+    DoWStrTest(convert("foo %s"), NULL, "foo (null)");
+    DoStrTest(convert("foo %hs"), NULL, "foo (null)");
+    DoWStrTest(convert("foo %ls"), NULL, "foo (null)");
+    DoWStrTest(convert("foo %ws"), NULL, "foo (null)");
+    DoWStrTest(convert("foo %Ls"), NULL, "foo (null)");
+    DoWStrTest(convert("foo %I64s"), NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;    

--- a/src/pal/tests/palsuite/c_runtime/fwprintf/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/fwprintf/test3/test3.cpp
@@ -37,6 +37,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest(convert("foo %5.2S"),"bar", "foo    ba");
     DoStrTest(convert("foo %-5S"), "bar", "foo bar  ");
     DoStrTest(convert("foo %05S"), "bar", "foo 00bar");
+    DoStrTest(convert("foo %S"), NULL, "foo (null)");
+    DoStrTest(convert("foo %hS"), NULL, "foo (null)");
+    DoWStrTest(convert("foo %lS"), NULL, "foo (null)");
+    DoWStrTest(convert("foo %wS"), NULL, "foo (null)");
+    DoStrTest(convert("foo %LS"), NULL, "foo (null)");
+    DoStrTest(convert("foo %I64S"), NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/printf/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/printf/test2/test2.cpp
@@ -38,6 +38,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest("foo %5.2s", "bar", "foo    ba");
     DoStrTest("foo %-5s", "bar", "foo bar  ");
     DoStrTest("foo %05s", "bar", "foo 00bar");
+    DoStrTest("foo %s", NULL, "foo (null)");
+    DoStrTest("foo %hs", NULL, "foo (null)");
+    DoWStrTest("foo %ls", NULL, "foo (null)");
+    DoWStrTest("foo %ws", NULL, "foo (null)");
+    DoStrTest("foo %Ls", NULL, "foo (null)");
+    DoStrTest("foo %I64s", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;    

--- a/src/pal/tests/palsuite/c_runtime/printf/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/printf/test3/test3.cpp
@@ -37,6 +37,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest("foo %5.2S", convert("bar"), "foo    ba");
     DoWStrTest("foo %-5S", convert("bar"), "foo bar  ");
     DoWStrTest("foo %05S", convert("bar"), "foo 00bar");
+    DoWStrTest("foo %S", NULL, "foo (null)");
+    DoStrTest("foo %hS", NULL, "foo (null)");
+    DoWStrTest("foo %lS", NULL, "foo (null)");
+    DoWStrTest("foo %wS", NULL, "foo (null)");
+    DoWStrTest("foo %LS", NULL, "foo (null)");
+    DoWStrTest("foo %I64S", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/sprintf_s/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/sprintf_s/test2/test2.cpp
@@ -40,6 +40,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest("foo %5.2s", "bar", "foo    ba");
     DoStrTest("foo %-5s", "bar", "foo bar  ");
     DoStrTest("foo %05s", "bar", "foo 00bar");
+    DoStrTest("foo %s", NULL, "foo (null)");
+    DoStrTest("foo %hs", NULL, "foo (null)");
+    DoWStrTest("foo %ls", NULL, "foo (null)");
+    DoWStrTest("foo %ws", NULL, "foo (null)");
+    DoStrTest("foo %Ls", NULL, "foo (null)");
+    DoStrTest("foo %I64s", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;    

--- a/src/pal/tests/palsuite/c_runtime/sprintf_s/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/sprintf_s/test3/test3.cpp
@@ -39,6 +39,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest("foo %5.2S", convert("bar"), "foo    ba");
     DoWStrTest("foo %-5S", convert("bar"), "foo bar  ");
     DoWStrTest("foo %05S", convert("bar"), "foo 00bar");
+    DoWStrTest("foo %S", NULL, "foo (null)");
+    DoStrTest("foo %hS", NULL, "foo (null)");
+    DoWStrTest("foo %lS", NULL, "foo (null)");
+    DoWStrTest("foo %wS", NULL, "foo (null)");
+    DoWStrTest("foo %LS", NULL, "foo (null)");
+    DoWStrTest("foo %I64S", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/swprintf/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/swprintf/test2/test2.cpp
@@ -40,6 +40,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest(convert("foo %5.2s"), convert("bar"), convert("foo    ba"));
     DoWStrTest(convert("foo %-5s"), convert("bar"), convert("foo bar  "));
     DoWStrTest(convert("foo %05s"), convert("bar"), convert("foo 00bar"));
+    DoWStrTest(convert("foo %s"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %hs"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %ls"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %ws"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %Ls"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %I64s"), NULL, convert("foo (null)"));
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/swprintf/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/swprintf/test3/test3.cpp
@@ -38,6 +38,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest(convert("foo %5.2S"),"bar", convert("foo    ba"));
     DoStrTest(convert("foo %-5S"), "bar", convert("foo bar  "));
     DoStrTest(convert("foo %05S"), "bar", convert("foo 00bar"));
+    DoStrTest(convert("foo %S"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %hS"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %lS"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %wS"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %LS"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %I64S"), NULL, convert("foo (null)"));
     PAL_Terminate();
     return PASS;
 }

--- a/src/pal/tests/palsuite/c_runtime/vfprintf/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vfprintf/test2/test2.cpp
@@ -38,6 +38,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest("foo %5.2s", "bar", "foo    ba");
     DoStrTest("foo %-5s", "bar", "foo bar  ");
     DoStrTest("foo %05s", "bar", "foo 00bar");
+    DoStrTest("foo %s", NULL, "foo (null)");
+    DoStrTest("foo %hs", NULL, "foo (null)");
+    DoStrTest("foo %ls", NULL, "foo (null)");
+    DoStrTest("foo %ws", NULL, "foo (null)");
+    DoStrTest("foo %Ls", NULL, "foo (null)");
+    DoStrTest("foo %I64s", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;    

--- a/src/pal/tests/palsuite/c_runtime/vfprintf/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vfprintf/test3/test3.cpp
@@ -37,6 +37,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest("foo %5.2S", convert("bar"), "foo    ba");
     DoWStrTest("foo %-5S", convert("bar"), "foo bar  ");
     DoWStrTest("foo %05S", convert("bar"), "foo 00bar");
+    DoWStrTest("foo %S", NULL, "foo (null)");
+    DoStrTest("foo %hS", NULL, "foo (null)");
+    DoWStrTest("foo %lS", NULL, "foo (null)");
+    DoWStrTest("foo %wS", NULL, "foo (null)");
+    DoWStrTest("foo %LS", NULL, "foo (null)");
+    DoWStrTest("foo %I64S", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/vprintf/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vprintf/test2/test2.cpp
@@ -38,6 +38,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest("foo %5.2s", "bar", "foo    ba");
     DoStrTest("foo %-5s", "bar", "foo bar  ");
     DoStrTest("foo %05s", "bar", "foo 00bar");
+    DoStrTest("foo %s", NULL, "foo (null)");
+    DoStrTest("foo %hs", NULL, "foo (null)");
+    DoWStrTest("foo %ls", NULL, "foo (null)");
+    DoWStrTest("foo %ws", NULL, "foo (null)");
+    DoStrTest("foo %Ls", NULL, "foo (null)");
+    DoStrTest("foo %I64s", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;    

--- a/src/pal/tests/palsuite/c_runtime/vprintf/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vprintf/test3/test3.cpp
@@ -37,6 +37,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest("foo %5.2S", convert("bar"), "foo    ba");
     DoWStrTest("foo %-5S", convert("bar"), "foo bar  ");
     DoWStrTest("foo %05S", convert("bar"), "foo 00bar");
+    DoWStrTest("foo %S", NULL, "foo (null)");
+    DoStrTest("foo %hS", NULL, "foo (null)");
+    DoWStrTest("foo %lS", NULL, "foo (null)");
+    DoWStrTest("foo %wS", NULL, "foo (null)");
+    DoWStrTest("foo %LS", NULL, "foo (null)");
+    DoWStrTest("foo %I64S", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/vsprintf/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vsprintf/test2/test2.cpp
@@ -36,6 +36,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest("foo %5.2s", "bar", "foo    ba");
     DoStrTest("foo %-5s", "bar", "foo bar  ");
     DoStrTest("foo %05s", "bar", "foo 00bar");   
+    DoStrTest("foo %s", NULL, "foo (null)");
+    DoStrTest("foo %hs", NULL, "foo (null)");
+    DoWStrTest("foo %ls", NULL, "foo (null)");
+    DoWStrTest("foo %ws", NULL, "foo (null)");
+    DoStrTest("foo %Ls", NULL, "foo (null)");
+    DoStrTest("foo %I64s", NULL, "foo (null)");
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/vsprintf/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vsprintf/test3/test3.cpp
@@ -37,6 +37,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest("foo %5.2S", convert("bar"), "foo    ba");
     DoWStrTest("foo %-5S", convert("bar"), "foo bar  ");
     DoWStrTest("foo %05S", convert("bar"), "foo 00bar");
+    DoWStrTest("foo %S", NULL, "foo (null)");
+    DoStrTest("foo %hS", NULL, "foo (null)");
+    DoWStrTest("foo %lS", NULL, "foo (null)");
+    DoWStrTest("foo %wS", NULL, "foo (null)");
+    DoWStrTest("foo %LS", NULL, "foo (null)");
+    DoWStrTest("foo %I64S", NULL, "foo (null)");
     
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/vswprintf/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vswprintf/test2/test2.cpp
@@ -34,6 +34,12 @@ int __cdecl main(int argc, char *argv[])
     DoWStrTest(convert("foo %5.2s"), convert("bar"), convert("foo    ba"));
     DoWStrTest(convert("foo %-5s"), convert("bar"), convert("foo bar  "));
     DoWStrTest(convert("foo %05s"), convert("bar"), convert("foo 00bar"));
+    DoWStrTest(convert("foo %s"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %hs"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %ls"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %ws"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %Ls"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %I64s"), NULL, convert("foo (null)"));
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/vswprintf/test3/test3.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vswprintf/test3/test3.cpp
@@ -34,6 +34,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest(convert("foo %5.2S"), "bar", convert("foo    ba"));
     DoStrTest(convert("foo %-5S"), "bar", convert("foo bar  "));
     DoStrTest(convert("foo %05S"), "bar", convert("foo 00bar"));
+    DoStrTest(convert("foo %S"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %hS"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %lS"), NULL, convert("foo (null)"));
+    DoWStrTest(convert("foo %wS"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %LS"), NULL, convert("foo (null)"));
+    DoStrTest(convert("foo %I64S"), NULL, convert("foo (null)"));
 
     PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/wprintf/test2/test2.cpp
+++ b/src/pal/tests/palsuite/c_runtime/wprintf/test2/test2.cpp
@@ -38,6 +38,12 @@ int __cdecl main(int argc, char *argv[])
     DoStrTest(u"foo %5.2s", u"bar", u"foo    ba");
     DoStrTest(u"foo %-5s", u"bar", u"foo bar  ");
     DoStrTest(u"foo %05s", u"bar", u"foo 00bar");
+    DoStrTest(u"foo %s", NULL, u"foo (null)");
+    DoStrTest(u"foo %hs", NULL, u"foo (null)");
+    DoStrTest(u"foo %ls", NULL, u"foo (null)");
+    DoStrTest(u"foo %ws", NULL, u"foo (null)");
+    DoStrTest(u"foo %Ls", NULL, u"foo (null)");
+    DoStrTest(u"foo %I64s", NULL, u"foo (null)");
 
     PAL_Terminate();
     return PASS;    


### PR DESCRIPTION
The functions implementing various printf flavors in PAL were not handling
correctly the case when a string pointer passed to them for %S and %s formats
was NULL. Instead of printing `(null)`, they were crashing.

This change fixes the problem and also adds PAL tests to verify it is working
properly.