### PR TITLE
[RyuJIT/ARM32] EH, switch implementation and various updates

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -470,6 +470,9 @@ protected:
     void genSetPSPSym(regNumber initReg, bool* pInitRegZeroed);
 
     void genUpdateCurrentFunclet(BasicBlock* block);
+#if defined(_TARGET_ARM_)
+    void genInsertNopForUnwinder(BasicBlock* block);
+#endif
 
 #else // FEATURE_EH_FUNCLETS
 
@@ -478,6 +481,13 @@ protected:
     {
         return;
     }
+
+#if defined(_TARGET_ARM_)
+    void genInsertNopForUnwinder(BasicBlock* block)
+    {
+        return;
+    }
+#endif
 
 #endif // FEATURE_EH_FUNCLETS
 

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -375,6 +375,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         case GT_LSH:
         case GT_RSH:
         case GT_RSZ:
+        case GT_ROR:
             genCodeForShift(treeNode);
             // genCodeForShift() calls genProduceReg()
             break;
@@ -1197,6 +1198,9 @@ instruction CodeGen::genGetInsForOper(genTreeOps oper, var_types type)
             break;
         case GT_XOR:
             ins = INS_XOR;
+            break;
+        case GT_ROR:
+            ins = INS_ror;
             break;
         default:
             unreached();

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -78,14 +78,9 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     // jump target using bbJumpDest - that is already used to point
     // to the finally block. So just skip past the BBJ_ALWAYS unless the
     // block is RETLESS.
-    if (!(block->bbFlags & BBF_RETLESS_CALL))
-    {
-        assert(block->isBBCallAlwaysPair());
-
-        lblk  = block;
-        block = block->bbNext;
-    }
-    return block;
+    assert(!(block->bbFlags & BBF_RETLESS_CALL));
+    assert(block->isBBCallAlwaysPair());
+    return block->bbNext;
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1015,7 +1015,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         {
 #ifdef DEBUG
             char message[256];
-            _snprintf_s(message, _countof(message), _TRUNCATE, "NYI: Unimplemented node type %s\n",
+            _snprintf_s(message, _countof(message), _TRUNCATE, "NYI: Unimplemented node type %s",
                         GenTree::NodeName(treeNode->OperGet()));
             NYIRAW(message);
 #else

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2814,6 +2814,37 @@ void CodeGen::genUpdateCurrentFunclet(BasicBlock* block)
         }
     }
 }
+
+#if defined(_TARGET_ARM_)
+void CodeGen::genInsertNopForUnwinder(BasicBlock* block)
+{
+    // If this block is the target of a finally return, we need to add a preceding NOP, in the same EH region,
+    // so the unwinder doesn't get confused by our "movw lr, xxx; movt lr, xxx; b Lyyy" calling convention that
+    // calls the funclet during non-exceptional control flow.
+    if (block->bbFlags & BBF_FINALLY_TARGET)
+    {
+        assert(block->bbFlags & BBF_JMP_TARGET);
+
+#ifdef DEBUG
+        if (compiler->verbose)
+        {
+            printf("\nEmitting finally target NOP predecessor for BB%02u\n", block->bbNum);
+        }
+#endif
+        // Create a label that we'll use for computing the start of an EH region, if this block is
+        // at the beginning of such a region. If we used the existing bbEmitCookie as is for
+        // determining the EH regions, then this NOP would end up outside of the region, if this
+        // block starts an EH region. If we pointed the existing bbEmitCookie here, then the NOP
+        // would be executed, which we would prefer not to do.
+
+        block->bbUnwindNopEmitCookie =
+            getEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur);
+
+        instGen(INS_nop);
+    }
+}
+#endif
+
 #endif // FEATURE_EH_FUNCLETS
 
 /*****************************************************************************

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -12680,30 +12680,7 @@ void CodeGen::genCodeForBBlist()
 
 #if FEATURE_EH_FUNCLETS
 #if defined(_TARGET_ARM_)
-        // If this block is the target of a finally return, we need to add a preceding NOP, in the same EH region,
-        // so the unwinder doesn't get confused by our "movw lr, xxx; movt lr, xxx; b Lyyy" calling convention that
-        // calls the funclet during non-exceptional control flow.
-        if (block->bbFlags & BBF_FINALLY_TARGET)
-        {
-            assert(block->bbFlags & BBF_JMP_TARGET);
-
-#ifdef DEBUG
-            if (compiler->verbose)
-            {
-                printf("\nEmitting finally target NOP predecessor for BB%02u\n", block->bbNum);
-            }
-#endif
-            // Create a label that we'll use for computing the start of an EH region, if this block is
-            // at the beginning of such a region. If we used the existing bbEmitCookie as is for
-            // determining the EH regions, then this NOP would end up outside of the region, if this
-            // block starts an EH region. If we pointed the existing bbEmitCookie here, then the NOP
-            // would be executed, which we would prefer not to do.
-
-            block->bbUnwindNopEmitCookie =
-                getEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur);
-
-            instGen(INS_nop);
-        }
+        genInsertNopForUnwinder(block);
 #endif // defined(_TARGET_ARM_)
 
         genUpdateCurrentFunclet(block);

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -246,6 +246,10 @@ void CodeGen::genCodeForBBlist()
             }
         }
 
+#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
+        genInsertNopForUnwinder(block);
+#endif
+
         /* Start a new code output block */
 
         genUpdateCurrentFunclet(block);

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -109,6 +109,10 @@ bool emitInsIsLoad(instruction ins);
 bool emitInsIsStore(instruction ins);
 bool emitInsIsLoadOrStore(instruction ins);
 
