### PR TITLE
GS checkes: only set lVExactSize for SIMD vars.

### DIFF
--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -406,11 +406,11 @@ void Compiler::gsParamsToShadows()
 
 #ifdef FEATURE_SIMD
         lvaTable[shadowVar].lvSIMDType            = varDsc->lvSIMDType;
-        lvaTable[shadowVar].lvExactSize           = varDsc->lvExactSize;
         lvaTable[shadowVar].lvUsedInSIMDIntrinsic = varDsc->lvUsedInSIMDIntrinsic;
         if (varDsc->lvSIMDType)
         {
-            lvaTable[shadowVar].lvBaseType = varDsc->lvBaseType;
+            lvaTable[shadowVar].lvExactSize = varDsc->lvExactSize;
+            lvaTable[shadowVar].lvBaseType  = varDsc->lvBaseType;
         }
 #endif
         lvaTable[shadowVar].lvRegStruct = varDsc->lvRegStruct;


### PR DESCRIPTION
Copying this field for non-SIMD variables causes a later call to
`lvaSetStruct` to skip critical initialization steps. Skipping these
steps led to failures in GC stress due to uninitialized frame variables
that contained GC pointers.