### PR TITLE
Fix unsigned_abs function on Unix

### DIFF
--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -699,11 +699,7 @@ inline unsigned int unsigned_abs(int x)
 #ifdef _TARGET_64BIT_
 inline size_t unsigned_abs(ssize_t x)
 {
-#ifndef FEATURE_PAL
     return ((size_t)abs(x));
-#else  // !FEATURE_PAL
-    return ((size_t)labs(x));
-#endif // !FEATURE_PAL
 }
 #endif // _TARGET_64BIT_
 


### PR DESCRIPTION
The unsigned_abs function in jit.h is implemented using labs function.
However labs has 32 bit argument / result, while the unsigned_abs expects
it to be 64 bit.
The correct function to use for FEATURE_PAL is llabs. But since we now have
abs overload for __int64 in pal.h, we can just remove the #ifdef for FEATURE_PAL
and use the same implementation for both Unix and Windows.