### PR TITLE
Enable IsInPrologOrEpilog only if GC Info Decoder is not used

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -278,12 +278,14 @@ virtual void * GetGSCookieAddr(PREGDISPLAY     pContext,
                                EECodeInfo    * pCodeInfo,
                                CodeManState  * pState) = 0;
 
+#ifndef USE_GC_INFO_DECODER
 /*
   Returns true if the given IP is in the given method's prolog or an epilog.
 */
 virtual bool IsInPrologOrEpilog(DWORD  relPCOffset,
                                 GCInfoToken gcInfoToken,
                                 size_t* prologSize) = 0;
+#endif
 
 /*
   Returns true if the given IP is in the synchronized region of the method (valid for synchronized methods only)
@@ -546,6 +548,7 @@ void * GetGSCookieAddr(PREGDISPLAY     pContext,
                        CodeManState  * pState);
 
 
+#ifndef USE_GC_INFO_DECODER
 /*
   Returns true if the given IP is in the given method's prolog or an epilog.
 */
@@ -554,6 +557,7 @@ bool IsInPrologOrEpilog(
                 DWORD       relOffset,
                 GCInfoToken gcInfoToken,
                 size_t*     prologSize);
+#endif
 
 /*
   Returns true if the given IP is in the synchronized region of the method (valid for synchronized functions only)

--- a/src/vm/eedbginterface.h
+++ b/src/vm/eedbginterface.h
@@ -139,8 +139,10 @@ public:
 
 #ifndef DACCESS_COMPILE
 
+#ifndef USE_GC_INFO_DECODER
     virtual BOOL IsInPrologOrEpilog(const BYTE *address,
                                     size_t* prologSize) = 0;
+#endif
 
     // Determine whether certain native offsets of the specified function are within
     // an exception filter or handler.

--- a/src/vm/eedbginterfaceimpl.cpp
+++ b/src/vm/eedbginterfaceimpl.cpp
@@ -483,6 +483,7 @@ MethodDesc *EEDbgInterfaceImpl::GetNativeCodeMethodDesc(const PCODE address)
     RETURN ExecutionManager::GetCodeMethodDesc(address);
 }
 
+#ifndef USE_GC_INFO_DECODER
 // IsInPrologOrEpilog doesn't seem to be used for code that uses GC_INFO_DECODER
 BOOL EEDbgInterfaceImpl::IsInPrologOrEpilog(const BYTE *address,
                                             size_t* prologSize)
@@ -511,6 +512,7 @@ BOOL EEDbgInterfaceImpl::IsInPrologOrEpilog(const BYTE *address,
 
     return FALSE;
 }
+#endif // USE_GC_INFO_DECODER
 
 // 
 // Given a collection of native offsets of a certain function, determine if each falls

--- a/src/vm/eedbginterfaceimpl.h
+++ b/src/vm/eedbginterfaceimpl.h
@@ -124,8 +124,10 @@ public:
 
     MethodDesc *GetNativeCodeMethodDesc(const PCODE address) DAC_UNEXPECTED();
 
+#ifndef USE_GC_INFO_DECODER
     BOOL IsInPrologOrEpilog(const BYTE *address,
                             size_t* prologSize);
+#endif
 
     void DetermineIfOffsetsInFilterOrHandler(const BYTE *functionAddress,
                                                   DebugOffsetToHandlerInfo *pOffsetToHandlerInfo,

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5502,6 +5502,7 @@ void * EECodeManager::GetGSCookieAddr(PREGDISPLAY     pContext,
 #endif
 }
 
+#ifndef USE_GC_INFO_DECODER
 /*****************************************************************************
  *
  *  Returns true if the given IP is in the given method's prolog or epilog.
@@ -5515,7 +5516,6 @@ bool EECodeManager::IsInPrologOrEpilog(DWORD       relPCoffset,
         GC_NOTRIGGER;
     } CONTRACTL_END;
 
-#ifndef USE_GC_INFO_DECODER
     hdrInfo info;
 
     DecodeGCHdrInfo(gcInfoToken, relPCoffset, &info);
@@ -5525,11 +5525,8 @@ bool EECodeManager::IsInPrologOrEpilog(DWORD       relPCoffset,
 
     return ((info.prologOffs != hdrInfo::NOT_IN_PROLOG) || 
             (info.epilogOffs != hdrInfo::NOT_IN_EPILOG));
-#else // USE_GC_INFO_DECODER
-    _ASSERTE(!"@NYI - EECodeManager::IsInPrologOrEpilog (EETwain.cpp)");
-    return false;
-#endif // USE_GC_INFO_DECODER
 }
+#endif // USE_GC_INFO_DECODER
 
 /*****************************************************************************
  *


### PR DESCRIPTION
IsInPrologOrEpilog is implemented only when USE_GC_INFO_DECODER is not set.

This commit hides its declarations when USE_GC_INFO_DECODER is not set, and removes unnecessary assert in it.