### PR TITLE
[x86/Linux] Enable two preconditions in ExceptionTracker::ResetThreadAb…

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -7032,8 +7032,10 @@ void ExceptionTracker::ResetThreadAbortStatus(PTR_Thread pThread, CrawlFrame *pC
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(pThread != NULL);
-        WIN64_ONLY(PRECONDITION(pCf != NULL);)
-        WIN64_ONLY(PRECONDITION(!sfCurrentStackFrame.IsNull());)
+#ifdef WIN64EXCEPTIONS
+        PRECONDITION(pCf != NULL);
+        PRECONDITION(!sfCurrentStackFrame.IsNull());
+#endif // WIN64EXCEPTIONS
     }
     CONTRACTL_END;
 


### PR DESCRIPTION
…ortStatus

These preconditions seems to be related WIN64EXCEPTIONS, but enclosed with WIN64 ifdefs.

This commit encloses these preconditions with WIN64EXCEPTIONS in order to enable them inside x86/Linux port.