### PR TITLE
Fix the GC total memory test.

### DIFF
--- a/tests/src/GC/API/GC/TotalMemory.cs
+++ b/tests/src/GC/API/GC/TotalMemory.cs
@@ -23,6 +23,7 @@ public class Test {
         int[] array2 = new int[40000];
         int memnew = (int) GC.GetTotalMemory(false);
         Console.WriteLine("Total Memory: " + memnew);
+        GC.KeepAlive(array2);
 
         if(memnew >= memold) {
             Console.WriteLine("Test for GC.TotalMemory passed!");


### PR DESCRIPTION
This test was relying upon the result of GC.GetTotalMemory() returning a
greater number after allocating a large array. However, the array was
not kept live past the call to GC.GetTotalMemory, which resulted in this
test failing under GCStress=0xC (in which a GC is performed after each
instruction). This change adds the requisite call to GC.KeepAlive to
keep the allocated array live enough to be observed by
GC.GetTotalMemory.