### PR TITLE
[RyuJIT/ARM32] Enable fallback to legacy JIT to facilitate testing

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -317,6 +317,8 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         case GT_SUB:
         case GT_MUL:
         {
+            genConsumeOperands(treeNode->AsOp());
+
             const genTreeOps oper = treeNode->OperGet();
             if ((oper == GT_ADD || oper == GT_SUB || oper == GT_MUL) && treeNode->gtOverflow())
             {
@@ -331,56 +333,8 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             // The arithmetic node must be sitting in a register (since it's not contained)
             noway_assert(targetReg != REG_NA);
 
-            regNumber op1reg = op1->gtRegNum;
-            regNumber op2reg = op2->gtRegNum;
-
-            GenTreePtr dst;
-            GenTreePtr src;
-
-            genConsumeIfReg(op1);
-            genConsumeIfReg(op2);
-
-            if (!varTypeIsFloating(targetType))
-            {
-                // This is the case of reg1 = reg1 op reg2
-                // We're ready to emit the instruction without any moves
-                if (op1reg == targetReg)
-                {
-                    dst = op1;
-                    src = op2;
-                }
-                // We have reg1 = reg2 op reg1
-                // In order for this operation to be correct
-                // we need that op is a commutative operation so
-                // we can convert it into reg1 = reg1 op reg2 and emit
-                // the same code as above
-                else if (op2reg == targetReg)
-                {
-                    assert(GenTree::OperIsCommutative(treeNode->OperGet()));
-                    dst = op2;
-                    src = op1;
-                }
-                // dest, op1 and op2 registers are different:
-                // reg3 = reg1 op reg2
-                // We can implement this by issuing a mov:
-                // reg3 = reg1
-                // reg3 = reg3 op reg2
-                else
-                {
-                    inst_RV_RV(ins_Move_Extend(targetType, true), targetReg, op1reg, op1->gtType);
-                    regTracker.rsTrackRegCopy(targetReg, op1reg);
-                    gcInfo.gcMarkRegPtrVal(targetReg, targetType);
-                    dst = treeNode;
-                    src = op2;
-                }
-
-                regNumber r = emit->emitInsBinary(ins, emitTypeSize(treeNode), dst, src);
-                assert(r == targetReg);
-            }
-            else
-            {
-                emit->emitIns_R_R_R(ins, emitTypeSize(treeNode), targetReg, op1reg, op2reg);
-            }
+            regNumber r = emit->emitInsTernary(ins, emitTypeSize(treeNode), treeNode, op1, op2);
+            assert(r == targetReg);
         }
             genProduceReg(treeNode);
             break;
@@ -1122,13 +1076,12 @@ void CodeGen::genCodeForShift(GenTreePtr tree)
 
     assert(tree->gtRegNum != REG_NA);
 
-    GenTreePtr operand = tree->gtGetOp1();
-    genConsumeReg(operand);
+    genConsumeOperands(tree->AsOp());
 
+    GenTreePtr operand = tree->gtGetOp1();
     GenTreePtr shiftBy = tree->gtGetOp2();
     if (!shiftBy->IsCnsIntOrI())
     {
-        genConsumeReg(shiftBy);
         getEmitter()->emitIns_R_R_R(ins, size, tree->gtRegNum, operand->gtRegNum, shiftBy->gtRegNum);
     }
     else

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -7646,5 +7646,174 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
     }
 }
 
+regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, GenTree* src1, GenTree* src2)
+{
+    regNumber result = REG_NA;
+
+    // dst can only be a reg
+    assert(!dst->isContained());
+
+    // find immed (if any) - it cannot be a dst
+    // Only one src can be an int.
+    GenTreeIntConCommon* intConst  = nullptr;
+    GenTree*             nonIntReg = nullptr;
+
+    if (varTypeIsFloating(dst))
+    {
+        // src1 can only be a reg
+        assert(!src1->isContained());
+        // src2 can only be a reg
+        assert(!src2->isContained());
+    }
+    else // not floating point
+    {
+        // src2 can be immed or reg
+        assert(!src2->isContained() || src2->isContainedIntOrIImmed());
+
+        // Check src2 first as we can always allow it to be a contained immediate
+        if (src2->isContainedIntOrIImmed())
+        {
+            intConst  = src2->AsIntConCommon();
+            nonIntReg = src1;
+        }
+        // Only for commutative operations do we check src1 and allow it to be a contained immediate
+        else if (dst->OperIsCommutative())
+        {
+            // src1 can be immed or reg
+            assert(!src1->isContained() || src1->isContainedIntOrIImmed());
+
+            // Check src1 and allow it to be a contained immediate
+            if (src1->isContainedIntOrIImmed())
+            {
+                assert(!src2->isContainedIntOrIImmed());
+                intConst  = src1->AsIntConCommon();
+                nonIntReg = src2;
+            }
+        }
+        else
+        {
+            // src1 can only be a reg
+            assert(!src1->isContained());
+        }
+    }
+    bool      isMulOverflow = false;
+    bool      isUnsignedMul = false;
+    regNumber extraReg      = REG_NA;
+    if (dst->gtOverflowEx())
+    {
+        NYI_ARM("emitInsTernary overflow");
+#if 0
+        if (ins == INS_add)
+        {
+            ins = INS_adds;
+        }
+        else if (ins == INS_sub)
+        {
+            ins = INS_subs;
+        }
+        else if (ins == INS_mul)
+        {
+            isMulOverflow = true;
+            isUnsignedMul = ((dst->gtFlags & GTF_UNSIGNED) != 0);
+            assert(intConst == nullptr); // overflow format doesn't support an int constant operand
+        }
+        else
+        {
+            assert(!"Invalid ins for overflow check");
+        }
+#endif
+    }
+    if (intConst != nullptr)
+    {
+        emitIns_R_R_I(ins, attr, dst->gtRegNum, nonIntReg->gtRegNum, intConst->IconValue());
+    }
+    else
+    {
+        if (isMulOverflow)
+        {
+            NYI_ARM("emitInsTernary overflow");
+#if 0
+            // Make sure that we have an internal register
+            assert(genCountBits(dst->gtRsvdRegs) == 2);
+
+            // There will be two bits set in tmpRegsMask.
+            // Remove the bit for 'dst->gtRegNum' from 'tmpRegsMask'
+            regMaskTP tmpRegsMask = dst->gtRsvdRegs & ~genRegMask(dst->gtRegNum);
+            assert(tmpRegsMask != RBM_NONE);
+            regMaskTP tmpRegMask = genFindLowestBit(tmpRegsMask); // set tmpRegMsk to a one-bit mask
+            extraReg             = genRegNumFromMask(tmpRegMask); // set tmpReg from that mask
+
+            if (isUnsignedMul)
+            {
+                if (attr == EA_4BYTE)
+                {
+                    // Compute 8 byte results from 4 byte by 4 byte multiplication.
+                    emitIns_R_R_R(INS_umull, EA_8BYTE, dst->gtRegNum, src1->gtRegNum, src2->gtRegNum);
+
+                    // Get the high result by shifting dst.
+                    emitIns_R_R_I(INS_lsr, EA_8BYTE, extraReg, dst->gtRegNum, 32);
+                }
+                else
+                {
+                    assert(attr == EA_8BYTE);
+                    // Compute the high result.
+                    emitIns_R_R_R(INS_umulh, attr, extraReg, src1->gtRegNum, src2->gtRegNum);
+
+                    // Now multiply without skewing the high result.
+                    emitIns_R_R_R(ins, attr, dst->gtRegNum, src1->gtRegNum, src2->gtRegNum);
+                }
+
+                // zero-sign bit comparision to detect overflow.
+                emitIns_R_I(INS_cmp, attr, extraReg, 0);
+            }
+            else
+            {
+                int bitShift = 0;
+                if (attr == EA_4BYTE)
+                {
+                    // Compute 8 byte results from 4 byte by 4 byte multiplication.
+                    emitIns_R_R_R(INS_smull, EA_8BYTE, dst->gtRegNum, src1->gtRegNum, src2->gtRegNum);
+
+                    // Get the high result by shifting dst.
+                    emitIns_R_R_I(INS_lsr, EA_8BYTE, extraReg, dst->gtRegNum, 32);
+
+                    bitShift = 31;
+                }
+                else
+                {
+                    assert(attr == EA_8BYTE);
+                    // Save the high result in a temporary register.
+                    emitIns_R_R_R(INS_smulh, attr, extraReg, src1->gtRegNum, src2->gtRegNum);
+
+                    // Now multiply without skewing the high result.
+                    emitIns_R_R_R(ins, attr, dst->gtRegNum, src1->gtRegNum, src2->gtRegNum);
+
+                    bitShift = 63;
+                }
+
+                // Sign bit comparision to detect overflow.
+                emitIns_R_R_I(INS_cmp, attr, extraReg, dst->gtRegNum, bitShift, INS_OPTS_ASR);
+            }
+#endif
+        }
+        else
+        {
+            // We can just multiply.
+            emitIns_R_R_R(ins, attr, dst->gtRegNum, src1->gtRegNum, src2->gtRegNum);
+        }
+    }
+
+    if (dst->gtOverflowEx())
+    {
+        NYI_ARM("emitInsTernary overflow");
+#if 1
+        assert(!varTypeIsFloating(dst));
+        codeGen->genCheckOverflow(dst);
+#endif
+    }
+
+    return dst->gtRegNum;
+}
+
 #endif // !LEGACY_BACKEND
 #endif // defined(_TARGET_ARM_)

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -2326,7 +2326,7 @@ void CodeGen::inst_RV_TT(instruction ins,
 #if CPU_LOAD_STORE_ARCH
     if (ins == INS_mov)
     {
-#if defined(_TARGET_ARM_)
+#if defined(_TARGET_ARM_) && CPU_LONG_USES_REGPAIR
         if (tree->TypeGet() != TYP_LONG)
         {
             ins = ins_Move_Extend(tree->TypeGet(), (tree->gtFlags & GTF_REG_VAL) != 0);
@@ -2341,7 +2341,7 @@ void CodeGen::inst_RV_TT(instruction ins,
             ins = ins_Move_Extend(TYP_INT,
                                   (tree->gtFlags & GTF_REG_VAL) != 0 && genRegPairHi(tree->gtRegPair) != REG_STK);
         }
-#elif defined(_TARGET_ARM64_)
+#elif defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
         ins = ins_Move_Extend(tree->TypeGet(), (tree->gtFlags & GTF_REG_VAL) != 0);
 #else
         NYI("CodeGen::inst_RV_TT with INS_mov");
@@ -2485,9 +2485,11 @@ AGAIN:
                 default:
                     regNumber regTmp;
 #ifndef LEGACY_BACKEND
+#if CPU_LONG_USES_REGPAIR
                     if (tree->TypeGet() == TYP_LONG)
                         regTmp = (offs == 0) ? genRegPairLo(tree->gtRegPair) : genRegPairHi(tree->gtRegPair);
                     else
+#endif // CPU_LONG_USES_REGPAIR
                         regTmp = tree->gtRegNum;
 #else  // LEGACY_BACKEND
                     if (varTypeIsFloating(tree))
@@ -2575,6 +2577,7 @@ AGAIN:
             inst_RV_IV(ins, reg, tree->gtIntCon.gtIconVal, emitActualTypeSize(tree->TypeGet()), flags);
             break;
 
+#if CPU_LONG_USES_REGPAIR
         case GT_CNS_LNG:
 
             assert(size == EA_4BYTE || size == EA_8BYTE);
@@ -2609,6 +2612,7 @@ AGAIN:
 
             inst_RV_IV(ins, reg, constVal, size, flags);
             break;
+#endif // CPU_LONG_USES_REGPAIR
 
         case GT_COMMA:
             tree = tree->gtOp.gtOp2;

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -845,7 +845,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
     DISPNODE(tree);
 
     NYI_IF(tree->TypeGet() == TYP_STRUCT, "lowering struct");
-    NYI_IF(tree->TypeGet() == TYP_LONG,   "lowering long");
+    NYI_IF(tree->TypeGet() == TYP_LONG, "lowering long");
     NYI_IF(tree->TypeGet() == TYP_DOUBLE, "lowering double");
 
     switch (tree->OperGet())

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -844,6 +844,10 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
     JITDUMP("TreeNodeInfoInit for: ");
     DISPNODE(tree);
 
+    NYI_IF(tree->TypeGet() == TYP_STRUCT, "lowering struct");
+    NYI_IF(tree->TypeGet() == TYP_LONG,   "lowering long");
+    NYI_IF(tree->TypeGet() == TYP_DOUBLE, "lowering double");
+
     switch (tree->OperGet())
     {
         GenTree* op1;
@@ -1183,13 +1187,16 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             break;
 
         default:
-#ifdef DEBUG
-            JitTls::GetCompiler()->gtDispTree(tree);
-#endif
             NYI_ARM("TreeNodeInfoInit default case");
         case GT_LCL_FLD:
         case GT_LCL_VAR:
         case GT_LCL_VAR_ADDR:
+        {
+            unsigned   varNum = tree->gtLclVarCommon.gtLclNum;
+            LclVarDsc* varDsc = comp->lvaTable + varNum;
+            NYI_IF(varTypeIsStruct(varDsc), "lowering struct var");
+            NYI_IF(varTypeIsLong(varDsc), "lowering long var");
+        }
         case GT_CLS_VAR_ADDR:
         case GT_IL_OFFSET:
         case GT_CNS_INT:

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1176,7 +1176,11 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   // TODO-ARM-CQ: Check for sdiv/udiv at runtime and generate it if available
   #define USE_HELPERS_FOR_INT_DIV  1       // BeagleBoard (ARMv7A) doesn't support SDIV/UDIV
   #define CPU_LOAD_STORE_ARCH      1
+#ifdef LEGACY_BACKEND
   #define CPU_LONG_USES_REGPAIR    1
+#else
+  #define CPU_LONG_USES_REGPAIR    0
+#endif
   #define CPU_HAS_FP_SUPPORT       1
   #define ROUND_FLOAT              0       // Do not round intermed float expression results
   #define CPU_HAS_BYTE_REGS        0
@@ -1418,6 +1422,10 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_INTRET               RBM_R0
   #define REG_LNGRET               REG_PAIR_R0R1
   #define RBM_LNGRET              (RBM_R1|RBM_R0)
+  #define REG_LNGRET_LO            REG_R0
+  #define REG_LNGRET_HI            REG_R1
+  #define RBM_LNGRET_LO            RBM_R0
+  #define RBM_LNGRET_HI            RBM_R1
 
   #define REG_FLOATRET             REG_F0
   #define RBM_FLOATRET             RBM_F0


### PR DESCRIPTION
This enables full pass of the debug build of `JIT/CodeGenBringUpTests` with the options:
```
COMPlus_AltJit=* COMPlus_AltJitAssertOnNYI=0
```
i.e. in the mode of falling back to the legacy JIT when hitting a NYI assertion.

The idea is to have a better way of tracking RyuJIT/ARM32 development by integrating with the CI system. Is it feasible to make an additional test configuration for dotnet-bot (say, `arm32ryujit` option)? 

(This is a part of #8496.)