### PR TITLE
[x86/Linux] Do NOT use pXXX fields

### DIFF
--- a/src/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/debug/daccess/dacdbiimplstackwalk.cpp
@@ -1156,13 +1156,13 @@ void DacDbiInterfaceImpl::UpdateContextFromRegDisp(REGDISPLAY * pRegDisp,
     // Do a partial copy first.
     pContext->ContextFlags = (CONTEXT_INTEGER | CONTEXT_CONTROL);
 
-    pContext->Edi = *pRegDisp->pEdi;
-    pContext->Esi = *pRegDisp->pEsi;
-    pContext->Ebx = *pRegDisp->pEbx;
-    pContext->Ebp = *pRegDisp->pEbp;
-    pContext->Eax = *pRegDisp->pEax;
-    pContext->Ecx = *pRegDisp->pEcx;
-    pContext->Edx = *pRegDisp->pEdx;
+    pContext->Edi = pRegDisp->ReadEdi();
+    pContext->Esi = pRegDisp->ReadEsi();
+    pContext->Ebx = pRegDisp->ReadEbx();
+    pContext->Ebp = pRegDisp->ReadEbp();
+    pContext->Eax = pRegDisp->ReadEax();
+    pContext->Ecx = pRegDisp->ReadEcx();
+    pContext->Edx = pRegDisp->ReadEdx();
     pContext->Esp = pRegDisp->SP;
     pContext->Eip = pRegDisp->ControlPC;
 

--- a/src/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/debug/daccess/dacdbiimplstackwalk.cpp
@@ -1156,13 +1156,13 @@ void DacDbiInterfaceImpl::UpdateContextFromRegDisp(REGDISPLAY * pRegDisp,
     // Do a partial copy first.
     pContext->ContextFlags = (CONTEXT_INTEGER | CONTEXT_CONTROL);
 
-    pContext->Edi = pRegDisp->ReadEdi();
-    pContext->Esi = pRegDisp->ReadEsi();
-    pContext->Ebx = pRegDisp->ReadEbx();
-    pContext->Ebp = pRegDisp->ReadEbp();
-    pContext->Eax = pRegDisp->ReadEax();
-    pContext->Ecx = pRegDisp->ReadEcx();
-    pContext->Edx = pRegDisp->ReadEdx();
+    pContext->Edi = *pRegDisp->GetEdiLocation();
+    pContext->Esi = *pRegDisp->GetEsiLocation();
+    pContext->Ebx = *pRegDisp->GetEbxLocation();
+    pContext->Ebp = *pRegDisp->GetEbpLocation();
+    pContext->Eax = *pRegDisp->GetEaxLocation();
+    pContext->Ecx = *pRegDisp->GetEcxLocation();
+    pContext->Edx = *pRegDisp->GetEdxLocation();
     pContext->Esp = pRegDisp->SP;
     pContext->Eip = pRegDisp->ControlPC;
 

--- a/src/debug/ee/debugger.inl
+++ b/src/debug/ee/debugger.inl
@@ -235,13 +235,13 @@ inline void FuncEvalFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     // Update all registers in the reg display from the CONTEXT we stored when the thread was hijacked for this func
     // eval. We have to update all registers, not just the callee saved registers, because we can hijack a thread at any
     // point for a func eval, not just at a call site.
-    pRD->RestoreEdi(&(pDE->m_context.Edi));
-    pRD->RestoreEsi(&(pDE->m_context.Esi));
-    pRD->RestoreEbx(&(pDE->m_context.Ebx));
-    pRD->RestoreEdx(&(pDE->m_context.Edx));
-    pRD->RestoreEcx(&(pDE->m_context.Ecx));
-    pRD->RestoreEax(&(pDE->m_context.Eax));
-    pRD->RestoreEbp(&(pDE->m_context.Ebp));
+    pRD->SetEdiLocation(&(pDE->m_context.Edi));
+    pRD->SetEsiLocation(&(pDE->m_context.Esi));
+    pRD->SetEbxLocation(&(pDE->m_context.Ebx));
+    pRD->SetEdxLocation(&(pDE->m_context.Edx));
+    pRD->SetEcxLocation(&(pDE->m_context.Ecx));
+    pRD->SetEaxLocation(&(pDE->m_context.Eax));
+    pRD->SetEbpLocation(&(pDE->m_context.Ebp));
     pRD->SP   = (DWORD)GetSP(&pDE->m_context);
     pRD->PCTAddr = GetReturnAddressPtr();
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);

--- a/src/debug/ee/debugger.inl
+++ b/src/debug/ee/debugger.inl
@@ -235,13 +235,13 @@ inline void FuncEvalFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     // Update all registers in the reg display from the CONTEXT we stored when the thread was hijacked for this func
     // eval. We have to update all registers, not just the callee saved registers, because we can hijack a thread at any
     // point for a func eval, not just at a call site.
-    pRD->pEdi = &(pDE->m_context.Edi);
-    pRD->pEsi = &(pDE->m_context.Esi);
-    pRD->pEbx = &(pDE->m_context.Ebx);
-    pRD->pEdx = &(pDE->m_context.Edx);
-    pRD->pEcx = &(pDE->m_context.Ecx);
-    pRD->pEax = &(pDE->m_context.Eax);
-    pRD->pEbp = &(pDE->m_context.Ebp);
+    pRD->RestoreEdi(&(pDE->m_context.Edi));
+    pRD->RestoreEsi(&(pDE->m_context.Esi));
+    pRD->RestoreEbx(&(pDE->m_context.Ebx));
+    pRD->RestoreEdx(&(pDE->m_context.Edx));
+    pRD->RestoreEcx(&(pDE->m_context.Ecx));
+    pRD->RestoreEax(&(pDE->m_context.Eax));
+    pRD->RestoreEbp(&(pDE->m_context.Ebp));
     pRD->SP   = (DWORD)GetSP(&pDE->m_context);
     pRD->PCTAddr = GetReturnAddressPtr();
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);

