### PR TITLE
[x86/Linux] Pass proper REGDISPLAY to GetGSCookieAddr (Do not merge)

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -1814,7 +1814,25 @@ CLRUnwindStatus ExceptionTracker::ProcessOSExceptionNotification(
 
         if (fIsFrameLess)
         {
-            pGSCookie = (GSCookie*)cfThisFrame.GetCodeManager()->GetGSCookieAddr(cfThisFrame.pRD,
+            PREGDISPLAY pRD = NULL;
+
+#ifdef USE_GC_INFO_DECODER
+
+            pRD = cfThisFrame.pRD;
+
+#else // USE_GC_INFO_DECODER
+
+#ifdef _TARGET_X86_
+            REGDISPLAY rd = *cfThisFrame.pRD;
+            rd.pEbp = &pContextRecord->Ebp;
+            pRD = &rd;
+#else  // _TARGET_X86_
+            PORTABILITY_ASSERT("ExceptionTracker::ProcessOSExceptionNotification");
+#endif // _TARGET_???_
+
+#endif // USE_GC_INFO_DECODER
+
+            pGSCookie = (GSCookie*)cfThisFrame.GetCodeManager()->GetGSCookieAddr(pRD,
                                                                                           &cfThisFrame.codeInfo,
                                                                                           &cfThisFrame.codeManState);
             if (pGSCookie)


### PR DESCRIPTION
This commit attempts to fix segmentation fault due to incorrect GSCookie address.

The current implementation computes GSCookie address via dereferencing pEbp field in REGDISPLAY, and adding some offsets, but  ExceptionTracker::ProcessOSExceptionNotification does not initialize pEbp.

This results in segmentation fault discussed in #8980.

In addition, the currenct implementation of FaultingExceptionFrame::UpdateRegDisplay does not updates pXXX fields at all, which incurs segmentation fault while checking GSCookie inside ExceptionTracker::FindNonvolatileRegisterPointers .

This commit attempts to update pEbp before GetGSCookieAddr call to fix #8980.