### PR TITLE
Remove __GNUC__ version checks

### DIFF
--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -223,19 +223,11 @@ inline void *__cdecl operator new(size_t, void *_P)
 // PAL_safe_offsetof is a version of offsetof that protects against an
 // overridden operator&
 
-#if defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 5 || __GNUC__ > 3)
 #define FIELD_OFFSET(type, field) __builtin_offsetof(type, field)
 #ifndef offsetof
 #define offsetof(type, field) __builtin_offsetof(type, field)
 #endif
 #define PAL_safe_offsetof(type, field) __builtin_offsetof(type, field)
-#else
-#define FIELD_OFFSET(type, field) (((LONG)(LONG_PTR)&(((type *)64)->field)) - 64)
-#ifndef offsetof
-#define offsetof(s,m)          ((size_t)((ptrdiff_t)&(((s *)64)->m)) - 64)
-#endif
-#define PAL_safe_offsetof(s,m) ((size_t)((ptrdiff_t)&(char&)(((s *)64)->m))-64)
-#endif
 
 #define CONTAINING_RECORD(address, type, field) \
     ((type *)((LONG_PTR)(address) - FIELD_OFFSET(type, field)))

--- a/src/pal/inc/rt/safecrt.h
+++ b/src/pal/inc/rt/safecrt.h
@@ -135,11 +135,7 @@ typedef _W64 unsigned int   uintptr_t;
 #define _UINTPTR_T_DEFINED
 #endif
 
-#if defined(_MSC_VER) || (defined(__GNUC__) && (__GNUC__ >= 3))
 #define SAFECRT_DEPRECATED __declspec(deprecated)
-#else
-#define SAFECRT_DEPRECATED
-#endif
 
 /* errno_t */
 #if !defined(_ERRCODE_DEFINED)

--- a/src/pal/src/exception/machexception.h
+++ b/src/pal/src/exception/machexception.h
@@ -25,8 +25,6 @@ extern "C"
 {
 #endif // __cplusplus
 
-#define HIJACK_ON_SIGNAL 1
-
 // List of exception types we will be watching for
 // NOTE: if you change any of these, you need to adapt s_nMachExceptionPortsMax in thread.hpp
 #define PAL_EXC_ILLEGAL_MASK   (EXC_MASK_BAD_INSTRUCTION | EXC_MASK_EMULATION)

--- a/src/pal/src/exception/signal.hpp
+++ b/src/pal/src/exception/signal.hpp
@@ -46,13 +46,6 @@ Function :
 --*/
 void SEHCleanupSignals();
 
-#if (__GNUC__ > 3 ||                                            \
-     (__GNUC__ == 3 && __GNUC_MINOR__ > 2))
-// For gcc > 3.2, sjlj exceptions semantics are no longer available
-// Therefore we need to hijack out of signal handlers before second pass
-#define HIJACK_ON_SIGNAL 1
-#endif
-
 #endif // !HAVE_MACH_EXCEPTIONS
 
 #endif /* _PAL_SIGNAL_HPP_ */

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -601,11 +601,7 @@ function_name() to call the system's implementation
 #define INFTIM  -1
 #endif // !HAVE_INFTIM
 
-#if (__GNUC__ >= 4)
 #define OffsetOf(TYPE, MEMBER) __builtin_offsetof(TYPE, MEMBER)
-#else
-#define OffsetOf(s, f) (INT)(SIZE_T)&(((s*)0)->f)
-#endif /* __GNUC__ version check*/
 
 #undef assert
 #define assert (Use__ASSERTE_instead_of_assert) assert


### PR DESCRIPTION
This change removes obsolete `__GNUC__` version checks at several places.
The minimum supported clang version is 3.5 and that generates __GNUC__
value of 4.