### PR TITLE
[WIP] Treat array indices as unsigned

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5715,7 +5715,7 @@ GenTreePtr Compiler::fgMorphArrayIndex(GenTreePtr tree)
         }
         else
         {
-            index = gtNewCastNode(TYP_I_IMPL, index, TYP_I_IMPL);
+            index = gtNewCastNode(TYP_I_IMPL, index, TYP_U_IMPL);
         }
     }
 #endif // _TARGET_64BIT_


### PR DESCRIPTION
Array indices are signed according to the ECMA spec but they're subject to bound checks that reject negative values so we can treat them as unsigned when widening to pointer size.

The advantage is that we end up using a `mov` instruction instead of a `movsx` instruction. The former sometimes has smaller encoding and it is supposed to have 0 latency on recent Intel CPUs.