### PR TITLE
[x86/Linux] Get Frame Pointer from CallerSp

### DIFF
--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5469,7 +5469,15 @@ void * EECodeManager::GetGSCookieAddr(PREGDISPLAY     pContext,
     
     if  (info->ebpFrame)
     {
-        return PVOID(SIZE_T((DWORD(*pContext->pEbp) - info->gsCookieOffset)));
+        DWORD curEBP;
+
+#ifdef WIN64EXCEPTIONS
+        curEBP = GetCallerSp(pContext) - 2 * 4;
+#else
+        curEBP = *pContext->pEbp;
+#endif
+
+        return PVOID(SIZE_T(curEBP - info->gsCookieOffset));
     }
     else
     {


### PR DESCRIPTION
GetGSCookieAddress uses pEbp to get the current frame pointer, but pEbp
is not properly initialized as discussed in #8980.

This commit revises GetGSCookieAddress to use CallerSp (as in other
architectures) to get Frame Pointer in order to fix #8980.