### PR TITLE
Remove PLATFORM_UNIX and FEATURE_PAL checks in PAL

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -50,7 +50,6 @@ Abstract:
 extern "C" {
 #endif
 
-#if defined (PLATFORM_UNIX)
 // This macro is used to standardize the wide character string literals between UNIX and Windows.
 // Unix L"" is UTF32, and on windows it's UTF16.  Because of built-in assumptions on the size
 // of string literals, it's important to match behaviour between Unix and Windows.  Unix will be defined
@@ -64,8 +63,6 @@ extern "C" {
 #define QUOTE_MACRO_L(x) QUOTE_MACRO_u(x)
 #define QUOTE_MACRO_u_HELPER(x)     u###x
 #define QUOTE_MACRO_u(x)            QUOTE_MACRO_u_HELPER(x)
-
-#endif
 
 #include <pal_char16.h>
 #include <pal_error.h>
@@ -2526,8 +2523,6 @@ PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 
 #define GetLogicalProcessorCacheSizeFromOS PAL_GetLogicalProcessorCacheSizeFromOS
 
-#ifdef PLATFORM_UNIX
-
 /* PAL_CS_NATIVE_DATA_SIZE is defined as sizeof(PAL_CRITICAL_SECTION_NATIVE_DATA) */
 
 #if defined(__APPLE__) && defined(__i386__)
@@ -2557,8 +2552,6 @@ PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 #error  PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
 #endif
     
-#endif // PLATFORM_UNIX
-
 // 
 typedef struct _CRITICAL_SECTION {
     PVOID DebugInfo;
@@ -2568,7 +2561,6 @@ typedef struct _CRITICAL_SECTION {
     HANDLE LockSemaphore;
     ULONG_PTR SpinCount;
 
-#ifdef PLATFORM_UNIX
     BOOL bInternal;
     volatile DWORD dwInitState;
     union CSNativeDataStorage
@@ -2576,7 +2568,6 @@ typedef struct _CRITICAL_SECTION {
         BYTE rgNativeDataStorage[PAL_CS_NATIVE_DATA_SIZE]; 
         VOID * pvAlign; // make sure the storage is machine-pointer-size aligned
     } csnds;    
-#endif // PLATFORM_UNIX    
 } CRITICAL_SECTION, *PCRITICAL_SECTION, *LPCRITICAL_SECTION;
 
 PALIMPORT VOID PALAPI EnterCriticalSection(IN OUT LPCRITICAL_SECTION lpCriticalSection);
@@ -4859,7 +4850,6 @@ CoCreateGuid(OUT GUID * pguid);
 /* Some C runtime functions needs to be reimplemented by the PAL.
    To avoid name collisions, those functions have been renamed using
    defines */
-#ifdef PLATFORM_UNIX
 #ifndef PAL_STDCPP_COMPAT
 #define exit          PAL_exit
 #define atexit        PAL_atexit
@@ -4962,7 +4952,6 @@ CoCreateGuid(OUT GUID * pguid);
 #endif // _AMD64_
 
 #endif // !PAL_STDCPP_COMPAT
-#endif // PLATFORM_UNIX
 
 #ifndef _CONST_RETURN
 #ifdef  __cplusplus
@@ -5241,17 +5230,11 @@ PALIMPORT char * __cdecl _strdup(const char *);
 
 #if defined(_MSC_VER)
 #define alloca _alloca
-#elif defined(PLATFORM_UNIX)
-#define _alloca alloca
 #else
-// MingW
-#define _alloca __builtin_alloca
-#define alloca __builtin_alloca
+#define _alloca alloca
 #endif //_MSC_VER
 
-#if defined(__GNUC__) && defined(PLATFORM_UNIX)
 #define alloca  __builtin_alloca
-#endif // __GNUC__
 
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 #define min(a, b) (((a) < (b)) ? (a) : (b))
@@ -6012,7 +5995,6 @@ public:
 
 // Platform-specific library naming
 // 
-#ifdef PLATFORM_UNIX
 #ifdef __APPLE__
 #define MAKEDLLNAME_W(name) u"lib" name u".dylib"
 #define MAKEDLLNAME_A(name)  "lib" name  ".dylib"
@@ -6020,10 +6002,6 @@ public:
 #define MAKEDLLNAME_W(name) u"lib" name u".so"
 #define MAKEDLLNAME_A(name)  "lib" name  ".so"
 #endif
-#else // PLATFORM_UNIX
-#define MAKEDLLNAME_W(name) name L".dll"
-#define MAKEDLLNAME_A(name) name  ".dll"
-#endif // PLATFORM_UNIX
 
 #ifdef UNICODE
 #define MAKEDLLNAME(x) MAKEDLLNAME_W(x)

--- a/src/pal/inc/pal_char16.h
+++ b/src/pal/inc/pal_char16.h
@@ -27,12 +27,10 @@ This file is used to define the wchar_t type as a 16-bit type on Unix.
 // vc++, for whom wchar_t is already a typedef instead of a built-in.
 
 #ifndef PAL_STDCPP_COMPAT
-#if defined (PLATFORM_UNIX) && defined(__GNUC__)
 #undef wchar_t
 #undef __WCHAR_TYPE__
 #define __WCHAR_TYPE__ __wchar_16_cpp__
 #define wchar_t __wchar_16_cpp__
-#endif // PLATFORM_UNIX
 
 // Set up the wchar_t type (which got preprocessed to __wchar_16_cpp__).
 // In C++11, the standard gives us char16_t, which is what we want (and matches types with u"")
@@ -40,7 +38,6 @@ This file is used to define the wchar_t type as a 16-bit type on Unix.
 // **** WARNING: Linking C and C++ objects will break with -fstrict-aliasing with GCC/Clang
 //               due to conditional typedef
 #if !defined(_WCHAR_T_DEFINED) || !defined(_MSC_VER)
-#if defined (PLATFORM_UNIX)
 #if defined(__cplusplus)
 #undef __WCHAR_TYPE__
 #define __WCHAR_TYPE__ char16_t
@@ -50,7 +47,7 @@ typedef char16_t wchar_t;
 #define __WCHAR_TYPE__ unsigned short
 typedef unsigned short wchar_t;
 #endif // __cplusplus
-#endif // PLATFORM_UNIX
+
 #ifndef _WCHAR_T_DEFINED
 #define _WCHAR_T_DEFINED
 #endif // !_WCHAR_T_DEFINED

--- a/src/pal/inc/pal_mstypes.h
+++ b/src/pal/inc/pal_mstypes.h
@@ -235,13 +235,8 @@ typedef long double LONG_DOUBLE;
 
 typedef void VOID;
 
-#ifndef PLATFORM_UNIX
-typedef long LONG;
-typedef unsigned long ULONG;
-#else
 typedef int LONG;       // NOTE: diff from windows.h, for LP64 compat
 typedef unsigned int ULONG; // NOTE: diff from windows.h, for LP64 compat
-#endif
 
 typedef __int64 LONGLONG;
 typedef unsigned __int64 ULONGLONG;
@@ -260,12 +255,7 @@ typedef UCHAR *PUCHAR;
 typedef char *PSZ;
 typedef ULONGLONG DWORDLONG;
 
-#ifndef PLATFORM_UNIX
-typedef unsigned long DWORD;
-#else
 typedef unsigned int DWORD; // NOTE: diff from  windows.h, for LP64 compat
-#endif
-
 typedef unsigned int DWORD32, *PDWORD32;
 
 typedef int BOOL;

--- a/src/pal/inc/rt/intsafe.h
+++ b/src/pal/inc/rt/intsafe.h
@@ -38,47 +38,6 @@ UnsignedMultiply128 (
 #endif
 #endif // _AMD64_
 
-#ifndef FEATURE_PAL
-
-#ifdef  _WIN64
-typedef unsigned __int64    size_t;
-typedef unsigned __int64    UINT_PTR;
-typedef unsigned __int64    ULONG_PTR;
-typedef unsigned __int64    DWORD_PTR;
-typedef unsigned __int64    SIZE_T;
-#else
-typedef __w64 unsigned int  size_t;
-typedef __w64 unsigned int  UINT_PTR;
-typedef __w64 unsigned long ULONG_PTR;
-typedef __w64 unsigned long DWORD_PTR;
-typedef __w64 unsigned long SIZE_T;
-#endif
-typedef          char       CHAR;
-typedef          int        INT;
-typedef          long       LONG;
-typedef unsigned char       UCHAR;
-typedef unsigned short      USHORT;
-typedef unsigned short      WORD;
-typedef unsigned int        UINT;
-typedef unsigned long       ULONG;
-typedef unsigned long       DWORD;
-typedef unsigned __int64    ULONGLONG;
-
-
-typedef LONG HRESULT;
-
-#ifndef SUCCEEDED
-#define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
-#endif
-
-#ifndef FAILED
-#define FAILED(hr) (((HRESULT)(hr)) < 0)
-#endif
-
-#define S_OK ((HRESULT)0x00000000L)
-
-#endif // !FEATURE_PAL
-
 #define INTSAFE_E_ARITHMETIC_OVERFLOW       ((HRESULT)0x80070216L)  // 0x216 = 534 = ERROR_ARITHMETIC_OVERFLOW
 
 #ifndef LOWORD

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1186,7 +1186,6 @@ typedef VOID (__stdcall *WAITORTIMERCALLBACK)(PVOID, BOOLEAN);
 
 #define _ReturnAddress() __builtin_return_address(0)
 
-#ifdef PLATFORM_UNIX
 #define DIRECTORY_SEPARATOR_CHAR_A '/'
 #define DIRECTORY_SEPARATOR_CHAR_W W('/')
 #define DIRECTORY_SEPARATOR_STR_A "/"
@@ -1194,15 +1193,6 @@ typedef VOID (__stdcall *WAITORTIMERCALLBACK)(PVOID, BOOLEAN);
 #define PATH_SEPARATOR_CHAR_W W(':')
 #define PATH_SEPARATOR_STR_W W(":")
 #define VOLUME_SEPARATOR_CHAR_W W('/')
-#else // PLATFORM_UNIX
-#define DIRECTORY_SEPARATOR_CHAR_A '\\'
-#define DIRECTORY_SEPARATOR_CHAR_W W('\\')
-#define DIRECTORY_SEPARATOR_STR_A "\\"
-#define DIRECTORY_SEPARATOR_STR_W W("\\")
-#define PATH_SEPARATOR_CHAR_W W(';')
-#define PATH_SEPARATOR_STR_W W(";")
-#define VOLUME_SEPARATOR_CHAR_W W(':')
-#endif // PLATFORM_UNIX
 
 #ifndef IMAGE_IMPORT_DESC_FIELD
 #define IMAGE_IMPORT_DESC_FIELD(img, f)     ((img).u.f)

--- a/src/pal/inc/rt/vsassert.h
+++ b/src/pal/inc/rt/vsassert.h
@@ -11,10 +11,6 @@
 #ifndef __VSASSERT_H__
 #define __VSASSERT_H__
 
-#ifndef FEATURE_PAL
-#error "FEATURE_PAL must be defined for this file"
-#else // FEATURE_PAL
-
 #define VSASSERT(e, szMsg)                                      \
 do {                                                            \
     if (!(e)) {                                                 \
@@ -94,5 +90,4 @@ do {                                                            \
 
 #define VsIgnoreAllocs(f)
 
-#endif // FEATURE_PAL
 #endif // __VSASSERT_H__

--- a/src/pal/inc/strsafe.h
+++ b/src/pal/inc/strsafe.h
@@ -24,14 +24,6 @@
 #pragma once
 #endif
 
-#if defined(PLATFORM_UNIX) && !defined (FEATURE_PAL)
-#define _NATIVE_WCHAR_T_DEFINED
-#endif // defined(PLATFORM_UNIX) && !defined (FEATURE_PAL)
-
-#if defined(PLATFORM_UNIX) && !defined (FEATURE_PAL)
-#define _vsnprintf vsnprintf
-#endif // defined(PLATFORM_UNIX) && !defined (FEATURE_PAL)
-
 #include <stdio.h>      // for _vsnprintf, getc, getwc
 #include <string.h>     // for memset
 #include <stdarg.h>     // for va_start, etc.
@@ -50,13 +42,6 @@ typedef __w64 unsigned int  size_t;
 typedef char16_t WCHAR;
 #define _WCHAR_T_DEFINED
 #endif
-
-#ifndef FEATURE_PAL
-#ifndef _HRESULT_DEFINED
-#define _HRESULT_DEFINED
-typedef LONG HRESULT;
-#endif // !_HRESULT_DEFINED
-#endif // !FEATURE_PAL
 
 #ifndef SUCCEEDED
 #define SUCCEEDED(hr)  ((HRESULT)(hr) >= 0)
@@ -150,14 +135,6 @@ STRSAFEAPI StringLengthWorkerA(const char* psz, size_t cchMax, size_t* pcch);
 STRSAFEAPI StringLengthWorkerW(const WCHAR* psz, size_t cchMax, size_t* pcch);
 #endif  // STRSAFE_INLINE
 
-#ifndef STRSAFE_LIB_IMPL
-#ifndef FEATURE_PAL
-// these functions are always inline
-STRSAFE_INLINE_API StringGetsExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, char** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags);
-STRSAFE_INLINE_API StringGetsExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags);
-#endif // !FEATURE_PAL
-#endif
-
 #ifndef STRSAFE_NO_CCH_FUNCTIONS
 /*++
 
@@ -247,7 +224,6 @@ STRSAFEAPI StringCchCopyA(char* pszDest, size_t cchDest, const char* pszSrc)
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCchCopyW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc)
 {
     HRESULT hr;
@@ -263,7 +239,6 @@ STRSAFEAPI StringCchCopyW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc)
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
 
@@ -361,7 +336,6 @@ STRSAFEAPI StringCbCopyA(char* pszDest, size_t cbDest, const char* pszSrc)
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCbCopyW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc)
 {
     HRESULT hr;
@@ -381,7 +355,6 @@ STRSAFEAPI StringCbCopyW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc)
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
 
@@ -506,7 +479,6 @@ STRSAFEAPI StringCchCopyExA(char* pszDest, size_t cchDest, const char* pszSrc, c
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCchCopyExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
@@ -527,7 +499,6 @@ STRSAFEAPI StringCchCopyExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc,
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
 
@@ -660,7 +631,6 @@ STRSAFEAPI StringCbCopyExA(char* pszDest, size_t cbDest, const char* pszSrc, cha
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCbCopyExW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, WCHAR** ppszDestEnd, size_t* pcbRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
@@ -689,7 +659,6 @@ STRSAFEAPI StringCbCopyExW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, W
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
 
@@ -784,7 +753,6 @@ STRSAFEAPI StringCchCopyNA(char* pszDest, size_t cchDest, const char* pszSrc, si
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCchCopyNW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, size_t cchSrc)
 {
     HRESULT hr;
@@ -801,7 +769,6 @@ STRSAFEAPI StringCchCopyNW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, 
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
 
@@ -902,7 +869,6 @@ STRSAFEAPI StringCbCopyNA(char* pszDest, size_t cbDest, const char* pszSrc, size
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCbCopyNW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, size_t cbSrc)
 {
     HRESULT hr;
@@ -925,7 +891,6 @@ STRSAFEAPI StringCbCopyNW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, si
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
 
@@ -1060,7 +1025,6 @@ STRSAFEAPI StringCchCopyNExA(char* pszDest, size_t cchDest, const char* pszSrc, 
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCchCopyNExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, size_t cchSrc, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
@@ -1082,7 +1046,6 @@ STRSAFEAPI StringCchCopyNExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
 
@@ -1226,7 +1189,6 @@ STRSAFEAPI StringCbCopyNExA(char* pszDest, size_t cbDest, const char* pszSrc, si
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCbCopyNExW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, size_t cbSrc, WCHAR** ppszDestEnd, size_t* pcbRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
@@ -1258,7 +1220,6 @@ STRSAFEAPI StringCbCopyNExW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, 
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
 
@@ -1345,7 +1306,6 @@ STRSAFEAPI StringCchCatA(char* pszDest, size_t cchDest, const char* pszSrc)
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCchCatW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc)
 {
     HRESULT hr;
@@ -1361,7 +1321,6 @@ STRSAFEAPI StringCchCatW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc)
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
 
@@ -1451,7 +1410,6 @@ STRSAFEAPI StringCbCatA(char* pszDest, size_t cbDest, const char* pszSrc)
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCbCatW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc)
 {
     HRESULT hr;
@@ -1470,7 +1428,6 @@ STRSAFEAPI StringCbCatW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc)
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
 
@@ -1598,7 +1555,6 @@ STRSAFEAPI StringCchCatExA(char* pszDest, size_t cchDest, const char* pszSrc, ch
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCchCatExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
@@ -1619,7 +1575,6 @@ STRSAFEAPI StringCchCatExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, 
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
 
@@ -1755,7 +1710,6 @@ STRSAFEAPI StringCbCatExA(char* pszDest, size_t cbDest, const char* pszSrc, char
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCbCatExW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, WCHAR** ppszDestEnd, size_t* pcbRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
@@ -1784,7 +1738,6 @@ STRSAFEAPI StringCbCatExW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, WC
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
 
@@ -1877,7 +1830,6 @@ STRSAFEAPI StringCchCatNA(char* pszDest, size_t cchDest, const char* pszSrc, siz
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCchCatNW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, size_t cchMaxAppend)
 {
     HRESULT hr;
@@ -1893,7 +1845,6 @@ STRSAFEAPI StringCchCatNW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, s
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
 
@@ -1993,7 +1944,6 @@ STRSAFEAPI StringCbCatNA(char* pszDest, size_t cbDest, const char* pszSrc, size_
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCbCatNW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, size_t cbMaxAppend)
 {
     HRESULT hr;
@@ -2016,7 +1966,6 @@ STRSAFEAPI StringCbCatNW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, siz
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
 
@@ -2147,7 +2096,6 @@ STRSAFEAPI StringCchCatNExA(char* pszDest, size_t cchDest, const char* pszSrc, s
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCchCatNExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, size_t cchMaxAppend, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
@@ -2168,7 +2116,6 @@ STRSAFEAPI StringCchCatNExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc,
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
 
@@ -2311,7 +2258,6 @@ STRSAFEAPI StringCbCatNExA(char* pszDest, size_t cbDest, const char* pszSrc, siz
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCbCatNExW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, size_t cbMaxAppend, WCHAR** ppszDestEnd, size_t* pcbRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
@@ -2344,7 +2290,6 @@ STRSAFEAPI StringCbCatNExW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, s
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
 
@@ -2403,62 +2348,7 @@ Return Value:
 
 --*/
 
-#ifndef FEATURE_PAL
-#ifndef STRSAFE_LIB_IMPL
-STRSAFE_INLINE_API StringCchGetsA(char* pszDest, size_t cchDest);
-STRSAFE_INLINE_API StringCchGetsW(WCHAR* pszDest, size_t cchDest);
-#ifdef UNICODE
-#define StringCchGets  StringCchGetsW
-#else
-#define StringCchGets  StringCchGetsA
-#endif // !UNICODE
-
-STRSAFE_INLINE_API StringCchGetsA(char* pszDest, size_t cchDest)
-{
-    HRESULT hr;
-
-    if (cchDest > STRSAFE_MAX_CCH)
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        size_t cbDest;
-        
-        // safe to multiply cchDest * sizeof(char) since cchDest < STRSAFE_MAX_CCH and sizeof(char) is 1
-        cbDest = cchDest * sizeof(char);
-
-        hr = StringGetsExWorkerA(pszDest, cchDest, cbDest, NULL, NULL, 0);
-    }
-
-    return hr;
-}
-
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
-STRSAFE_INLINE_API StringCchGetsW(WCHAR* pszDest, size_t cchDest)
-{
-    HRESULT hr;
-
-    if (cchDest > STRSAFE_MAX_CCH)
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        size_t cbDest;
-        
-        // safe to multiply cchDest * sizeof(WCHAR) since cchDest < STRSAFE_MAX_CCH and sizeof(WCHAR) is 2
-        cbDest = cchDest * sizeof(WCHAR);
-
-        hr = StringGetsExWorkerW(pszDest, cchDest, cbDest, NULL, NULL, 0);
-    }
-
-    return hr;
-}
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
-#endif  // !STRSAFE_LIB_IMPL
-#endif  // !FEATURE_PAL
 
 #ifndef STRSAFE_NO_CB_FUNCTIONS
 /*++
@@ -2514,60 +2404,7 @@ Return Value:
 
 --*/
 
-#ifndef FEATURE_PAL
-#ifndef STRSAFE_LIB_IMPL
-STRSAFE_INLINE_API StringCbGetsA(char* pszDest, size_t cbDest);
-STRSAFE_INLINE_API StringCbGetsW(WCHAR* pszDest, size_t cbDest);
-#ifdef UNICODE
-#define StringCbGets  StringCbGetsW
-#else
-#define StringCbGets  StringCbGetsA
-#endif // !UNICODE
-
-STRSAFE_INLINE_API StringCbGetsA(char* pszDest, size_t cbDest)
-{
-    HRESULT hr;
-    size_t cchDest;
-    
-    // convert to count of characters
-    cchDest = cbDest / sizeof(char);
-
-    if (cchDest > STRSAFE_MAX_CCH)
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        hr = StringGetsExWorkerA(pszDest, cchDest, cbDest, NULL, NULL, 0);
-    }
-
-    return hr;
-}
-
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
-STRSAFE_INLINE_API StringCbGetsW(WCHAR* pszDest, size_t cbDest)
-{
-    HRESULT hr;
-    size_t cchDest;
-    
-    // convert to count of characters
-    cchDest = cbDest / sizeof(WCHAR);
-
-    if (cchDest > STRSAFE_MAX_CCH)
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        hr = StringGetsExWorkerW(pszDest, cchDest, cbDest, NULL, NULL, 0);
-    }
-
-    return hr;
-}
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
-#endif  // !STRSAFE_LIB_IMPL
-#endif  // !FEATURE_PAL
 
 #ifndef STRSAFE_NO_CCH_FUNCTIONS
 /*++
@@ -2650,62 +2487,7 @@ Return Value:
 
 --*/
 
-#ifndef FEATURE_PAL
-#ifndef STRSAFE_LIB_IMPL
-STRSAFE_INLINE_API StringCchGetsExA(char* pszDest, size_t cchDest, char** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags);
-STRSAFE_INLINE_API StringCchGetsExW(WCHAR* pszDest, size_t cchDest, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags);
-#ifdef UNICODE
-#define StringCchGetsEx  StringCchGetsExW
-#else
-#define StringCchGetsEx  StringCchGetsExA
-#endif // !UNICODE
-
-STRSAFE_INLINE_API StringCchGetsExA(char* pszDest, size_t cchDest, char** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
-{
-    HRESULT hr;
-
-    if (cchDest > STRSAFE_MAX_CCH)
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        size_t cbDest;
-        
-        // safe to multiply cchDest * sizeof(char) since cchDest < STRSAFE_MAX_CCH and sizeof(char) is 1
-        cbDest = cchDest * sizeof(char);
-
-        hr = StringGetsExWorkerA(pszDest, cchDest, cbDest, ppszDestEnd, pcchRemaining, dwFlags);
-    }
-
-    return hr;
-}
-
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
-STRSAFE_INLINE_API StringCchGetsExW(WCHAR* pszDest, size_t cchDest, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
-{
-    HRESULT hr;
-
-    if (cchDest > STRSAFE_MAX_CCH)
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        size_t cbDest;
-        
-        // safe to multiply cchDest * sizeof(WCHAR) since cchDest < STRSAFE_MAX_CCH and sizeof(WCHAR) is 2
-        cbDest = cchDest * sizeof(WCHAR);
-
-        hr = StringGetsExWorkerW(pszDest, cchDest, cbDest, ppszDestEnd, pcchRemaining, dwFlags);
-    }
-
-    return hr;
-}
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
-#endif  // !STRSAFE_LIB_IMPL
-#endif  // !FEATURE_PAL
 
 #ifndef STRSAFE_NO_CB_FUNCTIONS
 /*++
@@ -2788,82 +2570,7 @@ Return Value:
 
 --*/
 
-#ifndef FEATURE_PAL
-#ifndef STRSAFE_LIB_IMPL
-STRSAFE_INLINE_API StringCbGetsExA(char* pszDest, size_t cbDest, char** ppszDestEnd, size_t* pbRemaining, unsigned long dwFlags);
-STRSAFE_INLINE_API StringCbGetsExW(WCHAR* pszDest, size_t cbDest, WCHAR** ppszDestEnd, size_t* pcbRemaining, unsigned long dwFlags);
-#ifdef UNICODE
-#define StringCbGetsEx  StringCbGetsExW
-#else
-#define StringCbGetsEx  StringCbGetsExA
-#endif // !UNICODE
-
-STRSAFE_INLINE_API StringCbGetsExA(char* pszDest, size_t cbDest, char** ppszDestEnd, size_t* pcbRemaining, unsigned long dwFlags)
-{
-    HRESULT hr;
-    size_t cchDest;
-    size_t cchRemaining = 0;
-
-    cchDest = cbDest / sizeof(char);
-
-    if (cchDest > STRSAFE_MAX_CCH)
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        hr = StringGetsExWorkerA(pszDest, cchDest, cbDest, ppszDestEnd, &cchRemaining, dwFlags);
-    }
-
-    if (SUCCEEDED(hr)                           ||
-        (hr == STRSAFE_E_INSUFFICIENT_BUFFER)   ||
-        (hr == STRSAFE_E_END_OF_FILE))
-    {
-        if (pcbRemaining)
-        {
-            // safe to multiply cchRemaining * sizeof(char) since cchRemaining < STRSAFE_MAX_CCH and sizeof(char) is 1
-            *pcbRemaining = (cchRemaining * sizeof(char)) + (cbDest % sizeof(char));
-        }
-    }
-
-    return hr;
-}
-
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
-STRSAFE_INLINE_API StringCbGetsExW(WCHAR* pszDest, size_t cbDest, WCHAR** ppszDestEnd, size_t* pcbRemaining, unsigned long dwFlags)
-{
-    HRESULT hr;
-    size_t cchDest;
-    size_t cchRemaining = 0;
-
-    cchDest = cbDest / sizeof(WCHAR);
-
-    if (cchDest > STRSAFE_MAX_CCH)
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        hr = StringGetsExWorkerW(pszDest, cchDest, cbDest, ppszDestEnd, &cchRemaining, dwFlags);
-    }
-
-    if (SUCCEEDED(hr)                           ||
-        (hr == STRSAFE_E_INSUFFICIENT_BUFFER)   ||
-        (hr == STRSAFE_E_END_OF_FILE))
-    {
-        if (pcbRemaining)
-        {
-            // safe to multiply cchRemaining * sizeof(WCHAR) since cchRemaining < STRSAFE_MAX_CCH and sizeof(WCHAR) is 2
-            *pcbRemaining = (cchRemaining * sizeof(WCHAR)) + (cbDest % sizeof(WCHAR));
-        }
-    }
-
-    return hr;
-}
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
-#endif  // !STRSAFE_LIB_IMPL
-#endif  // !FEATURE_PAL
 
 #ifndef STRSAFE_NO_CCH_FUNCTIONS
 /*++
@@ -2937,7 +2644,6 @@ STRSAFEAPI StringCchLengthA(const char* psz, size_t cchMax, size_t* pcch)
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCchLengthW(const WCHAR* psz, size_t cchMax, size_t* pcch)
 {
     HRESULT hr;
@@ -2953,7 +2659,6 @@ STRSAFEAPI StringCchLengthW(const WCHAR* psz, size_t cchMax, size_t* pcch)
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CCH_FUNCTIONS
 
@@ -3040,7 +2745,6 @@ STRSAFEAPI StringCbLengthA(const char* psz, size_t cbMax, size_t* pcb)
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCbLengthW(const WCHAR* psz, size_t cbMax, size_t* pcb)
 {
     HRESULT hr;
@@ -3066,7 +2770,6 @@ STRSAFEAPI StringCbLengthW(const WCHAR* psz, size_t cbMax, size_t* pcb)
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
 #endif  // !STRSAFE_NO_CB_FUNCTIONS
 
@@ -3103,7 +2806,6 @@ STRSAFEAPI StringCopyWorkerA(char* pszDest, size_t cchDest, const char* pszSrc)
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCopyWorkerW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc)
 {
     HRESULT hr = S_OK;
@@ -3133,7 +2835,6 @@ STRSAFEAPI StringCopyWorkerW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 
 STRSAFEAPI StringCopyExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, const char* pszSrc, char** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
@@ -3273,7 +2974,6 @@ STRSAFEAPI StringCopyExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, con
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCopyExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, const WCHAR* pszSrc, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr = S_OK;
@@ -3411,7 +3111,6 @@ STRSAFEAPI StringCopyExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, co
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 
 STRSAFEAPI StringCopyNWorkerA(char* pszDest, size_t cchDest, const char* pszSrc, size_t cchSrc)
 {
@@ -3444,7 +3143,6 @@ STRSAFEAPI StringCopyNWorkerA(char* pszDest, size_t cchDest, const char* pszSrc,
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCopyNWorkerW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, size_t cchSrc)
 {
     HRESULT hr = S_OK;
@@ -3475,7 +3173,6 @@ STRSAFEAPI StringCopyNWorkerW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSr
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 
 STRSAFEAPI StringCopyNExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, const char* pszSrc, size_t cchSrc, char** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
@@ -3616,7 +3313,6 @@ STRSAFEAPI StringCopyNExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, co
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCopyNExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, const WCHAR* pszSrc, size_t cchSrc, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr = S_OK;
@@ -3755,7 +3451,6 @@ STRSAFEAPI StringCopyNExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, c
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 
 STRSAFEAPI StringCatWorkerA(char* pszDest, size_t cchDest, const char* pszSrc)
 {
@@ -3774,7 +3469,6 @@ STRSAFEAPI StringCatWorkerA(char* pszDest, size_t cchDest, const char* pszSrc)
    return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCatWorkerW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc)
 {
    HRESULT hr;
@@ -3791,7 +3485,6 @@ STRSAFEAPI StringCatWorkerW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc)
 
    return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 
 STRSAFEAPI StringCatExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, const char* pszSrc, char** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
@@ -3940,7 +3633,6 @@ STRSAFEAPI StringCatExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, cons
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCatExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, const WCHAR* pszSrc, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr = S_OK;
@@ -4086,7 +3778,6 @@ STRSAFEAPI StringCatExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, con
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 
 STRSAFEAPI StringCatNWorkerA(char* pszDest, size_t cchDest, const char* pszSrc, size_t cchMaxAppend)
 {
@@ -4106,7 +3797,6 @@ STRSAFEAPI StringCatNWorkerA(char* pszDest, size_t cchDest, const char* pszSrc, 
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCatNWorkerW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, size_t cchMaxAppend)
 {
     HRESULT hr;
@@ -4124,7 +3814,6 @@ STRSAFEAPI StringCatNWorkerW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 
 STRSAFEAPI StringCatNExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, const char* pszSrc, size_t cchMaxAppend, char** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
@@ -4272,7 +3961,6 @@ STRSAFEAPI StringCatNExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, con
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringCatNExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, const WCHAR* pszSrc, size_t cchMaxAppend, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr = S_OK;
@@ -4419,7 +4107,6 @@ STRSAFEAPI StringCatNExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, co
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 
 STRSAFEAPI StringLengthWorkerA(const char* psz, size_t cchMax, size_t* pcch)
 {
@@ -4446,7 +4133,6 @@ STRSAFEAPI StringLengthWorkerA(const char* psz, size_t cchMax, size_t* pcch)
     return hr;
 }
 
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
 STRSAFEAPI StringLengthWorkerW(const WCHAR* psz, size_t cchMax, size_t* pcch)
 {
     HRESULT hr = S_OK;
@@ -4471,285 +4157,6 @@ STRSAFEAPI StringLengthWorkerW(const WCHAR* psz, size_t cchMax, size_t* pcch)
 
     return hr;
 }
-#endif // FEATURE_PAL || !PLATFORM_UNIX
 #endif  // STRSAFE_INLINE
-
-#ifndef STRSAFE_LIB_IMPL
-#ifndef FEATURE_PAL
-STRSAFE_INLINE_API StringGetsExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, char** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
-{
-    HRESULT hr = S_OK;
-    char* pszDestEnd = pszDest;
-    size_t cchRemaining = 0;
-
-    // ASSERT(cbDest == (cchDest * sizeof(char))    ||
-    //        cbDest == (cchDest * sizeof(char)) + (cbDest % sizeof(char)));
-
-    // only accept valid flags
-    if (dwFlags & (~STRSAFE_VALID_FLAGS))
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        if (dwFlags & STRSAFE_IGNORE_NULLS)
-        {
-            if (pszDest == NULL)
-            {
-                if ((cchDest != 0) || (cbDest != 0))
-                {
-                    // NULL pszDest and non-zero cchDest/cbDest is invalid
-                    hr = STRSAFE_E_INVALID_PARAMETER;
-                }
-            }
-        }
-
-        if (SUCCEEDED(hr))
-        {
-            if (cchDest <= 1)
-            {
-                pszDestEnd = pszDest;
-                cchRemaining = cchDest;
-
-                if (cchDest == 1)
-                {
-                    *pszDestEnd = '\0';
-                }
-
-                hr = STRSAFE_E_INSUFFICIENT_BUFFER;
-            }
-            else
-            {
-                char ch;
-
-                pszDestEnd = pszDest;
-                cchRemaining = cchDest;
-
-                while ((cchRemaining > 1) && (ch = (char)getc(stdin)) != '\n')
-                {
-                    if (ch == EOF)
-                    {
-                        if (pszDestEnd == pszDest)
-                        {
-                            // we failed to read anything from stdin
-                            hr = STRSAFE_E_END_OF_FILE;
-                        }
-                        break;
-                    }
-
-                    *pszDestEnd = ch;
-
-                    pszDestEnd++;
-                    cchRemaining--;
-                }
-
-                if (cchRemaining > 0)
-                {
-                    // there is extra room
-                    if (dwFlags & STRSAFE_FILL_BEHIND_NULL)
-                    {
-                        memset(pszDestEnd + 1, STRSAFE_GET_FILL_PATTERN(dwFlags), ((cchRemaining - 1) * sizeof(char)) + (cbDest % sizeof(char)));
-                    }
-                }
-
-                *pszDestEnd = '\0';
-            }
-        }
-    }
-
-    if (FAILED(hr))
-    {
-        if (pszDest)
-        {
-            if (dwFlags & STRSAFE_FILL_ON_FAILURE)
-            {
-                memset(pszDest, STRSAFE_GET_FILL_PATTERN(dwFlags), cbDest);
-            
-                if (STRSAFE_GET_FILL_PATTERN(dwFlags) == 0)
-                {
-                    pszDestEnd = pszDest;
-                    cchRemaining = cchDest;
-                }
-                else if (cchDest > 0)
-                {
-                    pszDestEnd = pszDest + cchDest - 1;
-                    cchRemaining = 1;
-
-                    // null terminate the end of the string
-                    *pszDestEnd = '\0';
-                }
-            }
-
-            if (dwFlags & (STRSAFE_NULL_ON_FAILURE | STRSAFE_NO_TRUNCATION))
-            {
-                if (cchDest > 0)
-                {
-                    pszDestEnd = pszDest;
-                    cchRemaining = cchDest;
-
-                    // null terminate the beginning of the string
-                    *pszDestEnd = '\0';
-                }
-            }
-        }
-    }
-
-    if (SUCCEEDED(hr)                           ||
-        (hr == STRSAFE_E_INSUFFICIENT_BUFFER)   ||
-        (hr == STRSAFE_E_END_OF_FILE))
-    {
-        if (ppszDestEnd)
-        {
-            *ppszDestEnd = pszDestEnd;
-        }
-
-        if (pcchRemaining)
-        {
-            *pcchRemaining = cchRemaining;
-        }
-    }
-
-    return hr;
-}
-
-#if defined(FEATURE_PAL) || !defined(PLATFORM_UNIX)
-STRSAFE_INLINE_API StringGetsExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
-{
-    HRESULT hr = S_OK;
-    WCHAR* pszDestEnd = pszDest;
-    size_t cchRemaining = 0;
-
-    // ASSERT(cbDest == (cchDest * sizeof(char))    ||
-    //        cbDest == (cchDest * sizeof(char)) + (cbDest % sizeof(char)));
-
-    // only accept valid flags
-    if (dwFlags & (~STRSAFE_VALID_FLAGS))
-    {
-        hr = STRSAFE_E_INVALID_PARAMETER;
-    }
-    else
-    {
-        if (dwFlags & STRSAFE_IGNORE_NULLS)
-        {
-            if (pszDest == NULL)
-            {
-                if ((cchDest != 0) || (cbDest != 0))
-                {
-                    // NULL pszDest and non-zero cchDest/cbDest is invalid
-                    hr = STRSAFE_E_INVALID_PARAMETER;
-                }
-            }
-        }
-
-        if (SUCCEEDED(hr))
-        {
-            if (cchDest <= 1)
-            {
-                pszDestEnd = pszDest;
-                cchRemaining = cchDest;
-
-                if (cchDest == 1)
-                {
-                    *pszDestEnd = L'\0';
-                }
-
-                hr = STRSAFE_E_INSUFFICIENT_BUFFER;
-            }
-            else
-            {
-                WCHAR ch;
-
-                pszDestEnd = pszDest;
-                cchRemaining = cchDest;
-
-                while ((cchRemaining > 1) && (ch = (WCHAR)getwc(stdin)) != L'\n')
-                {
-                    if (ch == EOF)
-                    {
-                        if (pszDestEnd == pszDest)
-                        {
-                            // we failed to read anything from stdin
-                            hr = STRSAFE_E_END_OF_FILE;
-                        }
-                        break;
-                    }
-
-                    *pszDestEnd = ch;
-
-                    pszDestEnd++;
-                    cchRemaining--;
-                }
-
-                if (cchRemaining > 0)
-                {
-                    // there is extra room
-                    if (dwFlags & STRSAFE_FILL_BEHIND_NULL)
-                    {
-                        memset(pszDestEnd + 1, STRSAFE_GET_FILL_PATTERN(dwFlags), ((cchRemaining - 1) * sizeof(WCHAR)) + (cbDest % sizeof(WCHAR)));
-                    }
-                }
-
-                *pszDestEnd = L'\0';
-            }
-        }
-    }
-
-    if (FAILED(hr))
-    {
-        if (pszDest)
-        {
-            if (dwFlags & STRSAFE_FILL_ON_FAILURE)
-            {
-                memset(pszDest, STRSAFE_GET_FILL_PATTERN(dwFlags), cbDest);
-
-                if (STRSAFE_GET_FILL_PATTERN(dwFlags) == 0)
-                {
-                    pszDestEnd = pszDest;
-                    cchRemaining = cchDest;
-                }
-                else if (cchDest > 0)
-                {
-                    pszDestEnd = pszDest + cchDest - 1;
-                    cchRemaining = 1;
-
-                    // null terminate the end of the string
-                    *pszDestEnd = L'\0';
-                }
-            }
-
-            if (dwFlags & (STRSAFE_NULL_ON_FAILURE | STRSAFE_NO_TRUNCATION))
-            {
-                if (cchDest > 0)
-                {
-                    pszDestEnd = pszDest;
-                    cchRemaining = cchDest;
-
-                    // null terminate the beginning of the string
-                    *pszDestEnd = L'\0';
-                }
-            }
-        }
-    }
-
-    if (SUCCEEDED(hr)                           ||
-        (hr == STRSAFE_E_INSUFFICIENT_BUFFER)   ||
-        (hr == STRSAFE_E_END_OF_FILE))
-    {
-        if (ppszDestEnd)
-        {
-            *ppszDestEnd = pszDestEnd;
-        }
-
-        if (pcchRemaining)
-        {
-            *pcchRemaining = cchRemaining;
-        }
-    }
-
-    return hr;
-}
-#endif // FEATURE_PAL || !PLATFORM_UNIX
-#endif  // !FEATURE_PAL
-#endif  // !STRSAFE_LIB_IMPL
 
 #endif  // _STRSAFE_H_INCLUDED_

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -335,7 +335,7 @@ function_name() to call the system's implementation
 #undef va_arg
 #endif
 
-#if !defined(_MSC_VER) && defined(FEATURE_PAL) && defined(_WIN64)
+#if !defined(_MSC_VER) && defined(_WIN64)
 #undef _BitScanForward64
 #endif 
 

--- a/src/pal/tests/palsuite/c_runtime/_snprintf_s/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_snprintf_s/test4/test4.cpp
@@ -33,7 +33,7 @@ int __cdecl main(int argc, char *argv[])
 	/*
 	**  Run only on 64 bit platforms
 	*/
