### PR TITLE
Cross-compile - Added libunwind8-dev as package prerequisite

### DIFF
--- a/Documentation/building/cross-building.md
+++ b/Documentation/building/cross-building.md
@@ -8,7 +8,7 @@ Requirements
 
 You need a Debian based host and the following packages needs to be installed:
 
-    ben@ubuntu ~/git/coreclr/ $ sudo apt-get install qemu qemu-user-static binfmt-support debootstrap
+    ben@ubuntu ~/git/coreclr/ $ sudo apt-get install qemu qemu-user-static binfmt-support debootstrap libunwind8-dev
 
 In addition, to cross compile CoreCLR the binutils for the target are required. So for arm you need:
 


### PR DESCRIPTION
Following the step-by-step cross compile document for ARM, found that libunwind8-dev was required.

Got an 'libunwind.so.8: cannot open shared object file: No such file or directory' error.

The solution was install libunwind8-dev as suggested by @mellinoe in [dotnet/corefx 8053](https://github.com/dotnet/corefx/issues/8053#issuecomment-214500837). 

Just added to the required apt-get install, but maybe is also a good idea to add it to prerequisites component check.