### PR TITLE
JIT: remove match accounting from inliner state machine

### DIFF
--- a/src/jit/sm.cpp
+++ b/src/jit/sm.cpp
@@ -51,11 +51,6 @@ void CodeSeqSM::Start(Compiler* comp)
 void CodeSeqSM::Reset()
 {
     curState = SM_STATE_ID_START;
-
-#ifdef DEBUG
-    // Reset the state occurence counts
-    memset(StateMatchedCounts, 0, sizeof(StateMatchedCounts));
-#endif
 }
 
 void CodeSeqSM::End()

--- a/src/jit/sm.h
+++ b/src/jit/sm.h
@@ -42,9 +42,7 @@ public:
     inline void TermStateMatch(SM_STATE_ID stateID DEBUGARG(bool verbose))
     {
         assert(States[stateID].term);
-        assert(StateMatchedCounts[stateID] < _UI16_MAX);
 #ifdef DEBUG
-        ++StateMatchedCounts[stateID];
 #ifndef SMGEN_COMPILE
         if (verbose)
         {
@@ -65,7 +63,6 @@ public:
     }
 
 #ifdef DEBUG
-    WORD        StateMatchedCounts[NUM_SM_STATES];
     const char* StateDesc(SM_STATE_ID stateID);
 #endif
 


### PR DESCRIPTION
The inliner's code-size estimating state machine keeps count of
matches, but the count was only used in an assert that checked
that the count did not overflow.

The assert fired when jit stress drove the inliner to evaluate a
huge method as a potential inline candidate and the count reached
the overflow value.

This change removes the counting and the related assert.

Closes #8932.