### PR TITLE
Clean up unused tailcall via helper nodes

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1859,6 +1859,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     bool               isClosed;
     LIR::ReadOnlyRange secondArgRange = BlockRange().GetTreeRange(arg0, &isClosed);
     assert(isClosed);
+    BlockRange().Remove(std::move(secondArgRange));
 
     argEntry->node->gtOp.gtOp1 = callTarget;
 


### PR DESCRIPTION
For x86 tailcall via helper, delete the unused placeholder target
location nodes when they are replaced. This removes an unneeded
instruction in the generated code.