### PR TITLE
Detach CoreLib from ResourceManager implementation

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -4021,6 +4021,7 @@
       <Member Status="ImplRoot" MemberType="Property" Name="DefinedTypes" />
       <!-- On Windows Phone Assembly.LoadFrom throws a NotSupportedException.  Prevent this internal helper from being stripped by the rewriter so that tests may reflect and call it since they need LoadFrom functionality -->
       <Member Status="ImplRoot" Name="InternalLoadFrom(System.String,System.Security.Policy.Evidence,System.Byte[],System.Configuration.Assemblies.AssemblyHashAlgorithm,System.Boolean,System.Boolean,System.Threading.StackCrawlMark@)" Condition="FEATURE_WINDOWSPHONE" />
+      <Member Name="InternalGetSatelliteAssembly(System.String,System.Globalization.CultureInfo,System.Version)" />
     </Type>
     <Type Name="System.Reflection.TypeInfo">
       <Member Name="#ctor" />

--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -1031,6 +1031,7 @@
     <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\__HResults.cs" />
     <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\FileBasedResourceGroveler.cs" />
     <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\IResourceGroveler.cs" />
+    <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\IResourceManager.cs" />
     <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\IResourceReader.cs" />
     <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\IResourceWriter.cs" />
     <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\LooselyLinkedResourceReference.cs" />
@@ -1046,6 +1047,7 @@
     <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\RuntimeResourceSet.cs" />
     <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\SatelliteContractVersionAttribute.cs" />
     <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\UltimateResourceFallbackLocation.cs" />
+    <ResourcesSources Include="$(BclSourcesRoot)\System\Resources\WindowsRuntimeResourceManagerBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <PermissionsSources Include="$(BclSourcesRoot)\System\Security\Permissions\EnvironmentPermission.cs" />

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -3303,7 +3303,7 @@ namespace System.Diagnostics.Tracing
                 IResourceManager resources = null;
                 EventSourceAttribute eventSourceAttrib = (EventSourceAttribute)GetCustomAttributeHelper(eventSourceType, typeof(EventSourceAttribute), flags);
                 if (eventSourceAttrib != null && eventSourceAttrib.LocalizationResources != null)
-                    resources = new ResourceManager(eventSourceAttrib.LocalizationResources, eventSourceType.Assembly());
+                    resources = (IResourceManager)Activator.CreateInstance(System.Diagnostics.Tracing.Internal.Environment.ResourceManagerType, eventSourceAttrib.LocalizationResources, eventSourceType.Assembly());
 
                 manifest = new ManifestBuilder(GetName(eventSourceType, flags), GetGuid(eventSourceType), eventSourceDllName,
                                                resources, flags);

--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -3300,7 +3300,7 @@ namespace System.Diagnostics.Tracing
                 }
 
                 // See if we have localization information.  
-                ResourceManager resources = null;
+                IResourceManager resources = null;
                 EventSourceAttribute eventSourceAttrib = (EventSourceAttribute)GetCustomAttributeHelper(eventSourceType, typeof(EventSourceAttribute), flags);
                 if (eventSourceAttrib != null && eventSourceAttrib.LocalizationResources != null)
                     resources = new ResourceManager(eventSourceAttrib.LocalizationResources, eventSourceType.Assembly());
@@ -6003,7 +6003,7 @@ namespace System.Diagnostics.Tracing
         /// Build a manifest for 'providerName' with the given GUID, which will be packaged into 'dllName'.
         /// 'resources, is a resource manager.  If specified all messages are localized using that manager.  
         /// </summary>
