### PR TITLE
Improve SIMD tests

### DIFF
--- a/tests/src/JIT/SIMD/VectorMin.cs
+++ b/tests/src/JIT/SIMD/VectorMin.cs
@@ -39,6 +39,7 @@ internal partial class VectorTest
             if (!(CheckValue<float>(C.X, result))) return Fail;
             if (!(CheckValue<float>(C.Y, result))) return Fail;
             if (!(CheckValue<float>(C.Z, result))) return Fail;
+            if (!(CheckValue<float>(C.W, result))) return Fail;
             return Pass;
         }
     }

--- a/tests/src/JIT/SIMD/VectorReturn.cs
+++ b/tests/src/JIT/SIMD/VectorReturn.cs
@@ -11,50 +11,134 @@ internal partial class VectorTest
 {
     private const int Pass = 100;
     private const int Fail = -1;
-    private static Vector2[] s_A;
-    private static Vector2 s_p0;
-    private static Vector2 s_p1;
-    private static Vector2 s_p2;
-    private static Vector2 s_p3;
+
+    private static Vector2[] s_v2_array;
+    private static Vector2 s_v2_0;
+    private static Vector2 s_v2_1;
+    private static Vector2 s_v2_2;
+    private static Vector2 s_v2_3;
+
+    private static Vector3[] s_v3_array;
+    private static Vector3 s_v3_0;
+    private static Vector3 s_v3_1;
+    private static Vector3 s_v3_2;
+    private static Vector3 s_v3_3;
+
+    private static Vector4[] s_v4_array;
+    private static Vector4 s_v4_0;
+    private static Vector4 s_v4_1;
+    private static Vector4 s_v4_2;
+    private static Vector4 s_v4_3;
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
     public static void init()
     {
-        s_A = new Vector2[10];
         Random random = new Random(100);
+
+        s_v2_array = new Vector2[10];
         for (int i = 0; i < 10; i++)
         {
-            s_A[i] = new Vector2(random.Next(100));
+            s_v2_array[i] = new Vector2(random.Next(100));
         }
-        s_p0 = new Vector2(random.Next(100));
-        s_p1 = new Vector2(random.Next(100));
-        s_p2 = new Vector2(random.Next(100));
-        s_p3 = new Vector2(random.Next(100));
+        s_v2_0 = new Vector2(random.Next(100));
+        s_v2_1 = new Vector2(random.Next(100));
+        s_v2_2 = new Vector2(random.Next(100));
+        s_v2_3 = new Vector2(random.Next(100));
+
+        s_v3_array = new Vector3[10];
+        for (int i = 0; i < 10; i++)
+        {
+            s_v3_array[i] = new Vector3(random.Next(100));
+        }
+        s_v3_0 = new Vector3(random.Next(100));
+        s_v3_1 = new Vector3(random.Next(100));
+        s_v3_2 = new Vector3(random.Next(100));
+        s_v3_3 = new Vector3(random.Next(100));
+
+        s_v4_array = new Vector4[10];
+        for (int i = 0; i < 10; i++)
+        {
+            s_v4_array[i] = new Vector4(random.Next(100));
+        }
+        s_v4_0 = new Vector4(random.Next(100));
+        s_v4_1 = new Vector4(random.Next(100));
+        s_v4_2 = new Vector4(random.Next(100));
+        s_v4_3 = new Vector4(random.Next(100));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Vector2 F1(float t)
+    public static Vector2 F1_v2(float t)
     {
         float ti = 1 - t;
         float t0 = ti * ti * ti;
         float t1 = 3 * ti * ti * t;
         float t2 = 3 * ti * t * t;
         float t3 = t * t * t;
-        return (t0 * s_p0) + (t1 * s_p1) + (t2 * s_p2) + (t3 * s_p3);
+        return (t0 * s_v2_0) + (t1 * s_v2_1) + (t2 * s_v2_2) + (t3 * s_v2_3);
     }
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
-    public static Vector2 F2(float u)
+    public static Vector2 F2_v2(float u)
     {
         if (u < 0)
-            return s_A[0];
+            return s_v2_array[0];
         if (u >= 1)
-            return s_A[1];
+            return s_v2_array[1];
         if (u < 0.1)
-            return s_A[2];
+            return s_v2_array[2];
         if (u > 0.9)
-            return s_A[3];
-        return F1(u);
+            return s_v2_array[3];
+        return F1_v2(u);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector3 F1_v3(float t)
+    {
+        float ti = 1 - t;
+        float t0 = ti * ti * ti;
+        float t1 = 3 * ti * ti * t;
+        float t2 = 3 * ti * t * t;
+        float t3 = t * t * t;
+        return (t0 * s_v3_0) + (t1 * s_v3_1) + (t2 * s_v3_2) + (t3 * s_v3_3);
+    }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public static Vector3 F2_v3(float u)
+    {
+        if (u < 0)
+            return s_v3_array[0];
+        if (u >= 1)
+            return s_v3_array[1];
+        if (u < 0.1)
+            return s_v3_array[2];
+        if (u > 0.9)
+            return s_v3_array[3];
+        return F1_v3(u);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector4 F1_v4(float t)
+    {
+        float ti = 1 - t;
+        float t0 = ti * ti * ti;
+        float t1 = 3 * ti * ti * t;
+        float t2 = 3 * ti * t * t;
+        float t3 = t * t * t;
+        return (t0 * s_v4_0) + (t1 * s_v4_1) + (t2 * s_v4_2) + (t3 * s_v4_3);
+    }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public static Vector4 F2_v4(float u)
+    {
+        if (u < 0)
+            return s_v4_array[0];
+        if (u >= 1)
+            return s_v4_array[1];
+        if (u < 0.1)
+            return s_v4_array[2];
+        if (u > 0.9)
+            return s_v4_array[3];
+        return F1_v4(u);
     }
 
     [MethodImplAttribute(MethodImplOptions.NoInlining)]
@@ -133,25 +217,51 @@ internal partial class VectorTest
     public static int Main()
     {
         init();
-        Vector2 result = F2(0.5F);
-        Vector2 expectedResult = F1(0.5F);
-        Console.WriteLine("Result is " + result.ToString());
-        if (!CheckValue<float>(result.X, expectedResult.X) || !CheckValue<float>(result.Y, expectedResult.Y))
+
+        Vector2 result_v2 = F2_v2(0.5F);
+        Vector2 expectedResult_v2 = F1_v2(0.5F);
+        Console.WriteLine("Result is " + result_v2.ToString());
+        if (!CheckValue<float>(result_v2.X, expectedResult_v2.X) || !CheckValue<float>(result_v2.Y, expectedResult_v2.Y))
         {
-            Console.WriteLine("Expected result is " + expectedResult.ToString());
-            Console.WriteLine("FAILED");
+            Console.WriteLine("Expected result is " + expectedResult_v2.ToString());
+            Console.WriteLine("Vector2 test FAILED");
+            return Fail;
+        }
+
+        Vector3 result_v3 = F2_v3(0.6F);
+        Vector3 expectedResult_v3 = F1_v3(0.6F);
+        Console.WriteLine("Result is " + result_v3.ToString());
+        if (!CheckValue<float>(result_v3.X, expectedResult_v3.X) ||
+            !CheckValue<float>(result_v3.Y, expectedResult_v3.Y) ||
+            !CheckValue<float>(result_v3.Z, expectedResult_v3.Z))
+        {
+            Console.WriteLine("Expected result is " + expectedResult_v3.ToString());
+            Console.WriteLine("Vector3 test FAILED");
+            return Fail;
+        }
+
+        Vector4 result_v4 = F2_v4(0.7F);
+        Vector4 expectedResult_v4 = F1_v4(0.7F);
+        Console.WriteLine("Result is " + result_v4.ToString());
+        if (!CheckValue<float>(result_v4.X, expectedResult_v4.X) ||
+            !CheckValue<float>(result_v4.Y, expectedResult_v4.Y) ||
+            !CheckValue<float>(result_v4.Z, expectedResult_v4.Z) ||
+            !CheckValue<float>(result_v4.W, expectedResult_v4.W))
+        {
+            Console.WriteLine("Expected result is " + expectedResult_v4.ToString());
+            Console.WriteLine("Vector4 test FAILED");
             return Fail;
         }
 
         if (VectorTReturnTest() != Pass)
         {
-            Console.WriteLine("FAILED");
+            Console.WriteLine("VectorTReturnTest FAILED");
             return Fail;
         }
 
         if (Vector3ReturnTest() != Pass)
         {
-            Console.WriteLine("FAILED");
+            Console.WriteLine("Vector3ReturnTest FAILED");
             return Fail;
         }
 


### PR DESCRIPTION
1. Since the F1/F2 tests of VectorReturn found an issue Vector2
on x86, I added variants of the same test for Vector3 and Vector4
(by basically copying F1/F2 and altering appropriately).
2. I noticed VectorMin for Vector4 wasn't checking the 'W' member,
so I fixed that.