### PR TITLE
Do not supply fx_root to run-corefx-tests

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2065,7 +2065,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         buildCommands += genStressModeScriptStep(os, scenario, Constants.jitStressModeScenarios[scenario], scriptFileName)
 
                         // Build and text corefx
-                        def fxRoot = "\$WORKSPACE%/_/fx"
+                        def fxRoot = "\$WORKSPACE/_/fx"
                         buildCommands += "python \$WORKSPACE/tests/scripts/run-corefx-tests.py -arch ${arch} -build_type ${configuration} -fx_root ${fxRoot} -fx_branch ${branch} -env_script ${scriptFileName}"
 
                         // Archive and process test result

--- a/tests/scripts/run-corefx-tests.py
+++ b/tests/scripts/run-corefx-tests.py
@@ -125,8 +125,6 @@ def validate_args(args):
         fx_root = os.path.join(clr_root, '_', 'fx')
     else:
         fx_root = os.path.normpath(fx_root)
-        validate_arg(fx_root, lambda item: os.path.isdir(
-            os.path.dirname(fx_root)))
 
     if env_script is not None:
         validate_arg(env_script, lambda item: os.path.isfile(env_script))


### PR DESCRIPTION
Supplying fx_root as a parameter to run-corefx-tests.py implies that the
directory already exists. This change updates netci.groovy to not supply
the path to fx_root so it will use the baked in default
(<coreclr_root>\_\fx), which bypasses the validation step.