### PR TITLE
Fix Ubuntu Perf Runs

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -128,8 +128,7 @@ def static getOSGroup(def os) {
                 --testNativeBinDir=\"\${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
                 --coreClrBinDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --mscorlibDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
-                --coreFxBinDir=\"\${WORKSPACE}/corefx/bin/${osGroup}.AnyCPU.${configuration};\${WORKSPACE}/corefx/bin/Unix.AnyCPU.${configuration};\${WORKSPACE}/corefx/bin/AnyOS.AnyCPU.${configuration}\" \\
-                --coreFxNativeBinDir=\"\${WORKSPACE}/corefx/bin/${osGroup}.${architecture}.${configuration}\" \\
+                --coreFxBinDir=\"\${WORKSPACE}/corefx\" \\
 				--runType=\"${runType}\" \\
 				--benchViewOS=\"${os}\" \\
 				--uploadToBenchview""")

--- a/tests/scripts/perf-prep.sh
+++ b/tests/scripts/perf-prep.sh
@@ -68,6 +68,7 @@ curl https://ci.dot.net/job/dotnet_corefx/job/master/job/ubuntu14.04_release/las
 # Unpack the corefx binaries
 pushd corefx > /dev/null
 tar -xf build.tar.gz
+rm build.tar.gz
 popd > /dev/null
 
 # Unzip the tests first.  Exit with 0


### PR DESCRIPTION
After the dev/eng work the Ubuntu perf runs were broken because of
layout changes in the bin drop of CoreFX.  We relied on these for the
CoreFX that we used during perf testing.  I have made changes on the
CoreFX side to tar up the new runtime folder instead of a collection of
other bin folder.  This change allows the infrastructure to consume
this.