### PR TITLE
Reduce Task and async method overheads

### DIFF
--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -63,7 +63,7 @@ namespace System.Runtime.CompilerServices
             // See comment on AsyncMethodBuilderCore.Start
             // AsyncMethodBuilderCore.Start(ref stateMachine);
 
-            if (stateMachine == null) throw new ArgumentNullException(nameof(stateMachine));
+            if (stateMachine == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.stateMachine);
             Contract.EndContractBlock();
 
             // Run the MoveNext method within a copy-on-write ExecutionContext scope.
@@ -72,7 +72,6 @@ namespace System.Runtime.CompilerServices
 
             Thread currentThread = Thread.CurrentThread;
             ExecutionContextSwitcher ecs = default(ExecutionContextSwitcher);
-            RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
                 ExecutionContext.EstablishCopyOnWriteScope(currentThread, ref ecs);
@@ -240,15 +239,8 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        // This property lazily instantiates the Task in a non-thread-safe manner.  
-        private Task Task 
-        {
-            get
-            {
-                if (m_task == null) m_task = new Task();
-                return m_task;
-            }
-        }
+        /// <summary>Lazily instantiate the Task in a non-thread-safe manner.</summary>
+        private Task Task => m_task ?? (m_task = new Task());
 
         /// <summary>
         /// Gets an object that may be used to uniquely identify this builder to the debugger.
@@ -295,7 +287,7 @@ namespace System.Runtime.CompilerServices
             // See comment on AsyncMethodBuilderCore.Start
             // AsyncMethodBuilderCore.Start(ref stateMachine);
 
-            if (stateMachine == null) throw new ArgumentNullException(nameof(stateMachine));
+            if (stateMachine == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.stateMachine);
             Contract.EndContractBlock();
 
             // Run the MoveNext method within a copy-on-write ExecutionContext scope.
@@ -304,7 +296,6 @@ namespace System.Runtime.CompilerServices
 
             Thread currentThread = Thread.CurrentThread;
             ExecutionContextSwitcher ecs = default(ExecutionContextSwitcher);
-            RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
                 ExecutionContext.EstablishCopyOnWriteScope(currentThread, ref ecs);
@@ -358,7 +349,11 @@ namespace System.Runtime.CompilerServices
         /// <summary>Gets the <see cref="System.Threading.Tasks.Task"/> for this builder.</summary>
         /// <returns>The <see cref="System.Threading.Tasks.Task"/> representing the builder's asynchronous operation.</returns>
         /// <exception cref="System.InvalidOperationException">The builder is not initialized.</exception>
-        public Task Task { get { return m_builder.Task; } }
+        public Task Task
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return m_builder.Task; }
+        }
 
         /// <summary>
         /// Completes the <see cref="System.Threading.Tasks.Task"/> in the 
@@ -449,7 +444,7 @@ namespace System.Runtime.CompilerServices
             // See comment on AsyncMethodBuilderCore.Start
             // AsyncMethodBuilderCore.Start(ref stateMachine);
 
-            if (stateMachine == null) throw new ArgumentNullException(nameof(stateMachine));
+            if (stateMachine == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.stateMachine);
             Contract.EndContractBlock();
 
             // Run the MoveNext method within a copy-on-write ExecutionContext scope.
@@ -458,7 +453,6 @@ namespace System.Runtime.CompilerServices
 
             Thread currentThread = Thread.CurrentThread;
             ExecutionContextSwitcher ecs = default(ExecutionContextSwitcher);
-            RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
                 ExecutionContext.EstablishCopyOnWriteScope(currentThread, ref ecs);
