### PR TITLE
[RyuJIT/ARM32]Implement NYI("Cast")

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -4620,13 +4620,8 @@ bool Lowering::NodesAreEquivalentLeaves(GenTreePtr tree1, GenTreePtr tree2)
     }
 }
 
-#ifdef _TARGET_64BIT_
 /**
  * Get common information required to handle a cast instruction
- *
- * Right now only supports 64 bit targets. In order to support 32 bit targets the
- * switch statement needs work.
- *
  */
 void Lowering::getCastDescription(GenTreePtr treeNode, CastInfo* castInfo)
 {
@@ -4662,7 +4657,6 @@ void Lowering::getCastDescription(GenTreePtr treeNode, CastInfo* castInfo)
         bool    signCheckOnly = false;
 
         // Do we need to compare the value, or just check masks
-
         switch (dstType)
         {
             default:
@@ -4696,9 +4690,13 @@ void Lowering::getCastDescription(GenTreePtr treeNode, CastInfo* castInfo)
                 }
                 else
                 {
+#ifdef _TARGET_64BIT_
                     typeMask = 0xFFFFFFFF80000000LL;
-                    typeMin  = INT_MIN;
-                    typeMax  = INT_MAX;
+#else
+                    typeMask = 0x80000000;
+#endif
+                    typeMin = INT_MIN;
+                    typeMax = INT_MAX;
                 }
                 break;
 
@@ -4709,7 +4707,11 @@ void Lowering::getCastDescription(GenTreePtr treeNode, CastInfo* castInfo)
                 }
                 else
                 {
+#ifdef _TARGET_64BIT_
                     typeMask = 0xFFFFFFFF00000000LL;
+#else
+                    typeMask = 0x00000000;
+#endif
                 }
                 break;
 
@@ -4732,8 +4734,6 @@ void Lowering::getCastDescription(GenTreePtr treeNode, CastInfo* castInfo)
         castInfo->typeMask = typeMask;
     }
 }
-
-#endif // _TARGET_64BIT_
 
 #ifdef DEBUG
 void Lowering::DumpNodeInfoMap()

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -45,9 +45,7 @@ public:
         bool    signCheckOnly; // For converting between unsigned/signed int
     };
 
-#ifdef _TARGET_64BIT_
     static void getCastDescription(GenTreePtr treeNode, CastInfo* castInfo);
-#endif // _TARGET_64BIT_
 
 private:
 #ifdef DEBUG

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -172,10 +172,8 @@ void Lowering::LowerCast(GenTree* tree)
     var_types  srcType = op1->TypeGet();
     var_types  tmpType = TYP_UNDEF;
 
-    // TODO-ARM-Cleanup: Remove following NYI assertions.
     if (varTypeIsFloating(srcType))
     {
-        NYI_ARM("Lowering for cast from float"); // Not tested yet.
         noway_assert(!tree->gtOverflow());
     }
 
@@ -893,7 +891,12 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 #ifdef DEBUG
             if (!tree->gtOverflow() && (varTypeIsFloating(castToType) || varTypeIsFloating(castOpType)))
             {
-                NYI_ARM("float cast");
+                // If converting to float/double, the operand must be 4 or 8 byte in size.
+                if (varTypeIsFloating(castToType))
+                {
+                    unsigned opSize = genTypeSize(castOpType);
+                    assert(opSize == 4 || opSize == 8);
+                }
             }
 #endif // DEBUG
 


### PR DESCRIPTION
Implement NYI("Cast") for ARM32-Ryujit.

Implement genIntToIntCast(), genFloatToFloatCast(),
genIntToFloatCast() and genFloatToIntCast() in codegenarm.cpp.
This commit bases upon ARM64 code.
(Code for int64/uint64 is marked as NYI_ARM)