### PR TITLE
[Ryujit/ARM32] Implement GT_INTRINSIC_Sqrt for floating point type

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -93,7 +93,8 @@ void CodeGen::genIntrinsic(GenTreePtr treeNode)
             break;
 
         case CORINFO_INTRINSIC_Sqrt:
-            NYI_ARM("genIntrinsic for sqrt - not implementd yet");
+            genConsumeOperands(treeNode->AsOp());
+            getEmitter()->emitInsBinary(INS_vsqrt, emitTypeSize(treeNode), treeNode, srcNode);
             break;
 
         default:

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -295,7 +295,14 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             // The src must be a register.
             regNumber operandReg = genConsumeReg(operand);
 
-            getEmitter()->emitIns_R_R_I(ins, emitTypeSize(treeNode), targetReg, operandReg, 0);
+            if (ins == INS_vneg)
+            {
+                getEmitter()->emitIns_R_R(ins, emitTypeSize(treeNode), targetReg, operandReg);
+            }
+            else
+            {
+                getEmitter()->emitIns_R_R_I(ins, emitTypeSize(treeNode), targetReg, operandReg, 0);
+            }
         }
             genProduceReg(treeNode);
             break;

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -882,11 +882,12 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             switch (tree->gtIntrinsic.gtIntrinsicId)
             {
                 case CORINFO_INTRINSIC_Abs:
+                case CORINFO_INTRINSIC_Sqrt:
                     info->srcCount = 1;
                     info->dstCount = 1;
                     break;
                 default:
-                    NYI_ARM("Lowering::TreeNodeInfoInit for GT_INRINSIC");
+                    NYI_ARM("Lowering::TreeNodeInfoInit for GT_INTRINSIC");
                     break;
             }
         }


### PR DESCRIPTION
Implement GT_INTRINSIC_Sqrt for floating point type

1. Implement GT_INTRINSIC_Sqrt for floating point.
   Generate same instruction (`vsqrt`) as in  legacy JIT.

2. Fix codegen for GT_NEG to handle floating point type correctly.

Five more tests are PASSED from `JIT/CodeGenBringUpTests/`.