@@ -502,7 +496,7 @@ namespace System.Runtime.CompilerServices
                 {
                     // Force the Task to be initialized prior to the first suspending await so 
                     // that the original stack-based builder has a reference to the right Task.
-                    var builtTask = this.Task;
+                    Task builtTask = this.Task;
 
                     // Box the state machine, then tell the boxed instance to call back into its own builder,
                     // so we can cache the boxed reference. NOTE: The language compiler may choose to use
@@ -542,7 +536,7 @@ namespace System.Runtime.CompilerServices
                 {
                     // Force the Task to be initialized prior to the first suspending await so 
                     // that the original stack-based builder has a reference to the right Task.
-                    var builtTask = this.Task;
+                    Task<TResult> builtTask = this.Task;
 
                     // Box the state machine, then tell the boxed instance to call back into its own builder,
                     // so we can cache the boxed reference. NOTE: The language compiler may choose to use
@@ -563,14 +557,13 @@ namespace System.Runtime.CompilerServices
         /// <returns>The <see cref="System.Threading.Tasks.Task{TResult}"/> representing the builder's asynchronous operation.</returns>
         public Task<TResult> Task
         {
-            get
-            {
-                // Get and return the task. If there isn't one, first create one and store it.
-                var task = m_task;
-                if (task == null) { m_task = task = new Task<TResult>(); }
-                return task;
-            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return m_task ?? InitializeTask(); }
         }
+
+        /// <summary>Initializes the task, which must not yet be initialized.</summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private Task<TResult> InitializeTask() => (m_task = new Task<TResult>());
 
         /// <summary>
         /// Completes the <see cref="System.Threading.Tasks.Task{TResult}"/> in the 
@@ -582,28 +575,49 @@ namespace System.Runtime.CompilerServices
         {
             // Get the currently stored task, which will be non-null if get_Task has already been accessed.
             // If there isn't one, get a task and store it.
-            var task = m_task;
-            if (task == null)
+            if (m_task == null)
             {
                 m_task = GetTaskForResult(result);
                 Debug.Assert(m_task != null, "GetTaskForResult should never return null");
             }
-            // Slow path: complete the existing task.
             else
             {
-                if (AsyncCausalityTracer.LoggingOn)
-                    AsyncCausalityTracer.TraceOperationCompletion(CausalityTraceLevel.Required, task.Id, AsyncCausalityStatus.Completed);
+                // Slow path: complete the existing task.
+                SetExistingTaskResult(result);
+            }
+        }
 
-                //only log if we have a real task that was previously created
-                if (System.Threading.Tasks.Task.s_asyncDebuggingEnabled)
-                {
-                    System.Threading.Tasks.Task.RemoveFromActiveTasks(task.Id);
-                }
+        /// <summary>Completes the already initialized task with the specified result.</summary>
+        /// <param name="result">The result to use to complete the task.</param>
+        private void SetExistingTaskResult(TResult result)
+        {
+            Debug.Assert(m_task != null, "Expected non-null task");
 
-                if (!task.TrySetResult(result))
-                {
-                    throw new InvalidOperationException(Environment.GetResourceString("TaskT_TransitionToFinal_AlreadyCompleted"));
-                }
+            if (AsyncCausalityTracer.LoggingOn || System.Threading.Tasks.Task.s_asyncDebuggingEnabled)
+            {
+                LogExistingTaskCompletion();
+            }
+
+            if (!m_task.TrySetResult(result))
+            {
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
+            }
+        }
+
+        /// <summary>Handles logging for the successful completion of an operation.</summary>
+        private void LogExistingTaskCompletion()
+        {
+            Debug.Assert(m_task != null);
+
+            if (AsyncCausalityTracer.LoggingOn)
+            {
+                AsyncCausalityTracer.TraceOperationCompletion(CausalityTraceLevel.Required, m_task.Id, AsyncCausalityStatus.Completed);
+            }
+
+            // only log if we have a real task that was previously created
+            if (System.Threading.Tasks.Task.s_asyncDebuggingEnabled)
+            {
+                System.Threading.Tasks.Task.RemoveFromActiveTasks(m_task.Id);
             }
         }
 
@@ -620,15 +634,14 @@ namespace System.Runtime.CompilerServices
 
             // Get the currently stored task, which will be non-null if get_Task has already been accessed.
             // If there isn't one, store the supplied completed task.
-            var task = m_task;
-            if (task == null)
+            if (m_task == null)
             {
                 m_task = completedTask;
             }
             else
             {
                 // Otherwise, complete the task that's there.
-                SetResult(default(TResult));
+                SetExistingTaskResult(default(TResult));
             }
         }
 
@@ -667,7 +680,7 @@ namespace System.Runtime.CompilerServices
 
             if (!successfullySet)
             {
-                throw new InvalidOperationException(Environment.GetResourceString("TaskT_TransitionToFinal_AlreadyCompleted"));
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
             }
         }
 
