### PR TITLE
Remove some Diagnostics.Eventing allocations

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -4221,7 +4221,7 @@ namespace System.Diagnostics.Tracing
         public EventListener()
         {
             // This will cause the OnEventSourceCreated callback to fire. 
-            CallBackForExistingEventSources(true, (obj, args) => args.EventSource.AddListener(this));
+            CallBackForExistingEventSources(true, (obj, args) => args.EventSource.AddListener((EventListener)obj));
         }
 
         /// <summary>
@@ -6741,6 +6741,7 @@ namespace System.Diagnostics.Tracing
             stringBuilder.Append(eventMessage, startIndex, count);
         }
 
+        private static readonly string[] s_escapes = { "&amp;", "&lt;", "&gt;", "&apos;", "&quot;", "%r", "%n", "%t" };
         // Manifest messages use %N conventions for their message substitutions.   Translate from
         // .NET conventions.   We can't use RegEx for this (we are in mscorlib), so we do it 'by hand' 
         private string TranslateToManifestConvention(string eventMessage, string evtName)
@@ -6808,16 +6809,10 @@ namespace System.Diagnostics.Tracing
                 }
                 else if ((chIdx = "&<>'\"\r\n\t".IndexOf(eventMessage[i])) >= 0)
                 {
-                    string[] escapes = { "&amp;", "&lt;", "&gt;", "&apos;", "&quot;", "%r", "%n", "%t" };
-                    var update = new Action<char, string>(
-                        (ch, escape) =>
-                        {
-                            UpdateStringBuilder(ref stringBuilder, eventMessage, writtenSoFar, i - writtenSoFar);
-                            i++;
-                            stringBuilder.Append(escape);
-                            writtenSoFar = i;
-                        });
-                    update(eventMessage[i], escapes[chIdx]);
+                    UpdateStringBuilder(ref stringBuilder, eventMessage, writtenSoFar, i - writtenSoFar);
+                    i++;
+                    stringBuilder.Append(s_escapes[chIdx]);
+                    writtenSoFar = i;
                 }
                 else
                     i++;


### PR DESCRIPTION
Remove some closure allocations

`escapes` `string[]` to static rather than function alloc

/cc @vancem

