### PR TITLE
Inlinable ArraySegment ctor

### DIFF
--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -45,7 +45,7 @@ namespace System
         public ArraySegment(T[] array, int offset, int count)
         {
             // Validate input arguments
-            if (array == null || offset < 0 || count < 0|| (array.Length - offset < count))
+            if (array == null || (offset | count) < 0 || (array.Length - offset < count))
                 ThrowConstructorValidationFailedExceptions(array, offset, count);
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -44,8 +44,9 @@ namespace System
 
         public ArraySegment(T[] array, int offset, int count)
         {
-            // Validate input arguments
-            if (array == null || (offset | count) < 0 || (array.Length - offset < count))
+            // Validate arguments, check is minimal instructions with reduced branching for inlinable fast-path
+            // Failure should be rare and location determination and message is delegated to failure functions
+            if (array == null | ((offset | count) < 0) || (array.Length - offset < count))
                 ThrowConstructorValidationFailedExceptions(array, offset, count);
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -47,7 +47,7 @@ namespace System
             // Validate arguments, check is minimal instructions with reduced branching for inlinable fast-path
             // Failure should be rare and location determination and message is delegated to failure functions
             if (array == null | ((offset | count) < 0) || (array.Length - offset < count))
-                ThrowConstructorValidationFailedExceptions(array, offset, count);
+                ThrowHelper.ThrowArraySegmentCtorValidationFailedExceptions(array, offset, count);
             Contract.EndContractBlock();
 
             _array = array;
@@ -152,24 +152,6 @@ namespace System
         public static bool operator !=(ArraySegment<T> a, ArraySegment<T> b)
         {
             return !(a == b);
-        }
-
-        private static void ThrowConstructorValidationFailedExceptions(T[] array, int offset, int count)
-        {
-            throw GetConstructorValidationFailedException(array, offset, count);
-        }
-
-        private static Exception GetConstructorValidationFailedException(T[] array, int offset, int count)
-        {
-            if (array == null)
-                return ThrowHelper.GetArgumentNullException(ExceptionArgument.array);
-            if (offset < 0)
-                return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-            if (count < 0)
-                return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-
-            Debug.Assert(array.Length - offset < count);
-            return ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffLen);
         }
 
         #region IList<T>

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -46,7 +46,7 @@ namespace System
         {
             // Validate arguments, check is minimal instructions with reduced branching for inlinable fast-path
             // Failure should be rare and location determination and message is delegated to failure functions
-            if ((array == null | (offset | count) < 0) || (array.Length - offset < count))
+            if (array == null || (offset | count) < 0 || (array.Length - offset < count))
                 ThrowHelper.ThrowArraySegmentCtorValidationFailedExceptions(array, offset, count);
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -46,7 +46,7 @@ namespace System
         {
             // Validate arguments, check is minimal instructions with reduced branching for inlinable fast-path
             // Failure should be rare and location determination and message is delegated to failure functions
-            if (array == null | ((offset | count) < 0) || (array.Length - offset < count))
+            if ((array == null | (offset | count) < 0) || (array.Length - offset < count))
                 ThrowHelper.ThrowArraySegmentCtorValidationFailedExceptions(array, offset, count);
             Contract.EndContractBlock();
 

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -15,8 +15,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 
 namespace System
@@ -46,14 +44,9 @@ namespace System
 
         public ArraySegment(T[] array, int offset, int count)
         {
-            if (array == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            if (offset < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-            if (count < 0)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-            if (array.Length - offset < count)
-                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
+            // Validate input arguments
+            if (array == null || offset < 0 || count < 0|| (array.Length - offset < count))
+                ThrowConstructorValidationFailedExceptions(array, offset, count);
             Contract.EndContractBlock();
 
             _array = array;
@@ -158,6 +151,24 @@ namespace System
         public static bool operator !=(ArraySegment<T> a, ArraySegment<T> b)
         {
             return !(a == b);
+        }
+
+        private static void ThrowConstructorValidationFailedExceptions(T[] array, int offset, int count)
+        {
+            throw GetConstructorValidationFailedException(array, offset, count);
+        }
+
+        private static Exception GetConstructorValidationFailedException(T[] array, int offset, int count)
+        {
+            if (array == null)
+                return ThrowHelper.GetArgumentNullException(ExceptionArgument.array);
+            if (offset < 0)
+                return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.offset, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+            if (count < 0)
+                return ThrowHelper.GetArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+
+            Debug.Assert(array.Length - offset < count);
+            return ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffLen);
         }
 
         #region IList<T>

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -39,7 +39,6 @@ namespace System {
     using Collections.Generic;
     using System.Runtime.CompilerServices;
     using System.Runtime.Serialization;
-    using System.Diagnostics;
     using System.Diagnostics.Contracts;
 
     [Pure]
@@ -125,8 +124,12 @@ namespace System {
             throw GetArgumentException(resource, argument);
         }
 
+        internal static ArgumentNullException GetArgumentNullException(ExceptionArgument argument) {
+            return new ArgumentNullException(GetArgumentName(argument));
+        }
+
         internal static void ThrowArgumentNullException(ExceptionArgument argument) {
-            throw new ArgumentNullException(GetArgumentName(argument));
+            throw GetArgumentNullException(argument);
         }
 
         internal static void ThrowArgumentNullException(ExceptionResource resource) {
@@ -209,7 +212,7 @@ namespace System {
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);
         }
 
-        private static ArgumentException GetArgumentException(ExceptionResource resource) {
+        internal static ArgumentException GetArgumentException(ExceptionResource resource) {
             return new ArgumentException(GetResourceString(resource));
         }
 
@@ -225,7 +228,7 @@ namespace System {
             return new ArgumentException(Environment.GetResourceString("Arg_WrongType", value, targetType), nameof(value));
         }
 
-        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
+        internal static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
             return new ArgumentOutOfRangeException(GetArgumentName(argument), GetResourceString(resource));
         }
 

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -124,7 +124,7 @@ namespace System {
             throw GetArgumentException(resource, argument);
         }
 
-        internal static ArgumentNullException GetArgumentNullException(ExceptionArgument argument) {
+        private static ArgumentNullException GetArgumentNullException(ExceptionArgument argument) {
             return new ArgumentNullException(GetArgumentName(argument));
         }
 
@@ -212,7 +212,24 @@ namespace System {
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);
         }
 
-        internal static ArgumentException GetArgumentException(ExceptionResource resource) {
+        internal static void ThrowArraySegmentCtorValidationFailedExceptions(object array, int offset, int count) {
+            Debug.Assert(array is Array);
+            throw GetArraySegmentCtorValidationFailedException(array, offset, count);
+        }
+
+        private static Exception GetArraySegmentCtorValidationFailedException(object array, int offset, int count) {
+            if (array == null)
+                return GetArgumentNullException(ExceptionArgument.array);
+            if (offset < 0)
+                return GetArgumentOutOfRangeException(ExceptionArgument.offset, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+            if (count < 0)
+                return GetArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+
+            Debug.Assert((array as Array).Length - offset < count);
+            return GetArgumentException(ExceptionResource.Argument_InvalidOffLen);
+        }
+
+        private static ArgumentException GetArgumentException(ExceptionResource resource) {
             return new ArgumentException(GetResourceString(resource));
         }
 
@@ -228,7 +245,7 @@ namespace System {
             return new ArgumentException(Environment.GetResourceString("Arg_WrongType", value, targetType), nameof(value));
         }
 
-        internal static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
             return new ArgumentOutOfRangeException(GetArgumentName(argument), GetResourceString(resource));
         }
 

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -212,12 +212,11 @@ namespace System {
             throw GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumOpCantHappen);
         }
 
-        internal static void ThrowArraySegmentCtorValidationFailedExceptions(object array, int offset, int count) {
-            Debug.Assert(array is Array);
+        internal static void ThrowArraySegmentCtorValidationFailedExceptions(Array array, int offset, int count) {
             throw GetArraySegmentCtorValidationFailedException(array, offset, count);
         }
 
-        private static Exception GetArraySegmentCtorValidationFailedException(object array, int offset, int count) {
+        private static Exception GetArraySegmentCtorValidationFailedException(Array array, int offset, int count) {
             if (array == null)
                 return GetArgumentNullException(ExceptionArgument.array);
             if (offset < 0)
@@ -225,7 +224,7 @@ namespace System {
             if (count < 0)
                 return GetArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
 
-            Debug.Assert((array as Array).Length - offset < count);
+            Debug.Assert(array.Length - offset < count);
             return GetArgumentException(ExceptionResource.Argument_InvalidOffLen);
         }
 


### PR DESCRIPTION
`ArraySegment``1:.ctor(ref,int,int):this` currently is too big to be inlinable and shows up on plaintext traces

![](https://aoa.blob.core.windows.net/aspnet/arraysegment.png)

This change shrinks it so it inlines

```
Successfully inlined ArraySegment`1:.ctor(ref,int,int):this (47 IL bytes) (depth 1) [profitable inline]
```

/cc @jkotas @stephentoub @AndyAyersMS 
