### PR TITLE
Fix DateTimeFormatInfo serialization on Unix

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/DateTimeFormatInfo.cs
@@ -2163,7 +2163,7 @@ namespace System.Globalization
         //
         // Positive TimeSpan Pattern
         //
-
+        [NonSerialized]
         private string _fullTimeSpanPositivePattern;
         internal String FullTimeSpanPositivePattern
         {
@@ -2187,7 +2187,7 @@ namespace System.Globalization
         //
         // Negative TimeSpan Pattern
         //
-
+        [NonSerialized]
         private string _fullTimeSpanNegativePattern;
         internal String FullTimeSpanNegativePattern
         {
@@ -2343,7 +2343,7 @@ namespace System.Globalization
         //
         // DateTimeFormatInfo tokenizer.  This is used by DateTime.Parse() to break input string into tokens.
         //
-
+        [NonSerialized]
         private TokenHashValue[] _dtfiTokenHash;
 
         private const int TOKEN_HASH_SIZE = 199;


### PR DESCRIPTION
The Unix version of the DateTimeFormatInfo src is missing some [NonSerialized] attributes on a few of its fields, one of which is of type TokenHashValue, which isn't [Serializable].  This is causing DateTimeFormatInfo to itself fail to serialize.

Fixes failures in https://github.com/dotnet/corefx/pull/15068
cc: @jkotas, @danmosemsft 