### PR TITLE
[Revived PR] Faster Buffer.MemoryCopy for AMD64

### DIFF
--- a/src/mscorlib/src/System/Buffer.cs
+++ b/src/mscorlib/src/System/Buffer.cs
@@ -258,11 +258,12 @@ namespace System {
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         internal unsafe static void MemoryCopyCore(byte* destination, byte* source, nuint length)
         {
-            const nuint PInvokeThreshold = 512;
 #if AMD64
+            const nuint PInvokeThreshold = 1024;
             const nuint CopyAlignment = 16; // SIMD is enabled for AMD64, so align on a 16-byte boundary
             const nuint BytesPerIteration = 64;
 #else
+            const nuint PInvokeThreshold = 512;
             const nuint CopyAlignment = 4; // Align on a 4-byte boundary
             const nuint BytesPerIteration = 16;
 #endif

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -455,9 +455,9 @@ namespace System
                     fixed (byte* pSource = &Unsafe.As<T, byte>(ref source))
                     {
 #if BIT64
-                        Buffer.Memmove(pDestination, pSource, (ulong)elementsCount * (ulong)Unsafe.SizeOf<T>());
+                        Buffer.MemoryCopyCore(pDestination, pSource, (ulong)elementsCount * (ulong)Unsafe.SizeOf<T>());
 #else
-                        Buffer.Memmove(pDestination, pSource, (uint)elementsCount * (uint)Unsafe.SizeOf<T>());
+                        Buffer.MemoryCopyCore(pDestination, pSource, (uint)elementsCount * (uint)Unsafe.SizeOf<T>());
 #endif
                     }
                 }


### PR DESCRIPTION
This is a revival of the PR at https://github.com/dotnet/coreclr/pull/6638 I had to close a few months earlier because it had too many comments. I basically re-wrote the code I had written earlier, except with a few changes:

- I removed the optimizations for ARM64. I know very little about that platform, so someone more qualified should probably optimize it.
- I kept things mostly the way they were for non-AMD64 platforms. The only major thing I changed was replacing branching at the beginning/end of the copy with unaligned writes.
- I very conservatively kept the P/Invoke threshold at 1024 bytes, because even though my benchmarks said that the managed implementation was faster up to 8192 bytes, @nietras' benchmarks were saying 1024.
  - After this is merged, I'll open up a new PR where I increase it back to 8192 and we can discuss more about the threshold size.
- I also renamed some things to make the code cleaner, e.g. so that variables have self-explanatory names.

**Please note:** I am looking to get this merged mostly as-is because it's a clear win over what we currently have. Once this gets in, then we can open the door for further discussion/experimentation/etc. over optimizations.

/cc @jkotas, @nietras @tannergooding @benaadams FYI