### PR TITLE
Update conservative value numbers during CSE

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5388,6 +5388,9 @@ protected:
 
         treeStmtLstPtr csdTreeList; // list of matching tree nodes: head
         treeStmtLstPtr csdTreeLast; // list of matching tree nodes: tail
+
+        ValueNum defConservativeVN; // if all def occurrences share the same conservative value
+                                    // number, this will reflect it; otherwise, NoVN.
     };
 
     static const size_t s_optCSEhashSize;


### PR DESCRIPTION
When a CSE candidate's defs all share the same conservative value number,
its uses can be updated to share that conservative value number as well
when CSE is performed, because we are removing any reloads that may have
been the cause of the divergence.  Performing this update can improve
subsequent range check elimination when the CSE use is array length or
index in a bounds check.