### PR TITLE
Stop build from leaving localpkg cache in src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
-localpkg/
 msbuild.log
 
 # add back architecture directories ignored in 'Build results'

--- a/dir.props
+++ b/dir.props
@@ -170,6 +170,8 @@
     <MinOSForArch>win7</MinOSForArch>
     <MinOSForArch Condition="'$(PackagePlatform)' == 'arm'">win8</MinOSForArch>
     <MinOSForArch Condition="'$(PackagePlatform)' == 'arm64'">win10</MinOSForArch>
+        <!-- This property must be set to disable local package installation -->
+    <SkipInstallLocallyBuiltPackages>true</SkipInstallLocallyBuiltPackages>
 
     <!-- Define packaging attributes for cross target components -->
     <HasCrossTargetComponents Condition="'$(TargetsWindows)' == 'true' and ('$(PackagePlatform)' =='arm64' or '$(PackagePlatform)' =='arm')">true</HasCrossTargetComponents>


### PR DESCRIPTION
https://github.com/dotnet/coreclr/issues/8130