### PR TITLE
Rejit support for R2R - WIP

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1304,6 +1304,12 @@ class ICorCompilePreloader
             CORINFO_METHOD_HANDLE method, 
             CORINFO_METHOD_HANDLE duplicateMethod) = 0;
 
+    // Returns a compressed encoding of the inline tracking map 
+    // for this compilation
+    virtual void GetSerializedInlineTrackingMap(
+            IN OUT SBuffer    * pSerializedInlineTrackingMap
+            ) = 0;
+
     //
     // Release frees the preloader
     //

--- a/src/inc/corprof.idl
+++ b/src/inc/corprof.idl
@@ -3740,15 +3740,20 @@ interface ICorProfilerInfo6 : ICorProfilerInfo5
 {
     /*
     * Returns an enumerator for all methods that 
-    * - belong to a given NGen module (inlinersModuleId) and 
+    * - belong to a given NGen or R2R module (inlinersModuleId) and 
     * - inlined a body of a given method (inlineeModuleId / inlineeMethodId). 
     *
     * If incompleteData is set to TRUE after function is called, it means that the methods enumerator 
     * doesn't contain all methods inlining a given method. 
     * It can happen when one or more direct or indirect dependencies of inliners module haven't been loaded yet.
-    * If profiler needs accurate data it should retry later when more modules are loaded (preferable on each module load).
+    * If profiler needs accurate data it should retry later when more modules are loaded (preferably on each module load).
     *
     * It can be used to lift limitation on inlining for ReJIT.
+    *
+    * NOTE: If the inlinee method is decorated with the System.Runtime.Versioning.NonVersionable attribute then
+    * then some inliners may not ever be reported. If you need to get a full accounting you can avoid the issue
+    * by disabling the use of all native images.
+    * 
     */
     HRESULT EnumNgenModuleMethodsInliningThisMethod(
         [in] ModuleID    inlinersModuleId,

--- a/src/inc/readytorun.h
+++ b/src/inc/readytorun.h
@@ -16,7 +16,8 @@
 #define READYTORUN_SIGNATURE 0x00525452 // 'RTR'
 
 #define READYTORUN_MAJOR_VERSION 0x0002
-#define READYTORUN_MINOR_VERSION 0x0000
+#define READYTORUN_MINOR_VERSION 0x0001
+// R2R Version 2.1 adds the READYTORUN_SECTION_INLINING_INFO section
 
 struct READYTORUN_HEADER
 {
@@ -57,6 +58,13 @@ enum ReadyToRunSectionType
     // 107 used by an older format of READYTORUN_SECTION_AVAILABLE_TYPES
     READYTORUN_SECTION_AVAILABLE_TYPES              = 108,
     READYTORUN_SECTION_INSTANCE_METHOD_ENTRYPOINTS  = 109,
+    READYTORUN_SECTION_INLINING_INFO                = 110  // Added in V2.1
+
+	// If you add a new section consider whether it is a breaking or non-breaking change.
+	// Usually it is non-breaking, but if it is preferable to have older runtimes fail
+	// to load the image vs. ignoring the new section it could be marked breaking.
+	// Increment the READYTORUN_MINOR_VERSION (non-breaking) or READYTORUN_MAJOR_VERSION
+	// (breaking) as appropriate.
 };
 
 //

--- a/src/mscorlib/src/System/Runtime/Versioning/NonVersionableAttribute.cs
+++ b/src/mscorlib/src/System/Runtime/Versioning/NonVersionableAttribute.cs
@@ -13,6 +13,12 @@
 ** is never changed in ReadyToRun native images. Any changes to such members or types would be 
 ** breaking changes for ReadyToRun.
 **
+** Applying this type also has the side effect that the inlining tables in R2R images will not
+** report that inlining of NonVersionable attributed methods occured. These inlining tables are used
+** by profilers to figure out the set of methods that need to be rejited when one method is instrumented,
+** so in effect NonVersionable methods are also non-instrumentable. Generally this is OK for
+** extremely trivial low level methods where NonVersionable gets used, but if there is any plan to 
+** significantly extend its usage or allow 3rd parties to use it please discuss with the diagnostics team.
 ===========================================================*/
 using System;
 using System.Diagnostics;

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -81,7 +81,8 @@ class TypeHandleList;
 class ProfileEmitter;
 class ReJitManager;
 class TrackingMap;
-class PersistentInlineTrackingMap;
+struct MethodInModule;
+class PersistentInlineTrackingMapNGen;
 
 // Hash table parameter of available classes (name -> module/class) hash
 #define AVAILABLE_CLASSES_HASH_BUCKETS 1024
@@ -104,7 +105,7 @@ class PersistentInlineTrackingMap;
 #define NATIVE_SYMBOL_READER_DLL W("diasymreader.dll")
 #endif
 
-typedef DPTR(PersistentInlineTrackingMap) PTR_PersistentInlineTrackingMap;
+typedef DPTR(PersistentInlineTrackingMapNGen) PTR_PersistentInlineTrackingMapNGen;
 
 extern VerboseLevel g_CorCompileVerboseLevel;
 #endif  // FEATURE_PREJIT
@@ -2667,7 +2668,8 @@ public:
     void NotifyProfilerLoadFinished(HRESULT hr);
 #endif // PROFILING_SUPPORTED
 
-    PTR_PersistentInlineTrackingMap GetNgenInlineTrackingMap();
+    BOOL HasInlineTrackingMap();
+    COUNT_T GetInliners(PTR_Module inlineeOwnerMod, mdMethodDef inlineeTkn, COUNT_T inlinersSize, MethodInModule inliners[], BOOL *incompleteData);
 
 public:
     void NotifyEtwLoadFinished(HRESULT hr);
@@ -3436,7 +3438,7 @@ private:
     DebuggerSpecificData  m_debuggerSpecificData;
 
     // This is a compressed read only copy of m_inlineTrackingMap, which is being saved to NGEN image.
-    PTR_PersistentInlineTrackingMap m_persistentInlineTrackingMap;
+    PTR_PersistentInlineTrackingMapNGen m_pPersistentInlineTrackingMapNGen;
 
 
     LPCSTR               *m_AssemblyRefByNameTable;  // array that maps mdAssemblyRef tokens into their simple name

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -68,6 +68,7 @@
 #include "argdestination.h"
 
 #include "versionresilienthashcode.h"
+#include "inlinetracking.h"
 
 #ifdef CROSSGEN_COMPILE
 CompilationDomain * theDomain;
@@ -6839,6 +6840,12 @@ ULONG CEEPreloader::Release()
 
     delete this;
     return 0;
+}
+
+void CEEPreloader::GetSerializedInlineTrackingMap(SBuffer* pBuffer)
+{
+    InlineTrackingMap * pInlineTrackingMap = m_image->GetInlineTrackingMap();
+    PersistentInlineTrackingMapR2R::Save(m_image->GetHeap(), pBuffer, pInlineTrackingMap);
 }
 
 void CEEPreloader::Error(mdToken token, Exception * pException)

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -654,6 +654,8 @@ public:
 
     ULONG Release();
 
+    void GetSerializedInlineTrackingMap(SBuffer* pBuffer);
+
     void Error(mdToken token, Exception * pException);
 };
 

