### PR TITLE
Remove bogus fgCurHeapDef guard

### DIFF
--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -265,10 +265,7 @@ void Compiler::fgPerNodeLocalVarLiveness(GenTree* tree)
                 GenTreePtr           addrArg         = tree->gtOp.gtOp1->gtEffectiveVal(/*commaOnly*/ true);
                 if (!addrArg->DefinesLocalAddr(this, /*width doesn't matter*/ 0, &dummyLclVarTree, &dummyIsEntire))
                 {
-                    if (!fgCurHeapDef)
-                    {
-                        fgCurHeapUse = true;
-                    }
+                    fgCurHeapUse = true;
                 }
                 else
                 {


### PR DESCRIPTION
We should set fgCurHeapUse when visiting a heap use regardless of whether
fgCurHeapDef is set, because we haven't proven that the def writes all
memory that the use might read.  This should have been included in #8757
but somehow slipped through.