### PR TITLE
Fix arm32 build break

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -11658,6 +11658,7 @@ DONE:
 
 void Compiler::fgClearFinallyTargetBit(BasicBlock* block)
 {
+    assert(fgComputePredsDone);
     assert((block->bbFlags & BBF_FINALLY_TARGET) != 0);
 
     for (flowList* pred = block->bbPreds; pred; pred = pred->flNext)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16910,6 +16910,8 @@ void Compiler::fgMorph()
     fgDebugCheckBBlist(false, false);
 #endif // DEBUG
 
+// RemoveEmptyFinally is disabled on ARM due to github issue #9013
+#ifndef _TARGET_ARM_
     fgRemoveEmptyFinally();
 
     EndPhase(PHASE_EMPTY_FINALLY);
@@ -16917,6 +16919,7 @@ void Compiler::fgMorph()
     fgCloneFinally();
 
     EndPhase(PHASE_CLONE_FINALLY);
+#endif // _TARGET_ARM_
 
     /* For x64 and ARM64 we need to mark irregular parameters early so that they don't get promoted */
     fgMarkImplicitByRefArgs();


### PR DESCRIPTION
fgClearFinallyTargetBit requires computePreds to have happened in order
to sucessfully leave the bit unset for cases where there are multiple
CALLFINALLY / BBJ_ALWAYS pairs that point to the same finally target on
ARM.

The change adds an assertion to fgClearFinallyTargetBit in addition
to disabling the optimization on ARM.

/cc @AndyAyersMS