### PR TITLE
Rename __reserved to __clr_reserved to avoid a conflict on Android

### DIFF
--- a/src/ToolBox/SOS/Strike/inc/dbgeng.h
+++ b/src/ToolBox/SOS/Strike/inc/dbgeng.h
@@ -42,7 +42,9 @@ typedef struct _MEMORY_BASIC_INFORMATION64* PMEMORY_BASIC_INFORMATION64;
 #define __out_xcount(x)
 #define __inout
 #define __inout_opt
-#define __reserved
+// Android defines various fields on struct which are named __reserved[x]; for example, in wchar.h,
+// so we must prefix __reserved with __clr_
+#define __clr_reserved
 #endif
 
 #ifdef __cplusplus
@@ -1509,7 +1511,7 @@ DECLARE_INTERFACE_(IDebugClient, IUnknown)
         THIS_
         __in ULONG Flags,
         __in PCSTR Options,
-        __in_opt __reserved PVOID Reserved
+        __in_opt __clr_reserved PVOID Reserved
         ) PURE;
     STDMETHOD(ConnectProcessServer)(
         THIS_
@@ -1937,7 +1939,7 @@ DECLARE_INTERFACE_(IDebugClient2, IUnknown)
         THIS_
         __in ULONG Flags,
         __in PCSTR Options,
-        __in_opt __reserved PVOID Reserved
+       __in_opt __clr_reserved PVOID Reserved
         ) PURE;
     STDMETHOD(ConnectProcessServer)(
         THIS_
@@ -2394,7 +2396,7 @@ DECLARE_INTERFACE_(IDebugClient3, IUnknown)
         THIS_
         __in ULONG Flags,
         __in PCSTR Options,
-        __in_opt __reserved PVOID Reserved
+        __in_opt __clr_reserved PVOID Reserved
         ) PURE;
     STDMETHOD(ConnectProcessServer)(
         THIS_
@@ -2902,7 +2904,7 @@ DECLARE_INTERFACE_(IDebugClient4, IUnknown)
         THIS_
         __in ULONG Flags,
         __in PCSTR Options,
-        __in_opt __reserved PVOID Reserved
+        __in_opt __clr_reserved PVOID Reserved
         ) PURE;
     STDMETHOD(ConnectProcessServer)(
         THIS_
@@ -3449,7 +3451,7 @@ DECLARE_INTERFACE_(IDebugClient5, IUnknown)
         THIS_
         __in ULONG Flags,
         __in PCSTR Options,
-        __in_opt __reserved PVOID Reserved
+        __in_opt __clr_reserved PVOID Reserved
         ) PURE;
     STDMETHOD(ConnectProcessServer)(
         THIS_
@@ -3961,7 +3963,7 @@ DECLARE_INTERFACE_(IDebugClient5, IUnknown)
         THIS_
         __in ULONG Flags,
         __in PCWSTR Options,
-        __in_opt __reserved PVOID Reserved
+        __in_opt __clr_reserved PVOID Reserved
         ) PURE;
     STDMETHOD(ConnectProcessServerWide)(
         THIS_

--- a/src/ToolBox/SOS/Strike/inc/dbgeng.h
+++ b/src/ToolBox/SOS/Strike/inc/dbgeng.h
@@ -45,6 +45,8 @@ typedef struct _MEMORY_BASIC_INFORMATION64* PMEMORY_BASIC_INFORMATION64;
 // Android defines various fields on struct which are named __reserved[x]; for example, in wchar.h,
 // so we must prefix __reserved with __clr_
 #define __clr_reserved
+#else
+#define __clr_reserved __reserved
 #endif
 
 #ifdef __cplusplus

--- a/src/ToolBox/SOS/Strike/inc/dbgeng.h
+++ b/src/ToolBox/SOS/Strike/inc/dbgeng.h
@@ -1941,7 +1941,7 @@ DECLARE_INTERFACE_(IDebugClient2, IUnknown)
         THIS_
         __in ULONG Flags,
         __in PCSTR Options,
-       __in_opt __clr_reserved PVOID Reserved
+        __in_opt __clr_reserved PVOID Reserved
         ) PURE;
     STDMETHOD(ConnectProcessServer)(
         THIS_

--- a/src/inc/palclr.h
+++ b/src/inc/palclr.h
@@ -617,6 +617,8 @@
 #define MAX_PATH_FNAME   MAX_PATH /* max. length of full pathname */
 #endif
 
+#define __clr_reserved __reserved
+
 #endif // __PALCLR_H__
 
 #include "palclr_win.h"

--- a/src/inc/sortversioning.h
+++ b/src/inc/sortversioning.h
@@ -32,8 +32,9 @@ namespace SortVersioning
         __in int cchSrc,
         __out_bcount_opt(cbDest) LPBYTE pDest,
         __in int cbDest,
-        __reserved LPVOID lpReserved,
-        __reserved LPARAM lParam);
+
+        __clr_reserved LPVOID lpReserved,
+        __clr_reserved LPARAM lParam);
 
     typedef int (*SORTCHANGECASE) (
         __in PSORTHANDLE pSortHandle,
@@ -42,8 +43,8 @@ namespace SortVersioning
         __in int cchSrc,
         __out_ecount_opt(cchDest) LPWSTR pDest,
         __in int cchDest,
-        __reserved LPVOID lpReserved,
-        __reserved LPARAM lParam);
+        __clr_reserved LPVOID lpReserved,
+        __clr_reserved LPARAM lParam);
 
     typedef int (*SORTCOMPARESTRING) (
         __in PSORTHANDLE pSortHandle,
@@ -52,8 +53,8 @@ namespace SortVersioning
         __in int cchCount1,
         __in LPCWSTR lpString2,
         __in int cchCount2,
-        __reserved LPVOID lpReserved,
-        __reserved LPARAM lParam);
+        __clr_reserved LPVOID lpReserved,
+        __clr_reserved LPARAM lParam);
 
     typedef int (*SORTFINDSTRING) (
         __in                    PSORTHANDLE pSortHandle,
@@ -63,8 +64,8 @@ namespace SortVersioning
         __in_ecount(cchValue)   LPCWSTR lpStringValue,
         __in                    int cchValue,
         __out_opt               LPINT pcchFound,
-        __reserved              LPVOID lpReserved,
-        __reserved              LPARAM lParam);
+        __clr_reserved              LPVOID lpReserved,
+        __clr_reserved              LPARAM lParam);
 
     typedef BOOL (*SORTISDEFINEDSTRING) (
         __in                PSORTHANDLE     pSortHandle,
@@ -78,8 +79,8 @@ namespace SortVersioning
         __in DWORD dwFlags,
         __in_ecount(cchSrc) LPCWSTR pSrc,
         __in int cchSrc,
-        __reserved LPVOID lpReserved,
-        __reserved LPARAM lParam);
+        __clr_reserved LPVOID lpReserved,
+        __clr_reserved LPARAM lParam);
 
 #define SORT_NAME_SIZE 85
 
