### PR TITLE
Use -O1 optimization for arm and armel

### DIFF
--- a/src/pal/tools/clang-compiler-override-arm.txt
+++ b/src/pal/tools/clang-compiler-override-arm.txt
@@ -1,0 +1,20 @@
+SET (CMAKE_C_FLAGS_INIT                "-Wall -std=c11")
+SET (CMAKE_C_FLAGS_DEBUG_INIT          "-g -O0")
+SET (CLR_C_FLAGS_CHECKED_INIT          "-g -O1")
+# Refer to the below instruction to support __thread with -O2/-O3 on Linux/ARM
+# https://github.com/dotnet/coreclr/blob/master/Documentation/building/linux-instructions.md
+SET (CMAKE_C_FLAGS_RELEASE_INIT        "-g -O1")
+SET (CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-g -O1")
+
+SET (CMAKE_CXX_FLAGS_INIT                "-Wall -Wno-null-conversion -std=c++11")
+SET (CMAKE_CXX_FLAGS_DEBUG_INIT          "-g -O0")
+SET (CLR_CXX_FLAGS_CHECKED_INIT          "-g -O1")
+SET (CMAKE_CXX_FLAGS_RELEASE_INIT        "-g -O1")
+SET (CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-g -O1")
+
+SET (CLR_DEFINES_DEBUG_INIT              DEBUG _DEBUG _DBG URTBLDENV_FRIENDLY=Checked BUILDENV_CHECKED=1)
+SET (CLR_DEFINES_CHECKED_INIT            DEBUG _DEBUG _DBG URTBLDENV_FRIENDLY=Checked BUILDENV_CHECKED=1)
+SET (CLR_DEFINES_RELEASE_INIT            NDEBUG URTBLDENV_FRIENDLY=Retail)
+SET (CLR_DEFINES_RELWITHDEBINFO_INIT     NDEBUG URTBLDENV_FRIENDLY=Retail)
+
+SET (CMAKE_INSTALL_PREFIX                $ENV{__CMakeBinDir})

--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -144,9 +144,15 @@ if [ "$build_arch" == "armel" ]; then
     cmake_extra_defines="$cmake_extra_defines -DARM_SOFTFP=1"
 fi
 
+if [ "$build_arch" == "arm" -o "$build_arch" == "armel" ]; then
+    overridefile=clang-compiler-override-arm.txt  
+else
+    overridefile=clang-compiler-override.txt  
+fi
+
 cmake \
   -G "$generator" \
-  "-DCMAKE_USER_MAKE_RULES_OVERRIDE=$1/src/pal/tools/clang-compiler-override.txt" \
+  "-DCMAKE_USER_MAKE_RULES_OVERRIDE=$1/src/pal/tools/$overridefile" \
   "-DCMAKE_AR=$llvm_ar" \
   "-DCMAKE_LINKER=$llvm_link" \
   "-DCMAKE_NM=$llvm_nm" \


### PR DESCRIPTION
Because there are bugs for -O3 optimization in clang (<=3.8) for arm, let's use -O1 instead of -O3 for arm.

This PR is made to address a request at https://github.com/dotnet/core-setup/issues/790#issuecomment-275433662
