### PR TITLE
Add argument that exclusively enables symbol stripping

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ fi
 
 usage()
 {
-    echo "Usage: $0 [BuildArch] [BuildType] [verbose] [coverage] [cross] [clangx.y] [ninja] [configureonly] [skipconfigure] [skipnative] [skipmscorlib] [skiptests] [cmakeargs] [bindir]"
+    echo "Usage: $0 [BuildArch] [BuildType] [verbose] [coverage] [cross] [clangx.y] [ninja] [configureonly] [skipconfigure] [skipnative] [skipmscorlib] [skiptests] [stripsymbols] [cmakeargs] [bindir]"
     echo "BuildArch can be: x64, x86, arm, armel, arm64"
     echo "BuildType can be: debug, checked, release"
     echo "coverage - optional argument to enable code coverage build (currently supported only for Linux and OSX)."
@@ -44,6 +44,7 @@ usage()
 	echo "   using all processors^)."
 	echo "-officialbuildid=^<ID^>: specify the official build ID to be used by this build."
 	echo "-Rebuild: passes /t:rebuild to the build projects."
+    echo "stripSymbols - Optional argument to strip native symbols during the build."
     echo "skipgenerateversion - disable version generation even if MSBuild is supported."
     echo "cmakeargs - user-settable additional arguments passed to CMake."
     echo "bindir - output directory (defaults to $__ProjectRoot/bin)"
@@ -611,7 +612,7 @@ while :; do
             __CrossBuild=1
             ;;
             
-		portablelinux)
+        portablelinux)
             if [ "$__BuildOS" == "Linux" ]; then
                 __PortableLinux=1
             else
@@ -621,8 +622,12 @@ while :; do
             ;;
             
         verbose)
-        __VerboseBuild=1
-        ;;
+            __VerboseBuild=1
+            ;;
+
+        stripsymbols)
+            __cmakeargs="$__cmakeargs -DSTRIP_SYMBOLS=true"
+            ;;
 
         clang3.5)
             __ClangMajorVersion=3

--- a/functions.cmake
+++ b/functions.cmake
@@ -121,7 +121,7 @@ endfunction()
 
 function(strip_symbols targetName outputFilename)
   if (CLR_CMAKE_PLATFORM_UNIX)
-    if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+    if (STRIP_SYMBOLS)
 
       # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
       # generator expression doesn't work correctly returning the wrong path and on
@@ -158,7 +158,7 @@ function(strip_symbols targetName outputFilename)
       endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
       set(${outputFilename} ${strip_destination_file} PARENT_SCOPE)
-    endif(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+    endif (STRIP_SYMBOLS)
   endif(CLR_CMAKE_PLATFORM_UNIX)
 endfunction()
 

--- a/src/.nuget/Microsoft.NETCore.ILAsm/alpine/3.4.3/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/alpine/3.4.3/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/debian/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/debian/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/fedora/23/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/fedora/23/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/fedora/24/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/fedora/24/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/linux/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/linux/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/opensuse/13.2/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/opensuse/13.2/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/opensuse/42.1/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/opensuse/42.1/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/osx/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/osx/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/rhel/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/rhel/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/14.04/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/14.04/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/16.04/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/16.04/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/16.10/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/ubuntu/16.10/Microsoft.NETCore.ILAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/win/Microsoft.NETCore.ILAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/win/Microsoft.NETCore.ILAsm.pkgproj
@@ -6,19 +6,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
   </PropertyGroup>
   <ItemGroup>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)ilasm.exe" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup>
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)ilasm.exe" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/alpine/3.4.3/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/alpine/3.4.3/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/debian/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/debian/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/fedora/23/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/fedora/23/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/fedora/24/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/fedora/24/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/linux/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/linux/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/opensuse/13.2/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/opensuse/13.2/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/opensuse/42.1/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/opensuse/42.1/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/osx/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/osx/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/rhel/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/rhel/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/14.04/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/14.04/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/16.04/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/16.04/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/16.10/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/ubuntu/16.10/Microsoft.NETCore.ILDAsm.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/win/Microsoft.NETCore.ILDAsm.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/win/Microsoft.NETCore.ILDAsm.pkgproj
@@ -6,20 +6,8 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
   </PropertyGroup>
   <ItemGroup>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)ildasm.exe" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)ildasmrc.dll" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup>
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)ildasm.exe" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)ildasmrc.dll" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/alpine/3.4.3/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/alpine/3.4.3/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/debian/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/debian/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/fedora/23/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/fedora/23/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/fedora/24/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/fedora/24/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/linux/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/linux/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/opensuse/13.2/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/opensuse/13.2/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/opensuse/42.1/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/opensuse/42.1/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/osx/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/osx/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.dylib" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/rhel/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/rhel/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/ubuntu/14.04/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/ubuntu/14.04/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/ubuntu/16.04/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/ubuntu/16.04/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/ubuntu/16.10/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/ubuntu/16.10/Microsoft.NETCore.Jit.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/win/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/win/Microsoft.NETCore.Jit.pkgproj
@@ -9,14 +9,13 @@
   <ItemGroup>
     <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)clrjit.dll" />
     <ArchitectureSpecificNativeFileAndSymbol Condition="'$(PackagePlatform)' == 'x86'" Include="$(BinDir)compatjit.dll" />
