### PR TITLE
Fix incorrect cast in gtFoldExprConst

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -13410,15 +13410,10 @@ GenTreePtr Compiler::gtFoldExprConst(GenTreePtr tree)
 #endif
 
 #ifdef _TARGET_64BIT_
-            // we need to properly re-sign-extend or truncate as needed.
-            if (tree->gtFlags & GTF_UNSIGNED)
-            {
-                i1 = UINT32(i1);
-            }
-            else
-            {
-                i1 = INT32(i1);
-            }
+            // Some operations are performed as 64 bit instead of 32 bit so the upper 32 bits
+            // need to be discarded. Since constant values are stored as ssize_t and the node
+            // has TYP_INT the result needs to be sign extended rather than zero extended.
+            i1 = INT32(i1);
 #endif // _TARGET_64BIT_
 
             /* Also all conditional folding jumps here since the node hanging from

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -190,9 +190,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\perf\doublealign\Locals\*">
             <Issue>8418</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_377155\DevDiv_377155\*">
-            <Issue>9282</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are x86 failures -->

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -79,4 +79,3 @@ Loader/classloader/TypeGeneratorTests/TypeGeneratorTest681/Generated681/Generate
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest682/Generated682/Generated682.sh
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest683/Generated683/Generated683.sh
 JIT/opt/perf/doublealign/Locals/Locals.sh
-JIT/Regression/JitBlue/DevDiv_377155/DevDiv_377155/DevDiv_377155.sh


### PR DESCRIPTION
The fact that an operation is unsigned affects the operation itself but that doesn't mean that the result of the operation is also unsigned. Constants are stored as `ssize_t` and the node type is `TYP_INT` so the result has to be sign extended, not zero extended.

Otherwise code that uses the return of `IconValue()` without first narrowing it to `int` will behave incorrectly. Such code does exists, even `gtFoldExprConst` does this when folding shift operations:

```C#
uint a = uint.MaxValue;
uint b = 0;
int r = (int)checked(a + b);
Console.WriteLine((r >> 2).ToString("X"));
```

The above code prints 3FFFFFFF instead of the expected FFFFFFFF.

This also makes `gtFoldExprConst` consistent with `ValueNumStore::EvalFuncForConstantArgs` which evaluates `TYP_INT` nodes as `int` and then casts to `ssize_t`.

Fixes #9282