### PR TITLE
Simplify #ifdef for UnwindStackFrame

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -190,6 +190,7 @@ virtual TADDR GetAmbientSP(PREGDISPLAY     pContext,
 */
 virtual ULONG32 GetStackParameterSize(EECodeInfo* pCodeInfo) = 0;
 
+#ifndef CROSSGEN_COMPILE
 /*
     Unwind the current stack frame, i.e. update the virtual register
     set in pContext. This will be similar to the state after the function
@@ -203,6 +204,7 @@ virtual bool UnwindStackFrame(PREGDISPLAY     pContext,
                               unsigned        flags,
                               CodeManState   *pState,
                               StackwalkCacheUnwindInfo  *pUnwindInfo) = 0;
+#endif // CROSSGEN_COMPILE
 
 /*
     Is the function currently at a "GC safe point" ?
@@ -404,6 +406,7 @@ TADDR GetAmbientSP(PREGDISPLAY     pContext,
 virtual 
 ULONG32 GetStackParameterSize(EECodeInfo* pCodeInfo);
 
+#ifndef CROSSGEN_COMPILE
 /*
     Unwind the current stack frame, i.e. update the virtual register
     set in pContext. This will be similar to the state after the function
@@ -419,6 +422,7 @@ bool UnwindStackFrame(
                 unsigned        flags,
                 CodeManState   *pState,
                 StackwalkCacheUnwindInfo  *pUnwindInfo);
+#endif // CROSSGEN_COMPILE
 
 enum QuickUnwindFlag
 {

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3985,7 +3985,8 @@ bool UnwindStackFrame(PREGDISPLAY     pContext,
 
 #endif // _TARGET_X86_
 
-#if defined(_TARGET_X86_) && !defined(WIN64EXCEPTIONS)
+#ifndef CROSSGEN_COMPILE
+#ifndef WIN64EXCEPTIONS
 
 /*****************************************************************************
  *
@@ -4003,11 +4004,16 @@ bool EECodeManager::UnwindStackFrame(PREGDISPLAY     pContext,
                                      CodeManState   *pState,
                                      StackwalkCacheUnwindInfo  *pUnwindInfo /* out-only, perf improvement */)
 {
+#ifdef _TARGET_X86_
     return ::UnwindStackFrame(pContext, pCodeInfo, flags, pState, pUnwindInfo);
+#else // _TARGET_X86_
+    PORTABILITY_ASSERT("EECodeManager::UnwindStackFrame");
+    return false;
+#endif // _TARGET_???_
 }
 
 /*****************************************************************************/
-#elif !defined(CROSSGEN_COMPILE) // _TARGET_X86_ - UnwindStackFrame
+#else // !WIN64EXCEPTIONS
 /*****************************************************************************/
 
 bool EECodeManager::UnwindStackFrame(PREGDISPLAY     pContext,
@@ -4037,19 +4043,9 @@ bool EECodeManager::UnwindStackFrame(PREGDISPLAY     pContext,
 }
 
 /*****************************************************************************/
-#else // _TARGET_X86_ - UnwindStackFrame
+#endif // WIN64EXCEPTIONS
+#endif // !CROSSGEN_COMPILE
 
-bool EECodeManager::UnwindStackFrame(PREGDISPLAY     pContext,
-                                     EECodeInfo     *pCodeInfo,
-                                     unsigned        flags,
-                                     CodeManState   *pState,
-                                     StackwalkCacheUnwindInfo  *pUnwindInfo /* out-only, perf improvement */)
-{
-    _ASSERTE(!"EECodeManager::UnwindStackFrame not supported in this build configuration");
-    return true;
-}
-
-#endif // _TARGET_X86_ - UnwindStackFrame
 /*****************************************************************************/
 
 /* report args in 'msig' to the GC.


### PR DESCRIPTION
The current implementation has the following #ifdef structure:
```
#ifdef _TARGET_X86_
~~~ 
#elseif WIN64EXCEPTIONS && !CROSSGEN_COMPILE
~~~
#else 
~~~
#endif 
```

This commit attempts to simplify the above structure as follows:
```
#ifndef CROSSGEN_COMPILE
#ifndef WIN64EXCEPTIONS
~~~
#else
~~~
#endif 
#endif 
```