### PR TITLE
[Wip] ASCII fastpath, System.Text cleanup

### DIFF
--- a/src/mscorlib/src/System/Text/DecoderBestFitFallback.cs
+++ b/src/mscorlib/src/System/Text/DecoderBestFitFallback.cs
@@ -8,10 +8,7 @@
 namespace System.Text
 {
     using System;
-    using System.Text;
     using System.Threading;
-    using System.Diagnostics;
-    using System.Diagnostics.Contracts;
 
     [Serializable]
     internal sealed class InternalDecoderBestFitFallback : DecoderFallback
@@ -34,13 +31,7 @@ namespace System.Text
         }
 
         // Maximum number of characters that this instance of this fallback could return
-        public override int MaxCharCount
-        {
-            get
-            {
-                return 1;
-            }
-        }
+        public override int MaxCharCount => 1;
 
         public override bool Equals(Object value)
         {
@@ -64,7 +55,7 @@ namespace System.Text
         internal char                   cBestFit = '\0';
         internal int                    iCount = -1;
         internal int                    iSize;
-        private InternalDecoderBestFitFallback  oFallback;
+        private readonly InternalDecoderBestFitFallback oFallback;
 
         // Private object for locking instead of locking on a public type for SQL reliability work.
         private static Object s_InternalSyncObject;
@@ -147,13 +138,7 @@ namespace System.Text
         }
 
         // How many characters left to output?
-        public override int Remaining
-        {
-            get
-            {
-                return (iCount > 0) ? iCount : 0;
-            }
-        }
+        public override int Remaining => (iCount > 0) ? iCount : 0;
 
         // Clear the buffer
         public override unsafe void Reset()

--- a/src/mscorlib/src/System/Text/DecoderExceptionFallback.cs
+++ b/src/mscorlib/src/System/Text/DecoderExceptionFallback.cs
@@ -22,13 +22,7 @@ namespace System.Text
         }
 
         // Maximum number of characters that this instance of this fallback could return
-        public override int MaxCharCount
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override int MaxCharCount => 0;
 
         public override bool Equals(Object value)
         {
@@ -67,13 +61,7 @@ namespace System.Text
         }
 
         // Exceptions are always empty
-        public override int Remaining
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override int Remaining => 0;
 
         private void Throw(byte[] bytesUnknown, int index)
         {
@@ -104,8 +92,8 @@ namespace System.Text
     [Serializable]
     public sealed class DecoderFallbackException : ArgumentException
     {
-        byte[]    bytesUnknown = null;
-        int       index = 0;
+        readonly byte[]    bytesUnknown = null;
+        readonly int       index = 0;
 
         public DecoderFallbackException()
             : base(Environment.GetResourceString("Arg_ArgumentException"))
@@ -136,20 +124,8 @@ namespace System.Text
             this.index = index;
         }
 
-        public byte[] BytesUnknown
-        {
-            get
-            {
-                return (bytesUnknown);
-            }
-        }
+        public byte[] BytesUnknown => (bytesUnknown);
 
-        public int Index
-        {
-            get
-            {
-                return this.index;
-            }
-        }
+        public int Index => this.index;
     }
 }

