### PR TITLE
Adding some missing APIs on core that where added to N.S 2.0

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -5551,6 +5551,7 @@
       <Member Name="GetFieldFromHandle(System.RuntimeFieldHandle)" />
       <Member Name="GetFieldFromHandle(System.RuntimeFieldHandle,System.RuntimeTypeHandle)" />
       <Member Name="GetValue(System.Object)" />
+      <Member Name="GetValueDirect(System.TypedReference)" />
       <Member Name="GetOptionalCustomModifiers" />
       <Member Name="GetRequiredCustomModifiers" />
       <Member Name="GetRawConstantValue" />
@@ -5558,6 +5559,7 @@
       <Member Name="GetHashCode" />
       <Member Name="SetValue(System.Object,System.Object)" />
       <Member Name="SetValue(System.Object,System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Globalization.CultureInfo)" />
+      <Member Name="SetValueDirect(System.TypedReference,System.Object)" />
       <Member MemberType="Property" Name="Attributes" />
       <Member MemberType="Property" Name="FieldHandle" />
       <Member MemberType="Property" Name="FieldType" />
@@ -7285,6 +7287,7 @@
       <Member Name="Concat(System.Object)" />
       <Member Name="Concat(System.Object,System.Object)" />
       <Member Name="Concat(System.Object,System.Object,System.Object)" />
+      <Member Name="Concat(System.Object,System.Object,System.Object,System.Object,__arglist)" />
       <Member Name="Concat(System.Object[])" />
       <Member Name="Concat(System.String,System.String)" />
       <Member Name="Concat(System.String,System.String,System.String)" />
@@ -9043,7 +9046,15 @@
       <Member Name="get_TypeName" />
       <Member MemberType="Property" Name="TypeName" />
     </Type>
-    <Type Name="System.TypedReference" />
+    <Type Name="System.TypedReference">
+      <Member Name="Equals(System.Object)" />
+      <Member Name="GetHashCode" />
+      <Member Name="GetTargetType(System.TypedReference)" />
+      <Member Name="MakeTypedReference(System.Object,System.Reflection.FieldInfo[])" />
+      <Member Name="SetTypedReference(System.TypedReference,System.Object)" />
+      <Member Name="TargetTypeToken(System.TypedReference)" />
+      <Member Name="ToObject(System.TypedReference)" />
+    </Type>
     <Type Name="System.TypeLoadException">
       <Member Name="#ctor" />
       <Member Name="#ctor(System.String)" />
@@ -11112,7 +11123,15 @@
     </Type>
     <Type Status="ImplRoot" Name="System.Runtime.InteropServices.PInvokeMap" />
     <Type Name="System.ArgIterator">  <!-- for MC++ -->
-      <Member Status="ImplRoot" Name="#ctor(System.RuntimeArgumentHandle,System.Void*)" /> <!-- EE - il stubs -->
+      <Member Name="#ctor(System.RuntimeArgumentHandle)" />
+      <Member Name="#ctor(System.RuntimeArgumentHandle,System.Void*)" />
+      <Member Name="End" />
+      <Member Name="Equals(System.Object)" />
+      <Member Name="GetHashCode" />
+      <Member Name="GetNextArg" />
+      <Member Name="GetNextArg(System.RuntimeTypeHandle)" />
+      <Member Name="GetNextArgType" />
+      <Member Name="GetRemainingCount" />
     </Type>
         <Type Name="System.Runtime.InteropServices.BestFitMappingAttribute">
       <Member MemberType="Field" Name="ThrowOnUnmappableChar" />

