### PR TITLE
Fix CoreFX Binary copying in netci.groovy

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2855,8 +2855,9 @@ combinedScenarios.each { scenario ->
                                     }
                                 }
                         
+                                shell ("mkdir ./bin/CoreFxBinDir")
                                 // Unpack the corefx binaries
-                                shell("tar -xf ./bin/build.tar.gz")
+                                shell("tar -xf ./bin/build.tar.gz -C ./bin/CoreFxBinDir")
 
                                 // Unzip the tests first.  Exit with 0
                                 shell("unzip -q -o ./bin/tests/tests.zip -d ./bin/tests/Windows_NT.${architecture}.${configuration} || exit 0")
@@ -2880,7 +2881,7 @@ combinedScenarios.each { scenario ->
                 --testNativeBinDir=\"\${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
                 --coreClrBinDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --mscorlibDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
-                --coreFxBinDir=\"\$(pwd)/fx/bin/runtime/netcoreapp-${osGroup}-Release-${architecture}\" \\
+                --coreFxBinDir=\"\${WORKSPACE}/bin/CoreFxBinDir\" \\
                 --limitedDumpGeneration \\
                 ${testEnvOpt} ${serverGCString} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${sequentialString} ${playlistString}""")
                             }


### PR DESCRIPTION
CoreFX no longer archives their binaries from the root bin folder, but rather just packages up everything in bin/runtime/netcoreapp-{OS}-{Config}-{Arch} into build.tar.gz. This should pick up binaries from the right place now.