### PR TITLE
Fix TplEventSource diagnostic error due to mismatched signature

### DIFF
--- a/src/mscorlib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -244,7 +244,7 @@ namespace System.Runtime.CompilerServices
                     (currentTaskAtBegin != null ? currentTaskAtBegin.m_taskScheduler.Id : TaskScheduler.Default.Id),
                     (currentTaskAtBegin != null ? currentTaskAtBegin.Id : 0),
                     task.Id, TplEtwProvider.TaskWaitBehavior.Asynchronous, 
-                    (continuationTask != null ? continuationTask.Id : 0), System.Threading.Thread.GetDomainID());
+                    (continuationTask != null ? continuationTask.Id : 0));
             }
 
             // Create a continuation action that outputs the end event and then invokes the user

--- a/src/mscorlib/src/System/Threading/Tasks/TPLETWProvider.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TPLETWProvider.cs
@@ -512,7 +512,7 @@ namespace System.Threading.Tasks
          Level = EventLevel.Informational, Keywords = Keywords.TaskTransfer|Keywords.Tasks)]
         public void TaskWaitBegin(
             int OriginatingTaskSchedulerID, int OriginatingTaskID,  // PFX_COMMON_EVENT_HEADER
-            int TaskID, TaskWaitBehavior Behavior, int ContinueWithTaskID, int appDomain)
+            int TaskID, TaskWaitBehavior Behavior, int ContinueWithTaskID)
         {
             if (IsEnabled() && IsEnabled(EventLevel.Informational, Keywords.TaskTransfer|Keywords.Tasks))
             {
@@ -534,8 +534,10 @@ namespace System.Threading.Tasks
                         Guid childActivityId = CreateGuidForTaskID(TaskID);
                         WriteEventWithRelatedActivityIdCore(TASKWAITBEGIN_ID, &childActivityId, 5, eventPayload);
                     }
-                    else 
+                    else
+                    {
                         WriteEventCore(TASKWAITBEGIN_ID, 5, eventPayload);
+                    }
                 }
             }
         }

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -3176,7 +3176,7 @@ namespace System.Threading.Tasks
                 Task currentTask = Task.InternalCurrent;
                 etwLog.TaskWaitBegin(
                     (currentTask != null ? currentTask.m_taskScheduler.Id : TaskScheduler.Default.Id), (currentTask != null ? currentTask.Id : 0),
-                    this.Id, TplEtwProvider.TaskWaitBehavior.Synchronous, 0, System.Threading.Thread.GetDomainID());
+                    this.Id, TplEtwProvider.TaskWaitBehavior.Synchronous, 0);
             }
 
             bool returnValue = IsCompleted;


### PR DESCRIPTION
Noticed this while looking at unrelated traces...

The TplEventSource TaskWaitBegin event is defined to take an int appDomain parameter, but it's not tracing that out, resulting in EventSource generating diagnostic events like "Event 10 was called with 5 argument(s), but it is defined with 6 parameter(s)."

@vancem, I've fixed it by removing the appDomain parameter, since it's not relevant to coreclr, but please let me know if I should instead trace out the value as a 6th argument... I wasn't sure which fix would be more impactful to existing tools that may be listening for this event.

cc: @davmason, @jkotas 