### PR TITLE
[x86/Linux] Clean up #ifdef for VerifyValidTransitionFromManagedCode

### DIFF
--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -2672,12 +2672,11 @@ StackWalkAction StackFrameIterator::NextRaw(void)
 #endif // !_TARGET_X86_
 
 
+#if defined(_DEBUG) && !defined(DACCESS_COMPILE) && !defined(WIN64EXCEPTIONS)
                 // We are transitioning from unmanaged code to managed code... lets do some validation of our
                 // EH mechanism on platforms that we can.
-#if defined(_DEBUG)  && !defined(DACCESS_COMPILE) && (defined(_TARGET_X86_) && !defined(FEATURE_PAL)) && !defined(WIN64EXCEPTIONS)               
-                // TODO: Revise this once we enable WIN64EXCEPTIONS for x86/Linux
                 VerifyValidTransitionFromManagedCode(m_crawl.pThread, &m_crawl);
-#endif // _DEBUG && !DACCESS_COMPILE && _TARGET_X86_ && !WIN64EXCEPTIONS
+#endif // _DEBUG && !DACCESS_COMPILE &&  !WIN64EXCEPTIONS
             }
         }
 


### PR DESCRIPTION
This commit cleans up TODO related with VerifyValidTransitionFromManagedCode, which was introduced while x86/Linux bring up.