### PR TITLE
Use POSIX "command" instead of non-standard "which"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,16 +2,8 @@
 
 # resolve python-version to use
 if [ "$PYTHON" == "" ] ; then
-    if which python >/dev/null 2>&1
+    if ! PYTHON=$(command -v python || command -v python2 || command -v python 2.7)
     then
-       PYTHON=python
-    elif which python2 >/dev/null 2>&1
-    then
-       PYTHON=python2
-    elif which python2.7 >/dev/null 2>&1
-    then
-       PYTHON=python2.7
-    else
        echo "Unable to locate build-dependency python2.x!" 1>&2
        exit 1
     fi
@@ -19,7 +11,7 @@ fi
 
 # validate python-dependency
 # useful in case of explicitly set option.
-if ! which $PYTHON > /dev/null 2>&1
+if ! command -v $PYTHON > /dev/null
 then
    echo "Unable to locate build-dependency python2.x ($PYTHON)!" 1>&2
    exit 1
@@ -196,11 +188,7 @@ build_native()
     if [ $__UseNinja == 1 ]; then
         generator="ninja"
         buildFile="build.ninja"
-        if which ninja >/dev/null 2>&1; then
-            buildTool="ninja"
-        elif which ninja-build >/dev/null 2>&1; then
-            buildTool="ninja-build"
-        else
+        if ! buildTool=$(command -v ninja || command -v ninja-build); then
            echo "Unable to locate ninja!" 1>&2
            exit 1
         fi

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -110,8 +110,7 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
             __DOTNET_LOCATION="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.${__DOTNET_TOOLS_VERSION}.tar.gz"
             # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
             echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> $__init_tools_log
-            which curl > /dev/null 2> /dev/null
-            if [ $? -ne 0 ]; then
+            if command -v curl > /dev/null; then
                 wget -q -O $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
             else
                 curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}

--- a/src/corefx/format-code.sh
+++ b/src/corefx/format-code.sh
@@ -2,10 +2,10 @@
 
 # OS X names clang-format as clang-format; Ubuntu uses
 # clang-format-version so check for the right one
-if which "clang-format-3.6" > /dev/null 2>&1 ; then
-   export CF="$(which clang-format-3.6)"
-elif which "clang-format" > /dev/null 2>&1 ; then
-   export CF="$(which clang-format)"
+if command -v "clang-format-3.6" > /dev/null; then
+   export CF="$(command -v clang-format-3.6)"
+elif command -v "clang-format" > /dev/null; then
+   export CF="$(command -v clang-format)"
 else
    echo "Unable to find clang-format"
    exit 1

--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -18,18 +18,18 @@ then
 fi
 
 # Set up the environment to be used for building with clang.
-if which "clang-$2.$3" > /dev/null 2>&1
+if command -v "clang-$2.$3" > /dev/null
     then
-        export CC="$(which clang-$2.$3)"
-        export CXX="$(which clang++-$2.$3)"
-elif which "clang$2$3" > /dev/null 2>&1
+        export CC="$(command -v clang-$2.$3)"
+        export CXX="$(command -v clang++-$2.$3)"
+elif command -v "clang$2$3" > /dev/null
     then
-        export CC="$(which clang$2$3)"
-        export CXX="$(which clang++$2$3)"
-elif which clang > /dev/null 2>&1
+        export CC="$(command -v clang$2$3)"
+        export CXX="$(command -v clang++$2$3)"
+elif command -v clang > /dev/null
     then
-        export CC="$(which clang)"
-        export CXX="$(which clang++)"
+        export CC="$(command -v clang)"
+        export CXX="$(command -v clang++)"
 else
     echo "Unable to find Clang Compiler"
     exit 1
@@ -97,12 +97,12 @@ else
   desired_llvm_version="-$desired_llvm_major_version.$desired_llvm_minor_version"
 fi
 locate_llvm_exec() {
-  if which "$llvm_prefix$1$desired_llvm_version" > /dev/null 2>&1
+  if command -v "$llvm_prefix$1$desired_llvm_version" > /dev/null 2>&1
   then
-    echo "$(which $llvm_prefix$1$desired_llvm_version)"
-  elif which "$llvm_prefix$1" > /dev/null 2>&1
+    echo "$(command -v $llvm_prefix$1$desired_llvm_version)"
+  elif command -v "$llvm_prefix$1" > /dev/null 2>&1
   then
-    echo "$(which $llvm_prefix$1)"
+    echo "$(command -v $llvm_prefix$1)"
   else
     exit 1
   fi


### PR DESCRIPTION
GNU `which` might not be installed on a minimal GNU/Linux installation.

It's also not listed in the [building instructions](https://github.com/dotnet/coreclr/blob/master/Documentation/building/linux-instructions.md#toolchain-setup)

Build failed on my Arch Linux base install without error messages (`stderr` is redirected to `/dev/null`) because of the missing GNU `which` command even though `python` is installed:

```
juergen@sammy:~/cxx/coreclr → ./build.sh 
Unable to locate build-dependency python2.x!
```

There is no need to use `which` because every POSIX shell provides [command](http://pubs.opengroup.org/onlinepubs/009696899/utilities/command.htmll) to get the pathname of a command.

I know there was already a [try](https://github.com/dotnet/coreclr/pull/6994) and [revert](https://github.com/dotnet/coreclr/pull/7025) 

I don't know why it was reverted/broke the build. Maybe because the original author @adityamandaleeka used `hash`  which has a different purpose (caching/manipulating command locations).
