### PR TITLE
Add a missing ref count bump in DecomposeLclFld.

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -411,6 +411,8 @@ GenTree* DecomposeLongs::DecomposeLclFld(LIR::Use& use)
     GenTree* hiResult = m_compiler->gtNewLclFldNode(loResult->gtLclNum, TYP_INT, loResult->gtLclOffs + 4);
     Range().InsertAfter(loResult, hiResult);
 
+    m_compiler->lvaIncRefCnts(hiResult);
+
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);
 }
 


### PR DESCRIPTION
DecomposeLclFld transforms a single lclFld node into two lclFld nodes
that reference the same lclVar, but was missing a corresponding ref
count bump. This was causing a failure in JIT/Methodical/fp/exgen/10w5d_cs_do
under JITStress=1 and JITStress=2.