### PR TITLE
Use fallback load context as binding context for dynamic parent assembly

### DIFF
--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -1256,6 +1256,15 @@ ICLRPrivBinder* AssemblySpec::GetBindingContextFromParentAssembly(AppDomain *pDo
         
         // ICLRPrivAssembly implements ICLRPrivBinder and thus, "is a" binder in a manner of semantics.
         pParentAssemblyBinder = pParentPEAssembly->GetBindingContext();
+        if (pParentAssemblyBinder == NULL)
+        {
+            if (pParentPEAssembly->IsDynamic())
+            {
+                // If the parent assembly is dynamically generated, then use its fallback load context
+                // as the binder.
+                pParentAssemblyBinder = pParentPEAssembly->GetFallbackLoadContextBinder();
+            }
+        }
     }
 
 #if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)


### PR DESCRIPTION
When determining the binding context from parent assembly, we were missing a check to look it up from fallback load context incase the assembly was dynamically generated.

Fixes https://github.com/dotnet/coreclr/issues/9030

@jkotas @rahku PTAL