-	#if defined(BIT64) && defined(PLATFORM_UNIX)
+	#if defined(BIT64)
 		Trace("Testing for 64 Bit Platforms \n");
 		DoPointerTest("%p", NULL, "NULL", "0000000000000000"); 
 		DoPointerTest("%p", ptr, "pointer to 0x123456", "0000000000123456");
@@ -61,7 +61,7 @@ int __cdecl main(int argc, char *argv[])
 		DoPointerTest("%Lp", ptr, "pointer to 0x123456", "00123456");
 		DoI64Test("%I64p", lptr, "pointer to 0x1234567887654321",
 				"1234567887654321");
-	#endif //defined(BIT64) && defined(PLATFORM_UNIX)
+	#endif //defined(BIT64)
 
 	PAL_Terminate();
     return PASS;

--- a/src/pal/tests/palsuite/c_runtime/_snwprintf_s/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_snwprintf_s/test4/test4.cpp
@@ -33,7 +33,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	DoPointerTest(convert("%p"), NULL, convert("0000000000000000"));
     DoPointerTest(convert("%p"), ptr, convert("0000000000123456"));

--- a/src/pal/tests/palsuite/c_runtime/_vsnprintf_s/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_vsnprintf_s/test4/test4.cpp
@@ -58,7 +58,7 @@ int __cdecl main(int argc, char *argv[])
 	/*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	DoPointerTest("%p", NULL, "NULL", "0000000000000000");
     DoPointerTest("%p", ptr, "pointer to 0x123456", "0000000000123456");

--- a/src/pal/tests/palsuite/c_runtime/_vsnwprintf_s/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/_vsnwprintf_s/test4/test4.cpp
@@ -64,7 +64,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
     Trace("Testing for 64 Bit Platforms \n");
     DoPointerTest(convert("%p"), NULL, convert("NULL"), convert("00000000"));
     DoPointerTest(convert("%p"), ptr, convert("pointer to 0x123456"),

--- a/src/pal/tests/palsuite/c_runtime/fprintf/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/fprintf/test4/test4.cpp
@@ -75,7 +75,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	DoTest("%p", NULL, "NULL", "0000000000000000", "0x0");
     DoTest("%p", ptr, "pointer to 0x123456", "0000000000123456", "0x123456");

--- a/src/pal/tests/palsuite/c_runtime/fwprintf/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/fwprintf/test4/test4.cpp
@@ -32,7 +32,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	DoPointerTest(convert("%p"), NULL, "NULL", "0000000000000000", "0x0");
     DoPointerTest(convert("%p"), ptr, "pointer to 0x123456", "0000000000123456", 

--- a/src/pal/tests/palsuite/c_runtime/printf/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/printf/test4/test4.cpp
@@ -29,7 +29,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	DoPointerTest("%p", NULL, "NULL", "0000000000000000");
     DoPointerTest("%p", ptr, "pointer to 0x123456", "0000000000123456");

--- a/src/pal/tests/palsuite/c_runtime/sprintf_s/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/sprintf_s/test4/test4.cpp
@@ -33,7 +33,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
     DoPointerTest("%p", NULL, "NULL", "0000000000000000");
     DoPointerTest("%p", ptr, "pointer to 0x123456", "0000000000123456");

--- a/src/pal/tests/palsuite/c_runtime/swprintf/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/swprintf/test4/test4.cpp
@@ -33,7 +33,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	DoPointerTest(convert("%p"), NULL, convert("0000000000000000"));
     DoPointerTest(convert("%p"), ptr, convert("0000000000123456"));

--- a/src/pal/tests/palsuite/c_runtime/vfprintf/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vfprintf/test4/test4.cpp
@@ -32,7 +32,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	DoPointerTest("%p", NULL, "NULL", "0000000000000000");
     DoPointerTest("%p", ptr, "pointer to 0x123456", "0000000000123456");

--- a/src/pal/tests/palsuite/c_runtime/vprintf/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vprintf/test4/test4.cpp
@@ -32,7 +32,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
     DoPointerTest("%p", NULL, "NULL", "0000000000000000");
     DoPointerTest("%p", ptr, "pointer to 0x123456", "0000000000123456");

--- a/src/pal/tests/palsuite/c_runtime/vsprintf/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vsprintf/test4/test4.cpp
@@ -31,7 +31,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	DoPointerTest("%p", NULL, "NULL", "0000000000000000");
     DoPointerTest("%p", ptr, "pointer to 0x123456", "0000000000123456");

--- a/src/pal/tests/palsuite/c_runtime/vswprintf/test4/test4.cpp
+++ b/src/pal/tests/palsuite/c_runtime/vswprintf/test4/test4.cpp
@@ -62,7 +62,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	DoPointerTest(convert("%p"), NULL, convert("NULL"), convert("0000000000000000"));
     DoPointerTest(convert("%p"), ptr, convert("pointer to 0x123456"), 

--- a/src/pal/tests/palsuite/common/ResultTime.h
+++ b/src/pal/tests/palsuite/common/ResultTime.h
@@ -11,11 +11,7 @@
 const char *szDotNetInstallEnvVar = "DOTNET_INSTALL";
 const char *szQASupportDirEnvVar = "QA_SUPPORT_DIR";
 
-#ifdef PLATFORM_UNIX
 #define SEPERATOR "/"
-#else
-#define SEPERATOR "\\"
-#endif
 char *getBuildNumber()
 {  
         char *szBuildFileName = "buildinfo.txt";
@@ -34,16 +30,6 @@ char *getBuildNumber()
             Fail("ERROR: Couldn't allocate enough memory to potentially store build number\n");    
         }
 
-#ifndef PLATFORM_UNIX
-        pDirectoryName = getenv(szDotNetInstallEnvVar);    
-        if (pDirectoryName == NULL)    
-        {        
-            /* This condition may exist if the test is being run in say the Dev environment.*/        
-            Trace("WARNING: Coriolis Test Environment may not be setup correctly. Variable DOTNET_INSTALL not set\n");        
-            _snprintf(szTempValue, 99, "0000.00");        
-            return szTempValue;  
-        }    
-#else        
         pDirectoryName = getenv(szQASupportDirEnvVar);    
         if (pDirectoryName == NULL)    
         {        
@@ -52,14 +38,8 @@ char *getBuildNumber()
             return szTempValue;  
         }
 
