### PR TITLE
Fix deserialization of EnumEqualityComparer

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -683,6 +683,9 @@
       <Member Name="GetHashCode(T)" />
       <Member MemberType="Property" Name="Default" />
     </Type>
+    <Type Name="System.Collections.Generic.EnumEqualityComparer&lt;T&gt;">
+      <Member Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
+    </Type>
     <Type Name="System.Collections.Generic.ICollection&lt;T&gt;">
       <Member Name="Add(T)" />
       <Member Name="Clear" />


### PR DESCRIPTION
Its deserialization ctor is getting removed by the rewriter, causing deserialization of its instances to fail.

cc: @danmosemsft 