### PR TITLE
Use nameof in place of hardcoded variable names

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/NumberFormatInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/NumberFormatInfo.cs
@@ -289,7 +289,7 @@ namespace System.Globalization
                 if (value < 0 || value > 99)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "CurrencyDecimalDigits",
+                                nameof(CurrencyDecimalDigits),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -357,14 +357,14 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("CurrencyGroupSizes",
+                    throw new ArgumentNullException(nameof(CurrencyGroupSizes),
                         SR.ArgumentNull_Obj);
                 }
                 Contract.EndContractBlock();
                 VerifyWritable();
 
                 Int32[] inputSizes = (Int32[])value.Clone();
-                CheckGroupSize("CurrencyGroupSizes", inputSizes);
+                CheckGroupSize(nameof(CurrencyGroupSizes), inputSizes);
                 currencyGroupSizes = inputSizes;
             }
         }
@@ -381,14 +381,14 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("NumberGroupSizes",
+                    throw new ArgumentNullException(nameof(NumberGroupSizes),
                         SR.ArgumentNull_Obj);
                 }
                 Contract.EndContractBlock();
                 VerifyWritable();
 
                 Int32[] inputSizes = (Int32[])value.Clone();
-                CheckGroupSize("NumberGroupSizes", inputSizes);
+                CheckGroupSize(nameof(NumberGroupSizes), inputSizes);
                 numberGroupSizes = inputSizes;
             }
         }
@@ -422,7 +422,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyGroupSeparator(value, "CurrencyGroupSeparator");
+                VerifyGroupSeparator(value, nameof(CurrencyGroupSeparator));
                 currencyGroupSeparator = value;
             }
         }
