### PR TITLE
Some more perf tweaks to ThreadPool

### DIFF
--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -11,19 +11,18 @@
 **
 =============================================================================*/
 
-using System.Security;
-using System.Security.Permissions;
-using System;
-using Microsoft.Win32;
-using System.Runtime.CompilerServices;
-using System.Runtime.ConstrainedExecution;
-using System.Runtime.InteropServices;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
 using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.Permissions;
+using Microsoft.Win32;
 
 namespace System.Threading
 {

--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -1435,9 +1435,14 @@ namespace System.Threading
         {
             if (!ThreadPoolGlobals.vmTpInitialized)
             {
-                ThreadPool.InitializeVMTp(ref ThreadPoolGlobals.enableWorkerTracking);
-                ThreadPoolGlobals.vmTpInitialized = true;
+                EnsureVMInitializedCore(); // separate out to help with inlining
             }
+        }
+        
+        private static void EnsureVMInitializedCore()
+        {
+            ThreadPool.InitializeVMTp(ref ThreadPoolGlobals.enableWorkerTracking);
+            ThreadPoolGlobals.vmTpInitialized = true;
         }
 
         // Native methods: 

--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -631,6 +631,24 @@ namespace System.Threading
         }
     }
 
+    // Simple random number generator. We don't need great randomness, we just need a little and for it to be fast.
+    internal sealed class FastRandom // xorshift prng
+    {
+        private uint _x, _w = 88675123, _y = 362436069, _z = 521288629;
+
+        public FastRandom(int seed) { _x = (uint)seed; }
+
+        public int Next(int maxValue)
+        {
+            uint t = _x ^ (_x << 11);
+            _x = _y; _y = _z; _z = _w;
+            _w = _w ^ (_w >> 19) ^ (t ^ (t >> 8));
+
+            int r = (int)_w & int.MaxValue;
+            return (int)(r * (1.0 / ((double)int.MaxValue + 1)) * maxValue);
+        }
+    }
+
     // Holds a WorkStealingQueue, and remmoves it from the list when this object is no longer referened.
     internal sealed class ThreadPoolWorkQueueThreadLocals
     {
@@ -639,7 +657,7 @@ namespace System.Threading
 
         public readonly ThreadPoolWorkQueue workQueue;
         public readonly ThreadPoolWorkQueue.WorkStealingQueue workStealingQueue;
-        public readonly Random random = new Random(Thread.CurrentThread.ManagedThreadId);
+        public readonly FastRandom random = new FastRandom(Thread.CurrentThread.ManagedThreadId);
 
         public ThreadPoolWorkQueueThreadLocals(ThreadPoolWorkQueue tpq)
         {

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -361,7 +361,7 @@ namespace System {
         updateValueFactory,
         concurrencyLevel,
         text,
-
+        callBack,
     }
 
     //


### PR DESCRIPTION
Main changes:
- The work-stealing system was storing all of the local lists in a sparse array.  Any time a thread went looking for work, it would pick a random place to start in the array and iterate through all of the cells.  But the array often was much larger than the number of lists it contained, because it a) grows doubling each time, and b) never shrinks when threads are removed, so all of the iterating needed to check for null on every cell.  And all of the reads were done with Volatile.Read, to account for potentially concurrent writes as threads were added/removed.  However, the addition/removal of thread-local lists is actually relatively rare (even when the thread pool takes threads in and out of service, it's not generally not allocating new threads or destroying old ones, just keeping them in reserve on the side for a while).  Instead, we can just use an immutable array that's always the right size.
- All of the old StackCrawlMark was still cluttering up {Unsafe}QueueUserWorkItem and preventing those functions and helpers from getting inlined.  I've removed that goo.
- Random.Next is used to determine where a thread should start looking for work to steal, and it was showing up in a trace as a few percentage points.  I've replaced it with a faster routine.
- Cleaned up some empty try blocks and the associated code around it, and helped a few other functions that were showing up in traces be more inlineable.

cc: @jkotas, @kouvel, @benaadams 