### PR TITLE
Add x86 perf runs to CoreCLR

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -27,8 +27,8 @@ def static getOSGroup(def os) {
 // Setup perflab tests runs
 [true, false].each { isPR ->
     ['Windows_NT'].each { os ->
-		['x64'].each { architecture ->
-			def newJob = job(Utilities.getFullJobName(project, "perf_perflab_${os}", isPR)) {
+		['x64', 'x86'].each { architecture ->
+			def newJob = job(Utilities.getFullJobName(project, "perf_perflab_${os}_${architecture}", isPR)) {
 				// Set the label.
 				label('windows_clr_perf')
 				wrappers {
@@ -76,9 +76,9 @@ def static getOSGroup(def os) {
 
 			if (isPR) {
 				TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
-				builder.setGithubContext("${os} CoreCLR Perf Tests")
+				builder.setGithubContext("${os} ${architecture} CoreCLR Perf Tests")
 				builder.triggerOnlyOnComment()
-				builder.setCustomTriggerPhrase("(?i).*test\\W+${os}\\W+perf.*")
+				builder.setCustomTriggerPhrase("(?i).*test\\W+${os}$_{architecture}\\W+perf.*")
 				builder.triggerForBranch(branch)
 				builder.emitTrigger(newJob)
 			}

--- a/perf.groovy
+++ b/perf.groovy
@@ -78,7 +78,7 @@ def static getOSGroup(def os) {
 				TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
 				builder.setGithubContext("${os} ${architecture} CoreCLR Perf Tests")
 				builder.triggerOnlyOnComment()
-				builder.setCustomTriggerPhrase("(?i).*test\\W+${os}$_{architecture}\\W+perf.*")
+				builder.setCustomTriggerPhrase("(?i).*test\\W+${os}_${architecture}\\W+perf.*")
 				builder.triggerForBranch(branch)
 				builder.emitTrigger(newJob)
 			}

--- a/tests/scripts/run-xunit-perf.sh
+++ b/tests/scripts/run-xunit-perf.sh
@@ -25,7 +25,7 @@ function print_usage {
     echo '  --coreClrBinDir=<path>           : Directory of the CoreCLR build (e.g. coreclr/bin/Product/Linux.x64.Debug).'
     echo '  --mscorlibDir=<path>             : Directory containing the built mscorlib.dll. If not specified, it is expected to be'
     echo '                                       in the directory specified by --coreClrBinDir.'
-    echo '  --coreFxBinDir="<path>"          : The path to the unpacled runtime folder that is produced as part of a CoreFX build'
+    echo '  --coreFxBinDir="<path>"          : The path to the unpacked runtime folder that is produced as part of a CoreFX build'
 	echo '  --uploadToBenchview              : Specify this flag in order to have the results of the run uploaded to Benchview.'
 	echo '                                     This also requires that the os flag and runtype flag to be set.  Lastly you must'
 	echo '                                     also have the BV_UPLOAD_SAS_TOKEN set to a SAS token for the Benchview upload container'


### PR DESCRIPTION
This is a change to add x86 perf runs to the CoreCLR repo.  This also
changes the command to launch a perf run from a PR to include the
architecture.