-#endif //PLATFORM_UNIX
-
-#ifndef PLATFORM_UNIX
-        _snprintf(szBuildFileLoc, MAX_PATH, "%s%s%s", pDirectoryName, SEPERATOR, szBuildFileName);
-#else
         // To avoid buffer overruns for pDirectoryName
         _snprintf(szBuildFileLoc, MAX_PATH, "%s/../1.0%s%s", pDirectoryName, SEPERATOR, szBuildFileName);
-#endif  //PLATFORM_UNIX
         fp = fopen( szBuildFileLoc, "r");    
         if( fp == NULL)    
         {        

--- a/src/pal/tests/palsuite/composite/object_management/semaphore/shared/main.cpp
+++ b/src/pal/tests/palsuite/composite/object_management/semaphore/shared/main.cpp
@@ -129,8 +129,6 @@ make the most sense to just skip the named semaphore test on Windows
 - from an object management perspective it doesn't really gain 
 us anything over what we already have."
 */
-#ifdef PLATFORM_UNIX
-
     ZeroMemory( objectSuffix, MAX_PATH );
 
     if(GetParameters(argc, argv))
@@ -272,7 +270,6 @@ us anything over what we already have."
         Trace("Test Failed\n");
     }
 
-#endif //PLATFORM_UNIX
     PAL_Terminate();
     return testReturnCode;
 }

