### PR TITLE
[x86/Linux] Initial patch to restore EBP for funclet

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1761,11 +1761,7 @@ public:
     // a PSPSym for functions with any EH.
     bool ehNeedsPSPSym() const
     {
-#ifdef _TARGET_X86_
-        return false;
-#else  // _TARGET_X86_
         return compHndBBtabCount > 0;
-#endif // _TARGET_X86_
     }
 
     bool     ehAnyFunclets();  // Are there any funclets in this function?

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -4088,7 +4088,7 @@ void Compiler::lvaFixVirtualFrameOffsets()
 {
     LclVarDsc* varDsc;
 
-#if FEATURE_EH_FUNCLETS && defined(_TARGET_AMD64_)
+#if FEATURE_EH_FUNCLETS && defined(_TARGET_XARCH_)
     if (lvaPSPSym != BAD_VAR_NUM)
     {
         // We need to fix the offset of the PSPSym so there is no padding between it and the outgoing argument space.
@@ -4097,7 +4097,10 @@ void Compiler::lvaFixVirtualFrameOffsets()
         varDsc = &lvaTable[lvaPSPSym];
         assert(varDsc->lvFramePointerBased); // We always access it RBP-relative.
         assert(!varDsc->lvMustInit);         // It is never "must init".
-        varDsc->lvStkOffs = codeGen->genCallerSPtoInitialSPdelta() + lvaLclSize(lvaOutgoingArgSpaceVar);
+        varDsc->lvStkOffs = codeGen->genCallerSPtoInitialSPdelta();
+#if FEATURE_FIXED_OUT_ARGS
+        varDsc->lvStkOffs += lvaLclSize(lvaOutgoingArgSpaceVar);
+#endif
     }
 #endif
 
@@ -5507,7 +5510,7 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
         }
     }
 
-#if FEATURE_EH_FUNCLETS && defined(_TARGET_AMD64_)
+#if FEATURE_EH_FUNCLETS && defined(_TARGET_XARCH_)
     if (lvaPSPSym != BAD_VAR_NUM)
     {
         // On AMD64, if we need a PSPSym, allocate it last, immediately above the outgoing argument
@@ -5516,7 +5519,7 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
         noway_assert(codeGen->isFramePointerUsed()); // We need an explicit frame pointer
         stkOffs = lvaAllocLocalAndSetVirtualOffset(lvaPSPSym, TARGET_POINTER_SIZE, stkOffs);
     }
-#endif // FEATURE_EH_FUNCLETS && defined(_TARGET_AMD64_)
+#endif // FEATURE_EH_FUNCLETS && defined(_TARGET_XARCH_)
 
 #ifdef _TARGET_ARM64_
     if (isFramePointerUsed())


### PR DESCRIPTION
This is a initial patch to restore EBP and Exception object for funclets
With this patch it fixes lots of try-catch fails like PinObj-neg.exe
Further changes maybe needed for nested try-catch.