### PR TITLE
Fix `Span<T>` GCStress issue on x86

### DIFF
--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -10227,6 +10227,14 @@ void MethodTableBuilder::CheckForSystemTypes()
         if (GetCl() == g_pByReferenceClass->GetCl())
         {
             pMT->SetIsByRefLike();
+#ifdef _TARGET_X86_
+            // x86 by default treats the type of ByReference<T> as the actual type of its IntPtr field, see calls to
+            // ComputeInternalCorElementTypeForValueType in this file. This is a special case where the struct needs to be
+            // treated as a value type so that its field can be considered as a by-ref pointer.
+            _ASSERTE(pMT->GetFlag(MethodTable::enum_flag_Category_Mask) == MethodTable::enum_flag_Category_PrimitiveValueType);
+            pMT->ClearFlag(MethodTable::enum_flag_Category_Mask);
+            pMT->SetInternalCorElementType(ELEMENT_TYPE_VALUETYPE);
+#endif
             return;
         }
 #endif
@@ -10289,6 +10297,14 @@ void MethodTableBuilder::CheckForSystemTypes()
         else if (strcmp(name, g_ByReferenceName) == 0)
         {
             pMT->SetIsByRefLike();
+#ifdef _TARGET_X86_
+            // x86 by default treats the type of ByReference<T> as the actual type of its IntPtr field, see calls to
+            // ComputeInternalCorElementTypeForValueType in this file. This is a special case where the struct needs to be
+            // treated as a value type so that its field can be considered as a by-ref pointer.
+            _ASSERTE(pMT->GetFlag(MethodTable::enum_flag_Category_Mask) == MethodTable::enum_flag_Category_PrimitiveValueType);
+            pMT->ClearFlag(MethodTable::enum_flag_Category_Mask);
+            pMT->SetInternalCorElementType(ELEMENT_TYPE_VALUETYPE);
+#endif
         }
 #endif
         else if (strcmp(name, g_ArgIteratorName) == 0)


### PR DESCRIPTION
x86 by default treats the type of `ByReference<T>` as the actual type of its IntPtr field as an optimization. `ByReference<T>` is a special case where the struct needs to be treated as a value type so that its field can be considered as a by-ref pointer. This fixes `GCStress=f` issues on span tests on x86.