### PR TITLE
Set BuildType in HelixPublish.proj

### DIFF
--- a/tests/helixpublish.proj
+++ b/tests/helixpublish.proj
@@ -1,5 +1,9 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
+  <PropertyGroup>
+    <__BuildType>$(ConfigurationGroup)</__BuildType>
+  </PropertyGroup>
+
   <Import Project="..\dir.props" />
   <Import Project="$(ToolsDir)CloudTest.targets" Condition="Exists('$(ToolsDir)CloudTest.targets')" />
 


### PR DESCRIPTION
This will stop BuildType from being forced to "Debug" in dir.props.