### PR TITLE
[ARM32/Linux] Fix cross-architecture build error: stub generation for crossgen

### DIFF
--- a/src/inc/crosscomp.h
+++ b/src/inc/crosscomp.h
@@ -68,7 +68,7 @@ typedef struct DECLSPEC_ALIGN(8) _T_CONTEXT {
         NEON128 Q[16];
         ULONGLONG D[32];
         DWORD S[32];
-    } DUMMYUNIONNAME;
+    };
 
     //
     // Debug registers


### PR DESCRIPTION
Fix union name in T_CONTEXT used by arm/stubs.cpp