### PR TITLE
Add parameterless overloads of TrimStart/TrimEnd

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -7477,7 +7477,9 @@
       <Member Name="Trim" />
       <Member Name="Trim(System.Char[])" />
       <Member Name="TrimEnd(System.Char[])" />
+      <Member Name="TrimEnd" />
       <Member Name="TrimStart(System.Char[])" />
+      <Member Name="TrimStart" />
       <Member MemberType="Property" Name="Chars(System.Int32)" />
       <Member MemberType="Property" Name="Length" />
       <Member Status="ImplRoot" Name="System.Collections.IEnumerable.GetEnumerator" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -3419,7 +3419,9 @@ namespace System
         public System.String Trim() { throw null; }
         public System.String Trim(params char[] trimChars) { throw null; }
         public System.String TrimEnd(params char[] trimChars) { throw null; }
+        public System.String TrimEnd() { throw null; }
         public System.String TrimStart(params char[] trimChars) { throw null; }
+        public System.String TrimStart() { throw null; }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public abstract partial class StringComparer : System.Collections.Generic.IComparer<string>, System.Collections.Generic.IEqualityComparer<string>, System.Collections.IComparer, System.Collections.IEqualityComparer

--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -1553,14 +1553,23 @@ namespace System
             }
             return TrimHelper(trimChars,TrimHead);
         }
-    
-    
+
+        // Removes a set of characters from the beginning of this string.
+        public String TrimStart() {
+            return TrimHelper(TrimHead);
+        }
+
         // Removes a set of characters from the end of this string.
         public String TrimEnd(params char[] trimChars) {
             if (null==trimChars || trimChars.Length == 0) {
                 return TrimHelper(TrimTail);
             }
             return TrimHelper(trimChars,TrimTail);
+        }
+        
+        // Removes a set of characters from the end of this string.
+        public String TrimEnd() {
+             TrimHelper(TrimTail);
         }
 
         // Trims the whitespace from both ends of the string.  Whitespace is defined by

--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -1555,9 +1555,8 @@ namespace System
         }
 
         // Removes a set of characters from the beginning of this string.
-        public String TrimStart() {
-            return TrimHelper(TrimHead);
-        }
+        public String TrimStart() => TrimHelper(TrimHead);
+        
 
         // Removes a set of characters from the end of this string.
         public String TrimEnd(params char[] trimChars) {
@@ -1568,9 +1567,8 @@ namespace System
         }
         
         // Removes a set of characters from the end of this string.
-        public String TrimEnd() {
-           return TrimHelper(TrimTail);
-        }
+        public String TrimEnd()=> TrimHelper(TrimTail);
+        
 
         // Trims the whitespace from both ends of the string.  Whitespace is defined by
         // Char.IsWhiteSpace.

--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -1569,7 +1569,7 @@ namespace System
         
         // Removes a set of characters from the end of this string.
         public String TrimEnd() {
-             TrimHelper(TrimTail);
+           return TrimHelper(TrimTail);
         }
 
         // Trims the whitespace from both ends of the string.  Whitespace is defined by


### PR DESCRIPTION
Add parameterless overloads of TrimStart/TrimEnd on String.Manipulation.cs, model.xml and ref/mscorlib.cs

Fix https://github.com/dotnet/corefx/issues/6485