### PR TITLE
Add logging for jumpsStubs and ClrVirtualAllocWithinRange

### DIFF
--- a/src/vm/codeman.h
+++ b/src/vm/codeman.h
@@ -1480,6 +1480,16 @@ private:
     };
     typedef SHash<JumpStubTraits> JumpStubTable;
 
+    static unsigned m_normal_JumpStubLookup;
+    static unsigned m_normal_JumpStubUnique;
+    static unsigned m_normal_JumpStubBlockAllocCount;
+    static unsigned m_normal_JumpStubBlockFullCount;
+
+    static unsigned m_LCG_JumpStubLookup;
+    static unsigned m_LCG_JumpStubUnique;
+    static unsigned m_LCG_JumpStubBlockAllocCount;
+    static unsigned m_LCG_JumpStubBlockFullCount;
+
     struct JumpStubCache
     {
         JumpStubCache() 


### PR DESCRIPTION
    Document jumpStub usage in Codeman.cpp
    Added new STRESS_LOG calls that do the following:
     logging for JumpStubs
          log the total count of jump stub lookups: JumpStubLookup
          log the number of actual jump stub thunks created: JumpStubUnique
          log the number of jump stub blocks allocated: JumpStubBlockAllocCount
          log the number jump stub blocks that are completely filled: JumpStubBlockFullCount
     logging for ClrVirtualAllocWithinRange
          log the total number of calls to ClrVirtualAllocWithinRange
          log the number of VirtualQuery operations used by the current call
          log the range that was requested
          log the return value
          log any reasons for failure.
