### PR TITLE
Check if xsave is enabled by OS before calling xgetbv in XmmYmmStateSupport

### DIFF
--- a/src/pal/src/arch/amd64/processor.cpp
+++ b/src/pal/src/arch/amd64/processor.cpp
@@ -54,10 +54,18 @@ Return value:
 extern "C" unsigned int XmmYmmStateSupport()
 {
     unsigned int eax;
-    __asm("  xgetbv\n" \
-        : "=a"(eax) /*output in eax*/\
-        : "c"(0) /*inputs - 0 in ecx*/\
-        : "eax", "edx" /* registers that are clobbered*/
+    __asm("  mov $1, %%eax\n" \
+          "  cpuid\n" \
+          "  xor %%eax, %%eax\n" \
+          "  and $0x18000000, %%ecx\n" /* check for xsave feature set and that it is enabled by the OS */ \
+          "  cmp $0x18000000, %%ecx\n" \
+          "  jne end\n" \
+          "  xor %%ecx, %%ecx\n" \
+          "  xgetbv\n" \
+          "end:\n" \
+        : "=a"(eax) /* output in eax */ \
+        : /* no inputs */ \
+        : "eax", "ecx", "edx" /* registers that are clobbered */
       );
     // Check OS has enabled both XMM and YMM state support
     return ((eax & 0x06) == 0x06) ? 1 : 0;

--- a/src/pal/src/arch/amd64/processor.cpp
+++ b/src/pal/src/arch/amd64/processor.cpp
@@ -65,7 +65,7 @@ extern "C" unsigned int XmmYmmStateSupport()
           "end:\n" \
         : "=a"(eax) /* output in eax */ \
         : /* no inputs */ \
-        : "eax", "ecx", "edx" /* registers that are clobbered */
+        : "eax", "ebx", "ecx", "edx" /* registers that are clobbered */
       );
     // Check OS has enabled both XMM and YMM state support
     return ((eax & 0x06) == 0x06) ? 1 : 0;


### PR DESCRIPTION
#8903

It appears that OS X does not enable `xsave` on older processors (such as the Core 2 Duo in my late 2010 Macbook Air), leading to the process being killed with `SIGILL` when [`XmmYmmStateSupport`](https://github.com/dotnet/coreclr/blob/85c0a5641d60aabe028a9e4b4ef07a7b58a2181b/src/pal/src/arch/amd64/processor.cpp#L54) gets called.

This is also causing failures on Travis test runs on OS X for Kestrel (e.g. https://travis-ci.org/aspnet/KestrelHttpServer/jobs/191433640#L1195).

@janvorli 