### PR TITLE
Rename Esp in x86 REGDISPLAY as SP

### DIFF
--- a/src/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/debug/daccess/dacdbiimplstackwalk.cpp
@@ -1163,7 +1163,7 @@ void DacDbiInterfaceImpl::UpdateContextFromRegDisp(REGDISPLAY * pRegDisp,
     pContext->Eax = *pRegDisp->pEax;
     pContext->Ecx = *pRegDisp->pEcx;
     pContext->Edx = *pRegDisp->pEdx;
-    pContext->Esp = pRegDisp->Esp;
+    pContext->Esp = pRegDisp->SP;
     pContext->Eip = pRegDisp->ControlPC;
 
     // If we still have the pointer to the leaf CONTEXT, and the leaf CONTEXT is the same as the CONTEXT for

--- a/src/debug/ee/debugger.inl
+++ b/src/debug/ee/debugger.inl
@@ -242,7 +242,7 @@ inline void FuncEvalFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->pEcx = &(pDE->m_context.Ecx);
     pRD->pEax = &(pDE->m_context.Eax);
     pRD->pEbp = &(pDE->m_context.Ebp);
-    pRD->Esp  = (DWORD)GetSP(&pDE->m_context);
+    pRD->SP   = (DWORD)GetSP(&pDE->m_context);
     pRD->PCTAddr = GetReturnAddressPtr();
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
 

--- a/src/debug/ee/i386/x86walker.cpp
+++ b/src/debug/ee/i386/x86walker.cpp
@@ -304,7 +304,7 @@ DWORD NativeWalker::GetRegisterValue(int registerNumber)
         return *m_registers->pEbx;
         break;
     case 4:
-        return m_registers->Esp;
+        return m_registers->SP;
         break;
     case 5:
         return *m_registers->pEbp;

--- a/src/debug/shared/i386/primitives.cpp
+++ b/src/debug/shared/i386/primitives.cpp
@@ -113,7 +113,7 @@ void SetDebuggerREGDISPLAYFromREGDISPLAY(DebuggerREGDISPLAY* pDRD, REGDISPLAY* p
     pDRD->pEax = NULL;
 #endif // !USE_REMOTE_REGISTER_ADDRESS
 
-    pDRD->SP   = pRD->Esp;
+    pDRD->SP   = pRD->SP;
     pDRD->PC   = pRD->ControlPC;
 
     // Please leave EBP, ESP, EIP at the front so I don't have to scroll

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -54,7 +54,7 @@ struct REGDISPLAY {
     DWORD * pEax;
 
     DWORD * pEbp;
-    DWORD   Esp;                // (Esp) Stack Pointer
+    DWORD   SP;                // Stack Pointer
     PCODE   ControlPC;
     TADDR   PCTAddr;
 
@@ -63,13 +63,13 @@ struct REGDISPLAY {
 inline TADDR GetRegdisplaySP(REGDISPLAY *display) {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    return (TADDR)display->Esp;
+    return (TADDR)display->SP;
 }
 
 inline void SetRegdisplaySP(REGDISPLAY *display, LPVOID sp ) {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    (display->Esp) = (DWORD)(size_t)sp;
+    (display->SP) = (DWORD)(size_t)sp;
 }
 
 inline TADDR GetRegdisplayFP(REGDISPLAY *display) {
@@ -379,7 +379,7 @@ inline void SyncRegDisplayToCurrentContext(REGDISPLAY* pRD)
     pRD->SP         = (DWORD)GetSP(pRD->pCurrentContext);
     pRD->ControlPC  = (DWORD)GetIP(pRD->pCurrentContext);
 #elif defined(_TARGET_X86_) // _TARGET_ARM_
-    pRD->Esp        = (DWORD)GetSP(pRD->pCurrentContext);
+    pRD->SP         = (DWORD)GetSP(pRD->pCurrentContext);
     pRD->ControlPC  = (DWORD)GetIP(pRD->pCurrentContext);
 #else // _TARGET_X86_
     PORTABILITY_ASSERT("SyncRegDisplayToCurrentContext");
@@ -407,7 +407,7 @@ inline void FillRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, PT_CONTEXT pC
     pRD->pEax = &(pctx->Eax);
     pRD->pEcx = &(pctx->Ecx);
     pRD->pEdx = &(pctx->Edx);
-    pRD->Esp  = pctx->Esp;
+    pRD->SP   = pctx->Esp;
     pRD->ControlPC = (PCODE)(pctx->Eip);
     pRD->PCTAddr = (UINT_PTR)&(pctx->Eip);
 #else // _TARGET_X86_
@@ -499,7 +499,7 @@ inline void CopyRegDisplay(const PREGDISPLAY pInRD, PREGDISPLAY pOutRD, T_CONTEX
     if (pInRD->pEax != NULL) {pOutCtx->Eax = *pInRD->pEax;} else {pInRD->pEax = NULL;}
     if (pInRD->pEcx != NULL) {pOutCtx->Ecx = *pInRD->pEcx;} else {pInRD->pEcx = NULL;}
     if (pInRD->pEdx != NULL) {pOutCtx->Edx = *pInRD->pEdx;} else {pInRD->pEdx = NULL;}
-    pOutCtx->Esp = pInRD->Esp;
+    pOutCtx->Esp = pInRD->SP;
     pOutCtx->Eip = pInRD->ControlPC;
 #else // _TARGET_X86_
     PORTABILITY_ASSERT("CopyRegDisplay");
@@ -591,7 +591,7 @@ inline void UpdateContextFromRegDisp(PREGDISPLAY pRegDisp, PT_CONTEXT pContext)
     pContext->Eax = *pRegDisp->pEax;
     pContext->Ecx = *pRegDisp->pEcx;
     pContext->Edx = *pRegDisp->pEdx;
-    pContext->Esp = pRegDisp->Esp;
+    pContext->Esp = pRegDisp->SP;
     pContext->Eip = pRegDisp->ControlPC;
 #else // _TARGET_X86_
     PORTABILITY_ASSERT("UpdateContextFromRegDisp");

--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -92,7 +92,7 @@ OOPStackUnwinderX86::VirtualUnwind(
     {
         rd.pEbp = &(ContextRecord->Ebp);
     }
-    rd.Esp = ContextRecord->Esp;
+    rd.SP = ContextRecord->Esp;
     rd.ControlPC = (PCODE)(ContextRecord->Eip);
     rd.PCTAddr = (UINT_PTR)&(ContextRecord->Eip);
 
@@ -118,7 +118,7 @@ OOPStackUnwinderX86::VirtualUnwind(
 #undef CALLEE_SAVED_REGISTER
     }
 
-    ContextRecord->Esp = rd.Esp;
+    ContextRecord->Esp = rd.SP;
     ContextRecord->Eip = rd.ControlPC;
     ContextRecord->Ebp = *rd.pEbp;
 

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -1300,11 +1300,7 @@ void ExceptionTracker::InitializeCurrentContextForCrawlFrame(CrawlFrame* pcfThis
         *(pRD->pCallerContext)      = *(pDispatcherContext->ContextRecord);
         pRD->IsCallerContextValid   = TRUE;
 
-#ifndef _TARGET_X86_
         pRD->SP = sfEstablisherFrame.SP;
-#else
-        pRD->Esp = sfEstablisherFrame.SP;
-#endif
         pRD->ControlPC = pDispatcherContext->ControlPc;
 
 #if defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)    

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -326,7 +326,7 @@ void TransitionFrame::UpdateRegDisplayHelper(const PREGDISPLAY pRD, UINT cbStack
 #else // WIN64EXCEPTIONS
 
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
-    pRD->Esp  = (DWORD)(pRD->PCTAddr + sizeof(TADDR) + cbStackPop);
+    pRD->SP  = (DWORD)(pRD->PCTAddr + sizeof(TADDR) + cbStackPop);
 
 #endif // WIN64EXCEPTIONS
 
@@ -569,7 +569,7 @@ void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 #define CALLEE_SAVED_REGISTER(regname) pRD->p##regname = (DWORD*) &regs->regname;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
-    pRD->Esp = m_Esp;
+    pRD->SP = m_Esp;
     pRD->PCTAddr = GetReturnAddressPtr();
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
 

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -213,7 +213,7 @@ void EHContext::Setup(PCODE resumePC, PREGDISPLAY regs)
     LIMITED_METHOD_DAC_CONTRACT;
 
     // EAX ECX EDX are scratch
-    this->Esp  = regs->Esp;
+    this->Esp  = regs->SP;
     this->Ebx = *regs->pEbx;
     this->Esi = *regs->pEsi;
     this->Edi = *regs->pEdi;
@@ -275,7 +275,7 @@ void TransitionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     _ASSERTE(pFunc != NULL);
     UpdateRegDisplayHelper(pRD, pFunc->CbStackPop());
 
-    LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    TransitionFrame::UpdateRegDisplay(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->Esp));
+    LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    TransitionFrame::UpdateRegDisplay(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
     RETURN;
 }
@@ -368,7 +368,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
         InsureInit(false, &unwindState);
         pRD->PCTAddr = dac_cast<TADDR>(unwindState.pRetAddr());
         pRD->ControlPC = unwindState.GetRetAddr();
-        pRD->Esp = unwindState._esp;
+        pRD->SP = unwindState._esp;
 
         // Get some special host instance memory
         // so we have a place to point to.
@@ -409,7 +409,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->pEbp = (DWORD*) m_MachState.pEbp();
     pRD->PCTAddr = dac_cast<TADDR>(m_MachState.pRetAddr());
     pRD->ControlPC = m_MachState.GetRetAddr();
-    pRD->Esp  = (DWORD) m_MachState.esp();
+    pRD->SP  = (DWORD) m_MachState.esp();
 
 #ifdef WIN64EXCEPTIONS
     pRD->IsCallerContextValid = FALSE;
@@ -419,7 +419,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     // Copy the saved state from the frame to the current context.
     //
     pRD->pCurrentContext->Eip = pRD->ControlPC;
-    pRD->pCurrentContext->Esp = pRD->Esp;
+    pRD->pCurrentContext->Esp = pRD->SP;
 
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = *pRD->p##regname;
     ENUM_CALLEE_SAVED_REGISTERS();
@@ -588,13 +588,13 @@ void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 
-    pRD->Esp = m_ctx.Esp;
+    pRD->SP = m_ctx.Esp;
     pRD->PCTAddr = GetReturnAddressPtr();
     pRD->ControlPC = m_ctx.Eip;
 
 #endif // WIN64EXCEPTIONS
 
-    LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    FaultingExceptionFrame::UpdateRegDisplay(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->Esp));
+    LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    FaultingExceptionFrame::UpdateRegDisplay(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
     RETURN;
 }
@@ -650,14 +650,14 @@ void InlinedCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
 
     /* Now we need to pop off the outgoing arguments */
-    pRD->Esp  = (DWORD) dac_cast<TADDR>(m_pCallSiteSP) + stackArgSize;
+    pRD->SP  = (DWORD) dac_cast<TADDR>(m_pCallSiteSP) + stackArgSize;
 
 #ifdef WIN64EXCEPTIONS
     pRD->IsCallerContextValid = FALSE;
     pRD->IsCallerSPValid      = FALSE;        // Don't add usage of this field.  This is only temporary.
 
     pRD->pCurrentContext->Eip = pRD->ControlPC;
-    pRD->pCurrentContext->Esp = pRD->Esp;
+    pRD->pCurrentContext->Esp = pRD->SP;
     pRD->pCurrentContext->Ebp = *pRD->pEbp;
 
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContextPointers->regname = NULL;
@@ -669,7 +669,7 @@ void InlinedCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     SyncRegDisplayToCurrentContext(pRD);
 #endif
 
-    LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    InlinedCallFrame::UpdateRegDisplay(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->Esp));
+    LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    InlinedCallFrame::UpdateRegDisplay(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
     RETURN;
 }
@@ -735,7 +735,7 @@ void ResumableFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->ControlPC = pUnwoundContext->Eip;
     pRD->PCTAddr = dac_cast<TADDR>(m_Regs) + offsetof(CONTEXT, Eip);
 
-    pRD->Esp  = m_Regs->Esp;
+    pRD->SP  = m_Regs->Esp;
 
     RETURN;
 }
@@ -764,7 +764,7 @@ void HijackFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->pEbp = &m_Args->Ebp;
     pRD->PCTAddr = dac_cast<TADDR>(m_Args) + offsetof(HijackArgs, Eip);
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
-    pRD->Esp  = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
+    pRD->SP  = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
 }
 
 #endif  // FEATURE_HIJACK
@@ -808,7 +808,7 @@ void TailCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 
     pRD->PCTAddr = GetReturnAddressPtr();
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
-    pRD->Esp  = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
+    pRD->SP  = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
 
     RETURN;
 }

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -7412,7 +7412,7 @@ Loop:
                 ZeroMemory(&rd, sizeof(rd));
 
                 rd.pEbp = &ctxCur.Ebp;
-                rd.Esp = ctxCur.Esp;
+                rd.SP = ctxCur.Esp;
                 rd.ControlPC = ctxCur.Eip;
 
                 codeInfo.GetCodeManager()->UnwindStackFrame(
@@ -7423,7 +7423,7 @@ Loop:
                     NULL);
 
                 ctxCur.Ebp = *(rd.pEbp);
-                ctxCur.Esp = rd.Esp;
+                ctxCur.Esp = rd.SP;
                 ctxCur.Eip = rd.ControlPC;
             }
             else


### PR DESCRIPTION
This commit renames Esp in x86 REGDISPLAY as SP to make it consistent with other architetures (as discussed in #8643).