### PR TITLE
Initial implementation of two field span.

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -988,6 +988,8 @@ enum CorInfoIntrinsics
     CORINFO_INTRINSIC_MemoryBarrier,
     CORINFO_INTRINSIC_GetCurrentManagedThread,
     CORINFO_INTRINSIC_GetManagedThreadId,
+    CORINFO_INTRINSIC_ByReference_Ctor,
+    CORINFO_INTRINSIC_ByReference_Value,
 
     CORINFO_INTRINSIC_Count,
     CORINFO_INTRINSIC_Illegal = -1,         // Not a true intrinsic,

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2836,7 +2836,8 @@ protected:
 
     void impImportLeave(BasicBlock* block);
     void impResetLeaveBlock(BasicBlock* block, unsigned jmpAddr);
-    GenTreePtr impIntrinsic(CORINFO_CLASS_HANDLE  clsHnd,
+    GenTreePtr impIntrinsic(GenTreePtr            newobjThis,
+                            CORINFO_CLASS_HANDLE  clsHnd,
                             CORINFO_METHOD_HANDLE method,
                             CORINFO_SIG_INFO*     sig,
                             int                   memberRef,

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1489,17 +1489,16 @@ var_types Compiler::impNormStructType(CORINFO_CLASS_HANDLE structHnd,
     const DWORD structFlags = info.compCompHnd->getClassAttribs(structHnd);
     var_types   structType  = TYP_STRUCT;
 
-#ifdef FEATURE_CORECLR
-    const bool hasGCPtrs = (structFlags & CORINFO_FLG_CONTAINS_GC_PTR) != 0;
-#else
-    // Desktop CLR won't report FLG_CONTAINS_GC_PTR for RefAnyClass - need to check explicitly.
-    const bool        isRefAny    = (structHnd == impGetRefAnyClass());
-    const bool        hasGCPtrs   = isRefAny || ((structFlags & CORINFO_FLG_CONTAINS_GC_PTR) != 0);
-#endif
+    // On coreclr the check for GC includes a "may" to account for the special
+    // ByRef like span structs.  The added check for "CONTAINS_STACK_PTR" is the particular bit.
+    // When this is set the struct will contain a ByRef that could be a GC pointer or a native
+    // pointer.
+    const bool mayContainGCPtrs =
+        ((structFlags & CORINFO_FLG_CONTAINS_STACK_PTR) != 0 || ((structFlags & CORINFO_FLG_CONTAINS_GC_PTR) != 0));
 
 #ifdef FEATURE_SIMD
     // Check to see if this is a SIMD type.
-    if (featureSIMD && !hasGCPtrs)
+    if (featureSIMD && !mayContainGCPtrs)
     {
         unsigned originalSize = info.compCompHnd->getClassSize(structHnd);
 
@@ -1532,9 +1531,10 @@ var_types Compiler::impNormStructType(CORINFO_CLASS_HANDLE structHnd,
         // Verify that the quick test up above via the class attributes gave a
         // safe view of the type's GCness.
         //
-        // Note there are cases where hasGCPtrs is true but getClassGClayout
+        // Note there are cases where mayContainGCPtrs is true but getClassGClayout
         // does not report any gc fields.
-        assert(hasGCPtrs || (numGCVars == 0));
+
+        assert(mayContainGCPtrs || (numGCVars == 0));
 
         if (pNumGCVars != nullptr)
         {
@@ -3271,7 +3271,8 @@ GenTreePtr Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
 // Returns the GenTree that should be used to do the intrinsic instead of the call.
 // Returns NULL if an intrinsic cannot be used
 
-GenTreePtr Compiler::impIntrinsic(CORINFO_CLASS_HANDLE  clsHnd,
+GenTreePtr Compiler::impIntrinsic(GenTreePtr            newobjThis,
+                                  CORINFO_CLASS_HANDLE  clsHnd,
                                   CORINFO_METHOD_HANDLE method,
                                   CORINFO_SIG_INFO*     sig,
                                   int                   memberRef,
@@ -3283,7 +3284,7 @@ GenTreePtr Compiler::impIntrinsic(CORINFO_CLASS_HANDLE  clsHnd,
 #if COR_JIT_EE_VERSION > 460
     CorInfoIntrinsics intrinsicID = info.compCompHnd->getIntrinsicID(method, &mustExpand);
 #else
-    CorInfoIntrinsics intrinsicID = info.compCompHnd->getIntrinsicID(method);
+    CorInfoIntrinsics intrinsicID                                      = info.compCompHnd->getIntrinsicID(method);
 #endif
     *pIntrinsicID = intrinsicID;
 
@@ -3607,7 +3608,33 @@ GenTreePtr Compiler::impIntrinsic(CORINFO_CLASS_HANDLE  clsHnd,
             retNode = op1;
             break;
 #endif
-
+        // Implement ByReference Ctor.  This wraps the assignment of the ref into a byref-like field
+        // in a value type.  The canonical example of this is Span<T>. In effect this is just a
+        // substitution.  The parameter byref will be assigned into the newly allocated object.
+        case CORINFO_INTRINSIC_ByReference_Ctor:
+        {
+            // Remove call to constructor and directly assign the byref passed
+            // to the call to the first slot of the ByReference struct.
+            op1                                    = impPopStack().val;
+            GenTreePtr           thisptr           = newobjThis;
+            CORINFO_FIELD_HANDLE fldHnd            = info.compCompHnd->getFieldInClass(clsHnd, 0);
+            GenTreePtr           field             = gtNewFieldRef(TYP_BYREF, fldHnd, thisptr, 0, false);
+            GenTreePtr           assign            = gtNewAssignNode(field, op1);
+            GenTreePtr           byReferenceStruct = gtCloneExpr(thisptr->gtGetOp1());
+            assert(byReferenceStruct != nullptr);
+            impPushOnStack(byReferenceStruct, typeInfo(TI_STRUCT, clsHnd));
+            retNode = assign;
+            break;
+        }
+        // Implement ptr value getter for ByReference struct.
+        case CORINFO_INTRINSIC_ByReference_Value:
+        {
+            op1                         = impPopStack().val;
+            CORINFO_FIELD_HANDLE fldHnd = info.compCompHnd->getFieldInClass(clsHnd, 0);
+            GenTreePtr           field  = gtNewFieldRef(TYP_BYREF, fldHnd, op1, 0, false);
+            retNode                     = field;
+            break;
+        }
         default:
             /* Unknown intrinsic */
             break;
@@ -6538,7 +6565,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         // <NICE> Factor this into getCallInfo </NICE>
         if ((mflags & CORINFO_FLG_INTRINSIC) && !pConstrainedResolvedToken)
         {
-            call = impIntrinsic(clsHnd, methHnd, sig, pResolvedToken->token, readonlyCall,
+            call = impIntrinsic(newobjThis, clsHnd, methHnd, sig, pResolvedToken->token, readonlyCall,
                                 (canTailCall && (tailCall != 0)), &intrinsicID);
 
             if (call != nullptr)

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -12719,5 +12719,8 @@
       <Member MemberType="Field" Name="Never" />
       <Member MemberType="Field" Name="Advanced" />
     </Type>
+    <Type Status="ImplRoot" Name="System.Runtime.CompilerServices.Unsafe">
+      <Member Status="ImplRoot" Name="AsPointer&lt;T&gt;(T@)" />
+    </Type>
   </Assembly>
 </ThinModel>

--- a/src/mscorlib/src/System/ByReference.cs
+++ b/src/mscorlib/src/System/ByReference.cs
@@ -15,16 +15,20 @@ namespace System
 
         public ByReference(ref T value)
         {
-            // TODO-SPAN: This has GC hole. It needs to be JIT intrinsic instead
-            unsafe { _value = (IntPtr)Unsafe.AsPointer(ref value); }
+            // Implemented as a JIT intrinsic - This default implementation is for 
+            // completeness and to provide a concrete error if called via reflection
+            // or if intrinsic is missed.
+            throw new System.PlatformNotSupportedException();
         }
 
         public ref T Value
         {
             get
             {
-                // TODO-SPAN: This has GC hole. It needs to be JIT intrinsic instead
-                unsafe { return ref Unsafe.As<IntPtr, T>(ref *(IntPtr*)_value); }
+                // Implemented as a JIT intrinsic - This default implementation is for 
+                // completeness and to provide a concrete error if called via reflection
+                // or if the intrinsic is missed.
+                throw new System.PlatformNotSupportedException();
             }
         }
     }

--- a/src/vm/argdestination.h
+++ b/src/vm/argdestination.h
@@ -176,8 +176,10 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
 
+        // SPAN-TODO: GC reporting - https://github.com/dotnet/coreclr/issues/8517
+
        _ASSERTE(IsStructPassedInRegs());
-     
+
         TADDR genRegDest = dac_cast<TADDR>(GetStructGenRegDestinationAddress());
         INDEBUG(int remainingBytes = fieldBytes;)
 

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -2466,7 +2466,18 @@ MethodDesc* Entry2MethodDesc(PCODE entryPoint, MethodTable *pMT)
 BOOL MethodDesc::IsFCallOrIntrinsic()
 {
     WRAPPER_NO_CONTRACT;
-    return (IsFCall() || IsArray());
+
+    if (IsFCall() || IsArray())
+        return TRUE;
+
+#ifdef FEATURE_SPAN_OF_T
+    // Intrinsic methods on ByReference<T> or Span<T>
+    MethodTable * pMT = GetMethodTable();
+    if (pMT->IsByRefLike() && pMT->GetModule()->IsSystem())
+        return TRUE;
+#endif
+
+    return FALSE;
 }
 
 //*******************************************************************************

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -4956,7 +4956,9 @@ void PromoteCarefully(promote_func   fn,
 void ReportPointersFromValueType(promote_func *fn, ScanContext *sc, PTR_MethodTable pMT, PTR_VOID pSrc)
 {
     WRAPPER_NO_CONTRACT;
-    
+
+    // SPAN-TODO: GC reporting - https://github.com/dotnet/coreclr/issues/8517
+
     if (!pMT->ContainsPointers())
         return;
     


### PR DESCRIPTION
Implements two field span struct which is comprised of a byref field
that may be an interior pointer to a managed object, or a native
pointer indicating the start of the span, and a length field which
describes the span of access.

Since there is no MSIL operation which assign a byref field, the jit
gets involved and treats the constructor and getter of a special struct
called ByReference that contains an declared IntPtr.  This special
struct is then used as a field in the span implementation and recognized
by the runtime as a field that may contain a GC pointer.  In
implementation, the ctor of ByReference is converted into an assignment
of the byref passed as the arguemnt, and the getter of the ByReference
value is returned by a reverse assignment.

Since there are some dependencies on CoreFX for the span implementation
local testing of the implementation has been done using the
BasicSpanTest.cs in the CoreCLR tests.  Once this is checked in and is
propagated to CoreFX the apporopate code in the packages will be enabled
and then may be referenced in CoreCLR tests.  At that time more span
tests will be added.