### PR TITLE
[x86/Linux] Check PC inside LazyMachState::unwindLazyState loop

### DIFF
--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -1323,6 +1323,8 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
 
         pvControlPc = GetIP(&ctx);
 
+        _ASSERTE(pvControlPc != 0);
+
         if (funCallDepth > 0)
         {
             --funCallDepth;


### PR DESCRIPTION
It is possible that LazyMachState::unwindLazyState falls into infinite loop if pvControlPc is 0 (which may indicate bugs in state capture or unwinding).

This commit adds an assertion inside  LazyMachState::unwindLazyState to prevent such infinite loop.