### PR TITLE
Replace binary literal with hex

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -24205,7 +24205,7 @@ private:
         var_types    pointerType;
         bool         doesReturnValue;
 
-        const int FAT_POINTER_MASK = 0b00000010;
+        const int FAT_POINTER_MASK = 0x2;
         const int HIGH_PROBABILITY = 80;
     };
 


### PR DESCRIPTION
The desktop build breaks with the binary literal used in the fat pointer
mask. Replace it with a hex equivalent.