### PR TITLE
Clean up LeaveFinally/LeaveCatch

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -318,6 +318,7 @@ virtual BOOL            IsInFilter(GCInfoToken gcInfoToken,
                                    PCONTEXT pCtx,
                                    DWORD curNestLevel) = 0;
 
+#ifndef WIN64EXCEPTIONS
 virtual BOOL            LeaveFinally(GCInfoToken gcInfoToken,
                                      unsigned offset,
                                      PCONTEXT pCtx) = 0;
@@ -325,6 +326,7 @@ virtual BOOL            LeaveFinally(GCInfoToken gcInfoToken,
 virtual void            LeaveCatch(GCInfoToken gcInfoToken,
                                    unsigned offset,
                                    PCONTEXT pCtx)=0;
+#endif // WIN64EXCEPTIONS
 
 #ifdef EnC_SUPPORTED
 
@@ -574,16 +576,18 @@ unsigned int GetFrameSize(GCInfoToken gcInfoToken);
 #ifndef DACCESS_COMPILE
 
 virtual const BYTE* GetFinallyReturnAddr(PREGDISPLAY pReg);
-virtual BOOL LeaveFinally(GCInfoToken gcInfoToken,
-                          unsigned offset,
-                          PCONTEXT pCtx);
 virtual BOOL IsInFilter(GCInfoToken gcInfoToken,
                         unsigned offset,
                         PCONTEXT pCtx,
                           DWORD curNestLevel);
+#ifndef WIN64EXCEPTIONS
+virtual BOOL LeaveFinally(GCInfoToken gcInfoToken,
+                          unsigned offset,
+                          PCONTEXT pCtx);
 virtual void LeaveCatch(GCInfoToken gcInfoToken,
                          unsigned offset,
                          PCONTEXT pCtx);
+#endif // WIN64EXCEPTIONS
 
 #ifdef EnC_SUPPORTED
 /*

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5729,6 +5729,7 @@ BOOL EECodeManager::IsInFilter(GCInfoToken gcInfoToken,
 }
 
 
+#if defined(_TARGET_X86_) && !defined(WIN64EXCEPTIONS)
 BOOL EECodeManager::LeaveFinally(GCInfoToken gcInfoToken,
                                 unsigned offset,
                                 PCONTEXT pCtx)
@@ -5738,7 +5739,6 @@ BOOL EECodeManager::LeaveFinally(GCInfoToken gcInfoToken,
         GC_NOTRIGGER;
     } CONTRACTL_END;
 
-#ifdef _TARGET_X86_
 
     hdrInfo info;
 
@@ -5762,10 +5762,6 @@ BOOL EECodeManager::LeaveFinally(GCInfoToken gcInfoToken,
 
     pCtx->Esp += sizeof(TADDR); // Pop the return value off the stack
     return TRUE;
-#else
-    PORTABILITY_ASSERT("EEJitManager::LeaveFinally is not implemented on this platform.");
-    return FALSE;
-#endif
 }
 
 void EECodeManager::LeaveCatch(GCInfoToken gcInfoToken,
@@ -5776,8 +5772,6 @@ void EECodeManager::LeaveCatch(GCInfoToken gcInfoToken,
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-
-#ifdef _TARGET_X86_
 
 #ifdef _DEBUG
     TADDR       baseSP;
@@ -5793,13 +5787,8 @@ void EECodeManager::LeaveCatch(GCInfoToken gcInfoToken,
 #endif
 
     return;
-
-#else // !_TARGET_X86_
-    PORTABILITY_ASSERT("EECodeManager::LeaveCatch is not implemented on this platform.");
-    return;
-#endif // _TARGET_X86_
 }
-
+#endif // _TARGET_X86_ && !WIN64EXCEPTIONS
 #endif // #ifndef DACCESS_COMPILE
 
 #ifdef DACCESS_COMPILE

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5729,7 +5729,7 @@ BOOL EECodeManager::IsInFilter(GCInfoToken gcInfoToken,
 }
 
 
-#if defined(_TARGET_X86_) && !defined(WIN64EXCEPTIONS)
+#ifndef WIN64EXCEPTIONS
 BOOL EECodeManager::LeaveFinally(GCInfoToken gcInfoToken,
                                 unsigned offset,
                                 PCONTEXT pCtx)
@@ -5788,7 +5788,7 @@ void EECodeManager::LeaveCatch(GCInfoToken gcInfoToken,
 
     return;
 }
-#endif // _TARGET_X86_ && !WIN64EXCEPTIONS
+#endif // !WIN64EXCEPTIONS
 #endif // #ifndef DACCESS_COMPILE
 
 #ifdef DACCESS_COMPILE


### PR DESCRIPTION
LeaveFinally and LeaveCatch are used only when WIN64EXCEPTIONS is not set ( x86/Windows is currently the only port that uses these methods).

This commit hides the declarations of these methods when WIN64EXCEPTIONS is set, and removes unnecessary #else region from the implementation of these methods.