### PR TITLE
Remove duplicate attributes from CoreLib that are in CoreFX

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6601,36 +6601,6 @@
     <Type Name="System.Runtime.InteropServices.AllowReversePInvokeCallsAttribute">
       <Member Name="#ctor" />
     </Type>
-    <Type Name="System.Runtime.InteropServices.AutomationProxyAttribute">
-      <Member Name="#ctor(System.Boolean)" />
-      <Member Name="get_Value" />
-      <Member MemberType="Property" Name="Value" />      
-    </Type>
-   <Type Name="System.Runtime.InteropServices.ComAliasNameAttribute">
-      <Member Name="#ctor(System.String)" />
-      <Member Name="get_Value" />
-      <Member MemberType="Property" Name="Value" />      
-    </Type>
-    <Type Name="System.Runtime.InteropServices.ComCompatibleVersionAttribute">
-      <Member Name="#ctor(System.Int32,System.Int32,System.Int32,System.Int32)" />
-      <Member Name="get_MajorVersion" />
-      <Member MemberType="Property" Name="MajorVersion" />      
-      <Member Name="get_MinorVersion" />
-      <Member MemberType="Property" Name="MinorVersion" />      
-      <Member Name="get_BuildNumber" />
-      <Member MemberType="Property" Name="BuildNumber" />      
-      <Member Name="get_RevisionNumber" />
-      <Member MemberType="Property" Name="RevisionNumber" />      
-    </Type>    
-    <Type Name="System.Runtime.InteropServices.ComConversionLossAttribute">
-      <Member Name="#ctor" />
-    </Type>
-    <Type Name="System.Runtime.InteropServices.ComRegisterFunctionAttribute">
-      <Member Name="#ctor" />
-    </Type>
-    <Type Name="System.Runtime.InteropServices.ComUnregisterFunctionAttribute">
-      <Member Name="#ctor" />
-    </Type>
     <Type Name="System.Runtime.InteropServices.ExternalException">
       <Member Name="#ctor" />
       <Member Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
@@ -6692,11 +6662,6 @@
     <Type Name="System.Runtime.InteropServices.ICustomFactory">
       <Member Name="CreateInstance(System.Type)" />
     </Type>
-    <Type Name="System.Runtime.InteropServices.ImportedFromTypeLibAttribute">
-      <Member Name="#ctor(System.String)" />
-      <Member Name="get_Value" />
-      <Member MemberType="Property" Name="Value" />      
-    </Type>    
     <Type Name="System.Runtime.InteropServices.InAttribute">
       <Member Name="#ctor" />
     </Type>
@@ -6733,7 +6698,7 @@
     <Type Name="System.Runtime.InteropServices.LCIDConversionAttribute">
       <Member Name="#ctor(System.Int32)" />
       <Member Name="get_Value" />
-      <Member MemberType="Property" Name="Value" />      
+      <Member MemberType="Property" Name="Value" />
     </Type>
     <Type Name="System.Runtime.InteropServices.Marshal">
       <Member MemberType="Field" Name="SystemDefaultCharSize" />
@@ -6908,13 +6873,6 @@
       <Member MemberType="Field" Name="SafeArraySubType" />
       <Member MemberType="Field" Name="SafeArrayUserDefinedSubType" />
     </Type>
-    <Type Name="System.Runtime.InteropServices.ManagedToNativeComInteropStubAttribute">
-      <Member Name="#ctor(System.Type,System.String)" />
-      <Member Name="get_ClassType" />
-      <Member MemberType="Property" Name="ClassType" />      
-      <Member Name="get_MethodName" />
-      <Member MemberType="Property" Name="MethodName" />      
-    </Type>       
     <Type Name="System.Runtime.InteropServices.MarshalDirectiveException" >
       <Member Name="#ctor" />
       <Member Name="#ctor(System.String)" />
@@ -6935,17 +6893,10 @@
     <Type Name="System.Runtime.InteropServices.PreserveSigAttribute">
       <Member Name="#ctor" />
     </Type>
