### PR TITLE
Publish test native bins from correct directory

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -22,7 +22,7 @@
 
   <PropertyGroup>
     <PublishPattern Condition="'$(PublishPattern)' == '' and '$(PublishTestNativeBins)' != 'true'">$(PackagesBinDir)**\*.nupkg</PublishPattern>
-    <PublishPattern Condition="'$(PublishPattern)' == '' and '$(PublishTestNativeBins)' == 'true'">$(OutputPath)\tests\src\**</PublishPattern>
+    <PublishPattern Condition="'$(PublishPattern)' == '' and '$(PublishTestNativeBins)' == 'true'">$(OutputPath)\bin\**</PublishPattern>
   </PropertyGroup>
 
   <Target Name="CreateContainerName"


### PR DESCRIPTION
$(OutputPath) now points to bin/Product/{os}.{arch}/{config}, where it used to point to bin/obj/{os}.{arch}/{config}. Inside bin/Product is a folder named 'bin' which contains all test native binaries - we should publish from there, instead of from obj. This will fix build breaks in the CoreCLR pipeline.