### PR TITLE
Default-trigger ARM64 testing on certain users' PRs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1186,13 +1186,45 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                contextString += " and Test"
             }
 
-            def arm64Users = ['erozenfeld', 'kyulee1', 'pgavlin', 'russellhadley', 'swaroop-sridhar', 'JosephTremoulet', 'jashook', 'RussKeldorph', 'gkhanna79', 'briansull', 'cmckinsey', 'jkotas', 'ramarag', 'markwilkie', 'rahku', 'tzwlai', 'weshaggard']
+            def arm64Users = [
+                'adiaaida',
+                'AndyAyersMS',
+                'briansull',
+                'BruceForstall',
+                'CarolEidt',
+                'cmckinsey',
+                'erozenfeld',
+                'jashook',
+                'JosephTremoulet',
+                'pgavlin',
+                'pkukol',
+                'russellhadley',
+                'RussKeldorph',
+                'sandreenko',
+                'sivarv',
+                'swaroop-sridhar',
+                'gkhanna79',
+                'jkotas',
+                'markwilkie',
+                'rahku',
+                'ramarag',
+                'tzwlai',
+                'weshaggard'
+            ]
+
             switch (os) {
                 case 'Windows_NT':
                     switch (scenario) {
                         case 'default':
-                            Utilities.addPrivateGithubPRTriggerForBranch(job, branch, contextString,
-                            "(?i).*test\\W+${os}\\W+${architecture}\\W+${configuration}.*", null, arm64Users)
+                            if (configuration == 'Release') {
+                                Utilities.addPrivateGithubPRTriggerForBranch(job, branch, contextString,
+                                "(?i).*test\\W+${os}\\W+${architecture}\\W+${configuration}.*", null, arm64Users)
+                            }
+                            else {
+                                // Add "Checked Build And Test" and "Debug Build" to the above users' PRs since many of them
+                                // are at higher risk of ARM64-breaking changes.
+                                Utilities.addDefaultPrivateGithubPRTriggerForBranch(job, branch, contextString, null, arm64Users)
+                            }
                             break
                         case 'pri1r2r':
                         case 'gcstress0x3':


### PR DESCRIPTION
Re-using the logic that allows certain users to request ARM64 testing to
default-trigger ARM64 testing on their PRs.  Ideally, we'd be able to
separate the list of people who have permission to trigger testing from
those that get testing by default, but that is harder than it seems.