### PR TITLE
Add/Expose String.EndsWith(char) and String.StartsWith(char)

### DIFF
--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -3157,6 +3157,11 @@ namespace System
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         [System.Security.SecuritySafeCriticalAttribute]
         public bool EndsWith(System.String value, System.StringComparison comparisonType) { throw null; }
+        public bool EndsWith(System.Char value) { throw null; }
+        public bool EndsWith(System.Char value, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
+        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+        [System.Security.SecuritySafeCriticalAttribute]
+        public bool EndsWith(System.Char value, System.StringComparison comparisonType) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.String value) { throw null; }
         public static bool Equals(System.String a, System.String b) { throw null; }
@@ -3268,6 +3273,11 @@ namespace System
         [System.Runtime.InteropServices.ComVisibleAttribute(false)]
         [System.Security.SecuritySafeCriticalAttribute]
         public bool StartsWith(System.String value, System.StringComparison comparisonType) { throw null; }
+        public bool StartsWith(System.Char value) { throw null; }
+        public bool StartsWith(System.Char value, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
+        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+        [System.Security.SecuritySafeCriticalAttribute]
+        public bool StartsWith(System.Char value, System.StringComparison comparisonType) { throw null; }
         public System.String Substring(int startIndex) { throw null; }
         [System.Security.SecuritySafeCriticalAttribute]
         public System.String Substring(int startIndex, int length) { throw null; }

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -3158,10 +3158,6 @@ namespace System
         [System.Security.SecuritySafeCriticalAttribute]
         public bool EndsWith(System.String value, System.StringComparison comparisonType) { throw null; }
         public bool EndsWith(System.Char value) { throw null; }
-        public bool EndsWith(System.Char value, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
-        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
-        [System.Security.SecuritySafeCriticalAttribute]
-        public bool EndsWith(System.Char value, System.StringComparison comparisonType) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public bool Equals(System.String value) { throw null; }
         public static bool Equals(System.String a, System.String b) { throw null; }
@@ -3274,10 +3270,6 @@ namespace System
         [System.Security.SecuritySafeCriticalAttribute]
         public bool StartsWith(System.String value, System.StringComparison comparisonType) { throw null; }
         public bool StartsWith(System.Char value) { throw null; }
-        public bool StartsWith(System.Char value, bool ignoreCase, System.Globalization.CultureInfo culture) { throw null; }
-        [System.Runtime.InteropServices.ComVisibleAttribute(false)]
-        [System.Security.SecuritySafeCriticalAttribute]
-        public bool StartsWith(System.Char value, System.StringComparison comparisonType) { throw null; }
         public System.String Substring(int startIndex) { throw null; }
         [System.Security.SecuritySafeCriticalAttribute]
         public System.String Substring(int startIndex, int length) { throw null; }

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -780,13 +780,32 @@ namespace System
         }
 
         [Pure]
-        internal bool EndsWith(char value) {
+        internal bool EndsWithOrdinal(char value) {
             int thisLen = this.Length;
             if (thisLen != 0) {
                 if (this[thisLen - 1] == value)
                     return true;
             }
             return false;
+        }
+
+        [Pure]
+        public Boolean EndsWith(Char value)
+        {
+            return EndsWith(new string(value, 1), StringComparison.CurrentCulture);
+        }
+
+        [Pure]
+        [ComVisible(false)]
+        public Boolean EndsWith(Char value, StringComparison comparisonType)
+        {
+            return EndsWith(new string(value, 1), comparisonType);
+        }
+
+        [Pure]
+        public Boolean EndsWith(Char value, Boolean ignoreCase, CultureInfo culture)
+        {
+            return EndsWith(new string(value, 1), ignoreCase, culture);
         }
 
         // Determines whether two strings match.
@@ -1134,6 +1153,25 @@ namespace System
                 referenceCulture = culture;
 
             return referenceCulture.CompareInfo.IsPrefix(this, value, ignoreCase ? CompareOptions.IgnoreCase : CompareOptions.None);
+        }
+
+        [Pure]
+        public Boolean StartsWith(Char value)
+        {
+            return StartsWith(new string(value, 1));
+        }
+
+        [Pure]
+        [ComVisible(false)]
+        public Boolean StartsWith(Char value, StringComparison comparisonType)
+        {
+            return StartsWith(new string(value, 1), comparisonType);
+        }
+
+        [Pure]
+        public Boolean StartsWith(Char value, Boolean ignoreCase, CultureInfo culture)
+        {
+            return StartsWith(new string(value, 1), ignoreCase, culture);
         }
     }
 }

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -780,32 +780,9 @@ namespace System
         }
 
         [Pure]
-        internal bool EndsWithOrdinal(char value) {
+        public Boolean EndsWith(char value) {
             int thisLen = this.Length;
-            if (thisLen != 0) {
-                if (this[thisLen - 1] == value)
-                    return true;
-            }
-            return false;
-        }
-
-        [Pure]
-        public Boolean EndsWith(Char value)
-        {
-            return EndsWith(new string(value, 1), StringComparison.CurrentCulture);
-        }
-
-        [Pure]
-        [ComVisible(false)]
-        public Boolean EndsWith(Char value, StringComparison comparisonType)
-        {
-            return EndsWith(new string(value, 1), comparisonType);
-        }
-
-        [Pure]
-        public Boolean EndsWith(Char value, Boolean ignoreCase, CultureInfo culture)
-        {
-            return EndsWith(new string(value, 1), ignoreCase, culture);
+            return thisLen != 0 && this[thisLen - 1] == value;
         }
 
         // Determines whether two strings match.
@@ -1156,22 +1133,6 @@ namespace System
         }
 
         [Pure]
-        public Boolean StartsWith(Char value)
-        {
-            return StartsWith(new string(value, 1));
-        }
-
-        [Pure]
-        [ComVisible(false)]
-        public Boolean StartsWith(Char value, StringComparison comparisonType)
-        {
-            return StartsWith(new string(value, 1), comparisonType);
-        }
-
-        [Pure]
-        public Boolean StartsWith(Char value, Boolean ignoreCase, CultureInfo culture)
-        {
-            return StartsWith(new string(value, 1), ignoreCase, culture);
-        }
+        public Boolean StartsWith(char value) => Length != 0 && m_firstChar == value;
     }
 }

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -780,7 +780,7 @@ namespace System
         }
 
         [Pure]
-        public Boolean EndsWith(char value) {
+        public bool EndsWith(char value) {
             int thisLen = this.Length;
             return thisLen != 0 && this[thisLen - 1] == value;
         }
@@ -1133,6 +1133,6 @@ namespace System
         }
 
         [Pure]
-        public Boolean StartsWith(char value) => Length != 0 && m_firstChar == value;
+        public bool StartsWith(char value) => Length != 0 && m_firstChar == value;
     }
 }

--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -781,7 +781,7 @@ namespace System
 
         [Pure]
         public bool EndsWith(char value) {
-            int thisLen = this.Length;
+            int thisLen = Length;
             return thisLen != 0 && this[thisLen - 1] == value;
         }
 


### PR DESCRIPTION
Add/Expose String.EndsWith(char) and String.StartsWith(char)

Fix https://github.com/dotnet/corefx/issues/4805