### PR TITLE
[x86/Linux] Fix segmentation fault during GSCookie check (WIP)

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4488,9 +4488,12 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex, CONTEXT
 
     do
     {
+        CONTEXT currentContext = *frameContext;
+
         codeInfo.Init(controlPc);
         dispatcherContext.FunctionEntry = codeInfo.GetFunctionEntry();
         dispatcherContext.ControlPc = controlPc;
+        dispatcherContext.ContextRecord = &currentContext;
         dispatcherContext.ImageBase = codeInfo.GetModuleBase();
 #if defined(_TARGET_ARM_) 
         dispatcherContext.ControlPcIsUnwound = !!(frameContext->ContextFlags & CONTEXT_UNWOUND_TO_CALL);
@@ -4519,7 +4522,6 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex, CONTEXT
             }
 
             dispatcherContext.EstablisherFrame = establisherFrame;
-            dispatcherContext.ContextRecord = frameContext;
 
             // Find exception handler in the current frame
             disposition = ProcessCLRException(ex.GetExceptionRecord(),

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -508,11 +508,11 @@ void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     }
     CONTRACT_END;
 
-#ifndef WIN64EXCEPTIONS
-    CalleeSavedRegisters* regs = GetCalleeSavedRegisters();
-
     // reset pContext; it's only valid for active (top-most) frame
     pRD->pContext = NULL;
+
+#ifndef WIN64EXCEPTIONS
+    CalleeSavedRegisters* regs = GetCalleeSavedRegisters();
 
 #define CALLEE_SAVED_REGISTER(regname) pRD->p##regname = (DWORD*) &regs->regname;
     ENUM_CALLEE_SAVED_REGISTERS();
@@ -520,21 +520,30 @@ void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->Esp = m_Esp;
     pRD->PCTAddr = GetReturnAddressPtr();
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
-#else
-    memcpy(pRD->pCurrentContext, &m_ctx, sizeof(CONTEXT));
 
-    pRD->ControlPC = m_ctx.Eip;
-
-    pRD->Esp = m_ctx.Esp;
-
-    pRD->pCurrentContextPointers->Ebx = &m_ctx.Ebx;
-    pRD->pCurrentContextPointers->Edi = &m_ctx.Edi;
-    pRD->pCurrentContextPointers->Esi = &m_ctx.Esi;
-    pRD->pCurrentContextPointers->Ebp = &m_ctx.Ebp;
+#else // WIN64EXCEPTIONS
 
     pRD->IsCallerContextValid = FALSE;
     pRD->IsCallerSPValid      = FALSE;        // Don't add usage of this field.  This is only temporary.
+
+    memcpy(pRD->pCurrentContext, &m_ctx, sizeof(CONTEXT));
+
+#define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContextPointers->regname = &m_ctx.regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+
+#define CALLEE_SAVED_REGISTER(regname) pRD->p##regname = &m_ctx.regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+
+    pRD->Esp = m_ctx.Esp;
+    pRD->PCTAddr = GetReturnAddressPtr();
+    pRD->ControlPC = m_ctx.Eip;
+
 #endif // WIN64EXCEPTIONS
+
+    LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    FaultingExceptionFrame::UpdateRegDisplay(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->Esp));
+
     RETURN;
 }
 

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -8192,6 +8192,7 @@ bool Thread::InitRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, bool validCo
             {
                 SetIP(pctx, 0);
 #ifdef _TARGET_X86_
+                pRD->pEbp = &(pctx->Ebp);
                 pRD->ControlPC = pctx->Eip;
                 pRD->PCTAddr = (TADDR)&(pctx->Eip);
 #elif defined(_TARGET_AMD64_)
@@ -8209,6 +8210,9 @@ bool Thread::InitRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, bool validCo
     }
 
     FillRegDisplay( pRD, pctx );
+#ifdef _TARGET_X86_
+    pRD->pEbp = &(pctx->Ebp);
+#endif
 
     return true;
 }


### PR DESCRIPTION
This commit attempts to fix segfault due to incorrect GSCookie address.

The current implementation computes GSCookie address via dereferencing pEbp field in REGDISPLAY, and adding some offsets, but pEbp is not initialized correctly.

This results in segmentation fault discussed in #8980.

In addition, the currenct implementation of FaultingExceptionFrame::UpdateRegDisplay does not updates pXXX fields at all, which incurs segmentation fault while checking GSCookie inside ExceptionTracker::FindNonvolatileRegisterPointers .

This commit attempts to update pEbp to fix #8980.