--- a/src/vm/dataimage.cpp
+++ b/src/vm/dataimage.cpp
@@ -126,8 +126,7 @@ DataImage::DataImage(Module *module, CEEPreloader *preloader)
     m_pZapImage->m_pDataImage = this;
 
     m_pInternedStructures = new InternedStructureHashTable();
-
-    m_inlineTrackingMap = NULL;
+    m_inlineTrackingMap = new InlineTrackingMap();
 }
 
 DataImage::~DataImage()

--- a/src/vm/inlinetracking.h
+++ b/src/vm/inlinetracking.h
@@ -2,12 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 // =============================================================================================
-// Definitions for tracking method inlinings in NGen images.
+// Definitions for tracking method inlinings in NGen and R2R images.
 // The only information stored is "who" got inlined "where", no offsets or inlining depth tracking. 
 // (No good for debugger yet.)
 // This information is later exposed to profilers and can be useful for ReJIT.
 // Runtime inlining is not being tracked because profilers can deduce it via callbacks anyway.
+//
+// This file is made of two major component groups:
+// a) InlineTrackingMap - This is a compilation time datastructure that holds an uncompressed
+//    version of the inline tracking information. It is appended to as methods are compiled.
+//    MethodInModule, InlineTrackingEntry, InlineTrackingMapTraits are all support infratsructure
+//    in this group.
+//
+// b) PersistentInlineTrackingMap[R2R/NGen] - These are the types that understand the image persistence 
+//    formats. At the end of image compilation one of them consumes all the data from an 
+//    InlineTrackingMap to encode it. At runtime an instance will be constructed to read back 
+//    the encoded data on demand. PersistantInlineTrackingMapR2R and PersistantInlineTrackingMapNGen
+//    would nominally use a common base type or interface, but due to ngen binary serialization vtables
+//    were avoided. See farther below for the different format descriptions.
 // =============================================================================================
