### PR TITLE
Clean up #else in EECodeManager::FixContext

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -161,7 +161,7 @@ enum
 };
 
 #ifndef DACCESS_COMPILE
-#ifdef _TARGET_X86_
+#ifndef WIN64EXCEPTIONS
 virtual void FixContext(ContextType     ctxType,
                         EHContext      *ctx,
                         EECodeInfo     *pCodeInfo,
@@ -171,7 +171,7 @@ virtual void FixContext(ContextType     ctxType,
                         CodeManState   *pState,
                         size_t       ** ppShadowSP,             // OUT
                         size_t       ** ppEndRegion) = 0;       // OUT
-#endif // _TARGET_X86_
+#endif // !WIN64EXCEPTIONS
 #endif // #ifndef DACCESS_COMPILE
 
 /*
@@ -368,7 +368,7 @@ public:
 
 
 #ifndef DACCESS_COMPILE
-#ifdef _TARGET_X86_
+#ifndef WIN64EXCEPTIONS
 /*
     Last chance for the runtime support to do fixups in the context
     before execution continues inside a filter, catch handler, or finally
@@ -383,7 +383,7 @@ void FixContext(ContextType     ctxType,
                 CodeManState   *pState,
                 size_t       ** ppShadowSP,             // OUT
                 size_t       ** ppEndRegion);           // OUT
-#endif // _TARGET_X86_
+#endif // !WIN64EXCEPTIONS
 #endif // #ifndef DACCESS_COMPILE
 
 /*

--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -161,7 +161,7 @@ enum
 };
 
 #ifndef DACCESS_COMPILE
-
+#ifdef _TARGET_X86_
 virtual void FixContext(ContextType     ctxType,
                         EHContext      *ctx,
                         EECodeInfo     *pCodeInfo,
@@ -171,7 +171,7 @@ virtual void FixContext(ContextType     ctxType,
                         CodeManState   *pState,
                         size_t       ** ppShadowSP,             // OUT
                         size_t       ** ppEndRegion) = 0;       // OUT
-
+#endif // _TARGET_X86_
 #endif // #ifndef DACCESS_COMPILE
 
 /*

--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -368,7 +368,7 @@ public:
 
 
 #ifndef DACCESS_COMPILE
-
+#ifdef _TARGET_X86_
 /*
     Last chance for the runtime support to do fixups in the context
     before execution continues inside a filter, catch handler, or finally
@@ -383,7 +383,7 @@ void FixContext(ContextType     ctxType,
                 CodeManState   *pState,
                 size_t       ** ppShadowSP,             // OUT
                 size_t       ** ppEndRegion);           // OUT
-
+#endif // _TARGET_X86_
 #endif // #ifndef DACCESS_COMPILE
 
 /*

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -693,6 +693,7 @@ inline size_t GetSizeOfFrameHeaderForEnC(hdrInfo * info)
 #endif // !USE_GC_INFO_DECODER
 
 #ifndef DACCESS_COMPILE
+#ifdef _TARGET_X86_
 
 /*****************************************************************************
  *
@@ -717,8 +718,6 @@ void EECodeManager::FixContext( ContextType     ctxType,
     } CONTRACTL_END;
 
     _ASSERTE((ctxType == FINALLY_CONTEXT) == (thrownObject == NULL));
-
-#ifdef _TARGET_X86_
 
     _ASSERTE(sizeof(CodeManStateBuf) <= sizeof(pState->stateBuf));
     CodeManStateBuf * stateBuf = (CodeManStateBuf*)pState->stateBuf;
@@ -773,11 +772,9 @@ void EECodeManager::FixContext( ContextType     ctxType,
      */
 
     *((OBJECTREF*)&(ctx->Eax)) = thrownObject;
-
-#else // !_TARGET_X86_
-    _ASSERTE(!"@NYI - EECodeManager::FixContext (EETwain.cpp)");
-#endif // _TARGET_X86_
 }
+
+#endif // _TARGET_X86_
 
 
 

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -693,7 +693,7 @@ inline size_t GetSizeOfFrameHeaderForEnC(hdrInfo * info)
 #endif // !USE_GC_INFO_DECODER
 
 #ifndef DACCESS_COMPILE
-#ifdef _TARGET_X86_
+#ifndef WIN64EXCEPTIONS
 
 /*****************************************************************************
  *
@@ -774,7 +774,7 @@ void EECodeManager::FixContext( ContextType     ctxType,
     *((OBJECTREF*)&(ctx->Eax)) = thrownObject;
 }
 
-#endif // _TARGET_X86_
+#endif // !WIN64EXCEPTIONS
 
 
 


### PR DESCRIPTION
It seems that only x86 ports uses EECodeManage::FixContext, but EECodeManage::FixContext contains unnecessary #else region in it.

This commit cleans up unnecessary #else region from EECodeManage::FixContext.