### PR TITLE
Cleaning up the extra argument in throw new ArgumentException(Argument_InvalidFlag) 

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -256,7 +256,7 @@ namespace System.Globalization
 
             if ((options & ValidSortkeyCtorMaskOffFlags) != 0)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             }
             
             byte [] keyData;

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Windows.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Windows.cs
@@ -356,7 +356,7 @@ namespace System.Globalization
 
             if ((options & ValidSortkeyCtorMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
             }
 
             throw new NotImplementedException();

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.cs
@@ -285,7 +285,7 @@ namespace System.Globalization
 
             if ((options & ValidCompareMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
             }
 
             //Our paradigm is that null sorts less than any other string and
@@ -376,7 +376,7 @@ namespace System.Globalization
             }
             else if ((options & ValidCompareMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
             }
 
             //
@@ -507,7 +507,7 @@ namespace System.Globalization
 
             if ((options & ValidIndexMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
             }
 
             return StartsWith(source, prefix, options);
@@ -557,7 +557,7 @@ namespace System.Globalization
 
             if ((options & ValidIndexMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
             }
 
             return EndsWith(source, suffix, options);
@@ -692,7 +692,7 @@ namespace System.Globalization
             // Validate CompareOptions
             // Ordinal can't be selected with other flags
             if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
 
             return IndexOfCore(source, new string(value, 1), startIndex, count, options);
         }
@@ -739,7 +739,7 @@ namespace System.Globalization
             // Validate CompareOptions
             // Ordinal can't be selected with other flags
             if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
 
             return IndexOfCore(source, value, startIndex, count, options);
         }
@@ -851,7 +851,7 @@ namespace System.Globalization
             if ((options & ValidIndexMaskOffFlags) != 0 &&
                 (options != CompareOptions.Ordinal) &&
                 (options != CompareOptions.OrdinalIgnoreCase))
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
 
             // Special case for 0 length input strings
             if (source.Length == 0 && (startIndex == -1 || startIndex == 0))
@@ -896,7 +896,7 @@ namespace System.Globalization
             if ((options & ValidIndexMaskOffFlags) != 0 &&
                 (options != CompareOptions.Ordinal) &&
                 (options != CompareOptions.OrdinalIgnoreCase))
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
 
             // Special case for 0 length input strings
             if (source.Length == 0 && (startIndex == -1 || startIndex == 0))
@@ -1025,7 +1025,7 @@ namespace System.Globalization
 
             if ((options & ValidHashCodeOfStringMaskOffFlags) != 0)
             {
-                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+                throw new ArgumentException(SR.Argument_InvalidFlag);
             }
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/Globalization/CompareInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.cs
@@ -412,7 +412,7 @@ namespace System.Globalization {
 
             if ((options & ValidCompareMaskOffFlags) != 0)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             }
 
             //Our paradigm is that null sorts less than any other string and
@@ -500,7 +500,7 @@ namespace System.Globalization {
             }
             else if ((options & ValidCompareMaskOffFlags) != 0)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             }
 
             //
@@ -564,7 +564,7 @@ namespace System.Globalization {
             }
 
             if ((options & ValidIndexMaskOffFlags) != 0) {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             }
 
 
@@ -616,7 +616,7 @@ namespace System.Globalization {
             }
 
             if ((options & ValidIndexMaskOffFlags) != 0) {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             }
 
             // to let the sorting DLL do the call optimization in case of Ascii strings, we check if the strings are in Ascii and then send the flag RESERVED_FIND_ASCII_STRING  to 
@@ -759,7 +759,7 @@ namespace System.Globalization {
             // Validate CompareOptions
             // Ordinal can't be selected with other flags
             if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
 
             // to let the sorting DLL do the call optimization in case of Ascii strings, we check if the strings are in Ascii and then send the flag RESERVED_FIND_ASCII_STRING  to 
             // the sorting DLL API SortFindString so sorting DLL don't have to check if the string is Ascii with every call to SortFindString.
@@ -811,7 +811,7 @@ namespace System.Globalization {
             // Validate CompareOptions
             // Ordinal can't be selected with other flags
             if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
 
             // to let the sorting DLL do the call optimization in case of Ascii strings, we check if the strings are in Ascii and then send the flag RESERVED_FIND_ASCII_STRING  to 
             // the sorting DLL API SortFindString so sorting DLL don't have to check if the string is Ascii with every call to SortFindString.
@@ -930,7 +930,7 @@ namespace System.Globalization {
             if ((options & ValidIndexMaskOffFlags) != 0 &&
                 (options != CompareOptions.Ordinal) &&
                 (options != CompareOptions.OrdinalIgnoreCase))
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
 
             // Special case for 0 length input strings
             if (source.Length == 0 && (startIndex == -1 || startIndex == 0))
@@ -980,7 +980,7 @@ namespace System.Globalization {
             if ((options & ValidIndexMaskOffFlags) != 0 &&
                 (options != CompareOptions.Ordinal) &&
                 (options != CompareOptions.OrdinalIgnoreCase))
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
 
             // Special case for 0 length input strings
             if (source.Length == 0 && (startIndex == -1 || startIndex == 0))
@@ -1053,7 +1053,7 @@ namespace System.Globalization {
 
             if ((options & ValidSortkeyCtorMaskOffFlags) != 0)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             }
             byte[] keyData = null;
             // The OS doesn't have quite the same behavior so we have to test for empty inputs
@@ -1074,7 +1074,7 @@ namespace System.Globalization {
             // If there was an error, return an error
             if (length == 0)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(source));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             }
 
             // If input was empty, return the empty byte[] we made earlier and skip this
@@ -1205,7 +1205,7 @@ namespace System.Globalization {
 
             if ((options & ValidHashCodeOfStringMaskOffFlags) != 0)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"), nameof(options));
+                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             }
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/Threading/EventWaitHandle.cs
+++ b/src/mscorlib/src/System/Threading/EventWaitHandle.cs
@@ -68,7 +68,7 @@ namespace System.Threading
                     break;
 
                 default:
-                    throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag",name));
+                    throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             };
                 
             if (_handle.IsInvalid)
@@ -117,7 +117,7 @@ namespace System.Threading
                     break;
 
                 default:
-                    throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag",name));
+                    throw new ArgumentException(Environment.GetResourceString("Argument_InvalidFlag"));
             };
 
             _handle = Win32Native.CreateEvent(secAttrs, isManualReset, initialState, name);


### PR DESCRIPTION
The resource string for Argument_InvalidFlag doesn't have any parameter.
see https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System.Private.CoreLib.txt#L145

@jkotas, PTAL