### PR TITLE
Copy lvExactSize to shadowVar

### DIFF
--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -406,6 +406,7 @@ void Compiler::gsParamsToShadows()
 
 #ifdef FEATURE_SIMD
         lvaTable[shadowVar].lvSIMDType            = varDsc->lvSIMDType;
+        lvaTable[shadowVar].lvExactSize           = varDsc->lvExactSize;
         lvaTable[shadowVar].lvUsedInSIMDIntrinsic = varDsc->lvUsedInSIMDIntrinsic;
         if (varDsc->lvSIMDType)
         {


### PR DESCRIPTION
For TYP_SIMD12 vars, we need to copy the lvExactSize to the shadowVar
so that we have the right size in lower.

Fixes #8550.