### PR TITLE
Fix putArgStk dstCount and ConsumeReg errors

### DIFF
--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -10892,7 +10892,6 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
     }
     else // addr is not contained, so we evaluate it into a register
     {
-        codeGen->genConsumeReg(addr);
         // Then load/store dataReg from/to [addrReg]
         emitIns_R_R(ins, ldstAttr, dataReg, addr->gtRegNum);
     }

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -1132,7 +1132,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_CNS_INT:
         case GT_PUTARG_REG:
         case GT_PUTARG_STK:
-            info->dstCount = (tree->TypeGet() == TYP_VOID) ? 0 : 1;
+            info->dstCount = tree->IsValue() ? 1 : 0;
             if (kind & (GTK_CONST | GTK_LEAF))
             {
                 info->srcCount = 0;

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -136,7 +136,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         GenTree* op2;
 
         default:
-            info->dstCount = (tree->TypeGet() == TYP_VOID) ? 0 : 1;
+            info->dstCount = tree->IsValue() ? 1 : 0;
             if (kind & (GTK_CONST | GTK_LEAF))
             {
                 info->srcCount = 0;


### PR DESCRIPTION
The LastConsumedNode used in genCheckConsumeNode was not initialized for arm64.
Fixing this exposed several places where nodes were being consumed twice or in the wrong order.
In addition, since GT_PUTARG_STK doesn't define a register, its dstCount needs to be zero. This is enabled by checking IsValue() instead of type of TYP_VOID for the default case of TreeNodeInfoInit. This was missed for both arm and arm64.

Fix #8898