--- a/src/mscorlib/src/System/ArgIterator.cs
+++ b/src/mscorlib/src/System/ArgIterator.cs
@@ -153,10 +153,11 @@ namespace System {
         public override bool Equals(Object o) 
         {  
             throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+        }
 
         public override int GetHashCode()
         { 
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204..
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
         }
 
         [System.CLSCompliantAttribute(false)]

--- a/src/mscorlib/src/System/ArgIterator.cs
+++ b/src/mscorlib/src/System/ArgIterator.cs
@@ -136,50 +136,49 @@ namespace System {
 #else
         public ArgIterator(RuntimeArgumentHandle arglist)
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
         }
 
         [CLSCompliant(false)]
         public unsafe ArgIterator(RuntimeArgumentHandle arglist, void* ptr)
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
         }
 
         public void End() 
         { 
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
         }
 
         public override bool Equals(Object o) 
         {  
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
-        }
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
 
         public override int GetHashCode()
         { 
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204..
         }
 
         [System.CLSCompliantAttribute(false)]
         public System.TypedReference GetNextArg()
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
         }
 
         [System.CLSCompliantAttribute(false)]
         public System.TypedReference GetNextArg(System.RuntimeTypeHandle rth)
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
         }
 
         public unsafe System.RuntimeTypeHandle GetNextArgType()
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
         }
 
         public int GetRemainingCount()
         {  
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
         }
 #endif //VARARGS_ENABLED
     }

