### PR TITLE
[x86/Linux] Fix incorrect update in HijackFrame::UpdateRegDisplay

### DIFF
--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -802,6 +802,7 @@ void ResumableFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 }
 
 // The HijackFrame has to know the registers that are pushed by OnHijackTripThread
+//  -> HijackFrame::UpdateRegDisplay should restore all the registers pushed by OnHijackTripThread
 void HijackFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 {
     CONTRACTL {
@@ -822,19 +823,15 @@ void HijackFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);
     pRD->pCurrentContext->Esp = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
 
-#define CALLEE_SAVED_REGISTER(reg) pRD->pCurrentContext->reg = m_Args->reg;
-    ENUM_CALLEE_SAVED_REGISTERS();
-#undef CALLEE_SAVED_REGISTER
-
-#define CALLEE_SAVED_REGISTER(reg) pRD->pCurrentContextPointers->reg = NULL;
-    ENUM_CALLEE_SAVED_REGISTERS();
-#undef CALLEE_SAVED_REGISTER
-
-#define ARGUMENT_AND_SCRATCH_REGISTER(reg) pRD->pCurrentContextPointers->reg = NULL;
-    ENUM_ARGUMENT_AND_SCRATCH_REGISTERS();
-#undef ARGUMENT_AND_SCRATCH_REGISTER
-
-    pRD->pCurrentContextPointers->Eax = (PDWORD) &m_Args->Eax;
+#define RESTORE_REG(reg) { pRD->pCurrentContext->reg = m_Args->reg; pRD->pCurrentContextPointers->reg = &m_Args->reg; }
+    RESTORE_REG(Edi);
+    RESTORE_REG(Esi);
+    RESTORE_REG(Ebx);
+    RESTORE_REG(Edx);
+    RESTORE_REG(Ecx);
+    RESTORE_REG(Eax);
+    RESTORE_REG(Ebp);
+#undef RESTORE_REG
 
     SyncRegDisplayToCurrentContext(pRD);
 

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -824,13 +824,13 @@ void HijackFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->pCurrentContext->Esp = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
 
 #define RESTORE_REG(reg) { pRD->pCurrentContext->reg = m_Args->reg; pRD->pCurrentContextPointers->reg = &m_Args->reg; }
-    RESTORE_REG(Edi);
-    RESTORE_REG(Esi);
-    RESTORE_REG(Ebx);
-    RESTORE_REG(Edx);
-    RESTORE_REG(Ecx);
-    RESTORE_REG(Eax);
-    RESTORE_REG(Ebp);
+#define CALLEE_SAVED_REGISTER(reg) RESTORE_REG(reg)
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+
+#define ARGUMENT_AND_SCRATCH_REGISTER(reg) RESTORE_REG(reg)
+    ENUM_ARGUMENT_AND_SCRATCH_REGISTERS();
+#undef ARGUMENT_AND_SCRATCH_REGISTER
 #undef RESTORE_REG
 
     SyncRegDisplayToCurrentContext(pRD);
@@ -840,14 +840,16 @@ void HijackFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     // This only describes the top-most frame
     pRD->pContext = NULL;
 
-    pRD->pEdi = &m_Args->Edi;
-    pRD->pEsi = &m_Args->Esi;
-    pRD->pEbx = &m_Args->Ebx;
-    pRD->pEdx = &m_Args->Edx;
-    pRD->pEcx = &m_Args->Ecx;
-    pRD->pEax = &m_Args->Eax;
+#define RESTORE_REG(reg) { pRD->p##reg = &m_Args->reg; }
+#define CALLEE_SAVED_REGISTER(reg) RESTORE_REG(reg)
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
 
-    pRD->pEbp = &m_Args->Ebp;
+#define ARGUMENT_AND_SCRATCH_REGISTER(reg) RESTORE_REG(reg)
+    ENUM_ARGUMENT_AND_SCRATCH_REGISTERS();
+#undef ARGUMENT_AND_SCRATCH_REGISTER
+#undef RESTORE_REG
+
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
     pRD->SP  = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
 


### PR DESCRIPTION
While x86/Linux bring up, HijackFrame::UpdateRegDisplay is revised similarly as the corresponding x64 implementation.

It turns out that this implementation is incorrect. The implementation of HijackFrame::UpdateRegDisplay should be aligned with OnHijackTripThread, but x64 and x86 has different OnHijackTripThread implementation.

This results which results in segfault discussed in #9435.

This commit revises HijackFrame::UpdateRegDisplay in order to fix #9435.