### PR TITLE
[x86/Linux] Fix calling convertion mismatch inside ilasm/ildasm

### DIFF
--- a/src/ilasm/assembler.h
+++ b/src/ilasm/assembler.h
@@ -56,7 +56,7 @@
 extern CoreCLRLoader *g_loader;
 extern char *g_pszExeFile;
 #endif
-typedef int(*MetaDataGetDispenserFunc) (
+typedef int(STDAPICALLTYPE *MetaDataGetDispenserFunc) (
     REFCLSID    rclsid,                 // The class to desired.
     REFIID      riid,                   // Interface wanted on class factory.
     LPVOID FAR  *ppv);                  // Return interface pointer here.

--- a/src/ildasm/dis.h
+++ b/src/ildasm/dis.h
@@ -152,24 +152,24 @@ char *DumpGenericPars(__inout_ecount(SZSTRING_SIZE) char* szString,
 #define CHECK_REMAINING_SIZE if(ovadd_le((size_t)szString, SZSTRING_SIZE_M4, (size_t)szptr)) break;
 #define SZSTRING_REMAINING_SIZE(x) (ovadd_le((size_t)szString,SZSTRING_SIZE,(size_t)(x))?0:(SZSTRING_SIZE-((size_t)(x)-(size_t)szString)))
 
-typedef int (*MetaDataGetDispenserFunc) (
+typedef int (STDAPICALLTYPE *MetaDataGetDispenserFunc) (
     REFCLSID    rclsid,                 // The class to desired.
     REFIID      riid,                   // Interface wanted on class factory.
     LPVOID FAR  *ppv);                  // Return interface pointer here.
 
-typedef int (*GetMetaDataInternalInterfaceFunc) (
+typedef int (STDAPICALLTYPE *GetMetaDataInternalInterfaceFunc) (
     LPVOID      pData,                  // [IN] in memory metadata section
     ULONG       cbData,                 // [IN] size of the metadata section
     DWORD       flags,                  // [IN] CorOpenFlags
     REFIID      riid,                   // [IN] desired interface
     void        **ppv);                 // [OUT] returned interface
 
-typedef int (*GetMetaDataInternalInterfaceFromPublicFunc) (
+typedef int (STDAPICALLTYPE *GetMetaDataInternalInterfaceFromPublicFunc) (
     IUnknown    *pv,                    // [IN] Given interface
     REFIID      riid,                   // [IN] desired interface
     void        **ppv);                 // [OUT] returned interface
 
-typedef int (*GetMetaDataPublicInterfaceFromInternalFunc) (
+typedef int (STDAPICALLTYPE *GetMetaDataPublicInterfaceFromInternalFunc) (
     void        *pv,                    // [IN] Given interface
     REFIID      riid,                   // [IN] desired interface
     void        **ppv);                 // [OUT] returned interface


### PR DESCRIPTION
ilasm/ildasm dynamically load serveral functions, but their signature does not match with that of the actual implementation.

This results in segmentation fault while running.

This commit fixes signature mismatch.