### PR TITLE
Reduce number of branches and IL size of string.Trim/TrimEnd/TrimStart methods

### DIFF
--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -1556,7 +1556,7 @@ namespace System
             {
                 return TrimWhiteSpaceHelper(TrimType.Both);
             }
-            fixed (char* pTrimChars = trimChars)
+            fixed (char* pTrimChars = &trimChars[0])
             {
                 return TrimHelper(pTrimChars, trimChars.Length, TrimType.Both);
             }
@@ -1575,7 +1575,7 @@ namespace System
             {
                 return TrimWhiteSpaceHelper(TrimType.Head);
             }
-            fixed (char* pTrimChars = trimChars)
+            fixed (char* pTrimChars = &trimChars[0])
             {
                 return TrimHelper(pTrimChars, trimChars.Length, TrimType.Head);
             }
@@ -1594,7 +1594,7 @@ namespace System
             {
                 return TrimWhiteSpaceHelper(TrimType.Tail);
             }
-            fixed (char* pTrimChars = trimChars)
+            fixed (char* pTrimChars = &trimChars[0])
             {
                 return TrimHelper(pTrimChars, trimChars.Length, TrimType.Tail);
             }


### PR DESCRIPTION
At the point where we use `fixed`, we already know the `char[]` is not null or empty, so we can reduce the number of branches and overall size of the method body by using the address of the first element. Based on the discussion here: https://github.com/dotnet/corefx/pull/15432#discussion_r97684916

cc: @stephentoub, @jkotas