@@ -435,7 +435,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("CurrencySymbol",
+                    throw new ArgumentNullException(nameof(CurrencySymbol),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -475,7 +475,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("NaNSymbol",
+                    throw new ArgumentNullException(nameof(NaNSymbol),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -494,7 +494,7 @@ namespace System.Globalization
                 if (value < 0 || value > 15)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "CurrencyNegativePattern",
+                                nameof(CurrencyNegativePattern),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -519,7 +519,7 @@ namespace System.Globalization
                 if (value < 0 || value > 4)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "NumberNegativePattern",
+                                nameof(NumberNegativePattern),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -544,7 +544,7 @@ namespace System.Globalization
                 if (value < 0 || value > 3)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "PercentPositivePattern",
+                                nameof(PercentPositivePattern),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -569,7 +569,7 @@ namespace System.Globalization
                 if (value < 0 || value > 11)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "PercentNegativePattern",
+                                nameof(PercentNegativePattern),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -593,7 +593,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("NegativeInfinitySymbol",
+                    throw new ArgumentNullException(nameof(NegativeInfinitySymbol),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -610,7 +610,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("NegativeSign",
+                    throw new ArgumentNullException(nameof(NegativeSign),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -628,7 +628,7 @@ namespace System.Globalization
                 if (value < 0 || value > 99)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "NumberDecimalDigits",
+                                nameof(NumberDecimalDigits),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -648,7 +648,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyDecimalSeparator(value, "NumberDecimalSeparator");
+                VerifyDecimalSeparator(value, nameof(NumberDecimalSeparator));
                 numberDecimalSeparator = value;
             }
         }
@@ -660,7 +660,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyGroupSeparator(value, "NumberGroupSeparator");
+                VerifyGroupSeparator(value, nameof(NumberGroupSeparator));
                 numberGroupSeparator = value;
             }
         }
@@ -674,7 +674,7 @@ namespace System.Globalization
                 if (value < 0 || value > 3)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "CurrencyPositivePattern",
+                                nameof(CurrencyPositivePattern),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -698,7 +698,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("PositiveInfinitySymbol",
+                    throw new ArgumentNullException(nameof(PositiveInfinitySymbol),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -715,7 +715,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("PositiveSign",
+                    throw new ArgumentNullException(nameof(PositiveSign),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -733,7 +733,7 @@ namespace System.Globalization
                 if (value < 0 || value > 99)
                 {
                     throw new ArgumentOutOfRangeException(
-                                "PercentDecimalDigits",
+                                nameof(PercentDecimalDigits),
                                 String.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
@@ -753,7 +753,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyDecimalSeparator(value, "PercentDecimalSeparator");
+                VerifyDecimalSeparator(value, nameof(PercentDecimalSeparator));
                 percentDecimalSeparator = value;
             }
         }
@@ -765,7 +765,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyGroupSeparator(value, "PercentGroupSeparator");
+                VerifyGroupSeparator(value, nameof(PercentGroupSeparator));
                 percentGroupSeparator = value;
             }
         }
@@ -781,7 +781,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("PercentSymbol",
+                    throw new ArgumentNullException(nameof(PercentSymbol),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -798,7 +798,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("PerMilleSymbol",
+                    throw new ArgumentNullException(nameof(PerMilleSymbol),
                         SR.ArgumentNull_String);
                 }
                 Contract.EndContractBlock();
@@ -813,7 +813,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyNativeDigits(value, "NativeDigits");
+                VerifyNativeDigits(value, nameof(NativeDigits));
                 nativeDigits = value;
             }
         }
@@ -824,7 +824,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyDigitSubstitution(value, "DigitSubstitution");
+                VerifyDigitSubstitution(value, nameof(DigitSubstitution));
                 digitSubstitution = (int) value;
             }
         }

--- a/src/mscorlib/src/System/DateTime.cs
+++ b/src/mscorlib/src/System/DateTime.cs
@@ -461,7 +461,7 @@ namespace System {
         // parts of the result are the same as those of this DateTime.
         //
         public DateTime AddYears(int value) {
-            if (value < -10000 || value > 10000) throw new ArgumentOutOfRangeException("years", Environment.GetResourceString("ArgumentOutOfRange_DateTimeBadYears"));
+            if (value < -10000 || value > 10000) throw new ArgumentOutOfRangeException(nameof(value), Environment.GetResourceString("ArgumentOutOfRange_DateTimeBadYears"));
             Contract.EndContractBlock();
             return AddMonths(value * 12);
         }

--- a/src/mscorlib/src/System/Decimal.cs
+++ b/src/mscorlib/src/System/Decimal.cs
@@ -378,7 +378,7 @@ namespace System {
             if (value == null)
                 return 1;
             if (!(value is Decimal))
-                throw new ArgumentException(Environment.GetResourceString("Arg_MustBeDecimal"), nameof(value));
+                throw new ArgumentException(Environment.GetResourceString("Arg_MustBeDecimal"));
     
             Decimal other = (Decimal)value;    
             return FCallCompare(ref this, ref other);

--- a/src/mscorlib/src/System/Decimal.cs
+++ b/src/mscorlib/src/System/Decimal.cs
@@ -378,7 +378,7 @@ namespace System {
             if (value == null)
                 return 1;
             if (!(value is Decimal))
-                throw new ArgumentException(Environment.GetResourceString("Arg_MustBeDecimal"));
+                throw new ArgumentException(Environment.GetResourceString("Arg_MustBeDecimal"), nameof(value));
     
             Decimal other = (Decimal)value;    
             return FCallCompare(ref this, ref other);

--- a/src/mscorlib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/mscorlib/src/System/Globalization/NumberFormatInfo.cs
@@ -312,7 +312,7 @@ namespace System.Globalization {
             get { return currencyDecimalSeparator; }
             set {
                 VerifyWritable();
-                VerifyDecimalSeparator(value, "CurrencyDecimalSeparator");
+                VerifyDecimalSeparator(value, nameof(CurrencyDecimalSeparator));
                 currencyDecimalSeparator = value;
             }
         }
@@ -361,7 +361,7 @@ namespace System.Globalization {
                 VerifyWritable();                
                 
                 Int32[] inputSizes = (Int32[])value.Clone();
-                CheckGroupSize("CurrencyGroupSizes", inputSizes);
+                CheckGroupSize(nameof(CurrencyGroupSizes), inputSizes);
                 currencyGroupSizes = inputSizes;
             }
 
@@ -382,7 +382,7 @@ namespace System.Globalization {
                 VerifyWritable();
                 
                 Int32[] inputSizes = (Int32[])value.Clone();
-                CheckGroupSize("NumberGroupSizes", inputSizes);
+                CheckGroupSize(nameof(NumberGroupSizes), inputSizes);
                 numberGroupSizes = inputSizes;
             }
         }
@@ -400,7 +400,7 @@ namespace System.Globalization {
                 Contract.EndContractBlock();
                 VerifyWritable();
                 Int32[] inputSizes = (Int32[])value.Clone();
-                CheckGroupSize("PercentGroupSizes", inputSizes);
+                CheckGroupSize(nameof(PercentGroupSizes), inputSizes);
                 percentGroupSizes = inputSizes;
             }
 
@@ -411,7 +411,7 @@ namespace System.Globalization {
             get { return currencyGroupSeparator; }
             set {
                 VerifyWritable();
-                VerifyGroupSeparator(value, "CurrencyGroupSeparator");
+                VerifyGroupSeparator(value, nameof(CurrencyGroupSeparator));
                 currencyGroupSeparator = value;
             }
         }
@@ -602,7 +602,7 @@ namespace System.Globalization {
             get { return numberDecimalSeparator; }
             set {
                 VerifyWritable();
-                VerifyDecimalSeparator(value, "NumberDecimalSeparator");
+                VerifyDecimalSeparator(value, nameof(NumberDecimalSeparator));
                 numberDecimalSeparator = value;
             }
         }
@@ -612,7 +612,7 @@ namespace System.Globalization {
             get { return numberGroupSeparator; }
             set {
                 VerifyWritable();
-                VerifyGroupSeparator(value, "NumberGroupSeparator");
+                VerifyGroupSeparator(value, nameof(NumberGroupSeparator));
                 numberGroupSeparator = value;
             }
         }
@@ -690,7 +690,7 @@ namespace System.Globalization {
             get { return percentDecimalSeparator; }
             set {
                 VerifyWritable();
-                VerifyDecimalSeparator(value, "PercentDecimalSeparator");
+                VerifyDecimalSeparator(value, nameof(PercentDecimalSeparator));
                 percentDecimalSeparator = value;
             }
         }
@@ -700,7 +700,7 @@ namespace System.Globalization {
             get { return percentGroupSeparator; }
             set {
                 VerifyWritable();
-                VerifyGroupSeparator(value, "PercentGroupSeparator");
+                VerifyGroupSeparator(value, nameof(PercentGroupSeparator));
                 percentGroupSeparator = value;
             }
         }
@@ -743,7 +743,7 @@ namespace System.Globalization {
             set
             {
                 VerifyWritable();
-                VerifyNativeDigits(value, "NativeDigits");
+                VerifyNativeDigits(value, nameof(NativeDigits));
                 nativeDigits = value;
             }
         }
@@ -755,7 +755,7 @@ namespace System.Globalization {
             set
             {
                 VerifyWritable();
-                VerifyDigitSubstitution(value, "DigitSubstitution");
+                VerifyDigitSubstitution(value, nameof(DigitSubstitution));
                 digitSubstitution = (int)value;
             }
         }


### PR DESCRIPTION
Replaces hardcoded variable names with call to `nameof` to keep code consistent with dotnet/corert#2483

Fixes #8967

/cc @jkotas 