### PR TITLE
Disable failing Helix tests until we fix underlying issues

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -405,6 +405,15 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\superpmi\superpmicollect\superpmicollect.cmd">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\k-nucleotide\k-nucleotide\k-nucleotide.cmd">
+            <Issue>9314</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\regexdna\regexdna\regexdna.cmd">
+            <Issue>9314</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\revcomp\revcomp\revcomp.cmd">
+            <Issue>9314</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are tests that fail on non-Windows, which we must not run when building against packages -->
@@ -415,6 +424,12 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\CoreMangLib\cti\system\convert\ConvertToInt32_4\ConvertToInt32_4.cmd">
             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\CoreMangLib\cti\system\globalization\datetimeformatinfo\DateTimeFormatInfoGetAbbreviatedMonthName\DateTimeFormatInfoGetAbbreviatedMonthName.cmd">
+            <Issue>9289</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\CoreMangLib\cti\system\globalization\datetimeformatinfo\DateTimeFormatInfoGetMonthName\DateTimeFormatInfoGetMonthName.cmd">
+            <Issue>9289</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\CoreMangLib\cti\system\datetime\DateTimeParseExact1\DateTimeParseExact1.cmd">
             <Issue>needs triage</Issue>


### PR DESCRIPTION
Relevant to https://github.com/dotnet/coreclr/issues/9314 and https://github.com/dotnet/coreclr/issues/9289