### PR TITLE
Call LowerBlockStore TreeNodeInfoInitBlockStore

### DIFF
--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -504,6 +504,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_STORE_BLK:
         case GT_STORE_OBJ:
         case GT_STORE_DYN_BLK:
+            LowerBlockStore(tree->AsBlk());
             TreeNodeInfoInitBlockStore(tree->AsBlk());
             break;
 
@@ -1256,7 +1257,6 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
             // The helper follows the regular ABI.
             dstAddr->gtLsraInfo.setSrcCandidates(l, RBM_ARG_0);
             initVal->gtLsraInfo.setSrcCandidates(l, RBM_ARG_1);
-            blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
             if (size != 0)
             {
                 // Reserve a temp register for the block size argument.
@@ -1333,7 +1333,6 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
                     GenTree* blockSize = blkNode->AsDynBlk()->gtDynamicSize;
                     blockSize->gtLsraInfo.setSrcCandidates(l, RBM_ARG_2);
                 }
-                blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
             }
             if (internalIntCount != 0)
             {


### PR DESCRIPTION
For arm64 call LowerBlockStore before TreeNodeInfoInitBlockStore
as done on other architectures. See #9375 for more history.