-        public ManifestBuilder(string providerName, Guid providerGuid, string dllName, ResourceManager resources,
+        public ManifestBuilder(string providerName, Guid providerGuid, string dllName, IResourceManager resources,
                                EventManifestOptions flags)
         {
 #if FEATURE_MANAGED_ETW_CHANNELS
@@ -6499,7 +6499,7 @@ namespace System.Diagnostics.Tracing
             List<CultureInfo> cultures = null;
             if (resources != null && (flags & EventManifestOptions.AllCultures) != 0)
             {
-                cultures = GetSupportedCultures(resources);
+                cultures = GetSupportedCultures();
             }
             else
             {
@@ -6596,7 +6596,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         /// <param name="resources"></param>
         /// <returns></returns>
-        private static List<CultureInfo> GetSupportedCultures(ResourceManager resources)
+        private static List<CultureInfo> GetSupportedCultures()
         {
             var cultures = new List<CultureInfo>();
 
@@ -6877,7 +6877,7 @@ namespace System.Diagnostics.Tracing
 #if FEATURE_MANAGED_ETW_CHANNELS
         string providerName;
 #endif
-        ResourceManager resources;      // Look up localized strings here.  
+        IResourceManager resources;      // Look up localized strings here.  
         EventManifestOptions flags;
         IList<string> errors;           // list of currently encountered errors
         Dictionary<string, List<int>> perEventByteArrayArgIndices;  // "event_name" -> List_of_Indices_of_Byte[]_Arg

--- a/src/mscorlib/src/System/Diagnostics/Eventing/StubEnvironment.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/StubEnvironment.cs
@@ -46,7 +46,7 @@ namespace System.Diagnostics.Tracing.Internal
             return GetResourceString(key, args);
         }
 
-        private static System.Resources.ResourceManager rm = new System.Resources.ResourceManager("Microsoft.Diagnostics.Tracing.Messages", typeof(Environment).Assembly());
+        private static System.Resources.IResourceManager rm = new System.Resources.ResourceManager("Microsoft.Diagnostics.Tracing.Messages", typeof(Environment).Assembly());
     }
 }
 

--- a/src/mscorlib/src/System/Diagnostics/Eventing/StubEnvironment.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/StubEnvironment.cs
@@ -46,6 +46,21 @@ namespace System.Diagnostics.Tracing.Internal
             return GetResourceString(key, args);
         }
 
