### PR TITLE
Remove all '.requires_signing' files before zipping tests

### DIFF
--- a/tests/helixprep.proj
+++ b/tests/helixprep.proj
@@ -42,6 +42,8 @@
     <Copy SourceFiles="$(CORE_ROOT)\xunit.console.netcore.exe"
           DestinationFolder="%(XunitDlls.RootDir)%(XunitDlls.Directory)"
     />
+    <Message Text="Deleting '.requires_signing' files to avoid file name lengths exceeding MAX_PATH" Importance="Low" />
+    <Delete Files="$(DiscoveryDirectory)\**\*.requires_signing" />
     <MSBuild Projects="helixprep.proj"
              Properties="BuildPath=%(XunitDlls.RootDir)%(XunitDlls.Directory);ProjectName=%(XunitDlls.Filename);BuildArchiveDir=$(TestWorkingDir)archive\tests\"
              Targets="ArchiveBuild" />


### PR DESCRIPTION
The path length of certain '.requires_signing' files in the test tree will exceed MAX_PATH when executing in Helix, due to the prefix part of the path that Helix generates. I wrote a quick program to check the length of all files in our test tree, and after this change, no file should have a name longer than 253 chars in that environment.