-    <CrossArchitectureSpecificNativeFile Include="$(BinDir)$(CrossTargetComponentFolder)\clrjit.dll" />
+    <CrossArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)$(CrossTargetComponentFolder)\clrjit.dll" />
   </ItemGroup>
   <ItemGroup>
     <!-- prevent accidental inclusion in AOT projects. -->
     <File Include="$(PlaceholderFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)-aot/native</TargetPath>
     </File>
-    <CrossArchitectureSpecificNativeSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/win/Microsoft.NETCore.Jit.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Jit/win/Microsoft.NETCore.Jit.pkgproj
@@ -7,34 +7,16 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
   </PropertyGroup>
   <ItemGroup>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)clrjit.dll" />
-    <ArchitectureSpecificNativeFile Condition="'$(PackagePlatform)' == 'x86'" Include="$(BinDir)compatjit.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)clrjit.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Condition="'$(PackagePlatform)' == 'x86'" Include="$(BinDir)compatjit.dll" />
     <CrossArchitectureSpecificNativeFile Include="$(BinDir)$(CrossTargetComponentFolder)\clrjit.dll" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(CrossTargetComponentFolder)_$(PackagePlatform)/native</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup>
     <!-- prevent accidental inclusion in AOT projects. -->
     <File Include="$(PlaceholderFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)-aot/native</TargetPath>
     </File>
-
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
     <CrossArchitectureSpecificNativeSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
-    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(CrossTargetComponentFolder)_$(PackagePlatform)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/alpine/3.4.3/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/alpine/3.4.3/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/debian/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/debian/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/fedora/23/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/fedora/23/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/fedora/24/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/fedora/24/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/linux/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/linux/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/opensuse/13.2/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/opensuse/13.2/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/opensuse/42.1/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/opensuse/42.1/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/osx/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/osx/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.dylib" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/rhel/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/rhel/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/ubuntu/14.04/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/ubuntu/14.04/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/ubuntu/16.04/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/ubuntu/16.04/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/ubuntu/16.10/Microsoft.NETCore.Native.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Native/ubuntu/16.10/Microsoft.NETCore.Native.pkgproj
@@ -10,21 +10,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/alpine/3.4.3/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/alpine/3.4.3/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/dir.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/dir.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
+
+  <ItemGroup>
+    <!-- No reference: don't permit reference to the implementation from lib -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/netstandard1.0</TargetPath>
+    </File>
+  </ItemGroup>
+</Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/fedora/23/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/fedora/23/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/fedora/24/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/fedora/24/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/linux/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/linux/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/13.2/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/13.2/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/42.1/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/opensuse/42.1/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/osx/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/osx/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -15,38 +15,14 @@
     <NativeSplittableBinary Include="$(BinDir)libsos.dylib" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.dylib" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
+  <ItemGroup>
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/14.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/14.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Condition="'$(PackagePlatform)'!='arm'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Condition="'$(PackagePlatform)'!='arm'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/16.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/16.04/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Condition="'$(PackagePlatform)' != 'arm'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Condition="'$(PackagePlatform)' != 'arm'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/16.10/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/16.10/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -17,38 +17,15 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
     <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
   <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
     <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -14,20 +14,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <LongNameFiles Include="mscordaccore.dll" />
