### PR TITLE
[x86/Linux] Allow push/pop in funclet prolog and epilog

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1643,12 +1643,10 @@ void emitter::emitCreatePlaceholderIG(insGroupPlaceholderType igType,
     {
         igPh->igFlags |= IGF_FUNCLET_PROLOG;
     }
-#ifdef DEBUG
     else if (igType == IGPT_FUNCLET_EPILOG)
     {
         igPh->igFlags |= IGF_FUNCLET_EPILOG;
     }
-#endif // DEBUG
 #endif // FEATURE_EH_FUNCLETS
 
     /* Link it into the placeholder list */

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -270,9 +270,7 @@ struct insGroup
 #define IGF_FINALLY_TARGET 0x0004 // this group is the start of a basic block that is returned to after a finally.
 #endif                            // FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
 #define IGF_FUNCLET_PROLOG 0x0008 // this group belongs to a funclet prolog
-#ifdef DEBUG
-#define IGF_FUNCLET_EPILOG 0x0010 // this group belongs to a funclet epilog. Currently, this is only needed for DEBUG.
-#endif
+#define IGF_FUNCLET_EPILOG 0x0010 // this group belongs to a funclet epilog.
 #define IGF_EPILOG 0x0020        // this group belongs to a main function epilog
 #define IGF_NOGCINTERRUPT 0x0040 // this IG is is a no-interrupt region (prolog, epilog, etc.)
 #define IGF_UPD_ISZ 0x0080       // some instruction sizes updated
@@ -491,12 +489,11 @@ protected:
         return (ig != nullptr) && ((ig->igFlags & IGF_FUNCLET_PROLOG) != 0);
     }
 
-#ifdef DEBUG
     bool emitIGisInFuncletEpilog(const insGroup* ig)
     {
         return (ig != nullptr) && ((ig->igFlags & IGF_FUNCLET_EPILOG) != 0);
     }
-#endif // DEBUG
+
 #endif // FEATURE_EH_FUNCLETS
 
     // If "ig" corresponds to the start of a basic block that is the

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -271,13 +271,13 @@ struct insGroup
 #endif                            // FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
 #define IGF_FUNCLET_PROLOG 0x0008 // this group belongs to a funclet prolog
 #define IGF_FUNCLET_EPILOG 0x0010 // this group belongs to a funclet epilog.
-#define IGF_EPILOG 0x0020        // this group belongs to a main function epilog
-#define IGF_NOGCINTERRUPT 0x0040 // this IG is is a no-interrupt region (prolog, epilog, etc.)
-#define IGF_UPD_ISZ 0x0080       // some instruction sizes updated
-#define IGF_PLACEHOLDER 0x0100   // this is a placeholder group, to be filled in later
-#define IGF_EMIT_ADD 0x0200      // this is a block added by the emitter
-                                 // because the codegen block was too big. Also used for
-                                 // placeholder IGs that aren't also labels.
+#define IGF_EPILOG 0x0020         // this group belongs to a main function epilog
+#define IGF_NOGCINTERRUPT 0x0040  // this IG is is a no-interrupt region (prolog, epilog, etc.)
+#define IGF_UPD_ISZ 0x0080        // some instruction sizes updated
+#define IGF_PLACEHOLDER 0x0100    // this is a placeholder group, to be filled in later
+#define IGF_EMIT_ADD 0x0200       // this is a block added by the emitter
+                                  // because the codegen block was too big. Also used for
+                                  // placeholder IGs that aren't also labels.
 
 // Mask of IGF_* flags that should be propagated to new blocks when they are created.
 // This allows prologs and epilogs to be any number of IGs, but still be

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -11196,21 +11196,14 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     assert(sz == emitSizeOfInsDsc(id));
 
 #if !FEATURE_FIXED_OUT_ARGS
-    bool bUpdateStackLv = true;
+    bool updateStackLevel = !emitIGisInProlog(ig) && !emitIGisInEpilog(ig);
 
-    if (emitIGisInProlog(ig))
-        bUpdateStackLv = false;
-    if (emitIGisInEpilog(ig))
-        bUpdateStackLv = false;
 #if FEATURE_EH_FUNCLETS
-    if (emitIGisInFuncletProlog(ig))
-        bUpdateStackLv = false;
-    if (emitIGisInFuncletEpilog(ig))
-        bUpdateStackLv = false;
+    updateStackLevel = updateStackLevel && !emitIGisInFuncletProlog(ig) && !emitIGisInFuncletEpilog(ig);
 #endif // FEATURE_EH_FUNCLETS
 
     // Make sure we keep the current stack level up to date
-    if (bUpdateStackLv)
+    if (updateStackLevel)
     {
         switch (ins)
         {

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -11196,9 +11196,17 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     assert(sz == emitSizeOfInsDsc(id));
 
 #if !FEATURE_FIXED_OUT_ARGS
+    bool bUpdateStackLv = true;
+
+    if (emitIGisInProlog(ig)) bUpdateStackLv = false;
+    if (emitIGisInEpilog(ig)) bUpdateStackLv = false;
+#if FEATURE_EH_FUNCLETS
+    if (emitIGisInFuncletProlog(ig)) bUpdateStackLv = false;
+    if (emitIGisInFuncletEpilog(ig)) bUpdateStackLv = false;
+#endif // FEATURE_EH_FUNCLETS
 
     // Make sure we keep the current stack level up to date
-    if (!emitIGisInProlog(ig) && !emitIGisInEpilog(ig))
+    if (bUpdateStackLv)
     {
         switch (ins)
         {

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -11198,11 +11198,15 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 #if !FEATURE_FIXED_OUT_ARGS
     bool bUpdateStackLv = true;
 
-    if (emitIGisInProlog(ig)) bUpdateStackLv = false;
-    if (emitIGisInEpilog(ig)) bUpdateStackLv = false;
+    if (emitIGisInProlog(ig))
+        bUpdateStackLv = false;
+    if (emitIGisInEpilog(ig))
+        bUpdateStackLv = false;
 #if FEATURE_EH_FUNCLETS
-    if (emitIGisInFuncletProlog(ig)) bUpdateStackLv = false;
-    if (emitIGisInFuncletEpilog(ig)) bUpdateStackLv = false;
+    if (emitIGisInFuncletProlog(ig))
+        bUpdateStackLv = false;
+    if (emitIGisInFuncletEpilog(ig))
+        bUpdateStackLv = false;
 #endif // FEATURE_EH_FUNCLETS
 
     // Make sure we keep the current stack level up to date


### PR DESCRIPTION
The current implementation updates stack level even for funclet prolog and epilog, which results in assert failure.

This commit revises emitter not to update stack level while emitting funclet prolog and epilog in order to allow the use of push/pop instruction.