### PR TITLE
Remove EnumEqualityComparer serialization compat workarounds

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -683,9 +683,6 @@
       <Member Name="GetHashCode(T)" />
       <Member MemberType="Property" Name="Default" />
     </Type>
-    <Type Name="System.Collections.Generic.EnumEqualityComparer&lt;T&gt;">
-      <Member Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
-    </Type>
     <Type Name="System.Collections.Generic.ICollection&lt;T&gt;">
       <Member Name="Add(T)" />
       <Member Name="Clear" />

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Security;
-using System.Runtime.Serialization;
 
 namespace System.Collections.Generic
 {
@@ -367,7 +366,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    internal class EnumEqualityComparer<T> : EqualityComparer<T>, ISerializable where T : struct
+    internal class EnumEqualityComparer<T> : EqualityComparer<T> where T : struct
     {
         [Pure]
         public override bool Equals(T x, T y) {
@@ -383,16 +382,6 @@ namespace System.Collections.Generic
         }
 
         public EnumEqualityComparer() { }
-
-        // This is used by the serialization engine.
-        protected EnumEqualityComparer(SerializationInfo information, StreamingContext context) { }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context) {
-            // For back-compat we need to serialize the comparers for enums with underlying types other than int as ObjectEqualityComparer 
-            if (Type.GetTypeCode(Enum.GetUnderlyingType(typeof(T))) != TypeCode.Int32) {
-                info.SetType(typeof(ObjectEqualityComparer<T>));
-            }
-        }
 
         // Equals method for the comparer itself.
         public override bool Equals(Object obj) =>
@@ -427,12 +416,9 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    internal sealed class SByteEnumEqualityComparer<T> : EnumEqualityComparer<T>, ISerializable where T : struct
+    internal sealed class SByteEnumEqualityComparer<T> : EnumEqualityComparer<T> where T : struct
     {
         public SByteEnumEqualityComparer() { }
-
-        // This is used by the serialization engine.
-        public SByteEnumEqualityComparer(SerializationInfo information, StreamingContext context) { }
 
         [Pure]
         public override int GetHashCode(T obj) {
@@ -442,12 +428,9 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    internal sealed class ShortEnumEqualityComparer<T> : EnumEqualityComparer<T>, ISerializable where T : struct
+    internal sealed class ShortEnumEqualityComparer<T> : EnumEqualityComparer<T> where T : struct
     {
         public ShortEnumEqualityComparer() { }
-
-        // This is used by the serialization engine.
-        public ShortEnumEqualityComparer(SerializationInfo information, StreamingContext context) { }
 
         [Pure]
         public override int GetHashCode(T obj) {
@@ -457,7 +440,7 @@ namespace System.Collections.Generic
     }
 
     [Serializable]
-    internal sealed class LongEnumEqualityComparer<T> : EqualityComparer<T>, ISerializable where T : struct
+    internal sealed class LongEnumEqualityComparer<T> : EqualityComparer<T> where T : struct
     {
         [Pure]
         public override bool Equals(T x, T y) {
@@ -480,16 +463,6 @@ namespace System.Collections.Generic
             GetType().GetHashCode();
 
         public LongEnumEqualityComparer() { }
-
-        // This is used by the serialization engine.
-        public LongEnumEqualityComparer(SerializationInfo information, StreamingContext context) { }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            // The LongEnumEqualityComparer does not exist on 4.0 so we need to serialize this comparer as ObjectEqualityComparer
-            // to allow for roundtrip between 4.0 and 4.5.
-            info.SetType(typeof(ObjectEqualityComparer<T>));
-        }
 
         internal override int IndexOf(T[] array, T value, int startIndex, int count)
         {


### PR DESCRIPTION
This code exists to support serialization roundtrip between .NET 4 and .NET 4.5, which we don't need for .NET Core.

Fixes https://github.com/dotnet/coreclr/issues/8893
cc: @jkotas, @ianhays 