-    <LongNameFiles Include="sos.dll" />
-  </ItemGroup>
+    <LongNameFileName Include="mscordaccore.dll" />
+    <LongNameFileName Include="sos.dll" />
 
-  <Target Name="CopyLongNamedBinaries" BeforeTargets="CreatePackage">
-    <Copy
-      SourceFiles="@(LongNameFiles -> '$(BinDir)%(Identity)')"
-      DestinationFiles="@(LongNameFiles -> '$(BinDir)%(FileName)$(LongNameSuffix)%(Extension)')">
-    </Copy>
-    <Copy Condition="'$(HasCrossTargetComponents)' == 'true'"
-      SourceFiles="@(LongNameFiles -> '$(BinDir)$(CrossTargetComponentFolder)\%(Identity)')"
-      DestinationFiles="@(LongNameFiles -> '$(BinDir)$(CrossTargetComponentFolder)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')">
-    </Copy>
-  </Target>
+    <ArchitectureSpecificNativeFile Include="@(LongNameFileName -> '$(BinDir)%(FileName)$(LongNameSuffix)%(Extension)')">
+      <LongName>true</LongName>
+      <CopySourcePath>$(BinDir)%(FileName)%(Extension)</CopySourcePath>
+    </ArchitectureSpecificNativeFile>
+
+    <CrossArchitectureSpecificNativeFileAndSymbol Include="@(LongNameFileName -> '$(BinDir)$(CrossTargetComponentFolder)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')">
+      <LongName>true</LongName>
+      <CopySourcePath>$(BinDir)$(CrossTargetComponentFolder)\%(FileName)%(Extension)</CopySourcePath>
+      <TargetPath>tools\$(CrossTargetComponentFolder)_$(PackagePlatform)</TargetPath>
+    </CrossArchitectureSpecificNativeFileAndSymbol>
+  </ItemGroup>
 
   <ItemGroup>
     <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)clretwrc.dll" />
@@ -46,10 +46,6 @@
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\mscordaccore.dll" />
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\mscordbi.dll" />
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\sos.dll" />
-    <File Include="@(LongNameFiles -> '$(BinDir)%(FileName)$(LongNameSuffix)%(Extension)')">
-      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
     <!-- prevent accidental inclusion in AOT projects. -->
     <File Include="$(PlaceholderFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)-aot/lib/netstandard1.0</TargetPath>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <LongNameFiles Include="mscordaccore.dll"/>
-    <LongNameFiles Include="sos.dll"/>
+    <LongNameFiles Include="mscordaccore.dll" />
+    <LongNameFiles Include="sos.dll" />
   </ItemGroup>
 
   <Target Name="CopyLongNamedBinaries" BeforeTargets="CreatePackage">
@@ -46,19 +46,9 @@
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\mscordaccore.dll" />
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\mscordbi.dll" />
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\sos.dll" />
-    <ArchitectureSpecificNativeFile Include="@(ArchitectureSpecificNativeFileAndSymbol)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath> 
-    </File>
-    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
-    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificToolFile)">
-      <TargetPath>tools/$(CrossTargetComponentFolder)_$(PackagePlatform)</TargetPath>
+    <File Include="@(LongNameFiles -> '$(BinDir)%(FileName)$(LongNameSuffix)%(Extension)')">
+      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath>
+      <IsSymbolFile>true</IsSymbolFile>
     </File>
     <!-- prevent accidental inclusion in AOT projects. -->
     <File Include="$(PlaceholderFile)">
@@ -66,30 +56,6 @@
     </File>
     <File Include="$(PlaceholderFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)-aot/native</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <!-- Symbols -->
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFileAndSymbol -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificLibFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificToolFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <ArchitectureSpecificNativeSymbol Include="@(LongNameFiles -> '$(BinDir)%(FileName)$(LongNameSuffix)%(Extension)')" />
-    <AdditionalLibPackageExcludes Include="@(LongNameFiles -> 'runtimes\$(PackageTargetRuntime)\native\%(FileName)$(LongNameSuffix)%(Extension)')" />
-    <CrossArchitectureSpecificNativeSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" 
-                                           Include="@(CrossArchitectureSpecificToolFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <CrossArchitectureSpecificNativeSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" 
-                                           Include="@(LongNameFiles -> '$(BinDir)$(CrossTargetComponentFolder)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')" />
-    <AdditionalLibPackageExcludes Condition="'$(HasCrossTargetComponents)' == 'true'" 
-                                  Include="@(LongNameFiles -> 'tools\$(CrossTargetComponentFolder)_$(PackagePlatform)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath> 
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
-    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeSymbol)">
-      <TargetPath>tools\$(CrossTargetComponentFolder)_$(PackagePlatform)</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
     </File>
   </ItemGroup>
 