+        private static volatile Type s_resourceManagerType = null;
+        internal static Type ResourceManagerType
+        {
+            get
+            {
+                if (s_resourceManagerType == null)
+                {
+                    Assembly resourceManagerAssembly = Assembly.Load("System.Resources.ResourceManager, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+                    s_resourceManagerType = resourceManagerAssembly.GetType("System.Resources.ResourceManager", true);
+                }
+
+                return s_resourceManagerType;
+            }
+        }
+
         private static System.Resources.IResourceManager rm = new System.Resources.ResourceManager("Microsoft.Diagnostics.Tracing.Messages", typeof(Environment).Assembly());
     }
 }

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -73,6 +73,8 @@ namespace System {
             // Is this thread currently doing infinite resource lookups?
             private int infinitelyRecursingCount;
 
+            private Type resourceManagerType = null;
+
             // Data representing one individual resource lookup on a thread.
             internal class GetResourceStringUserData
             {
@@ -152,12 +154,6 @@ namespace System {
                 if (rh.currentlyLoading == null)
                     rh.currentlyLoading = new List<string>();
 
-                Assembly resourceManagerAssembly = Assembly.Load("System.Resources.ResourceManager, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
-                Type resourceManagerType = resourceManagerAssembly.GetType("System.Resources.ResourceManager");
-                Debug.Assert(resourceManagerType != null);
-                Type resourceReaderType = resourceManagerAssembly.GetType("System.Resources.ResourceReader");
-                Debug.Assert(resourceReaderType != null);
-
                 // Call class constructors preemptively, so that we cannot get into an infinite
                 // loop constructing a TypeInitializationException.  If this were omitted,
                 // we could get the Infinite recursion assert above by failing type initialization
@@ -165,6 +161,12 @@ namespace System {
 
                 if (!rh.resourceManagerInited)
                 {
+                    Assembly resourceManagerAssembly = Assembly.Load("System.Resources.ResourceManager, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+                    resourceManagerType = resourceManagerAssembly.GetType("System.Resources.ResourceManager");
+                    Debug.Assert(resourceManagerType != null);
+                    Type resourceReaderType = resourceManagerAssembly.GetType("System.Resources.ResourceReader");
+                    Debug.Assert(resourceReaderType != null);
+
                     // process-critical code here.  No ThreadAbortExceptions
                     // can be thrown here.  Other exceptions percolate as normal.
                     RuntimeHelpers.PrepareConstrainedRegions();

--- a/src/mscorlib/src/System/Reflection/Assembly.cs
+++ b/src/mscorlib/src/System/Reflection/Assembly.cs
@@ -1925,6 +1925,7 @@ namespace System.Reflection
             return InternalGetSatelliteAssembly(name, culture, version, true, ref stackMark);
         }
 
+        [FriendAccessAllowed] // Used by ResourceManager
         [MethodImplAttribute(MethodImplOptions.NoInlining)] // Methods containing StackCrawlMark local var has to be marked non-inlineable  
         internal RuntimeAssembly InternalGetSatelliteAssembly(String name,
                                                               CultureInfo culture,

--- a/src/mscorlib/src/System/Reflection/Assembly.cs
+++ b/src/mscorlib/src/System/Reflection/Assembly.cs
@@ -894,6 +894,7 @@ namespace System.Reflection
        HOSTED,
     }
 
+    [FriendAccessAllowed] // Used by ResourceManager
     [Serializable]
     internal class RuntimeAssembly : Assembly
     {
@@ -1926,6 +1927,15 @@ namespace System.Reflection
         }
 
         [FriendAccessAllowed] // Used by ResourceManager
+        [MethodImplAttribute(MethodImplOptions.NoInlining)] // Methods containing StackCrawlMark local var has to be marked non-inlineable  
+        public RuntimeAssembly InternalGetSatelliteAssembly(String name,
+                                                              CultureInfo culture,
+                                                              Version version)
+        {
+            StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
+            return InternalGetSatelliteAssembly(name, culture, version, false, ref stackMark);
+        }
+
         [MethodImplAttribute(MethodImplOptions.NoInlining)] // Methods containing StackCrawlMark local var has to be marked non-inlineable  
         internal RuntimeAssembly InternalGetSatelliteAssembly(String name,
                                                               CultureInfo culture,

--- a/src/mscorlib/src/System/Resources/IResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/IResourceManager.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace System.Resources
+{
+    /// <summary>
+    /// Private interface between CoreLib and ResourceManager so that CoreLib can access resources
+    /// </summary>
+    [FriendAccessAllowed]
+    public interface IResourceManager
+    {
+        String GetString(String name);
+        String GetString(String name, CultureInfo culture);
+    }
+}

--- a/src/mscorlib/src/System/Resources/ResourceManager.cs
+++ b/src/mscorlib/src/System/Resources/ResourceManager.cs
@@ -33,37 +33,6 @@ namespace System.Resources {
     using System.Diagnostics;
     using System.Diagnostics.Contracts;
 
-#if FEATURE_APPX
-    //
-    // This is implemented in System.Runtime.WindowsRuntime as function System.Resources.WindowsRuntimeResourceManager,
-    // allowing us to ask for a WinRT-specific ResourceManager.
-    // It is important to have WindowsRuntimeResourceManagerBase as regular class with virtual methods and default implementations. 
-    // Defining WindowsRuntimeResourceManagerBase as abstract class or interface will cause issues when adding more methods to it 
-    // because it’ll create dependency between mscorlib and System.Runtime.WindowsRuntime which will require always shipping both DLLs together. 
-    // Also using interface or abstract class will not play nice with FriendAccessAllowed.
-    //
-    [FriendAccessAllowed]
-    internal class WindowsRuntimeResourceManagerBase
-    {
-        public virtual bool Initialize(string libpath, string reswFilename, out PRIExceptionInfo exceptionInfo){exceptionInfo = null; return false;}
-
-        public virtual String GetString(String stringName, String startingCulture, String neutralResourcesCulture){return null;}
-
-        public virtual CultureInfo GlobalResourceContextBestFitCultureInfo { 
-            get { return null; } 
-        }
-        
-        public virtual bool SetGlobalResourceContextDefaultCulture(CultureInfo ci) { return false; }
-    }
-
-    [FriendAccessAllowed]
-    internal class PRIExceptionInfo
-    {
-        public string _PackageSimpleName;
-        public string _ResWFile;
-    }
-#endif // FEATURE_APPX
-
     // Resource Manager exposes an assembly's resources to an application for
     // the correct CultureInfo.  An example would be localizing text for a 
     // user-visible message.  Create a set of resource files listing a name 
@@ -150,7 +119,7 @@ namespace System.Resources {
 
     [Serializable]
     [System.Runtime.InteropServices.ComVisible(true)]
-    public class ResourceManager
+    public class ResourceManager : IResourceManager
     {
 
         internal class CultureNameResourceSetPair {

--- a/src/mscorlib/src/System/Resources/WindowsRuntimeResourceManagerBase.cs
+++ b/src/mscorlib/src/System/Resources/WindowsRuntimeResourceManagerBase.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Resources
+{
+    using System;
+    using System.IO;
+    using System.Globalization;
+    using System.Collections;
+    using System.Text;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+    using System.Security;
+    using System.Security.Permissions;
+    using System.Threading;
+    using System.Runtime.InteropServices;
+    using System.Runtime.CompilerServices;
+    using Microsoft.Win32;
+    using System.Collections.Generic;
+    using System.Runtime.Versioning;
+    using System.Diagnostics;
+    using System.Diagnostics.Contracts;
+
+#if FEATURE_APPX
+    //
+    // This is implemented in System.Runtime.WindowsRuntime as function System.Resources.WindowsRuntimeResourceManager,
+    // allowing us to ask for a WinRT-specific ResourceManager.
+    // It is important to have WindowsRuntimeResourceManagerBase as regular class with virtual methods and default implementations. 
+    // Defining WindowsRuntimeResourceManagerBase as abstract class or interface will cause issues when adding more methods to it 
+    // because it’ll create dependency between mscorlib and System.Runtime.WindowsRuntime which will require always shipping both DLLs together. 
+    // Also using interface or abstract class will not play nice with FriendAccessAllowed.
+    //
+    [FriendAccessAllowed]
+    internal class WindowsRuntimeResourceManagerBase
+    {
+        public virtual bool Initialize(string libpath, string reswFilename, out PRIExceptionInfo exceptionInfo) { exceptionInfo = null; return false; }
+
+        public virtual String GetString(String stringName, String startingCulture, String neutralResourcesCulture) { return null; }
+
+        public virtual CultureInfo GlobalResourceContextBestFitCultureInfo
+        {
+            get { return null; }
+        }
+
+        public virtual bool SetGlobalResourceContextDefaultCulture(CultureInfo ci) { return false; }
+    }
+
+    [FriendAccessAllowed]
+    internal class PRIExceptionInfo
+    {
+        public string _PackageSimpleName;
+        public string _ResWFile;
+    }
+#endif // FEATURE_APPX
+}

--- a/src/mscorlib/src/mscorlib.Friends.cs
+++ b/src/mscorlib/src/mscorlib.Friends.cs
@@ -16,6 +16,9 @@ using System.Runtime.CompilerServices;
 // Depends on WindowsRuntimeImportAttribute
 [assembly: InternalsVisibleTo("System.Runtime.WindowsRuntime.UI.Xaml, PublicKey=" + _InternalsVisibleToKeys.EcmaPublicKeyFull, AllInternalsVisible=false)]
 
+// Depends on internals of Assembly and IResourceManager
+[assembly: InternalsVisibleTo("System.Resources.ResourceManager, PublicKey=" + _InternalsVisibleToKeys.EcmaPublicKeyFull, AllInternalsVisible = false)]
+
 internal class _InternalsVisibleToKeys
 {
   // Token = b77a5c561934e089

--- a/src/mscorlib/src/mscorlib.Friends.cs
+++ b/src/mscorlib/src/mscorlib.Friends.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("System.Runtime.WindowsRuntime.UI.Xaml, PublicKey=" + _InternalsVisibleToKeys.EcmaPublicKeyFull, AllInternalsVisible=false)]
 
 // Depends on internals of Assembly and IResourceManager
-[assembly: InternalsVisibleTo("System.Resources.ResourceManager, PublicKey=" + _InternalsVisibleToKeys.EcmaPublicKeyFull, AllInternalsVisible = false)]
+[assembly: InternalsVisibleTo("System.Resources.ResourceManager, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293", AllInternalsVisible = false)]
 
 internal class _InternalsVisibleToKeys
 {


### PR DESCRIPTION
In preparation for moving ResourceManager to CoreFX, this removes the (few) direct usages of ResourceManager from CoreLib. For the most part, code already uses Environment.GetResourceString. This change makes that and EventSource (which gets resources from other assemblies) use ResourceManager via a private interface and exposes the private contract needed for CoreFX ResourceManager to build against CoreLib.