### PR TITLE
Default gcAllowVeryLargeObjects to true

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -338,7 +338,7 @@ RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_GCprnLvl, W("GCprnLvl"), "Spe
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCRetainVM, W("GCRetainVM"), 0, "When set we put the segments that should be deleted on a standby list (instead of releasing them back to the OS) which will be considered to satisfy new segment requests (note that the same thing can be specified via API which is the supported way)")
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_GCSegmentSize, W("GCSegmentSize"), "Specifies the managed heap segment size")
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_GCLOHCompact, W("GCLOHCompact"), "Specifies the LOH compaction mode")
-RETAIL_CONFIG_DWORD_INFO(EXTERNAL_gcAllowVeryLargeObjects, W("gcAllowVeryLargeObjects"), 0, "allow allocation of 2GB+ objects on GC heap")
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_gcAllowVeryLargeObjects, W("gcAllowVeryLargeObjects"), 1, "allow allocation of 2GB+ objects on GC heap")
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_GCStress, W("GCStress"), 0, "trigger GCs at regular intervals", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_GcStressOnDirectCalls, W("GcStressOnDirectCalls"), 0, "whether to trigger a GC on direct calls", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_GCStressStart, W("GCStressStart"), 0, "start GCStress after N stress GCs have been attempted")

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-RTM/b539509/b539509.cs
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-RTM/b539509/b539509.cs
@@ -133,7 +133,7 @@ public class AA<TA, TB, TC, TD, TE, TF>
         do
         {
             bool[, , , ,][,] local8 = (new bool[81u, 98u, ((uint)(58.0f)), ((uint)(36.0f)),
-                74u][,]);
+                74u*4u][,]);
             while ((((uint)(local5)) != 4u))
             {
                 if (Convert.ToBoolean((local5 + local5)))

--- a/tests/src/JIT/jit64/regress/vsw/539509/test1.cs
+++ b/tests/src/JIT/jit64/regress/vsw/539509/test1.cs
@@ -162,7 +162,7 @@ public class AA<TA, TB, TC, TD, TE, TF>
         do
         {
             bool[,,,,][,] local8 = (new bool[81u, 98u, ((uint)(58.0f)), ((uint)(36.0f)),
-                74u][,]);
+                74u*4u][,]);
             while ((((uint)(local5)) != 4u))
             {
                 if (Convert.ToBoolean((local5 + local5)))


### PR DESCRIPTION
It seems to me that this option should be enabled by default in a new framework such as .NET Core. 

The only reason I can think of why one might want to disable this option is poorly written unsafe code that assumes that objects can't be larger than 2GB and thus offsets can be represented using `int`. Any compat concerns?

Fixes #8847