--- a/src/.nuget/Microsoft.NETCore.TestHost/alpine/3.4.3/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/alpine/3.4.3/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/debian/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/debian/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/fedora/23/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/fedora/23/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/fedora/24/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/fedora/24/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/linux/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/linux/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/opensuse/13.2/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/opensuse/13.2/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/opensuse/42.1/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/opensuse/42.1/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/osx/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/osx/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/rhel/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/rhel/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/ubuntu/14.04/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/ubuntu/14.04/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/ubuntu/16.04/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/ubuntu/16.04/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/ubuntu/16.10/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/ubuntu/16.10/Microsoft.NETCore.TestHost.pkgproj
@@ -9,21 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/win/Microsoft.NETCore.TestHost.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.TestHost/win/Microsoft.NETCore.TestHost.pkgproj
@@ -6,19 +6,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
   </PropertyGroup>
   <ItemGroup>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)CoreRun.exe" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup>
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)CoreRun.exe" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/Microsoft.TargetingPack.Private.CoreCLR/Microsoft.TargetingPack.Private.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.TargetingPack.Private.CoreCLR/Microsoft.TargetingPack.Private.CoreCLR.pkgproj
@@ -7,10 +7,5 @@
     <PackagePlatforms>x64;</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
   </PropertyGroup>
