### PR TITLE
Remove unnecessary private String.SplitInternal method

### DIFF
--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -1040,15 +1040,15 @@ namespace System
         }
 
         [ComVisible(false)]
-        public String[] Split(char separator, StringSplitOptions options = StringSplitOptions.None) {
+        public unsafe String[] Split(char separator, StringSplitOptions options = StringSplitOptions.None) {
             Contract.Ensures(Contract.Result<String[]>() != null);
-            return SplitInternal(separator, Int32.MaxValue, options);
+            return SplitInternal(&separator, 1, int.MaxValue, options);
         }
 
         [ComVisible(false)]
-        public String[] Split(char separator, int count, StringSplitOptions options = StringSplitOptions.None) {
+        public unsafe String[] Split(char separator, int count, StringSplitOptions options = StringSplitOptions.None) {
             Contract.Ensures(Contract.Result<String[]>() != null);
-            return SplitInternal(separator, count, options);
+            return SplitInternal(&separator, 1, count, options);
         }
 
         // Creates an array of strings by splitting this string at each
@@ -1092,11 +1092,6 @@ namespace System
         {
             Contract.Ensures(Contract.Result<String[]>() != null);
             return SplitInternal(separator, count, options);
-        }
-
-        private unsafe String[] SplitInternal(char separator, int count, StringSplitOptions options)
-        {
-            return SplitInternal(&separator, 1, count, options);
         }
 
         private unsafe String[] SplitInternal(char[] separator, int count, StringSplitOptions options)


### PR DESCRIPTION
Avoid the unnecessary intermediate method call.