### PR TITLE
Treat RHEL 7.x versions as RHEL 7 when building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -322,7 +322,7 @@ isMSBuildOnNETCoreSupported()
                 "opensuse.42.1-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
-                "rhel.7.2-x64")
+                "rhel.7"*"-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
                 "ubuntu.14.04-x64")


### PR DESCRIPTION
All RHEL 7.x versions are backwards compatible with each other. A .NET Core build from 7.2 works fine on RHEL 7.3, for example. Treat this as a general case and handle all 7.x versions the same.

This change only affects whether CoreCLR packages are built or not.

Without this change, a `build.sh` works fine on RHEL 7.3 but a `build-packages.sh` fails. After this change, both work fine on RHEL 7.3.