+// Generate code for a load or store operation and handle the case
+// of contained GT_LEA op1 with [base + index<<scale + offset]
+void emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataReg, GenTreeIndir* indir);
+
 /*****************************************************************************
 *
 *  Convert between an index scale in bytes to a smaller encoding used for

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -2577,7 +2577,6 @@ AGAIN:
             inst_RV_IV(ins, reg, tree->gtIntCon.gtIconVal, emitActualTypeSize(tree->TypeGet()), flags);
             break;
 
-#if CPU_LONG_USES_REGPAIR
         case GT_CNS_LNG:
 
             assert(size == EA_4BYTE || size == EA_8BYTE);
@@ -2598,8 +2597,7 @@ AGAIN:
                 constVal = (ssize_t)(tree->gtLngCon.gtLconVal >> 32);
                 size     = EA_4BYTE;
             }
-#ifndef LEGACY_BACKEND
-#ifdef _TARGET_ARM_
+#if defined(_TARGET_ARM_) && CPU_LONG_USES_REGPAIR
             if ((ins != INS_mov) && !arm_Valid_Imm_For_Instr(ins, constVal, flags))
             {
                 regNumber constReg = (offs == 0) ? genRegPairLo(tree->gtRegPair) : genRegPairHi(tree->gtRegPair);
@@ -2607,12 +2605,10 @@ AGAIN:
                 getEmitter()->emitIns_R_R(ins, size, reg, constReg, flags);
                 break;
             }
-#endif // _TARGET_ARM_
-#endif // !LEGACY_BACKEND
+#endif // _TARGET_ARM_ && CPU_LONG_USES_REGPAIR
 
             inst_RV_IV(ins, reg, constVal, size, flags);
             break;
-#endif // CPU_LONG_USES_REGPAIR
 
         case GT_COMMA:
             tree = tree->gtOp.gtOp2;

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -2326,7 +2326,7 @@ void CodeGen::inst_RV_TT(instruction ins,
 #if CPU_LOAD_STORE_ARCH
     if (ins == INS_mov)
     {
-#if defined(_TARGET_ARM_)
+#if defined(_TARGET_ARM_) && CPU_LONG_USES_REGPAIR
         if (tree->TypeGet() != TYP_LONG)
         {
             ins = ins_Move_Extend(tree->TypeGet(), (tree->gtFlags & GTF_REG_VAL) != 0);
@@ -2341,7 +2341,7 @@ void CodeGen::inst_RV_TT(instruction ins,
             ins = ins_Move_Extend(TYP_INT,
                                   (tree->gtFlags & GTF_REG_VAL) != 0 && genRegPairHi(tree->gtRegPair) != REG_STK);
         }
-#elif defined(_TARGET_ARM64_)
+#elif defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
         ins = ins_Move_Extend(tree->TypeGet(), (tree->gtFlags & GTF_REG_VAL) != 0);
 #else
         NYI("CodeGen::inst_RV_TT with INS_mov");
@@ -2485,9 +2485,11 @@ AGAIN:
                 default:
                     regNumber regTmp;
 #ifndef LEGACY_BACKEND
+#if CPU_LONG_USES_REGPAIR
                     if (tree->TypeGet() == TYP_LONG)
                         regTmp = (offs == 0) ? genRegPairLo(tree->gtRegPair) : genRegPairHi(tree->gtRegPair);
                     else
+#endif // CPU_LONG_USES_REGPAIR
                         regTmp = tree->gtRegNum;
 #else  // LEGACY_BACKEND
                     if (varTypeIsFloating(tree))
@@ -2575,6 +2577,7 @@ AGAIN:
             inst_RV_IV(ins, reg, tree->gtIntCon.gtIconVal, emitActualTypeSize(tree->TypeGet()), flags);
             break;
 
+#if CPU_LONG_USES_REGPAIR
         case GT_CNS_LNG:
 
             assert(size == EA_4BYTE || size == EA_8BYTE);
@@ -2609,6 +2612,7 @@ AGAIN:
 
             inst_RV_IV(ins, reg, constVal, size, flags);
             break;
+#endif // CPU_LONG_USES_REGPAIR
 
         case GT_COMMA:
             tree = tree->gtOp.gtOp2;

--- a/src/jit/jiteh.cpp
+++ b/src/jit/jiteh.cpp
@@ -1075,7 +1075,7 @@ void* Compiler::ehEmitCookie(BasicBlock* block)
 
     void* cookie;
 
-#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
+#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_) && defined(LEGACY_BACKEND)
     if (block->bbFlags & BBF_FINALLY_TARGET)
     {
         // Use the offset of the beginning of the NOP padding, not the main block.

--- a/src/jit/jiteh.cpp
+++ b/src/jit/jiteh.cpp
@@ -1075,7 +1075,7 @@ void* Compiler::ehEmitCookie(BasicBlock* block)
 
     void* cookie;
 
-#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_) && defined(LEGACY_BACKEND)
+#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
     if (block->bbFlags & BBF_FINALLY_TARGET)
     {
         // Use the offset of the beginning of the NOP padding, not the main block.

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1187,9 +1187,6 @@ void Lowering::LowerCall(GenTree* node)
 
     LowerArgsForCall(call);
 
-// RyuJIT arm is not set up for lowered call control
-#ifndef _TARGET_ARM_
-
     // note that everything generated from this point on runs AFTER the outgoing args are placed
     GenTree* result = nullptr;
 
@@ -1294,7 +1291,6 @@ void Lowering::LowerCall(GenTree* node)
 
         call->gtControlExpr = result;
     }
-#endif //!_TARGET_ARM_
 
     if (comp->opts.IsJit64Compat())
     {

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -595,6 +595,11 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
     {
         NYI_ARM("float reg varargs");
     }
+
+    if (call->NeedsNullCheck())
+    {
+        info->internalIntCount++;
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -912,6 +912,12 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             }
             break;
 
+        case GT_ARR_BOUNDS_CHECK:
+            // Consumes arrLen and index. Has no result.
+            info->srcCount = 2;
+            info->dstCount = 0;
+            break;
+
         case GT_LEA:
         {
             GenTreeAddrMode* lea = tree->AsAddrMode();

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -1049,7 +1049,14 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             break;
 
         default:
+#ifdef DEBUG
+            char message[256];
+            _snprintf_s(message, _countof(message), _TRUNCATE, "NYI: Unimplemented node type %s",
+                        GenTree::NodeName(tree->OperGet()));
+            NYIRAW(message);
+#else
             NYI_ARM("TreeNodeInfoInit default case");
+#endif
         case GT_LCL_FLD:
         case GT_LCL_FLD_ADDR:
         case GT_LCL_VAR:

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -944,13 +944,17 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             }
             info->dstCount = 1;
 
+            // On ARM we may need a single internal register
+            // (when both conditions are true then we still only need a single internal register)
             if ((index != nullptr) && (cns != 0))
             {
-                NYI_ARM("GT_LEA: index and cns are not nil");
+                // ARM does not support both Index and offset so we need an internal register
+                info->internalIntCount = 1;
             }
             else if (!emitter::emitIns_valid_imm_for_add(cns, INS_FLAGS_DONT_CARE))
             {
-                NYI_ARM("GT_LEA: invalid imm");
+                // This offset can't be contained in the add instruction, so we need an internal register
+                info->internalIntCount = 1;
             }
         }
         break;

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -1051,6 +1051,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         default:
             NYI_ARM("TreeNodeInfoInit default case");
         case GT_LCL_FLD:
+        case GT_LCL_FLD_ADDR:
         case GT_LCL_VAR:
         case GT_LCL_VAR_ADDR:
         {
@@ -1059,6 +1060,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             NYI_IF(varTypeIsStruct(varDsc), "lowering struct var");
             NYI_IF(varTypeIsLong(varDsc), "lowering long var");
         }
+        case GT_PHYSREG:
         case GT_CLS_VAR_ADDR:
         case GT_IL_OFFSET:
         case GT_CNS_INT:

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -695,6 +695,10 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
     JITDUMP("TreeNodeInfoInit for: ");
     DISPNODE(tree);
 
+    NYI_IF(tree->TypeGet() == TYP_STRUCT, "lowering struct");
+    NYI_IF(tree->TypeGet() == TYP_LONG, "lowering long");
+    NYI_IF(tree->TypeGet() == TYP_DOUBLE, "lowering double");
+
     switch (tree->OperGet())
     {
         GenTree* op1;
@@ -1041,13 +1045,16 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             break;
 
         default:
-#ifdef DEBUG
-            JitTls::GetCompiler()->gtDispTree(tree);
-#endif
             NYI_ARM("TreeNodeInfoInit default case");
         case GT_LCL_FLD:
         case GT_LCL_VAR:
         case GT_LCL_VAR_ADDR:
+        {
+            unsigned   varNum = tree->gtLclVarCommon.gtLclNum;
+            LclVarDsc* varDsc = comp->lvaTable + varNum;
+            NYI_IF(varTypeIsStruct(varDsc), "lowering struct var");
+            NYI_IF(varTypeIsLong(varDsc), "lowering long var");
+        }
         case GT_CLS_VAR_ADDR:
         case GT_IL_OFFSET:
         case GT_CNS_INT:

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -271,6 +271,7 @@ void Lowering::TreeNodeInfoInitIndir(GenTreePtr indirTree)
     if (index != nullptr && !modifiedSources)
     {
         info->srcCount++;
+        info->internalIntCount++;
     }
 }
 

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1182,7 +1182,11 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   // TODO-ARM-CQ: Check for sdiv/udiv at runtime and generate it if available
   #define USE_HELPERS_FOR_INT_DIV  1       // BeagleBoard (ARMv7A) doesn't support SDIV/UDIV
   #define CPU_LOAD_STORE_ARCH      1
+#ifdef LEGACY_BACKEND
   #define CPU_LONG_USES_REGPAIR    1
+#else
+  #define CPU_LONG_USES_REGPAIR    0
+#endif
   #define CPU_HAS_FP_SUPPORT       1
   #define ROUND_FLOAT              0       // Do not round intermed float expression results
   #define CPU_HAS_BYTE_REGS        0
@@ -1424,6 +1428,10 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_INTRET               RBM_R0
   #define REG_LNGRET               REG_PAIR_R0R1
   #define RBM_LNGRET              (RBM_R1|RBM_R0)
+  #define REG_LNGRET_LO            REG_R0
+  #define REG_LNGRET_HI            REG_R1
+  #define RBM_LNGRET_LO            RBM_R0
+  #define RBM_LNGRET_HI            RBM_R1
 
   #define REG_FLOATRET             REG_F0
   #define RBM_FLOATRET             RBM_F0


### PR DESCRIPTION
This pull request enables `JIT/Methodical/eh` tests. They are now mostly (396 out of 403) passing with the option:
```
COMPlus_AltJit="Class1:* a:* test:* Foo:* Test:* main"
```
(This list basically describes all the proper methods inside the tests.)

Out of the 7 failing tests, 5 tests assert on NYI lowering of block stores, and 2 tests fail the same way as with the legacy backend:
```
...
FAIL badcodeafterfinally_d.exe
Unhandled Exception: System.InvalidProgramException: Common Language Runtime detected an invalid program.
   at Test.GetObj()
   at Test.Main()
FAIL badcodeafterfinally_r.exe
```

(This issue is a part of #8496.)