--- a/src/mscorlib/src/System/Text/DecoderFallback.cs
+++ b/src/mscorlib/src/System/Text/DecoderFallback.cs
@@ -2,13 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-using System;
-using System.Security;
 using System.Threading;
 using System.Globalization;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
 
 namespace System.Text
 {
@@ -17,8 +12,8 @@ namespace System.Text
     {
         internal bool                  bIsMicrosoftBestFitFallback = false;
 
-        private static volatile DecoderFallback replacementFallback; // Default fallback, uses no best fit & "?"
-        private static volatile DecoderFallback exceptionFallback;
+        private static volatile DecoderFallback s_replacementFallback; // Default fallback, uses no best fit & "?"
+        private static volatile DecoderFallback s_exceptionFallback;
 
         // Private object for locking instead of locking on a internal type for SQL reliability work.
         private static Object s_InternalSyncObject;
@@ -41,12 +36,12 @@ namespace System.Text
         {
             get
             {
-                if (replacementFallback == null)
+                if (s_replacementFallback == null)
                     lock(InternalSyncObject)
-                        if (replacementFallback == null)
-                            replacementFallback = new DecoderReplacementFallback();
+                        if (s_replacementFallback == null)
+                            s_replacementFallback = new DecoderReplacementFallback();
 
-                return replacementFallback;
+                return s_replacementFallback;
             }
         }
 
@@ -55,12 +50,12 @@ namespace System.Text
         {
             get
             {
-                if (exceptionFallback == null)
+                if (s_exceptionFallback == null)
                     lock(InternalSyncObject)
-                        if (exceptionFallback == null)
-                            exceptionFallback = new DecoderExceptionFallback();
+                        if (s_exceptionFallback == null)
+                            s_exceptionFallback = new DecoderExceptionFallback();
 
-                return exceptionFallback;
+                return s_exceptionFallback;
             }
         }
 
@@ -76,13 +71,7 @@ namespace System.Text
 
         public abstract int MaxCharCount { get; }
 
-        internal bool IsMicrosoftBestFitFallback
-        {
-            get
-            {
-                return bIsMicrosoftBestFitFallback;
-            }
-        }
+        internal bool IsMicrosoftBestFitFallback => bIsMicrosoftBestFitFallback;
     }
 
 

--- a/src/mscorlib/src/System/Text/DecoderNLS.cs
+++ b/src/mscorlib/src/System/Text/DecoderNLS.cs
@@ -4,11 +4,9 @@
 
 namespace System.Text
 {
-    using System.Runtime.Serialization;
-    using System.Security.Permissions;
-    using System.Text;
     using System;
     using System.Diagnostics.Contracts;
+    using System.Runtime.Serialization;
     // A Decoder is used to decode a sequence of blocks of bytes into a
     // sequence of blocks of characters. Following instantiation of a decoder,
     // sequential blocks of bytes are converted into blocks of characters through
@@ -67,11 +65,10 @@ namespace System.Text
 
         public override void Reset()
         {
-            if (m_fallbackBuffer != null)
-                m_fallbackBuffer.Reset();
+            m_fallbackBuffer?.Reset();
         }
 
-        public override unsafe int GetCharCount(byte[] bytes, int index, int count)
+        public override int GetCharCount(byte[] bytes, int index, int count)
         {
             return GetCharCount(bytes, index, count, false);
         }
@@ -79,18 +76,11 @@ namespace System.Text
         public override unsafe int GetCharCount(byte[] bytes, int index, int count, bool flush)
         {
             // Validate Parameters
-            if (bytes == null)
-                throw new ArgumentNullException(nameof(bytes),
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (index < 0 || count < 0)
-                throw new ArgumentOutOfRangeException((index<0 ? nameof(index) : nameof(count)),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - index < count)
-                throw new ArgumentOutOfRangeException(nameof(bytes),
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
+            if (bytes == null || index < 0 || count < 0 ||
+                (bytes.Length - index < count))
+            {
+                EncodingForwarder.ThrowValidationFailedException(bytes, index, count);
+            }
             Contract.EndContractBlock();
 
             // Avoid null fixed problem
@@ -105,13 +95,10 @@ namespace System.Text
         public unsafe override int GetCharCount(byte* bytes, int count, bool flush)
         {
             // Validate parameters
-            if (bytes == null)
-                throw new ArgumentNullException(nameof(bytes),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            if (bytes == null || count < 0)
+            {
+                EncodingForwarder.ThrowValidationFailedException(bytes);
+            }
             Contract.EndContractBlock();
 
             // Remember the flush
@@ -122,7 +109,7 @@ namespace System.Text
             return m_encoding.GetCharCount(bytes, count, this);
         }
 
-        public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                              char[] chars, int charIndex)
         {
             return GetChars(bytes, byteIndex, byteCount, chars, charIndex, false);
@@ -132,22 +119,12 @@ namespace System.Text
                                              char[] chars, int charIndex, bool flush)
         {
             // Validate Parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? nameof(bytes) : nameof(chars),
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? nameof(byteIndex) : nameof(byteCount)),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if ( bytes.Length - byteIndex < byteCount)
-                throw new ArgumentOutOfRangeException(nameof(bytes),
-                    Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (charIndex < 0 || charIndex > chars.Length)
-                throw new ArgumentOutOfRangeException(nameof(charIndex),
-                    Environment.GetResourceString("ArgumentOutOfRange_Index"));
-
+            if (bytes == null || chars == null || byteIndex < 0 || byteCount < 0 ||
+                (bytes.Length - byteIndex < byteCount) ||
+                (charIndex < 0 || charIndex > chars.Length))
+            {
+                EncodingForwarder.ThrowValidationFailedException(bytes, byteIndex, byteCount, chars);
+            }
             Contract.EndContractBlock();
 
             // Avoid empty input fixed problem
@@ -170,13 +147,10 @@ namespace System.Text
                                               char* chars, int charCount, bool flush)
         {
             // Validate parameters
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException((chars == null ? nameof(chars) : nameof(bytes)),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteCount < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((byteCount<0 ? nameof(byteCount) : nameof(charCount)),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            if (chars == null || bytes == null || byteCount < 0 || charCount < 0)
+            {
+                EncodingForwarder.ThrowValidationFailedException(bytes, byteCount, chars);
+            }
             Contract.EndContractBlock();
 
             // Remember our flush
@@ -194,26 +168,13 @@ namespace System.Text
                                               out int bytesUsed, out int charsUsed, out bool completed)
         {
             // Validate parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException((bytes == null ? nameof(bytes) : nameof(chars)),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteIndex < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((byteIndex<0 ? nameof(byteIndex) : nameof(byteCount)),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (charIndex < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((charIndex<0 ? nameof(charIndex) : nameof(charCount)),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-
-            if (bytes.Length - byteIndex < byteCount)
-                throw new ArgumentOutOfRangeException(nameof(bytes),
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
-            if (chars.Length - charIndex < charCount)
-                throw new ArgumentOutOfRangeException(nameof(chars),
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCountBuffer"));
-
+            if (bytes == null || chars == null || 
+                byteIndex < 0 || byteCount < 0 || charIndex < 0 || charCount < 0 ||
+                (bytes.Length - byteIndex < byteCount) ||
+                (chars.Length - charIndex < charCount))
+            {
+                EncodingForwarder.ThrowValidationFailedException(chars, charIndex, charCount, bytes, byteIndex, byteCount);
+            }
             Contract.EndContractBlock();
 
             // Avoid empty input problem
@@ -240,13 +201,10 @@ namespace System.Text
                                               out int bytesUsed, out int charsUsed, out bool completed)
         {
             // Validate input parameters
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException(chars == null ? nameof(chars) : nameof(bytes),
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteCount < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((byteCount<0 ? nameof(byteCount) : nameof(charCount)),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            if (bytes == null || chars == null || charCount < 0 || byteCount < 0)
+            {
+                EncodingForwarder.ThrowValidationFailedException(chars, charCount, bytes);
+            }
             Contract.EndContractBlock();
 
             // We don't want to throw
@@ -265,22 +223,10 @@ namespace System.Text
             // Our data thingys are now full, we can return
         }
 
-        public bool MustFlush
-        {
-            get
-            {
-                return m_mustFlush;
-            }
-        }
+        public bool MustFlush => m_mustFlush;
 
         // Anything left in our decoder?
-        internal virtual bool HasState
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal virtual bool HasState => false;
 
         // Allow encoding to clear our must flush instead of throwing (in ThrowCharsOverflow)
         internal void ClearMustFlush()

--- a/src/mscorlib/src/System/Text/DecoderReplacementFallback.cs
+++ b/src/mscorlib/src/System/Text/DecoderReplacementFallback.cs
@@ -5,14 +5,13 @@
 namespace System.Text
 {
     using System;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
 
     [Serializable]
     public sealed class DecoderReplacementFallback : DecoderFallback
     {
         // Our variables
-        private String strDefault;
+        private readonly String strDefault;
 
         // Construction.  Default replacement fallback uses no best fit and ? replacement string
         public DecoderReplacementFallback() : this("?")
@@ -64,13 +63,7 @@ namespace System.Text
             strDefault = replacement;
         }
 
-        public String DefaultString
-        {
-             get
-             {
-                return strDefault;
-             }
-        }
+        public String DefaultString => strDefault;
 
         public override DecoderFallbackBuffer CreateFallbackBuffer()
         {
@@ -78,13 +71,7 @@ namespace System.Text
         }
 
         // Maximum number of characters that this instance of this fallback could return
-        public override int MaxCharCount
-        {
-            get
-            {
-                return strDefault.Length;
-            }
-        }
+        public override int MaxCharCount => strDefault.Length;
 
         public override bool Equals(Object value)
         {
@@ -107,7 +94,7 @@ namespace System.Text
     public sealed class DecoderReplacementFallbackBuffer : DecoderFallbackBuffer
     {
         // Store our default string
-        private String strDefault;
+        private readonly String strDefault;
         int fallbackCount = -1;
         int fallbackIndex = -1;
 
@@ -178,14 +165,7 @@ namespace System.Text
         }
 
         // How many characters left to output?
-        public override int Remaining
-        {
-            get
-            {
-                // Our count is 0 for 1 character left.
-                return (fallbackCount < 0) ? 0 : fallbackCount;
-            }
-        }
+        public override int Remaining => (fallbackCount < 0) ? 0 : fallbackCount;
 
         // Clear the buffer
         public override unsafe void Reset()

--- a/src/mscorlib/src/System/Text/EncoderBestFitFallback.cs
+++ b/src/mscorlib/src/System/Text/EncoderBestFitFallback.cs
@@ -9,9 +9,7 @@ namespace System.Text
 {
     using System;
     using System.Globalization;
-    using System.Text;
     using System.Threading;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
 
     [Serializable]
@@ -34,13 +32,7 @@ namespace System.Text
         }
 
         // Maximum number of characters that this instance of this fallback could return
-        public override int MaxCharCount
-        {
-            get
-            {
-                return 1;
-            }
-        }
+        public override int MaxCharCount => 1;
 
         public override bool Equals(Object value)
         {
@@ -62,9 +54,9 @@ namespace System.Text
     {
         // Our variables
         private char                    cBestFit = '\0';
-        private InternalEncoderBestFitFallback  oFallback;
         private int                     iCount = -1;
         private int                     iSize;
+        private readonly InternalEncoderBestFitFallback  oFallback;
 
         // Private object for locking instead of locking on a public type for SQL reliability work.
         private static Object s_InternalSyncObject;
@@ -175,13 +167,7 @@ namespace System.Text
 
 
         // How many characters left to output?
-        public override int Remaining
-        {
-            get
-            {
-                return (iCount > 0) ? iCount : 0;
-            }
-        }
+        public override int Remaining => (iCount > 0) ? iCount : 0;
 
         // Clear the buffer
         public override unsafe void Reset()

--- a/src/mscorlib/src/System/Text/EncoderExceptionFallback.cs
+++ b/src/mscorlib/src/System/Text/EncoderExceptionFallback.cs
@@ -22,13 +22,7 @@ namespace System.Text
         }
 
         // Maximum number of characters that this instance of this fallback could return
-        public override int MaxCharCount
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override int MaxCharCount => 0;
 
         public override bool Equals(Object value)
         {
@@ -94,22 +88,16 @@ namespace System.Text
         }
 
         // Exceptions are always empty
-        public override int Remaining
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public override int Remaining => 0;
     }
 
     [Serializable]
     public sealed class EncoderFallbackException : ArgumentException
     {
-        char    charUnknown;
-        char    charUnknownHigh;
-        char    charUnknownLow;
-        int     index;
+        readonly char charUnknown;
+        readonly char charUnknownHigh;
+        readonly char charUnknownLow;
+        readonly int  index;
 
         public EncoderFallbackException()
             : base(Environment.GetResourceString("Arg_ArgumentException"))
@@ -162,37 +150,13 @@ namespace System.Text
             this.index = index;
         }
 
-        public char CharUnknown
-        {
-            get
-            {
-                return (charUnknown);
-            }
-        }
+        public char CharUnknown => (charUnknown);
 
-        public char CharUnknownHigh
-        {
-            get
-            {
-                return (charUnknownHigh);
-            }
-        }
+        public char CharUnknownHigh => (charUnknownHigh);
 
-        public char CharUnknownLow
-        {
-            get
-            {
-                return (charUnknownLow);
-            }
-        }
+        public char CharUnknownLow => (charUnknownLow);
 
-        public int Index
-        {
-            get
-            {
-                return index;
-            }
-        }
+        public int Index => index;
 
         // Return true if the unknown character is a surrogate pair.
         public bool IsUnknownSurrogate()

--- a/src/mscorlib/src/System/Text/EncoderFallback.cs
+++ b/src/mscorlib/src/System/Text/EncoderFallback.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Security;
 using System.Threading;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
 
 namespace System.Text
 {

--- a/src/mscorlib/src/System/Text/EncoderReplacementFallback.cs
+++ b/src/mscorlib/src/System/Text/EncoderReplacementFallback.cs
@@ -5,15 +5,13 @@
 namespace System.Text
 {
     using System;
-    using System.Runtime;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
 
     [Serializable]
     public sealed class EncoderReplacementFallback : EncoderFallback
     {
         // Our variables
-        private String strDefault;
+        private readonly String strDefault;
 
         // Construction.  Default replacement fallback uses no best fit and ? replacement string
         public EncoderReplacementFallback() : this("?")
@@ -66,13 +64,7 @@ namespace System.Text
             strDefault = replacement;
         }
 
-        public String DefaultString
-        {
-             get
-             {
-                return strDefault;
-             }
-        }
+        public String DefaultString => strDefault;
 
         public override EncoderFallbackBuffer CreateFallbackBuffer()
         {
@@ -80,13 +72,7 @@ namespace System.Text
         }
 
         // Maximum number of characters that this instance of this fallback could return
-        public override int MaxCharCount
-        {
-            get
-            {
-                return strDefault.Length;
-            }
-        }
+        public override int MaxCharCount => strDefault.Length;
 
         public override bool Equals(Object value)
         {

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -5,20 +5,12 @@
 namespace System.Text
 {
     using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Runtime;
-    using System.Runtime.Remoting;
-    using System.Runtime.Serialization;
-    using System.Globalization;
-    using System.Security;
-    using System.Security.Permissions;
-    using System.Threading;
-    using System.Text;
-    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Contracts;
-    using Win32Native = Microsoft.Win32.Win32Native;
+    using System.Globalization;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Serialization;
+    using System.Threading;
 
     // This abstract base class represents a character encoding. The class provides
     // methods to convert arrays and strings of Unicode characters to and from
@@ -83,7 +75,7 @@ namespace System.Text
     // generally executes faster.
     //
 
-    [System.Runtime.InteropServices.ComVisible(true)]
+    [ComVisible(true)]
     [Serializable]
     public abstract class Encoding : ICloneable
     {
@@ -106,54 +98,10 @@ namespace System.Text
         private const int CodePageNoSymbol      = 42;       // Symbol code page not supported
         private const int CodePageUnicode       = 1200;     // Unicode
         private const int CodePageBigEndian     = 1201;     // Big Endian Unicode
-        private const int CodePageWindows1252   = 1252;     // Windows 1252 code page
-
-        // 20936 has same code page as 10008, so we'll special case it
-        private const int CodePageMacGB2312 = 10008;
-        private const int CodePageGB2312    = 20936;
-        private const int CodePageMacKorean = 10003;
-        private const int CodePageDLLKorean = 20949;
-
-        // ISO 2022 Code Pages
-        private const int ISO2022JP         = 50220;
-        private const int ISO2022JPESC      = 50221;
-        private const int ISO2022JPSISO     = 50222;
-        private const int ISOKorean         = 50225;
-        private const int ISOSimplifiedCN   = 50227;
-        private const int EUCJP             = 51932;
-        private const int ChineseHZ         = 52936;    // HZ has ~}~{~~ sequences
-
-        // 51936 is the same as 936
-        private const int DuplicateEUCCN    = 51936;
-        private const int EUCCN             = 936;
-
-        private const int EUCKR             = 51949;
 
         // Latin 1 & ASCII Code Pages
         internal const int CodePageASCII    = 20127;    // ASCII
         internal const int ISO_8859_1       = 28591;    // Latin1
-
-        // ISCII
-        private const int ISCIIAssemese     = 57006;
-        private const int ISCIIBengali      = 57003;
-        private const int ISCIIDevanagari   = 57002;
-        private const int ISCIIGujarathi    = 57010;
-        private const int ISCIIKannada      = 57008;
-        private const int ISCIIMalayalam    = 57009;
-        private const int ISCIIOriya        = 57007;
-        private const int ISCIIPanjabi      = 57011;
-        private const int ISCIITamil        = 57004;
-        private const int ISCIITelugu       = 57005;
-
-        // GB18030
-        private const int GB18030           = 54936;
-
-        // Other
-        private const int ISO_8859_8I       = 38598;
-        private const int ISO_8859_8_Visual = 28598;
-
-        // 50229 is currently unsupported // "Chinese Traditional (ISO-2022)"
-        private const int ENC50229          = 50229;
 
         // Special code pages
         private const int CodePageUTF7      = 65000;
@@ -183,7 +131,6 @@ namespace System.Text
         protected Encoding() : this(0)
         {
         }
-
 
         protected Encoding(int codePage)
         {
@@ -627,17 +574,10 @@ namespace System.Text
 
         // True if and only if the encoding only uses single byte code points.  (Ie, ASCII, 1252, etc)
 
-        [System.Runtime.InteropServices.ComVisible(false)]
-        public virtual bool IsSingleByte
-        {
-            get
-            {
-                return false;
-            }
-        }
+        [ComVisible(false)]
+        public virtual bool IsSingleByte => false;
 
-
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public EncoderFallback EncoderFallback
         {
             get
@@ -659,7 +599,7 @@ namespace System.Text
         }
 
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public DecoderFallback DecoderFallback
         {
             get
@@ -681,7 +621,7 @@ namespace System.Text
         }
 
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public virtual Object Clone()
         {
             Encoding newEncoding = (Encoding)this.MemberwiseClone();
@@ -691,16 +631,8 @@ namespace System.Text
             return newEncoding;
         }
 
-
-        [System.Runtime.InteropServices.ComVisible(false)]
-        public bool IsReadOnly
-        {
-            get
-            {
-                return (m_isReadOnly);
-            }
-        }
-
+        [ComVisible(false)]
+        public bool IsReadOnly => (m_isReadOnly);
 
         // Returns an encoding for the ASCII character set. The returned encoding
         // will be an instance of the ASCIIEncoding class.
@@ -720,10 +652,7 @@ namespace System.Text
         public virtual int GetByteCount(char[] chars)
         {
             if (chars == null)
-            {
-                throw new ArgumentNullException(nameof(chars),
-                    Environment.GetResourceString("ArgumentNull_Array"));
-            }
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars, ExceptionResource.ArgumentNull_Array);
             Contract.EndContractBlock();
 
             return GetByteCount(chars, 0, chars.Length);
@@ -733,7 +662,7 @@ namespace System.Text
         public virtual int GetByteCount(String s)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             Contract.EndContractBlock();
 
             char[] chars = s.ToCharArray();
@@ -752,20 +681,13 @@ namespace System.Text
         [Pure]
         public int GetByteCount(string s, int index, int count)
         {
-            if (s == null)
-                throw new ArgumentNullException(nameof(s), 
-                    Environment.GetResourceString("ArgumentNull_String"));
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            if (index > s.Length - count)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
+            // Validate input parameters
+            if (s == null || index < 0 || count < 0 ||
+                (index > s.Length - count))
+            {
+                EncodingForwarder.ThrowValidationFailedException(s, index, count);
+            }
             Contract.EndContractBlock();
-
             unsafe
             {
                 fixed (char* pChar = s)
@@ -781,17 +703,14 @@ namespace System.Text
         // a 3rd party encoding.
         [Pure]
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public virtual unsafe int GetByteCount(char* chars, int count)
         {
             // Validate input parameters
-            if (chars == null)
-                throw new ArgumentNullException(nameof(chars),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            if (chars == null || count < 0)
+            {
+                EncodingForwarder.ThrowValidationFailedException(chars, count);
+            }
             Contract.EndContractBlock();
 
             char[] arrChar = new char[count];
@@ -820,11 +739,9 @@ namespace System.Text
         public virtual byte[] GetBytes(char[] chars)
         {
             if (chars == null)
-            {
-                throw new ArgumentNullException(nameof(chars),
-                    Environment.GetResourceString("ArgumentNull_Array"));
-            }
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars, ExceptionResource.ArgumentNull_Array);
             Contract.EndContractBlock();
+
             return GetBytes(chars, 0, chars.Length);
         }
 
@@ -858,8 +775,7 @@ namespace System.Text
         public virtual byte[] GetBytes(String s)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s),
-                    Environment.GetResourceString("ArgumentNull_String"));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s, ExceptionResource.ArgumentNull_String);
             Contract.EndContractBlock();
 
             int byteCount = GetByteCount(s);
@@ -873,47 +789,45 @@ namespace System.Text
         // string range.
         //
         [Pure]
-        public byte[] GetBytes(string s, int index, int count)
+        public unsafe byte[] GetBytes(string s, int index, int count)
         {
-            if (s == null)
-                throw new ArgumentNullException(nameof(s),
-                    Environment.GetResourceString("ArgumentNull_String"));
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-            if (index > s.Length - count)
-                throw new ArgumentOutOfRangeException(nameof(index),
-                      Environment.GetResourceString("ArgumentOutOfRange_IndexCount"));
+            // Validate input parameters
+            if (s == null || index < 0 || count < 0 ||
+                (index > s.Length - count))
+            {
+                EncodingForwarder.ThrowValidationFailedException(s, index, count);
+            }
             Contract.EndContractBlock();
 
-            unsafe
+            byte[] bytes;
+            fixed (char* pChar = s)
             {
-                fixed (char* pChar = s)
+                int byteCount = GetByteCount(pChar + index, count);
+                if (byteCount == 0)
                 {
-                    int byteCount = GetByteCount(pChar + index, count);
-                    if (byteCount == 0)
-                        return Array.Empty<byte>();
-
-                    byte[] bytes = new byte[byteCount];
+                    bytes = Array.Empty<byte>();
+                }
+                else
+                {
+                    bytes = new byte[byteCount];
                     fixed (byte* pBytes = &bytes[0])
                     {
                         int bytesReceived = GetBytes(pChar + index, count, pBytes, byteCount);
                         Debug.Assert(byteCount == bytesReceived);
                     }
-                    return bytes;
                 }
             }
+            
+            return bytes;
         }
 
         public virtual int GetBytes(String s, int charIndex, int charCount,
                                        byte[] bytes, int byteIndex)
         {
             if (s == null)
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
             Contract.EndContractBlock();
+
             return GetBytes(s.ToCharArray(), charIndex, charCount, bytes, byteIndex);
         }
 
@@ -943,18 +857,15 @@ namespace System.Text
         // when we copy the buffer so that we don't overflow byteCount either.
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public virtual unsafe int GetBytes(char* chars, int charCount,
                                               byte* bytes, int byteCount)
         {
             // Validate input parameters
-            if (bytes == null || chars == null)
-                throw new ArgumentNullException(bytes == null ? nameof(bytes) : nameof(chars),
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (charCount < 0 || byteCount < 0)
-                throw new ArgumentOutOfRangeException((charCount<0 ? nameof(charCount) : nameof(byteCount)),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            if (bytes == null || chars == null || charCount < 0 || byteCount < 0)
+            {
+                EncodingForwarder.ThrowValidationFailedException(chars, charCount, bytes);
+            }
             Contract.EndContractBlock();
 
             // Get the char array to convert
@@ -994,10 +905,7 @@ namespace System.Text
         public virtual int GetCharCount(byte[] bytes)
         {
             if (bytes == null)
-            {
-                throw new ArgumentNullException(nameof(bytes),
-                    Environment.GetResourceString("ArgumentNull_Array"));
-            }
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);
             Contract.EndContractBlock();
             return GetCharCount(bytes, 0, bytes.Length);
         }
@@ -1012,17 +920,14 @@ namespace System.Text
         // ones we need a working (if slow) default implimentation)
         [Pure]
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public virtual unsafe int GetCharCount(byte* bytes, int count)
         {
             // Validate input parameters
-            if (bytes == null)
-                throw new ArgumentNullException(nameof(bytes),
-                      Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count),
-                      Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            if (bytes == null || count < 0)
+            {
+               EncodingForwarder.ThrowValidationFailedException(bytes);
+            }
             Contract.EndContractBlock();
 
             byte[] arrbyte = new byte[count];
@@ -1048,10 +953,7 @@ namespace System.Text
         public virtual char[] GetChars(byte[] bytes)
         {
             if (bytes == null)
-            {
-                throw new ArgumentNullException(nameof(bytes),
-                    Environment.GetResourceString("ArgumentNull_Array"));
-            }
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);
             Contract.EndContractBlock();
             return GetChars(bytes, 0, bytes.Length);
         }
@@ -1099,18 +1001,15 @@ namespace System.Text
         // when we copy the buffer so that we don't overflow charCount either.
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public virtual unsafe int GetChars(byte* bytes, int byteCount,
                                               char* chars, int charCount)
         {
             // Validate input parameters
-            if (chars == null || bytes == null)
-                throw new ArgumentNullException(chars == null ? nameof(chars) : nameof(bytes),
-                    Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteCount < 0 || charCount < 0)
-                throw new ArgumentOutOfRangeException((byteCount<0 ? nameof(byteCount) : nameof(charCount)),
-                    Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            if (bytes == null || chars == null || charCount < 0 || byteCount < 0)
+            {
+                EncodingForwarder.ThrowValidationFailedException(bytes, byteCount, chars);
+            }
             Contract.EndContractBlock();
 
             // Get the byte array to convert
@@ -1154,14 +1053,14 @@ namespace System.Text
 
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public unsafe string GetString(byte* bytes, int byteCount)
         {
-            if (bytes == null)
-                throw new ArgumentNullException(nameof(bytes), Environment.GetResourceString("ArgumentNull_Array"));
-
-            if (byteCount < 0)
-                throw new ArgumentOutOfRangeException(nameof(byteCount), Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            // Validate input parameters
+            if (bytes == null || byteCount < 0)
+            {
+                ThrowValidationFailedStringException(bytes);
+            }
             Contract.EndContractBlock();
 
             return String.CreateStringFromEncoding(bytes, byteCount, this);
@@ -1170,27 +1069,19 @@ namespace System.Text
         // Returns the code page identifier of this encoding. The returned value is
         // an integer between 0 and 65535 if the encoding has a code page
         // identifier, or -1 if the encoding does not represent a code page.
-        //
-
-        public virtual int CodePage
-        {
-            get
-            {
-                return m_codePage;
-            }
-        }
+        public virtual int CodePage => m_codePage;
 
         // IsAlwaysNormalized
         // Returns true if the encoding is always normalized for the specified encoding form
         [Pure]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public bool IsAlwaysNormalized()
         {
             return this.IsAlwaysNormalized(NormalizationForm.FormC);
         }
 
         [Pure]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public virtual bool IsAlwaysNormalized(NormalizationForm form)
         {
             // Assume false unless the encoding knows otherwise
@@ -1221,12 +1112,8 @@ namespace System.Text
             // defaultEncoding should be null if we get here, but we can't
             // assert that in case another thread beat us to the initialization
 
-            Encoding enc;
-
-
             // For silverlight we use UTF8 since ANSI isn't available
-            enc = UTF8;
-
+            Encoding enc = UTF8;
 
             // This method should only ever return one Encoding instance
             return Interlocked.CompareExchange(ref defaultEncoding, enc, null) ?? enc;
@@ -1287,8 +1174,8 @@ namespace System.Text
         public virtual String GetString(byte[] bytes)
         {
             if (bytes == null)
-                throw new ArgumentNullException(nameof(bytes),
-                    Environment.GetResourceString("ArgumentNull_Array"));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);
+
             Contract.EndContractBlock();
 
             return GetString(bytes, 0, bytes.Length);
@@ -1418,6 +1305,19 @@ namespace System.Text
             decoder.ClearMustFlush();
         }
 
+        private static unsafe void ThrowValidationFailedStringException(byte* bytes)
+        {
+            throw GetValidationFailedStringException(bytes);
+        }
+
+        private static unsafe Exception GetValidationFailedStringException(byte* bytes)
+        {
+            if (bytes == null)
+                return ThrowHelper.GetArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);
+            // if (byteCount < 0)
+            return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.byteCount, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+        }
+
         [Serializable]
         internal class DefaultEncoder : Encoder, IObjectReference, ISerializable
         {
@@ -1543,9 +1443,9 @@ namespace System.Text
         [Serializable]
         internal class DefaultDecoder : Decoder, IObjectReference, ISerializable
         {
-            private Encoding m_encoding;
+            private readonly Encoding m_encoding;
             [NonSerialized]
-            private bool m_hasInitializedEncoding;
+            private readonly bool m_hasInitializedEncoding;
 
             public DefaultDecoder(Encoding encoding)
             {
@@ -1668,16 +1568,17 @@ namespace System.Text
 
         internal class EncodingCharBuffer
         {
+            readonly unsafe char* charStart;
+            readonly unsafe char* charEnd;
+            readonly Encoding     enc;
+            readonly DecoderNLS   decoder;
+            readonly unsafe byte* byteStart;
+            readonly unsafe byte* byteEnd;
+            readonly DecoderFallbackBuffer fallbackBuffer;
+
             unsafe char* chars;
-            unsafe char* charStart;
-            unsafe char* charEnd;
             int          charCountResult = 0;
-            Encoding     enc;
-            DecoderNLS   decoder;
-            unsafe byte* byteStart;
-            unsafe byte* byteEnd;
             unsafe byte* bytes;
-            DecoderFallbackBuffer fallbackBuffer;
 
             internal unsafe EncodingCharBuffer(Encoding enc, DecoderNLS decoder, char* charStart, int charCount,
                                                     byte* byteStart, int byteCount)
@@ -1723,23 +1624,9 @@ namespace System.Text
                 return true;
             }
 
-            internal unsafe bool AddChar(char ch)
+            internal bool AddChar(char ch)
             {
                 return AddChar(ch,1);
-            }
-
-
-            internal unsafe bool AddChar(char ch1, char ch2, int numBytes)
-            {
-                // Need room for 2 chars
-                if (chars >= charEnd - 1)
-                {
-                    // Throw maybe
-                    bytes-=numBytes;                                        // Didn't encode these bytes
-                    enc.ThrowCharsOverflow(decoder, bytes <= byteStart);    // Throw?
-                    return false;                                           // No throw, but no store either
-                }
-                return AddChar(ch1, numBytes) && AddChar(ch2, numBytes);
             }
 
             internal unsafe void AdjustBytes(int count)
@@ -1747,19 +1634,7 @@ namespace System.Text
                 bytes += count;
             }
 
-            internal unsafe bool MoreData
-            {
-                get
-                {
-                    return bytes < byteEnd;
-                }
-            }
-
-            // Do we have count more bytes?
-            internal unsafe bool EvenMoreData(int count)
-            {
-                return (bytes <= byteEnd - count);
-            }
+            internal unsafe bool MoreData => (bytes < byteEnd);
 
             // GetNextByte shouldn't be called unless the caller's already checked more data or even more data,
             // but we'll double check just to make sure.
@@ -1771,36 +1646,12 @@ namespace System.Text
                 return *(bytes++);
             }
 
-            internal unsafe int BytesUsed
-            {
-                get
-                {
-                    return (int)(bytes - byteStart);
-                }
-            }
+            internal unsafe int BytesUsed => (int)(bytes - byteStart);
 
-            internal unsafe bool Fallback(byte fallbackByte)
+            internal bool Fallback(byte fallbackByte)
             {
                 // Build our buffer
                 byte[] byteBuffer = new byte[] { fallbackByte };
-
-                // Do the fallback and add the data.
-                return Fallback(byteBuffer);
-            }
-
-            internal unsafe bool Fallback(byte byte1, byte byte2)
-            {
-                // Build our buffer
-                byte[] byteBuffer = new byte[] { byte1, byte2 };
-
-                // Do the fallback and add the data.
-                return Fallback(byteBuffer);
-            }
-
-            internal unsafe bool Fallback(byte byte1, byte byte2, byte byte3, byte byte4)
-            {
-                // Build our buffer
-                byte[] byteBuffer = new byte[] { byte1, byte2, byte3, byte4 };
 
                 // Do the fallback and add the data.
                 return Fallback(byteBuffer);
@@ -1830,27 +1681,23 @@ namespace System.Text
                 return true;
             }
 
-            internal unsafe int Count
-            {
-                get
-                {
-                    return charCountResult;
-                }
-            }
+            internal int Count => charCountResult;
         }
 
         internal class EncodingByteBuffer
         {
+            readonly unsafe byte* byteStart;
+            readonly unsafe byte* byteEnd;
+            readonly unsafe char* charStart;
+            readonly unsafe char* charEnd;
+            readonly Encoding     enc;
+            readonly EncoderNLS   encoder;
+
+            internal readonly EncoderFallbackBuffer fallbackBuffer;
+
             unsafe byte* bytes;
-            unsafe byte* byteStart;
-            unsafe byte* byteEnd;
             unsafe char* chars;
-            unsafe char* charStart;
-            unsafe char* charEnd;
             int          byteCountResult = 0;
-            Encoding     enc;
-            EncoderNLS   encoder;
-            internal EncoderFallbackBuffer fallbackBuffer;
 
             internal unsafe EncodingByteBuffer(Encoding inEncoding, EncoderNLS inEncoder,
                         byte* inByteStart, int inByteCount, char* inCharStart, int inCharCount)
@@ -1898,39 +1745,19 @@ namespace System.Text
                 return true;
             }
 
-            internal unsafe bool AddByte(byte b1)
+            internal bool AddByte(byte b1)
             {
                 return (AddByte(b1, 0));
             }
 
-            internal unsafe bool AddByte(byte b1, byte b2)
+            internal bool AddByte(byte b1, byte b2)
             {
                 return (AddByte(b1, b2, 0));
             }
 
-            internal unsafe bool AddByte(byte b1, byte b2, int moreBytesExpected)
+            internal bool AddByte(byte b1, byte b2, int moreBytesExpected)
             {
                 return (AddByte(b1, 1 + moreBytesExpected) && AddByte(b2, moreBytesExpected));
-            }
-
-            internal unsafe bool AddByte(byte b1, byte b2, byte b3)
-            {
-                return AddByte(b1, b2, b3, (int)0);
-            }
-
-            internal unsafe bool AddByte(byte b1, byte b2, byte b3, int moreBytesExpected)
-            {
-                return (AddByte(b1, 2 + moreBytesExpected) &&
-                        AddByte(b2, 1 + moreBytesExpected) &&
-                        AddByte(b3, moreBytesExpected));
-            }
-
-            internal unsafe bool AddByte(byte b1, byte b2, byte b3, byte b4)
-            {
-                return (AddByte(b1, 3) &&
-                        AddByte(b2, 2) &&
-                        AddByte(b3, 1) &&
-                        AddByte(b4, 0));
             }
 
             internal unsafe void MovePrevious(bool bThrow)
@@ -1950,20 +1777,7 @@ namespace System.Text
                     enc.ThrowBytesOverflow(encoder, bytes == byteStart);    // Throw? (and reset fallback if not converting)
             }
 
-            internal unsafe bool Fallback(char charFallback)
-            {
-                // Do the fallback
-                return fallbackBuffer.InternalFallback(charFallback, ref chars);
-            }
-
-            internal unsafe bool MoreData
-            {
-                get
-                {
-                    // See if fallbackBuffer is not empty or if there's data left in chars buffer.
-                    return ((fallbackBuffer.Remaining > 0) || (chars < charEnd));
-                }
-            }
+            internal unsafe bool MoreData => ((fallbackBuffer.Remaining > 0) || (chars < charEnd));
 
             internal unsafe char GetNextChar()
             {
@@ -1980,21 +1794,9 @@ namespace System.Text
                 return cReturn;
              }
 
-            internal unsafe int CharsUsed
-            {
-                get
-                {
-                    return (int)(chars - charStart);
-                }
-            }
+            internal unsafe int CharsUsed => (int)(chars - charStart);
 
-            internal unsafe int Count
-            {
-                get
-                {
-                    return byteCountResult;
-                }
-            }
+            internal int Count => byteCountResult;
         }
     }
 }

--- a/src/mscorlib/src/System/Text/EncodingInfo.cs
+++ b/src/mscorlib/src/System/Text/EncodingInfo.cs
@@ -5,15 +5,13 @@
 namespace System.Text
 {
     using System;
-    using System.Text;
-
 
     [Serializable]
     public sealed class EncodingInfo
     {
-        int     iCodePage;          // Code Page #
-        String  strEncodingName;    // Short name (web name)
-        String  strDisplayName;     // Full localized name
+        readonly int    iCodePage;          // Code Page #
+        readonly String strEncodingName;    // Short name (web name)
+        readonly String strDisplayName;     // Full localized name
 
         internal EncodingInfo(int codePage, string name, string displayName)
         {
@@ -22,32 +20,11 @@ namespace System.Text
             this.strDisplayName = displayName;
         }
 
+        public int CodePage => iCodePage;
 
-        public int CodePage
-        {
-            get
-            {
-                return iCodePage;
-            }
-        }
+        public String Name => strEncodingName;
 
-
-        public String Name
-        {
-            get
-            {
-                return strEncodingName;
-            }
-        }
-
-
-        public String DisplayName
-        {
-            get
-            {
-                return strDisplayName;
-            }
-        }
+        public String DisplayName => strDisplayName;
 
 
         public Encoding GetEncoding()

--- a/src/mscorlib/src/System/Text/EncodingNLS.cs
+++ b/src/mscorlib/src/System/Text/EncodingNLS.cs
@@ -4,18 +4,12 @@
 
 namespace System.Text
 {
-    
     using System;
-    using System.Diagnostics.Contracts;
-    using System.Collections;
-    using System.Runtime.Remoting;
-    using System.Globalization;
-    using System.Threading;
-    using Win32Native = Microsoft.Win32.Win32Native;
-    
+    using System.Runtime.InteropServices;
+
     // This class overrides Encoding with the things we need for our NLS Encodings
-    
-    [System.Runtime.InteropServices.ComVisible(true)]
+
+    [ComVisible(true)]
     [Serializable]
     internal abstract class EncodingNLS : Encoding
     {    

--- a/src/mscorlib/src/System/Text/EncodingProvider.cs
+++ b/src/mscorlib/src/System/Text/EncodingProvider.cs
@@ -5,10 +5,9 @@
 namespace System.Text
 {
     using System;
-    using System.Collections;
-    using System.Collections.Generic;
+    using System.Runtime.InteropServices;
 
-    [System.Runtime.InteropServices.ComVisible(true)]
+    [ComVisible(true)]
     public abstract class EncodingProvider
     {
         public EncodingProvider() { }
@@ -131,7 +130,7 @@ namespace System.Text
             return null;
         }
 
-        private static Object s_InternalSyncObject = new Object();
+        private static readonly Object s_InternalSyncObject = new Object();
         private static volatile EncodingProvider[] s_providers;
     }
 }

--- a/src/mscorlib/src/System/Text/Latin1Encoding.cs
+++ b/src/mscorlib/src/System/Text/Latin1Encoding.cs
@@ -5,17 +5,8 @@
 namespace System.Text
 {
     using System;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
-    using System.Globalization;
-    using System.Runtime.InteropServices;
-    using System.Security;
-    using System.Collections;
-    using System.Runtime.CompilerServices;
     using System.Runtime.Serialization;
-    using System.Security.Permissions;
-
-
     //
     // Latin1Encoding is a simple override to optimize the GetString version of Latin1Encoding.
     // because of the best fit cases we can't do this when encoding the string, only when decoding

--- a/src/mscorlib/src/System/Text/Normalization.Windows.cs
+++ b/src/mscorlib/src/System/Text/Normalization.Windows.cs
@@ -7,11 +7,8 @@ namespace System.Text
     using System;
     using System.Security;
     using System.Globalization;
-    using System.Text;
     using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
-    using System.Runtime.Versioning;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
 
     // This internal class wraps up our normalization behavior
@@ -259,14 +256,14 @@ namespace System.Text
             return new String(cBuffer, 0, iLength);
         }
 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        unsafe private static extern int nativeNormalizationNormalizeString(
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern int nativeNormalizationNormalizeString(
             NormalizationForm normForm, ref int iError,
             String lpSrcString, int cwSrcLength,
             char[] lpDstString, int cwDstLength);
 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        unsafe private static extern bool nativeNormalizationIsNormalizedString(
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern bool nativeNormalizationIsNormalizedString(
             NormalizationForm normForm, ref int iError,
             String lpString, int cwLength);
 

--- a/src/mscorlib/src/System/Text/Normalization.cs
+++ b/src/mscorlib/src/System/Text/Normalization.cs
@@ -5,7 +5,7 @@
 namespace System.Text
 {
     // This is the enumeration for Normalization Forms
-[System.Runtime.InteropServices.ComVisible(true)]
+    [System.Runtime.InteropServices.ComVisible(true)]
     public enum NormalizationForm
     {
         FormC    = 1,

--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -10,19 +10,15 @@
 ** class.
 **
 ===========================================================*/
-namespace System.Text {
-    using System.Text;
-    using System.Runtime;
-    using System.Runtime.Serialization;
+namespace System.Text
+{
     using System;
-    using System.Runtime.CompilerServices;
-    using System.Runtime.Versioning;
-    using System.Security;
-    using System.Threading;
-    using System.Globalization;
-    using System.Diagnostics;
-    using System.Diagnostics.Contracts;
     using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.Globalization;
+    using System.Runtime.CompilerServices;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Serialization;
 
     // This class represents a mutable string.  It is convenient for situations in
     // which it is desirable to modify a string, perhaps by removing, replacing, or 
@@ -41,7 +37,7 @@ namespace System.Text {
     // Console.WriteLine(sb1);
     // Console.WriteLine(sb2);
     // 
-    [System.Runtime.InteropServices.ComVisible(true)]
+    [ComVisible(true)]
     [Serializable]
     public sealed class StringBuilder : ISerializable
     {
@@ -715,20 +711,20 @@ namespace System.Text {
             }
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public StringBuilder AppendLine() {
             Contract.Ensures(Contract.Result<StringBuilder>() != null);
             return Append(Environment.NewLine);
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public StringBuilder AppendLine(string value) {
             Contract.Ensures(Contract.Result<StringBuilder>() != null);
             Append(value);
             return Append(Environment.NewLine);
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count) {
             if (destination == null) {
                 throw new ArgumentNullException(nameof(destination));

--- a/src/mscorlib/src/System/Text/StringBuilderCache.cs
+++ b/src/mscorlib/src/System/Text/StringBuilderCache.cs
@@ -31,7 +31,6 @@
 **            cache and return the resulting string
 **
 ===========================================================*/
-using System.Threading;
 
 namespace System.Text
 {

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -8,11 +8,8 @@
 
 namespace System.Text
 {
-
     using System;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
-    using System.Globalization;
     // Encodes text into and out of UTF-32.  UTF-32 is a way of writing
     // Unicode characters with a single storage unit (32 bits) per character,
     //

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -9,14 +9,12 @@
 namespace System.Text
 {
     using System;
-    using System.Runtime.Serialization;
-    using System.Security.Permissions;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
-
+    using System.Runtime.InteropServices;
+    using System.Runtime.Serialization;
 
     [Serializable]
-    [System.Runtime.InteropServices.ComVisible(true)]
+    [ComVisible(true)]
     public class UTF7Encoding : Encoding
     {
         private const String base64Chars =
@@ -127,7 +125,7 @@ namespace System.Text
 
 
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override bool Equals(Object value)
         {
             UTF7Encoding that = value as UTF7Encoding;
@@ -142,7 +140,7 @@ namespace System.Text
 
         // Compared to all the other encodings, variations of UTF7 are unlikely
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override int GetHashCode()
         {
             return this.CodePage + this.EncoderFallback.GetHashCode() + this.DecoderFallback.GetHashCode();
@@ -170,20 +168,20 @@ namespace System.Text
             return EncodingForwarder.GetByteCount(this, chars, index, count);
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override int GetByteCount(String s)
         {
             return EncodingForwarder.GetByteCount(this, s);
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, count);
         }
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override int GetBytes(String s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
@@ -206,7 +204,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             return EncodingForwarder.GetBytes(this, chars, charCount, bytes, byteCount);
@@ -221,7 +219,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, count);
@@ -234,7 +232,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             return EncodingForwarder.GetChars(this, bytes, byteCount, chars, charCount);
@@ -243,7 +241,7 @@ namespace System.Text
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override String GetString(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetString(this, bytes, index, count);

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -18,11 +18,10 @@
 namespace System.Text
 {
     using System;
-    using System.Globalization;
-    using System.Runtime.Serialization;
-    using System.Security.Permissions;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
+    using System.Globalization;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Serialization;
 
     // Encodes text into and out of UTF-8.  UTF-8 is a way of writing
     // Unicode characters with variable numbers of bytes per character,
@@ -37,7 +36,7 @@ namespace System.Text
     // switch the byte orderings.
 
     [Serializable]
-[System.Runtime.InteropServices.ComVisible(true)]
+    [ComVisible(true)]
     public class UTF8Encoding : Encoding
     {
         /*
@@ -54,10 +53,15 @@ namespace System.Text
         */
 
         private const int UTF8_CODEPAGE=65001;
-        
+
+        // Allow for devirtualization (see https://github.com/dotnet/coreclr/issues/1166#issuecomment-276251559)
+        internal sealed class UTF8EncodingSealed : UTF8Encoding
+        {
+            public UTF8EncodingSealed() : base(encoderShouldEmitUTF8Identifier: true) {}
+        }
         // Used by Encoding.UTF8 for lazy initialization
         // The initialization code will not be run until a static member of the class is referenced
-        internal static readonly UTF8Encoding s_default = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        internal static readonly UTF8EncodingSealed s_default = new UTF8EncodingSealed();
 
         // Yes, the idea of emitting U+FEFF as a UTF-8 identifier has made it into
         // the standard.
@@ -131,7 +135,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, count);
@@ -159,7 +163,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             return EncodingForwarder.GetBytes(this, chars, charCount, bytes, byteCount);
@@ -174,7 +178,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, count);
@@ -187,7 +191,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             return EncodingForwarder.GetChars(this, bytes, byteCount, chars, charCount);
@@ -196,7 +200,7 @@ namespace System.Text
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override String GetString(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetString(this, bytes, index, count);

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -9,15 +9,12 @@
 namespace System.Text
 {
     using System;
-    using System.Globalization;
     using System.Runtime.Serialization;
-    using System.Security.Permissions;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
-
+    using System.Runtime.InteropServices;
 
     [Serializable]
-    [System.Runtime.InteropServices.ComVisible(true)]
+    [ComVisible(true)]
     public class UnicodeEncoding : Encoding
     {
         // Used by Encoding.BigEndianUnicode/Unicode for lazy initialization
@@ -111,7 +108,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
             return EncodingForwarder.GetByteCount(this, chars, count);
@@ -139,7 +136,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             return EncodingForwarder.GetBytes(this, chars, charCount, bytes, byteCount);
@@ -154,7 +151,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             return EncodingForwarder.GetCharCount(this, bytes, count);
@@ -167,7 +164,7 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             return EncodingForwarder.GetChars(this, bytes, byteCount, chars, charCount);
@@ -176,7 +173,7 @@ namespace System.Text
         // Returns a string containing the decoded representation of a range of
         // bytes in a byte array.
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override String GetString(byte[] bytes, int index, int count)
         {
             return EncodingForwarder.GetString(this, bytes, index, count);
@@ -1659,7 +1656,7 @@ namespace System.Text
         }
 
 
-        [System.Runtime.InteropServices.ComVisible(false)]
+        [ComVisible(false)]
         public override System.Text.Encoder GetEncoder()
         {
             return new EncoderNLS(this);

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -77,6 +77,11 @@ namespace System {
                                                     ExceptionResource.ArgumentOutOfRange_Index);
         }
 
+        internal static void ThrowCountArgumentOutOfRange_NeedNonNegNumException() {
+            throw GetArgumentOutOfRangeException(ExceptionArgument.count,
+                                                    ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+        }
+
         internal static void ThrowIndexArgumentOutOfRange_NeedNonNegNumException() {
             throw GetArgumentOutOfRangeException(ExceptionArgument.index, 
                                                     ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
@@ -205,6 +210,18 @@ namespace System {
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumFailedVersion);
         }
 
+        internal static ArgumentNullException GetArgumentNullException(ExceptionArgument argument) {
+            return new ArgumentNullException(GetArgumentName(argument));
+        }
+
+        internal static ArgumentNullException GetArgumentNullException(ExceptionArgument argument, ExceptionResource resource) {
+            throw new ArgumentNullException(GetArgumentName(argument), GetResourceString(resource));
+        }
+
+        internal static void ThrowArgumentNullException(ExceptionArgument argument, ExceptionResource resource) {
+            throw GetArgumentNullException(argument, resource);
+        }
+
         internal static void ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen() {
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);
         }
@@ -225,7 +242,7 @@ namespace System {
             return new ArgumentException(Environment.GetResourceString("Arg_WrongType", value, targetType), nameof(value));
         }
 
-        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
+        internal static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
             return new ArgumentOutOfRangeException(GetArgumentName(argument), GetResourceString(resource));
         }
 
@@ -361,6 +378,13 @@ namespace System {
         updateValueFactory,
         concurrencyLevel,
         text,
+        s,
+        chars,
+        bytes,
+        byteIndex,
+        charIndex,
+        byteCount,
+        charCount,
 
     }
 
@@ -466,7 +490,13 @@ namespace System {
         ConcurrentDictionary_ArrayNotLargeEnough,
         ConcurrentDictionary_ArrayIncorrectType,
         ConcurrentCollection_SyncRoot_NotSupported,
-
+        ArgumentNull_Array,
+        ArgumentOutOfRange_IndexCountBuffer,
+        ArgumentNull_String,
+        ArgumentOutOfRange_GetByteCountOverflow,
+        ArgumentOutOfRange_GetCharCountOverflow,
+        Argument_ConversionOverflow,
+        Argument_FallbackBufferNotEmpty,
     }
 }
 


### PR DESCRIPTION
Need to change how the workhorse+fallback functions are done

Current jitdiff with the fastpath; should drop more when doing fallback correctly as suggested by @jkotas in https://github.com/dotnet/coreclr/pull/9187#discussion_r98521142
```
Summary:
(Note: Lower is better)

Total bytes of diff: -1771 (-0.05 % of base)
    diff is an improvement.

Total byte diff includes 5517 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had   42 unique methods,     5517 unique bytes

Top file improvements by size (bytes):
       -1771 : System.Private.CoreLib.dasm (-0.05 % of base)

1 total files with size differences.

Top method regessions by size (bytes):
        1327 : System.Private.CoreLib.dasm - ASCIIEncoding:GetBytesFallback(long,int,long,int,ref):int:this
         704 : System.Private.CoreLib.dasm - ASCIIEncoding:GetBytes(ref,int,int,ref,int):int:this (2 methods)
         366 : System.Private.CoreLib.dasm - ASCIIEncoding:TryEncode(long,int,long,int,byref,byref):bool
         310 : System.Private.CoreLib.dasm - EncodingForwarder:GetValidationFailedException(ref,int,int,ref):ref
         297 : System.Private.CoreLib.dasm - EncodingForwarder:GetValidationFailedException(ref,int,int):ref
         271 : System.Private.CoreLib.dasm - EncodingForwarder:GetValidationFailedException(ref):ref
         244 : System.Private.CoreLib.dasm - EncodingForwarder:GetValidationFailedException(ref,ref,int,int,ref):ref
         236 : System.Private.CoreLib.dasm - ASCIIEncoding:GetBytesValidated(long,int):ref:this
         234 : System.Private.CoreLib.dasm - ASCIIEncoding:GetBytes(long,int,long,int):int:this
         209 : System.Private.CoreLib.dasm - EncodingForwarder:GetValidationFailedException(ref,int,int,ref,int,int):ref

Top method improvements by size (bytes):
        -985 : System.Private.CoreLib.dasm - ASCIIEncoding:GetBytes(long,int,long,int,ref):int:this
        -634 : System.Private.CoreLib.dasm - EncodingForwarder:GetBytes(ref,ref,int,int,ref,int):int (2 methods)
        -352 : System.Private.CoreLib.dasm - Decoder:Convert(ref,int,int,ref,int,int,bool,byref,byref,byref):this
        -352 : System.Private.CoreLib.dasm - Encoder:Convert(ref,int,int,ref,int,int,bool,byref,byref,byref):this
        -350 : System.Private.CoreLib.dasm - DecoderNLS:Convert(ref,int,int,ref,int,int,bool,byref,byref,byref):this
        -293 : System.Private.CoreLib.dasm - EncodingForwarder:GetChars(ref,ref,int,int,ref,int):int
        -283 : System.Private.CoreLib.dasm - DecoderNLS:GetChars(ref,int,int,ref,int,bool):int:this
        -266 : System.Private.CoreLib.dasm - EncodingForwarder:GetString(ref,ref,int,int):ref
        -260 : System.Private.CoreLib.dasm - Encoding:GetBytes(ref,int,int):ref:this (2 methods)
        -259 : System.Private.CoreLib.dasm - Encoding:GetByteCount(ref,int,int):int:this

132 total methods with size differences.
```