### PR TITLE
Mark a small number of tests heap-verify-incompatible.

### DIFF
--- a/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
+++ b/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_d.csproj
@@ -15,8 +15,9 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
 
-    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
+    <!-- NOTE: this test simply takes too long to complete under GC stress/heap verify; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
+++ b/tests/src/JIT/Methodical/fp/exgen/10w5d_cs_r.csproj
@@ -15,8 +15,9 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
 
-    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
+    <!-- NOTE: this test simply takes too long to complete under GC stress/heap verify; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Methodical/tailcall/Desktop/_il_relthread-race.csproj
+++ b/tests/src/JIT/Methodical/tailcall/Desktop/_il_relthread-race.csproj
@@ -14,6 +14,9 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
+    <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Methodical/tailcall_v4/hijacking.ilproj
+++ b/tests/src/JIT/Methodical/tailcall_v4/hijacking.ilproj
@@ -14,6 +14,10 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314.csproj
@@ -14,6 +14,10 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/jit64/opt/cg/cgstress/CgStress1_d.csproj
+++ b/tests/src/JIT/jit64/opt/cg/cgstress/CgStress1_d.csproj
@@ -14,6 +14,10 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/jit64/opt/cg/cgstress/CgStress1_r.csproj
+++ b/tests/src/JIT/jit64/opt/cg/cgstress/CgStress1_r.csproj
@@ -14,6 +14,10 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
+    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_d.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_d.csproj
@@ -15,8 +15,9 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
 
-    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
+    <!-- NOTE: this test simply takes too long to complete under GC stress/heap verify; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_r.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_r.csproj
@@ -15,8 +15,9 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
 
-    <!-- NOTE: this test simply takes too long to complete under GC stress; it is not fundamentally incompatible -->
+    <!-- NOTE: this test simply takes too long to complete under GC stress/heap verify; it is not fundamentally incompatible -->
     <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
These tests simply take too long to execute when run with heap
verification.