-  <ItemGroup>
-    <File Include="$(BinDir)/System.Private.CoreLib.dll">
-      <TargetPath>lib/netstandard1.0</TargetPath>
-    </File>
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Add path globs specific to native binaries to exclude unnecessary files from packages. -->
+  <Choose>
+    <When Condition="$(PackageTargetRuntime.StartsWith('win'))" />
+    <When Condition="$(PackageTargetRuntime.StartsWith('osx'))">
+      <PropertyGroup>
+        <LibraryFileExtension>.dylib</LibraryFileExtension>
+        <SymbolFileExtension>.dwarf</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <LibraryFileExtension>.so</LibraryFileExtension>
+        <SymbolFileExtension>.dbg</SymbolFileExtension>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <ItemGroup Condition="'$(SymbolFileExtension)' != ''">
+    <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolFileExtension)"/>
+  </ItemGroup>
+  <ItemGroup Condition="'$(LibraryFileExtension)' != ''">
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A$(LibraryFileExtension)"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.a"/>
+    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <NativeWithSymbolFile Include="@(NativeSplittableBinary);
+                                   @(NativeBinary);
+                                   @(ArchitectureSpecificNativeFile);
+                                   @(ArchitectureSpecificNativeFileAndSymbol)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </NativeWithSymbolFile>
+    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
+    <NativeWithSymbolFile Include="@(ArchitectureSpecificLibFile)">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
+    </NativeWithSymbolFile>
+    <NativeWithSymbolFile Include="@(ArchitectureSpecificToolFile)">
+      <TargetPath>tools</TargetPath>
+    </NativeWithSymbolFile>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(HasCrossTargetComponents)'=='true'">
+    <NativeWithSymbolFile Include="@(CrossArchitectureSpecificNativeFileAndSymbol)">
+      <TargetPath Condition="'%(TargetPath)'==''">runtimes/$(CrossTargetComponentFolder)_$(PackagePlatform)/native</TargetPath>
+    </NativeWithSymbolFile>
+    <NativeWithSymbolFile Include="@(CrossArchitectureSpecificToolFile)">
+      <TargetPath>tools/$(CrossTargetComponentFolder)_$(PackagePlatform)</TargetPath>
+    </NativeWithSymbolFile>
+  </ItemGroup>
+
+  <ItemGroup >
+    <File Include="@(NativeWithSymbolFile)" />
+  </ItemGroup>
+
+  <Target Name="CopyLongNamedBinaries" BeforeTargets="CreatePackage">
+    <ItemGroup>
+      <LongNameFile Include="@(NativeWithSymbolFile)"
+                    Condition="'%(NativeWithSymbolFile.LongName)'=='true'" />
+
+      <!-- Only include long-name DAC/SOS in symbol package. -->
+      <AdditionalLibPackageExcludes Include="@(LongNameFile -> '%2A%2A\%(Filename)%(Extension)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="%(CopySourcePath)"
+          DestinationFiles="@(LongNameFile)" />
+  </Target>
+
+  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
+    <ItemGroup>
+      <!-- On Windows, trim ".dll" before adding ".pdb". -->
+      <WindowsNativeFile Include="@(NativeWithSymbolFile)"
+                         Condition="'%(NativeWithSymbolFile.Extension)'=='.dll' OR '%(NativeWithSymbolFile.Extension)'=='.exe'" />
+      <NativeDllFileWithoutExtension Include="@(WindowsNativeFile -> '%(RootDir)%(Directory)PDB\%(Filename)')" />
+      <WindowsSymbolFile Include="@(NativeDllFileWithoutExtension -> '%(Identity).pdb')" />
+
+      <!--
+        Search for all xplat symbol file extensions on every xplat native binary. Some binaries have
+        no ".so" or ".dylib" extension, so we can't tell which convention its symbol files would
+        use. On xplat, the symbol extension is simply appended. 
+      -->
+      <NonWindowsNativeFile Include="@(NativeWithSymbolFile)"
+                            Exclude="@(WindowsNativeFile)" />
+
+      <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity).dbg')" />
+      <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity).dwarf')" />
+
+      <ExistingWindowsSymbolFile Include="@(WindowsSymbolFile)" Condition="Exists('%(Identity)')" />
+      <ExistingNonWindowsSymbolFile Include="@(NonWindowsSymbolFile)" Condition="Exists('%(Identity)') AND '$(SkipPackagingXplatSymbols)'!='true'" />
+
+      <File Include="@(ExistingWindowsSymbolFile);@(ExistingNonWindowsSymbolFile)">
+        <IsSymbolFile>true</IsSymbolFile>
+      </File>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <NeedsPlaceholderPdb Condition="'@(ExistingNonWindowsSymbolFile)'!='' AND '@(ExistingWindowsSymbolFile)'==''">true</NeedsPlaceholderPdb>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <File Include="$(MSBuildThisFileDirectory)\_.pdb"
+            Condition="'$(NeedsPlaceholderPdb)'=='true' AND '$(PackageTargetRuntime)'!=''">
+        <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+        <IsSymbolFile>true</IsSymbolFile>
+      </File>
+    </ItemGroup>
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
See https://github.com/dotnet/corefx/pull/15440. This adds a `stripSymbols` option that can be toggled independently of the build configuration, for the build-from-source effort. I'll need to make a build definition change to turn symbol stripping back on once this gets merged. /cc @ellismg 

This includes a pkgproj refactor. The current CoreCLR packaging system ties the symbol items to whether the build is Release mode or not, and that causes errors with the new independent option. The main goal of the refactor is to make the package system flexibly detect symbols, and it also significantly reduces pkgproj duplication to make more improvements possible in the future.

I tested out the outputs of win-x64, win-arm64, osx, ubuntu16.10, and alpine3.4.3, and they look reasonable: https://gist.github.com/dagood/74c5e40fbaaa2fe9ecf3765f381cfe80. (Note: I did those diffs before rebasing over https://github.com/dotnet/coreclr/pull/9313, FYI @jkotas.) A few intended differences:

 * No `libSystem.Globalization.Native.a` in symbol packages. To be consistent, that non-symbol file shouldn't have been there anyway. (Binaries and symbols should actually both be kept in the symbol packages, but I'll leave that for another time to keep the diff smaller.)
 * Includes `tools/crossgen.dbg/dwarf` in the symbol packages. Seems like it was just missed.
 * Removes `_.pdb` from some windows symbol packages, where it shouldn't be needed.
 * Move some symbol files from `runtimes/win10-arm64/native` and `runtimes/win7-x64/native` to be next to their respective binaries. Will make it slightly easier to find these, if someone's looking manually.

I tried to separate it into reasonable commits, for now. `Refactor all pkgproj files: centralize logic` was tooled. PTAL @wtgodbe @gkhanna79 