--- a/src/mscorlib/src/System/ArgIterator.cs
+++ b/src/mscorlib/src/System/ArgIterator.cs
@@ -16,6 +16,18 @@ namespace System {
     [StructLayout(LayoutKind.Sequential)]
     public struct ArgIterator
     {
+        private IntPtr ArgCookie;               // Cookie from the EE.
+
+        // The SigPointer structure consists of the following members.  (Note: this is an inline native SigPointer data type)
+        private IntPtr sigPtr;                  // Pointer to remaining signature.
+        private IntPtr sigPtrLen;               // Remaining length of the pointer
+
+        // Note, sigPtrLen is actually a DWORD, but on 64bit systems this structure becomes
+        // 8-byte aligned, which requires us to pad it.
+            
+        private IntPtr ArgPtr;                  // Pointer to remaining args.
+        private int    RemainingArgs;           // # of remaining args.
+        
 #if VARARGS_ENABLED //The JIT doesn't support Varargs calling convention.
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private extern ArgIterator(IntPtr arglist);
@@ -121,18 +133,6 @@ namespace System {
         {
             throw new NotSupportedException(Environment.GetResourceString("NotSupported_NYI"));
         }
-
-        private IntPtr ArgCookie;               // Cookie from the EE.
-
-        // The SigPointer structure consists of the following members.  (Note: this is an inline native SigPointer data type)
-        private IntPtr sigPtr;                  // Pointer to remaining signature.
-        private IntPtr sigPtrLen;               // Remaining length of the pointer
-
-        // Note, sigPtrLen is actually a DWORD, but on 64bit systems this structure becomes
-        // 8-byte aligned, which requires us to pad it.
-            
-        private IntPtr ArgPtr;                  // Pointer to remaining args.
-        private int    RemainingArgs;           // # of remaining args.
 #else
         public ArgIterator(RuntimeArgumentHandle arglist)
         {

--- a/src/mscorlib/src/System/ArgIterator.cs
+++ b/src/mscorlib/src/System/ArgIterator.cs
@@ -16,6 +16,7 @@ namespace System {
     [StructLayout(LayoutKind.Sequential)]
     public struct ArgIterator
     {
+#if VARARGS_ENABLED //The JIT doesn't support Varargs calling convention.
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private extern ArgIterator(IntPtr arglist);
 
@@ -34,7 +35,6 @@ namespace System {
         // This is much like the C va_start macro
 
         [CLSCompliant(false)]
-
         public unsafe ArgIterator(RuntimeArgumentHandle arglist, void* ptr) : this(arglist.Value, ptr)
         {
         }
@@ -133,5 +133,54 @@ namespace System {
             
         private IntPtr ArgPtr;                  // Pointer to remaining args.
         private int    RemainingArgs;           // # of remaining args.
+#else
+        public ArgIterator(RuntimeArgumentHandle arglist)
+        {
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+        }
+
+        [CLSCompliant(false)]
+        public unsafe ArgIterator(RuntimeArgumentHandle arglist, void* ptr)
+        {
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+        }
+
+        public void End() 
+        { 
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+        }
+
+        public override bool Equals(Object o) 
+        {  
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+        }
+
+        public override int GetHashCode()
+        { 
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+        }
+
+        [System.CLSCompliantAttribute(false)]
+        public System.TypedReference GetNextArg()
+        {
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+        }
+
+        [System.CLSCompliantAttribute(false)]
+        public System.TypedReference GetNextArg(System.RuntimeTypeHandle rth)
+        {
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+        }
+
+        public unsafe System.RuntimeTypeHandle GetNextArgType()
+        {
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+        }
+
+        public int GetRemainingCount()
+        {  
+            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator https://github.com/dotnet/standard/issues/20#issuecomment-272775599.
+        }
+#endif //VARARGS_ENABLED
     }
 }

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -373,10 +373,8 @@ FCFuncEnd()
 
 FCFuncStart(gTypedReferenceFuncs)
     FCFuncElement("InternalToObject", ReflectionInvocation::TypedReferenceToObject)
-#ifndef FEATURE_CORECLR
     FCFuncElement("InternalSetTypedReference", ReflectionInvocation::SetTypedReference)
     FCFuncElement("InternalMakeTypedReference", ReflectionInvocation::MakeTypedReference)
-#endif
 FCFuncEnd()
 
 FCFuncStart(gSystem_Type)
@@ -568,12 +566,8 @@ FCFuncEnd()
 FCFuncStart(gCOMFieldHandleNewFuncs)
     FCFuncElement("GetValue", RuntimeFieldHandle::GetValue)
     FCFuncElement("SetValue", RuntimeFieldHandle::SetValue)
-#ifndef FEATURE_CORECLR
     FCFuncElement("GetValueDirect", RuntimeFieldHandle::GetValueDirect)
-#endif
-#ifdef FEATURE_SERIALIZATION
     FCFuncElement("SetValueDirect", RuntimeFieldHandle::SetValueDirect)
-#endif
     FCFuncElement("GetName", RuntimeFieldHandle::GetName)
     FCFuncElement("_GetUtf8Name", RuntimeFieldHandle::GetUtf8Name)
     FCFuncElement("MatchesNameHash", RuntimeFieldHandle::MatchesNameHash)
@@ -1812,13 +1806,11 @@ FCFuncEnd()
 
 FCFuncStart(gVarArgFuncs)
     FCFuncElementSig(COR_CTOR_METHOD_NAME, &gsig_IM_IntPtr_PtrVoid_RetVoid, VarArgsNative::Init2)
-#ifndef FEATURE_CORECLR
     FCFuncElementSig(COR_CTOR_METHOD_NAME, &gsig_IM_IntPtr_RetVoid, VarArgsNative::Init)
     FCFuncElement("GetRemainingCount", VarArgsNative::GetRemainingCount)
     FCFuncElement("_GetNextArgType", VarArgsNative::GetNextArgType)
     FCFuncElement("FCallGetNextArg", VarArgsNative::DoGetNextArg)
     FCFuncElement("InternalGetNextArg", VarArgsNative::GetNextArg2)
-#endif // FEATURE_CORECLR
 FCFuncEnd()
 
 FCFuncStart(gMonitorFuncs)


### PR DESCRIPTION
This is work needed in coreclr for issue [dotnet/corefx #15362](https://github.com/dotnet/corefx/issues/15362)

ArgIterator apis throw PlatformNotSupported() in implementation since in order to enable Vararg calling convetions there is work needed in the JIT as @jkotas mentions [here](https://github.com/dotnet/standard/issues/20#issuecomment-272775599)

Tests are [dotnet/corefx #15643](https://github.com/dotnet/corefx/pull/15643)

/cc @weshaggard @danmosemsft 