-    <Type Name="System.Runtime.InteropServices.PrimaryInteropAssemblyAttribute">
-      <Member Name="#ctor(System.Int32,System.Int32)" />
-      <Member Name="get_MajorVersion" />
-      <Member MemberType="Property" Name="MajorVersion" />
-      <Member Name="get_MinorVersion" />
-      <Member MemberType="Property" Name="MinorVersion" />
-    </Type>    
     <Type Name="System.Runtime.InteropServices.ProgIdAttribute">
       <Member Name="#ctor(System.String)" />
       <Member Name="get_Value" />
-      <Member MemberType="Property" Name="Value" />      
+      <Member MemberType="Property" Name="Value" />
     </Type>
     <Type Name="System.Runtime.InteropServices.SafeHandle">
       <Member MemberType="Field" Name="handle" />
@@ -6966,18 +6917,6 @@
       <Member MemberType="Property" Name="IsClosed" />
       <Member MemberType="Property" Name="IsInvalid" />
     </Type>
-   <Type Name="System.Runtime.InteropServices.TypeLibImportClassAttribute">
-      <Member Name="#ctor(System.Type)" />
-      <Member Name="get_Value" />
-      <Member MemberType="Property" Name="Value" />
-    </Type>
-    <Type Name="System.Runtime.InteropServices.TypeLibVersionAttribute">
-      <Member Name="#ctor(System.Int32,System.Int32)" />
-      <Member Name="get_MajorVersion" />
-      <Member MemberType="Property" Name="MajorVersion" />
-      <Member Name="get_MinorVersion" />
-      <Member MemberType="Property" Name="MinorVersion" />
-    </Type>       
     <Type Name="System.Runtime.InteropServices.CriticalHandle">
       <Member MemberType="Field" Name="handle" />
       <Member MemberType="Field" Name="_stackTrace" Flavor="chk,dbg" />
@@ -11144,13 +11083,6 @@
       <Member Name="#ctor(System.Boolean)" />
       <Member MemberType="Property" Name="BestFitMapping" />
       <Member Name="get_BestFitMapping" />
-    </Type>
-    <Type Name="System.Runtime.InteropServices.ComEventInterfaceAttribute">
-      <Member Name="#ctor(System.Type,System.Type)" />
-      <Member MemberType="Property" Name="EventProvider" />
-      <Member MemberType="Property" Name="SourceInterface" />
-      <Member Name="get_EventProvider" />
-      <Member Name="get_SourceInterface" />
     </Type>
     <Type Name="System.Runtime.InteropServices.ComEventsHelper">
       <Member Name="Combine(System.Object,System.Guid,System.Int32,System.Delegate)" />

--- a/src/mscorlib/ref/mscorlib.cs
+++ b/src/mscorlib/ref/mscorlib.cs
@@ -10339,13 +10339,6 @@ namespace System.Runtime.InteropServices
     {
         public AllowReversePInvokeCallsAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1029), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class AutomationProxyAttribute : System.Attribute
-    {
-        public AutomationProxyAttribute(bool val) { }
-        public bool Value { get { throw null; } }
-    }    
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ArrayWithOffset
@@ -10416,43 +10409,12 @@ namespace System.Runtime.InteropServices
         public CoClassAttribute(System.Type coClass) { }
         public System.Type CoClass { get { throw null; } }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(10624), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class ComAliasNameAttribute : System.Attribute
