### PR TITLE
Fix morphing of GT_FIELD of SIMD in IND context

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6074,8 +6074,8 @@ GenTreePtr Compiler::fgMorphField(GenTreePtr tree, MorphAddrContext* mac)
     }
 
 #ifdef FEATURE_SIMD
-    // if this field belongs to simd struct, tranlate it to simd instrinsic.
-    if (mac == nullptr || mac->m_kind != MACK_Addr)
+    // if this field belongs to simd struct, translate it to simd instrinsic.
+    if (mac == nullptr)
     {
         GenTreePtr newTree = fgMorphFieldToSIMDIntrinsicGet(tree);
         if (newTree != tree)
@@ -10472,12 +10472,12 @@ GenTreePtr Compiler::getSIMDStructFromField(GenTreePtr tree,
 }
 
 /*****************************************************************************
-*  If a read operation tries to access simd struct field, then transform the this
-*  operation to to the SIMD intrinsic SIMDIntrinsicGetItem, and return the new tree.
+*  If a read operation tries to access simd struct field, then transform the
+*  operation to the SIMD intrinsic SIMDIntrinsicGetItem, and return the new tree.
 *  Otherwise, return the old tree.
 *  Argument:
 *   tree - GenTreePtr. If this pointer points to simd struct which is used for simd
-*          intrinsic. We will morph it as simd intrinsic SIMDIntrinsicGetItem.
+*          intrinsic, we will morph it as simd intrinsic SIMDIntrinsicGetItem.
 *  Return:
 *   A GenTreePtr which points to the new tree. If the tree is not for simd intrinsic,
 *   return nullptr.
@@ -10491,7 +10491,6 @@ GenTreePtr Compiler::fgMorphFieldToSIMDIntrinsicGet(GenTreePtr tree)
     GenTreePtr simdStructNode = getSIMDStructFromField(tree, &baseType, &index, &simdSize);
     if (simdStructNode != nullptr)
     {
-
         assert(simdSize >= ((index + 1) * genTypeSize(baseType)));
         GenTree* op2 = gtNewIconNode(index);
         tree         = gtNewSIMDNode(baseType, simdStructNode, op2, SIMDIntrinsicGetItem, baseType, simdSize);
@@ -10504,11 +10503,11 @@ GenTreePtr Compiler::fgMorphFieldToSIMDIntrinsicGet(GenTreePtr tree)
 
 /*****************************************************************************
 *  Transform an assignment of a SIMD struct field to SIMD intrinsic
-*  SIMDIntrinsicGetItem, and return a new tree. If If it is not such an assignment,
+*  SIMDIntrinsicSet*, and return a new tree. If it is not such an assignment,
 *  then return the old tree.
 *  Argument:
 *   tree - GenTreePtr. If this pointer points to simd struct which is used for simd
-*          intrinsic. We will morph it as simd intrinsic set.
+*          intrinsic, we will morph it as simd intrinsic set.
 *  Return:
 *   A GenTreePtr which points to the new tree. If the tree is not for simd intrinsic,
 *   return nullptr.
@@ -10561,7 +10560,8 @@ GenTreePtr Compiler::fgMorphFieldAssignToSIMDIntrinsicSet(GenTreePtr tree)
     return tree;
 }
 
-#endif
+#endif // FEATURE_SIMD
+
 /*****************************************************************************
  *
  *  Transform the given GTK_SMPOP tree for code generation.


### PR DESCRIPTION
The primary change is the first, to remove the `|| mac->m_kind != MACK_Addr` condition from the clause determining if we are going to attempt to morph to a SIMD `get[i]` intrinsic. This was causing a problem on x86 in a particularly obscure corner case of implementing Vector<T>::DotProduct() in MinOpts. However, the change is applicable to amd64 as well, and in fact leads to slightly better code in a few cases where we now load a small SIMD value from the proper offset with a small sized load, instead of loading the whole vector and then right shifting to get the desired bytes in the low part of the SIMD register.

The remaining changes are spelling, grammar, and formatting fixes.
