### PR TITLE
Simplify #ifdef in EECodeManager::GetGSCookieAddr 

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -270,6 +270,7 @@ virtual PTR_VOID GetParamTypeArg(PREGDISPLAY     pContext,
 virtual GenericParamContextType GetParamContextType(PREGDISPLAY     pContext,
                                                     EECodeInfo *    pCodeInfo) = 0;
 
+#ifndef CROSSGEN_COMPILE
 /*
     Returns the offset of the GuardStack cookie if it exists.
     Returns NULL if there is no cookie.
@@ -277,6 +278,7 @@ virtual GenericParamContextType GetParamContextType(PREGDISPLAY     pContext,
 virtual void * GetGSCookieAddr(PREGDISPLAY     pContext,
                                EECodeInfo    * pCodeInfo,
                                CodeManState  * pState) = 0;
+#endif
 
 /*
   Returns true if the given IP is in the given method's prolog or an epilog.
@@ -536,6 +538,7 @@ PTR_VOID GetExactGenericsToken(SIZE_T          baseStackSlot,
 
 #endif // WIN64EXCEPTIONS && !CROSSGEN_COMPILE
 
+#ifndef CROSSGEN_COMPILE
 /*
     Returns the offset of the GuardStack cookie if it exists.
     Returns NULL if there is no cookie.
@@ -544,6 +547,7 @@ virtual
 void * GetGSCookieAddr(PREGDISPLAY     pContext,
                        EECodeInfo    * pCodeInfo,
                        CodeManState  * pState);
+#endif
 
 
 /*

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5427,6 +5427,7 @@ PTR_VOID EECodeManager::GetExactGenericsToken(SIZE_T          baseStackSlot,
 
 #endif // WIN64EXCEPTIONS / CROSSGEN_COMPILE
 
+#ifndef CROSSGEN_COMPILE
 /*****************************************************************************/
 
 void * EECodeManager::GetGSCookieAddr(PREGDISPLAY     pContext,
@@ -5473,7 +5474,7 @@ void * EECodeManager::GetGSCookieAddr(PREGDISPLAY     pContext,
         return PVOID(SIZE_T(pContext->SP + argSize + info->gsCookieOffset));
     }
 
-#elif defined(USE_GC_INFO_DECODER) && !defined(CROSSGEN_COMPILE)
+#elif defined(USE_GC_INFO_DECODER)
     if (pCodeInfo->IsFunclet())
     {
         return NULL;
@@ -5501,6 +5502,7 @@ void * EECodeManager::GetGSCookieAddr(PREGDISPLAY     pContext,
     return NULL;
 #endif
 }
+#endif
 
 /*****************************************************************************
  *


### PR DESCRIPTION
This commit simplifies #ifdef inside EECodeManager::GetGSCookieAddr via enabling it only when CROSSGEN_COMPILE is not defined.