### PR TITLE
[x86/Linux] Fix generic context(hidden arg) position

### DIFF
--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -829,15 +829,24 @@ Stub * CreateInstantiatingILStub(MethodDesc* pTargetMD, void* pHiddenArg)
     CreateInstantiatingILStubTargetSig(pTargetMD, typeContext, &stubSigBuilder);
     
     // 2. Emit the method body
+    unsigned int numArgs = msig.NumFixedArgs();
     if (msig.HasThis())
     {
         // 2.1 Push the thisptr
         pCode->EmitLoadThis();
+        numArgs++;
     }
 
-    // 2.2 Push the hidden context param 
-    // InstantiatingStub
-    pCode->EmitLDC((TADDR)pHiddenArg);
+#if defined(_TARGET_X86_)
+    if (numArgs < NUM_ARGUMENT_REGISTERS)
+    {
+#endif // _TARGET_X86_
+        // 2.2 Push the hidden context param
+        // InstantiatingStub
+        pCode->EmitLDC((TADDR)pHiddenArg);
+#if defined(_TARGET_X86_)
+    }
+#endif // _TARGET_X86_
 
     // 2.3 Push the rest of the arguments
     for (unsigned i = 0; i < msig.NumFixedArgs();i++)
@@ -845,10 +854,19 @@ Stub * CreateInstantiatingILStub(MethodDesc* pTargetMD, void* pHiddenArg)
         pCode->EmitLDARG(i);
     }
 
-    // 2.4 Push the target address
+#if defined(_TARGET_X86_)
+    if (numArgs >= NUM_ARGUMENT_REGISTERS)
+    {
+        // 2.4 Push the hidden context param
+        // InstantiatingStub
+        pCode->EmitLDC((TADDR)pHiddenArg);
+    }
+#endif // _TARGET_X86_
+
+    // 2.5 Push the target address
     pCode->EmitLDC((TADDR)pTargetMD->GetMultiCallableAddrOfCode(CORINFO_ACCESS_ANY));
 
-    // 2.5 Do the calli
+    // 2.6 Do the calli
     pCode->EmitCALLI(TOKEN_ILSTUB_TARGET_SIG, msig.NumFixedArgs() + 1, msig.IsReturnTypeVoid() ? 0 : 1);
     pCode->EmitRET();
 


### PR DESCRIPTION
This fixes how to handle generic context position in x86 by num of arguments
