### PR TITLE
Fix issue #8139 amd64 decoder bug.

### DIFF
--- a/src/ToolBox/SOS/Strike/eeheap.cpp
+++ b/src/ToolBox/SOS/Strike/eeheap.cpp
@@ -1614,9 +1614,9 @@ void LoaderHeapTraverse(CLRDATA_ADDRESS blockData,size_t blockSize,BOOL blockIsC
 \**********************************************************************/
 void PrintHeapSize(DWORD_PTR total, DWORD_PTR wasted)
 {
-    ExtOut("Size: 0x%" POINTERSIZE_TYPE "x (%" POINTERSIZE_TYPE "lu) bytes", total, total);
+    ExtOut("Size: 0x%" POINTERSIZE_TYPE "x (%" POINTERSIZE_TYPE "u) bytes", total, total);
     if (wasted)
-        ExtOut(" total, 0x%" POINTERSIZE_TYPE "x (%" POINTERSIZE_TYPE "lu) bytes wasted", wasted,  wasted);    
+        ExtOut(" total, 0x%" POINTERSIZE_TYPE "x (%" POINTERSIZE_TYPE "u) bytes wasted", wasted,  wasted);    
     ExtOut(".\n");
 }
 

--- a/src/debug/ee/amd64/amd64walker.cpp
+++ b/src/debug/ee/amd64/amd64walker.cpp
@@ -131,10 +131,11 @@ void NativeWalker::Decode()
     {
         case 0xff:
         {
-
             BYTE modrm = *ip++;
 
-            _ASSERT(modrm != NULL);
+            // Ignore "inc dword ptr [reg]" instructions
+            if (modrm == 0)
+                break;
             
             BYTE mod = (modrm & 0xC0) >> 6;
             BYTE reg = (modrm & 0x38) >> 3;

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4616,8 +4616,7 @@ void CodeGen::genStoreInd(GenTreePtr node)
                     assert(rmwSrc == data->gtGetOp2());
                     genCodeForShiftRMW(storeInd);
                 }
-                else if (!compiler->opts.compDbgCode && data->OperGet() == GT_ADD &&
-                         (rmwSrc->IsIntegralConst(1) || rmwSrc->IsIntegralConst(-1)))
+                else if (data->OperGet() == GT_ADD && (rmwSrc->IsIntegralConst(1) || rmwSrc->IsIntegralConst(-1)))
                 {
                     // Generate "inc/dec [mem]" instead of "add/sub [mem], 1".
                     //


### PR DESCRIPTION
Ignore modrm == 0 which ignores "inc dword ptr []" instructions.

Also fixed minor EEHeap formatting bug on Linux.