### PR TITLE
Remove internal self-replicating support from Tasks

### DIFF
--- a/src/mscorlib/src/System/Threading/Tasks/TaskFactory.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskFactory.cs
@@ -225,7 +225,7 @@ namespace System.Threading.Tasks
                       TaskCreationOptions.PreferFairness |
                       TaskCreationOptions.RunContinuationsAsynchronously)) != 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(creationOptions));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.creationOptions);
             }
             Contract.EndContractBlock();
         }
@@ -1597,7 +1597,7 @@ namespace System.Threading.Tasks
                       TaskCreationOptions.PreferFairness |
                       TaskCreationOptions.LongRunning)) != 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(creationOptions));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.creationOptions);
             }
         }
 

--- a/src/mscorlib/src/System/Threading/Tasks/future.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/future.cs
@@ -341,16 +341,10 @@ namespace System.Threading.Tasks
         /// <param name="cancellationToken">The CancellationToken for the task.</param>
         /// <param name="creationOptions">Options to control the future's behavior.</param>
         /// <param name="internalOptions">Internal options to control the future's behavior.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="creationOptions"/> argument specifies
-        /// a SelfReplicating <see cref="Task{TResult}"/>, which is illegal."/>.</exception>
         internal Task(Func<TResult> valueSelector, Task parent, CancellationToken cancellationToken,
             TaskCreationOptions creationOptions, InternalTaskOptions internalOptions, TaskScheduler scheduler) :
             base(valueSelector, null, parent, cancellationToken, creationOptions, internalOptions, scheduler)
         {
-            if ((internalOptions & InternalTaskOptions.SelfReplicating) != 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.creationOptions, ExceptionResource.TaskT_ctor_SelfReplicating);
-            }
         }
 
         internal Task(
@@ -371,16 +365,10 @@ namespace System.Threading.Tasks
         /// <param name="scheduler">The task scheduler which will be used to execute the future.</param>
         /// <param name="creationOptions">Options to control the future's behavior.</param>
         /// <param name="internalOptions">Internal options to control the future's behavior.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="creationOptions"/> argument specifies
-        /// a SelfReplicating <see cref="Task{TResult}"/>, which is illegal."/>.</exception>
         internal Task(Delegate valueSelector, object state, Task parent, CancellationToken cancellationToken,
             TaskCreationOptions creationOptions, InternalTaskOptions internalOptions, TaskScheduler scheduler) :
             base(valueSelector, state, parent, cancellationToken, creationOptions, internalOptions, scheduler)
         {
-            if ((internalOptions & InternalTaskOptions.SelfReplicating) != 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.creationOptions, ExceptionResource.TaskT_ctor_SelfReplicating);
-            }
         }
 
 
@@ -395,10 +383,6 @@ namespace System.Threading.Tasks
             if (scheduler == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.scheduler);
-            }
-            if ((internalOptions & InternalTaskOptions.SelfReplicating) != 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.creationOptions, ExceptionResource.TaskT_ctor_SelfReplicating);
             }
 
             // Create and schedule the future.
@@ -419,10 +403,6 @@ namespace System.Threading.Tasks
             if (scheduler == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.scheduler);
-            }
-            if ((internalOptions & InternalTaskOptions.SelfReplicating) != 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.creationOptions, ExceptionResource.TaskT_ctor_SelfReplicating);
             }
 
             // Create and schedule the future.

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -451,7 +451,6 @@ namespace System {
         Task_ContinueWith_NotOnAnything,
         Task_ContinueWith_ESandLR,
         TaskT_TransitionToFinal_AlreadyCompleted,
-        TaskT_ctor_SelfReplicating,
         TaskCompletionSourceT_TrySetException_NullException,
         TaskCompletionSourceT_TrySetException_NoExceptions,
         InvalidOperation_WrongAsyncResultOrEndCalledMultiple,


### PR DESCRIPTION
In the initial TPL prototype, Tasks had a feature that allowed them to "replicate", meaning to schedule a copy of themselves.  Prior to shipping the initial version, this feature was made internal, as it was deemed unnecessary, but by then the Parallel loops constructs had already been built on top of them.  Now that Parallel no longer depends on this feature (and isn't in CoreLib), we can entirely rip it out.

cc: @kouvel, @AlfredoMS 