### PR TITLE
[x86/Linux] Fix RtlRestoreContext

### DIFF
--- a/src/pal/src/arch/i386/context2.S
+++ b/src/pal/src/arch/i386/context2.S
@@ -113,31 +113,20 @@ LOCAL_LABEL(Done_Restore_CONTEXT_FLOATING_POINT):
     movdqu xmm7, [eax + CONTEXT_Xmm7]
 LOCAL_LABEL(Done_Restore_CONTEXT_EXTENDED_REGISTERS):
 
-    // Restore CONTROL register(s)
-    mov   ecx, [eax + CONTEXT_Eip]
-    mov   [esp], ecx
+    // Restore Stack
+    mov   esp, [eax + CONTEXT_Esp]
 
-    mov   ecx, [eax + CONTEXT_Esp]
-    push  ecx
-    mov   ecx, [eax + CONTEXT_Ebp]
-    push  ecx
-
-    pop   ebp
-    pop   esp
+    // Create a minimal frame
+    push  DWORD PTR [eax + CONTEXT_Eip]
+    push  DWORD PTR [eax + CONTEXT_Ebp]
 
     // Restore INTEGER register(s)
-    mov   ecx, [eax + CONTEXT_Edi]
-    push  ecx
-    mov   ecx, [eax + CONTEXT_Esi]
-    push  ecx
-    mov   ecx, [eax + CONTEXT_Edx]
-    push  ecx
-    mov   ecx, [eax + CONTEXT_Ecx]
-    push  ecx
-    mov   ecx, [eax + CONTEXT_Ebx]
-    push  ecx
-    mov   ecx, [eax + CONTEXT_Eax]
-    push  ecx
+    push  DWORD PTR [eax + CONTEXT_Edi]
+    push  DWORD PTR [eax + CONTEXT_Esi]
+    push  DWORD PTR [eax + CONTEXT_Edx]
+    push  DWORD PTR [eax + CONTEXT_Ecx]
+    push  DWORD PTR [eax + CONTEXT_Ebx]
+    push  DWORD PTR [eax + CONTEXT_Eax]
 
     pop   eax
     pop   ebx
@@ -146,6 +135,8 @@ LOCAL_LABEL(Done_Restore_CONTEXT_EXTENDED_REGISTERS):
     pop   esi
     pop   edi
 
-    ret   8
+    // Resume
+    pop   ebp
+    ret
 LEAF_END RtlRestoreContext, _TEXT
 

--- a/src/pal/src/arch/i386/context2.S
+++ b/src/pal/src/arch/i386/context2.S
@@ -118,25 +118,17 @@ LOCAL_LABEL(Done_Restore_CONTEXT_EXTENDED_REGISTERS):
 
     // Create a minimal frame
     push  DWORD PTR [eax + CONTEXT_Eip]
-    push  DWORD PTR [eax + CONTEXT_Ebp]
 
-    // Restore INTEGER register(s)
-    push  DWORD PTR [eax + CONTEXT_Edi]
-    push  DWORD PTR [eax + CONTEXT_Esi]
-    push  DWORD PTR [eax + CONTEXT_Edx]
-    push  DWORD PTR [eax + CONTEXT_Ecx]
-    push  DWORD PTR [eax + CONTEXT_Ebx]
-    push  DWORD PTR [eax + CONTEXT_Eax]
-
-    pop   eax
-    pop   ebx
-    pop   ecx
-    pop   edx
-    pop   esi
-    pop   edi
+    // Restore register(s)
+    mov   ebp, [eax + CONTEXT_Ebp]
+    mov   edi, [eax + CONTEXT_Edi]
+    mov   esi, [eax + CONTEXT_Esi]
+    mov   edx, [eax + CONTEXT_Edx]
+    mov   ecx, [eax + CONTEXT_Ecx]
+    mov   ebx, [eax + CONTEXT_Ebx]
+    mov   eax, [eax + CONTEXT_Eax]
 
     // Resume
-    pop   ebp
     ret
 LEAF_END RtlRestoreContext, _TEXT
 


### PR DESCRIPTION
The current implementation of ``RtlRestoreContext`` for x86/Linux is incorrect. which results in segfault discussed in #8887. 

This commit re-implements ``RtlRestoreContext`` to resolve #8887.