### PR TITLE
Avoid unnecessary branches when fixing non-null/empty arrays

### DIFF
--- a/src/mscorlib/corefx/System/IO/FileStream.Win32.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.Win32.cs
@@ -1277,7 +1277,7 @@ namespace System.IO
             int r = 0;
             int numBytesRead = 0;
 
-            fixed (byte* p = bytes)
+            fixed (byte* p = &bytes[0])
             {
                 if (_useAsyncIO)
                     r = Interop.Kernel32.ReadFile(handle, p + offset, count, IntPtr.Zero, overlapped);
@@ -1322,7 +1322,7 @@ namespace System.IO
             int numBytesWritten = 0;
             int r = 0;
 
-            fixed (byte* p = bytes)
+            fixed (byte* p = &bytes[0])
             {
                 if (_useAsyncIO)
                     r = Interop.Kernel32.WriteFile(handle, p + offset, count, IntPtr.Zero, overlapped);

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -154,7 +154,7 @@ namespace System {
                 if (lengths[i] < 0)
                     ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.lengths, i, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
 
-            fixed (int* pLengths = lengths)
+            fixed (int* pLengths = &lengths[0])
                 return InternalCreate((void*)t.TypeHandle.Value,lengths.Length,pLengths,null);
         }
 
@@ -211,8 +211,8 @@ namespace System {
                 if (lengths[i] < 0)
                     ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.lengths, i, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
 
-            fixed (int* pLengths = lengths)
-                fixed(int* pLowerBounds = lowerBounds)
+            fixed (int* pLengths = &lengths[0])
+                fixed(int* pLowerBounds = &lowerBounds[0])
                     return InternalCreate((void*)t.TypeHandle.Value,lengths.Length,pLengths,pLowerBounds);
         }
 
@@ -328,7 +328,7 @@ namespace System {
             Contract.EndContractBlock();
 
             TypedReference elemref = new TypedReference();
-            fixed(int* pIndices = indices)
+            fixed(int* pIndices = &indices[0])
                 InternalGetReference(&elemref, indices.Length, pIndices);
             return TypedReference.InternalToObject(&elemref);
         }
@@ -485,7 +485,7 @@ namespace System {
             Contract.EndContractBlock();
 
             TypedReference elemref = new TypedReference();
-            fixed(int* pIndices = indices)
+            fixed(int* pIndices = &indices[0])
                 InternalGetReference(&elemref, indices.Length, pIndices);
             InternalSetValue(&elemref,value);
         }

--- a/src/mscorlib/src/System/BitConverter.cs
+++ b/src/mscorlib/src/System/BitConverter.cs
@@ -63,7 +63,7 @@ namespace System {
             Contract.Ensures(Contract.Result<byte[]>().Length == 2);
 
             byte[] bytes = new byte[2];
-            fixed(byte* b = bytes)
+            fixed(byte* b = &bytes[0])
                 *((short*)b) = value;
             return bytes;
         }
@@ -76,7 +76,7 @@ namespace System {
             Contract.Ensures(Contract.Result<byte[]>().Length == 4);
 
             byte[] bytes = new byte[4];
-            fixed(byte* b = bytes)
+            fixed(byte* b = &bytes[0])
                 *((int*)b) = value;
             return bytes;
         }
@@ -89,7 +89,7 @@ namespace System {
             Contract.Ensures(Contract.Result<byte[]>().Length == 8);
 
             byte[] bytes = new byte[8];
-            fixed(byte* b = bytes)
+            fixed(byte* b = &bytes[0])
                 *((long*)b) = value;
             return bytes;
         }

--- a/src/mscorlib/src/System/Convert.cs
+++ b/src/mscorlib/src/System/Convert.cs
@@ -2202,7 +2202,7 @@ namespace System {
 
             string returnString = string.FastAllocateString(stringLength);
             fixed (char* outChars = returnString){
-                fixed (byte* inData = inArray) {
+                fixed (byte* inData = &inArray[0]) {
                     int j = ConvertToBase64Array(outChars,inData,offset,length, insertLineBreaks);
                     BCLDebug.Assert(returnString.Length == j, "returnString.Length == j");
                     return returnString;
@@ -2265,7 +2265,7 @@ namespace System {
                 throw new ArgumentOutOfRangeException(nameof(offsetOut), Environment.GetResourceString("ArgumentOutOfRange_OffsetOut"));
 
             fixed (char* outChars = &outArray[offsetOut]) {
-                fixed (byte* inData = inArray) { 
+                fixed (byte* inData = &inArray[0]) { 
                    retVal = ConvertToBase64Array(outChars,inData,offsetIn,length, insertLineBreaks);
                 }
             }
@@ -2282,7 +2282,7 @@ namespace System {
             int i;
 
             // get a pointer to the base64Table to avoid unnecessary range checking
-            fixed(char* base64 = base64Table) {
+            fixed(char* base64 = &base64Table[0]) {
                 for (i=offset; i<calcLength; i+=3)
                 {
                     if (insertLineBreaks) {

--- a/src/mscorlib/src/System/IO/BinaryWriter.cs
+++ b/src/mscorlib/src/System/IO/BinaryWriter.cs
@@ -185,7 +185,7 @@ namespace System.IO {
 
             Debug.Assert(_encoding.GetMaxByteCount(1) <= 16, "_encoding.GetMaxByteCount(1) <= 16)");
             int numBytes = 0;
-            fixed(byte * pBytes = _buffer) {
+            fixed(byte * pBytes = &_buffer[0]) {
                 numBytes = _encoder.GetBytes(&ch, 1, pBytes, _buffer.Length, flush: true);
             }
             OutStream.Write(_buffer, 0, numBytes);
@@ -382,7 +382,7 @@ namespace System.IO {
                         }
                         fixed (char* pChars = value)
                         {
-                            fixed (byte* pBytes = _largeByteBuffer)
+                            fixed (byte* pBytes = &_largeByteBuffer[0])
                             {
                                 byteLen = _encoder.GetBytes(pChars + charStart, charCount, pBytes, _largeByteBuffer.Length, charCount == numLeft);
                             }

--- a/src/mscorlib/src/System/IO/PinnedBufferMemoryStream.cs
+++ b/src/mscorlib/src/System/IO/PinnedBufferMemoryStream.cs
@@ -42,7 +42,7 @@ namespace System.IO {
             _pinningHandle = new GCHandle(array, GCHandleType.Pinned);
             // Now the byte[] is pinned for the lifetime of this instance.
             // But I also need to get a pointer to that block of memory...
-            fixed(byte* ptr = _array)
+            fixed(byte* ptr = &_array[0])
                 Initialize(ptr, len, len, FileAccess.Read, true);
         }
 

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -343,7 +343,8 @@ namespace System
                             // no one should be looking for a member whose name is longer than 1024
                             if (cUtf8Name > MAXNAMELEN)
                             {
-                                fixed (byte* pUtf8Name = new byte[cUtf8Name])
+                                byte[] utf8Name = new byte[cUtf8Name];
+                                fixed (byte* pUtf8Name = &utf8Name[0])
                                 {
                                     list = GetListByName(pName, cNameLen, pUtf8Name, cUtf8Name, listType, cacheType);
                                 }

--- a/src/mscorlib/src/System/StubHelpers.cs
+++ b/src/mscorlib/src/System/StubHelpers.cs
@@ -27,7 +27,8 @@ namespace  System.StubHelpers {
         unsafe static internal byte[] DoAnsiConversion(string str, bool fBestFit, bool fThrowOnUnmappableChar, out int cbLength)
         {
             byte[] buffer = new byte[(str.Length + 1) * Marshal.SystemMaxDBCSCharSize];
-            fixed (byte *bufferPtr = buffer)
+            BCLDebug.Assert(buffer.Length != 0);
+            fixed (byte *bufferPtr = &buffer[0])
             {
                 cbLength = str.ConvertToAnsi(bufferPtr, buffer.Length, fBestFit, fThrowOnUnmappableChar);
             }
@@ -218,7 +219,7 @@ namespace  System.StubHelpers {
             // null argument.
             char[] cCharBuffer = new char[numChar + 1];
             cCharBuffer[numChar] = '\0';
-            fixed (char* pBuffer = cCharBuffer)
+            fixed (char* pBuffer = &cCharBuffer[0])
             {
                 numChar = Encoding.UTF8.GetChars((byte*)pNative, nbBytes, pBuffer, numChar);
                 // replace string builder internal buffer

--- a/src/mscorlib/src/System/Text/DecoderNLS.cs
+++ b/src/mscorlib/src/System/Text/DecoderNLS.cs
@@ -98,7 +98,7 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call pointer version
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
                 return GetCharCount(pBytes + index, count, flush);
         }
 
@@ -159,8 +159,8 @@ namespace System.Text
                 chars = new char[1];
 
             // Just call pointer version
-            fixed (byte* pBytes = bytes)
-                fixed (char* pChars = chars)
+            fixed (byte* pBytes = &bytes[0])
+                fixed (char* pChars = &chars[0])
                     // Remember that charCount is # to decode, not size of array
                     return GetChars(pBytes + byteIndex, byteCount,
                                     pChars + charIndex, charCount, flush);
@@ -223,9 +223,9 @@ namespace System.Text
                 chars = new char[1];
 
             // Just call the pointer version (public overrides can't do this)
-            fixed (byte* pBytes = bytes)
+            fixed (byte* pBytes = &bytes[0])
             {
-                fixed (char* pChars = chars)
+                fixed (char* pChars = &chars[0])
                 {
                     Convert(pBytes + byteIndex, byteCount, pChars + charIndex, charCount, flush,
                         out bytesUsed, out charsUsed, out completed);

--- a/src/mscorlib/src/System/Text/EncoderNLS.cs
+++ b/src/mscorlib/src/System/Text/EncoderNLS.cs
@@ -98,7 +98,7 @@ namespace System.Text
 
             // Just call the pointer version
             int result = -1;
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
             {
                 result = GetByteCount(pChars + index, count, flush);
             }
@@ -151,8 +151,8 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call pointer version
-            fixed (char* pChars = chars)
-                fixed (byte* pBytes = bytes)
+            fixed (char* pChars = &chars[0])
+                fixed (byte* pBytes = &bytes[0])
 
                     // Remember that charCount is # to decode, not size of array.
                     return GetBytes(pChars + charIndex, charCount,
@@ -212,9 +212,9 @@ namespace System.Text
                 bytes = new byte[1];
 
             // Just call the pointer version (can't do this for non-msft encoders)
-            fixed (char* pChars = chars)
+            fixed (char* pChars = &chars[0])
             {
-                fixed (byte* pBytes = bytes)
+                fixed (byte* pBytes = &bytes[0])
                 {
                     Convert(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, flush,
                         out charsUsed, out bytesUsed, out completed);

--- a/src/mscorlib/src/System/Text/EncodingForwarder.cs
+++ b/src/mscorlib/src/System/Text/EncodingForwarder.cs
@@ -130,7 +130,7 @@ namespace System.Text
             if (bytes.Length == 0)
                 bytes = new byte[1];
             
-            fixed (char* pChars = s) fixed (byte* pBytes = bytes)
+            fixed (char* pChars = s) fixed (byte* pBytes = &bytes[0])
             {
                 return encoding.GetBytes(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, encoder: null);
             }
@@ -170,7 +170,7 @@ namespace System.Text
                 bytes = new byte[1];
             
             // Just call the (internal) pointer version
-            fixed (char* pChars = chars) fixed (byte* pBytes = bytes)
+            fixed (char* pChars = chars) fixed (byte* pBytes = &bytes[0])
             {
                 return encoding.GetBytes(pChars + charIndex, charCount, pBytes + byteIndex, byteCount, encoder: null);
             }
@@ -266,7 +266,7 @@ namespace System.Text
             if (chars.Length == 0)
                 chars = new char[1];
 
-            fixed (byte* pBytes = bytes) fixed (char* pChars = chars)
+            fixed (byte* pBytes = bytes) fixed (char* pChars = &chars[0])
             {
                 return encoding.GetChars(pBytes + byteIndex, byteCount, pChars + charIndex, charCount, decoder: null);
             }


### PR DESCRIPTION
Follow-up of https://github.com/dotnet/coreclr/pull/9115, applied throughout to places where `fixed` is used with arrays known not to be null or empty. Based on the discussion here: https://github.com/dotnet/corefx/pull/15432#discussion_r97684916