### PR TITLE
Remove lazy initialization of Task.CompletedTask

### DIFF
--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -1617,21 +1617,8 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static TaskFactory Factory { get { return s_factory; } }
 
-        /// <summary>A task that's already been completed successfully.</summary>
-        private static Task s_completedTask;
-
         /// <summary>Gets a task that's already been completed successfully.</summary>
-        /// <remarks>May not always return the same instance.</remarks>        
-        public static Task CompletedTask
-        {
-            get
-            {
-                var completedTask = s_completedTask;
-                if (completedTask == null)
-                    s_completedTask = completedTask = new Task(false, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default(CancellationToken)); // benign initialization race condition
-                return completedTask;
-            }
-        }
+        public static Task CompletedTask { get; } = new Task(false, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default(CancellationToken));
 
         /// <summary>
         /// Provides an event that can be used to wait for completion.

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -147,7 +147,6 @@ namespace System.Threading.Tasks
         private static StackGuard t_stackGuard;  // The stack guard object for this thread
 
         internal static int s_taskIdCounter; //static counter used to generate unique task IDs
-        private readonly static TaskFactory s_factory = new TaskFactory();
 
         private volatile int m_taskId; // this task's unique ID. initialized only if it is ever requested
 
@@ -1615,7 +1614,7 @@ namespace System.Threading.Tasks
         /// of <see cref="System.Threading.Tasks.TaskFactory"/>, as would result from using
         /// the default constructor on TaskFactory.
         /// </remarks>
-        public static TaskFactory Factory { get { return s_factory; } }
+        public static TaskFactory Factory { get; } = new TaskFactory();
 
         /// <summary>Gets a task that's already been completed successfully.</summary>
         public static Task CompletedTask { get; } = new Task(false, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default(CancellationToken));


### PR DESCRIPTION
The lazy-initialization code of Task.CompletedTask is causing it to be an "unprofitable inline".  For workloads that make heavy use of Task-returning methods that complete synchronously, this is showing up as a measurable impact, e.g. in a simple benchmark reading and writing to the channels in the channels lib on corefxlabs, it's resulting in 2-5% overhead.  However, as it's used by a bunch of core .NET types, e.g. a bunch of streams like FileStream and MemoryStream, it's rare that it won't be needed, and it's often needed very early in a program's execution.  This commit just removes the lazy-initialization, removing a branch and allowing the getter to be inlined.

cc: @jkotas, @AndyAyersMS 