### PR TITLE
Remove #if false blocks?

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -3910,17 +3910,6 @@ namespace System.Diagnostics.Tracing
             return -1;
         }
 
-#if false // This routine is not needed at all, it was used for unit test debugging. 
-        [Conditional("DEBUG")]
-        private static void OutputDebugString(string msg)
-        {
-#if !ES_BUILD_PCL
-            msg = msg.TrimEnd('\r', '\n') +
-                    string.Format(CultureInfo.InvariantCulture, ", Thrd({0})" + Environment.NewLine, Thread.CurrentThread.ManagedThreadId);
-            System.Diagnostics.Debugger.Log(0, null, msg);
-#endif
-        }
-#endif
 
         /// <summary>
         /// Sends an error message to the debugger (outputDebugString), as well as the EventListeners 

--- a/src/mscorlib/src/System/Diagnostics/Eventing/TraceLogging/EventFieldFormat.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/TraceLogging/EventFieldFormat.cs
@@ -20,12 +20,6 @@ namespace System.Diagnostics.Tracing
         /// Field receives default formatting based on the field's underlying type.
         /// </summary>
         Default = 0,
-#if false 
-        /// <summary>
-        /// Field should not be displayed.
-        /// </summary>
-        NoPrint = 1,
-#endif
         /// <summary>
         /// Field should be formatted as character or string data.
         /// Typically applied to 8-bit or 16-bit integers.
@@ -45,40 +39,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         Hexadecimal = 4,
 
-#if false 
-        /// <summary>
-        /// Field should be formatted as a process identifier. Typically applied to
-        /// 32-bit integer types.
-        /// </summary>
-        ProcessId = 5,
-
-        /// <summary>
-        /// Field should be formatted as a thread identifier. Typically applied to
-        /// 32-bit integer types.
-        /// </summary>
-        ThreadId = 6,
-
-        /// <summary>
-        /// Field should be formatted as an Internet port. Typically applied to 16-bit integer
-        /// types.
-        /// </summary>
-        Port = 7,
-        /// <summary>
-        /// Field should be formatted as an Internet Protocol v4 address. Typically applied to
-        /// 32-bit integer types.
-        /// </summary>
-        Ipv4Address = 8,
-
-        /// <summary>
-        /// Field should be formatted as an Internet Protocol v6 address. Typically applied to
-        /// byte[] types.
-        /// </summary>
-        Ipv6Address = 9,
-        /// <summary>
-        /// Field should be formatted as a SOCKADDR. Typically applied to byte[] types.
-        /// </summary>
-        SocketAddress = 10,
-#endif
         /// <summary>
         /// Field should be formatted as XML string data. Typically applied to
         /// strings or arrays of 8-bit or 16-bit integers.
@@ -90,41 +50,10 @@ namespace System.Diagnostics.Tracing
         /// strings or arrays of 8-bit or 16-bit integers.
         /// </summary>
         Json = 12,
-#if false 
-        /// <summary>
-        /// Field should be formatted as a Win32 error code. Typically applied to
-        /// 32-bit integer types.
-        /// </summary>
-        Win32Error = 13,
-
-        /// <summary>
-        /// Field should be formatted as an NTSTATUS code. Typically applied to
-        /// 32-bit integer types.
-        /// </summary>
-        NTStatus = 14,
-#endif
         /// <summary>
         /// Field should be formatted as an HRESULT code. Typically applied to
         /// 32-bit integer types.
         /// </summary>
         HResult = 15,
-#if false 
-        /// <summary>
-        /// Field should be formatted as a FILETIME. Typically applied to 64-bit
-        /// integer types. This is the default format for DateTime types.
-        /// </summary>
-        FileTime = 16,
-        /// <summary>
-        /// When applied to a numeric type, indicates that the type should be formatted
-        /// as a signed integer. This is the default format for signed integer types.
-        /// </summary>
-        Signed = 17,
-
-        /// <summary>
-        /// When applied to a numeric type, indicates that the type should be formatted
-        /// as an unsigned integer. This is the default format for unsigned integer types.
-        /// </summary>
-        Unsigned = 18,
-#endif
     }
 }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/TraceLogging/Statics.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/TraceLogging/Statics.cs
@@ -211,12 +211,6 @@ namespace System.Diagnostics.Tracing
                     return TraceLoggingDataType.Boolean8;
                 case EventFieldFormat.Hexadecimal:
                     return TraceLoggingDataType.HexInt8;
-#if false 
-                case EventSourceFieldFormat.Signed:
-                    return TraceLoggingDataType.Int8;
-                case EventSourceFieldFormat.Unsigned:
-                    return TraceLoggingDataType.UInt8;
-#endif
                 default:
                     return MakeDataType(native, format);
             }
@@ -240,14 +234,6 @@ namespace System.Diagnostics.Tracing
                     return TraceLoggingDataType.Char16;
                 case EventFieldFormat.Hexadecimal:
                     return TraceLoggingDataType.HexInt16;
