### PR TITLE
Fix incorrect comment

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -809,8 +809,8 @@ struct BasicBlock : private LIR::Range
     VARSET_TP bbLiveOut; // variables live on exit
 
     // Use, def, live in/out information for the implicit "Heap" variable.
-    unsigned bbHeapUse : 1;
-    unsigned bbHeapDef : 1;
+    unsigned bbHeapUse : 1; // must be set to true for any block that references the global Heap
+    unsigned bbHeapDef : 1; // must be set to true for any block that mutates the global Heap
     unsigned bbHeapLiveIn : 1;
     unsigned bbHeapLiveOut : 1;
     unsigned bbHeapHavoc : 1; // If true, at some point the block does an operation that leaves the heap

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1129,8 +1129,8 @@ class LiveVarAnalysis
         VarSetOps::DiffD(m_compiler, m_liveIn, block->bbVarDef);
         VarSetOps::UnionD(m_compiler, m_liveIn, block->bbVarUse);
 
-        // Even if m_heapDef is set, we must assume that it doesn't kill heap if m_heapLiveOut, since
-        // (without proof otherwise) the use and def may touch different heap memory at run-time.
+        // Even if block->bbHeapDef is set, we must assume that it doesn't kill heap liveness from m_heapLiveOut,
+        // since (without proof otherwise) the use and def may touch different heap memory at run-time.
         m_heapLiveIn = m_heapLiveOut || block->bbHeapUse;
 
         /* Can exceptions from this block be handled (in this function)? */


### PR DESCRIPTION
Rewrite bogus reference to nonexistsent `m_HeapDef` to correctly refer to
`block->bbHeapDef`.  Also change "doesn't kill heap" to "doesn't kill heap
liveness" (since it still kills availability).