### PR TITLE
Fix check for JIT dasm

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -1143,7 +1143,7 @@ if [ ! -z "$gcsimulator" ]; then
     export RunningGCSimulatorTests=1
 fi
 
-if [ ! -z "$jitdisasm" ]; then
+if [[ ! "$jitdisasm" -eq 0 ]]; then
     echo "Running jit disasm"
     export RunningJitDisasm=1
 fi


### PR DESCRIPTION
Commit https://github.com/dotnet/coreclr/commit/37139ef1a7631e618ee587287b48d49dad04be94 added a switch to runtest.sh to enable running JIT dasm. Unfortunately, the condition that checks the value of the variable was using `-z` when it should be comparing against 0, the initial value that was set for the variable. As a result, it was always being treated as enabled.

I noticed this because I was getting errors related to JIT dasm when trying to validate some runtime changes I made locally, even though I never specified the `--jitdasm` argument. Looking at CI logs, it turns out that our CI builds have also been running as though this switch was being specified all this while.

@sbomer