### PR TITLE
Reduce SeekUnroll iter count

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
@@ -62,9 +62,9 @@ public static class SeekUnroll
     // Iteration counts for inner loop set to have each call take 1 or
     // 2 seconds or so in release, finish quickly in debug.
 #if DEBUG
-    const int InnerIterations = 1;
+    static int InnerIterations = 1;
 #else
-    const int InnerIterations = 1000000000;
+    static int InnerIterations = 1000000000;
 #endif
 
     // Function to meaure InnerLoop using the xunit-perf benchmark measurement facilities
@@ -143,6 +143,14 @@ public static class SeekUnroll
     public static int Main()
     {
         int failures = 0;
+
+        // On non-hardware accelerated platforms, the test times out because it runs for too long.
+        // In those cases, we decrease InnerIterations so the test doesn't time out.
+        if (!Vector.IsHardwareAccelerated)
+        {
+            InnerIterations = 100000;
+        }
+
         foreach(int index in IndicesToTest)
         {
             ManualLoopTimes = new long[10];


### PR DESCRIPTION
On non-hardware accelerated platforms, reduce the inner iteration count in
SeekUnroll. This test was timing out in x86 release builds because the
iteration count was too high.