--- a/src/pal/tests/palsuite/miscellaneous/FormatMessageW/test2/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/FormatMessageW/test2/test.cpp
@@ -460,7 +460,7 @@ int test11(int num, ...)
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 	Trace("Testing for 64 Bit Platforms \n");
 	if(memcmp(OutBuffer, 
               convert("Pal 00000000000123AB and foo Testing"),

--- a/src/pal/tests/palsuite/miscellaneous/InterLockedExchangeAdd/test1/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/InterLockedExchangeAdd/test1/test.cpp
@@ -36,7 +36,7 @@ int __cdecl main(int argc, char *argv[])
 
 
 
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
     ptrValue = (LONG *) malloc(sizeof(LONG));
 
     if(ptrValue == NULL)

--- a/src/pal/tests/palsuite/miscellaneous/InterlockedCompareExchange64/test1/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/InterlockedCompareExchange64/test1/test.cpp
@@ -42,7 +42,7 @@ int __cdecl main(int argc, char *argv[]) {
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
     /* Compare START_VALUE with BaseVariableToManipulate, they're equal, 
        so exchange 
     */
@@ -55,18 +55,10 @@ int __cdecl main(int argc, char *argv[]) {
     /* Exchanged, these should be equal now */
     if(BaseVariableToManipulate != ValueToExchange) 
     {
-#ifdef PLATFORM_UNIX
         Fail("ERROR: A successful compare and exchange should have occurred, "
              "making the variable have the value of %ll, as opposed to the "
              "current value of %ll.",
              ValueToExchange,BaseVariableToManipulate);  
-#else
-        Fail("ERROR: A successful compare and exchange should have occurred, "
-             "making the variable have the value of %I64, as opposed to the "
-             "current value of %d.",
-             ValueToExchange,BaseVariableToManipulate);  
-
-#endif
     }
   
     /* Check to make sure it returns the original number which 
@@ -74,15 +66,9 @@ int __cdecl main(int argc, char *argv[]) {
     */
     if(TheReturn != START_VALUE) 
     {
-#ifdef PLATFORM_UNIX
         Fail("ERROR: The return value after the first exchange should be the "
              "former value of the variable, which was %ll, but it is now %ll.",
              START_VALUE,TheReturn);
-#else
-        Fail("ERROR: The return value after the first exchange should be the "
-             "former value of the variable, which was %I64, but it is now %I64.",
-             START_VALUE,TheReturn);
-#endif
 
     }
 
@@ -103,20 +89,13 @@ int __cdecl main(int argc, char *argv[]) {
   
     if(BaseVariableToManipulate != TempValue) 
     {
-#ifdef PLATFORM_UNIX
         Fail("ERROR:  An attempted exchange should have failed due to "
              "the compare failing.  But, it seems to have succeeded.  The "
              "value should be %ll but is %ll in this case.",
              TempValue,BaseVariableToManipulate);  
-#else
-        Fail("ERROR:  An attempted exchange should have failed due to "
-             "the compare failing.  But, it seems to have succeeded.  The "
-             "value should be %I64 but is %I64 in this case.",
-             TempValue,BaseVariableToManipulate);  
-#endif
     }
 
-#endif  //if defined(BIT64) && defined(PLATFORM_UNIX)
+#endif  //if defined(BIT64)
     PAL_Terminate();
     return PASS; 
 }

--- a/src/pal/tests/palsuite/miscellaneous/InterlockedCompareExchange64/test2/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/InterlockedCompareExchange64/test2/test.cpp
@@ -47,7 +47,7 @@ int __cdecl main(int argc, char *argv[])
 	/*
 	**  Run only on 64 bit platforms
 	*/
-	#if defined(BIT64) && defined(PLATFORM_UNIX)
+	#if defined(BIT64)
 
 		//Create MAX_THREADS threads that will operate on the global counter
 		for (i=0;i<MAX_THREADS;i++)
@@ -84,7 +84,7 @@ int __cdecl main(int argc, char *argv[])
 			Fail("Test Case Failed: InterlockedDecrement \n");
 		}
 
-	#endif  //defined(BIT64) && defined(PLATFORM_UNIX)
+	#endif  //defined(BIT64)
 	
     PAL_Terminate();
     return PASS; 

--- a/src/pal/tests/palsuite/miscellaneous/InterlockedDecrement64/test1/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/InterlockedDecrement64/test1/test.cpp
@@ -36,7 +36,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
     /* Compare START_VALUE with BaseVariableToManipulate, they're equal, 
        so exchange 
     */
@@ -46,27 +46,17 @@ int __cdecl main(int argc, char *argv[])
     /* Decremented twice, it should be -2 now */
     if(TheValue != -2) 
     {
-#ifdef PLATFORM_UNIX
         Fail("ERROR: After being decremented twice, the value should be -2, "
              "but it is really %ll.",TheValue);
-#else
-        Fail("ERROR: After being decremented twice, the value should be -2, "
-             "but it is really %I64.",TheValue);
-#endif
     }
   
     /* Check to make sure it returns itself */
     if(TheReturn != TheValue) 
     {
-#ifdef PLATFORM_UNIX
         Fail("ERROR: The function should have returned the new value of %d "
              "but instead returned %ll.",TheValue,TheReturn);    
-#else
-        Fail("ERROR: After being decremented twice, the value should be -2, "
-             "but it is really %I64.",TheValue);
-#endif
     }
-#endif  //defined(BIT64) && defined(PLATFORM_UNIX)
+#endif  //defined(BIT64)
     PAL_Terminate();
     return PASS; 
 } 

--- a/src/pal/tests/palsuite/miscellaneous/InterlockedDecrement64/test2/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/InterlockedDecrement64/test2/test.cpp
@@ -40,7 +40,7 @@ int __cdecl main(int argc, char *argv[])
         return FAIL;
     }
 	
-	#if defined(BIT64) && defined(PLATFORM_UNIX)
+	#if defined(BIT64)
 
 		//Create MAX_THREADS threads that will operate on the global counter
 		for (i=0;i<MAX_THREADS;i++)
@@ -79,7 +79,7 @@ int __cdecl main(int argc, char *argv[])
 			Fail("Test Case Failed: InterlockedDecrement \n");
 		}
 
