### PR TITLE
Change '.' to '-' in publishing test native binaries

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -33,6 +33,7 @@
       <ContainerName Condition="'$(__Container)' == '' and '$(PublishTestNativeBins)' == 'true'">coreclr-$(PreReleaseLabel)-$(BuildNumberMajor)-$(BuildNumberMinor)-$(__DistroRid)-$(__BuildArch)</ContainerName>
       <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' != 'true'">$(__Container)</ContainerName>
       <ContainerName Condition="'$(__Container)' != '' and '$(PublishTestNativeBins)' == 'true'">$(__Container)-$(__DistroRid)-$(__BuildArch)</ContainerName>
+      <ContainerName>$(ContainerName.Replace(".","-"))</ContainerName>
     </PropertyGroup>
   </Target>
 

--- a/src/syncAzure.proj
+++ b/src/syncAzure.proj
@@ -6,6 +6,7 @@
     <ContainerNamePrefix Condition="'$(ContainerNamePrefix)' == ''">coreclr-$(PreReleaseLabel)</ContainerNamePrefix>
     <ContainerName Condition="'$(__Container)' == '' and '$(ContainerNamePrefix)' != '' and '$(BuildNumberMajor)' != '' and '$(BuildNumberMinor)' != ''">$(ContainerNamePrefix)-$(BuildNumberMajor)-$(BuildNumberMinor)</ContainerName>
     <ContainerName Condition="'$(__Container)' != ''">$(__Container)</ContainerName>
+    <ContainerName>$(ContainerName.Replace(".","-"))</ContainerName>
     <DownloadDirectory Condition="'$(PublishTestNativeBins)' != 'true'">$(PackagesDir)AzureTransfer</DownloadDirectory>
     <DownloadDirectory Condition="'$(PublishTestNativeBins)' == 'true'">$(PackagesDir)TestNativeBins</DownloadDirectory>
   </PropertyGroup>


### PR DESCRIPTION
This will fix errors caused by trying to upload files into Azure blobs with periods in the name (Was trying to assign them suffixes based off of RIDs, which contain periods). Will also change the workflow of 'sync.cmd -n", as that command now requires a Container prefix & an RID, instead of an entire Container name. I would allow entire Container names, but then the work of transforming the RID would fall into a VSO build definition instead of in code.