-#if false
-                case EventSourceFieldFormat.Port:
-                    return TraceLoggingDataType.Port;
-                case EventSourceFieldFormat.Signed:
-                    return TraceLoggingDataType.Int16;
-                case EventSourceFieldFormat.Unsigned:
-                    return TraceLoggingDataType.UInt16;
-#endif
                 default:
                     return MakeDataType(native, format);
             }
@@ -271,26 +257,8 @@ namespace System.Diagnostics.Tracing
                     return TraceLoggingDataType.Boolean32;
                 case EventFieldFormat.Hexadecimal:
                     return TraceLoggingDataType.HexInt32;
-#if false 
-                case EventSourceFieldFormat.Ipv4Address:
-                    return TraceLoggingDataType.Ipv4Address;
-                case EventSourceFieldFormat.ProcessId:
-                    return TraceLoggingDataType.ProcessId;
-                case EventSourceFieldFormat.ThreadId:
-                    return TraceLoggingDataType.ThreadId;
-                case EventSourceFieldFormat.Win32Error:
-                    return TraceLoggingDataType.Win32Error;
-                case EventSourceFieldFormat.NTStatus:
-                    return TraceLoggingDataType.NTStatus;
-#endif
                 case EventFieldFormat.HResult:
                     return TraceLoggingDataType.HResult;
-#if false 
-                case EventSourceFieldFormat.Signed:
-                    return TraceLoggingDataType.Int32;
-                case EventSourceFieldFormat.Unsigned:
-                    return TraceLoggingDataType.UInt32;
-#endif
                 default:
                     return MakeDataType(native, format);
             }
@@ -312,14 +280,6 @@ namespace System.Diagnostics.Tracing
                     return native;
                 case EventFieldFormat.Hexadecimal:
                     return TraceLoggingDataType.HexInt64;
-#if false 
-                case EventSourceFieldFormat.FileTime:
-                    return TraceLoggingDataType.FileTime;
-                case EventSourceFieldFormat.Signed:
-                    return TraceLoggingDataType.Int64;
-                case EventSourceFieldFormat.Unsigned:
-                    return TraceLoggingDataType.UInt64;
-#endif
                 default:
                     return MakeDataType(native, format);
             }
@@ -341,12 +301,6 @@ namespace System.Diagnostics.Tracing
                     return native;
                 case EventFieldFormat.Hexadecimal:
                     return HexIntPtrType;
-#if false 
-                case EventSourceFieldFormat.Signed:
-                    return IntPtrType;
-                case EventSourceFieldFormat.Unsigned:
-                    return UIntPtrType;
-#endif
                 default:
                     return MakeDataType(native, format);
             }

--- a/src/mscorlib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingDataType.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingDataType.cs
@@ -226,49 +226,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         HexInt16 = UInt16 + (EventFieldFormat.Hexadecimal << 8),
 
-#if false 
-        /// <summary>
-        /// Formatted type.
-        /// Encoding assumes 32-bit value.
-        /// Decoding treats as process identifier.
-        /// </summary>
-        ProcessId = UInt32 + (EventSourceFieldFormat.ProcessId << 8),
-
-        /// <summary>
-        /// Formatted type.
-        /// Encoding assumes 32-bit value.
-        /// Decoding treats as thread identifier.
-        /// </summary>
-        ThreadId = UInt32 + (EventSourceFieldFormat.ThreadId << 8),
-
-        /// <summary>
-        /// Formatted type.
-        /// Encoding assumes 16-bit value.
-        /// Decoding treats as IP port.
-        /// </summary>
-        Port = UInt16 + (EventSourceFieldFormat.Port << 8),
-
-        /// <summary>
-        /// Formatted type.
-        /// Encoding assumes 32-bit value.
-        /// Decoding treats as IPv4 address.
-        /// </summary>
-        Ipv4Address = UInt32 + (EventSourceFieldFormat.Ipv4Address << 8),
-
-        /// <summary>
-        /// Formatted type.
-        /// Encoding assumes 16-bit bytecount followed by binary data.
-        /// Decoding treats as IPv6 address.
-        /// </summary>
-        Ipv6Address = Binary + (EventSourceFieldFormat.Ipv6Address << 8),
-
-        /// <summary>
-        /// Formatted type.
-        /// Encoding assumes 16-bit bytecount followed by binary data.
-        /// Decoding treats as SOCKADDR.
-        /// </summary>
-        SocketAddress = Binary + (EventSourceFieldFormat.SocketAddress << 8),
-#endif
         /// <summary>
         /// Formatted type.
         /// Encoding assumes null-terminated Char16 string.
@@ -324,21 +281,6 @@ namespace System.Diagnostics.Tracing
         /// Decoding treats as MBCS JSON.
         /// </summary>
         CountedMbcsJson = CountedMbcsString + (EventFieldFormat.Json << 8),
-#if false 
-        /// <summary>
-        /// Formatted type.
-        /// Encoding assumes 32-bit value.
-        /// Decoding treats as Win32 error.
-        /// </summary>
-        Win32Error = UInt32 + (EventSourceFieldFormat.Win32Error << 8),
-
-        /// <summary>
-        /// Formatted type.
-        /// Encoding assumes 32-bit value.
-        /// Decoding treats as NTSTATUS.
-        /// </summary>
-        NTStatus = UInt32 + (EventSourceFieldFormat.NTStatus << 8),
-#endif
         /// <summary>
         /// Formatted type.
         /// Encoding assumes 32-bit value.

