### PR TITLE
Add Container arg to config.json for package publishing

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,12 @@
       "values": [],
       "defaultValue": ""
     },
+    "__Container": {
+      "description": "Container name for Azure upload.",
+      "valueType": "property",
+      "values": [],
+      "defaultValue": ""
+    },
     "MsBuildFileLogging": {
       "description": "MsBuild logging options.",
       "valueType": "passThrough",
@@ -392,6 +398,12 @@
           "description": "Account name to connect to Azure Blob storage.",
           "settings": {
             "CloudDropAccountName": "default"
+          }
+        },
+        "container": {
+          "description": "Container name to download from in Azure Blob storage.",
+          "settings": {
+            "__Container": "default"
           }
         },
         "verbose": {


### PR DESCRIPTION
This will replace '/p:ContainerName=xxx' with '-Container=xxx' when running publish-packages.sh. This was a required change for Master, and since Master and 1.1.0 use the same VSO build definition, we need this change for 1.1.0 as well. It will not change behavior.

CC @gkhanna79 @dagood @MattGal 