### PR TITLE
[x86/Linux] Clean up non-WIN64EXCEPTIONS code

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -322,6 +322,7 @@ virtual unsigned int GetFrameSize(GCInfoToken gcInfoToken) = 0;
 
 /* Debugger API */
 
+#ifndef WIN64EXCEPTIONS
 virtual const BYTE*     GetFinallyReturnAddr(PREGDISPLAY pReg)=0;
 
 virtual BOOL            IsInFilter(GCInfoToken gcInfoToken,
@@ -329,7 +330,6 @@ virtual BOOL            IsInFilter(GCInfoToken gcInfoToken,
                                    PCONTEXT pCtx,
                                    DWORD curNestLevel) = 0;
 
-#ifndef WIN64EXCEPTIONS
 virtual BOOL            LeaveFinally(GCInfoToken gcInfoToken,
                                      unsigned offset,
                                      PCONTEXT pCtx) = 0;
@@ -598,12 +598,12 @@ unsigned int GetFrameSize(GCInfoToken gcInfoToken);
 
 #ifndef DACCESS_COMPILE
 
+#ifndef WIN64EXCEPTIONS
 virtual const BYTE* GetFinallyReturnAddr(PREGDISPLAY pReg);
 virtual BOOL IsInFilter(GCInfoToken gcInfoToken,
                         unsigned offset,
                         PCONTEXT pCtx,
                           DWORD curNestLevel);
-#ifndef WIN64EXCEPTIONS
 virtual BOOL LeaveFinally(GCInfoToken gcInfoToken,
                           unsigned offset,
                           PCONTEXT pCtx);

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5699,16 +5699,12 @@ unsigned int EECodeManager::GetFrameSize(GCInfoToken gcInfoToken)
 
 /*****************************************************************************/
 
+#ifndef WIN64EXCEPTIONS
 const BYTE* EECodeManager::GetFinallyReturnAddr(PREGDISPLAY pReg)
 {
     LIMITED_METHOD_CONTRACT;
 
-#ifdef _TARGET_X86_
     return *(const BYTE**)(size_t)(GetRegdisplaySP(pReg));
-#else
-    PORTABILITY_ASSERT("EECodeManager::GetFinallyReturnAddr is not implemented on this platform.");
-    return NULL;
-#endif
 }
 
 BOOL EECodeManager::IsInFilter(GCInfoToken gcInfoToken,
@@ -5720,8 +5716,6 @@ BOOL EECodeManager::IsInFilter(GCInfoToken gcInfoToken,
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-
-#ifdef _TARGET_X86_
 
     /* Extract the necessary information from the info block header */
 
@@ -5747,15 +5741,9 @@ BOOL EECodeManager::IsInFilter(GCInfoToken gcInfoToken,
 //    _ASSERTE(nestingLevel == curNestLevel);
 
     return frameType == FR_FILTER;
-
-#else
-    PORTABILITY_ASSERT("EECodeManager::IsInFilter is not implemented on this platform.");
-    return FALSE;
-#endif
 }
 
 
-#ifndef WIN64EXCEPTIONS
 BOOL EECodeManager::LeaveFinally(GCInfoToken gcInfoToken,
                                 unsigned offset,
                                 PCONTEXT pCtx)

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -1644,6 +1644,7 @@ const char *TCFStringFromConst(TRY_CATCH_FINALLY tcf)
 }
 #endif //LOGGING
 
+#ifndef WIN64EXCEPTIONS
 // We're unwinding if we'll return to the EE's code.  Otherwise
 // we'll return to someplace in the current code.  Anywhere outside
 // this function is "EE code".
@@ -1675,7 +1676,6 @@ bool FinallyIsUnwinding(EHRangeTreeNode *pNode,
         return false;
 }
 
-#ifndef WIN64EXCEPTIONS
 BOOL LeaveCatch(ICodeManager* pEECM,
                 Thread *pThread,
                 CONTEXT *pCtx,
@@ -1690,7 +1690,6 @@ BOOL LeaveCatch(ICodeManager* pEECM,
     }
     CONTRACTL_END;
 
-#ifndef FEATURE_PAL
     // We can assert these things here, and skip a call
     // to COMPlusCheckForAbort later.
 
@@ -1708,10 +1707,6 @@ BOOL LeaveCatch(ICodeManager* pEECM,
 
     SetSP(pCtx, (UINT_PTR)esp);
     return TRUE;
-#else // FEATURE_PAL
-    PORTABILITY_ASSERT("LeaveCatch");
-    return FALSE;
-#endif
 }
 #endif // WIN64EXCEPTIONS
 
@@ -1926,7 +1921,7 @@ HRESULT IsLegalTransition(Thread *pThread,
                 case TCF_NONE:
                 case TCF_TRY:
                 {
-#if !defined(WIN64EXCEPTIONS)
+#ifndef WIN64EXCEPTIONS
                     if (!FinallyIsUnwinding(pNode, pEECM, pReg, addrStart))
                     {
                         CONTEXT *pFilterCtx = pThread->GetFilterContext();
@@ -1946,14 +1941,14 @@ HRESULT IsLegalTransition(Thread *pThread,
                     {
                         return CORDBG_E_CANT_SET_IP_OUT_OF_FINALLY;
                     }
-#else  // _WIN64
+#else // !WIN64EXCEPTIONS
                     // <NOTE>
                     // Setting IP out of a non-unwinding finally clause is not supported on WIN64EXCEPTIONS because of funclets.
                     // This scenario is disabled with approval from VS because it's not considered to be a common user
                     // scenario.
                     // </NOTE>
                     return CORDBG_E_CANT_SET_IP_OUT_OF_FINALLY_ON_WIN64;
-#endif // _WIN64
+#endif // WIN64EXCEPTIONS
 
                     break;
                 }


### PR DESCRIPTION
This commit cleans up non-WIN64EXCEPTIONS code (such as GetFinallyReturnAddr, IsInFilter) from x86/Linux build.