### PR TITLE
Update isUsedFromMemory to include CNS_DBLs

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -590,7 +590,8 @@ public:
 
     bool isUsedFromMemory() const
     {
-        return ((isContained() && (isMemoryOp() || (OperGet() == GT_LCL_VAR))) || isUsedFromSpillTemp());
+        return ((isContained() && (isMemoryOp() || (OperGet() == GT_LCL_VAR) || (OperGet() == GT_CNS_DBL))) ||
+                isUsedFromSpillTemp());
     }
 
     bool isLclVarUsedFromMemory() const

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_370233/DevDiv_370233.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_370233/DevDiv_370233.il
@@ -1,0 +1,136 @@
+.assembly extern mscorlib{}
+.assembly DevDiv_370233{}
+.class C extends [mscorlib]System.Object
+{
+   .method static unsigned int32 M(bool, bool)
+   {
+      .maxstack  65535
+      .locals init (unsigned int32, unsigned int64, unsigned int8, unsigned int8, native int, float64, char, unsigned int16, bool, char, bool)
+
+      ldloc 0x0006
+      ldc.i4 0x11467af6
+      shr
+      conv.ovf.u8
+      dup
+      sub
+      ldloc.s 0x06
+      ldloc.s 0x07
+      neg
+      rem.un
+      conv.ovf.i8.un
+      xor
+      neg
+      conv.ovf.u
+      conv.r4
+      ldloc 0x0005
+      ldloc.s 0x05
+      ckfinite
+      ckfinite
+      conv.r4
+      ceq
+      ldarg 0x0001
+      conv.r4
+      pop
+      pop
+      ldloc 0x0001
+      ldloc 0x0001
+      neg
+      conv.i8
+      ldloc.s 0x04
+      shr
+      clt.un
+      conv.ovf.i1.un
+      conv.i8
+      not
+      nop
+      ldc.i8 0x16cb54ea7cfcd50d
+      ldloc 0x0001
+      clt
+      ldloc.s 0x01
+      conv.ovf.u1
+      conv.ovf.i2.un
+      cgt
+      conv.ovf.i8
+      ldc.i8 0x6be45c7b8c08f1d5
+      conv.ovf.u8
+      ldloc.s 0x01
+      add.ovf
+      not
+      ldloc.s 0x03
+      shr.un
+      ldloc.s 0x01
+      add
+      not
+      ldloc.s 0x03
+      neg
+      shr
+      nop
+      conv.u4
+      neg
+      shr.un
+      ceq
+      ldloc 0x0001
+      conv.r4
+      ldc.r8 float64(0x9b4c7410aec1e6d3)
+      add
+      ldloc.s 0x00
+      ldarg.s 0x00
+      xor
+      ldloc.s 0x08
+      mul
+      not
+      conv.r.un
+      ldloc.s 0x02
+      ldloc 0x0006
+      add
+      conv.r4
+      mul
+      cgt
+      ldloc.s 0x05
+      ldloc.s 0x05
+      cgt.un
+      ldarg 0x0001
+      not
+      shl
+      div
+      ldc.i8 0x5892c0a0bd150d05
+      ldc.i8 0x8c33eb17e67e9772
+      neg
+      ceq
+      not
+      ldloc.s 0x00
+      ldloc 0x0003
+      ceq
+      or
+      pop
+      xor
+      conv.r.un
+      ceq
+      conv.u2
+      ret
+   }
+
+   .method static int32 Main() cil managed
+   {
+       .entrypoint
+
+       .try
+       {
+           ldc.i4     0
+           ldc.i4.s   0
+           call unsigned int32 C::M(bool, bool)
+           pop
+           leave.s done
+       }
+       catch [mscorlib]System.Exception
+       {
+           pop
+           leave.s done
+       }
+
+   done:
+       ldc.i4 100
+       ret
+   }
+}
+// Dumped 1

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_370233/DevDiv_370233.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_370233/DevDiv_370233.ilproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_370233.il" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_JitStressRegs=0x200
+]]></CLRTestBatchPreCommands>
+  <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_JitStressRegs=0x200
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Contained GT_CNS_DBLs should also be considered as isUsedFromMemory.

Fixes VSO 370233.