@@ -114,8 +115,8 @@ namespace SortVersioning
                                __in_ecount(cchCount2) LPCWSTR lpString2,
                                __in int cchCount2,
                                __in_opt CONST NLSVERSIONINFO * lpVersionInformation,
-                               __reserved LPVOID lpReserved,
-                               __reserved LPARAM lParam );
+                               __clr_reserved LPVOID lpReserved,
+                               __clr_reserved LPARAM lParam );
     __success(return != 0) int WINAPI SortDllCompareString(
         __in PSORTHANDLE pSort,
         __in DWORD dwCmpFlags,
@@ -134,8 +135,8 @@ namespace SortVersioning
                            __out_ecount_opt(cchDest)  LPWSTR lpDestStr, // really this should be __out_awcount_opt(dwMapFlags & LCMAP_SORTKEY, cchDest)
                            __in int cchDest,
                            __in_opt CONST NLSVERSIONINFO * lpVersionInformation,
-                           __reserved LPVOID lpReserved,
-                           __reserved LPARAM lParam );    
+                           __clr_reserved LPVOID lpReserved,
+                           __clr_reserved LPARAM lParam );    
 
    __success(return != 0) int WINAPI SortDllChangeCase(
         __in PSORTHANDLE pSort,
@@ -165,8 +166,8 @@ namespace SortVersioning
                         __in int cchValue,
                         __out_opt LPINT pcchFound,
                         __in_opt CONST NLSVERSIONINFO * lpVersionInformation,
-                        __reserved LPVOID lpReserved,
-                        __reserved LPARAM lParam);
+                        __clr_reserved LPVOID lpReserved,
+                        __clr_reserved LPARAM lParam);
 
     __success(return != 0) int WINAPI SortDllFindString(
         __in PSORTHANDLE pSort,

--- a/src/inc/sortversioning.h
+++ b/src/inc/sortversioning.h
@@ -64,8 +64,8 @@ namespace SortVersioning
         __in_ecount(cchValue)   LPCWSTR lpStringValue,
         __in                    int cchValue,
         __out_opt               LPINT pcchFound,
-        __clr_reserved              LPVOID lpReserved,
-        __clr_reserved              LPARAM lParam);
+        __clr_reserved          LPVOID lpReserved,
+        __clr_reserved          LPARAM lParam);
 
     typedef BOOL (*SORTISDEFINEDSTRING) (
         __in                PSORTHANDLE     pSortHandle,

--- a/src/pal/inc/rt/sal.h
+++ b/src/pal/inc/rt/sal.h
@@ -2861,7 +2861,7 @@ of each annotation, see the advanced annotations section.
 #define __success(expr)                      _Success_(expr)
 #define __nullterminated                     _Null_terminated_
 #define __nullnullterminated
-#define __clr_reserved                           _SAL1_Source_(__reserved, (), _Reserved_)
+#define __clr_reserved                       _SAL1_Source_(__reserved, (), _Reserved_)
 #define __checkReturn                        _SAL1_Source_(__checkReturn, (), _Check_return_)
 #define __typefix(ctype)                     _SAL1_Source_(__typefix, (ctype), __inner_typefix(ctype))
 #define __override                           __inner_override

--- a/src/pal/inc/rt/sal.h
+++ b/src/pal/inc/rt/sal.h
@@ -2861,7 +2861,7 @@ of each annotation, see the advanced annotations section.
 #define __success(expr)                      _Success_(expr)
 #define __nullterminated                     _Null_terminated_
 #define __nullnullterminated
-#define __reserved                           _SAL1_Source_(__reserved, (), _Reserved_)
+#define __clr_reserved                           _SAL1_Source_(__reserved, (), _Reserved_)
 #define __checkReturn                        _SAL1_Source_(__checkReturn, (), _Check_return_)
 #define __typefix(ctype)                     _SAL1_Source_(__typefix, (ctype), __inner_typefix(ctype))
 #define __override                           __inner_override

--- a/src/pal/inc/rt/specstrings_strict.h
+++ b/src/pal/inc/rt/specstrings_strict.h
@@ -626,7 +626,7 @@
 #define __in_awcount(expr,size)  __allowed(on_parameter)   
 #define __nullterminated         _SAL_VERSION_CHECK(__nullterminated)
 #define __nullnullterminated     _SAL_VERSION_CHECK(__nullnullterminated)
-#define __clr_reserved               _SAL_VERSION_CHECK(__reserved)
+#define __clr_reserved           _SAL_VERSION_CHECK(__reserved)
 #define __checkReturn            _SAL_VERSION_CHECK(__checkReturn)
 #define __typefix(ctype)         __allowed(on_parameter_or_return) 
 #define __override               __allowed(on_function) 

--- a/src/pal/inc/rt/specstrings_strict.h
+++ b/src/pal/inc/rt/specstrings_strict.h
@@ -626,7 +626,7 @@
 #define __in_awcount(expr,size)  __allowed(on_parameter)   
 #define __nullterminated         _SAL_VERSION_CHECK(__nullterminated)
 #define __nullnullterminated     _SAL_VERSION_CHECK(__nullnullterminated)
-#define __reserved               _SAL_VERSION_CHECK(__reserved)
+#define __clr_reserved               _SAL_VERSION_CHECK(__reserved)
 #define __checkReturn            _SAL_VERSION_CHECK(__checkReturn)
 #define __typefix(ctype)         __allowed(on_parameter_or_return) 
 #define __override               __allowed(on_function) 

--- a/src/pal/inc/rt/specstrings_undef.h
+++ b/src/pal/inc/rt/specstrings_undef.h
@@ -445,7 +445,7 @@
 #undef __readableTo
 #undef __readonly
 #undef __refparam
-#undef __reserved
+#undef __clr_reserved
 #undef __rpc_entry
 #undef __source_code_content
 #undef __struct_bcount


### PR DESCRIPTION
On Android, the system headers define various fields named `__reserved`. This conflicts with the `#define __reserved` in some of the CLR headers.

Examples include:
* [wchar.h](https://android.googlesource.com/platform/development/+/master/ndk/platforms/android-21/include/wchar.h)
* [pthread.h](https://android.googlesource.com/platform/development/+/master/ndk/platforms/android-21/include/pthread.h)

This PR renames the CLR `__reserved` to `__clr_reserved` to avoid that conflict.