### PR TITLE
[x86/Linux] Do NOT use QuickUnwindStackFrame

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -36,6 +36,9 @@
 #define USE_GC_INFO_DECODER
 #endif
 
+#if (defined(_TARGET_X86_) && !defined(FEATURE_PAL)) || defined(_TARGET_AMD64_)
+#define HAS_QUICKUNWIND
+#endif
 
 #if CHECK_APP_DOMAIN_LEAKS
 #define CHECK_APP_DOMAIN    GC_CALL_CHECK_APP_DOMAIN
@@ -434,6 +437,7 @@ bool UnwindStackFrame(
                 StackwalkCacheUnwindInfo  *pUnwindInfo);
 #endif // CROSSGEN_COMPILE
 
+#ifdef HAS_QUICKUNWIND
 enum QuickUnwindFlag
 {
     UnwindCurrentStackFrame,
@@ -450,6 +454,7 @@ void QuickUnwindStackFrame(
              PREGDISPLAY pRD,
              StackwalkCacheEntry *pCacheEntry,
              QuickUnwindFlag flag);
+#endif // HAS_QUICKUNWIND
 
 /*
     Is the function currently at a "GC safe point" ?

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3104,7 +3104,7 @@ size_t EECodeManager::GetCallerSp( PREGDISPLAY  pRD )
 
 #endif // WIN64EXCEPTIONS && !CROSSGEN_COMPILE
 
-#ifdef USE_QUICKUNWIND
+#ifdef HAS_QUICKUNWIND
 /*
   *  Light unwind the current stack frame, using provided cache entry.
   *  pPC, Esp and pEbp of pContext are updated.
@@ -3195,7 +3195,7 @@ void EECodeManager::QuickUnwindStackFrame(PREGDISPLAY pRD, StackwalkCacheEntry *
     PORTABILITY_ASSERT("EECodeManager::QuickUnwindStackFrame is not implemented on this platform.");
 #endif // !_TARGET_X86_ && !_TARGET_AMD64_
 }
-#endif // USE_QUICKUNWIND
+#endif // HAS_QUICKUNWIND
 
 /*****************************************************************************/
 #ifdef _TARGET_X86_ // UnwindStackFrame

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3063,7 +3063,7 @@ void EECodeManager::EnsureCallerContextIsValid( PREGDISPLAY  pRD, StackwalkCache
 
     if( !pRD->IsCallerContextValid )
     {
-#if !defined(DACCESS_COMPILE)
+#if !defined(DACCESS_COMPILE) && defined(HAS_QUICKUNWIND)
         if (pCacheEntry != NULL)
         {
             // lightened schema: take stack unwind info from stackwalk cache
@@ -3104,6 +3104,7 @@ size_t EECodeManager::GetCallerSp( PREGDISPLAY  pRD )
 
 #endif // WIN64EXCEPTIONS && !CROSSGEN_COMPILE
 
+#ifdef USE_QUICKUNWIND
 /*
   *  Light unwind the current stack frame, using provided cache entry.
   *  pPC, Esp and pEbp of pContext are updated.
@@ -3194,6 +3195,7 @@ void EECodeManager::QuickUnwindStackFrame(PREGDISPLAY pRD, StackwalkCacheEntry *
     PORTABILITY_ASSERT("EECodeManager::QuickUnwindStackFrame is not implemented on this platform.");
 #endif // !_TARGET_X86_ && !_TARGET_AMD64_
 }
+#endif // USE_QUICKUNWIND
 
 /*****************************************************************************/
 #ifdef _TARGET_X86_ // UnwindStackFrame

--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -2464,7 +2464,7 @@ StackWalkAction StackFrameIterator::NextRaw(void)
              DBG_ADDR(GetRegdisplaySP(m_crawl.pRD)), 
              DBG_ADDR(GetControlPC(m_crawl.pRD))));
 
-#if !defined(DACCESS_COMPILE)
+#if !defined(DACCESS_COMPILE) && defined(HAS_QUICKUNWIND)
         StackwalkCacheEntry *pCacheEntry = m_crawl.GetStackwalkCacheEntry();
         if (pCacheEntry != NULL)
         {
@@ -2474,7 +2474,7 @@ StackWalkAction StackFrameIterator::NextRaw(void)
             EECodeManager::QuickUnwindStackFrame(m_crawl.pRD, pCacheEntry, EECodeManager::UnwindCurrentStackFrame);
         }
         else
-#endif // !DACCESS_COMPILE
+#endif // !DACCESS_COMPILE && HAS_QUICKUNWIND
         {
 #if !defined(DACCESS_COMPILE)
             // non-optimized stack unwind schema, doesn't use StackwalkCache


### PR DESCRIPTION
This commit deprecates access to QuickUnwindStackFrame from x86/Linux CLR (as discussed in #9286).