-#endif  //defined(BIT64) && defined(PLATFORM_UNIX)
+#endif  //defined(BIT64)
 	
     PAL_Terminate();
     return PASS; 

--- a/src/pal/tests/palsuite/miscellaneous/InterlockedExchange64/test1/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/InterlockedExchange64/test1/test.cpp
@@ -39,7 +39,7 @@ int __cdecl main(int argc, char *argv[]) {
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 
     TheReturn = InterlockedExchange64(&TheValue,NewValue);
   
@@ -48,13 +48,8 @@ int __cdecl main(int argc, char *argv[]) {
     */  
     if(TheValue != NewValue) 
     {
-#ifdef PLATFORM_UNIX
         Fail("ERROR: The value which was exchanged should now be %ll, but "
              "instead it is %ll.",NewValue,TheValue);    
-#else
-        Fail("ERROR: The value which was exchanged should now be %I64, but "
-             "instead it is %I64.",NewValue,TheValue);    
-#endif
     }
   
     /* Check to make sure it returns the origional number which 'TheValue' was 
@@ -63,18 +58,12 @@ int __cdecl main(int argc, char *argv[]) {
   
     if(TheReturn != START_VALUE) 
     {
-#ifdef PLATFORM_UNIX
         Fail("ERROR: The value returned should be the value before the "
              "exchange happened, which was %ll, but %ll was returned.",
              START_VALUE,TheReturn);
-#else
-        Fail("ERROR: The value returned should be the value before the "
-             "exchange happened, which was %I64, but %I64 was returned.",
-             START_VALUE,TheReturn);
-#endif
     }
 
-#endif  // BIT64 && PLATFORM_UNIX
+#endif  // BIT64
     PAL_Terminate();
     return PASS; 
 } 

--- a/src/pal/tests/palsuite/miscellaneous/InterlockedIncrement64/test1/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/InterlockedIncrement64/test1/test.cpp
@@ -37,7 +37,7 @@ int __cdecl main(int argc, char *argv[])
 /*
 **  Run only on 64 bit platforms
 */
-#if defined(BIT64) && defined(PLATFORM_UNIX)
+#if defined(BIT64)
 
     InterlockedIncrement64(&TheValue);
     TheReturn = InterlockedIncrement64(&TheValue);
@@ -45,28 +45,18 @@ int __cdecl main(int argc, char *argv[])
     /* Incremented twice, it should be 2 now */
     if(TheValue != 2) 
     {
-#ifdef PLATFORM_UNIX
         Fail("ERROR: The value was incremented twice and shoud now be 2, "
              "but it is really %ll",TheValue); 
-#else
-        Fail("ERROR: The value was incremented twice and shoud now be 2, "
-             "but it is really %I64",TheValue); 
-#endif
     }
   
     /* Check to make sure it returns itself */
     if(TheReturn != TheValue) 
     {
-#ifdef PLATFORM_UNIX
         Fail("ERROR: The function should return the new value, which shoud "
              "have been %d, but it returned %ll.",TheValue,TheReturn);          
-#else
-        Fail("ERROR: The function should return the new value, which shoud "
-             "have been %d, but it returned %I64.",TheValue,TheReturn);          
-#endif
     }
 
-#endif  //defined(BIT64) && defined(PLATFORM_UNIX)
+#endif  //defined(BIT64)
     PAL_Terminate();
     return PASS; 
 } 

--- a/src/pal/tests/palsuite/miscellaneous/InterlockedIncrement64/test2/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/InterlockedIncrement64/test2/test.cpp
@@ -43,7 +43,7 @@ int __cdecl main(int argc, char *argv[])
 	/*
 	**  Run only on 64 bit platforms
 	*/
-	#if defined(BIT64) && defined(PLATFORM_UNIX)
+	#if defined(BIT64)
 
 		//Create MAX_THREADS threads that will operate on the global counter
 		for (i=0;i<MAX_THREADS;i++)
@@ -81,7 +81,7 @@ int __cdecl main(int argc, char *argv[])
 			{
 				Fail("Test Case Failed: InterlockedDecrement \n");
 			}
-	#endif  //defined(BIT64) && defined(PLATFORM_UNIX)
+	#endif  //defined(BIT64)
 	
     PAL_Terminate();
     return PASS; 

--- a/src/pal/tests/palsuite/threading/CreateThread/test1/test1.cpp
+++ b/src/pal/tests/palsuite/threading/CreateThread/test1/test1.cpp
@@ -15,11 +15,7 @@
 
 #include <palsuite.h>
 
-#ifndef PLATFORM_UNIX
-#define LLFORMAT "%I64u"
-#else
 #define LLFORMAT "%llu"
-#endif
 
 ULONGLONG dwCreateThreadTestParameter = 0;
 


### PR DESCRIPTION
This change removes all ifdefs for PLATFORM_UNIX and FEATURE_PAL
from PAL and also removes dead code that was never compiled in PAL
due to both of them being always defined for PAL.