### PR TITLE
Refactor GT_IND value-numbering

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -6226,6 +6226,39 @@ void Compiler::fgValueNumberTree(GenTreePtr tree, bool evalAsgLhsInd)
                     fgValueNumberArrIndexVal(tree, elemTypeEq, arrVN, inxVN, addrXvnp.GetLiberal(), fldSeq);
                 }
             }
+            else if (tree->gtFlags & GTF_IND_ARR_LEN)
+            {
+                // It's an array length.  The argument is the sum of an array ref with some integer values...
+                ValueNum arrRefLib  = vnStore->VNForRefInAddr(tree->gtOp.gtOp1->gtVNPair.GetLiberal());
+                ValueNum arrRefCons = vnStore->VNForRefInAddr(tree->gtOp.gtOp1->gtVNPair.GetConservative());
+
+                assert(vnStore->TypeOfVN(arrRefLib) == TYP_REF || vnStore->TypeOfVN(arrRefLib) == TYP_BYREF);
+                if (vnStore->IsVNConstant(arrRefLib))
+                {
+                    // (or in weird cases, a REF or BYREF constant, in which case the result is an exception).
+                    tree->gtVNPair.SetLiberal(
+                        vnStore->VNWithExc(ValueNumStore::VNForVoid(),
+                                           vnStore->VNExcSetSingleton(
+                                               vnStore->VNForFunc(TYP_REF, VNF_NullPtrExc, arrRefLib))));
+                }
+                else
+                {
+                    tree->gtVNPair.SetLiberal(vnStore->VNForFunc(TYP_INT, VNFunc(GT_ARR_LENGTH), arrRefLib));
+                }
+                assert(vnStore->TypeOfVN(arrRefCons) == TYP_REF || vnStore->TypeOfVN(arrRefCons) == TYP_BYREF);
+                if (vnStore->IsVNConstant(arrRefCons))
+                {
+                    // (or in weird cases, a REF or BYREF constant, in which case the result is an exception).
+                    tree->gtVNPair.SetConservative(
+                        vnStore->VNWithExc(ValueNumStore::VNForVoid(),
+                                           vnStore->VNExcSetSingleton(
+                                               vnStore->VNForFunc(TYP_REF, VNF_NullPtrExc, arrRefCons))));
+                }
+                else
+                {
+                    tree->gtVNPair.SetConservative(vnStore->VNForFunc(TYP_INT, VNFunc(GT_ARR_LENGTH), arrRefCons));
+                }
+            }
 
             // In general we skip GT_IND nodes on that are the LHS of an assignment.  (We labeled these earlier.)
             // We will "evaluate" this as part of the assignment.  (Unless we're explicitly told by
@@ -6504,49 +6537,6 @@ void Compiler::fgValueNumberTree(GenTreePtr tree, bool evalAsgLhsInd)
                                             vnStore->VNPExcSetSingleton(
                                                 vnStore->VNPairForFunc(TYP_REF, VNF_NullPtrExc,
                                                                        tree->gtOp.gtOp1->gtVNPair)));
-                    break;
-
-                case GT_BLK:
-                case GT_OBJ:
-                case GT_IND:
-                    if (tree->gtFlags & GTF_IND_ARR_LEN)
-                    {
-                        // It's an array length.  The argument is the sum of an array ref with some integer values...
-                        ValueNum arrRefLib  = vnStore->VNForRefInAddr(tree->gtOp.gtOp1->gtVNPair.GetLiberal());
-                        ValueNum arrRefCons = vnStore->VNForRefInAddr(tree->gtOp.gtOp1->gtVNPair.GetConservative());
-
-                        assert(vnStore->TypeOfVN(arrRefLib) == TYP_REF || vnStore->TypeOfVN(arrRefLib) == TYP_BYREF);
-                        if (vnStore->IsVNConstant(arrRefLib))
-                        {
-                            // (or in weird cases, a REF or BYREF constant, in which case the result is an exception).
-                            tree->gtVNPair.SetLiberal(
-                                vnStore->VNWithExc(ValueNumStore::VNForVoid(),
-                                                   vnStore->VNExcSetSingleton(
-                                                       vnStore->VNForFunc(TYP_REF, VNF_NullPtrExc, arrRefLib))));
-                        }
-                        else
-                        {
-                            tree->gtVNPair.SetLiberal(vnStore->VNForFunc(TYP_INT, VNFunc(GT_ARR_LENGTH), arrRefLib));
-                        }
-                        assert(vnStore->TypeOfVN(arrRefCons) == TYP_REF || vnStore->TypeOfVN(arrRefCons) == TYP_BYREF);
-                        if (vnStore->IsVNConstant(arrRefCons))
-                        {
-                            // (or in weird cases, a REF or BYREF constant, in which case the result is an exception).
-                            tree->gtVNPair.SetConservative(
-                                vnStore->VNWithExc(ValueNumStore::VNForVoid(),
-                                                   vnStore->VNExcSetSingleton(
-                                                       vnStore->VNForFunc(TYP_REF, VNF_NullPtrExc, arrRefCons))));
-                        }
-                        else
-                        {
-                            tree->gtVNPair.SetConservative(
-                                vnStore->VNForFunc(TYP_INT, VNFunc(GT_ARR_LENGTH), arrRefCons));
-                        }
-                    }
-                    else
-                    {
-                        tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));
-                    }
                     break;
 
                 case GT_LOCKADD: // Binop


### PR DESCRIPTION
Method `fgValueNumberTree` had two pieces of code each attempting to
assume responsibility for `GT_IND` and some block ops.  The one later in
the function wasn't reachable because those ops would always take the
first path.  This change moves the special logic for `GTF_IND_ARR_LEN`,
which was only present in the unreachable code, up to the reachable code,
and removes the unreachable code.