### PR TITLE
Fix non-deterministic AVX2 detection

### DIFF
--- a/src/vm/cgensys.h
+++ b/src/vm/cgensys.h
@@ -105,6 +105,7 @@ inline void GetSpecificCpuInfo(CORINFO_CPU * cpuInfo)
 
 #if (defined(_TARGET_X86_) || defined(_TARGET_AMD64_)) && !defined(CROSSGEN_COMPILE)
 extern "C" DWORD __stdcall getcpuid(DWORD arg, unsigned char result[16]);
+extern "C" DWORD __stdcall getextcpuid(DWORD arg1, DWORD arg2, unsigned char result[16]);
 extern "C" DWORD __stdcall xmmYmmStateSupport();
 #endif
 

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -1339,7 +1339,7 @@ void EEJitManager::SetCpuInfo()
                         CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX);
                         if (maxCpuId >= 0x07)
                         {
-                            (void) getcpuid(0x07, buffer);
+                            (void) getextcpuid(0, 0x07, buffer);
                             if ((buffer[4]  & 0x20) != 0)
                             {
                                 CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX2);


### PR DESCRIPTION
The caller required ECX to be zero when calling CPUID, but wasn't calling
the getextcpuid() function to cause that to happen.