### PR TITLE
Support cross-building CoreCLR for arm64 Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ else (WIN32)
       # Ensure that objcopy is present
       if (DEFINED ENV{CROSSCOMPILE} AND NOT DEFINED CLR_CROSS_COMPONENTS_BUILD)
         if (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
-          find_program(OBJCOPY ${TOOLCHAIN}-objcopy)
+          find_program(OBJCOPY ${TOOLCHAIN_PREFIX}objcopy)
         elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
           find_program(OBJCOPY objcopy)
         else()

--- a/functions.cmake
+++ b/functions.cmake
@@ -222,7 +222,7 @@ endfunction()
 function(verify_dependencies targetName errorMessage)
     # We don't need to verify dependencies on OSX, since missing dependencies
     # result in link error over there.
-    if (NOT CLR_CMAKE_PLATFORM_DARWIN)
+    if (NOT CLR_CMAKE_PLATFORM_DARWIN AND NOT CLR_CMAKE_PLATFORM_ANDROID)
         add_custom_command(
             TARGET ${targetName}
             POST_BUILD

--- a/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
@@ -23,8 +23,13 @@ endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL 
 # pthread by the process executable ensures that all locks are initialized properly.
 target_link_libraries(coreconsole
     unixcoreruncommon
-    pthread
 )
+
+if(NOT CLR_CMAKE_PLATFORM_ANDROID)
+  target_link_libraries(coreconsole
+    pthread
+  )
+endif()
 
 add_dependencies(coreconsole
     coreclr

--- a/src/coreclr/hosts/unixcorerun/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcorerun/CMakeLists.txt
@@ -23,8 +23,14 @@ endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL 
 # pthread by the process executable ensures that all locks are initialized properly.
 target_link_libraries(corerun
     unixcoreruncommon
-    pthread
 )
+
+# Android implements pthread natively
+if(NOT CLR_CMAKE_PLATFORM_ANDROID)
+  target_link_libraries(corerun
+    pthread
+  )
+endif()
 
 add_dependencies(corerun
     coreclr

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -293,6 +293,22 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     find_library(INTL intl)
   endif()
 
+  # On Android, we don't need to link with gcc_s, pthread and rt
+  if(NOT CLR_CMAKE_PLATFORM_ANDROID)
+    target_link_libraries(coreclrpal
+      gcc_s
+      pthread
+      rt
+    )
+  endif()
+
+  if(CLR_CMAKE_PLATFORM_ANDROID)
+    target_link_libraries(coreclrpal
+      gnustl_shared
+      android-support
+      android-glob)
+  endif()
+
   if(NOT CLR_CMAKE_PLATFORM_ANDROID)
     find_library(UNWIND NAMES unwind)
 
@@ -326,22 +342,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   endif()
 
   find_library(UNWIND_GENERIC NAMES unwind-generic)
-
-  # On Android, we don't need to link with gcc_s, pthread and rt
-  if(NOT CLR_CMAKE_PLATFORM_ANDROID)
-    target_link_libraries(coreclrpal
-      gcc_s
-      pthread
-      rt
-    )
-  endif()
-
-  if(CLR_CMAKE_PLATFORM_ANDROID)
-    target_link_libraries(coreclrpal
-      gnustl_shared
-      android-support
-      android-glob)
-  endif()
 
   target_link_libraries(coreclrpal
     dl

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -281,30 +281,72 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     find_library(UNWIND_ARCH NAMES unwind-arm)
   endif()
 
+  if(PAL_CMAKE_PLATFORM_ARCH_ARM64)
+    find_library(UNWIND_ARCH NAMES unwind-aarch64)
+  endif()
+
   if(PAL_CMAKE_PLATFORM_ARCH_AMD64)
     find_library(UNWIND_ARCH NAMES unwind-x86_64)
   endif()
 
-  if(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+  if(CLR_CMAKE_PLATFORM_ALPINE_LINUX OR CLR_CMAKE_PLATFORM_ANDROID)
     find_library(INTL intl)
   endif()
 
-  find_library(UNWIND NAMES unwind)
+  if(NOT CLR_CMAKE_PLATFORM_ANDROID)
+    find_library(UNWIND NAMES unwind)
+
+    if(UNWIND STREQUAL UNWIND-NOTFOUND)
+      message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev and libunwind8.")
+    endif(UNWIND STREQUAL UNWIND-NOTFOUND)
+
+    target_link_libraries(coreclrpal ${UNWIND})
+  endif()
+
+  if(CLR_MAKE_PLATFORM_ANDROID)
+    find_library(ANDROID_SUPPORT NAMES android-support)
+    find_library(ANDROID_GLOB NAMES android-glob)
+    find_library(INTL NAMES intl)
+
+    if(UNWIND_ARCH STREQUAL UNWIND_ARCH-NOTFOUND)
+      message(FATAL_ERROR "Cannot find libunwind.")
+    endif()
+
+    if(ANDROID_SUPPORT STREQUAL ANDROID_SUPPORT-NOTFOUND)
+      message(FATAL_ERROR "Cannot find android-support.")
+    endif()
+
+    if(ANDROID_GLOB STREQUAL ANDROID_GLOB-NOTFOUND)
+      message(FATAL_ERROR "Cannot find android-glob.")
+    endif()
+
+    if(INTL STREQUAL INTL-NOTFOUND)
+      message(FATAL_ERROR "Cannot find libintl.")
+    endif()
+  endif()
+
   find_library(UNWIND_GENERIC NAMES unwind-generic)
 
+  # On Android, we don't need to link with gcc_s, pthread and rt
+  if(NOT CLR_CMAKE_PLATFORM_ANDROID)
+    target_link_libraries(coreclrpal
+      gcc_s
+      pthread
+      rt
+    )
+  endif()
+
+  if(CLR_CMAKE_PLATFORM_ANDROID)
+    target_link_libraries(coreclrpal
+      gnustl_shared
+      android-support
+      android-glob)
+  endif()
+
   target_link_libraries(coreclrpal
-    gcc_s
-    pthread
-    rt
     dl
     uuid
   )
-
-  if(UNWIND STREQUAL UNWIND-NOTFOUND)
-    message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev and libunwind8.")
-  endif(UNWIND STREQUAL UNWIND-NOTFOUND)
-
-  target_link_libraries(coreclrpal ${UNWIND})
 
   if(NOT UNWIND_GENERIC STREQUAL UNWIND_GENERIC-NOTFOUND)
     target_link_libraries(coreclrpal ${UNWIND_GENERIC})

--- a/src/pal/tests/palsuite/CMakeLists.txt
+++ b/src/pal/tests/palsuite/CMakeLists.txt
@@ -5,10 +5,14 @@ project(PALTESTSUITE)
 include_directories(${PALTESTSUITE_SOURCE_DIR}/common)
 
 # All test will link against these libraries:
-set(COMMON_TEST_LIBRARIES
-    pthread
-    m
-    coreclrpal)
+# pthread and m are part of the Android C library (bionic),
+# so we don't need to link them seperately
+if(NOT CLR_CMAKE_PLATFORM_ANDROID)
+  list(APPEND COMMON_TEST_LIBRARIES pthread)
+  list(APPEND COMMON_TEST_LIBRARIES m)
+endif()
+
+list(APPEND COMMON_TEST_LIBRARIES coreclrpal)
 
 add_compile_options(-Wno-incompatible-pointer-types-discards-qualifiers)
 add_compile_options(-Wno-int-to-void-pointer-cast)


### PR DESCRIPTION
This PR patches the CMake files so that they support cross-building CoreCLR for arm64 Android.

An overview of the changes:
* Fix the path to `objcopy`
* Don't run `verify-so.sh` when cross-building for Android
* Don't link with gcc_s, m and pthread on Android (I confirm there is no gcc_s); but do link with gnustl_shared, android-support, android-glob and intl
* Link with `unwind-aarch64` on arm64