### PR TITLE
Hide VirtualUnwindXXX for DACESS_COMPILE

### DIFF
--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -656,20 +656,7 @@ PCODE Thread::VirtualUnwindCallFrame(T_CONTEXT* pContext,
     return uControlPc;
 }
 
-#ifdef DACCESS_COMPILE
-
-PCODE Thread::VirtualUnwindLeafCallFrame(T_CONTEXT* pContext)
-{
-    DacNotImpl();
-    return 0;
-}
-UINT_PTR Thread::VirtualUnwindToFirstManagedCallFrame(T_CONTEXT* pContext)
-{
-    DacNotImpl();
-    return 0;
-}
-
-#else  // !DACCESS_COMPILE
+#ifndef DACCESS_COMPILE
 
 // static
 PCODE Thread::VirtualUnwindLeafCallFrame(T_CONTEXT* pContext)
@@ -794,7 +781,7 @@ UINT_PTR Thread::VirtualUnwindToFirstManagedCallFrame(T_CONTEXT* pContext)
     return uControlPc;
 }
 
-#endif // DACCESS_COMPILE
+#endif // !DACCESS_COMPILE
 #endif // WIN64EXCEPTIONS
 
 #ifdef _DEBUG

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -3615,10 +3615,12 @@ public:
     static PCODE VirtualUnwindCallFrame(T_CONTEXT* pContext, T_KNONVOLATILE_CONTEXT_POINTERS* pContextPointers = NULL,
                                            EECodeInfo * pCodeInfo = NULL);
     static UINT_PTR VirtualUnwindCallFrame(PREGDISPLAY pRD, EECodeInfo * pCodeInfo = NULL);
+#ifndef DACCESS_COMPILE
     static PCODE VirtualUnwindLeafCallFrame(T_CONTEXT* pContext);
     static PCODE VirtualUnwindNonLeafCallFrame(T_CONTEXT* pContext, T_KNONVOLATILE_CONTEXT_POINTERS* pContextPointers = NULL,
         PT_RUNTIME_FUNCTION pFunctionEntry = NULL, UINT_PTR uImageBase = NULL);
     static UINT_PTR VirtualUnwindToFirstManagedCallFrame(T_CONTEXT* pContext);
+#endif // DACCESS_COMPILE
 #endif // WIN64EXCEPTIONS
 
     // During a <clinit>, this thread must not be asynchronously


### PR DESCRIPTION
It seems that VirtualUnwindXXX methods are unused for DACESS_COMPILE mode, but has dummy implementation.

This commit hides VirtualUnwindXXX for DACESS_COMPILE, and removes dummy implementation.