This is part of "Enable RyuJIT Backend for ARM32" (issue #8496).

# Example
`JIT/CodeGenBringUpTests/FPRoots/`  with ryujit for ARM32.

## Before
`JIT/CodeGenBringUpTests/FPRoots/` is FAILED with ryujit for ARM32 due to assertion.

1. NYI assertion occurs for `GT_INTRINSIC` in `lowerarm.cpp`
```
FAILED   - [  59][  12s]JIT/CodeGenBringUpTests/FPRoots/FPRoots.sh
               BEGIN EXECUTION
               /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170124/corerun FPRoots.exe   

               Assert failure(PID 26526 [0x0000679e], Thread: 26526 [0x679e]): Assertion failed 'NYI_ARM: Lowering::TreeNodeInfoInit for GT_INRINSIC' in 'BringUpTest:FPRoots(float,float,float,byref,byref)' (IL size 83)

                   File: /home/hk0110/work/dxl/dotnet/github/hqueue/coreclr/src/jit/lowerarm.cpp Line: 889
                   Image: /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170124/corerun

               ./FPRoots.sh: line 130: 26526 Aborted                 (core dumped) $_DebuggerFullPath "$CORE_ROOT/corerun" FPRoots.exe $CLRTestExecutionArguments
               Expected: 100
               Actual: 134
               END EXECUTION - FAILED
```

2. After Implementing `GT_INTRINSIC_Sqrt`
A new assertion occurs at codegen for `GT_NET` of floating point type.

```
Assert failure(PID 3351 [0x00000d17], Thread: 3351 [0x0d17]): Assertion failed '!"Unexpected instruction"' in 'BringUpTest:FPRoots(float,float,float,byref,byref)' (IL size 83)

    File: /home/hk0110/work/dxl/dotnet/github/hqueue/coreclr/src/jit/emitarm.cpp Line: 2798
```

## After
After updating codegen for GT_NEG, `JIT/CodeGenBringUpTests/FPRoots/` is PASSED with ryujit for ARM32.

```
PASSED   - [  59][  14s]JIT/CodeGenBringUpTests/FPRoots/FPRoots.sh
               BEGIN EXECUTION
               /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170124working/corerun FPRoots.exe
               3
               2
               3,2
               Expected: 100
               Actual: 100
               END EXECUTION - PASSED
```

## Generated code
We can find `vsqrt` and `vneg` are generated correctly.

```
; Assembly listing for method BringUpTest:FPRoots(float,float,float,byref,byref)
; Emitting BLENDED_CODE for generic ARM CPU
; optimized code
; r11 based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T01] ( 11,  11  )   float  ->   f0        
;  V01 arg1         [V01,T00] ( 16,  16  )   float  ->   f1        
;  V02 arg2         [V02,T06] (  6,   6  )   float  ->   f2        
;  V03 arg3         [V03,T04] (  7,   7  )   byref  ->   r0        
;  V04 arg4         [V04,T05] (  7,   7  )   byref  ->   r4        
;# V05 OutArgs      [V05    ] (  1,   1  )  lclBlk ( 0) [sp+0x00]  
;  V06 cse0         [V06,T02] ( 12,  12  )   float  ->   f8        
;  V07 cse1         [V07,T03] (  9,   9  )   float  ->   f0        
;  V08 cse2         [V08,T07] (  6,   6  )   float  ->   f9        
;
; Lcl frame size = 4

G_M56409_IG01:
000000  E92D 4818      push    {r3,r4,r11,lr}
000004  F10D 0B08      add     r11, sp, 8
000008  460C           mov     r4, r1

G_M56409_IG02:
00000A  EE20 4AA0      vmul    s8, s1, s1
00000E  F04F 4381      mov     r3, 0x40800000
000012  EE04 3A90      vmov.i2f s9, r3
000016  EE60 4A24      vmul    s9, s0, s9
00001A  EE64 4A81      vmul    s9, s9, s2
00001E  EE34 4A64      vsub    s8, s8, s9
000022  EEB7 4AC4      vcvt.f2d d8, s8
000026  EEB1 4BC4      vsqrt   d8, d8
00002A  EEB7 4BC4      vcvt.d2f s8, d8
00002E  EEF1 4A60      vneg    s9, s1
000032  EE34 5A24      vadd    s10, s8, s9
000036  F04F 4380      mov     r3, 0x40000000
00003A  EE05 3A90      vmov.i2f s11, r3
00003E  EE20 0A25      vmul    s0, s0, s11
000042  EE85 5A00      vdiv    s10, s10, s0
000046  ED80 5A00      vstr    s10, [r0]
00004A  EE34 4AC4      vsub    s8, s9, s8
00004E  EE84 0A00      vdiv    s0, s8, s0
000052  ED84 0A00      vstr    s0, [r4]
000056  ED90 0A00      vldr    s0, [r0]
00005A  F245 13F5      movw    r3, 0x51f5
00005E  F2C7 13CA      movt    r3, 0x71ca
000062  4798           blx     r3               // System.Console:WriteLine(float)
000064  ED94 0A00      vldr    s0, [r4]
000068  F245 13F5      movw    r3, 0x51f5
00006C  F2C7 13CA      movt    r3, 0x71ca
000070  4798           blx     r3               // System.Console:WriteLine(float)

G_M56409_IG03:
000072  E8BD 8818      pop     {r3,r4,r11,pc}

; Total bytes of code 118, prolog size 8 for method BringUpTest:FPRoots(float,float,float,byref,byref)
```


# Summary with JIT/CodeGenBringUpTests
`JIT/CodeGenBringUpTests/` with `COMPlus_AltJit=BringUpTest:*`

## Before
```
=======================
     Test Results
=======================
# CoreCLR Bin Dir  :
# Tests Discovered : 139
# Passed           : 89
# Failed           : 50
# Skipped          : 0
=======================
```
## After
Following five more tests are PASSED.
-  JIT/CodeGenBringUpTests/FPArea/FPArea.exe
-  JIT/CodeGenBringUpTests/FPCall1/FPCall1.exe
-  JIT/CodeGenBringUpTests/FPDist/FPDist.exe
-  JIT/CodeGenBringUpTests/FPNeg/FPNeg.exe
-  JIT/CodeGenBringUpTests/FPRoots/FPRoots.exe

```
=======================
     Test Results
=======================
# CoreCLR Bin Dir  :
# Tests Discovered : 139
# Passed           : 94
# Failed           : 45
# Skipped          : 0
=======================
```