### PR TITLE
Change input file finding mechanism for BenchmarksGame tests

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/regexdna/regexdna.csharp-6.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/regexdna/regexdna.csharp-6.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 
@@ -39,40 +40,20 @@ public static class Regexdna
 
    static string FindInput(string s)
    {
-       string CoreRoot = System.Environment.GetEnvironmentVariable("CORE_ROOT");
-
-       if (CoreRoot == null)
-       {
-           Console.WriteLine("This benchmark requries CORE_ROOT to be set");
-           return null;
-       }
 
        string inputFile = s ?? InputFile;
 
-       // Normal testing -- input file will end up next to the assembly
-       // and CoreRoot points at the test overlay dir
-       string[] pathPartsNormal = new string[] {
-           CoreRoot, "..", "..", "JIT", "Performance",
-           "CodeQuality", "BenchmarksGame", "regexdna", "regexdna", inputFile
-       };
-
-       string inputPathNormal = Path.Combine(pathPartsNormal);
-
-       // Perf testing -- input file will end up next to the assembly
-       // and CoreRoot points at this directory
-       string[] pathPartsPerf = new string[] { CoreRoot, inputFile };
-
-       string inputPathPerf = Path.Combine(pathPartsPerf);
+       // Input file will end up next to the assembly
+       string currentDirectory = AssemblyDir;
+       string[] inputPathParts = new string[] {currentDirectory, inputFile};
 
        string inputPath = null;
 
-       if (File.Exists(inputPathNormal))
+       Console.WriteLine(Path.Combine(inputPathParts));
+
+       if (File.Exists(Path.Combine(inputPathParts)))
        {
-           inputPath = inputPathNormal;
-       }
-       else if (File.Exists(inputPathPerf))
-       {
-           inputPath = inputPathPerf;
+           inputPath = Path.Combine(inputPathParts);
        }
 
        if (inputPath != null)
@@ -225,6 +206,8 @@ public static class Regexdna
            }
        }
    }
+
+   public static string AssemblyDir => typeof(Regexdna).GetTypeInfo().Assembly.Location;
 }
 
 }

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/revcomp/revcomp.csharp-1.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/revcomp/revcomp.csharp-1.cs
@@ -53,40 +53,18 @@ public static class Revcomp
 
    static string FindInput(string s)
    {
-       string CoreRoot = System.Environment.GetEnvironmentVariable("CORE_ROOT");
-
-       if (CoreRoot == null)
-       {
-           Console.WriteLine("This benchmark requries CORE_ROOT to be set");
-           return null;
-       }
 
        string inputFile = s ?? InputFile;
 
-       // Normal testing -- input file will end up next to the assembly
-       // and CoreRoot points at the test overlay dir
-       string[] pathPartsNormal = new string[] {
-           CoreRoot, "..", "..", "JIT", "Performance",
-           "CodeQuality", "BenchmarksGame", "revcomp", "revcomp", inputFile
-       };
-
-       string inputPathNormal = Path.Combine(pathPartsNormal);
-
-       // Perf testing -- input file will end up next to the assembly
-       // and CoreRoot points at this directory
-       string[] pathPartsPerf = new string[] { CoreRoot, inputFile };
-
-       string inputPathPerf = Path.Combine(pathPartsPerf);
+       // Input file will end up next to the assembly
+       string currentDirectory = AppContext.BaseDirectory;
+       string[] inputPathParts = new string[] {currentDirectory, inputFile};
 
        string inputPath = null;
 
-       if (File.Exists(inputPathNormal))
+       if (File.Exists(Path.Combine(inputPathParts)))
        {
-           inputPath = inputPathNormal;
-       }
-       else if (File.Exists(inputPathPerf))
-       {
-           inputPath = inputPathPerf;
+           inputPath = Path.Combine(inputPathParts);
        }
 
        if (inputPath != null)

--- a/tests/src/JIT/config/benchmark/project.json
+++ b/tests/src/JIT/config/benchmark/project.json
@@ -31,7 +31,7 @@
     "xunit.runner.utility": "2.2.0-beta2-build3300"
   },
   "frameworks": {
-    "netstandard1.4": {
+    "netstandard1.5": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"


### PR DESCRIPTION
These tests were looking for their input file relative to CORE_ROOT - in Helix, the directory structure assumed by these tests is not maintained. Instead, CORE_ROOT points to "some directory somewhere" which contains the runtime dependencies, while the tests live somewhere else entirely. This PR changes the mechanism for finding input files in 2 JIT tests, such that we always looks for them in the same directory as the executing assembly, instead of looking for them relative to the location of Core_Root.