### PR TITLE
[ARM32/Linux] Fix calling convention - stdcall in crossgen

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1456,12 +1456,19 @@ class ICorCompilationDomain
 /*********************************************************************************
  * ICorCompileInfo is the interface for a compiler
  *********************************************************************************/
-
+#if defined(_X86_) and !defined(FEATURE_PAL)
 // Define function pointer ENCODEMODULE_CALLBACK
 typedef DWORD (__stdcall *ENCODEMODULE_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle);
 
 // Define function pointer DEFINETOKEN_CALLBACK
 typedef void (__stdcall *DEFINETOKEN_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle, DWORD index, mdTypeRef* token);
+#else
+// Define function pointer ENCODEMODULE_CALLBACK
+typedef DWORD (*ENCODEMODULE_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle);
+
+// Define function pointer DEFINETOKEN_CALLBACK
+typedef void (*DEFINETOKEN_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle, DWORD index, mdTypeRef* token);
+#endif
 
 typedef HRESULT (__stdcall *CROSS_DOMAIN_CALLBACK)(LPVOID pArgs);
 

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1456,19 +1456,19 @@ class ICorCompilationDomain
 /*********************************************************************************
  * ICorCompileInfo is the interface for a compiler
  *********************************************************************************/
-#if defined(_X86_) and !defined(FEATURE_PAL)
-// Define function pointer ENCODEMODULE_CALLBACK
-typedef DWORD (__stdcall *ENCODEMODULE_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle);
-
-// Define function pointer DEFINETOKEN_CALLBACK
-typedef void (__stdcall *DEFINETOKEN_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle, DWORD index, mdTypeRef* token);
-#else
+#if defined(_X86_) && defined(FEATURE_PAL)
 // Define function pointer ENCODEMODULE_CALLBACK
 typedef DWORD (*ENCODEMODULE_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle);
 
 // Define function pointer DEFINETOKEN_CALLBACK
 typedef void (*DEFINETOKEN_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle, DWORD index, mdTypeRef* token);
-#endif
+#else // !_X86_ || !FEATURE_PAL
+// Define function pointer ENCODEMODULE_CALLBACK
+typedef DWORD (__stdcall *ENCODEMODULE_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle);
+
+// Define function pointer DEFINETOKEN_CALLBACK
+typedef void (__stdcall *DEFINETOKEN_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle, DWORD index, mdTypeRef* token);
+#endif // _X86_ && FEATURE_PAL
 
 typedef HRESULT (__stdcall *CROSS_DOMAIN_CALLBACK)(LPVOID pArgs);
 

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1456,21 +1456,13 @@ class ICorCompilationDomain
 /*********************************************************************************
  * ICorCompileInfo is the interface for a compiler
  *********************************************************************************/
-#if defined(_X86_) && defined(FEATURE_PAL)
 // Define function pointer ENCODEMODULE_CALLBACK
 typedef DWORD (*ENCODEMODULE_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle);
 
 // Define function pointer DEFINETOKEN_CALLBACK
 typedef void (*DEFINETOKEN_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle, DWORD index, mdTypeRef* token);
-#else // !_X86_ || !FEATURE_PAL
-// Define function pointer ENCODEMODULE_CALLBACK
-typedef DWORD (__stdcall *ENCODEMODULE_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle);
 
