### PR TITLE
Add #!/bin/bash to beginning of shell test scripts

### DIFF
--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -274,7 +274,7 @@ $(BashCLRTestArgPrep)
       <!-- NOTE! semicolons must be escaped with %3B boooo -->
       <_CLRTestExecutionScriptText>
         <![CDATA[
-%23%21/bin/bash
+%23%21/usr/bin/env bash
 TakeLock()
 {
     echo "in takeLock"

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -274,6 +274,7 @@ $(BashCLRTestArgPrep)
       <!-- NOTE! semicolons must be escaped with %3B boooo -->
       <_CLRTestExecutionScriptText>
         <![CDATA[
+%23%21/bin/bash
 TakeLock()
 {
     echo "in takeLock"


### PR DESCRIPTION
Should solve baseservices test failures in Helix