### PR TITLE
Disable checked arm64 jobs until jobs are stable

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1216,7 +1216,8 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                 case 'Windows_NT':
                     switch (scenario) {
                         case 'default':
-                            if (configuration == 'Release') {
+                            // For now only run Debug jobs on PR Trigger.
+                            if (configuration != 'Debug') {
                                 Utilities.addPrivateGithubPRTriggerForBranch(job, branch, contextString,
                                 "(?i).*test\\W+${os}\\W+${architecture}\\W+${configuration}.*", null, arm64Users)
                             }


### PR DESCRIPTION
Jobs currently are expected to run red until a lstFile update goes in. Therefore,
disable the job as a PR trigger until it is clean.

@RussKeldorph @adiaaida ptal