### PR TITLE
[ARM32/Linx] cross-architecture build: restrict build project list

### DIFF
--- a/crosscomponents.cmake
+++ b/crosscomponents.cmake
@@ -7,4 +7,13 @@ set (CLR_CROSS_COMPONENTS_LIST
   sos
   clrjit
   protojit
-)  
+)
+
+if(CLR_CMAKE_PLATFORM_LINUX AND CLR_CMAKE_TARGET_ARCH_ARM)
+    list(REMOVE_ITEM CLR_CROSS_COMPONENTS_LIST
+        mscordaccore
+        mscordbi
+        sos
+    )
+endif()
+

--- a/crosscomponents.cmake
+++ b/crosscomponents.cmake
@@ -1,19 +1,15 @@
 add_definitions(-DCROSS_COMPILE)
 
-set (CLR_CROSS_COMPONENTS_LIST  
-  crossgen   
-  mscordaccore   
-  mscordbi   
-  sos
-  clrjit
-  protojit
+set (CLR_CROSS_COMPONENTS_LIST
+    crossgen   
+    clrjit
+    protojit
 )
 
-if(CLR_CMAKE_PLATFORM_LINUX AND CLR_CMAKE_TARGET_ARCH_ARM)
-    list(REMOVE_ITEM CLR_CROSS_COMPONENTS_LIST
+if(NOT CLR_CMAKE_PLATFORM_LINUX)
+    list (APPEND CLR_CROSS_COMPONENTS_LIST
         mscordaccore
         mscordbi
         sos
     )
 endif()
-


### PR DESCRIPTION
Restrict build project for ARM32/Linux cross-architecture
We can build these projects. (release build)
- crossgen
- clrjit
- protojit

Support these first, and others later.
We can't build cross-architecture mscordaccore, mscordbi and sos in Linux yet. But crossgen can be used to generate ni files, and superpmi(generated by clrjit) and protojit can be used to implement Ryujit ARM32.