### PR TITLE
Use full set of runtimes for all test project.json files

### DIFF
--- a/tests/src/Common/empty/project.json
+++ b/tests/src/Common/empty/project.json
@@ -8,9 +8,13 @@
     "win7-x86": {},
     "win7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "osx.10.10-x64": {},
     "centos.7-x64": {},
     "rhel.7-x64": {},
-    "debian.8-x64": {}
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
   }
 }

--- a/tests/src/Common/targeting_pack_ref/project.json
+++ b/tests/src/Common/targeting_pack_ref/project.json
@@ -14,9 +14,13 @@
     "win7-x86": {},
     "win7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "osx.10.10-x64": {},
     "centos.7-x64": {},
     "rhel.7-x64": {},
-    "debian.8-x64": {}
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
   }
 }

--- a/tests/src/Common/test_dependencies/project.json
+++ b/tests/src/Common/test_dependencies/project.json
@@ -82,9 +82,13 @@
     "win7-x86": {},
     "win7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "osx.10.10-x64": {},
     "centos.7-x64": {},
     "rhel.7-x64": {},
-    "debian.8-x64": {}
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
   }
 }

--- a/tests/src/Common/test_runtime/project.json
+++ b/tests/src/Common/test_runtime/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.NETCore.Platforms": "2.0.0-beta-25001-02",
     "Microsoft.DotNet.CoreCLR.TestDependencies": "1.0.0-prerelease",
     "jit-dasm": "0.0.1.4",
     "cijobs": "0.0.1.2",
@@ -17,9 +18,13 @@
     "win7-x86": {},
     "win7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "osx.10.10-x64": {},
     "centos.7-x64": {},
     "rhel.7-x64": {},
-    "debian.8-x64": {}
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
   }
 }

--- a/tests/src/JIT/config/extra/project.json
+++ b/tests/src/JIT/config/extra/project.json
@@ -24,9 +24,13 @@
     "win7-x86": {},
     "win7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "osx.10.10-x64": {},
     "centos.7-x64": {},
     "rhel.7-x64": {},
-    "debian.8-x64": {}
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
   }
 }

--- a/tests/src/JIT/config/minimal/project.json
+++ b/tests/src/JIT/config/minimal/project.json
@@ -13,9 +13,13 @@
     "win7-x86": {},
     "win7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "osx.10.10-x64": {},
     "centos.7-x64": {},
     "rhel.7-x64": {},
-    "debian.8-x64": {}
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
   }
 }

--- a/tests/src/JIT/config/threading+thread/project.json
+++ b/tests/src/JIT/config/threading+thread/project.json
@@ -15,9 +15,13 @@
     "win7-x86": {},
     "win7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "osx.10.10-x64": {},
     "centos.7-x64": {},
     "rhel.7-x64": {},
-    "debian.8-x64": {}
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
   }
 }

--- a/tests/src/JIT/config/threading/project.json
+++ b/tests/src/JIT/config/threading/project.json
@@ -13,9 +13,13 @@
     "win7-x86": {},
     "win7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "osx.10.10-x64": {},
     "centos.7-x64": {},
     "rhel.7-x64": {},
-    "debian.8-x64": {}
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
   }
 }

--- a/tests/src/TestWrappersConfig/project.json
+++ b/tests/src/TestWrappersConfig/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.NETCore.Platforms": "2.0.0-beta-25001-02",
     "xunit": "2.2.0-beta2-build3300",
     "xunit.assert": "2.2.0-beta2-build3300",
     "xunit.core": "2.2.0-beta2-build3300",
@@ -20,9 +21,13 @@
     "win7-x86": {},
     "win7-x64": {},
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "osx.10.10-x64": {},
     "centos.7-x64": {},
     "rhel.7-x64": {},
-    "debian.8-x64": {}
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
   }
 }


### PR DESCRIPTION
Tests in Helix were failing for Ubuntu16.04, Ubuntu16.10, and Fedora23, because we weren't pulling down packages for those platforms - meaning that the Core_Root that was built from packages didn't have a large set of the test dependencies for those platforms. This should fix that error