### PR TITLE
Improve string.Equals OrdinalIgnoreCase performance for matching chars

### DIFF
--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -133,6 +133,47 @@ namespace System
             }
         }
 
+        private unsafe static bool EqualsIgnoreCaseAsciiHelper(String strA, String strB)
+        {
+            Contract.Requires(strA != null);
+            Contract.Requires(strB != null);
+            Contract.Requires(strA.Length == strB.Length);
+            Contract.EndContractBlock();
+            int length = strA.Length;
+
+            fixed (char* ap = &strA.m_firstChar) fixed (char* bp = &strB.m_firstChar)
+            {
+                char* a = ap;
+                char* b = bp;
+
+                while (length != 0)
+                {
+                    int charA = *a;
+                    int charB = *b;
+
+                    Debug.Assert((charA | charB) <= 0x7F, "strings have to be ASCII");
+
+                    if (charA == charB ||
+                       ((charA | 0x20) == (charB | 0x20) &&
+                          (uint)((charA | 0x20) - 'a') <= (uint)('z' - 'a')))
+                    {
+                        a++;
+                        b++;
+                        length--;
+                    }
+                    else
+                    {
+                        goto ReturnFalse;
+                    }
+                }
+
+                return true;
+
+                ReturnFalse:
+                return false;
+            }
+        }
+
         private unsafe static bool StartsWithOrdinalHelper(String str, String startsWith)
         {
             Contract.Requires(str != null);
@@ -865,7 +906,7 @@ namespace System
 
                     // If both strings are ASCII strings, we can take the fast path.
                     if (this.IsAscii() && value.IsAscii()) {
-                        return (CompareOrdinalIgnoreCaseHelper(this, value) == 0);
+                        return EqualsIgnoreCaseAsciiHelper(this, value);
                     }
 
 #if FEATURE_COREFX_GLOBALIZATION
@@ -934,7 +975,7 @@ namespace System
                     else {
                         // If both strings are ASCII strings, we can take the fast path.
                         if (a.IsAscii() && b.IsAscii()) {
-                            return (CompareOrdinalIgnoreCaseHelper(a, b) == 0);
+                            return EqualsIgnoreCaseAsciiHelper(a, b);
                         }
                         // Take the slow path.
 

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -153,6 +153,7 @@ namespace System
 
                     Debug.Assert((charA | charB) <= 0x7F, "strings have to be ASCII");
 
+                    // Ordinal equals or lowercase equals if the result ends up in the a-z range 
                     if (charA == charB ||
                        ((charA | 0x20) == (charB | 0x20) &&
                           (uint)((charA | 0x20) - 'a') <= (uint)('z' - 'a')))


### PR DESCRIPTION
Take 2.

Case insensitive equality was found to be a bit of a hot spot in Kestrel recently. This PR looks at the ASCII comparison portion of string.Equals(string, string, StringComparison.OrdinalIgnoreCase).

These changes improve the situation where the two strings have mostly the same casing. Also provides greater consistency for uppercase values.

It was difficult to improve CompareOrdinalIgnoreCaseHelper without a performance regression to some type of compare. I think that case insensitive equality is common enough that this path can be broken out into its own helper.

The full CoreFX tests have been run on the change.

**Isolated perf results**
https://gist.github.com/bbowyersmyth/eb7ebcf7829f0275575541f2334d2826

Both strings uppercase and equal

|                      Method | length |        Mean |    StdDev |
|---------------------------- |------- |------------ |---------- |
| CompareOrdinalIgnoreCaseOld |      1 |   3.5419 ns | 0.0976 ns |
| EqualsIgnoreCaseAsciiHelper |      1 |   1.5192 ns | 0.0542 ns |
| CompareOrdinalIgnoreCaseOld |      5 |  10.6964 ns | 0.0626 ns |
| EqualsIgnoreCaseAsciiHelper |      5 |   4.3562 ns | 0.0963 ns |
| CompareOrdinalIgnoreCaseOld |     12 |  22.7722 ns | 0.4212 ns |
| EqualsIgnoreCaseAsciiHelper |     12 |   8.4117 ns | 0.0483 ns |
| CompareOrdinalIgnoreCaseOld |     50 |  81.8152 ns | 1.0844 ns |
| EqualsIgnoreCaseAsciiHelper |     50 |  36.4938 ns | 0.2509 ns |
| CompareOrdinalIgnoreCaseOld |    100 | 149.5299 ns | 4.6956 ns |
| EqualsIgnoreCaseAsciiHelper |    100 |  65.0116 ns | 1.0579 ns |

Both strings lowercase and equal

|                      Method | length |        Mean |    StdDev |
|---------------------------- |------- |------------ |---------- |
| CompareOrdinalIgnoreCaseOld |      1 |   2.8132 ns | 0.0639 ns |
| EqualsIgnoreCaseAsciiHelper |      1 |   1.5883 ns |0.0785 ns |
| CompareOrdinalIgnoreCaseOld |      5 |   8.3198 ns |0.0455 ns |
| EqualsIgnoreCaseAsciiHelper |      5 |   4.4446 ns |0.0172 ns |
| CompareOrdinalIgnoreCaseOld |     12 |  18.7582 ns |0.5537 ns |
| EqualsIgnoreCaseAsciiHelper |     12 |   8.3566 ns |0.0869 ns |
| CompareOrdinalIgnoreCaseOld |     50 |  60.3602 ns |0.2715 ns |
| EqualsIgnoreCaseAsciiHelper |     50 |  37.0570 ns |0.7045 ns |
| CompareOrdinalIgnoreCaseOld |    100 | 108.4164 ns |1.5262 ns |
| EqualsIgnoreCaseAsciiHelper |    100 |  64.9119 ns |1.1720 ns |

String A uppercase, string B lowercase and insensitive equal

|                      Method | length |        Mean |    StdDev |
|---------------------------- |------- |------------ |---------- |
| CompareOrdinalIgnoreCaseOld |      1 |   3.3074 ns | 0.0748 ns |
| EqualsIgnoreCaseAsciiHelper |      1 |   1.6406 ns | 0.0628 ns |
| CompareOrdinalIgnoreCaseOld |      5 |   9.2650 ns | 0.1892 ns |
| EqualsIgnoreCaseAsciiHelper |      5 |   5.1333 ns | 0.0594 ns |
| CompareOrdinalIgnoreCaseOld |     12 |  18.6674 ns | 0.2852 ns |
| EqualsIgnoreCaseAsciiHelper |     12 |  11.2529 ns | 0.0562 ns |
| CompareOrdinalIgnoreCaseOld |     50 |  68.1628 ns | 2.5063 ns |
| EqualsIgnoreCaseAsciiHelper |     50 |  51.7755 ns | 0.2773 ns |
| CompareOrdinalIgnoreCaseOld |    100 | 130.9364 ns | 2.1915 ns |
| EqualsIgnoreCaseAsciiHelper |    100 |  93.3051 ns | 0.7183 ns |

String A lowercase, string B uppercase and insensitive equal

|                      Method | length |        Mean |    StdDev |
|---------------------------- |------- |------------ |---------- |
| CompareOrdinalIgnoreCaseOld |      1 |   3.1224 ns | 0.0738 ns |
| EqualsIgnoreCaseAsciiHelper |      1 |   1.6779 ns | 0.0584 ns |
| CompareOrdinalIgnoreCaseOld |      5 |   8.7303 ns | 0.0433 ns |
| EqualsIgnoreCaseAsciiHelper |      5 |   5.0501 ns | 0.1020 ns |
| CompareOrdinalIgnoreCaseOld |     12 |  16.3910 ns | 0.2941 ns |
| EqualsIgnoreCaseAsciiHelper |     12 |  11.1347 ns | 0.2034 ns |
| CompareOrdinalIgnoreCaseOld |     50 |  59.6391 ns | 0.9095 ns |
| EqualsIgnoreCaseAsciiHelper |     50 |  50.7764 ns | 0.9085 ns |
| CompareOrdinalIgnoreCaseOld |    100 | 112.4222 ns | 1.7497 ns |
| EqualsIgnoreCaseAsciiHelper |    100 |  96.1793 ns | 0.4552 ns |
