### PR TITLE
Do not rerun LVA if only live-out has changed.

### DIFF
--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1155,9 +1155,12 @@ class LiveVarAnalysis
 
                 noway_assert(block->bbFlags & BBF_INTERNAL);
 
-                liveInChanged = !VarSetOps::Equal(m_compiler, VarSetOps::Intersection(m_compiler, block->bbLiveIn, m_liveIn), m_liveIn);
+                liveInChanged =
+                    !VarSetOps::Equal(m_compiler, VarSetOps::Intersection(m_compiler, block->bbLiveIn, m_liveIn),
+                                      m_liveIn);
                 if (liveInChanged ||
-                    !VarSetOps::Equal(m_compiler, VarSetOps::Intersection(m_compiler, block->bbLiveOut, m_liveOut), m_liveOut))
+                    !VarSetOps::Equal(m_compiler, VarSetOps::Intersection(m_compiler, block->bbLiveOut, m_liveOut),
+                                      m_liveOut))
                 {
 #ifdef DEBUG
                     if (m_compiler->verbose)


### PR DESCRIPTION
If only the live-out set for a block changes during live variable
analysis, the LVA algorithm does not need to be re-run. As per the
dataflow equations for LVA:

    liveOut(block) = union(liveIn(s) for all s in successors(block))

Thus, unless a change to the live-out set for a block propagates through
to a change to the live-in set for that block, it will not affect the
live-in/out sets of any of its predecessors and liveness need not be
re-run.