### PR TITLE
[x86/Linux] Fix Release build Error

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5959,11 +5959,11 @@ void Compiler::gtComputeFPlvls(GenTreePtr tree)
             noway_assert(!isflt);
             break;
 
-#ifdef DEBUG
         default:
+#ifdef DEBUG
             noway_assert(!"Unhandled special operator in gtComputeFPlvls()");
-            break;
 #endif
+            break;
     }
 
 DONE:


### PR DESCRIPTION
This commit fixes the following compile  error for x86/Linux Release build:
```
src/jit/gentree.cpp:5907:13: error: 119 enumeration values not handled in switch: 'GT_NONE', 'GT_LCL_VAR', 'GT_LCL_FLD'... [-Werror,-Wswitch]
    switch (oper)
```