### PR TITLE
Disable GC/Scenarios/DoublinkList/doublinkgen

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <Project DefaultTargets = "GetListOfTestCmds" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\doublinkgen\*">
+            <Issue>6574</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\GC\Coverage\271010\*">
             <Issue>3392</Issue>
         </ExcludeList>

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -71,6 +71,7 @@ GC/Features/LOHFragmentation/lohfragmentation/lohfragmentation.sh
 GC/Features/SustainedLowLatency/scenario/scenario.sh
 GC/Regressions/dev10bugs/536168/536168/536168.sh
 GC/Stress/Framework/ReliabilityFramework/ReliabilityFramework.sh
+GC/Scenarios/DoublinkList/doublinkgen/doublinkgen.sh
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest612/Generated612/Generated612.sh
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest613/Generated613/Generated613.sh
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest614/Generated614/Generated614.sh


### PR DESCRIPTION
This test fails often and blocks people's PRs. See https://github.com/dotnet/coreclr/issues/6574 for the ongoing investigation.
