### PR TITLE
Speed up test native binary syncing in pipeline

### DIFF
--- a/config.json
+++ b/config.json
@@ -441,6 +441,13 @@
             "Project": "./src/syncAzure.proj"
           }
         },
+        "n": {
+          "description": "Downloads test native binaries. The values for '-AzureAccount', '-AzureToken', and '-Container' are required",
+          "settings": {
+            "Project": "./src/syncAzure.proj",
+            "PublishTestNativeBins": "true"
+          }
+        },
         "azureToken": {
           "description": "Account token to connect to Azure Blob storage.",
           "settings": {
@@ -475,12 +482,6 @@
           "description": "To download a specific group of product packages, specify build number. The value for -BuildMajor required.",
           "settings": {
             "BuildNumberMinor": "default"
-          }
-        },
-        "PublishTestNativeBins": {
-          "description": "Downloads Published test native binaries.",
-          "settings": {
-            "PublishTestNativeBins": "default"
           }
         }
       },

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -14,7 +14,7 @@
     <ItemGroup>
       <ForPublishing>
         <RelativeBlobPath Condition="'$(PublishTestNativeBins)' != 'true'">$(__BuildType)/%(RecursiveDir)%(Filename)%(Extension)</RelativeBlobPath>
-        <RelativeBlobPath Condition="'$(PublishTestNativeBins)' == 'true'">$(__DistroRid)-$(__BuildArch)/$(__BuildType)/%(RecursiveDir)%(Filename)%(Extension)</RelativeBlobPath>    
+        <RelativeBlobPath Condition="'$(PublishTestNativeBins)' == 'true'">$(__BuildType)/%(RecursiveDir)%(Filename)%(Extension)</RelativeBlobPath>    
       </ForPublishing>
     </ItemGroup>
     <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />
@@ -30,9 +30,9 @@
           Condition="'$(ContainerName)' == '' or '$(PublishTestNativeBins)' == 'true'">
     <PropertyGroup>
       <ContainerName Condition="'$(__Container)' == '' and '$(PublishTestNativeBins)' != 'true'">coreclr-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
-      <ContainerName Condition="'$(__Container)' == '' and '$(PublishTestNativeBins)' == 'true'">coreclr-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-test-native-bins</ContainerName>
+      <ContainerName Condition="'$(__Container)' == '' and '$(PublishTestNativeBins)' == 'true'">coreclr-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(__DistroRid)-$(__BuildArch)</ContainerName>
       <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' != 'true'">$(__Container)</ContainerName>
-      <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' == 'true'">$(__Container)-test-native-bins</ContainerName>
+      <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' == 'true'">$(__Container)-$(__DistroRid)-$(__BuildArch)</ContainerName>
     </PropertyGroup>
   </Target>
 

--- a/src/syncAzure.proj
+++ b/src/syncAzure.proj
@@ -5,8 +5,7 @@
   <PropertyGroup>
     <ContainerNamePrefix Condition="'$(ContainerNamePrefix)' == ''">coreclr-$(PreReleaseLabel)</ContainerNamePrefix>
     <ContainerName Condition="'$(__Container)' == '' and '$(ContainerNamePrefix)' != '' and '$(BuildNumberMajor)' != '' and '$(BuildNumberMinor)' != ''">$(ContainerNamePrefix)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
-    <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' != 'true'">$(__Container)</ContainerName>
-    <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' == 'true'">$(__Container)-test-native-bins</ContainerName>
+    <ContainerName Condition="'$(__Container)' != ''">$(__Container)</ContainerName>
     <DownloadDirectory Condition="'$(PublishTestNativeBins)' != 'true'">$(PackagesDir)AzureTransfer</DownloadDirectory>
     <DownloadDirectory Condition="'$(PublishTestNativeBins)' == 'true'">$(PackagesDir)TestNativeBins</DownloadDirectory>
   </PropertyGroup>
@@ -16,6 +15,7 @@
   <Target Name="ValidateRequiredProperties">
     <Error Condition="'$(CloudDropAccountName)' == ''" Text="Missing property CloudDropAccountName." />
     <Error Condition="'$(CloudDropAccessToken)' == ''" Text="Missing property CloudDropAccessToken." />
+    <Error Condition="'$(__Container)' == '' and '$(PublishTestNativeBins)' == 'true'" Text="Missing property Container." />
   </Target>
 
   <Target Name="Build" DependsOnTargets="ValidateRequiredProperties;DownloadBlobsFromAzureTargets" />

--- a/sync.cmd
+++ b/sync.cmd
@@ -7,7 +7,6 @@ if /I [%1] == [-help] goto Usage
 @if [%1]==[] set __args=-p
 
  @call %~dp0run.cmd sync %__args% %*
- @call %~dp0run.cmd sync -PublishTestNativeBins %__args% %*
 @exit /b %ERRORLEVEL%
 
 :Usage
@@ -27,6 +26,12 @@ echo                 -BuildMajor
 echo                 -BuildMinor
 echo              To download from a specific container, specify:
 echo                 -Container="container name"
+echo     -n     - Downloads test native binaries for the specified OS
+echo              The following properties are required:
+echo                 -AzureAccount="Account name"
+echo                 -AzureToken="Access token"
+echo                 -Container="container name (with RID suffix)"
+echo.
 echo.
 echo.
 echo If no option is specified then sync.cmd -p is implied.


### PR DESCRIPTION
This will make publish-packages.sh publish test native binaries into an Azure container named {build-label}-{Runtime ID}, instead of in a folder named {Runtime-ID} inside of a container named {build-label}-test-native-bins. That way, you only have to download from the container with binaries for the OS you're building for, rather than downloading binaries for all non-windows OS's. The workflow for this is:

`sync.cmd -n -AzureAccount=xxx -AzureToken=yyy -Container=zzz`

Where 'zzz' is the name of the container with the native binaries you desire (i.e. {build-label}-{runtime ID}. Once this is merged, it will require pipeline changes.