--- a/src/debug/ee/i386/x86walker.cpp
+++ b/src/debug/ee/i386/x86walker.cpp
@@ -292,28 +292,28 @@ DWORD NativeWalker::GetRegisterValue(int registerNumber)
     switch (registerNumber)
     {
     case 0:
-        return m_registers->ReadEax();
+        return *m_registers->GetEaxLocation();
         break;
     case 1:
-        return m_registers->ReadEcx();
+        return *m_registers->GetEcxLocation();
         break;
     case 2:
-        return m_registers->ReadEdx();
+        return *m_registers->GetEdxLocation();
         break;
     case 3:
-        return m_registers->ReadEbx();
+        return *m_registers->GetEbxLocation();
         break;
     case 4:
         return m_registers->SP;
         break;
     case 5:
-        return m_registers->ReadEbp();
+        return *m_registers->GetEbpLocation();
         break;
     case 6:
-        return m_registers->ReadEsi();
+        return *m_registers->GetEsiLocation();
         break;
     case 7:
-        return m_registers->ReadEdi();
+        return *m_registers->GetEdiLocation();
         break;
     default:
         _ASSERTE(!"Invalid register number!");

--- a/src/debug/ee/i386/x86walker.cpp
+++ b/src/debug/ee/i386/x86walker.cpp
@@ -292,28 +292,28 @@ DWORD NativeWalker::GetRegisterValue(int registerNumber)
     switch (registerNumber)
     {
     case 0:
-        return *m_registers->pEax;
+        return m_registers->ReadEax();
         break;
     case 1:
-        return *m_registers->pEcx;
+        return m_registers->ReadEcx();
         break;
     case 2:
-        return *m_registers->pEdx;
+        return m_registers->ReadEdx();
         break;
     case 3:
-        return *m_registers->pEbx;
+        return m_registers->ReadEbx();
         break;
     case 4:
         return m_registers->SP;
         break;
     case 5:
-        return *m_registers->pEbp;
+        return m_registers->ReadEbp();
         break;
     case 6:
-        return *m_registers->pEsi;
+        return m_registers->ReadEsi();
         break;
     case 7:
-        return *m_registers->pEdi;
+        return m_registers->ReadEdi();
         break;
     default:
         _ASSERTE(!"Invalid register number!");

--- a/src/debug/shared/i386/primitives.cpp
+++ b/src/debug/shared/i386/primitives.cpp
@@ -88,12 +88,12 @@ void SetDebuggerREGDISPLAYFromREGDISPLAY(DebuggerREGDISPLAY* pDRD, REGDISPLAY* p
     // Frame pointer        
     LPVOID FPAddress = GetRegdisplayFPAddress(pRD);
     pDRD->FP  = (FPAddress == NULL ? 0 : *((SIZE_T *)FPAddress));
-    pDRD->Edi  = (pRD->LocateEdi() == NULL ? 0 : pRD->ReadEdi());
-    pDRD->Esi  = (pRD->LocateEsi() == NULL ? 0 : pRD->ReadEsi());
-    pDRD->Ebx  = (pRD->LocateEbx() == NULL ? 0 : pRD->ReadEbx());
-    pDRD->Edx  = (pRD->LocateEdx() == NULL ? 0 : pRD->ReadEdx());
-    pDRD->Ecx  = (pRD->LocateEcx() == NULL ? 0 : pRD->ReadEcx());
-    pDRD->Eax  = (pRD->LocateEax() == NULL ? 0 : pRD->ReadEax());
+    pDRD->Edi = (pRD->GetEdiLocation() == NULL ? 0 : *pRD->GetEdiLocation());
+    pDRD->Esi = (pRD->GetEsiLocation() == NULL ? 0 : *pRD->GetEsiLocation());
+    pDRD->Ebx = (pRD->GetEbxLocation() == NULL ? 0 : *pRD->GetEbxLocation());
+    pDRD->Edx = (pRD->GetEdxLocation() == NULL ? 0 : *pRD->GetEdxLocation());
+    pDRD->Ecx = (pRD->GetEcxLocation() == NULL ? 0 : *pRD->GetEcxLocation());
+    pDRD->Eax = (pRD->GetEsiLocation() == NULL ? 0 : *pRD->GetEaxLocation());
 
 #if defined(USE_REMOTE_REGISTER_ADDRESS)
     pDRD->pFP = PushedRegAddr(pRD, FPAddress);

--- a/src/debug/shared/i386/primitives.cpp
+++ b/src/debug/shared/i386/primitives.cpp
@@ -88,12 +88,12 @@ void SetDebuggerREGDISPLAYFromREGDISPLAY(DebuggerREGDISPLAY* pDRD, REGDISPLAY* p
     // Frame pointer        
     LPVOID FPAddress = GetRegdisplayFPAddress(pRD);
     pDRD->FP  = (FPAddress == NULL ? 0 : *((SIZE_T *)FPAddress));
-    pDRD->Edi  = (pRD->pEdi == NULL ? 0 : *(pRD->pEdi));
-    pDRD->Esi  = (pRD->pEsi == NULL ? 0 : *(pRD->pEsi));
-    pDRD->Ebx  = (pRD->pEbx == NULL ? 0 : *(pRD->pEbx));
-    pDRD->Edx  = (pRD->pEdx == NULL ? 0 : *(pRD->pEdx));
-    pDRD->Ecx  = (pRD->pEcx == NULL ? 0 : *(pRD->pEcx));
-    pDRD->Eax  = (pRD->pEax == NULL ? 0 : *(pRD->pEax));
+    pDRD->Edi  = (pRD->LocateEdi() == NULL ? 0 : pRD->ReadEdi());
+    pDRD->Esi  = (pRD->LocateEsi() == NULL ? 0 : pRD->ReadEsi());
+    pDRD->Ebx  = (pRD->LocateEbx() == NULL ? 0 : pRD->ReadEbx());
+    pDRD->Edx  = (pRD->LocateEdx() == NULL ? 0 : pRD->ReadEdx());
+    pDRD->Ecx  = (pRD->LocateEcx() == NULL ? 0 : pRD->ReadEcx());
+    pDRD->Eax  = (pRD->LocateEax() == NULL ? 0 : pRD->ReadEax());
 
 #if defined(USE_REMOTE_REGISTER_ADDRESS)
     pDRD->pFP = PushedRegAddr(pRD, FPAddress);

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -89,7 +89,7 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
 
 #define NONVOLATILE_REG_METHODS(reg) \
     inline PDWORD Get##reg##Location(void) { return (pCurrentContextPointers) ? pCurrentContextPointers->reg : &pCurrentContext->reg; } \
-    inline void   Set##reg##Location(PDWORD p##reg) { if (pCurrentContextPointers) { pCurrentContextPointers->reg = p##reg; } pCurrentContext->reg = *p##reg; }
+    inline void   Set##reg##Location(PDWORD p##reg) { pCurrentContextPointers->reg = p##reg; }
 
 #endif // WIN64EXCEPTIONS
 

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -78,7 +78,7 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
     inline void   Restore##reg(PDWORD p##reg) { this->p##reg = p##reg; } \
     inline void   Trash##reg(PDWORD p##reg)   { this->p##reg = p##reg; }
 
-#define NONVOLATILE_REG_METHODS(reg) VOLATILE_REG_METHOD(reg)
+#define NONVOLATILE_REG_METHODS(reg) VOLATILE_REG_METHODS(reg)
 
 #else // !WIN64EXCEPTIONS
 

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -75,35 +75,28 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
 
 #ifndef WIN64EXCEPTIONS
 
-#define VOLATILE_REG_METHODS(reg) \
+#define REG_METHODS(reg) \
     inline PDWORD Get##reg##Location(void) { return p##reg;  } \
     inline void   Set##reg##Location(PDWORD p##reg) { this->p##reg = p##reg; }
 
-#define NONVOLATILE_REG_METHODS(reg) VOLATILE_REG_METHODS(reg)
-
 #else // !WIN64EXCEPTIONS
 
-#define VOLATILE_REG_METHODS(reg) \
-    inline PDWORD Get##reg##Location(void) { return &pCurrentContext->reg; } \
-    inline void   Set##reg##Location(PDWORD p##reg) { pCurrentContext->reg = *p##reg; }
-
-#define NONVOLATILE_REG_METHODS(reg) \
+#define REG_METHODS(reg) \
     inline PDWORD Get##reg##Location(void) { return (pCurrentContextPointers) ? pCurrentContextPointers->reg : &pCurrentContext->reg; } \
     inline void   Set##reg##Location(PDWORD p##reg) { pCurrentContextPointers->reg = p##reg; }
 
 #endif // WIN64EXCEPTIONS
 
-    VOLATILE_REG_METHODS(Eax)
-    VOLATILE_REG_METHODS(Ecx)
-    VOLATILE_REG_METHODS(Edx)
+    REG_METHODS(Eax)
+    REG_METHODS(Ecx)
+    REG_METHODS(Edx)
 
-    NONVOLATILE_REG_METHODS(Ebx)
-    NONVOLATILE_REG_METHODS(Esi)
-    NONVOLATILE_REG_METHODS(Edi)
-    NONVOLATILE_REG_METHODS(Ebp)
+    REG_METHODS(Ebx)
+    REG_METHODS(Esi)
+    REG_METHODS(Edi)
+    REG_METHODS(Ebp)
 
-#undef VOLATILE_REG_METHODS
-#undef NONVOLATILE_REG_METHODS
+#undef REG_METHODS
 
     TADDR   PCTAddr;
 };
@@ -430,6 +423,10 @@ inline void FillRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, PT_CONTEXT pC
     pRD->ctxPtrsOne.Esi = &pctx->Esi;
     pRD->ctxPtrsOne.Edi = &pctx->Edi;
     pRD->ctxPtrsOne.Ebp = &pctx->Ebp;
+
+    pRD->ctxPtrsOne.Eax = &pctx->Eax;
+    pRD->ctxPtrsOne.Ecx = &pctx->Ecx;
+    pRD->ctxPtrsOne.Edx = &pctx->Edx;
 #else // _TARGET_X86_
     PORTABILITY_ASSERT("FillRegDisplay");
 #endif // _TARGET_???_ (ELSE)

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -63,13 +63,13 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
                                 // used to preserve context saved in the frame that
                                 // could be otherwise wiped by the unwinding
 
-    DWORD * pEax;
-    DWORD * pEcx;
-    DWORD * pEdx;
-
-    DWORD * pEbx;
-    DWORD * pEsi;
     DWORD * pEdi;
+    DWORD * pEsi;
+    DWORD * pEbx;
+    DWORD * pEdx;
+    DWORD * pEcx;
+    DWORD * pEax;
+
     DWORD * pEbp;
 #endif // !WIN64EXCEPTIONS
 

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -73,8 +73,8 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
     DWORD * pEbp;
 
 #define VOLATILE_REG_METHODS(reg) \
-    inline DWORD  Read##reg(void)   { return *pReg; } \
-    inline PDWORD Locate##reg(void) { return pReg;  } \
+    inline DWORD  Read##reg(void)   { return *p##Reg; } \
+    inline PDWORD Locate##reg(void) { return p##Reg;  } \
     inline void   Restore##reg(PDWORD p##reg) { this->p##reg = p##reg; } \
     inline void   Trash##reg(PDWORD p##reg)   { this->p##reg = p##reg; }
 

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -73,8 +73,8 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
     DWORD * pEbp;
 
 #define VOLATILE_REG_METHODS(reg) \
-    inline DWORD  Read##reg(void)   { return *p##Reg; } \
-    inline PDWORD Locate##reg(void) { return p##Reg;  } \
+    inline DWORD  Read##reg(void)   { return *p##reg; } \
+    inline PDWORD Locate##reg(void) { return p##reg;  } \
     inline void   Restore##reg(PDWORD p##reg) { this->p##reg = p##reg; } \
     inline void   Trash##reg(PDWORD p##reg)   { this->p##reg = p##reg; }
 

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -82,7 +82,7 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
 #else // !WIN64EXCEPTIONS
 
 #define REG_METHODS(reg) \
-    inline PDWORD Get##reg##Location(void) { return (pCurrentContextPointers) ? pCurrentContextPointers->reg : &pCurrentContext->reg; } \
+    inline PDWORD Get##reg##Location(void) { return pCurrentContextPointers->reg; } \
     inline void   Set##reg##Location(PDWORD p##reg) { pCurrentContextPointers->reg = p##reg; }
 
 #endif // WIN64EXCEPTIONS
@@ -419,14 +419,10 @@ inline void FillRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, PT_CONTEXT pC
 
     pRD->ctxPtrsOne.Lr = &pctx->Lr;
 #elif defined(_TARGET_X86_) // _TARGET_ARM_
-    pRD->ctxPtrsOne.Ebx = &pctx->Ebx;
-    pRD->ctxPtrsOne.Esi = &pctx->Esi;
-    pRD->ctxPtrsOne.Edi = &pctx->Edi;
-    pRD->ctxPtrsOne.Ebp = &pctx->Ebp;
-
-    pRD->ctxPtrsOne.Eax = &pctx->Eax;
-    pRD->ctxPtrsOne.Ecx = &pctx->Ecx;
-    pRD->ctxPtrsOne.Edx = &pctx->Edx;
+    for (int i = 0; i < 7; i++)
+    {
+        *(&pRD->ctxPtrsOne.Esi + i) = (&pctx->Esi + i);
+    }
 #else // _TARGET_X86_
     PORTABILITY_ASSERT("FillRegDisplay");
 #endif // _TARGET_???_ (ELSE)

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -106,36 +106,6 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
 #undef NONVOLATILE_REG_METHODS
 
     TADDR   PCTAddr;
-
-    enum TAG
-    {
-      TAG_EBX,
-      TAG_ESI,
-      TAG_EDI,
-      TAG_EBP
-    };
-
-    inline void SetLocation(TAG tag, PDWORD pReg)
-    {
-        switch (tag)
-        {
-        case TAG_EBX:
-            SetEbxLocation(pReg);
-            break;
-        case TAG_ESI:
-            SetEsiLocation(pReg);
-            break;
-        case TAG_EDI:
-            SetEdiLocation(pReg);
-            break;
-        case TAG_EBP:
-            SetEbpLocation(pReg);
-            break;
-        default:
-            _ASSERTE(!"Invalid register");
-            break;
-        }
-    }
 };
 
 inline TADDR GetRegdisplaySP(REGDISPLAY *display) {

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1796,10 +1796,16 @@ typedef struct _CONTEXT {
 typedef struct _KNONVOLATILE_CONTEXT_POINTERS {
 
     // TODO WIP x86/Linux, need to fix this.
+    // Callee-saved registers
     PDWORD Ebx;
     PDWORD Esi;
     PDWORD Edi;
     PDWORD Ebp;
+
+    // Caller-saved registers
+    PDWORD Eax;
+    PDWORD Ecx;
+    PDWORD Edx;
 
 } KNONVOLATILE_CONTEXT_POINTERS, *PKNONVOLATILE_CONTEXT_POINTERS;
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1795,17 +1795,18 @@ typedef struct _CONTEXT {
 
 typedef struct _KNONVOLATILE_CONTEXT_POINTERS {
 
-    // TODO WIP x86/Linux, need to fix this.
-    // Callee-saved registers
-    PDWORD Ebx;
-    PDWORD Esi;
+    // The ordering of these fields should be aligned with that
+    // of corresponding fields in CONTEXT
+    //
+    // (See FillRegDisplay in inc/regdisp.h for details)
     PDWORD Edi;
-    PDWORD Ebp;
-
-    // Caller-saved registers
-    PDWORD Eax;
-    PDWORD Ecx;
+    PDWORD Esi;
+    PDWORD Ebx;
     PDWORD Edx;
+    PDWORD Ecx;
+    PDWORD Eax;
+
+    PDWORD Ebp;
 
 } KNONVOLATILE_CONTEXT_POINTERS, *PKNONVOLATILE_CONTEXT_POINTERS;
 

--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -97,6 +97,10 @@ OOPStackUnwinderX86::VirtualUnwind(
 
     ContextRecord->ContextFlags |= CONTEXT_UNWOUND_TO_CALL;
 
+#define CALLER_SAVED_REGISTER(reg) if (rd.pCurrentContextPointers->reg) ContextRecord->reg = *rd.pCurrentContextPointers->reg;
+    ENUM_CALLER_SAVED_REGISTERS();
+#undef CALLER_SAVED_REGISTER
+
 #define CALLEE_SAVED_REGISTER(reg) if (rd.pCurrentContextPointers->reg) ContextRecord->reg = *rd.pCurrentContextPointers->reg;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER

--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -75,12 +75,14 @@ OOPStackUnwinderX86::VirtualUnwind(
 
     REGDISPLAY rd;
 
-    rd.pCurrentContext = ContextRecord;
-    rd.pCurrentContextPointers = ContextPointers;
+    FillRegDisplay(&rd, ContextRecord);
 
-    rd.SP = ContextRecord->Esp;
-    rd.ControlPC = (PCODE)(ContextRecord->Eip);
     rd.PCTAddr = (UINT_PTR)&(ContextRecord->Eip);
+
+    if (ContextPointers)
+    {
+        rd.pCurrentContextPointers = ContextPointers;
+    }
 
     CodeManState codeManState;
     codeManState.dwIsSet = 0;
@@ -94,6 +96,10 @@ OOPStackUnwinderX86::VirtualUnwind(
     }
 
     ContextRecord->ContextFlags |= CONTEXT_UNWOUND_TO_CALL;
+
+#define CALLEE_SAVED_REGISTER(reg) if (rd.pCurrentContextPointers->reg) ContextRecord->reg = *rd.pCurrentContextPointers->reg;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
 
     ContextRecord->Esp = rd.SP;
     ContextRecord->Eip = rd.ControlPC;

--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -75,23 +75,9 @@ OOPStackUnwinderX86::VirtualUnwind(
 
     REGDISPLAY rd;
 
-    if (ContextPointers != NULL)
-    {
-#define CALLEE_SAVED_REGISTER(reg) rd.p##reg = ContextPointers->reg;
-        ENUM_CALLEE_SAVED_REGISTERS();
-#undef CALLEE_SAVED_REGISTER
-    }
-    else
-    {
-#define CALLEE_SAVED_REGISTER(reg) rd.p##reg = NULL;
-        ENUM_CALLEE_SAVED_REGISTERS();
-#undef CALLEE_SAVED_REGISTER
-    }
+    rd.pCurrentContext = ContextRecord;
+    rd.pCurrentContextPointers = ContextPointers;
 
-    if (rd.pEbp == NULL)
-    {
-        rd.pEbp = &(ContextRecord->Ebp);
-    }
     rd.SP = ContextRecord->Esp;
     rd.ControlPC = (PCODE)(ContextRecord->Eip);
     rd.PCTAddr = (UINT_PTR)&(ContextRecord->Eip);
@@ -107,22 +93,10 @@ OOPStackUnwinderX86::VirtualUnwind(
         return HRESULT_FROM_WIN32(ERROR_READ_FAULT);
     }
 
-#define CALLEE_SAVED_REGISTER(reg) if (rd.p##reg != NULL) { ContextRecord->reg = *rd.p##reg; }
-    ENUM_CALLEE_SAVED_REGISTERS();
-#undef CALLEE_SAVED_REGISTER
-    
-    if (ContextPointers != NULL) 
-    {
-#define CALLEE_SAVED_REGISTER(reg) if (rd.p##reg != &(ContextRecord->reg)) { ContextPointers->reg = rd.p##reg; }
-        ENUM_CALLEE_SAVED_REGISTERS();
-#undef CALLEE_SAVED_REGISTER
-    }
-
     ContextRecord->ContextFlags |= CONTEXT_UNWOUND_TO_CALL;
 
     ContextRecord->Esp = rd.SP;
     ContextRecord->Eip = rd.ControlPC;
-    ContextRecord->Ebp = *rd.pEbp;
 
     return S_OK;
 }

--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -97,9 +97,9 @@ OOPStackUnwinderX86::VirtualUnwind(
 
     ContextRecord->ContextFlags |= CONTEXT_UNWOUND_TO_CALL;
 
-#define CALLER_SAVED_REGISTER(reg) if (rd.pCurrentContextPointers->reg) ContextRecord->reg = *rd.pCurrentContextPointers->reg;
-    ENUM_CALLER_SAVED_REGISTERS();
-#undef CALLER_SAVED_REGISTER
+#define ARGUMENT_AND_SCRATCH_REGISTER(reg) if (rd.pCurrentContextPointers->reg) ContextRecord->reg = *rd.pCurrentContextPointers->reg;
+    ENUM_ARGUMENT_AND_SCRATCH_REGISTERS();
+#undef ARGUMENT_AND_SCRATCH_REGISTER
 
 #define CALLEE_SAVED_REGISTER(reg) if (rd.pCurrentContextPointers->reg) ContextRecord->reg = *rd.pCurrentContextPointers->reg;
     ENUM_CALLEE_SAVED_REGISTERS();

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -1642,10 +1642,10 @@ void *      getCalleeSavedReg(PREGDISPLAY pContext, regNum reg)
 
     switch (reg)
     {
-        case REGI_EBP: return pContext->pEbp;
-        case REGI_EBX: return pContext->pEbx;
-        case REGI_ESI: return pContext->pEsi;
-        case REGI_EDI: return pContext->pEdi;
+        case REGI_EBP: return pContext->LocateEbp();
+        case REGI_EBX: return pContext->LocateEbx();
+        case REGI_ESI: return pContext->LocateEsi();
+        case REGI_EDI: return pContext->LocateEdi();
 
         default: _ASSERTE(!"bad info.thisPtrResult"); return NULL;
     }
@@ -2840,7 +2840,9 @@ void    TRASH_CALLEE_UNSAVED_REGS(PREGDISPLAY pContext)
     /* This is not completely correct as we lose the current value, but
        it should not really be useful to anyone. */
     static DWORD s_badData = 0xDEADBEEF;
-    pContext->pEax = pContext->pEcx = pContext->pEdx = &s_badData;
+    pContext->TrashEax(&s_badData);
+    pContext->TrashEcx(&s_badData);
+    pContext->TrashEdx(&s_badData);
 #endif //_DEBUG
 }
 
@@ -3126,9 +3128,11 @@ void EECodeManager::QuickUnwindStackFrame(PREGDISPLAY pRD, StackwalkCacheEntry *
     if (pCacheEntry->fUseEbpAsFrameReg)
     {
         _ASSERTE(pCacheEntry->fUseEbp);
+        TADDR curEBP = (TADDR)pRD->ReadEbp();
+
         // EBP frame, update ESP through EBP, since ESPOffset may vary
-        pRD->pEbp = PTR_DWORD((TADDR)*pRD->pEbp);
-        pRD->SP = (TADDR)pRD->pEbp + sizeof(void*);
+        pRD->RestoreEbp(PTR_DWORD(curEBP));
+        pRD->SP = curEBP + sizeof(void*);
     }
     else
     {
@@ -3203,12 +3207,12 @@ const RegMask CALLEE_SAVED_REGISTERS_MASK[] =
     RM_EBP  // last register to be pushed
 };
 
-const SIZE_T REGDISPLAY_OFFSET_OF_CALLEE_SAVED_REGISTERS[] =
+const REGDISPLAY::TAG CALLEE_SAVED_REGISTERS_TAG[] =
 {
-    offsetof(REGDISPLAY, pEdi), // first register to be pushed
-    offsetof(REGDISPLAY, pEsi),
-    offsetof(REGDISPLAY, pEbx),
-    offsetof(REGDISPLAY, pEbp)  // last register to be pushed
+    REGDISPLAY::TAG_EDI, // first register to be pushed
+    REGDISPLAY::TAG_ESI,
+    REGDISPLAY::TAG_EBX,
+    REGDISPLAY::TAG_EBP  // last register to be pushed
 };
 
 /*****************************************************************************/
@@ -3275,8 +3279,7 @@ void UnwindEspFrameEpilog(
                Get the value from the stack if needed */
             if ((flags & UpdateAllRegs) || (regMask == RM_EBP))
             {
-                SIZE_T offsetOfRegPtr = REGDISPLAY_OFFSET_OF_CALLEE_SAVED_REGISTERS[i - 1];
-                *(LPVOID*)(PBYTE(pContext) + offsetOfRegPtr) = PTR_DWORD((TADDR)ESP);
+                pContext->Restore(CALLEE_SAVED_REGISTERS_TAG[i - 1], PTR_DWORD((TADDR)ESP));
             }
 
             /* Adjust ESP */
@@ -3381,7 +3384,7 @@ void UnwindEbpDoubleAlignFrameEpilog(
             unsigned calleeSavedRegsSize = info->savedRegsCountExclFP * sizeof(void*); 
 
             if (!InstructionAlreadyExecuted(offset, info->epilogOffs))
-                ESP = (*pContext->pEbp) - calleeSavedRegsSize;
+                ESP = pContext->ReadEbp() - calleeSavedRegsSize;
             
             offset = SKIP_LEA_ESP_EBP(-int(calleeSavedRegsSize), epilogBase, offset);
         }
@@ -3399,8 +3402,7 @@ void UnwindEbpDoubleAlignFrameEpilog(
         {
             if (flags & UpdateAllRegs)
             {
-                SIZE_T offsetOfRegPtr = REGDISPLAY_OFFSET_OF_CALLEE_SAVED_REGISTERS[i - 1];
-                *(LPVOID*)(PBYTE(pContext) + offsetOfRegPtr) = PTR_DWORD((TADDR)ESP);
+                pContext->Restore(CALLEE_SAVED_REGISTERS_TAG[i - 1], PTR_DWORD((TADDR)ESP));
             }
             ESP += sizeof(void*);
         }
@@ -3411,7 +3413,7 @@ void UnwindEbpDoubleAlignFrameEpilog(
     if (needMovEspEbp)
     {
         if (!InstructionAlreadyExecuted(offset, info->epilogOffs))
-            ESP = *pContext->pEbp;
+            ESP = pContext->ReadEbp();
             
         offset = SKIP_MOV_REG_REG(epilogBase, offset);
     }
@@ -3419,7 +3421,7 @@ void UnwindEbpDoubleAlignFrameEpilog(
     // Have we executed the pop EBP?
     if (!InstructionAlreadyExecuted(offset, info->epilogOffs))
     {
-        pContext->pEbp = PTR_DWORD(TADDR(ESP));
+        pContext->RestoreEbp(PTR_DWORD(TADDR(ESP)));
         ESP += sizeof(void*);
     }
     offset = SKIP_POP_REG(epilogBase, offset);
@@ -3552,16 +3554,16 @@ void UnwindEspFrameProlog(
 
     // Always restore EBP
     if (regsMask & RM_EBP)
-        pContext->pEbp = savedRegPtr++;
+        pContext->RestoreEbp(savedRegPtr++);
 
     if (flags & UpdateAllRegs)
     {
         if (regsMask & RM_EBX)
-            pContext->pEbx = savedRegPtr++;
+            pContext->RestoreEbx(savedRegPtr++);
         if (regsMask & RM_ESI)
-            pContext->pEsi = savedRegPtr++;
+            pContext->RestoreEsi(savedRegPtr++);
         if (regsMask & RM_EDI)
-            pContext->pEdi = savedRegPtr++;
+            pContext->RestoreEdi(savedRegPtr++);
 
         TRASH_CALLEE_UNSAVED_REGS(pContext);
     }
@@ -3627,8 +3629,7 @@ void UnwindEspFrame(
             if ((regMask & regsMask) == 0)
                 continue;
             
-            SIZE_T offsetOfRegPtr = REGDISPLAY_OFFSET_OF_CALLEE_SAVED_REGISTERS[i - 1];
-            *(LPVOID*)(PBYTE(pContext) + offsetOfRegPtr) = PTR_DWORD((TADDR)ESP);
+            pContext->Restore(CALLEE_SAVED_REGISTERS_TAG[i - 1], PTR_DWORD((TADDR)ESP));
 
             ESP += sizeof(unsigned);
         }
@@ -3706,7 +3707,7 @@ void UnwindEbpDoubleAlignFrameProlog(
        can be determined using EBP. Since we are still in the prolog,
        we need to know our exact location to determine the callee-saved registers */
        
-    const unsigned curEBP = *pContext->pEbp;
+    const unsigned curEBP = pContext->ReadEbp();
     
     if (flags & UpdateAllRegs)
     {        
@@ -3739,8 +3740,7 @@ void UnwindEbpDoubleAlignFrameProlog(
             
             if (InstructionAlreadyExecuted(offset, curOffs))
             {
-                SIZE_T offsetOfRegPtr = REGDISPLAY_OFFSET_OF_CALLEE_SAVED_REGISTERS[i];
-                *(LPVOID*)(PBYTE(pContext) + offsetOfRegPtr) = --pSavedRegs;
+                pContext->Restore(CALLEE_SAVED_REGISTERS_TAG[i], PTR_DWORD(--pSavedRegs));
             }
 
             // "push reg"
@@ -3752,7 +3752,7 @@ void UnwindEbpDoubleAlignFrameProlog(
     
     /* The caller's saved EBP is pointed to by our EBP */
 
-    pContext->pEbp = PTR_DWORD((TADDR)curEBP);
+    pContext->RestoreEbp(PTR_DWORD((TADDR)curEBP));
     pContext->SP = DWORD((TADDR)(curEBP + sizeof(void *)));
     
     /* Stack pointer points to return address */
@@ -3776,7 +3776,7 @@ bool UnwindEbpDoubleAlignFrame(
     _ASSERTE(info->ebpFrame || info->doubleAlign);
 
     const unsigned curESP =  pContext->SP;
-    const unsigned curEBP = *pContext->pEbp;
+    const unsigned curEBP =  pContext->ReadEbp();
 
     /* First check if we are in a filter (which is obviously after the prolog) */
 
@@ -3819,8 +3819,14 @@ bool UnwindEbpDoubleAlignFrame(
             {
                 static DWORD s_badData = 0xDEADBEEF;
 
-                pContext->pEax = pContext->pEbx = pContext->pEcx =
-                pContext->pEdx = pContext->pEsi = pContext->pEdi = &s_badData;
+                pContext->TrashEax(&s_badData);
+                pContext->TrashEcx(&s_badData);
+                pContext->TrashEdx(&s_badData);
+
+                pContext->TrashEbx(&s_badData);
+                pContext->TrashEsi(&s_badData);
+                pContext->TrashEdi(&s_badData);
+                pContext->TrashEbp(&s_badData);
             }
 #endif
 
@@ -3863,8 +3869,7 @@ bool UnwindEbpDoubleAlignFrame(
             if ((info->savedRegMask & regMask) == 0)
                 continue;
             
-            SIZE_T offsetOfRegPtr = REGDISPLAY_OFFSET_OF_CALLEE_SAVED_REGISTERS[i];
-            *(LPVOID*)(PBYTE(pContext) + offsetOfRegPtr) = --pSavedRegs;
+            pContext->Restore(CALLEE_SAVED_REGISTERS_TAG[i], --pSavedRegs);
         }
     }
 
@@ -3879,7 +3884,7 @@ bool UnwindEbpDoubleAlignFrame(
 
     /* The caller's saved EBP is pointed to by our EBP */
 
-    pContext->pEbp = PTR_DWORD((TADDR)curEBP);
+    pContext->RestoreEbp(PTR_DWORD((TADDR)curEBP));
 
     return true;
 }
@@ -4118,7 +4123,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
     GCInfoToken gcInfoToken = pCodeInfo->GetGCInfoToken();
     unsigned  curOffs = pCodeInfo->GetRelOffset();
 
-    unsigned  EBP     = *pContext->pEbp;
+    unsigned  EBP     =  pContext->ReadEbp();
     unsigned  ESP     =  pContext->SP;
 
     unsigned  ptrOffs;
@@ -4185,7 +4190,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
             if (dspPtr)                                                 \
                 printf("    Live pointer register %s: ", #regName);     \
                 pCallBack(hCallBack,                                    \
-                          (OBJECTREF*)(pContext->p##regName),           \
+                          (OBJECTREF*)(pContext->Locate##regName()),    \
                           (iptr ? GC_CALL_INTERIOR : 0)                 \
                           | CHECK_APP_DOMAIN                            \
                           DAC_ARG(DacSlotLocation(reg, 0, false)));     \
@@ -4194,7 +4199,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
 #define CHK_AND_REPORT_REG(reg, doIt, iptr, regName)                    \
         if  (doIt)                                                      \
                 pCallBack(hCallBack,                                    \
-                          (OBJECTREF*)(pContext->p##regName),           \
+                          (OBJECTREF*)(pContext->Locate##regName()),    \
                           (iptr ? GC_CALL_INTERIOR : 0)                 \
                           | CHECK_APP_DOMAIN                            \
                           DAC_ARG(DacSlotLocation(reg, 0, false)));
@@ -5019,7 +5024,7 @@ OBJECTREF* EECodeManager::GetAddrOfSecurityObjectFromCachedInfo(PREGDISPLAY pRD,
     // We pretend that filters are ESP-based methods in UnwindEbpDoubleAlignFrame().
     // Hence we cannot enforce this assert.
     // _ASSERTE(stackwalkCacheUnwindInfo->fUseEbpAsFrameReg);
-    return (OBJECTREF *) (size_t) (DWORD(*pRD->pEbp) - (securityObjectOffset * sizeof(void*)));
+    return (OBJECTREF *) (size_t) (pRD->ReadEbp() - (securityObjectOffset * sizeof(void*)));
 #else
     PORTABILITY_ASSERT("EECodeManager::GetAddrOfSecurityObjectFromContext is not implemented on this platform.");
     return NULL;
@@ -5059,7 +5064,7 @@ OBJECTREF* EECodeManager::GetAddrOfSecurityObject(CrawlFrame *pCF)
         if(stateBuf->hdrInfoBody.prologOffs == hdrInfo::NOT_IN_PROLOG &&
                 stateBuf->hdrInfoBody.epilogOffs == hdrInfo::NOT_IN_EPILOG)
         {
-            return (OBJECTREF *)(size_t)(((DWORD)*pRD->pEbp) - GetSecurityObjectOffset(&stateBuf->hdrInfoBody));
+            return (OBJECTREF *)(size_t)(pRD->ReadEbp() - GetSecurityObjectOffset(&stateBuf->hdrInfoBody));
         }
     }
 #elif defined(USE_GC_INFO_DECODER) && !defined(CROSSGEN_COMPILE)
@@ -5161,7 +5166,7 @@ OBJECTREF EECodeManager::GetInstance( PREGDISPLAY    pContext,
     if (info.ebpFrame)
     {
         _ASSERTE(stackDepth == 0);
-        taArgBase = *pContext->pEbp;
+        taArgBase =  pContext->ReadEbp();
     }
     else
     {

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3826,7 +3826,6 @@ bool UnwindEbpDoubleAlignFrame(
                 pContext->TrashEbx(&s_badData);
                 pContext->TrashEsi(&s_badData);
                 pContext->TrashEdi(&s_badData);
-                pContext->TrashEbp(&s_badData);
             }
 #endif
 

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3209,15 +3209,29 @@ const RegMask CALLEE_SAVED_REGISTERS_MASK[] =
 
 static void SetLocation(PREGDISPLAY pRD, int ind, PDWORD loc)
 {
-    static const REGDISPLAY::TAG CALLEE_SAVED_REGISTERS_TAG[] =
+#ifdef WIN64EXCEPTIONS
+    static const SIZE_T OFFSET_OF_CALLEE_SAVED_REGISTERS[] =
     {
-        REGDISPLAY::TAG_EDI, // first register to be pushed
-        REGDISPLAY::TAG_ESI,
-        REGDISPLAY::TAG_EBX,
-        REGDISPLAY::TAG_EBP  // last register to be pushed
+        offsetof(T_KNONVOLATILE_CONTEXT_POINTERS, Edi), // first register to be pushed
+        offsetof(T_KNONVOLATILE_CONTEXT_POINTERS, Esi),
+        offsetof(T_KNONVOLATILE_CONTEXT_POINTERS, Ebx),
+        offsetof(T_KNONVOLATILE_CONTEXT_POINTERS, Ebp), // last register to be pushed
     };
 
-    pRD->SetLocation(CALLEE_SAVED_REGISTERS_TAG[ind], loc);
+    SIZE_T offsetOfRegPtr = OFFSET_OF_CALLEE_SAVED_REGISTERS[ind];
+    *(LPVOID*)(PBYTE(pRD->pCurrentContextPointers) + offsetOfRegPtr) = loc;
+#else
+    static const SIZE_T OFFSET_OF_CALLEE_SAVED_REGISTERS[] =
+    {
+        offsetof(REGDISPLAY, pEdi), // first register to be pushed
+        offsetof(REGDISPLAY, pEsi),
+        offsetof(REGDISPLAY, pEbx),
+        offsetof(REGDISPLAY, pEbp), // last register to be pushed
+    };
+
+    SIZE_T offsetOfRegPtr = OFFSET_OF_CALLEE_SAVED_REGISTERS[ind];
+    *(LPVOID*)(PBYTE(pRD) + offsetOfRegPtr) = loc;
+#endif
 }
 
 /*****************************************************************************/

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3207,13 +3207,18 @@ const RegMask CALLEE_SAVED_REGISTERS_MASK[] =
     RM_EBP  // last register to be pushed
 };
 
-const REGDISPLAY::TAG CALLEE_SAVED_REGISTERS_TAG[] =
+static void SetLocation(PREGDISPLAY pRD, int ind, PDWORD loc)
 {
-    REGDISPLAY::TAG_EDI, // first register to be pushed
-    REGDISPLAY::TAG_ESI,
-    REGDISPLAY::TAG_EBX,
-    REGDISPLAY::TAG_EBP  // last register to be pushed
-};
+    static const REGDISPLAY::TAG CALLEE_SAVED_REGISTERS_TAG[] =
+    {
+        REGDISPLAY::TAG_EDI, // first register to be pushed
+        REGDISPLAY::TAG_ESI,
+        REGDISPLAY::TAG_EBX,
+        REGDISPLAY::TAG_EBP  // last register to be pushed
+    };
+
+    pRD->SetLocation(CALLEE_SAVED_REGISTERS_TAG[ind], loc);
+}
 
 /*****************************************************************************/
 
@@ -3279,7 +3284,7 @@ void UnwindEspFrameEpilog(
                Get the value from the stack if needed */
             if ((flags & UpdateAllRegs) || (regMask == RM_EBP))
             {
-                pContext->SetLocation(CALLEE_SAVED_REGISTERS_TAG[i - 1], PTR_DWORD((TADDR)ESP));
+                SetLocation(pContext, i - 1, PTR_DWORD((TADDR)ESP));
             }
 
             /* Adjust ESP */
@@ -3402,7 +3407,7 @@ void UnwindEbpDoubleAlignFrameEpilog(
         {
             if (flags & UpdateAllRegs)
             {
-                pContext->SetLocation(CALLEE_SAVED_REGISTERS_TAG[i - 1], PTR_DWORD((TADDR)ESP));
+                SetLocation(pContext, i - 1, PTR_DWORD((TADDR)ESP));
             }
             ESP += sizeof(void*);
         }
@@ -3629,7 +3634,7 @@ void UnwindEspFrame(
             if ((regMask & regsMask) == 0)
                 continue;
             
-            pContext->SetLocation(CALLEE_SAVED_REGISTERS_TAG[i - 1], PTR_DWORD((TADDR)ESP));
+            SetLocation(pContext, i - 1, PTR_DWORD((TADDR)ESP));
 
             ESP += sizeof(unsigned);
         }
@@ -3740,7 +3745,7 @@ void UnwindEbpDoubleAlignFrameProlog(
             
             if (InstructionAlreadyExecuted(offset, curOffs))
             {
-                pContext->SetLocation(CALLEE_SAVED_REGISTERS_TAG[i], PTR_DWORD(--pSavedRegs));
+                SetLocation(pContext, i, PTR_DWORD(--pSavedRegs));
             }
 
             // "push reg"
@@ -3868,7 +3873,7 @@ bool UnwindEbpDoubleAlignFrame(
             if ((info->savedRegMask & regMask) == 0)
                 continue;
             
-            pContext->SetLocation(CALLEE_SAVED_REGISTERS_TAG[i], --pSavedRegs);
+            SetLocation(pContext, i, --pSavedRegs);
         }
     }
 

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -2006,8 +2006,8 @@ BOOL MulticastFrame::TraceFrame(Thread *thread, BOOL fromPatch,
 
 #if defined(_TARGET_X86_)
     // At this point the counter hasn't been incremented yet.
-    delegateCount = *regs->pEdi + 1;
-    pbDel = *(BYTE **)( (size_t)*(regs->pEsi) + GetOffsetOfTransitionBlock() + ArgIterator::GetThisOffset());
+    delegateCount =  regs->ReadEdi() + 1;
+    pbDel = *(BYTE **)( (size_t)regs->ReadEsi() + GetOffsetOfTransitionBlock() + ArgIterator::GetThisOffset());
 #elif defined(_TARGET_AMD64_)
     // At this point the counter hasn't been incremented yet.
     delegateCount = (int)regs->pCurrentContext->Rdi + 1;

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -2006,8 +2006,8 @@ BOOL MulticastFrame::TraceFrame(Thread *thread, BOOL fromPatch,
 
 #if defined(_TARGET_X86_)
     // At this point the counter hasn't been incremented yet.
-    delegateCount =  regs->ReadEdi() + 1;
-    pbDel = *(BYTE **)( (size_t)regs->ReadEsi() + GetOffsetOfTransitionBlock() + ArgIterator::GetThisOffset());
+    delegateCount = *regs->GetEdiLocation() + 1;
+    pbDel = *(BYTE **)( (size_t)*regs->GetEsiLocation() + GetOffsetOfTransitionBlock() + ArgIterator::GetThisOffset());
 #elif defined(_TARGET_AMD64_)
     // At this point the counter hasn't been incremented yet.
     delegateCount = (int)regs->pCurrentContext->Rdi + 1;

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1565,10 +1565,10 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
             
             _ASSERTE(pThread->PreemptiveGCDisabled());    // Epilogs should be in cooperative mode, no GC can happen right now. 
             bool gcHappened = gcCover->gcCount != GCHeapUtilities::GetGCHeap()->GetGcCount();
-            checkAndUpdateReg(gcCover->callerRegs.Edi, regDisp.ReadEdi(), gcHappened);
-            checkAndUpdateReg(gcCover->callerRegs.Esi, regDisp.ReadEsi(), gcHappened);
-            checkAndUpdateReg(gcCover->callerRegs.Ebx, regDisp.ReadEbx(), gcHappened);
-            checkAndUpdateReg(gcCover->callerRegs.Ebp, regDisp.ReadEbp(), gcHappened);
+            checkAndUpdateReg(gcCover->callerRegs.Edi, *regDisp.GetEdiLocation(), gcHappened);
+            checkAndUpdateReg(gcCover->callerRegs.Esi, *regDisp.GetEsiLocation(), gcHappened);
+            checkAndUpdateReg(gcCover->callerRegs.Ebx, *regDisp.GetEbxLocation(), gcHappened);
+            checkAndUpdateReg(gcCover->callerRegs.Ebp, *regDisp.GetEbpLocation(), gcHappened);
             
             gcCover->gcCount = GCHeapUtilities::GetGCHeap()->GetGcCount();
 

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1565,10 +1565,10 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
             
             _ASSERTE(pThread->PreemptiveGCDisabled());    // Epilogs should be in cooperative mode, no GC can happen right now. 
             bool gcHappened = gcCover->gcCount != GCHeapUtilities::GetGCHeap()->GetGcCount();
-            checkAndUpdateReg(gcCover->callerRegs.Edi, *regDisp.pEdi, gcHappened);
-            checkAndUpdateReg(gcCover->callerRegs.Esi, *regDisp.pEsi, gcHappened);
-            checkAndUpdateReg(gcCover->callerRegs.Ebx, *regDisp.pEbx, gcHappened);
-            checkAndUpdateReg(gcCover->callerRegs.Ebp, *regDisp.pEbp, gcHappened);
+            checkAndUpdateReg(gcCover->callerRegs.Edi, regDisp.ReadEdi(), gcHappened);
+            checkAndUpdateReg(gcCover->callerRegs.Esi, regDisp.ReadEsi(), gcHappened);
+            checkAndUpdateReg(gcCover->callerRegs.Ebx, regDisp.ReadEbx(), gcHappened);
+            checkAndUpdateReg(gcCover->callerRegs.Ebp, regDisp.ReadEbp(), gcHappened);
             
             gcCover->gcCount = GCHeapUtilities::GetGCHeap()->GetGcCount();
 

--- a/src/vm/i386/cgencpu.h
+++ b/src/vm/i386/cgencpu.h
@@ -154,6 +154,11 @@ typedef INT32 StackElemType;
 // This represents some of the FramedMethodFrame fields that are
 // stored at negative offsets.
 //--------------------------------------------------------------------
+#define ENUM_CALLER_SAVED_REGISTERS() \
+    CALLER_SAVED_REGISTER(Eax) \
+    CALLER_SAVED_REGISTER(Ecx) \
+    CALLER_SAVED_REGISTER(Edx)
+
 #define ENUM_CALLEE_SAVED_REGISTERS() \
     CALLEE_SAVED_REGISTER(Edi) \
     CALLEE_SAVED_REGISTER(Esi) \

--- a/src/vm/i386/cgencpu.h
+++ b/src/vm/i386/cgencpu.h
@@ -154,10 +154,10 @@ typedef INT32 StackElemType;
 // This represents some of the FramedMethodFrame fields that are
 // stored at negative offsets.
 //--------------------------------------------------------------------
-#define ENUM_CALLER_SAVED_REGISTERS() \
-    CALLER_SAVED_REGISTER(Eax) \
-    CALLER_SAVED_REGISTER(Ecx) \
-    CALLER_SAVED_REGISTER(Edx)
+#define ENUM_ARGUMENT_AND_SCRATCH_REGISTERS() \
+    ARGUMENT_AND_SCRATCH_REGISTER(Eax) \
+    ARGUMENT_AND_SCRATCH_REGISTER(Ecx) \
+    ARGUMENT_AND_SCRATCH_REGISTER(Edx)
 
 #define ENUM_CALLEE_SAVED_REGISTERS() \
     CALLEE_SAVED_REGISTER(Edi) \

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -305,6 +305,9 @@ void TransitionFrame::UpdateRegDisplayHelper(const PREGDISPLAY pRD, UINT cbStack
     pRD->IsCallerContextValid = FALSE;
     pRD->IsCallerSPValid      = FALSE;
 
+    pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);;
+    pRD->pCurrentContext->Esp = GetSP();
+
     T_CONTEXT * pContext = pRD->pCurrentContext;
 #define CALLEE_SAVED_REGISTER(regname) pContext->regname = regs->regname;
     ENUM_CALLEE_SAVED_REGISTERS();
@@ -314,9 +317,6 @@ void TransitionFrame::UpdateRegDisplayHelper(const PREGDISPLAY pRD, UINT cbStack
 #define CALLEE_SAVED_REGISTER(regname) pContextPointers->regname = (DWORD*)&regs->regname;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
-
-    pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);;
-    pRD->pCurrentContext->Esp = GetSP();
 
     SyncRegDisplayToCurrentContext(pRD);
 

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -60,6 +60,7 @@ extern "C" DWORD STDCALL GetSpecificCpuFeaturesAsm(DWORD *pInfo);
 
 void generate_noref_copy (unsigned nbytes, StubLinkerCPU* sl);
 
+#ifdef WIN64EXCEPTIONS
 void UpdateRegDisplayFromCalleeSavedRegisters(REGDISPLAY * pRD, CalleeSavedRegisters * regs)
 {
     LIMITED_METHOD_CONTRACT;
@@ -83,6 +84,7 @@ void ClearRegDisplayArgumentAndScratchRegisters(REGDISPLAY * pRD)
     ENUM_ARGUMENT_AND_SCRATCH_REGISTERS();
 #undef ARGUMENT_AND_SCRATCH_REGISTER
 }
+#endif // WIN64EXCEPTIONS
 
 #ifndef DACCESS_COMPILE
 

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -251,10 +251,10 @@ void EHContext::UpdateFrame(PREGDISPLAY regs)
     LOG((LF_EH, LL_INFO1000, "Updating saved EDI: *%p= %p\n", regs->LocateEdi(), this->Edi));
     LOG((LF_EH, LL_INFO1000, "Updating saved EBP: *%p= %p\n", regs->LocateEbp(), this->Ebp));
     
-    regs->RestoreEbx(PDWORD(&this->Ebx));
-    regs->RestoreEsi(PDWORD(&this->Esi));
-    regs->RestoreEdi(PDWORD(&this->Edi));
-    regs->RestoreEbp(PDWORD(&this->Ebp));
+    *regs->LocateEbx() = this->Ebx;
+    *regs->LocateEsi() = this->Esi;
+    *regs->LocateEdi() = this->Edi;
+    *regs->LocateEbp() = this->Ebp;
 }
 
 void TransitionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -79,9 +79,9 @@ void ClearRegDisplayArgumentAndScratchRegisters(REGDISPLAY * pRD)
 {
     LIMITED_METHOD_CONTRACT;
 
-#define CALLER_SAVED_REGISTER(regname) pRD->pCurrentContextPointers->regname = NULL;
-    ENUM_CALLER_SAVED_REGISTERS();
-#undef CALLER_SAVED_REGISTER
+#define ARGUMENT_AND_SCRATCH_REGISTER(regname) pRD->pCurrentContextPointers->regname = NULL;
+    ENUM_ARGUMENT_AND_SCRATCH_REGISTERS();
+#undef ARGUMENT_AND_SCRATCH_REGISTER
 }
 
 #ifndef DACCESS_COMPILE
@@ -601,6 +601,10 @@ void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->SP = m_ctx.Esp;
     pRD->ControlPC = m_ctx.Eip;
 
+#define ARGUMENT_AND_SCRATCH_REGISTER(regname) pRD->pCurrentContextPointers->regname = &m_ctx.regname;
+    ENUM_ARGUMENT_AND_SCRATCH_REGISTERS();
+#undef ARGUMENT_AND_SCRATCH_REGISTER
+
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContextPointers->regname = &m_ctx.regname;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
@@ -737,9 +741,9 @@ void ResumableFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->SP = m_Regs->Esp;
     pRD->ControlPC = m_Regs->Eip;
 
-#define CALLER_SAVED_REGISTER(reg) pRD->pCurrentContextPointers->reg = &m_Regs->reg;
-    ENUM_CALLER_SAVED_REGISTERS();
-#undef CALLER_SAVED_REGISTER
+#define ARGUMENT_AND_SCRATCH_REGISTER(reg) pRD->pCurrentContextPointers->reg = &m_Regs->reg;
+    ENUM_ARGUMENT_AND_SCRATCH_REGISTERS();
+#undef ARGUMENT_AND_SCRATCH_REGISTER
 
 #define CALLEE_SAVED_REGISTER(reg) pRD->pCurrentContextPointers->reg = &m_Regs->reg;
     ENUM_CALLEE_SAVED_REGISTERS();
@@ -818,13 +822,15 @@ void HijackFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 
-#define CALLEE_SAVED_REGISTER(reg) pRD->pCurrentContextPointers->reg = &m_Args->reg;
+#define CALLEE_SAVED_REGISTER(reg) pRD->pCurrentContextPointers->reg = NULL;
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 
-#define CALLER_SAVED_REGISTER(reg) pRD->pCurrentContextPointers->reg = &m_Args->reg;
-    ENUM_CALLER_SAVED_REGISTERS();
-#undef CALLER_SAVED_REGISTER
+#define ARGUMENT_AND_SCRATCH_REGISTER(reg) pRD->pCurrentContextPointers->reg = NULL;
+    ENUM_ARGUMENT_AND_SCRATCH_REGISTERS();
+#undef ARGUMENT_AND_SCRATCH_REGISTER
+
+    pRD->pCurrentContextPointers->Eax = (PDWORD) &m_Args->Eax;
 
     SyncRegDisplayToCurrentContext(pRD);
 

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -7411,7 +7411,7 @@ Loop:
                 REGDISPLAY rd;
                 ZeroMemory(&rd, sizeof(rd));
 
-                rd.pEbp = &ctxCur.Ebp;
+                rd.RestoreEbp(&ctxCur.Ebp);
                 rd.SP = ctxCur.Esp;
                 rd.ControlPC = ctxCur.Eip;
 
@@ -7422,7 +7422,7 @@ Loop:
                     &codeManState, 
                     NULL);
 
-                ctxCur.Ebp = *(rd.pEbp);
+                ctxCur.Ebp = rd.ReadEbp();
                 ctxCur.Esp = rd.SP;
                 ctxCur.Eip = rd.ControlPC;
             }

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -7411,7 +7411,7 @@ Loop:
                 REGDISPLAY rd;
                 ZeroMemory(&rd, sizeof(rd));
 
-                rd.RestoreEbp(&ctxCur.Ebp);
+                rd.SetEbpLocation(&ctxCur.Ebp);
                 rd.SP = ctxCur.Esp;
                 rd.ControlPC = ctxCur.Eip;
 
@@ -7422,7 +7422,7 @@ Loop:
                     &codeManState, 
                     NULL);
 
-                ctxCur.Ebp = rd.ReadEbp();
+                ctxCur.Ebp = *rd.GetEbpLocation();
                 ctxCur.Esp = rd.SP;
                 ctxCur.Eip = rd.ControlPC;
             }


### PR DESCRIPTION
This commit removes pXXX fields in REGDISPLAY, and revises all the references on these fields (as discussed in #8998) to refers corresponding fields in pCurrentContext and pCurrentContetPointers. 