### PR TITLE
Disable delete_next_card_table

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -22,6 +22,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\collect\*">
             <Issue>3392</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Coverage\delete_next_card_table\*">
+            <Issue>9064</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\getgeneration\*">
             <Issue>3392</Issue>
         </ExcludeList>


### PR DESCRIPTION
Since 163983e was checked in, various tests have been failing because
delete_next_card_table is meant to allocate memory until it OOMs. Disable
this test to get the lab in better shape until we can deal with the GC bug
in #9064, then move it to the long gc test leg.