### PR TITLE
Get call arg value numbers from late args

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -6697,16 +6697,7 @@ Compiler::NodeToIntMap* Compiler::FindReachableNodesInNodeTestData()
                         if (arg->gtFlags & GTF_LATE_ARG)
                         {
                             // Find the corresponding late arg.
-                            GenTreePtr lateArg = nullptr;
-                            for (unsigned j = 0; j < call->fgArgInfo->ArgCount(); j++)
-                            {
-                                if (call->fgArgInfo->ArgTable()[j]->argNum == i)
-                                {
-                                    lateArg = call->fgArgInfo->ArgTable()[j]->node;
-                                    break;
-                                }
-                            }
-                            assert(lateArg != nullptr);
+                            GenTreePtr lateArg = call->fgArgInfo->GetLateArg(i);
                             if (GetNodeTestData()->Lookup(lateArg, &tlAndN))
                             {
                                 reachable->Set(lateArg, 0);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1342,6 +1342,9 @@ public:
     {
         return argsComplete;
     }
+
+    // Get the late arg for arg at position argIndex.  Caller must ensure this position has a late arg.
+    GenTreePtr GetLateArg(unsigned argIndex);
 };
 
 #ifdef DEBUG

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2431,6 +2431,22 @@ void fgArgInfo::EvalArgsToTemps()
 #endif
 }
 
+// Get the late arg for arg at position argIndex.
+// argIndex - 0-based position to get late arg for.
+//            Caller must ensure this position has a late arg.
+GenTreePtr fgArgInfo::GetLateArg(unsigned argIndex)
+{
+    for (unsigned j = 0; j < this->ArgCount(); j++)
+    {
+        if (this->ArgTable()[j]->argNum == argIndex)
+        {
+            return this->ArgTable()[j]->node;
+        }
+    }
+    // Caller must ensure late arg exists.
+    unreached();
+}
+
 void fgArgInfo::RecordStkLevel(unsigned stkLvl)
 {
     assert(!IsUninitialized(stkLvl));

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -6549,9 +6549,6 @@ void Compiler::fgValueNumberTree(GenTreePtr tree, bool evalAsgLhsInd)
 
                 case GT_JTRUE:
                 case GT_LIST:
-#ifndef LEGACY_BACKEND
-                case GT_FIELD_LIST:
-#endif // !LEGACY_BACKEND
                     // These nodes never need to have a ValueNumber
                     tree->gtVNPair.SetBoth(ValueNumStore::NoVN);
                     break;

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -6975,16 +6975,7 @@ void Compiler::fgValueNumberCall(GenTreeCall* call)
         if (arg->OperGet() == GT_ARGPLACE)
         {
             // Find the corresponding late arg.
-            GenTreePtr lateArg = nullptr;
-            for (unsigned j = 0; j < call->fgArgInfo->ArgCount(); j++)
-            {
-                if (call->fgArgInfo->ArgTable()[j]->argNum == i)
-                {
-                    lateArg = call->fgArgInfo->ArgTable()[j]->node;
-                    break;
-                }
-            }
-            assert(lateArg != nullptr);
+            GenTreePtr lateArg = call->fgArgInfo->GetLateArg(i);
             assert(lateArg->gtVNPair.BothDefined());
             arg->gtVNPair   = lateArg->gtVNPair;
             updatedArgPlace = true;


### PR DESCRIPTION
When an arg has an associated late arg, take its value number from
the late arg (which represents the value) rather than the other one
(which represents argument setup).

This fixes the issue that is blocking #9169.

This change also includes a little cleanup of some related code.