+
 #ifndef INLINETRACKING_H_
 #define INLINETRACKING_H_
 #include "corhdr.h"
@@ -15,6 +29,10 @@
 #include "sarray.h"
 #include "crsttypes.h"
 #include "daccess.h"
+
+
+
+// ---------------------------------- Compile time support ----------------------------------------------
 
 class MethodDesc;
 typedef DPTR(class MethodDesc)          PTR_MethodDesc;
@@ -128,6 +146,17 @@ public:
 
 typedef DPTR(InlineTrackingMap) PTR_InlineTrackingMap;
 
+
+
+
+// ------------------------------------ Persistance support ----------------------------------------------------------
+
+
+
+
+
+// NGEN format
+//
 // This is a persistent map that is stored inside each NGen-ed module image and is used to track 
 // inlines in the NGEN-ed code inside this module. 
 // At runtime this map is used by profiler to track methods that inline a given method, 
@@ -135,25 +164,25 @@ typedef DPTR(InlineTrackingMap) PTR_InlineTrackingMap;
 // It doesn't require any load time unpacking and serves requests directly from NGEN image.
 //
 // It is composed of two arrays:
-// m_inlineeIndex - sorted (by InlineeRecord.key i.e. by module then token) array of InlineeRecords, given an inlinee module name hash (8 bits) 
+// m_inlineeIndex - sorted (by ZapInlineeRecord.key i.e. by module then token) array of ZapInlineeRecords, given an inlinee module name hash (8 bits) 
 //                  and a method token (24 bits) we use binary search to find if this method has ever been inlined in NGen-ed code of this image.
 //                  Each record has m_offset, which is an offset inside m_inlinersBuffer, it has more data on where the method got inlined.
 //
-//                  It is totally possible to have more than one InlineeRecords with the same key, not only due hash collision, but also due to 
+//                  It is totally possible to have more than one ZapInlineeRecords with the same key, not only due hash collision, but also due to 
 //                  the fact that we create one record for each (inlinee module / inliner module) pair. 
 //                  For example: we have MyModule!MyType that uses mscorlib!List<T>. Let's say List<T>.ctor got inlined into
 //                  MyType.GetAllThinds() and into List<MyType>.FindAll. In this case we'll have two InlineeRecords for mscorlib!List<T>.ctor
 //                  one for MyModule and another one for mscorlib.
-//                  PersistentInlineTrackingMap.GetInliners() always reads all InlineeRecords as long as they have the same key, few of them filtered out as hash collisions
-//                  others provide legitimate inlining information for methods from different modules.
+//                  PersistentInlineTrackingMap.GetInliners() always reads all ZapInlineeRecords as long as they have the same key, few of them filtered out 
+//                  as hash collisions others provide legitimate inlining information for methods from different modules.
 //
-// m_inlinersBuffer - byte array compressed by NibbleWriter. At any valid offset taken from InlineeRecord from m_inlineeIndex, there is a compressed chunk 
+// m_inlinersBuffer - byte array compressed by NibbleWriter. At any valid offset taken from ZapInlineeRecord from m_inlineeIndex, there is a compressed chunk 
 //                    of this format: 
 //                    [InlineeModuleZapIndex][InlinerModuleZapIndex] [N - # of following inliners] [#1 inliner method RID] ... [#N inliner method RID]
 //                    [InlineeModuleZapIndex] is used to verify that we actually found a desired inlinee module (not just a name hash collision).
 //                    [InlinerModuleZapIndex] is an index of a module that owns following method tokens (inliners)
 //                    [1..N inliner RID] are the sorted diff compressed method RIDs from the module specified by InlinerModuleZapIndex, 
