### PR TITLE
Fix GC reporting for Span<T> passed in registers on Unix

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -2874,6 +2874,9 @@ void SystemDomain::LoadBaseSystemClasses()
 
 #ifdef FEATURE_SPAN_OF_T
     // Load ByReference class
+    //
+    // NOTE: ByReference<T> must be the first by-ref-like system type to be loaded,
+    //       because MethodTable::ClassifyEightBytesWithManagedLayout depends on it.
     g_pByReferenceClass = MscorlibBinder::GetClass(CLASS__BYREFERENCE);
 #endif
 

--- a/src/vm/argdestination.h
+++ b/src/vm/argdestination.h
@@ -201,7 +201,8 @@ public:
                     _ASSERTE(eightByteSize == 8);
                     _ASSERTE(IS_ALIGNED((SIZE_T)genRegDest, 8));
 
-                    (*fn)(dac_cast<PTR_PTR_Object>(genRegDest), sc, 0);
+                    uint32_t flags = eightByteClassification == SystemVClassificationTypeIntegerByRef ? GC_CALL_INTERIOR : 0;
+                    (*fn)(dac_cast<PTR_PTR_Object>(genRegDest), sc, flags);
                 }
 
                 genRegDest += eightByteSize;

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -5028,20 +5028,18 @@ void ReportPointersFromValueTypeArg(promote_func *fn, ScanContext *sc, PTR_Metho
 {
     WRAPPER_NO_CONTRACT;
 
-    if(pMT->ContainsPointers())
-    {
-#if defined(UNIX_AMD64_ABI) && defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)    
-        if (pSrc->IsStructPassedInRegs())
-        {
-            pSrc->ReportPointersFromStructInRegisters(fn, sc, pMT->GetNumInstanceFieldBytes());
-            return;
-        }
-#endif // UNIX_AMD64_ABI && FEATURE_UNIX_AMD64_STRUCT_PASSING
-    }
-    else if (!pMT->IsByRefLike())
+    if (!pMT->ContainsPointers() && !pMT->IsByRefLike())
     {
         return;
     }
+
+#if defined(UNIX_AMD64_ABI) && defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)    
+    if (pSrc->IsStructPassedInRegs())
+    {
+        pSrc->ReportPointersFromStructInRegisters(fn, sc, pMT->GetNumInstanceFieldBytes());
+        return;
+    }
+#endif // UNIX_AMD64_ABI && FEATURE_UNIX_AMD64_STRUCT_PASSING
 
     ReportPointersFromValueType(fn, sc, pMT, pSrc->GetDestinationAddress());
 }


### PR DESCRIPTION
Part of fix for #9033

Test coverage is already there in CoreFX's span tests.