### PR TITLE
Fix arm64 build break

### DIFF
--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -8,7 +8,7 @@
 
 #ifdef DEBUG_REGDISPLAY
 class Thread;
-
+struct REGDISPLAY;
 void CheckRegDisplaySP (REGDISPLAY *pRD);
 #endif // DEBUG_REGDISPLAY
 


### PR DESCRIPTION
Fix arm64 build break caused by commit https://github.com/dotnet/coreclr/commit/285c9f3002627135a8a152fea8ef97c93c8a27e0#diff-0a77138fa545bcae1099ae8734fea0f1