### PR TITLE
Add gtGetPossibleOp2()

### DIFF
--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -2593,7 +2593,7 @@ regMaskTP CodeGen::genRestoreAddrMode(GenTreePtr addr, GenTreePtr tree, bool loc
 
             if (tree->gtOp.gtOp1)
                 regMask |= genRestoreAddrMode(addr, tree->gtOp.gtOp1, lockPhase);
-            if (tree->gtGetOp2())
+            if (tree->gtGetOp2IfPresent())
                 regMask |= genRestoreAddrMode(addr, tree->gtOp.gtOp2, lockPhase);
         }
         else if (tree->gtOper == GT_ARR_ELEM)
@@ -3042,7 +3042,7 @@ AGAIN:
 
     noway_assert(kind & GTK_SMPOP);
 
-    if (tree->gtGetOp2())
+    if (tree->gtGetOp2IfPresent())
     {
         genEvalSideEffects(tree->gtOp.gtOp1);
 
@@ -9692,7 +9692,7 @@ void CodeGen::genCodeForTreeSmpOp(GenTreePtr tree, regMaskTP destReg, regMaskTP 
     const genTreeOps oper     = tree->OperGet();
     const var_types  treeType = tree->TypeGet();
     GenTreePtr       op1      = tree->gtOp.gtOp1;
-    GenTreePtr       op2      = tree->gtGetOp2();
+    GenTreePtr       op2      = tree->gtGetOp2IfPresent();
     regNumber        reg      = DUMMY_INIT(REG_CORRUPT);
     regMaskTP        regs     = regSet.rsMaskUsed;
     regMaskTP        needReg  = destReg;
@@ -13397,7 +13397,7 @@ void CodeGen::genCodeForTreeLng(GenTreePtr tree, regMaskTP needReg, regMaskTP av
         int         helper;
 
         GenTreePtr op1 = tree->gtOp.gtOp1;
-        GenTreePtr op2 = tree->gtGetOp2();
+        GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
         switch (oper)
         {

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -6788,14 +6788,14 @@ void Compiler::CopyTestDataToCloneTree(GenTreePtr from, GenTreePtr to)
             assert(to->gtOp.gtOp1 == nullptr);
         }
 
-        if (from->gtGetOp2() != nullptr)
+        if (from->gtGetOp2IfPresent() != nullptr)
         {
-            assert(to->gtGetOp2() != nullptr);
+            assert(to->gtGetOp2IfPresent() != nullptr);
             CopyTestDataToCloneTree(from->gtGetOp2(), to->gtGetOp2());
         }
         else
         {
-            assert(to->gtGetOp2() == nullptr);
+            assert(to->gtGetOp2IfPresent() == nullptr);
         }
 
         return;

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17793,7 +17793,7 @@ void Compiler::fgSetTreeSeqHelper(GenTreePtr tree, bool isLIR)
     if (kind & GTK_SMPOP)
     {
         GenTreePtr op1 = tree->gtOp.gtOp1;
-        GenTreePtr op2 = tree->gtGetOp2();
+        GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
         // Special handling for GT_LIST
         if (tree->OperGet() == GT_LIST)
@@ -20329,7 +20329,7 @@ void Compiler::fgDebugCheckFlags(GenTreePtr tree)
     else if (kind & GTK_SMPOP)
     {
         GenTreePtr op1 = tree->gtOp.gtOp1;
-        GenTreePtr op2 = tree->gtGetOp2();
+        GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
         // During GS work, we make shadow copies for params.
         // In gsParamsToShadows(), we create a shadow var of TYP_INT for every small type param.

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -678,7 +678,7 @@ Compiler::fgWalkResult Compiler::fgWalkTreePreRec(GenTreePtr* pTree, fgWalkData*
 
         if (kind & GTK_SMPOP)
         {
-            if (tree->gtGetOp2())
+            if (tree->gtGetOp2IfPresent())
             {
                 if (tree->gtOp.gtOp1 != nullptr)
                 {
@@ -1301,7 +1301,7 @@ Compiler::fgWalkResult Compiler::fgWalkTreeRec(GenTreePtr* pTree, fgWalkData* fg
             }
         }
 
-        if (tree->gtGetOp2())
+        if (tree->gtGetOp2IfPresent())
         {
             result = fgWalkTreeRec<doPreOrder, doPostOrder>(&tree->gtOp.gtOp2, fgWalkData);
             if (result == WALK_ABORT)
@@ -2447,7 +2447,7 @@ AGAIN:
 
     if (kind & GTK_SMPOP)
     {
-        if (tree->gtGetOp2())
+        if (tree->gtGetOp2IfPresent())
         {
             if (gtHasRef(tree->gtOp.gtOp1, lclNum, defOnly))
             {
@@ -3181,7 +3181,7 @@ AGAIN:
             }
         }
 
-        if (tree->gtGetOp2())
+        if (tree->gtGetOp2IfPresent())
         {
             /* It's a binary operator */
             if (!lvaLclVarRefsAccum(tree->gtOp.gtOp1, findPtr, refsPtr, &allVars, &trkdVars))
@@ -4151,7 +4151,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
         unsigned lvl2; // scratch variable
 
         GenTreePtr op1 = tree->gtOp.gtOp1;
-        GenTreePtr op2 = tree->gtGetOp2();
+        GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
         costEx = 0;
         costSz = 0;
@@ -5766,7 +5766,7 @@ void Compiler::gtComputeFPlvls(GenTreePtr tree)
     if (kind & GTK_SMPOP)
     {
         GenTreePtr op1 = tree->gtOp.gtOp1;
-        GenTreePtr op2 = tree->gtGetOp2();
+        GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
         /* Check for some special cases */
 
@@ -8085,7 +8085,7 @@ GenTreePtr Compiler::gtCloneExpr(
             case GT_SIMD:
             {
                 GenTreeSIMD* simdOp = tree->AsSIMD();
-                copy                = gtNewSIMDNode(simdOp->TypeGet(), simdOp->gtGetOp1(), simdOp->gtGetOp2(),
+                copy                = gtNewSIMDNode(simdOp->TypeGet(), simdOp->gtGetOp1(), simdOp->gtGetOp2IfPresent(),
                                      simdOp->gtSIMDIntrinsicID, simdOp->gtSIMDBaseType, simdOp->gtSIMDSize);
             }
             break;
@@ -8133,7 +8133,7 @@ GenTreePtr Compiler::gtCloneExpr(
             }
         }
 
-        if (tree->gtGetOp2())
+        if (tree->gtGetOp2IfPresent())
         {
             copy->gtOp.gtOp2 = gtCloneExpr(tree->gtOp.gtOp2, addFlags, deepVarNum, deepVarVal);
         }
@@ -8184,7 +8184,7 @@ GenTreePtr Compiler::gtCloneExpr(
         {
             copy->gtFlags |= (copy->gtOp.gtOp1->gtFlags & GTF_ALL_EFFECT);
         }
-        if (copy->gtGetOp2() != nullptr)
+        if (copy->gtGetOp2IfPresent() != nullptr)
         {
             copy->gtFlags |= (copy->gtGetOp2()->gtFlags & GTF_ALL_EFFECT);
         }
@@ -11317,7 +11317,7 @@ void Compiler::gtDispTree(GenTreePtr   tree,
     {
         if (!topOnly)
         {
-            if (tree->gtGetOp2())
+            if (tree->gtGetOp2IfPresent())
             {
                 // Label the childMsgs of the GT_COLON operator
                 // op2 is the then part
@@ -12681,7 +12681,7 @@ GenTreePtr Compiler::gtFoldExprConst(GenTreePtr tree)
     assert(kind & (GTK_UNOP | GTK_BINOP));
 
     GenTreePtr op1 = tree->gtOp.gtOp1;
-    GenTreePtr op2 = tree->gtGetOp2();
+    GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
     if (!opts.OptEnabled(CLFLG_CONSTANTFOLD))
     {
@@ -14573,7 +14573,7 @@ void Compiler::gtExtractSideEffList(GenTreePtr  expr,
     if (kind & GTK_SMPOP)
     {
         GenTreePtr op1 = expr->gtOp.gtOp1;
-        GenTreePtr op2 = expr->gtGetOp2();
+        GenTreePtr op2 = expr->gtGetOp2IfPresent();
 
         if (flags & GTF_EXCEPT)
         {

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -166,7 +166,7 @@ private:
     // operands.
     //
     // Arguments:
-    //     tree  -  Gentree of a bininary operation.
+    //     tree  -  Gentree of a binary operation.
     //
     // Returns
     //     None.

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -1048,7 +1048,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             }
             else if (kind & (GTK_SMPOP))
             {
-                if (tree->gtGetOp2() != nullptr)
+                if (tree->gtGetOp2IfPresent() != nullptr)
                 {
                     info->srcCount = 2;
                 }

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -107,7 +107,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             }
             else if (kind & (GTK_SMPOP))
             {
-                if (tree->gtGetOp2() != nullptr)
+                if (tree->gtGetOp2IfPresent() != nullptr)
                 {
                     info->srcCount = 2;
                 }
@@ -1492,9 +1492,10 @@ void Lowering::TreeNodeInfoInitSIMD(GenTree* tree)
             // The result is baseType of SIMD struct.
             info->srcCount = 2;
 
-            op2 = tree->gtGetOp2()
-                  // If the index is a constant, mark it as contained.
-                  if (CheckImmedAndMakeContained(tree, op2))
+            op2 = tree->gtGetOp2();
+
+            // If the index is a constant, mark it as contained.
+            if (CheckImmedAndMakeContained(tree, op2))
             {
                 info->srcCount = 1;
             }

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -990,7 +990,7 @@ void Lowering::TreeNodeInfoInitSimple(GenTree* tree)
     }
     else if (kind & (GTK_SMPOP))
     {
-        if (tree->gtGetOp2() != nullptr)
+        if (tree->gtGetOp2IfPresent() != nullptr)
         {
             info->srcCount = 2;
         }

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -913,7 +913,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
                     op1->gtType = simdType;
                 }
 
-                GenTree* op2 = simdNode->gtGetOp2();
+                GenTree* op2 = simdNode->gtGetOp2IfPresent();
                 if (op2 != nullptr && op2->gtType == TYP_STRUCT)
                 {
                     op2->gtType = simdType;

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -1724,7 +1724,7 @@ regMaskTP Compiler::rpPredictBlkAsgRegUse(GenTreePtr   tree,
     bool        useBarriers   = false;
     GenTreeBlk* dst           = tree->gtGetOp1()->AsBlk();
     GenTreePtr  dstAddr       = dst->Addr();
-    GenTreePtr  srcAddrOrFill = tree->gtGetOp2();
+    GenTreePtr  srcAddrOrFill = tree->gtGetOp2IfPresent();
 
     size_t blkSize = dst->gtBlkSize;
 
@@ -2478,7 +2478,7 @@ regMaskTP Compiler::rpPredictTreeRegUse(GenTreePtr   tree,
     if (kind & GTK_SMPOP)
     {
         GenTreePtr op1 = tree->gtOp.gtOp1;
-        GenTreePtr op2 = tree->gtGetOp2();
+        GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
         GenTreePtr opsPtr[3];
         regMaskTP  regsPtr[3];

--- a/src/jit/registerfp.cpp
+++ b/src/jit/registerfp.cpp
@@ -243,7 +243,7 @@ void CodeGen::genFloatSimple(GenTree* tree, RegSet::RegisterPreference* pref)
         case GT_COMMA:
         {
             GenTreePtr op1 = tree->gtOp.gtOp1;
-            GenTreePtr op2 = tree->gtGetOp2();
+            GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
             if (tree->gtFlags & GTF_REVERSE_OPS)
             {
@@ -318,7 +318,7 @@ void CodeGen::genFloatAssign(GenTree* tree)
 {
     var_types  type = tree->TypeGet();
     GenTreePtr op1  = tree->gtGetOp1();
-    GenTreePtr op2  = tree->gtGetOp2();
+    GenTreePtr op2  = tree->gtGetOp2IfPresent();
 
     regMaskTP needRegOp1 = RBM_ALLINT;
     regMaskTP addrReg    = RBM_NONE;
@@ -846,7 +846,7 @@ void CodeGen::genFloatArith(GenTreePtr tree, RegSet::RegisterPreference* tgtPref
     var_types  type = tree->TypeGet();
     genTreeOps oper = tree->OperGet();
     GenTreePtr op1  = tree->gtGetOp1();
-    GenTreePtr op2  = tree->gtGetOp2();
+    GenTreePtr op2  = tree->gtGetOp2IfPresent();
 
     regNumber  tgtReg;
     unsigned   varNum;

--- a/src/jit/stackfp.cpp
+++ b/src/jit/stackfp.cpp
@@ -1376,7 +1376,7 @@ void CodeGen::genCodeForTreeStackFP_Asg(GenTreePtr tree)
     emitAttr   size;
     unsigned   offs;
     GenTreePtr op1 = tree->gtOp.gtOp1;
-    GenTreePtr op2 = tree->gtGetOp2();
+    GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
     assert(tree->OperGet() == GT_ASG);
 
@@ -1693,14 +1693,14 @@ void CodeGen::genCodeForTreeStackFP_Arithm(GenTreePtr tree)
     if (tree->gtFlags & GTF_REVERSE_OPS)
     {
         bReverse = true;
-        op1      = tree->gtGetOp2();
+        op1      = tree->gtGetOp2IfPresent();
         op2      = tree->gtOp.gtOp1;
     }
     else
     {
         bReverse = false;
         op1      = tree->gtOp.gtOp1;
-        op2      = tree->gtGetOp2();
+        op2      = tree->gtGetOp2IfPresent();
     }
 
     regNumber result;
@@ -1928,7 +1928,7 @@ void CodeGen::genCodeForTreeStackFP_AsgArithm(GenTreePtr tree)
     GenTreePtr op1, op2;
 
     op1 = tree->gtOp.gtOp1;
-    op2 = tree->gtGetOp2();
+    op2 = tree->gtGetOp2IfPresent();
 
     genSetupForOpStackFP(op1, op2, (tree->gtFlags & GTF_REVERSE_OPS) ? true : false, true, false, true);
 
@@ -2208,7 +2208,7 @@ void CodeGen::genCodeForTreeStackFP_SmpOp(GenTreePtr tree)
         case GT_COMMA:
         {
             GenTreePtr op1 = tree->gtOp.gtOp1;
-            GenTreePtr op2 = tree->gtGetOp2();
+            GenTreePtr op2 = tree->gtGetOp2IfPresent();
 
             if (tree->gtFlags & GTF_REVERSE_OPS)
             {


### PR DESCRIPTION
It was noticed that many uses of gtGetOp2() fully expect op2 to
exist and be non-nullptr, and the use of gtGetOp2() was simply
for style/readability purposes. However, it has a cost, as it
checks whether the tree is binary first, and returns nullptr if
not. For most cases, this is unecessary and expensive.

Introduce a new gtGetPossibleOp2() function that captures the
previous behavior: checking if the tree node is binary before
returning op2, or returning nullptr otherwise. gtGetOp2() is
changed to simply return gtOp2 directly, without any checking
in non-DEBUG builds. It can be used if you know the op2 exists.

Most uses of gtGetOp2() were left alone (and hence get the new
behavior). The ones that need the old behavior were renamed
gtGetPossibleOp2().

Mostly newer code is affected, as older code would generally
access gtOp2 directly, whereas newer code started using gtGetOp2()
for style and symmetry, especially after gtGetOp1() was introduced.