### PR TITLE
Fix DevDiv 362706

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -14051,10 +14051,20 @@ GenTree* Compiler::fgMorphModToSubMulDiv(GenTreeOp* tree)
     {
         numerator = fgMakeMultiUse(&tree->gtOp1);
     }
+    else if (lvaLocalVarRefCounted && numerator->OperIsLocal())
+    {
+        // Morphing introduces new lclVar references. Increase ref counts
+        lvaIncRefCnts(numerator);
+    }
 
     if (!denominator->OperIsLeaf())
     {
         denominator = fgMakeMultiUse(&tree->gtOp2);
+    }
+    else if (lvaLocalVarRefCounted && denominator->OperIsLocal())
+    {
+        // Morphing introduces new lclVar references. Increase ref counts
+        lvaIncRefCnts(denominator);
     }
 
     // The numerator and denominator may have been assigned to temps, in which case

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_362706/DevDiv_362706.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_362706/DevDiv_362706.il
@@ -1,0 +1,162 @@
+// Reading from 'C:\SuperPMI\compiler_hpp__1784____Assertion_failed__lvRefCnt.mc' dumping raw IL for MC Indexes to console
+// ProcessName - 'ILGEN'
+.assembly extern mscorlib{}
+.assembly DevDiv_362706{}
+.class C extends [mscorlib]System.Object
+{
+   .method static unsigned int64 M(float32, int32) cil managed noinlining
+   {
+      .maxstack  65535
+      .locals init (unsigned int8, native unsigned int)
+
+      ldc.i8 0x085d689753da3de1
+      ldc.i8 0xe61597946032e570
+      clt.un
+      conv.u8
+      ldc.i8 0x7982285f972837bd
+      ldc.i8 0xbff060a0e0e2eeba
+      sub
+      ldloc 0x0001
+      shl
+      mul.ovf
+      ldarg.s 0x00
+      starg.s 0x00
+      brtrue IL_005f
+      ldc.i8 0xbcb846d27e2968bf
+      conv.r.un
+      ckfinite
+      pop
+      ldarg.s 0x01
+      conv.ovf.i8
+      ldc.i8 0xe3b63c00f2954a6c
+      ldc.i8 0x3332cfb7aa00a0b0
+      div.un
+      clt
+      stloc 0x0001
+
+IL_005f:
+      ldloc 0x0000
+      ldc.i4 0x1ef1d296
+      ldc.r8 float64(0x157cd4c7a3c884f1)
+      ldc.r8 float64(0xa5da6ecb57585851)
+      add
+      ckfinite
+      neg
+      conv.r.un
+      conv.ovf.i4.un
+      cgt.un
+      not
+      or
+      ldarg.s 0x00
+      conv.r.un
+      ldarg 0x0000
+      ldc.i8 0x9cb75a81b3443e9c
+      conv.ovf.u8.un
+      conv.i4
+      pop
+      neg
+      cgt.un
+      ldloc 0x0001
+      ldc.i4 0x1bf905b2
+      ldloc.s 0x00
+      xor
+      rem
+      ldloc.s 0x00
+      ldc.r8 float64(0x94424127b67875d0)
+      ldc.i8 0x96e1b4664d5ad509
+      conv.ovf.i2
+      conv.r4
+      add
+      conv.ovf.u2.un
+      shr.un
+      shr
+      ldc.i8 0x1919368cc08e5eb1
+      ldc.i8 0x4b6a3f418d2e0236
+      ceq
+      ceq
+      starg.s 0x01
+      bgt IL_011a
+      ldarg.s 0x00
+      conv.ovf.i8.un
+      ldloc 0x0000
+      ldc.r8 float64(0x7e83ec1e8c2e0e94)
+      conv.ovf.i2
+      shl
+      not
+      not
+      conv.i8
+      conv.ovf.u8
+      ldc.i4 0x8a3055bd
+      neg
+      ldarg 0x0001
+      xor
+      conv.i8
+      ldc.i4 0xa2d0ea18
+      shr.un
+      ldc.i8 0x53ac012d34eb9f44
+      xor
+      neg
+      add
+      ldarg 0x0000
+      conv.ovf.u4.un
+      shr
+      or
+      conv.r8
+      pop
+
+IL_011a:
+      ldarg 0x0000
+      neg
+      ldarg 0x0000
+      neg
+      div
+      ldloc.s 0x01
+      ldarg 0x0001
+      ldloc 0x0000
+      ldloc 0x0001
+      and
+      shl
+      mul.ovf.un
+      starg.s 0x01
+      ldc.i4 0xc47fec23
+      conv.r8
+      div
+      conv.ovf.i8.un
+      not
+      ldc.r8 float64(0x401dee505a2add2e)
+      ldc.i8 0x0dc5a76cd1306317
+      conv.i1
+      conv.r8
+      add
+      conv.r4
+      conv.ovf.i1.un
+      nop
+      stloc.s 0x00
+      nop
+      ret
+   }
+
+   .method static int32 Main() cil managed
+   {
+       .entrypoint
+
+       .try
+       {
+           ldc.r4		float32(0xFF800000)
+           ldc.i4.s   25
+           call unsigned int64 C::M(float32, int32)
+           pop
+           leave.s done
+       }
+       catch [mscorlib]System.Exception
+       {
+           pop
+           leave.s done
+       }
+
+   done:
+       ldc.i4 100
+       ret
+   }
+}
+// Dumped 1

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_362706/DevDiv_362706.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_362706/DevDiv_362706.ilproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_362706.il" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_JitStressRegs=0x200
+]]></CLRTestBatchPreCommands>
+  <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_JitStressRegs=0x200
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
The issue here was that when we morphed a mod into a sub mul div, we would
ultimately decrease the ref counts to the numerator of the original mod
without performing a corresponding increase. The fix is to increase the
ref count when morphing into the sub mul div.