@@ -704,6 +717,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <param name="result">The result for which we need a task.</param>
         /// <returns>The completed task containing the result.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // method looks long, but for a given TResult it results in a relatively small amount of asm
         private Task<TResult> GetTaskForResult(TResult result)
         {
             Contract.Ensures(
@@ -846,9 +860,9 @@ namespace System.Runtime.CompilerServices
         /// <exception cref="System.InvalidOperationException">The builder is incorrectly initialized.</exception>
         public void SetStateMachine(IAsyncStateMachine stateMachine)
         {
-            if (stateMachine == null) throw new ArgumentNullException(nameof(stateMachine));
+            if (stateMachine == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.stateMachine);
             Contract.EndContractBlock();
-            if (m_stateMachine != null) throw new InvalidOperationException(Environment.GetResourceString("AsyncMethodBuilder_InstanceNotInitialized"));
+            if (m_stateMachine != null) ThrowHelper.ThrowInvalidOperationException(ExceptionResource.AsyncMethodBuilder_InstanceNotInitialized);
             m_stateMachine = stateMachine;
         }
 
@@ -1104,9 +1118,9 @@ namespace System.Runtime.CompilerServices
             return action;
         }
 
-    ///<summary>
-    /// Given an action, see if it is a contiunation wrapper and has a Task associated with it.  If so return it (null otherwise)
-    ///</summary>
+        ///<summary>
+        /// Given an action, see if it is a contiunation wrapper and has a Task associated with it.  If so return it (null otherwise)
+        ///</summary>
         internal static Task TryGetContinuationTask(Action action)
         {
             if (action != null) 

--- a/src/mscorlib/src/System/Threading/Tasks/TaskCompletionSource.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskCompletionSource.cs
@@ -276,7 +276,7 @@ namespace System.Threading.Tasks
         public bool TrySetResult(TResult result)
         {
             bool rval = m_task.TrySetResult(result);
-            if (!rval && !m_task.IsCompleted) SpinUntilCompleted();
+            if (!rval) SpinUntilCompleted();
             return rval;
         }
 

--- a/src/mscorlib/src/System/Threading/Tasks/TaskFactory.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskFactory.cs
@@ -40,30 +40,20 @@ namespace System.Threading.Tasks
     public class TaskFactory
     {
         // member variables
-        private CancellationToken m_defaultCancellationToken;
-        private TaskScheduler m_defaultScheduler;
-        private TaskCreationOptions m_defaultCreationOptions;
-        private TaskContinuationOptions m_defaultContinuationOptions;
+        private readonly CancellationToken m_defaultCancellationToken;
+        private readonly TaskScheduler m_defaultScheduler;
+        private readonly TaskCreationOptions m_defaultCreationOptions;
+        private readonly TaskContinuationOptions m_defaultContinuationOptions;
 
-
-        private TaskScheduler DefaultScheduler
-        {
-            get
-            {
-                if (m_defaultScheduler == null) return TaskScheduler.Current;
-                else return m_defaultScheduler;
-            }
-        }
+        private TaskScheduler DefaultScheduler => m_defaultScheduler ?? TaskScheduler.Current;
 
         // sister method to above property -- avoids a TLS lookup
         private TaskScheduler GetDefaultScheduler(Task currTask)
         {
-            if (m_defaultScheduler != null) return m_defaultScheduler;
-            else if ((currTask != null)
-                && ((currTask.CreationOptions & TaskCreationOptions.HideScheduler) == 0)
-                )
-                return currTask.ExecutingTaskScheduler;
-            else return TaskScheduler.Default;
+            return
+                m_defaultScheduler ??
+                (currTask != null && (currTask.CreationOptions & TaskCreationOptions.HideScheduler) == 0 ? currTask.ExecutingTaskScheduler :
+                 TaskScheduler.Default);
         }
 
         /* Constructors */

--- a/src/mscorlib/src/System/Threading/Tasks/TaskFactory.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskFactory.cs
@@ -2337,7 +2337,8 @@ namespace System.Threading.Tasks
 
             public void Invoke(Task completingTask)
             {
-                if (Interlocked.CompareExchange(ref m_firstTaskAlreadyCompleted, 1, 0) == 0)
+                if (m_firstTaskAlreadyCompleted == 0 &&
+                    Interlocked.Exchange(ref m_firstTaskAlreadyCompleted, 1) == 0)
                 {
                     if (AsyncCausalityTracer.LoggingOn)
                     {

--- a/src/mscorlib/src/System/Threading/Tasks/TaskScheduler.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskScheduler.cs
@@ -203,7 +203,10 @@ namespace System.Threading.Tasks
             bool bInlined = false;
             try
             {
-                task.FireTaskScheduledIfNeeded(this);
+                if (TplEtwProvider.Log.IsEnabled())
+                {
+                    task.FireTaskScheduledIfNeeded(this);
+                }
                 bInlined = TryExecuteTaskInline(task, taskWasPreviouslyQueued);
             }
             finally
@@ -256,7 +259,10 @@ namespace System.Threading.Tasks
         {
             Contract.Requires(task != null);
 
-            task.FireTaskScheduledIfNeeded(this);
+            if (TplEtwProvider.Log.IsEnabled())
+            {
+                task.FireTaskScheduledIfNeeded(this);
+            }
 
             this.QueueTask(task);
         }
@@ -440,7 +446,7 @@ namespace System.Threading.Tasks
                 throw new InvalidOperationException(Environment.GetResourceString("TaskScheduler_ExecuteTask_WrongTaskScheduler"));
             }
 
-            return task.ExecuteEntry(true);
+            return task.ExecuteEntry();
         }
 
         ////////////////////////////////////////////////////////////
@@ -684,16 +690,7 @@ namespace System.Threading.Tasks
         }
 
         // preallocated SendOrPostCallback delegate
-        private static SendOrPostCallback s_postCallback = new SendOrPostCallback(PostCallback);
-
-        // this is where the actual task invocation occures
-        private static void PostCallback(object obj)
-        {
-            Task task = (Task) obj;
-
-            // calling ExecuteEntry with double execute check enabled because a user implemented SynchronizationContext could be buggy
-            task.ExecuteEntry(true);
-        }
+        private static readonly SendOrPostCallback s_postCallback = s => ((Task)s).ExecuteEntry(); // with double-execute check because SC could be buggy
     }
 
     /// <summary>

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -362,6 +362,7 @@ namespace System {
         text,
         callBack,
         type,
+        stateMachine,
     }
 
     //
@@ -467,6 +468,7 @@ namespace System {
         ConcurrentCollection_SyncRoot_NotSupported,
         ArgumentOutOfRange_Enum,
         InvalidOperation_HandleIsNotInitialized,
+        AsyncMethodBuilder_InstanceNotInitialized,
     }
 }
 


### PR DESCRIPTION
This PR attempts to reduce the overhead associated with executing Tasks and invoking async methods.

Microbenchmarks look pretty good:
- Repeatedly creating an ```AsyncTaskMethodBuilder<bool>``` and completing it "synchronously" (before accessing its Task) with a known cached value: *1.95x*
- Repeatedly creating an ```AsyncTaskMethodBuilder<int>``` and completing it "synchronously" (before accessing its Task) with a known non-cached value:  *1.53x*
- Repeatedly creating an ```AsyncTaskMethodBuilder<int>``` and completing it "asynchronously" (after accessing its Task):  *1.38x*
- Repeatedly invoking an empty async ```Task<bool>``` method: *1.26x*
- Repeatedly creating and completing a TaskCompletionSource<int>(): *1.37x*
- Repeatedly creating and completing a TaskCompletionSource<int>(object): *1.29x*
- Having ProcessorCount worker threads continually queueing a task to its local queue, popping/executing it: *1.06x*
- Having ProcessorCount worker threads continually queueing a task to the global queue, dequeueing/executing one: Fluctuated within noise +/- 1-2%
- Long chain of synchronous continuations: Fluctuated within noise +/- 1-2%
- Long chain of asynchronous continuations: Fluctuated within noise +/- 1-2%

(I'd like to hold off on merging though until doing some more verification on ASP.NET workloads to make sure they're at least not negatively affected.)

cc: @jkotas, @kouvel, @benaadams