-//                    those methods directly or indirectly inlined code from inlinee method specified by InlineeRecord.
+//                    those methods directly or indirectly inlined code from inlinee method specified by ZapInlineeRecord.
 //                    Since all the RIDs are sorted we'are actually able to save some space by using diffs instead of values, because NibbleWriter 
 //                    is good at saving small numbers.
 //                    For example for RIDs: 5, 6, 19, 25, 30, we'll write: 5, 1 (=6-5), 13 (=19-6), 6 (=25-19), 5 (=30-25)
@@ -170,39 +199,111 @@ typedef DPTR(InlineTrackingMap) PTR_InlineTrackingMap;
 // |  -     -     -  | InlineeModuleZapIndex | InlinerModuleZapIndex  | SavedInlinersCount (N) | rid1 | rid2 | ...... | ridN |  -   -   -  |
 // +-----------------+-----------------------+------------------------+------------------------+------+------+--------+------+-------------+
 //
-class PersistentInlineTrackingMap
+
+
+
+
+
+
+
+
+
+// R2R encoding variation for the map
+//
+// It has several differences from the NGEN encoding. NGEN refers to methods outside the current assembly via module index + foreign module's token
+// but R2R can't take those fragile dependencies. Instead we refer to all methods via MethodDef tokens in the current assembly's metadata. This
+// is sufficient for everything we need to track now but in the future we may need to upgrade to a more expressive encoding. Currently NonVersionable
+// attributed methods may be inlined but will not be tracked. This shows up as a known limitation in the profiler APIs that expose this data.
+//
+// The format changes from NGEN:
+//  a) The InlineIndex uses a MethodDef RID token as the key.
+//  b) InlineeModuleZapIndex is omitted because the module is always the current one being compiled.
+//  c) InlinerModuleZapIndex is similarly omitted.
+//  d) (a), (b) and (c) together imply there is at most one entry in the inlineeIndex for any given key
+//  e) A trivial header is now explicitly described
+//  
+//
+// The resulting serialized format is a sequence of blobs:
+// 1) Header (4 byte aligned)
+//       short   MajorVersion - currently set to 1, increment on breaking change
+//       short   MinorVersion - currently set to 0, increment on non-breaking format addition
+//       int     SizeOfInlineIndex - size in bytes of the inline index
+// 
+// 2) InlineIndex - Immediately following header. This is a sorted (by ZapInlineeRecord.key) array of ZapInlineeRecords, given a method token (32 bits)
+//                  we use binary search to find if this method has ever been inlined in R2R code of this image. Each record has m_offset, which is
+//                  an offset inside InlinersBuffer, it has more data on where the method got inlined. There is at most one ZapInlineeRecord with the 
+//                  same key.
+//
+// 3) InlinersBuffer - Located immediately following the InlineIndex (Header RVA + sizeof(Header) + header.SizeOfInlineIndex)
+//                  This is a byte array compressed by NibbleWriter. At any valid offset taken from ZapInlineeRecord from InlineeIndex, there is a 
+//                  compressed chunk  of this format: 
+//                  [N - # of following inliners] [#1 inliner method RID] ... [#N inliner method RID]
+//                  [1..N inliner RID] are the sorted diff compressed method RIDs interpreted as MethodDefs in this assembly's metadata, 
+//                  Those methods directly or indirectly inlined code from inlinee method specified by ZapInlineeRecord.
+//                  Since all the RIDs are sorted we'are actually able to save some space by using diffs instead of values, because NibbleWriter 
+//                  is good at saving small numbers.
+//                  For example for RIDs: 5, 6, 19, 25, 30, we'll write: 5, 1 (=6-5), 13 (=19-6), 6 (=25-19), 5 (=30-25)
+//
+// InlineeIndex
+// +-----+-----+---------------------------------------+-----+-----+
+// |  -  |  -  | m_key {MethodDefToken); m_offset      |  -  |  -  |  
+// +-----+-----+---------------------------------|-----+-----+-----+
+//                                               |
+//                    +--------------------------+
+//                    |
+// InlinersBuffer    \-/
+// +-----------------+------------------------+------+------+--------+------+-------------+
+// |  -     -     -  | SavedInlinersCount (N) | rid1 | rid2 | ...... | ridN |  -   -   -  |
+// +-----------------+------------------------+------+------+--------+------+-------------+
+//
+
+
+
+//A common key format for R2R and NGEN. If the formats
+//diverge further this might become irrelevant
+struct ZapInlineeRecord
+{
+    DWORD m_key;
+    DWORD m_offset;
+
+    ZapInlineeRecord()
+        : m_key(0)
+    {
+        LIMITED_METHOD_CONTRACT;
+    }
+
+    void InitForR2R(RID rid)
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_key = rid;
+    }
+
+    void InitForNGen(RID rid, LPCUTF8 simpleName);
+
+    bool operator <(const ZapInlineeRecord& other) const
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return m_key < other.m_key;
+    }
+
+    bool operator ==(const ZapInlineeRecord& other) const
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return m_key == other.m_key;
+    }
+};
+
+typedef DPTR(ZapInlineeRecord) PTR_ZapInlineeRecord;
+
+
+// This type knows how to serialize and deserialize the inline tracking map format within an NGEN image. See
+// above for a description of the format.
+class PersistentInlineTrackingMapNGen
 {
 private:
-    struct InlineeRecord
-    {
-        DWORD m_key;
-        DWORD m_offset;
-
-        InlineeRecord()
-            : m_key(0)
-        {
-            LIMITED_METHOD_CONTRACT;
-        }
-
-        InlineeRecord(RID rid, LPCUTF8 simpleName);
-
-        bool operator <(const InlineeRecord& other) const
-        {
-            LIMITED_METHOD_DAC_CONTRACT;
-            return m_key < other.m_key;
-        }
-
-        bool operator ==(const InlineeRecord& other) const
-        {
-            LIMITED_METHOD_DAC_CONTRACT;
-            return m_key == other.m_key;
-        }
-    };
-    typedef DPTR(InlineeRecord) PTR_InlineeRecord;
-
     PTR_Module m_module;
 
-    PTR_InlineeRecord m_inlineeIndex;
+    PTR_ZapInlineeRecord m_inlineeIndex;
     DWORD m_inlineeIndexSize;
 
     PTR_BYTE m_inlinersBuffer;
@@ -210,23 +311,63 @@ private:
 
 public:
 
-    PersistentInlineTrackingMap(Module *module)
+    PersistentInlineTrackingMapNGen(Module *module)
         : m_module(dac_cast<PTR_Module>(module))
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(module != NULL);
     }
 
