### PR TITLE
[GDB-JIT][Linux] Fix incorrect DWARF offset for types with typedef

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1021,8 +1021,10 @@ void ByteTypeInfo::DumpStrings(char* ptr, int& offset)
 void ByteTypeInfo::DumpDebugInfo(char *ptr, int &offset)
 {
     m_typedef_info->DumpDebugInfo(ptr, offset);
-    m_type_offset = m_typedef_info->m_typedef_type_offset;
     PrimitiveTypeInfo::DumpDebugInfo(ptr, offset);
+    // Replace offset from real type to typedef
+    if (ptr != nullptr)
+        m_type_offset = m_typedef_info->m_typedef_type_offset;
 }
 
 void PrimitiveTypeInfo::DumpDebugInfo(char* ptr, int& offset)


### PR DESCRIPTION
 This PR fixes incorrect DWARF offset for primitive types with typedef node (char, byte and sbyte).
@janvorli, @mikem8361 PTAL
\CC: @Dmitri-Botcharnikov @chunseoklee @ayuckhulk 