### PR TITLE
Fix Linux perf run script

### DIFF
--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -213,7 +213,7 @@ function create_core_overlay {
     if [ -z "$coreFxNativeBinDir" ]; then
         exit_with_error "$errorSource" "One of --coreOverlayDir or --coreFxBinDir must be specified." "$printUsage"
     fi
-    if [ ! -d "$coreFxNativeBinDir/Native" ]; then
+    if [ ! -d "$coreFxNativeBinDir/Native" -a ! -d "$coreFxNativeBinDir/native" ]; then
         exit_with_error "$errorSource" "Directory specified by --coreNativeFxBinDir does not exist: $coreFxNativeBinDir/Native"
     fi
 


### PR DESCRIPTION
We rely on the build of CoreFX that we grab from the Corefx runs on the
main Jenkins instance.  With the recent changes the name of one of the
folders as been changed from "Native" to "native".  The checking that we
were doing was not case insensitive and as a result we started failing.
I have made that check now look for both the upper case and lower case
version of the word.