### PR TITLE
Add mkdir for CoreFx directory

### DIFF
--- a/tests/scripts/perf-prep.sh
+++ b/tests/scripts/perf-prep.sh
@@ -62,6 +62,7 @@ python3.5 ./tests/scripts/Microsoft.BenchView.JSONFormat/tools/machinedata.py
 curl https://ci.dot.net/job/$perfBranch/job/master/job/release_windows_nt/lastSuccessfulBuild/artifact/bin/tests/tests.zip -o tests.zip
 
 # Corefx components.  We now have full stack builds on all distros we test here, so we can copy straight from CoreFX jobs.
+mkdir corefx
 curl https://ci.dot.net/job/dotnet_corefx/job/master/job/ubuntu14.04_release/lastSuccessfulBuild/artifact/bin/build.tar.gz -o ./corefx/build.tar.gz
 
 # Unpack the corefx binaries


### PR DESCRIPTION
In PR 8997 I accidentally removed the mkdir that creates the corefx
directory for us to copy the test zip into.  I did this when I was
adding Https to the URLs that we use to download the information from
Jenkins.  This adds back that bit.