### PR TITLE
Remove cross appdomains cultures checks

### DIFF
--- a/src/mscorlib/src/System.Private.CoreLib.txt
+++ b/src/mscorlib/src/System.Private.CoreLib.txt
@@ -1052,7 +1052,6 @@ InvalidOperation_CantCancelCtrlBreak = Applications may not prevent control-brea
 InvalidOperation_CalledTwice = The method cannot be called twice on the same instance.
 InvalidOperation_CollectionCorrupted = A prior operation on this collection was interrupted by an exception. Collection's state is no longer trusted.
 InvalidOperation_CriticalTransparentAreMutuallyExclusive = SecurityTransparent and SecurityCritical attributes cannot be applied to the assembly scope at the same time.
-InvalidOperation_SubclassedObject = Cannot set sub-classed {0} object to {1} object.
 InvalidOperation_ExceptionStateCrossAppDomain = Thread.ExceptionState cannot access an ExceptionState from a different AppDomain.
 InvalidOperation_DebuggerLaunchFailed = Debugger unable to launch.
 InvalidOperation_ApartmentStateSwitchFailed = Failed to set the specified COM apartment state.

--- a/src/mscorlib/src/System/Globalization/CultureInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CultureInfo.cs
@@ -366,25 +366,6 @@ namespace System.Globalization {
         }
 #endif // FEATURE_USE_LCID
 
-        //
-        // CheckDomainSafetyObject throw if the object is customized object which cannot be attached to 
-        // other object (like CultureInfo or DateTimeFormatInfo).
-        //
-
-        internal static void CheckDomainSafetyObject(Object obj, Object container)
-        {
-            if (obj.GetType().Assembly != typeof(System.Globalization.CultureInfo).Assembly) {
-                
-                throw new InvalidOperationException(
-                            String.Format(
-                                CultureInfo.CurrentCulture, 
-                                Environment.GetResourceString("InvalidOperation_SubclassedObject"), 
-                                obj.GetType(),
-                                container.GetType()));
-            }
-            Contract.EndContractBlock();
-        }
-
 #region Serialization
         // We need to store the override from the culture data record.
         private bool    m_useUserOverride;
@@ -417,21 +398,6 @@ namespace System.Globalization {
             }
 #endif
             m_isInherited = (this.GetType() != typeof(System.Globalization.CultureInfo));
-
-            // in case we have non customized CultureInfo object we shouldn't allow any customized object  
-            // to be attached to it for cross app domain safety.
-            if (this.GetType().Assembly == typeof(System.Globalization.CultureInfo).Assembly)
-            {
-                if (textInfo != null)
-                {
-                    CheckDomainSafetyObject(textInfo, this);
-                }
-                
-                if (compareInfo != null)
-                {
-                    CheckDomainSafetyObject(compareInfo, this);
-                }
-            }
         }
 
 #if FEATURE_USE_LCID

--- a/src/mscorlib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -408,10 +408,6 @@ namespace System.Globalization {
                 calendar = (Calendar) GregorianCalendar.GetDefaultInstance().Clone();
                 calendar.SetReadOnlyState(m_isReadOnly);
             }
-            else
-            {
-                CultureInfo.CheckDomainSafetyObject(calendar, this);
-            }
             InitializeOverridableProperties(m_cultureData, calendar.ID);
 
             //
@@ -586,12 +582,6 @@ namespace System.Globalization {
                 if (value == calendar) {
                     return;
                 }
-
-                //
-                // Because the culture is agile object which can be attached to a thread and then thread can travel
-                // to another app domain then we prevent attaching any customized object to culture that we cannot contol.
-                //
-                CultureInfo.CheckDomainSafetyObject(value, this);
 
                 for (int i = 0; i < this.OptionalCalendars.Length; i++)
                 {


### PR DESCRIPTION
In the ful framework, CultureInfo and other globalization objects are marked as agile which means it can cross the appdomains. In coreclr we don't have multiple appdomains anymore so these checks are not really needed.
removing these checks will make coreclr consistent when running on Windows and other OS's

Fixes #9250