### PR TITLE
[x86/Linux] Intreface-based x86 unwinder (Work in progress)

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -641,7 +641,35 @@ HRESULT FixContextForEnC(PCONTEXT        pCtx,
 };
 
 #ifdef _TARGET_X86_
-bool UnwindStackFrame(PREGDISPLAY     pContext,
+struct IUnwindFrameReader
+{
+    IUnwindFrameReader() = default;
+    virtual ~IUnwindFrameReader() = default;
+
+    virtual DWORD GetSP(void) = 0;
+    virtual DWORD GetFP(void) = 0;
+    virtual DWORD GetPC(void) = 0;
+};
+
+struct IUnwindFrameListener
+{
+    IUnwindFrameListener() = default;
+    virtual ~IUnwindFrameListener() = default;
+
+    virtual void NotifyEaxLocation(PDWORD loc) = 0;
+    virtual void NotifyEbxLocation(PDWORD loc) = 0;
+    virtual void NotifyEcxLocation(PDWORD loc) = 0;
+    virtual void NotifyEdxLocation(PDWORD loc) = 0;
+    virtual void NotifyEsiLocation(PDWORD loc) = 0;
+    virtual void NotifyEdiLocation(PDWORD loc) = 0;
+    virtual void NotifyEbpLocation(PDWORD loc) = 0;
+
+    virtual void NotifySP(DWORD SP, DWORD stackArgumentSize) = 0;
+    virtual void NotifyPCLocation(PDWORD loc) = 0;
+};
+
+bool UnwindStackFrame(IUnwindFrameReader *pUnwindFrameReader,
+                      IUnwindFrameListener *pUnwindFrameListener,
                       EECodeInfo     *pCodeInfo,
                       unsigned        flags,
                       CodeManState   *pState,

--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -34,15 +34,10 @@ private:
     T_KNONVOLATILE_CONTEXT_POINTERS ctxPtrs;
 
 public:
-    DWORD EstablisherFrame;
-
-public:
     UnwindFrameListener(PCONTEXT pContextRecord, PKNONVOLATILE_CONTEXT_POINTERS pContextPointers)
     {
         this->pContextRecord = pContextRecord;
         this->pContextPointers = (pContextPointers) ? pContextPointers : &ctxPtrs;
-
-        this->EstablisherFrame = 0xdeadbeaf;
     }
 
     virtual ~UnwindFrameListener() = default;
@@ -66,8 +61,7 @@ public:
 
     virtual void NotifySP(DWORD SP, DWORD stackArgumentSize)
     {
-        pContextRecord->Esp = SP;
-        EstablisherFrame = SP;
+        pContextRecord->Esp = SP + stackArgumentSize;
     }
 
     virtual void NotifyPCLocation(PDWORD loc)
@@ -159,7 +153,7 @@ OOPStackUnwinderX86::VirtualUnwind(
     // For x86, the value of Establisher Frame Pointer is Caller SP
     //
     // (Please refers to CLR ABI for details)
-    *EstablisherFrame = unwindFrameListener.EstablisherFrame;
+    *EstablisherFrame = ContextRecord->Esp;
     return S_OK;
 }
 


### PR DESCRIPTION
This commit revises x86 unwinder based on two interfaces: IUnwindFrameReader and IUnwindFrameListener.

To be specific, this commit revises x86 unwinder to read initial values from IUnwindFrameReader and notify changes during unwinding via IUnwindFrameListener, which allows flexible and uniform implementation for Linux and Windows.