### PR TITLE
Add version increment into Sort(Comparison<T>)

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -927,7 +927,9 @@ namespace System.Collections.Generic {
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             Contract.EndContractBlock();
 
-            Array.Reverse(_items, index, count);
+            if (count > 1) {
+                Array.Reverse(_items, index, count);
+            }
             _version++;
         }
         
@@ -966,7 +968,9 @@ namespace System.Collections.Generic {
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             Contract.EndContractBlock();
 
-            Array.Sort<T>(_items, index, count, comparer);
+            if (count > 1) {
+                Array.Sort<T>(_items, index, count, comparer);
+            }
             _version++;
         }
 
@@ -976,10 +980,10 @@ namespace System.Collections.Generic {
             }
             Contract.EndContractBlock();
 
-            if (_size > 0) {
+            if (_size > 1) {
                 ArraySortHelper<T>.Sort(_items, 0, _size, comparison);
-                _version++;
             }
+            _version++;
         }
 
         // ToArray returns an array containing the contents of the List.

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -976,8 +976,9 @@ namespace System.Collections.Generic {
             }
             Contract.EndContractBlock();
 
-            if( _size > 0) {
+            if (_size > 0) {
                 ArraySortHelper<T>.Sort(_items, 0, _size, comparison);
+                _version++;
             }
         }
 


### PR DESCRIPTION
Add version increment into `Sort(Comparison<T>)`.

The `List<T>.Sort(Comparison<T>)` method should throw `InvalidOperationException` when called in a foreach loop.

This is done by incrementing the `_version` field which is being checked in the `Enumerator`.
Version is incremented in all other methods that modify the list.
This change adds missing version increment into the `List<T>.Sort(Comparison<T>)` method.

_Also `(` moved to the correct place._

Fix #8943