### PR TITLE
Change switch value widening

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -11566,22 +11566,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 op1 = impPopStack().val;
                 assertImp(genActualTypeIsIntOrI(op1->TypeGet()));
 
-#ifdef _TARGET_64BIT_
-                // Widen 'op1' on 64-bit targets
-                if (op1->TypeGet() != TYP_I_IMPL)
-                {
-                    if (op1->OperGet() == GT_CNS_INT)
-                    {
-                        op1->gtType = TYP_I_IMPL;
-                    }
-                    else
-                    {
-                        op1 = gtNewCastNode(TYP_I_IMPL, op1, TYP_I_IMPL);
-                    }
-                }
-#endif // _TARGET_64BIT_
-                assert(genActualType(op1->TypeGet()) == TYP_I_IMPL);
-
                 /* We can create a switch node */
 
                 op1 = gtNewOperNode(GT_SWITCH, TYP_VOID, op1);
@@ -15966,11 +15950,11 @@ SPILLSTACK:
                 }
                 else
                 {
-                    assert(addTree->gtOper == GT_SWITCH && genActualType(addTree->gtOp.gtOp1->gtType) == TYP_I_IMPL);
+                    assert(addTree->gtOper == GT_SWITCH && genActualTypeIsIntOrI(addTree->gtOp.gtOp1->TypeGet()));
 
                     unsigned temp = lvaGrabTemp(true DEBUGARG("spill addStmt SWITCH"));
                     impAssignTempGen(temp, addTree->gtOp.gtOp1, level);
-                    addTree->gtOp.gtOp1 = gtNewLclvNode(temp, TYP_I_IMPL);
+                    addTree->gtOp.gtOp1 = gtNewLclvNode(temp, genActualType(addTree->gtOp.gtOp1->TypeGet()));
                 }
             }
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -465,7 +465,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     // both GT_SWITCH lowering code paths.
     // This condition is of the form: if (temp > jumpTableLength - 2){ goto jumpTable[jumpTableLength - 1]; }
     GenTreePtr gtDefaultCaseCond = comp->gtNewOperNode(GT_GT, TYP_INT, comp->gtNewLclvNode(tempLclNum, tempLclType),
-                                                       comp->gtNewIconNode(jumpCnt - 2, TYP_INT));
+                                                       comp->gtNewIconNode(jumpCnt - 2, tempLclType));
 
     // Make sure we perform an unsigned comparison, just in case the switch index in 'temp'
     // is now less than zero 0 (that would also hit the default case).
@@ -678,9 +678,16 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
 
         JITDUMP("Lowering switch BB%02u: using jump table expansion\n", originalSwitchBB->bbNum);
 
+        GenTree* switchValue = comp->gtNewLclvNode(tempLclNum, tempLclType);
+#ifdef _TARGET_64BIT_
+        if (tempLclType != TYP_I_IMPL)
+        {
+            // Note that the switch value is unsigned so the cast should be unsigned as well.
+            switchValue = comp->gtNewCastNode(TYP_I_IMPL, switchValue, TYP_U_IMPL);
+        }
+#endif
         GenTreePtr gtTableSwitch =
-            comp->gtNewOperNode(GT_SWITCH_TABLE, TYP_VOID, comp->gtNewLclvNode(tempLclNum, tempLclType),
-                                comp->gtNewJmpTableNode());
+            comp->gtNewOperNode(GT_SWITCH_TABLE, TYP_VOID, switchValue, comp->gtNewJmpTableNode());
         /* Increment the lvRefCnt and lvRefCntWtd for temp */
         tempVarDsc->incRefCnts(blockWeight, comp);
 
@@ -2192,7 +2199,6 @@ void Lowering::LowerCompare(GenTree* cmp)
             // automatically inserts a cast from int32 to long on 64 bit architectures. However, the JIT
             // accidentally generates int/long comparisons internally:
             //   - loop cloning compares int (and even small int) index limits against long constants
-            //   - switch lowering compares a 64 bit switch value against a int32 constant
             //
             // TODO-Cleanup: The above mentioned issues should be fixed and then the code below may be
             // replaced with an assert or at least simplified. The special casing of constants in code


### PR DESCRIPTION
For 64 bit target the importer sign extends the switch value to long but
- the switch value is supposed to be unsigned (it is compared to the switch arm count which is unsigned int32 in the CIL spec)
- this widening is needed to index the jump table, it is not needed when handling the default case

Changing the cast to unsigned and moving it just before jump table indexing usually results in smaller code:
- movsx becomes mov which is shorter
- the default case comparison no longer requires a REX prefix (if R8-R15 aren't used)

Fixes #8760