--- a/src/mscorlib/src/System/Reflection/Emit/ParameterToken.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/ParameterToken.cs
@@ -27,11 +27,6 @@ namespace System.Reflection.Emit {
         public static readonly ParameterToken Empty = new ParameterToken();
         internal int m_tkParameter;
     
-#if false
-        public ParameterToken() {
-            m_tkParameter=0;
-        }
-#endif
         
         internal ParameterToken(int tkParam) {
             m_tkParameter = tkParam;

--- a/src/mscorlib/src/System/Reflection/Emit/TypeToken.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeToken.cs
@@ -27,11 +27,6 @@ namespace System.Reflection.Emit {
 
         internal int m_class;
     
-#if false
-        public TypeToken() {
-            m_class=0;
-        }
-#endif
         
         internal TypeToken(int str) {
             m_class=str;

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -840,36 +840,6 @@ namespace System.Runtime.CompilerServices
 
         // This method is copy&pasted into the public Start methods to avoid size overhead of valuetype generic instantiations.
         // Ideally, we would build intrinsics to get the raw ref address and raw code address of MoveNext, and just use the shared implementation.
-#if false
-        /// <summary>Initiates the builder's execution with the associated state machine.</summary>
-        /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
-        /// <param name="stateMachine">The state machine instance, passed by reference.</param>
-        /// <exception cref="System.ArgumentNullException">The <paramref name="stateMachine"/> argument is null (Nothing in Visual Basic).</exception>
-        [DebuggerStepThrough]
-        internal static void Start<TStateMachine>(ref TStateMachine stateMachine)
-            where TStateMachine : IAsyncStateMachine
-        {
-            if (stateMachine == null) throw new ArgumentNullException(nameof(stateMachine));
-            Contract.EndContractBlock();
-
-            // Run the MoveNext method within a copy-on-write ExecutionContext scope.
-            // This allows us to undo any ExecutionContext changes made in MoveNext,
-            // so that they won't "leak" out of the first await.
-
-            Thread currentThread = Thread.CurrentThread;
-            ExecutionContextSwitcher ecs = default(ExecutionContextSwitcher);
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                ExecutionContext.EstablishCopyOnWriteScope(currentThread, ref ecs);
-                stateMachine.MoveNext();
-            }
-            finally
-            {
-                ecs.Undo(currentThread);
-            }
-        }
-#endif
 
         /// <summary>Associates the builder with the state machine it represents.</summary>
         /// <param name="stateMachine">The heap-allocated state machine object.</param>

--- a/src/mscorlib/src/System/Security/Permissions/IsolatedStoragePermission.cs
+++ b/src/mscorlib/src/System/Security/Permissions/IsolatedStoragePermission.cs
@@ -123,32 +123,6 @@ namespace System.Security.Permissions {
             }
         }
 
-#if false
-        internal long MachineQuota {
-            set{
-                m_machineQuota = value;
-            }
-            get{
-                return m_machineQuota;
-            }
-        }
-        internal long ExpirationDays {
-            set{
-                m_expirationDays = value;
-            }
-            get{
-                return m_expirationDays;
-            }
-        }
-        internal bool PermanentData {
-            set{
-                m_permanentData = value;
-            }
-            get{
-                return m_permanentData;
-            }
-        }
-#endif
 
         public IsolatedStorageContainment UsageAllowed {
             set{

--- a/src/mscorlib/src/System/Security/Permissions/UIPermission.cs
+++ b/src/mscorlib/src/System/Security/Permissions/UIPermission.cs
@@ -184,35 +184,6 @@ namespace System.Security.Permissions
             }
         }
 
-#if false    
-        //------------------------------------------------------
-        //
-        // OBJECT METHOD OVERRIDES
-        //
-        //------------------------------------------------------
-        public String ToString()
-        {
-    #if _DEBUG
-            StringBuilder sb = new StringBuilder();
-            sb.Append("UIPermission(");
-            if (IsUnrestricted())
-            {
-                sb.Append("Unrestricted");
-            }
-            else
-            {
-                sb.Append(m_stateNameTableWindow[m_windowFlag]);
-                sb.Append(", ");
-                sb.Append(m_stateNameTableClipboard[m_clipboardFlag]);
-            }
-            
-            sb.Append(")");
-            return sb.ToString();
-    #else
-            return super.ToString();
-    #endif
-        }
-#endif
         
         //------------------------------------------------------
         //


### PR DESCRIPTION
The [deadregions](https://github.com/dotnet/codeformatter/blob/6fd15554b0b513c33228877abffb5311409fa39b/src/DeadRegions/README.md) tool can remove these automatically so I figured it's worth putting up a PR.

I don't see these in CoreRT so it doesn't diverge us.

Are there any we should keep? 
@AlexGhiondea, @joperezr  @stephentoub 