### PR TITLE
Fix encoding of native signatures in the presence of Enum.GetHashCode optimization

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5180,6 +5180,14 @@ void CEEInfo::getCallInfo(
             {
                 // Pretend this was a "constrained. UnderlyingType" instruction prefix
                 constrainedType = TypeHandle(MscorlibBinder::GetElementType(constrainedType.GetVerifierCorElementType()));
+
+                // Native image signature encoder will use this field. It needs to match that pretended type, a bogus signature
+                // would be produced otherwise.
+                pConstrainedResolvedToken->hClass = (CORINFO_CLASS_HANDLE)constrainedType.AsPtr();
+
+                // Clear the token and typespec because of they do not match hClass anymore.
+                pConstrainedResolvedToken->token = mdTokenNil;
+                pConstrainedResolvedToken->pTypeSpec = NULL;
             }
         }
 

--- a/tests/src/readytorun/main.cs
+++ b/tests/src/readytorun/main.cs
@@ -99,6 +99,11 @@ class Program
         {
              ((Object)s).ToString();
         }
+
+        // Enum.GetHashCode optimization requires special treatment
+        // in native signature encoding
+        MyEnum e = MyEnum.Apple;
+        e.GetHashCode();
     }
 
     static void TestConstrainedMethodCalls_Unsupported()

--- a/tests/src/readytorun/test.cs
+++ b/tests/src/readytorun/test.cs
@@ -403,3 +403,10 @@ public class ByteChildClass : ByteBaseClass
         ChildByte = 67;
     }
 }
+
+public enum MyEnum
+{
+    Apple = 1,
+    Banana = 2,
+    Orange = 3
+}


### PR DESCRIPTION
Fixes #9118