+    // runtime deserialization
+    COUNT_T GetInliners(PTR_Module inlineeOwnerMod, mdMethodDef inlineeTkn, COUNT_T inlinersSize, MethodInModule inliners[], BOOL *incompleteData);
+
+    // compile-time serialization
+#ifndef DACCESS_COMPILE
     void Save(DataImage *image, InlineTrackingMap* runtimeMap);
     void Fixup(DataImage *image);
 
-    COUNT_T GetInliners(PTR_Module inlineeOwnerMod, mdMethodDef inlineeTkn, COUNT_T inlinersSize, MethodInModule inliners[], BOOL *incompleteData);
-
 private:
-    void ProcessInlineTrackingEntry(DataImage *image, SBuffer *inlinersBuffer, SArray<InlineeRecord> *inlineeIndex, InlineTrackingEntry *entry);
+#endif
+
     Module *GetModuleByIndex(DWORD index);
+
 };
 
-typedef DPTR(PersistentInlineTrackingMap) PTR_PersistentInlineTrackingMap;
+typedef DPTR(PersistentInlineTrackingMapNGen) PTR_PersistentInlineTrackingMapNGen;
+
+
+// This type knows how to serialize and deserialize the inline tracking map format within an R2R image. See
+// above for a description of the format.
+#ifdef FEATURE_READYTORUN
+class PersistentInlineTrackingMapR2R
+{
+private:
+    PTR_Module m_module;
+
+    PTR_ZapInlineeRecord m_inlineeIndex;
+    DWORD m_inlineeIndexSize;
+
+    PTR_BYTE m_inlinersBuffer;
+    DWORD m_inlinersBufferSize;
+
+public:
+
+    // runtime deserialization
+#ifndef DACCESS_COMPILE
+    static BOOL TryLoad(Module* pModule, const BYTE* pBuffer, DWORD cbBuffer, AllocMemTracker *pamTracker, PersistentInlineTrackingMapR2R** ppLoadedMap);
+#endif
+    COUNT_T GetInliners(PTR_Module inlineeOwnerMod, mdMethodDef inlineeTkn, COUNT_T inlinersSize, MethodInModule inliners[], BOOL *incompleteData);
+
+
+    // compile time serialization
+#ifndef DACCESS_COMPILE
+    static void Save(ZapHeap* pHeap, SBuffer *saveTarget, InlineTrackingMap* runtimeMap);
+#endif
+
+};
+
+typedef DPTR(PersistentInlineTrackingMapR2R) PTR_PersistentInlineTrackingMapR2R;
+#endif //FEATURE_READYTORUN
+
 
 #endif //INLINETRACKING_H_

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1619,6 +1619,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
             else
 #endif // FEATURE_INTERPRETER
             {
+                ReJitPublishMethodHolder publishWorker(this, pCode);
                 SetStableEntryPointInterlocked(pCode);
             }
         }

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -9397,8 +9397,7 @@ HRESULT ProfToEEInterfaceImpl::EnumNgenModuleMethodsInliningThisMethod(
         return CORPROF_E_DATAINCOMPLETE;
     }
 
