### PR TITLE
Improve CompareOrdinalIgnoreCaseHelper performance for matching chars

### DIFF
--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -29,28 +29,35 @@ namespace System
             {
                 char* a = ap;
                 char* b = bp;
+                int charA;
+                int charB;
 
                 while (length != 0) 
                 {
-                    int charA = *a;
-                    int charB = *b;
+                    charA = *a;
+                    charB = *b;
 
                     Debug.Assert((charA | charB) <= 0x7F, "strings have to be ASCII");
 
-                    // uppercase both chars - notice that we need just one compare per char
-                    if ((uint)(charA - 'a') <= (uint)('z' - 'a')) charA -= 0x20;
-                    if ((uint)(charB - 'a') <= (uint)('z' - 'a')) charB -= 0x20;
-
-                    //Return the (case-insensitive) difference between them.
-                    if (charA != charB)
-                        return charA - charB;
-
-                    // Next char
-                    a++; b++;
-                    length--;
+                    // Ordinal equals or lowercase equals if the result ends up in the a-z range
+                    if (charA == charB ||
+                       ((charA | 0x20) == (charB | 0x20) &&
+                          (uint)((charA | 0x20) - 'a') <= (uint)('z' - 'a')))
+                    {
+                        a++;
+                        b++;
+                        length--;
+                    }
+                    else
+                    {
+                        goto ReturnDiff;
+                    }
                 }
 
                 return strA.Length - strB.Length;
+
+                ReturnDiff:
+                return charA - charB;
             }
         }
 


### PR DESCRIPTION
Case insensitive equality was found to be a bit of a hot spot in Kestrel recently. This PR looks at the ASCII comparison portion of string.Equals(string, string, StringComparison.OrdinalIgnoreCase).

These changes improve the situation where the two strings have mostly the same casing. Also provides greater consistency for uppercase values.

The return value is no longer the case-insensitive difference. For Equals this is not important. The other caller is Compare(string, string, StringComparison.OrdinalIgnoreCase) which returns less-than-zero, zero, or greater-than-zero. I double checked the MSDN docs and statement "The return value is the result of the last comparison performed" is a little unclear.

**Isolated perf results**
https://gist.github.com/bbowyersmyth/c970da26f3ffe560c52f88f11b566761

Both strings uppercase and equal

|                       Method | length |        Mean |    StdDev |
|----------------------------- |------- |------------ |---------- |
|   CompareOrdinalIgnoreCaseOld |      1 |   3.6167 ns | 0.1174 ns |
|CompareOrdinalIgnoreCaseNew |      1 |   2.1271 ns | 0.0134 ns |
|   CompareOrdinalIgnoreCaseOld |      5 |  10.9638 ns | 0.0676 ns |
|CompareOrdinalIgnoreCaseNew |      5 |   4.9523 ns | 0.0268 ns |
|   CompareOrdinalIgnoreCaseOld |     12 |  23.1462 ns | 0.1087 ns |
|CompareOrdinalIgnoreCaseNew |     12 |   8.8905 ns | 0.0323 ns |
|   CompareOrdinalIgnoreCaseOld |     50 |  82.5768 ns | 0.5873 ns |
|CompareOrdinalIgnoreCaseNew |     50 |  38.4832 ns | 0.1216 ns |
|   CompareOrdinalIgnoreCaseOld |    100 | 150.9390 ns | 1.7287 ns |
| CompareOrdinalIgnoreCaseNew |    100 |  65.7698 ns | 1.4723 ns |

Both strings lowercase and equal

|                       Method | length |        Mean |    StdDev |
|----------------------------- |------- |------------ |---------- |
|   CompareOrdinalIgnoreCaseOld |      1 |   2.9886 ns | 0.0095 ns |
|CompareOrdinalIgnoreCaseNew |      1 |   2.1560 ns | 0.0116 ns |
|   CompareOrdinalIgnoreCaseOld |      5 |   8.2860 ns | 0.0216 ns |
|CompareOrdinalIgnoreCaseNew |      5 |   4.9110 ns | 0.0239 ns |
|   CompareOrdinalIgnoreCaseOld |     12 |  17.6475 ns | 0.2873 ns |
|CompareOrdinalIgnoreCaseNew |     12 |   8.8646 ns | 0.0448 ns |
|   CompareOrdinalIgnoreCaseOld |     50 |  60.6212 ns | 0.3223 ns |
|CompareOrdinalIgnoreCaseNew |     50 |  38.4926 ns | 0.0776 ns |
|   CompareOrdinalIgnoreCaseOld |    100 | 107.7771 ns | 2.5784 ns |
|CompareOrdinalIgnoreCaseNew |    100 |  66.5882 ns | 0.1470 ns |

String A uppercase, string B lowercase and insensitive equal

|                       Method | length |        Mean |    StdDev |
|----------------------------- |------- |------------ |---------- |
|   CompareOrdinalIgnoreCaseOld |      1 |   3.1110 ns | 0.0904 ns |
|CompareOrdinalIgnoreCaseNew |      1 |   2.4069 ns | 0.0764 ns |
|   CompareOrdinalIgnoreCaseOld |      5 |   7.7163 ns | 0.0732 ns |
|CompareOrdinalIgnoreCaseNew |      5 |   5.5804 ns | 0.2073 ns |
|   CompareOrdinalIgnoreCaseOld |     12 |  15.7974 ns | 0.4283 ns |
|CompareOrdinalIgnoreCaseNew |     12 |  12.3610 ns | 0.2782 ns |
|   CompareOrdinalIgnoreCaseOld |     50 |  60.1847 ns | 0.8217 ns |
|CompareOrdinalIgnoreCaseNew |     50 |  54.3583 ns | 0.7680 ns |
|   CompareOrdinalIgnoreCaseOld |    100 | 106.0032 ns | 1.3267 ns |
|CompareOrdinalIgnoreCaseNew |    100 |  99.1902 ns | 0.9223 ns |

String A lowercase, string B uppercase and insensitive equal

|                       Method | length |        Mean |    StdDev |
|----------------------------- |------- |------------ |---------- |
|   CompareOrdinalIgnoreCaseOld |      1 |   3.1358 ns | 0.0262 ns |
|CompareOrdinalIgnoreCaseNew |      1 |   2.2707 ns | 0.0176 ns |
|   CompareOrdinalIgnoreCaseOld |      5 |   8.7510 ns | 0.0332 ns |
|CompareOrdinalIgnoreCaseNew |      5 |   6.7003 ns | 0.1086 ns |
|   CompareOrdinalIgnoreCaseOld |     12 |  16.5851 ns | 0.0825 ns |
|CompareOrdinalIgnoreCaseNew |     12 |  12.3526 ns | 0.0272 ns |
|   CompareOrdinalIgnoreCaseOld |     50 |  59.9519 ns | 1.3253 ns |
|CompareOrdinalIgnoreCaseNew |     50 |  57.6248 ns | 0.2695 ns |
|   CompareOrdinalIgnoreCaseOld |    100 | 113.8013 ns | 0.4595 ns |
|CompareOrdinalIgnoreCaseNew |    100 | 107.0028 ns | 0.2336 ns |
