### PR TITLE
JIT: fixup finally target flag after finally opts run

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3425,6 +3425,7 @@ public:
     bool fgComputePredsDone; // Have we computed the bbPreds list
     bool fgCheapPredsValid;  // Is the bbCheapPreds list valid?
     bool fgDomsComputed;     // Have we computed the dominator sets?
+    bool fgOptimizedFinally; // Did we optimize any try-finallys?
 
     bool     fgHasSwitch;  // any BBJ_SWITCH jumps?
     bool     fgHasPostfix; // any postfix ++/-- found?
@@ -3502,6 +3503,8 @@ public:
     void fgCloneFinally();
 
     void fgCleanupContinuation(BasicBlock* continuation);
+
+    void fgUpdateFinallyTargetFlags();
 
     GenTreePtr fgGetCritSectOfStaticMethod();
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16915,8 +16915,6 @@ void Compiler::fgMorph()
     fgDebugCheckBBlist(false, false);
 #endif // DEBUG
 
-// RemoveEmptyFinally is disabled on ARM due to github issue #9013
-#ifndef _TARGET_ARM_
     fgRemoveEmptyTry();
 
     EndPhase(PHASE_EMPTY_TRY);
@@ -16928,7 +16926,8 @@ void Compiler::fgMorph()
     fgCloneFinally();
 
     EndPhase(PHASE_CLONE_FINALLY);
-#endif // _TARGET_ARM_
+
+    fgUpdateFinallyTargetFlags();
 
     /* For x64 and ARM64 we need to mark irregular parameters early so that they don't get promoted */
     fgMarkImplicitByRefArgs();


### PR DESCRIPTION
The finally target flag can't be incrementally maintaned during finally
opts, so flag if any of these opts run and then run a post-opts fixup pass
to properly determine the flag value.

Only impacts arm targets.

Closes #9015.