-    PersistentInlineTrackingMap *inliningMap = inlinersModule->GetNgenInlineTrackingMap();
-    if (inliningMap == NULL)
+    if (!inlinersModule->HasInlineTrackingMap())
     {
         return CORPROF_E_DATAINCOMPLETE;
     }
@@ -9411,14 +9410,14 @@ HRESULT ProfToEEInterfaceImpl::EnumNgenModuleMethodsInliningThisMethod(
     EX_TRY
     {
         // Trying to use static buffer
-        COUNT_T methodsAvailable = inliningMap->GetInliners(inlineeOwnerModule, inlineeMethodId, staticBufferSize, staticBuffer, incompleteData);
+        COUNT_T methodsAvailable = inlinersModule->GetInliners(inlineeOwnerModule, inlineeMethodId, staticBufferSize, staticBuffer, incompleteData);
 
         // If static buffer is not enough, allocate an array.
         if (methodsAvailable > staticBufferSize)
         {
             DWORD dynamicBufferSize = methodsAvailable;
             dynamicBuffer = methodsBuffer = new MethodInModule[dynamicBufferSize];
-            methodsAvailable = inliningMap->GetInliners(inlineeOwnerModule, inlineeMethodId, dynamicBufferSize, dynamicBuffer, incompleteData);                
+            methodsAvailable = inlinersModule->GetInliners(inlineeOwnerModule, inlineeMethodId, dynamicBufferSize, dynamicBuffer, incompleteData);                
             if (methodsAvailable > dynamicBufferSize)
             {
                 _ASSERTE(!"Ngen image inlining info changed, this shouldn't be possible.");

--- a/src/vm/readytoruninfo.h
+++ b/src/vm/readytoruninfo.h
@@ -13,6 +13,7 @@
 #define _READYTORUNINFO_H_
 
 #include "nativeformatreader.h"
+#include "inlinetracking.h"
 
 typedef DPTR(struct READYTORUN_SECTION) PTR_READYTORUN_SECTION;
 
@@ -40,7 +41,9 @@ class ReadyToRunInfo
     Crst                            m_Crst;
     PtrHashMap                      m_entryPointToMethodDescMap;
 
-    ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYTORUN_HEADER * pHeader);
+    PTR_PersistentInlineTrackingMapR2R m_pPersistentInlineTrackingMap;
+
+    ReadyToRunInfo(Module * pModule, PEImageLayout * pLayout, READYTORUN_HEADER * pHeader, AllocMemTracker *pamTracker);
 
 public:
     static BOOL IsReadyToRunEnabled();
@@ -118,10 +121,16 @@ public:
 
     static DWORD GetFieldBaseOffset(MethodTable * pMT);
 
+    PTR_PersistentInlineTrackingMapR2R GetInlineTrackingMap()
+    {
+        return m_pPersistentInlineTrackingMap;
+    }
+
 private:
     BOOL GetTypeNameFromToken(IMDInternalImport * pImport, mdToken mdType, LPCUTF8 * ppszName, LPCUTF8 * ppszNameSpace);
     BOOL GetEnclosingToken(IMDInternalImport * pImport, mdToken mdType, mdToken * pEnclosingToken);
     BOOL CompareTypeNameOfTokens(mdToken mdToken1, IMDInternalImport * pImport1, mdToken mdToken2, IMDInternalImport * pImport2);
+	BOOL IsImageVersionAtLeast(int majorVersion, int minorVersion);
 };
 
 class DynamicHelpers

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1742,6 +1742,7 @@ void ZapImage::Compile()
         OutputEntrypointsTableForReadyToRun();
         OutputDebugInfoForReadyToRun();
         OutputTypesTableForReadyToRun(m_pMDImport);
+        OutputInliningTableForReadyToRun();
     }
     else
 #endif

--- a/src/zap/zapimage.h
+++ b/src/zap/zapimage.h
@@ -557,6 +557,7 @@ private:
     void OutputEntrypointsTableForReadyToRun();
     void OutputDebugInfoForReadyToRun();
     void OutputTypesTableForReadyToRun(IMDInternalImport * pMDImport);
+    void OutputInliningTableForReadyToRun();
 
     void CopyDebugDirEntry();
     void CopyWin32VersionResource();

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3622,8 +3622,13 @@ void ZapInfo::reportInliningDecision (CORINFO_METHOD_HANDLE inlinerHnd,
                                                 CorInfoInline inlineResult,
                                                 const char * reason)
 {
-
-
+    if (!dontInline(inlineResult) && inlineeHnd != NULL)
+    {
+        // We deliberately report  m_currentMethodHandle (not inlinerHnd) as inliner, because
+        // if m_currentMethodHandle != inlinerHnd, it simply means that inlinerHnd is intermediate link 
+        // in inlining into m_currentMethodHandle, and we have no interest to track those intermediate links now.
+        m_pImage->m_pPreloader->ReportInlining(m_currentMethodHandle, inlineeHnd);
+    }
     return m_pEEJitInfo->reportInliningDecision(inlinerHnd, inlineeHnd, inlineResult, reason);
 }
 

--- a/src/zap/zapreadytorun.cpp
+++ b/src/zap/zapreadytorun.cpp
@@ -380,6 +380,15 @@ void ZapImage::OutputDebugInfoForReadyToRun()
     GetReadyToRunHeader()->RegisterSection(READYTORUN_SECTION_DEBUG_INFO, pBlob);
 }
 
