### PR TITLE
[x86/Linux] Fix GetCallerSp

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1782,6 +1782,7 @@ typedef struct _CONTEXT {
 
     UCHAR   ExtendedRegisters[MAXIMUM_SUPPORTED_EXTENSION];
 
+    ULONG   ResumeEsp;
 } CONTEXT, *PCONTEXT, *LPCONTEXT;
 
 // To support saving and loading xmm register context we need to know the offset in the ExtendedRegisters

--- a/src/pal/src/arch/i386/asmconstants.h
+++ b/src/pal/src/arch/i386/asmconstants.h
@@ -28,3 +28,4 @@
 #define CONTEXT_Xmm5 CONTEXT_Xmm4+16
 #define CONTEXT_Xmm6 CONTEXT_Xmm5+16
 #define CONTEXT_Xmm7 CONTEXT_Xmm6+16
+#define CONTEXT_ResumeEsp CONTEXT_ExtendedRegisters+512

--- a/src/pal/src/arch/i386/context2.S
+++ b/src/pal/src/arch/i386/context2.S
@@ -42,6 +42,7 @@ LEAF_ENTRY CONTEXT_CaptureContext, _TEXT
     mov   [eax + CONTEXT_Ebp], ebp
     lea   ebx, [esp + 12]
     mov   [eax + CONTEXT_Esp], ebx
+    mov   [eax + CONTEXT_ResumeEsp], ebx
     mov   ebx, [esp + 8]
     mov   [eax + CONTEXT_Eip], ebx
 
@@ -114,7 +115,7 @@ LOCAL_LABEL(Done_Restore_CONTEXT_FLOATING_POINT):
 LOCAL_LABEL(Done_Restore_CONTEXT_EXTENDED_REGISTERS):
 
     // Restore Stack
-    mov   esp, [eax + CONTEXT_Esp]
+    mov   esp, [eax + CONTEXT_ResumeEsp]
 
     // Create a minimal frame
     push  DWORD PTR [eax + CONTEXT_Eip]

--- a/src/pal/src/arch/i386/exceptionhelper.S
+++ b/src/pal/src/arch/i386/exceptionhelper.S
@@ -23,7 +23,7 @@ LEAF_ENTRY ThrowExceptionFromContextInternal, _TEXT
         mov   ebx, [esp + 8]  // eax: CONTEXT *
 
         mov   ebp, [ebx + CONTEXT_Ebp]
-        mov   esp, [ebx + CONTEXT_Esp]
+        mov   esp, [ebx + CONTEXT_ResumeEsp]
 
         // The ESP is re-initialized as the target frame's value, so the current function's
         // CFA is now right at the ESP.

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -155,6 +155,7 @@ static void UnwindContextToWinContext(unw_cursor_t *cursor, CONTEXT *winContext)
 #elif defined(_X86_)
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Eip);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Esp);
+    unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->ResumeEsp);
     unw_get_reg(cursor, UNW_X86_EBP, (unw_word_t *) &winContext->Ebp);
     unw_get_reg(cursor, UNW_X86_EBX, (unw_word_t *) &winContext->Ebx);
     unw_get_reg(cursor, UNW_X86_ESI, (unw_word_t *) &winContext->Esi);

