### PR TITLE
[GDB-JIT][Linux] Add support of base classes introspection  

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -773,7 +773,7 @@ const unsigned char AbbrevTable[] = {
         0, 0,
 
     18, DW_TAG_inheritance, DW_CHILDREN_no, DW_AT_type, DW_FORM_ref4, DW_AT_data_member_location, DW_FORM_data1,
-        DW_AT_accessibility, DW_FORM_data1, 0, 0,
+        0, 0,
 
     0
 };
@@ -924,7 +924,6 @@ struct __attribute__((packed)) DebugInfoInheritance
     uint8_t m_abbrev;
     uint32_t m_type;
     uint8_t m_data_member_location;
-    uint8_t m_accessibility;
 };
 
 struct __attribute__((packed)) DebugInfoClassMember
@@ -1489,12 +1488,15 @@ void ClassTypeInfo::DumpDebugInfo(char* ptr, int& offset)
     {
         if (ptr != nullptr)
         {
-
             DebugInfoInheritance buf;
             buf.m_abbrev = 18;
-            buf.m_type = offset + sizeof(DebugInfoInheritance) + sizeof(DebugInfoRefType) + 1;
+            if (m_parent->m_type_offset != 0)
+               buf.m_type = m_parent->m_type_offset;
+            else
+               buf.m_type = offset + sizeof(DebugInfoInheritance) + 1;
+            // All classes passed by referenence, so we have to skip DW_TAG_pointer_type node (otherwise lldb crashed).
+            buf.m_type += sizeof(DebugInfoRefType);
             buf.m_data_member_location = 0;
-            buf.m_accessibility = 1;
             memcpy(ptr + offset, &buf, sizeof(DebugInfoInheritance));
         }
         offset += sizeof(DebugInfoInheritance);

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -137,8 +137,10 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle, NotifyGdb::PTK_TypeInfoMap pTyp
                     info->members[1].m_member_type = arrayTypeInfo;
                 }
             }
-            // Ignore inheritance from System.Object class.
-            if (pMT->GetParentMethodTable() && pMT->GetParentMethodTable()->GetParentMethodTable()) {
+            // Ignore inheritance from System.Object and System.ValueType classes.
+            if (!typeHandle.IsValueType() &&
+                pMT->GetParentMethodTable() && pMT->GetParentMethodTable()->GetParentMethodTable())
+            {
                 static_cast<ClassTypeInfo*>(typeInfo)->m_parent =
                     GetTypeInfoFromTypeHandle(typeHandle.GetParent(), pTypeMap);
             }

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1453,9 +1453,17 @@ void ClassTypeInfo::DumpDebugInfo(char* ptr, int& offset)
         return;
     }
 
-    if (m_parent != nullptr && m_parent->m_type_offset == 0)
+    if (m_parent != nullptr)
     {
-        m_parent->DumpDebugInfo(ptr, offset);
+        if (m_parent->m_type_offset == 0)
+        {
+            m_parent->DumpDebugInfo(ptr, offset);
+        }
+        else if (RefTypeInfo* m_p = dynamic_cast<RefTypeInfo*>(m_parent))
+        {
+            if (m_p->m_value_type->m_type_offset == 0)
+                m_p->m_value_type->DumpDebugInfo(ptr, offset);
+        }
     }
 
     // make sure that types of all members are dumped

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -245,7 +245,7 @@ public:
 
     int m_num_members;
     TypeMember* members;
-    ClassTypeInfo* m_parent;
+    TypeInfoBase* m_parent;
 };
 
 class TypeMember: public DwarfDumpable

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -245,6 +245,7 @@ public:
 
     int m_num_members;
     TypeMember* members;
+    ClassTypeInfo* m_parent;
 };
 
 class TypeMember: public DwarfDumpable


### PR DESCRIPTION
This PR adds generation of DWARF information for base classes. Now lldb shows values for fields from base classes.
Sample code: 
```
using System;

public class Parent
{
    public short p1;
    public double p2;
}
public class Child1 : Parent
{
    public int a;
    public double f;
    public static int sch1;
}
public class Child2 : Parent
{
    public int b;
    public long l;
    public static int sch2;
}
public class TestProgram
{
    public static void Main()
    {
        Child1.sch1 = 2;
        Child2.sch2 = 12;
        Child1 ch1 = new Child1();
        Child2 ch2 = new Child2();
        ch1.a = -1;
        ch1.f = 1.5;
        ch1.p1 = -100;
        ch1.p2 = -5.5;
        ch2.b = 11;
        ch2.l = 22;
        ch2.p1 = 100;
        ch2.p2 = 5.5;
    }
}
```

Here is lldb output: 

```
$ CORECLR_GDBJIT='test-parents.exe' ~/FP/LLVM/release/bin/lldb -o "breakpoint set -m false -f test-parents.cs -l 40" -o "r" -o "fr v" ./corerun test-parents.exe
(lldb) target create "./corerun"
Current executable set to './corerun' (x86_64).
(lldb) settings set -- target.run-args  "test-parents.exe"
(lldb) breakpoint set -m false -f test-parents.cs -l 40
Breakpoint 1: no locations (pending).
WARNING:  Unable to resolve breakpoint to any actual locations.
(lldb) r
1 location added to breakpoint 1
Process 8544 stopped
* thread #1: tid = 8544, 0x00007fff7d7286b0 JIT(0x71cc20)`TestProgram::Main() + 240 at test-parents.cs:40, name = 'corerun', stop reason = breakpoint 1.1
    frame #0: 0x00007fff7d7286b0 JIT(0x71cc20)`TestProgram::Main() + 240 at test-parents.cs:40
   37  	        ch2.b = 11;
   38  	        ch2.l = 22;
   39  	        ch2.p1 = 100;
-> 40  	        ch2.p2 = 5.5;
   41  	    }
   42  	}

Process 8544 launched: './corerun' (x86_64)
(lldb) fr v
(Child1 *) ch1 = 0x00007fff60030338
(Child2 *) ch2 = 0x00007fff6003f6a8
(lldb) p *ch1
(Child1) $0 = {
  Parent = (p1 = -100, p2 = -5.5)
  a = -1
  f = 1.5
}
(lldb) p *ch2
(Child2) $1 = {
  Parent = (p1 = 100, p2 = 0)
  b = 11
  l = 22
}
(lldb) 
```
@mikem8361, @janvorli, PTAL

\CC: @Dmitri-Botcharnikov @chunseoklee @ayuckhulk 