### PR TITLE
Clean up #else in EECodeManager::GetAmbientSP

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -174,6 +174,7 @@ virtual void FixContext(ContextType     ctxType,
 
 #endif // #ifndef DACCESS_COMPILE
 
+#ifdef _TARGET_X86_
 /*
     Gets the ambient stack pointer value at the given nesting level within
     the method.
@@ -183,6 +184,7 @@ virtual TADDR GetAmbientSP(PREGDISPLAY     pContext,
                            DWORD           dwRelOffset,
                            DWORD           nestingLevel,
                            CodeManState   *pState) = 0;
+#endif // _TARGET_X86_
 
 /*
     Get the number of bytes used for stack parameters.
@@ -386,6 +388,7 @@ void FixContext(ContextType     ctxType,
 
 #endif // #ifndef DACCESS_COMPILE
 
+#ifdef _TARGET_X86_
 /*
     Gets the ambient stack pointer value at the given nesting level within
     the method.
@@ -396,6 +399,7 @@ TADDR GetAmbientSP(PREGDISPLAY     pContext,
                    DWORD           dwRelOffset,
                    DWORD           nestingLevel,
                    CodeManState   *pState);
+#endif // _TARGET_X86_
 
 /*
     Get the number of bytes used for stack parameters.

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5812,6 +5812,7 @@ void EECodeManager::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 #endif // #ifdef DACCESS_COMPILE
 
 
+#ifdef _TARGET_X86_
 /*
  *  GetAmbientSP
  *
@@ -5834,7 +5835,6 @@ TADDR EECodeManager::GetAmbientSP(PREGDISPLAY     pContext,
         SUPPORTS_DAC;
     } CONTRACTL_END;
 
-#ifdef _TARGET_X86_
     GCInfoToken gcInfoToken = pCodeInfo->GetGCInfoToken();
 
     _ASSERTE(sizeof(CodeManStateBuf) <= sizeof(pState->stateBuf));
@@ -5907,12 +5907,8 @@ TADDR EECodeManager::GetAmbientSP(PREGDISPLAY     pContext,
     }
 
     return baseSP;
-
-#else // !_TARGET_X86_
-    PORTABILITY_ASSERT("EECodeManager::GetAmbientSP is not implemented on this platform.");
-    return 0;
-#endif // _TARGET_X86_
 }
+#endif // _TARGET_X86_
 
 /*
     Get the number of bytes used for stack parameters.


### PR DESCRIPTION
Only x86 ports uses EECodeManager::GetAmbientSP, but it contains unnecessary #else region for other architectures.

This commit cleans up unnecessary #else region from EECodeManager::GetAmbientSP.