-// Define function pointer DEFINETOKEN_CALLBACK
-typedef void (__stdcall *DEFINETOKEN_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle, DWORD index, mdTypeRef* token);
-#endif // _X86_ && FEATURE_PAL
-
-typedef HRESULT (__stdcall *CROSS_DOMAIN_CALLBACK)(LPVOID pArgs);
+typedef HRESULT (*CROSS_DOMAIN_CALLBACK)(LPVOID pArgs);
 
 class ICorCompileInfo
 {

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -351,13 +351,13 @@ ZapGenericSignature * ZapImportTable::GetGenericSignature(PVOID signature, BOOL 
 // At ngen time Zapper::CompileModule PlaceFixups called from
 //     code:ZapSig.GetSignatureForTypeHandle
 //
-#if defined(_X86_) && !defined(FEATURE_PAL)
-/*static*/ DWORD __stdcall ZapImportTable::EncodeModuleHelper( LPVOID compileContext,
-                                                CORINFO_MODULE_HANDLE referencedModule)
-#else
+#if defined(_X86_) && defined(FEATURE_PAL)
 /*static*/ DWORD ZapImportTable::EncodeModuleHelper( LPVOID compileContext,
                                                 CORINFO_MODULE_HANDLE referencedModule)
-#endif
+#else // !_X86_ || !FEATURE_PAL
+/*static*/ DWORD __stdcall ZapImportTable::EncodeModuleHelper( LPVOID compileContext,
+                                                CORINFO_MODULE_HANDLE referencedModule)
+#endif // _X86_ && FEATURE_PAL
 {
     ZapImportTable * pTable = (ZapImportTable *)compileContext;
     return pTable->GetIndexOfModule(referencedModule);

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -351,8 +351,13 @@ ZapGenericSignature * ZapImportTable::GetGenericSignature(PVOID signature, BOOL 
 // At ngen time Zapper::CompileModule PlaceFixups called from
 //     code:ZapSig.GetSignatureForTypeHandle
 //
+#if defined(_X86_) && !defined(FEATURE_PAL)
 /*static*/ DWORD __stdcall ZapImportTable::EncodeModuleHelper( LPVOID compileContext,
                                                 CORINFO_MODULE_HANDLE referencedModule)
+#else
+/*static*/ DWORD ZapImportTable::EncodeModuleHelper( LPVOID compileContext,
+                                                CORINFO_MODULE_HANDLE referencedModule)
+#endif
 {
     ZapImportTable * pTable = (ZapImportTable *)compileContext;
     return pTable->GetIndexOfModule(referencedModule);

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -351,13 +351,8 @@ ZapGenericSignature * ZapImportTable::GetGenericSignature(PVOID signature, BOOL 
 // At ngen time Zapper::CompileModule PlaceFixups called from
 //     code:ZapSig.GetSignatureForTypeHandle
 //
-#if defined(_X86_) && defined(FEATURE_PAL)
 /*static*/ DWORD ZapImportTable::EncodeModuleHelper( LPVOID compileContext,
                                                 CORINFO_MODULE_HANDLE referencedModule)
-#else // !_X86_ || !FEATURE_PAL
-/*static*/ DWORD __stdcall ZapImportTable::EncodeModuleHelper( LPVOID compileContext,
-                                                CORINFO_MODULE_HANDLE referencedModule)
-#endif // _X86_ && FEATURE_PAL
 {
     ZapImportTable * pTable = (ZapImportTable *)compileContext;
     return pTable->GetIndexOfModule(referencedModule);

--- a/src/zap/zapimport.h
+++ b/src/zap/zapimport.h
@@ -301,11 +301,7 @@ class ZapImportTable : public ZapNode
 
     ModuleReferenceEntry * GetModuleReference(CORINFO_MODULE_HANDLE handle);
 
-#if defined(_X86_) && defined(FEATURE_PAL)
     static DWORD EncodeModuleHelper(LPVOID referencingModule, CORINFO_MODULE_HANDLE referencedModule);
-#else // !_X86_ || !FEATURE_PAL
-    static DWORD __stdcall EncodeModuleHelper(LPVOID referencingModule, CORINFO_MODULE_HANDLE referencedModule);
-#endif // _X86_ && FEATURE_PAL
 
     ImportTable m_imports;          // Interned ZapImport *
     SHash< NoRemoveSHashTraits < ZapBlob::SHashTraits > > m_blobs; // Interned ZapBlos for signatures and fixups

--- a/src/zap/zapimport.h
+++ b/src/zap/zapimport.h
@@ -301,7 +301,11 @@ class ZapImportTable : public ZapNode
 
     ModuleReferenceEntry * GetModuleReference(CORINFO_MODULE_HANDLE handle);
 
+#if defined(_X86_) and !defined(FEATURE_PAL)
     static DWORD __stdcall EncodeModuleHelper(LPVOID referencingModule, CORINFO_MODULE_HANDLE referencedModule);
+#else
+    static DWORD EncodeModuleHelper(LPVOID referencingModule, CORINFO_MODULE_HANDLE referencedModule);
+#endif
 
     ImportTable m_imports;          // Interned ZapImport *
     SHash< NoRemoveSHashTraits < ZapBlob::SHashTraits > > m_blobs; // Interned ZapBlos for signatures and fixups

--- a/src/zap/zapimport.h
+++ b/src/zap/zapimport.h
@@ -301,11 +301,11 @@ class ZapImportTable : public ZapNode
 
     ModuleReferenceEntry * GetModuleReference(CORINFO_MODULE_HANDLE handle);
 
-#if defined(_X86_) and !defined(FEATURE_PAL)
-    static DWORD __stdcall EncodeModuleHelper(LPVOID referencingModule, CORINFO_MODULE_HANDLE referencedModule);
-#else
+#if defined(_X86_) && defined(FEATURE_PAL)
     static DWORD EncodeModuleHelper(LPVOID referencingModule, CORINFO_MODULE_HANDLE referencedModule);
-#endif
+#else // !_X86_ || !FEATURE_PAL
+    static DWORD __stdcall EncodeModuleHelper(LPVOID referencingModule, CORINFO_MODULE_HANDLE referencedModule);
+#endif // _X86_ && FEATURE_PAL
 
     ImportTable m_imports;          // Interned ZapImport *
     SHash< NoRemoveSHashTraits < ZapBlob::SHashTraits > > m_blobs; // Interned ZapBlos for signatures and fixups


### PR DESCRIPTION
- Fix calling convention:
not use stdcall for ENCODEMODULE_CALLBACK & DEFINETOKEN_CALLBACK in linux/x86
x86-host/arm32-target crossgen & x86 crossgen
build error in clang 3.9: not allowed calling convention casting