### PR TITLE
Move GC/Coverage/delete_next_card_table to the Long GC playlist

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -25,9 +25,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\collect\*">
             <Issue>3392</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\GC\Coverage\delete_next_card_table\*">
-            <Issue>9064</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\getgeneration\*">
             <Issue>3392</Issue>
         </ExcludeList>

--- a/tests/longRunningGcTests.txt
+++ b/tests/longRunningGcTests.txt
@@ -8,3 +8,4 @@ GC/Features/PartialCompaction/partialcompactionwloh/partialcompactionwloh.sh
 GC/Features/SustainedLowLatency/sustainedlowlatency_race_reverse/sustainedlowlatency_race_reverse.sh
 GC/Features/SustainedLowLatency/sustainedlowlatency_race/sustainedlowlatency_race.sh
 GC/Regressions/v2.0-beta2/462651/462651/462651.sh
+GC/Coverage/delete_next_card_table/delete_next_card_table.sh

--- a/tests/src/GC/Coverage/delete_next_card_table.csproj
+++ b/tests/src/GC/Coverage/delete_next_card_table.csproj
@@ -14,6 +14,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <IsLongRunningGCTest>true</IsLongRunningGCTest>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Recently it was discovered that this test was behaving badly in the CI (see https://github.com/dotnet/coreclr/pull/9233). The GC bug (https://github.com/dotnet/coreclr/issues/9064) has been fixed, so this PR moves it to the long GC playlist where it won't disturb other tests.