### PR TITLE
[GDB-JIT][Linux] Fix incorrect displaying of (s)byte and char in lldb

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -32,6 +32,7 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle, NotifyGdb::PTK_TypeInfoMap pTyp
     {
         case ELEMENT_TYPE_I1:
         case ELEMENT_TYPE_U1:
+        case ELEMENT_TYPE_CHAR:
             typeInfo = new (nothrow) ByteTypeInfo(typeHandle, CorElementTypeToDWEncoding[corType]);
             if (typeInfo == nullptr)
                 return nullptr;
@@ -39,7 +40,6 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle, NotifyGdb::PTK_TypeInfoMap pTyp
             break;
         case ELEMENT_TYPE_VOID:
         case ELEMENT_TYPE_BOOLEAN:
-        case ELEMENT_TYPE_CHAR:
         case ELEMENT_TYPE_I2:
         case ELEMENT_TYPE_U2:
         case ELEMENT_TYPE_I4:
@@ -1012,6 +1012,8 @@ void ByteTypeInfo::DumpStrings(char* ptr, int& offset)
         strcpy(m_typedef_info->m_typedef_name, "byte");
     else if (strcmp(m_type_name, "System.SByte") == 0)
         strcpy(m_typedef_info->m_typedef_name, "sbyte");
+    else if (strcmp(m_type_name, "char16_t") == 0)
+        strcpy(m_typedef_info->m_typedef_name, "char");
     else
         strcpy(m_typedef_info->m_typedef_name, m_type_name);
     m_typedef_info->DumpStrings(ptr, offset);

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -30,11 +30,16 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle, NotifyGdb::PTK_TypeInfoMap pTyp
     CorElementType corType = typeHandle.GetSignatureCorElementType();
     switch (corType)
     {
+        case ELEMENT_TYPE_I1:
+        case ELEMENT_TYPE_U1:
+            typeInfo = new (nothrow) ByteTypeInfo(typeHandle, CorElementTypeToDWEncoding[corType]);
+            if (typeInfo == nullptr)
+                return nullptr;
+            typeInfo->m_type_size = CorTypeInfo::Size(corType);
+            break;
         case ELEMENT_TYPE_VOID:
         case ELEMENT_TYPE_BOOLEAN:
         case ELEMENT_TYPE_CHAR:
-        case ELEMENT_TYPE_I1:
-        case ELEMENT_TYPE_U1:
         case ELEMENT_TYPE_I2:
         case ELEMENT_TYPE_U2:
         case ELEMENT_TYPE_I4:
@@ -678,8 +683,7 @@ const unsigned char AbbrevTable[] = {
     2, DW_TAG_base_type, DW_CHILDREN_no,
         DW_AT_name, DW_FORM_strp, DW_AT_encoding, DW_FORM_data1, DW_AT_byte_size, DW_FORM_data1, 0, 0,
 
-    3, DW_TAG_typedef, DW_CHILDREN_no,
-        DW_AT_name, DW_FORM_strp, DW_AT_decl_file, DW_FORM_data1, DW_AT_decl_line, DW_FORM_data1,
+    3, DW_TAG_typedef, DW_CHILDREN_no, DW_AT_name, DW_FORM_strp,
         DW_AT_type, DW_FORM_ref4, 0, 0,
 
     4, DW_TAG_subprogram, DW_CHILDREN_yes,
@@ -893,6 +897,13 @@ struct __attribute__((packed)) DebugInfoVar
     uint32_t m_var_type;
 };
 
+struct __attribute__((packed)) DebugInfoTypeDef
+{
+    uint8_t m_typedef_abbrev;
+    uint32_t m_typedef_name;
+    uint32_t m_typedef_type;
+};
+
 struct __attribute__((packed)) DebugInfoClassType
 {
     uint8_t m_type_abbrev;
@@ -962,6 +973,69 @@ TypeHandle TypeInfoBase::GetTypeHandle()
 TypeKey* TypeInfoBase::GetTypeKey()
 {
     return &typeKey;
+}
+
+void TypeDefInfo::DumpStrings(char *ptr, int &offset)
+{
+    if (ptr != nullptr)
+    {
+        strcpy(ptr + offset, m_typedef_name);
+        m_typedef_name_offset = offset;
+    }
+    offset += strlen(m_typedef_name) + 1;
+}
+
+void TypeDefInfo::DumpDebugInfo(char *ptr, int &offset)
+{
+    if (ptr != nullptr)
+    {
+        DebugInfoTypeDef buf;
+        buf.m_typedef_abbrev = 3;
+        buf.m_typedef_name = m_typedef_name_offset;
+        buf.m_typedef_type = offset + sizeof(DebugInfoTypeDef);
+        m_typedef_type_offset = offset;
+
+        memcpy(ptr + offset,
+               &buf,
+               sizeof(DebugInfoTypeDef));
+    }
+
+    offset += sizeof(DebugInfoTypeDef);
+}
+
+
+void ByteTypeInfo::DumpStrings(char* ptr, int& offset)
+{
+    PrimitiveTypeInfo::DumpStrings(ptr, offset);
+    m_typedef_info->m_typedef_name = new (nothrow) char[strlen(m_type_name) + 1];
+    if (strcmp(m_type_name, "System.Byte") == 0)
+        strcpy(m_typedef_info->m_typedef_name, "byte");
+    else if (strcmp(m_type_name, "System.SByte") == 0)
+        strcpy(m_typedef_info->m_typedef_name, "sbyte");
+    else
+        strcpy(m_typedef_info->m_typedef_name, m_type_name);
+    m_typedef_info->DumpStrings(ptr, offset);
+}
+
+void ByteTypeInfo::DumpDebugInfo(char *ptr, int &offset)
+{
+    m_typedef_info->DumpDebugInfo(ptr, offset);
+    //PrimitiveTypeInfo::DumpDebugInfo(ptr, offset);
+    if (ptr != nullptr)
+    {
+        DebugInfoType bufType;
+        bufType.m_type_abbrev = 2;
+        bufType.m_type_name = m_type_name_offset;
+        bufType.m_encoding = m_type_encoding;
+        bufType.m_byte_size = m_type_size;
+
+        memcpy(ptr + offset,
+               &bufType,
+               sizeof(DebugInfoType));
+        m_type_offset = m_typedef_info->m_typedef_type_offset;
+    }
+
+    offset += sizeof(DebugInfoType);
 }
 
 void PrimitiveTypeInfo::DumpDebugInfo(char* ptr, int& offset)
@@ -1877,9 +1951,9 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
 
     elfFile.MemPtr.SuppressRelease();
 
-#ifdef GDBJIT_DUMPELF
+    //#ifdef GDBJIT_DUMPELF
     DumpElf(methodName, elfFile);
-#endif
+    //#endif
 
     /* Create GDB JIT structures */
     NewHolder<jit_code_entry> jit_symbols = new (nothrow) jit_code_entry;

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1003,7 +1003,6 @@ void TypeDefInfo::DumpDebugInfo(char *ptr, int &offset)
     offset += sizeof(DebugInfoTypeDef);
 }
 
-
 void ByteTypeInfo::DumpStrings(char* ptr, int& offset)
 {
     PrimitiveTypeInfo::DumpStrings(ptr, offset);
@@ -1022,22 +1021,8 @@ void ByteTypeInfo::DumpStrings(char* ptr, int& offset)
 void ByteTypeInfo::DumpDebugInfo(char *ptr, int &offset)
 {
     m_typedef_info->DumpDebugInfo(ptr, offset);
-    //PrimitiveTypeInfo::DumpDebugInfo(ptr, offset);
-    if (ptr != nullptr)
-    {
-        DebugInfoType bufType;
-        bufType.m_type_abbrev = 2;
-        bufType.m_type_name = m_type_name_offset;
-        bufType.m_encoding = m_type_encoding;
-        bufType.m_byte_size = m_type_size;
-
-        memcpy(ptr + offset,
-               &bufType,
-               sizeof(DebugInfoType));
-        m_type_offset = m_typedef_info->m_typedef_type_offset;
-    }
-
-    offset += sizeof(DebugInfoType);
+    m_type_offset = m_typedef_info->m_typedef_type_offset;
+    PrimitiveTypeInfo::DumpDebugInfo(ptr, offset);
 }
 
 void PrimitiveTypeInfo::DumpDebugInfo(char* ptr, int& offset)
@@ -1953,9 +1938,9 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
 
     elfFile.MemPtr.SuppressRelease();
 
-    //#ifdef GDBJIT_DUMPELF
+#ifdef GDBJIT_DUMPELF
     DumpElf(methodName, elfFile);
-    //#endif
+#endif
 
     /* Create GDB JIT structures */
     NewHolder<jit_code_entry> jit_symbols = new (nothrow) jit_code_entry;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -204,11 +204,10 @@ public:
     int m_typedef_name_offset;
 };
 
-class ByteTypeInfo: public PrimitiveTypeInfo
+class ByteTypeInfo : public PrimitiveTypeInfo
 {
 public:
-    ByteTypeInfo(TypeHandle typeHandle, int encoding)
-        : PrimitiveTypeInfo(typeHandle, encoding)
+    ByteTypeInfo(TypeHandle typeHandle, int encoding) : PrimitiveTypeInfo(typeHandle, encoding)
     {
         m_typedef_info = new (nothrow) TypeDefInfo(nullptr, 0);
     }
@@ -219,7 +218,7 @@ public:
     void DumpDebugInfo(char* ptr, int& offset) override;
     void DumpStrings(char* ptr, int& offset) override;
 
-    TypeDefInfo *m_typedef_info;
+    TypeDefInfo* m_typedef_info;
 };
 
 class RefTypeInfo: public TypeInfoBase

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -184,6 +184,44 @@ public:
     int m_type_encoding;
 };
 
+class TypeDefInfo : public DwarfDumpable
+{
+public:
+    TypeDefInfo(char *typedef_name,int typedef_type):
+    m_typedef_name(typedef_name), m_typedef_type(typedef_type) {}
+    void DumpStrings(char* ptr, int& offset) override;
+    void DumpDebugInfo(char* ptr, int& offset) override;
+    virtual ~TypeDefInfo()
+    {
+        if (m_typedef_name != nullptr)
+        {
+            delete [] m_typedef_name;
+        }
+    }
+    char *m_typedef_name;
+    int m_typedef_type;
+    int m_typedef_type_offset;
+    int m_typedef_name_offset;
+};
+
+class ByteTypeInfo: public PrimitiveTypeInfo
+{
+public:
+    ByteTypeInfo(TypeHandle typeHandle, int encoding)
+        : PrimitiveTypeInfo(typeHandle, encoding)
+    {
+        m_typedef_info = new (nothrow) TypeDefInfo(nullptr, 0);
+    }
+    virtual ~ByteTypeInfo()
+    {
+        delete m_typedef_info;
+    }
+    void DumpDebugInfo(char* ptr, int& offset) override;
+    void DumpStrings(char* ptr, int& offset) override;
+
+    TypeDefInfo *m_typedef_info;
+};
+
 class RefTypeInfo: public TypeInfoBase
 {
 public:


### PR DESCRIPTION
This PR adds typedef for `byte`, `sbyte` and `char` C# types to fix incorrect displaying of these types in lldb.
Without this fix lldb trying to convert DWARF types to C++ basic types and shows `byte` as `unsigned char`, `sbyte` as `char`, and `char` as `short`.
@janvorli, @mikem8361 PTAL

\CC: @Dmitri-Botcharnikov @chunseoklee 