### PR TITLE
Clean up EnumGcRefs

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -229,6 +229,7 @@ virtual unsigned FindEndOfLastInterruptibleRegion(unsigned curOffset,
                                                   GCInfoToken gcInfoToken) = 0;
 #endif // _TARGET_AMD64_ && _DEBUG
 
+#ifndef CROSSGEN_COMPILE
 /*
     Enumerate all live object references in that function using
     the virtual register set. Same reference location cannot be enumerated
@@ -242,6 +243,7 @@ virtual bool EnumGcRefs(PREGDISPLAY     pContext,
                         GCEnumCallback  pCallback,
                         LPVOID          hCallBack,
                         DWORD           relOffsetOverride = NO_OVERRIDE_OFFSET) = 0;
+#endif // !CROSSGEN_COMPILE
 
 /*
     Return the address of the local security object reference
@@ -478,6 +480,7 @@ unsigned FindEndOfLastInterruptibleRegion(unsigned curOffset,
                                           GCInfoToken gcInfoToken);
 #endif // _TARGET_AMD64_ && _DEBUG
 
+#ifndef CROSSGEN_COMPILE
 /*
     Enumerate all live object references in that function using
     the virtual register set. Same reference location cannot be enumerated
@@ -492,6 +495,7 @@ bool EnumGcRefs(PREGDISPLAY     pContext,
                 GCEnumCallback  pCallback,
                 LPVOID          hCallBack,
                 DWORD           relOffsetOverride = NO_OVERRIDE_OFFSET);
+#endif // !CROSSGEN_COMPILE
 
 #ifdef FEATURE_CONSERVATIVE_GC
 // Temporary conservative collection, for testing purposes, until we have


### PR DESCRIPTION
This commit cleans up EnumGcRefs.

This commit first declares EnumGcRefs only for !CROSSGEN_COMPILE, and then revises the implementation as follows:
  #ifndef CROSSGEN_COMPILE
  #ifndef USE_GC_INFO_DECODER (use USE_GC_INFO_DECODER instead of _TARGET_X86_)
  ...
  #else 
  ...
  #endif
  #endif

In addition, this commit removes several unnecessary #ifdef inside EnumGcRefs implemenation for USE_GC_INFO_DECODER.