### PR TITLE
Arm64 remove assert gtBlkOpKind == BlkOpKindHelper

### DIFF
--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -1252,11 +1252,10 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
         else
 #endif // 0
         {
-            assert(blkNode->gtBlkOpKind == GenTreeBlk::BlkOpKindHelper);
+            blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
             // The helper follows the regular ABI.
             dstAddr->gtLsraInfo.setSrcCandidates(l, RBM_ARG_0);
             initVal->gtLsraInfo.setSrcCandidates(l, RBM_ARG_1);
-            blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
             if (size != 0)
             {
                 // Reserve a temp register for the block size argument.
@@ -1312,7 +1311,7 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
             else
 #endif // 0
             {
-                assert(blkNode->gtBlkOpKind == GenTreeBlk::BlkOpKindHelper);
+                blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
                 dstAddr->gtLsraInfo.setSrcCandidates(l, RBM_ARG_0);
                 // The srcAddr goes in arg1.
                 if (srcAddrOrFill != nullptr)
@@ -1333,7 +1332,6 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
                     GenTree* blockSize = blkNode->AsDynBlk()->gtDynamicSize;
                     blockSize->gtLsraInfo.setSrcCandidates(l, RBM_ARG_2);
                 }
-                blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
             }
             if (internalIntCount != 0)
             {


### PR DESCRIPTION
We will unconditionally assign blkNode->gtBlkOpKind to BlkOpKindHelper in lsraarm64.cpp. Which makes the assert seemingly unnecessary. 

@CarolEidt @briansull ptal
/cc @dotnet/arm64-contrib @dotnet/jit-contrib 