### PR TITLE
Fix pull request title automation

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -41,7 +41,7 @@ def static getOSGroup(def os) {
 			{
 				parameters
 				{
-					stringParam('BenchviewCommitName', '%ghprbPullTitle%', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+					stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
 				}
 			}
 			def configuration = 'Release'
@@ -107,7 +107,7 @@ def static getOSGroup(def os) {
 			{
 				parameters
 				{
-					stringParam('BenchviewCommitName', '\$ghprbPullTitle', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+					stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
 				}
 			}
 			def osGroup = getOSGroup(os)


### PR DESCRIPTION
When I added the ability to give a custom name to a run that was kicked
off using the PR leg I did it by adding an additional parameter.  When
using a variable name there I need to use the dollar sign syntax of
groovy and not an environment variable.