--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -499,11 +499,13 @@ void CONTEXTFromNativeContext(const native_context_t *native, LPCONTEXT lpContex
     if ((contextFlags & CONTEXT_CONTROL) == CONTEXT_CONTROL)
     {
         ASSIGN_CONTROL_REGS
-#ifdef _ARM_
+#if defined(_ARM_)
         // WinContext assumes that the least bit of Pc is always 1 (denoting thumb)
         // although the pc value retrived from native context might not have set the least bit.
         // This becomes especially problematic if the context is on the JIT_WRITEBARRIER.
         lpContext->Pc |= 0x1;
+#elif defined(_X86_)
+        lpContext->ResumeEsp = MCREG_Esp(native->uc_mcontext);
 #endif
     }
 
@@ -945,6 +947,7 @@ CONTEXT_GetThreadContextFromThreadState(
                 lpContext->Esi = pState->esi;
                 lpContext->Ebp = pState->ebp;
                 lpContext->Esp = pState->esp;
+                lpContext->ResumeEsp = pState->esp;
                 lpContext->SegSs = pState->ss;
                 lpContext->EFlags = pState->eflags;
                 lpContext->Eip = pState->eip;

--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -76,6 +76,7 @@ OOPStackUnwinderX86::VirtualUnwind(
 
     FillRegDisplay(&rd, ContextRecord);
 
+    rd.SP = ContextRecord->ResumeEsp;
     rd.PCTAddr = (UINT_PTR)&(ContextRecord->Eip);
 
     if (ContextPointers)
@@ -104,13 +105,14 @@ OOPStackUnwinderX86::VirtualUnwind(
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 
-    ContextRecord->Esp = rd.SP;
+    ContextRecord->Esp = rd.SP - codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo);
+    ContextRecord->ResumeEsp = rd.SP;
     ContextRecord->Eip = rd.ControlPC;
 
     // For x86, the value of Establisher Frame Pointer is Caller SP
     //
     // (Please refers to CLR ABI for details)
-    *EstablisherFrame = rd.SP - codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo);
+    *EstablisherFrame = ContextRecord->Esp;
     return S_OK;
 }
 

--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -110,7 +110,7 @@ OOPStackUnwinderX86::VirtualUnwind(
     // For x86, the value of Establisher Frame Pointer is Caller SP
     //
     // (Please refers to CLR ABI for details)
-    *EstablisherFrame = ContextRecord->Esp;
+    *EstablisherFrame = rd.SP - codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo);
     return S_OK;
 }
 

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3099,7 +3099,17 @@ size_t EECodeManager::GetCallerSp( PREGDISPLAY  pRD )
     {
         EnsureCallerContextIsValid(pRD, NULL);
     }
-    return (size_t) (GetSP(pRD->pCallerContext));
+
+    size_t res = GetSP(pRD->pCallerContext);
+
+#ifdef _TARGET_X86_
+    EECodeInfo codeInfo;
+    codeInfo.Init((PCODE) pRD->ControlPC);
+
+    res -= codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo);
+#endif // _TARGET_X86_
+
+    return res;
 }
 
 #endif // WIN64EXCEPTIONS && !CROSSGEN_COMPILE

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3100,16 +3100,7 @@ size_t EECodeManager::GetCallerSp( PREGDISPLAY  pRD )
         EnsureCallerContextIsValid(pRD, NULL);
     }
 
-    size_t res = GetSP(pRD->pCallerContext);
-
-#ifdef _TARGET_X86_
-    EECodeInfo codeInfo;
-    codeInfo.Init((PCODE) pRD->ControlPC);
-
-    res -= codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo);
-#endif // _TARGET_X86_
-
-    return res;
+    return GetSP(pRD->pCallerContext);
 }
 
 #endif // WIN64EXCEPTIONS && !CROSSGEN_COMPILE

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -299,7 +299,12 @@ void TransitionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 
     MethodDesc * pFunc = GetFunction();
     _ASSERTE(pFunc != NULL);
+
+#ifdef WIN64EXCEPTIONS
+    UpdateRegDisplayHelper(pRD, 0);
+#else
     UpdateRegDisplayHelper(pRD, pFunc->CbStackPop());
+#endif // WIN64EXCEPTIONS
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    TransitionFrame::UpdateRegDisplay(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -328,7 +328,7 @@ void TransitionFrame::UpdateRegDisplayHelper(const PREGDISPLAY pRD, UINT cbStack
     pRD->IsCallerSPValid      = FALSE;
 
     pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);;
-    pRD->pCurrentContext->Esp = GetSP();
+    pRD->pCurrentContext->Esp = (DWORD)(pRD->PCTAddr + sizeof(TADDR) + cbStackPop);
 
     UpdateRegDisplayFromCalleeSavedRegisters(pRD, regs);
     ClearRegDisplayArgumentAndScratchRegisters(pRD);


### PR DESCRIPTION
x86 unwinder takes care of callee-poped stack elements, and thus Caller's Esp is not same as Caller-SP (discussed in #9366).

This commit revises GetCallerSp to return correct Caller-SP for x86.