-    {
-        public ComAliasNameAttribute(String val) { }
-        public String Value { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class ComCompatibleVersionAttribute : System.Attribute
-    {
-        public ComCompatibleVersionAttribute(System.Int32 major, System.Int32 minor, System.Int32 build, System.Int32 revision) { }
-        public System.Int32 MajorVersion { get { throw null; } }
-        public System.Int32 MinorVersion { get { throw null; } }
-        public System.Int32 BuildNumber { get { throw null;} }
-        public System.Int32 RevisionNumber { get { throw null; } }
-    }    
-    [System.AttributeUsageAttribute((System.AttributeTargets)(32767), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class ComConversionLossAttribute : Attribute
-    {
-        public ComConversionLossAttribute() { }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class ComDefaultInterfaceAttribute : System.Attribute
     {
         public ComDefaultInterfaceAttribute(System.Type defaultInterface) { }
         public System.Type Value { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1024), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class ComEventInterfaceAttribute : System.Attribute
-    {
-        public ComEventInterfaceAttribute(System.Type SourceInterface, System.Type EventProvider) { }
-        public System.Type EventProvider { get { throw null; } }
-        public System.Type SourceInterface { get { throw null; } }
     }
     public static partial class ComEventsHelper
     {
@@ -10493,12 +10455,6 @@ namespace System.Runtime.InteropServices
         PropGet = 1,
         PropSet = 2,
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class ComRegisterFunctionAttribute : Attribute
-    {
-        public ComRegisterFunctionAttribute() { }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited=true)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class ComSourceInterfacesAttribute : System.Attribute
@@ -10509,12 +10465,6 @@ namespace System.Runtime.InteropServices
         public ComSourceInterfacesAttribute(System.Type sourceInterface1, System.Type sourceInterface2, System.Type sourceInterface3) { }
         public ComSourceInterfacesAttribute(System.Type sourceInterface1, System.Type sourceInterface2, System.Type sourceInterface3, System.Type sourceInterface4) { }
         public string Value { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class ComUnregisterFunctionAttribute : Attribute
-    {
-        public ComUnregisterFunctionAttribute() { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(5597), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -10716,13 +10666,6 @@ namespace System.Runtime.InteropServices
         [System.Security.SecurityCriticalAttribute]
         System.Runtime.InteropServices.CustomQueryInterfaceResult GetInterface(ref System.Guid iid, out System.IntPtr ppv);
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class ImportedFromTypeLibAttribute : System.Attribute
-    {
-        public ImportedFromTypeLibAttribute(String val) { }
-        public String Value { get { throw null; } }
-    }   
     [System.AttributeUsageAttribute((System.AttributeTargets)(2048), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class InAttribute : System.Attribute
@@ -10766,7 +10709,7 @@ namespace System.Runtime.InteropServices
     {
         public LCIDConversionAttribute(System.Int32 val) { }
         public System.Int32 Value { get { throw null; } }
-    }    
+    }
     [System.Security.SecurityCriticalAttribute]
     public static partial class Marshal
     {
@@ -11062,14 +11005,6 @@ namespace System.Runtime.InteropServices
         [System.Security.SecurityCriticalAttribute]
         public static void ZeroFreeGlobalAllocUnicode(System.IntPtr s) { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(64), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class ManagedToNativeComInteropStubAttribute : System.Attribute
-    {
-        public ManagedToNativeComInteropStubAttribute(System.Type classType, System.String methodName) { }
-        public System.Type ClassType { get { throw null; } }
-        public System.String MethodName { get { throw null; } }
-    }    
     [System.AttributeUsageAttribute((System.AttributeTargets)(10496), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class MarshalAsAttribute : System.Attribute
@@ -11122,21 +11057,13 @@ namespace System.Runtime.InteropServices
     {
         public PreserveSigAttribute() { }
     }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false, AllowMultiple = true)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class PrimaryInteropAssemblyAttribute : System.Attribute
-    {
-        public PrimaryInteropAssemblyAttribute(System.Int32 major, System.Int32 minor) { }
-        public System.Int32 MajorVersion { get { throw null; } }
-        public System.Int32 MinorVersion { get { throw null; } }
-    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(4), Inherited=false)]
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class ProgIdAttribute : System.Attribute
     {
         public ProgIdAttribute(String val) { }
         public String Value { get { throw null; } }
-    }  
+    }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public partial class SafeArrayRankMismatchException : System.SystemException
     {
@@ -11230,21 +11157,6 @@ namespace System.Runtime.InteropServices
         public TypeIdentifierAttribute(string scope, string identifier) { }
         public string Identifier { get { throw null; } }
         public string Scope { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1024), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class TypeLibImportClassAttribute : System.Attribute
-    {
-        public TypeLibImportClassAttribute(System.Type val) { }
-        public String Value { get { throw null; } }
-    }
-    [System.AttributeUsageAttribute((System.AttributeTargets)(1), Inherited=false)]
-    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
-    public sealed partial class TypeLibVersionAttribute : System.Attribute
-    {
-        public TypeLibVersionAttribute(System.Int32 major, System.Int32 minor) { }
-        public System.Int32 MajorVersion { get { throw null; } }
-        public System.Int32 MinorVersion { get { throw null; } }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public sealed partial class UnknownWrapper

--- a/src/mscorlib/src/System/Internal.cs
+++ b/src/mscorlib/src/System/Internal.cs
@@ -19,15 +19,7 @@ using System.StubHelpers;
 using System.Threading.Tasks;
 
 #if FEATURE_COMINTEROP
-
 using System.Runtime.InteropServices.WindowsRuntime;
-
-[assembly:Guid("BED7F4EA-1A96-11d2-8F08-00A0C9A6186D")]
-
-// The following attribute are required to ensure COM compatibility.
-[assembly:System.Runtime.InteropServices.ComCompatibleVersion(1, 0, 3300, 0)]
-[assembly:System.Runtime.InteropServices.TypeLibVersion(2, 4)]
-
 #endif // FEATURE_COMINTEROP
 
 [assembly:DefaultDependencyAttribute(LoadHint.Always)]

--- a/src/mscorlib/src/System/Runtime/InteropServices/Attributes.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Attributes.cs
@@ -148,19 +148,7 @@ namespace System.Runtime.InteropServices{
         public bool Value { get { return _val; } }
     }
 
-    [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class TypeLibImportClassAttribute : Attribute
-    {
-        internal String _importClassName;
-        public TypeLibImportClassAttribute(Type importClass)
-        {
-            _importClassName = importClass.ToString();
-        }
-        public String Value { get { return _importClassName; } }
-    }
-
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)] 
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class LCIDConversionAttribute : Attribute
     {
@@ -169,28 +157,10 @@ namespace System.Runtime.InteropServices{
         {
             _val = lcid;
         }
-        public int Value { get {return _val;} } 
+        public int Value { get {return _val;} }
     }
 
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)] 
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class ComRegisterFunctionAttribute : Attribute
-    {
-        public ComRegisterFunctionAttribute()
-        {
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)] 
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class ComUnregisterFunctionAttribute : Attribute
-    {
-        public ComUnregisterFunctionAttribute()
-        {
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)] 
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class ProgIdAttribute : Attribute
     {
@@ -199,46 +169,7 @@ namespace System.Runtime.InteropServices{
         {
             _val = progId;
         }
-        public String Value { get {return _val;} }  
-    }
-    
-    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)] 
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class ImportedFromTypeLibAttribute : Attribute
-    {
-        internal String _val;
-        public ImportedFromTypeLibAttribute(String tlbFile)
-        {
-            _val = tlbFile;
-        }
         public String Value { get {return _val;} }
-    }
-
-    [Obsolete("The IDispatchImplAttribute is deprecated.", false)]
-    [Serializable]
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public enum IDispatchImplType
-    {
-        SystemDefinedImpl   = 0,
-        InternalImpl        = 1,
-        CompatibleImpl      = 2,
-    }
-
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, Inherited = false)] 
-    [Obsolete("This attribute is deprecated and will be removed in a future version.", false)]
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class IDispatchImplAttribute : Attribute
-    {
-        internal IDispatchImplType _val;
-        public IDispatchImplAttribute(IDispatchImplType implType)
-        {
-            _val = implType;
-        }
-        public IDispatchImplAttribute(short implType)
-        {
-            _val = (IDispatchImplType)implType;
-        }
-        public IDispatchImplType Value { get {return _val;} }   
     }
 
     [AttributeUsage(AttributeTargets.Class, Inherited = true)] 
@@ -269,15 +200,6 @@ namespace System.Runtime.InteropServices{
         public String Value { get {return _val;} }  
     }    
 
-    [AttributeUsage(AttributeTargets.All, Inherited = false)] 
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class ComConversionLossAttribute : Attribute
-    {
-        public ComConversionLossAttribute()
-        {
-        }
-    }
-    
     [Serializable]
     [System.Runtime.InteropServices.ComVisible(true)]
     public enum VarEnum
@@ -849,47 +771,6 @@ namespace System.Runtime.InteropServices{
         public int Value { get { return _val; } }
     }
 
-    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)] 
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class ComAliasNameAttribute : Attribute
-    {
-        internal String _val;
-        public ComAliasNameAttribute(String alias)
-        {
-            _val = alias;
-        }
-        public String Value { get {return _val;} }  
-    }    
-
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Interface, Inherited = false)] 
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class AutomationProxyAttribute : Attribute
-    {
-        internal bool _val;
-        public AutomationProxyAttribute(bool val)
-        {
-            _val = val;
-        }
-        public bool Value { get {return _val;} }
-    }
-
-    [AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = true)] 
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class PrimaryInteropAssemblyAttribute : Attribute
-    {
-        internal int _major;
-        internal int _minor;
-        
-        public PrimaryInteropAssemblyAttribute(int major, int minor)
-        {
-            _major = major;
-            _minor = minor;
-        }
-        
-        public int MajorVersion { get {return _major;} }
-        public int MinorVersion { get {return _minor;} }
-    }
-
     [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
     [System.Runtime.InteropServices.ComVisible(true)]
     public sealed class CoClassAttribute : Attribute
@@ -902,63 +783,6 @@ namespace System.Runtime.InteropServices{
         }
 
         public Type CoClass { get { return _CoClass; } }
-    }
-
-    [AttributeUsage(AttributeTargets.Interface, Inherited = false)]
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class ComEventInterfaceAttribute : Attribute
-    {
-        internal Type _SourceInterface;
-        internal Type _EventProvider;
-        
-        public ComEventInterfaceAttribute(Type SourceInterface, Type EventProvider)
-        {
-            _SourceInterface = SourceInterface;
-            _EventProvider = EventProvider;
-        }
-
-        public Type SourceInterface { get {return _SourceInterface;} }       
-        public Type EventProvider { get {return _EventProvider;} }
-    }
-
-    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)] 
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class TypeLibVersionAttribute : Attribute
-    {
-        internal int _major;
-        internal int _minor;
-        
-        public TypeLibVersionAttribute(int major, int minor)
-        {
-            _major = major;
-            _minor = minor;
-        }
-        
-        public int MajorVersion { get {return _major;} }
-        public int MinorVersion { get {return _minor;} }
-    }
-
-    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)] 
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class ComCompatibleVersionAttribute : Attribute
-    {
-        internal int _major;
-        internal int _minor;
-        internal int _build;
-        internal int _revision;
-        
-        public ComCompatibleVersionAttribute(int major, int minor, int build, int revision)
-        {
-            _major = major;
-            _minor = minor;
-            _build = build;
-            _revision = revision;
-        }
-        
-        public int MajorVersion { get {return _major;} }
-        public int MinorVersion { get {return _minor;} }
-        public int BuildNumber { get {return _build;} }
-        public int RevisionNumber { get {return _revision;} }
     }
 
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
@@ -989,33 +813,5 @@ namespace System.Runtime.InteropServices{
 
         public CharSet CharSet { get { return _CharSet; } }
     }
-
-    [Obsolete("This attribute has been deprecated.  Application Domains no longer respect Activation Context boundaries in IDispatch calls.", false)]
-    [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
-    [System.Runtime.InteropServices.ComVisible(true)]
-    public sealed class SetWin32ContextInIDispatchAttribute : Attribute
-    {
-        public SetWin32ContextInIDispatchAttribute()
-        {
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-    [System.Runtime.InteropServices.ComVisible(false)]
-    public sealed class ManagedToNativeComInteropStubAttribute : Attribute
-    {
-        internal Type _classType;
-        internal String _methodName;
-
-        public ManagedToNativeComInteropStubAttribute(Type classType, String methodName)
-        {
-            _classType = classType;
-            _methodName = methodName;
-        }
-
-        public Type ClassType { get { return _classType; } }
-        public String MethodName { get { return _methodName; } }
-    }    
-
 }
 


### PR DESCRIPTION
Couldn't remove LCIDConversionAttribute as it is being used in mscorlib.

@jkotas @tijoytom 