### PR TITLE
Android - Fix duplicate definitions of INT_MIN and PAGE_SIZE in unit tests

### DIFF
--- a/src/pal/tests/palsuite/threading/NamedMutex/test1/nopal.cpp
+++ b/src/pal/tests/palsuite/threading/NamedMutex/test1/nopal.cpp
@@ -16,7 +16,9 @@
 
 #define _countof(a) (sizeof(a) / sizeof(a[0]))
 
+#ifndef __ANDROID__
 #define PAGE_SIZE (4096)
+#endif
 
 auto test_strcpy = strcpy;
 auto test_strcmp = strcmp;

--- a/src/pal/tests/palsuite/threading/NamedMutex/test1/nopal.cpp
+++ b/src/pal/tests/palsuite/threading/NamedMutex/test1/nopal.cpp
@@ -16,9 +16,8 @@
 
 #define _countof(a) (sizeof(a) / sizeof(a[0]))
 
-#ifndef __ANDROID__
+#undef PAGE_SIZE
 #define PAGE_SIZE (4096)
-#endif
 
 auto test_strcpy = strcpy;
 auto test_strcmp = strcmp;

--- a/tests/src/Interop/common/types.h
+++ b/tests/src/Interop/common/types.h
@@ -5,9 +5,8 @@
 #ifndef _INTEROP_TYPES__H
 #define _INTEROP_TYPES__H
 
-#ifndef __ANDROID__
+#undef INT_MIN
 #define INT_MIN	   (-2147483647 - 1)
-#endif
 
 typedef char16_t WCHAR;
 typedef unsigned long DWORD;

--- a/tests/src/Interop/common/types.h
+++ b/tests/src/Interop/common/types.h
@@ -5,7 +5,9 @@
 #ifndef _INTEROP_TYPES__H
 #define _INTEROP_TYPES__H
 
+#ifndef __ANDROID__
 #define INT_MIN	   (-2147483647 - 1)
+#endif
 
 typedef char16_t WCHAR;
 typedef unsigned long DWORD;


### PR DESCRIPTION
Both `INT_MIN` and `PAGE_SIZE` already exist on Android, but are redefined for the unit tests. This PR fixes that conflict.