+void ZapImage::OutputInliningTableForReadyToRun()
+{
+    SBuffer serializedInlineTrackingBuffer;
+    m_pPreloader->GetSerializedInlineTrackingMap(&serializedInlineTrackingBuffer);
+    ZapNode * pBlob = ZapBlob::NewAlignedBlob(this, (PVOID)(const BYTE*) serializedInlineTrackingBuffer, serializedInlineTrackingBuffer.GetSize(), 4);
+    m_pDebugSection->Place(pBlob);
+    GetReadyToRunHeader()->RegisterSection(READYTORUN_SECTION_INLINING_INFO, pBlob);
+}
+
 void ZapImage::OutputTypesTableForReadyToRun(IMDInternalImport * pMDImport)
 {
     NativeWriter writer;


### PR DESCRIPTION
Attempting to use Rejit with R2R rapidly hits two issues:
a) The prestub never communicates to the RejitManager that new code from an R2R image is about to be used. This causes pending requests to rejit a method never
to be honored. Fixed in prestub.cpp

b) ICorProfilerInfo6::EnumNgenMethodsInliningThisMethod didn't work with R2R images because R2R images did not carry the inline tracking table. The majority of the changes address this part. Currently only intra-module inlining is supported. Cross module inlining via NonVersionableAttribute won't be tracked by design.

This change isn't ready to be checked in yet, but it does demonstrate the proposed file format, the layout of the code, and works well enough to pass really trivial functional tests on windows. Most of my planned work at this point is going to be subjecting it to broader testing (still on windows), fixing issues, and responding to PR feedback. Linux is on the roadmap and may work as-is, but verifying that is not part of this PR. I'm going to look into putting a better guard in place so that anyone adding cross module inlining in the future will realize the implications for the profiler. I wasn't planning to do perf investigation for size on disk as this format should be strictly smaller than NGEN's and we already accepted the perf overhead in that case.