### PR TITLE
Clean up EECodeManager:GetAddrOfSecurityObject

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -245,11 +245,13 @@ virtual bool EnumGcRefs(PREGDISPLAY     pContext,
                         DWORD           relOffsetOverride = NO_OVERRIDE_OFFSET) = 0;
 #endif // !CROSSGEN_COMPILE
 
+#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 /*
     Return the address of the local security object reference
     (if available).
 */
 virtual OBJECTREF* GetAddrOfSecurityObject(CrawlFrame *pCF) = 0;
+#endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
 
 /*
     For a non-static method, "this" pointer is passed in as argument 0.
@@ -518,8 +520,10 @@ static OBJECTREF* GetAddrOfSecurityObjectFromCachedInfo(
         StackwalkCacheUnwindInfo * stackwalkCacheUnwindInfo);
 #endif // _TARGET_X86_
 
+#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 virtual
 OBJECTREF* GetAddrOfSecurityObject(CrawlFrame *pCF) DAC_UNEXPECTED();
+#endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
 
 virtual
 OBJECTREF GetInstance(

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5034,7 +5034,7 @@ OBJECTREF* EECodeManager::GetAddrOfSecurityObjectFromCachedInfo(PREGDISPLAY pRD,
 }
 #endif // _TARGET_X86_
 
-#ifndef DACCESS_COMPILE
+#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 OBJECTREF* EECodeManager::GetAddrOfSecurityObject(CrawlFrame *pCF)
 {
     CONTRACTL {
@@ -5052,7 +5052,7 @@ OBJECTREF* EECodeManager::GetAddrOfSecurityObject(CrawlFrame *pCF)
 
     _ASSERTE(sizeof(CodeManStateBuf) <= sizeof(pState->stateBuf));
 
-#if defined(_TARGET_X86_)
+#ifndef USE_GC_INFO_DECODER
     CodeManStateBuf * stateBuf = (CodeManStateBuf*)pState->stateBuf;
 
     /* Extract the necessary information from the info block header */
@@ -5070,7 +5070,7 @@ OBJECTREF* EECodeManager::GetAddrOfSecurityObject(CrawlFrame *pCF)
             return (OBJECTREF *)(size_t)(*pRD->GetEbpLocation() - GetSecurityObjectOffset(&stateBuf->hdrInfoBody));
         }
     }
-#elif defined(USE_GC_INFO_DECODER) && !defined(CROSSGEN_COMPILE)
+#else // !USE_GC_INFO_DECODER
 
     GcInfoDecoder gcInfoDecoder(
             gcInfoToken,
@@ -5105,13 +5105,11 @@ OBJECTREF* EECodeManager::GetAddrOfSecurityObject(CrawlFrame *pCF)
         OBJECTREF* pSlot = (OBJECTREF*) (spOffset + uCallerSP);
         return pSlot;
     }
-#else // !_TARGET_X86_ && !(USE_GC_INFO_DECODER && !CROSSGEN_COMPILE)
-    PORTABILITY_ASSERT("EECodeManager::GetAddrOfSecurityObject is not implemented on this platform.");
-#endif
+#endif // USE_GC_INFO_DECODER
 
     return NULL;
 }
-#endif
+#endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
 
 /*****************************************************************************
  *

--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -52,6 +52,7 @@ Assembly* CrawlFrame::GetAssembly()
     return pAssembly;
 }
 
+#ifndef DACCESS_COMPILE
 OBJECTREF* CrawlFrame::GetAddrOfSecurityObject()
 {
     CONTRACTL {
@@ -98,6 +99,7 @@ OBJECTREF* CrawlFrame::GetAddrOfSecurityObject()
     }
     return NULL;
 }
+#endif
 
 BOOL CrawlFrame::IsInCalleesFrames(LPVOID stackPointer)
 {

--- a/src/vm/stackwalk.h
+++ b/src/vm/stackwalk.h
@@ -107,6 +107,7 @@ public:
 
     BOOL IsInCalleesFrames(LPVOID stackPointer);
 
+#ifndef DACCESS_COMPILE
     /* Returns address of the securityobject stored in the current function (method?)
        Returns NULL if
             - not a function OR
@@ -114,6 +115,7 @@ public:
               (which is an error)
      */
     OBJECTREF * GetAddrOfSecurityObject();
+#endif // DACCESS_COMPILE
 
     // Fetch the extra type argument passed in some cases
     PTR_VOID GetParamTypeArg();


### PR DESCRIPTION
This commit simplifies #ifdef inside EECodeManager::GetAddrOfSecurityObject.