### PR TITLE
Fix warning from an unsigned/signed comparison

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7578,7 +7578,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
             simdTmpReg = genRegNumFromMask(rsvdRegs & RBM_ALLFLOAT);
             assert(genIsValidFloatReg(simdTmpReg));
         }
-        assert(genCountBits(rsvdRegs) == ((intTmpReg == REG_NA) ? 0 : 1) + ((simdTmpReg == REG_NA) ? 0 : 1));
+        assert(genCountBits(rsvdRegs) == (unsigned)((intTmpReg == REG_NA) ? 0 : 1) + ((simdTmpReg == REG_NA) ? 0 : 1));
     }
 
     for (GenTreeFieldList* current = fieldList; current != nullptr; current = current->Rest())


### PR DESCRIPTION
This fixes a desktop build break introduced with #8644.

@BruceForstall ptal
/cc @dotnet/jit-contrib 