### PR TITLE
Clean up GetAddrOfSecurityObjectFromCachedInfo

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -496,6 +496,7 @@ bool EnumGcRefsConservative(PREGDISPLAY     pRD,
                             LPVOID          hCallBack);
 #endif // FEATURE_CONSERVATIVE_GC
 
+#ifdef _TARGET_X86_
 /*
    Return the address of the local security object reference
    using data that was previously cached before in UnwindStackFrame
@@ -504,6 +505,7 @@ bool EnumGcRefsConservative(PREGDISPLAY     pRD,
 static OBJECTREF* GetAddrOfSecurityObjectFromCachedInfo(
         PREGDISPLAY pRD,
         StackwalkCacheUnwindInfo * stackwalkCacheUnwindInfo);
+#endif // _TARGET_X86_
 
 virtual
 OBJECTREF* GetAddrOfSecurityObject(CrawlFrame *pCF) DAC_UNEXPECTED();

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5026,6 +5026,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
 
 #endif // _TARGET_X86_
 
+#ifdef _TARGET_X86_
 /*****************************************************************************
  *
  *  Return the address of the local security object reference
@@ -5036,18 +5037,15 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
 OBJECTREF* EECodeManager::GetAddrOfSecurityObjectFromCachedInfo(PREGDISPLAY pRD, StackwalkCacheUnwindInfo * stackwalkCacheUnwindInfo)
 {
     LIMITED_METHOD_CONTRACT;
-#ifdef _TARGET_X86_
     size_t securityObjectOffset = stackwalkCacheUnwindInfo->securityObjectOffset;
+
     _ASSERTE(securityObjectOffset != 0);
     // We pretend that filters are ESP-based methods in UnwindEbpDoubleAlignFrame().
     // Hence we cannot enforce this assert.
     // _ASSERTE(stackwalkCacheUnwindInfo->fUseEbpAsFrameReg);
     return (OBJECTREF *) (size_t) (*pRD->GetEbpLocation() - (securityObjectOffset * sizeof(void*)));
-#else
-    PORTABILITY_ASSERT("EECodeManager::GetAddrOfSecurityObjectFromContext is not implemented on this platform.");
-    return NULL;
-#endif
 }
+#endif // _TARGET_X86_
 
 #ifndef DACCESS_COMPILE
 OBJECTREF* EECodeManager::GetAddrOfSecurityObject(CrawlFrame *pCF)


### PR DESCRIPTION
GetAddrOfSecurityObjectFromCachedInfo seems to be X86-specific, but has
ifdef for other architectures.

This commit declares GetAddrOfSecurityObjectFromCachedInfo only for X86
to simplify its implementation.