### PR TITLE
Updating jit/valuenum to properly handle the single-precision versions of the math intrinsics.

### DIFF
--- a/src/jit/utils.h
+++ b/src/jit/utils.h
@@ -638,6 +638,8 @@ public:
     static unsigned __int64 convertDoubleToUInt64(double d);
 
     static double round(double x);
+
+    static float round(float x);
 };
 
 // The CLR requires that critical section locks be initialized via its ClrCreateCriticalSection API...but

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -205,6 +205,7 @@ private:
     int GetConstantInt32(ValueNum argVN);
     INT64 GetConstantInt64(ValueNum argVN);
     double GetConstantDouble(ValueNum argVN);
+    float GetConstantSingle(ValueNum argVN);
 
     // Assumes that all the ValueNum arguments of each of these functions have been shown to represent constants.
     // Assumes that "vnf" is a operator of the appropriate arity (unary for the first, binary for the second).


### PR DESCRIPTION
This resolves https://github.com/dotnet/coreclr/issues/7689