### PR TITLE
Cleanup uses of string.Split

### DIFF
--- a/src/mscorlib/src/System/Globalization/JapaneseCalendar.cs
+++ b/src/mscorlib/src/System/Globalization/JapaneseCalendar.cs
@@ -311,7 +311,7 @@ namespace System.Globalization {
             // Get Strings
             //
             // Needs to be a certain length e_a_E_A at least (7 chars, exactly 4 groups)
-            String[] names = data.Split(new char[] {'_'});
+            String[] names = data.Split('_');
 
             // Should have exactly 4 parts
             // 0 - Era Name

--- a/src/mscorlib/src/System/Security/Util/StringExpressionSet.cs
+++ b/src/mscorlib/src/System/Security/Util/StringExpressionSet.cs
@@ -33,8 +33,8 @@ namespace System.Security.Util {
         protected String[] m_expressionsArray;
 
         protected bool m_throwOnRelative;
-        
-        protected static readonly char[] m_separators = { ';' };
+
+        private const char Separator = ';';
         protected static readonly char[] m_trimChars = { ' ' };
 #if !PLATFORM_UNIX
         protected static readonly char m_directorySeparator = '\\';
@@ -127,7 +127,7 @@ namespace System.Security.Util {
             if (m_expressions == null)
                 m_expressions = str;
             else
-                m_expressions = m_expressions + m_separators[0] + str;
+                m_expressions = m_expressions + Separator + str;
 
             m_expressionsArray = null;
 
@@ -289,7 +289,7 @@ namespace System.Security.Util {
             }
             else
             {
-                return expressions.Split( m_separators );
+                return expressions.Split(Separator);
             }
         }
 
@@ -475,14 +475,14 @@ namespace System.Security.Util {
                 while (enumerator.MoveNext())
                 {
                     if (!first)
-                        sb.Append( m_separators[0] );
+                        sb.Append(Separator);
                     else
                         first = false;
                             
                     String currentString = (String)enumerator.Current;
                     if (currentString != null)
                     {
-                        int indexOfSeparator = currentString.IndexOf( m_separators[0] );
+                        int indexOfSeparator = currentString.IndexOf(Separator);
 
                         if (indexOfSeparator != -1)
                             sb.Append( '\"' );

--- a/src/mscorlib/src/System/Security/Util/URLString.cs
+++ b/src/mscorlib/src/System/Security/Util/URLString.cs
@@ -1196,8 +1196,6 @@ namespace System.Security.Util {
     {
         private bool m_checkForIllegalChars;
 
-        private new static char[] m_separators = { '/' };
-
         // From KB #Q177506, file/folder illegal characters are \ / : * ? " < > | 
         protected static char[] m_illegalDirectoryCharacters = { '\\', ':', '*', '?', '"', '<', '>', '|' };
         
@@ -1223,7 +1221,7 @@ namespace System.Security.Util {
             Contract.EndContractBlock();
 
             ArrayList list = new ArrayList();
-            String[] separatedArray = directory.Split(m_separators);
+            String[] separatedArray = directory.Split('/');
             
             for (int index = 0; index < separatedArray.Length; ++index)
             {
@@ -1282,8 +1280,6 @@ namespace System.Security.Util {
     [Serializable]
     internal class LocalSiteString : SiteString
     {
-        private new static char[] m_separators = { '/' };
-
         public LocalSiteString( String site )
         {
             m_site = site.Replace( '|', ':');
@@ -1303,7 +1299,7 @@ namespace System.Security.Util {
             Contract.EndContractBlock();
 
             ArrayList list = new ArrayList();
-            String[] separatedArray = directory.Split(m_separators);
+            String[] separatedArray = directory.Split('/');
             
             for (int index = 0; index < separatedArray.Length; ++index)
             {

--- a/src/mscorlib/src/System/Security/Util/sitestring.cs
+++ b/src/mscorlib/src/System/Security/Util/sitestring.cs
@@ -14,8 +14,6 @@ namespace System.Security.Util {
         protected String m_site;
         protected ArrayList m_separatedSite;
 
-        protected static char[] m_separators = { '.' };
-        
         protected internal SiteString()
         {
             // Only call this in derived classes when you know what you're doing.
@@ -58,7 +56,7 @@ namespace System.Security.Util {
 
             // Regular hostnames or IPv4 addresses
             // We dont need to do this for IPv4 addresses, but it's easier to do it anyway
-            String[] separatedArray = site.Split( m_separators );
+            String[] separatedArray = site.Split('.');
             
             for (int index = separatedArray.Length-1; index > -1; --index)
             {

--- a/src/mscorlib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.Win32.cs
@@ -784,7 +784,7 @@ namespace System
             // filePath   = "C:\Windows\System32\tzres.dll"
             // resourceId = -100
             //
-            string[] resources = resource.Split(',', StringSplitOptions.None);
+            string[] resources = resource.Split(',');
             if (resources.Length != 2)
             {
                 return string.Empty;

--- a/src/mscorlib/src/System/Version.cs
+++ b/src/mscorlib/src/System/Version.cs
@@ -34,7 +34,6 @@ namespace System {
         private readonly int _Minor;
         private readonly int _Build = -1;
         private readonly int _Revision = -1;
-        private static readonly char[] SeparatorsArray = new char[] { '.' };
     
         public Version(int major, int minor, int build, int revision) {
             if (major < 0) 
@@ -301,7 +300,7 @@ namespace System {
                 return false;
             }
 
-            String[] parsedComponents = version.Split(SeparatorsArray);
+            String[] parsedComponents = version.Split('.');
             int parsedComponentsLength = parsedComponents.Length;
             if ((parsedComponentsLength < 2) || (parsedComponentsLength > 4)) {
                 result.SetFailure(ParseFailureKind.ArgumentException);


### PR DESCRIPTION
Now that there's an overload of Split that takes a single char, use it instead of the array-based overload.