### PR TITLE
Download native binaries into a folder named 'RID'

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -224,8 +224,8 @@ if defined __RuntimeId (
     )
 
     call "%__ProjectDir%\run.cmd" build -Project=%__ProjectDir%\tests\runtest.proj -CreateNonWindowsTestOverlay -RuntimeId="%__RuntimeId%"  -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %__unprocessedBuildArgs%
-    for /R %__PackagesDir%\TestNativeBins\%__RuntimeId% %%f in (*.so) do copy %%f %Core_Overlay%
-    for /R %__PackagesDir%\TestNativeBins\%__RuntimeId% %%f in (*.dylib) do copy %%f %Core_Overlay%
+    for /R %__PackagesDir%\TestNativeBins\%__RuntimeId%\%__BuildType% %%f in (*.so) do copy %%f %Core_Overlay%
+    for /R %__PackagesDir%\TestNativeBins\%__RuntimeId%\%__BuildType% %%f in (*.dylib) do copy %%f %Core_Overlay%
 
     echo %__MsgPrefix% Created the runtime layout for %__RuntimeId% in %CORE_OVERLAY%
 )

--- a/config.json
+++ b/config.json
@@ -466,6 +466,12 @@
             "__Container": "default"
           }
         },
+        "runtimeId": {
+          "description": "Runtime ID of the binaries in the specified container.",
+          "settings": {
+            "RuntimeId": "default"
+          }
+        },
         "verbose": {
           "description": "Passes /flp:v=diag to the msbuild command or the value passed by the user.",
           "settings": {

--- a/src/syncAzure.proj
+++ b/src/syncAzure.proj
@@ -8,7 +8,7 @@
     <ContainerName Condition="'$(__Container)' != ''">$(__Container)</ContainerName>
     <ContainerName>$(ContainerName.Replace(".","-"))</ContainerName>
     <DownloadDirectory Condition="'$(PublishTestNativeBins)' != 'true'">$(PackagesDir)AzureTransfer</DownloadDirectory>
-    <DownloadDirectory Condition="'$(PublishTestNativeBins)' == 'true'">$(PackagesDir)TestNativeBins</DownloadDirectory>
+    <DownloadDirectory Condition="'$(PublishTestNativeBins)' == 'true'">$(PackagesDir)TestNativeBins\$(RuntimeId)</DownloadDirectory>
   </PropertyGroup>
 
   <Import Project="$(ToolsDir)SyncCloudContent.targets" />
@@ -17,6 +17,7 @@
     <Error Condition="'$(CloudDropAccountName)' == ''" Text="Missing property CloudDropAccountName." />
     <Error Condition="'$(CloudDropAccessToken)' == ''" Text="Missing property CloudDropAccessToken." />
     <Error Condition="'$(__Container)' == '' and '$(PublishTestNativeBins)' == 'true'" Text="Missing property Container." />
+    <Error Condition="'$(RuntimeId)' == '' and '$(PublishTestNativeBins)' == 'true'" Text="Missing property RuntimeId." />
   </Target>
 
   <Target Name="Build" DependsOnTargets="ValidateRequiredProperties;DownloadBlobsFromAzureTargets" />

--- a/sync.cmd
+++ b/sync.cmd
@@ -26,11 +26,12 @@ echo                 -BuildMajor
 echo                 -BuildMinor
 echo              To download from a specific container, specify:
 echo                 -Container="container name"
-echo     -n     - Downloads test native binaries for the specified OS
+echo     -n     - Downloads test native binaries from the specified container
 echo              The following properties are required:
 echo                 -AzureAccount="Account name"
 echo                 -AzureToken="Access token"
-echo                 -Container="container name (with RID suffix)"
+echo                 -Container="Container name"
+echo                 -RuntimeId="RID" (Needs to match what's in the container)
 echo.
 echo.
 echo.


### PR DESCRIPTION
When I changed the publishing pattern of test native binaries (from publishing into a Container named 'xxx-test-native-bins', with folders in the container for each RID, to publishing each RID's binaries into its own container named 'xxx-{RID}'), I broke the part of build-test that copies those binaries into Core_Root, as they were no longer in the same folder as they used to be. This was causing some tests to fail on non-windows. This should fix that error.