### PR TITLE
Disable GC LargeMemory tests that were failing in Helix

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -494,6 +494,18 @@
         <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\Allocation\finalizertest\finalizertest.cmd">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\Allocation\largeexceptiontest\largeexceptiontest.cmd">
+            <Issue>3392</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\gettotalmemory\gettotalmemory.cmd">
+            <Issue>3392</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\keepalive\keepalive.cmd">
+            <Issue>3392</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\suppressfinalize\suppressfinalize.cmd">
+            <Issue>3392</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\dev10bugs\536168\536168\536168.cmd">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
These tests were failing on Ubuntu with OutOfMemoryExceptions in Helix - I spoke with @swgillespie about these tests, and it sounds like LargeMemory tests often behave badly outside of Windows, and there are a few other LargeMemory tests already disabled there - additionally, these same tests were already disabled on Windows x86. So I think it's best to disable them on non-Windows in Helix as well, but keep them running on Windows x64.

CC @gkhanna79 @MattGal 