### PR TITLE
[WIP] Change LSRA to update intervals correctly for arm32

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7047,6 +7047,15 @@ void LinearScan::allocateRegisters()
             if (regRecord->assignedInterval != nullptr && !regRecord->assignedInterval->isActive &&
                 regRecord->assignedInterval->isConstant)
             {
+#ifdef _TARGET_ARM_
+                if ((regRecord->assignedInterval->registerType == TYP_DOUBLE) &&
+                    isFloatRegType(regRecord->registerType))
+                {
+                    regNumber  nextRegNum        = REG_NEXT(regRecord->regNum);
+                    RegRecord* nextRegRec        = getRegisterRecord(nextRegNum);
+                    nextRegRec->assignedInterval = nullptr;
+                }
+#endif // _TARGET_ARM_
                 regRecord->assignedInterval = nullptr;
             }
             INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_FIXED_REG, nullptr, currentRefPosition->assignedReg()));


### PR DESCRIPTION
Change LSRA to update interval correctly for arm32

We should update `assignedInterval` of a pair of `RegRecord` properly for `TYP_DOUBLE` in `arm32`.
Unless we experience various faulty scenarios with assertion.

## Before
For arm32, one of faulty scenario in `JIT/CodeGenBringUpTests/DblAdd` is as follows.
- We set and clear `assignedInterval` in a pair of `RecRecord` at `unassignPhysReg()` and `assignPhysReg()` for TYP_DOUBLE.
- However we only clear `assignedInterval` for 1st `RecRecord` and don't for 2nd `RecRecord` during LSRA.
- Later we visit `unassignPhysReg()` for the 2nd `RecRecord` while LSRA, because `assignedInterval` is not cleared properly before. And this time, a new pair of `RecRecord` is consist of the 2nd `RecRecord` and another 3rd `RecRecord`.
- After clearing `assignedInterval` of 2nd `RecRecord` with `checkAndClearInterval()` and we also try to clear `assignedInterval` of 3rd `RecRecord` when type is `TYP_DOUBLE`.
- However `assignedInterval` is already `nullptr` and an assertion is raised, because 3rd `RecRecord` is not being used.

You can find a similar logic at `LinearScan::unassignPhysReg()` and `LinearScan::assignPhysReg()` with `__TARGET_ARM__` defined.

For example,
```
FAILED   - [   0][   8s]JIT/CodeGenBringUpTests/DblAdd/DblAdd.sh
               BEGIN EXECUTION
               /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170125/corerun DblAdd.exe
               
               Assert failure(PID 12033 [0x00002f01], Thread: 12033 [0x2f01]): Assertion failed 'assignedInterval != nullptr' in 'BringUpTest:Main():int' (IL size 62)
               
                   File: /home/hk0110/work/dxl/dotnet/github/hqueue/coreclr/src/jit/lsra.cpp Line: 6197
                   Image: /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170125/corerun
               
               ./DblAdd.sh: line 130: 12033 Aborted                 (core dumped) $_DebuggerFullPath "$CORE_ROOT/corerun" DblAdd.exe $CLRTestExecutionArguments
               Expected: 100
               Actual: 134
               END EXECUTION - FAILED
```

For `JIT/CodeGenBringUpTests/` with `COMPlus_AltJit=BringUpTest:*` for arm32 ryujit.
```
=======================
     Test Results
=======================
# CoreCLR Bin Dir  : 
# Tests Discovered : 139
# Passed           : 94
# Failed           : 45
# Skipped          : 0
=======================
```
About 29 assertions are related to this issue in `JIT/CodeGenBringUpTests/`.

## Proposed fix
Let's update both `assignedInterval` in a pair of `RecRecord` when neccessary for arm32.

## After
Update both `assignedInterval` in a pair of `RecRecord` when neccessary.

```
PASSED   - [   0][  10s]JIT/CodeGenBringUpTests/DblAdd/DblAdd.sh
               BEGIN EXECUTION
               /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170125debugging/corerun DblAdd.exe
               2
               Expected: 100
               Actual: 100
               END EXECUTION - PASSED
```

For `JIT/CodeGenBringUpTests/` with `COMPlus_AltJit=BringUpTest:*` for arm32 ryujit.
About 21 assertions are gone.
```
=======================
     Test Results
=======================
# CoreCLR Bin Dir  : 
# Tests Discovered : 139
# Passed           : 115
# Failed           : 24
# Skipped          : 0
=======================
```
## Status
Still there are remaining assertions related to `assignedInterval` for arm32. 
I'm looking into other places where a pair of `assignedInterval` is not updated correctly.

Looking for your help. Thanks!

(This is a part of #8496 "Enable RyuJIT Backend for ARM32".)