### PR TITLE
GcHandle Perf Tweaks

### DIFF
--- a/src/mscorlib/src/System/Runtime/InteropServices/GcHandle.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/GcHandle.cs
@@ -9,10 +9,8 @@ namespace System.Runtime.InteropServices
     using System.Threading;
     using System.Diagnostics.Contracts;
 #if BIT64
-    using nuint = System.UInt64;
     using nint = System.Int64;
 #else
-    using nuint = System.UInt32;
     using nint = System.Int32;
 #endif
 
@@ -46,13 +44,8 @@ namespace System.Runtime.InteropServices
     [StructLayout(LayoutKind.Sequential)]
     public struct GCHandle
     {
-#if BIT64
-    private const long NoFlag = ~1L;
-#else
-    private const int NoFlag = ~1;
-#endif
-    // IMPORTANT: This must be kept in sync with the GCHandleType enum.
-    private const GCHandleType MaxHandleType = GCHandleType.Pinned;
+        // IMPORTANT: This must be kept in sync with the GCHandleType enum.
+        private const GCHandleType MaxHandleType = GCHandleType.Pinned;
 
 #if MDA_SUPPORTED
         static GCHandle()
@@ -76,7 +69,7 @@ namespace System.Runtime.InteropServices
             if (type == GCHandleType.Pinned)
             {
                 // Record if the handle is pinned.
-                handle = (IntPtr)((nuint)handle | 1);
+                handle = (IntPtr)((nint)handle | 1);
             }
 
             m_handle = handle;
@@ -243,13 +236,13 @@ namespace System.Runtime.InteropServices
         private static IntPtr GetHandleValue(IntPtr handle)
         {
             // Remove Pin flag
-            return new IntPtr((nint)handle & NoFlag);
+            return new IntPtr((nint)handle & ~(nint)1);
         }
 
         internal bool IsPinned()
         {
             // Check Pin flag
-            return ((nuint)m_handle & 1) != 0;
+            return ((nint)m_handle & 1) != 0;
         }
 
         // Internal native calls that this implementation uses.

--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -178,7 +178,7 @@ namespace System.Runtime.Loader
         // implementation.
         private static Assembly Resolve(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
         {
-            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.GetTargetFromIntPtr(gchManagedAssemblyLoadContext));
+            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchManagedAssemblyLoadContext).Target);
             
             return context.ResolveUsingLoad(assemblyName);
         }
@@ -187,7 +187,7 @@ namespace System.Runtime.Loader
         // after trying assembly resolution via Load override and TPA load context without success.
         private static Assembly ResolveUsingResolvingEvent(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
         {
-            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.GetTargetFromIntPtr(gchManagedAssemblyLoadContext));
+            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchManagedAssemblyLoadContext).Target);
             
             // Invoke the AssemblyResolve event callbacks if wired up
             return context.ResolveUsingEvent(assemblyName);
@@ -317,7 +317,7 @@ namespace System.Runtime.Loader
         // implementation.
         private static IntPtr ResolveUnmanagedDll(String unmanagedDllName, IntPtr gchManagedAssemblyLoadContext)
         {
-            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.GetTargetFromIntPtr(gchManagedAssemblyLoadContext));
+            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchManagedAssemblyLoadContext).Target);
             return context.LoadUnmanagedDll(unmanagedDllName);
         }
 
@@ -391,7 +391,7 @@ namespace System.Runtime.Loader
                 }
                 else
                 {
-                    loadContextForAssembly = (AssemblyLoadContext)(GCHandle.GetTargetFromIntPtr(ptrAssemblyLoadContext));
+                    loadContextForAssembly = (AssemblyLoadContext)(GCHandle.FromIntPtr(ptrAssemblyLoadContext).Target);
                 }
             }
 

--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -178,7 +178,7 @@ namespace System.Runtime.Loader
         // implementation.
         private static Assembly Resolve(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
         {
-            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchManagedAssemblyLoadContext).Target);
+            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.GetTargetFromIntPtr(gchManagedAssemblyLoadContext));
             
             return context.ResolveUsingLoad(assemblyName);
         }
@@ -187,7 +187,7 @@ namespace System.Runtime.Loader
         // after trying assembly resolution via Load override and TPA load context without success.
         private static Assembly ResolveUsingResolvingEvent(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
         {
-            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchManagedAssemblyLoadContext).Target);
+            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.GetTargetFromIntPtr(gchManagedAssemblyLoadContext));
             
             // Invoke the AssemblyResolve event callbacks if wired up
             return context.ResolveUsingEvent(assemblyName);
@@ -317,7 +317,7 @@ namespace System.Runtime.Loader
         // implementation.
         private static IntPtr ResolveUnmanagedDll(String unmanagedDllName, IntPtr gchManagedAssemblyLoadContext)
         {
-            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchManagedAssemblyLoadContext).Target);
+            AssemblyLoadContext context = (AssemblyLoadContext)(GCHandle.GetTargetFromIntPtr(gchManagedAssemblyLoadContext));
             return context.LoadUnmanagedDll(unmanagedDllName);
         }
 
@@ -391,7 +391,7 @@ namespace System.Runtime.Loader
                 }
                 else
                 {
-                    loadContextForAssembly = (AssemblyLoadContext)(GCHandle.FromIntPtr(ptrAssemblyLoadContext).Target);
+                    loadContextForAssembly = (AssemblyLoadContext)(GCHandle.GetTargetFromIntPtr(ptrAssemblyLoadContext));
                 }
             }
 

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -232,7 +232,7 @@ namespace System {
             return new ArgumentException(GetResourceString(resource));
         }
 
-        private static InvalidOperationException GetInvalidOperationException(ExceptionResource resource) {
+        internal static InvalidOperationException GetInvalidOperationException(ExceptionResource resource) {
             return new InvalidOperationException(GetResourceString(resource));
         }
 
@@ -244,7 +244,7 @@ namespace System {
             return new ArgumentException(Environment.GetResourceString("Arg_WrongType", value, targetType), nameof(value));
         }
 
-        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
+        internal static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource) {
             return new ArgumentOutOfRangeException(GetArgumentName(argument), GetResourceString(resource));
         }
 
@@ -381,6 +381,7 @@ namespace System {
         concurrencyLevel,
         text,
         callBack,
+        type,
     }
 
     //
@@ -484,7 +485,8 @@ namespace System {
         ConcurrentDictionary_ArrayNotLargeEnough,
         ConcurrentDictionary_ArrayIncorrectType,
         ConcurrentCollection_SyncRoot_NotSupported,
-
+        ArgumentOutOfRange_Enum,
+        InvalidOperation_HandleIsNotInitialized,
     }
 }
 


### PR DESCRIPTION
GCHandle is either mostly a thin wrapper around VM functions; or simple bitshifts and casts. However its current implementation has significant overhead as it is called a huge amount and its functions are marked by NGen as permanently uninlinable.

Previously 2,028.497 GCHandle calls for 158,475 libuv write calls (in Marshal)

![](https://aoa.blob.core.windows.net/aspnet/GCHandle1.png)

After 814 GCHandle calls for 2,760,965 libuv write calls (in Marshal)

![](https://aoa.blob.core.windows.net/aspnet/GCHandle2.png)

Mostly they are fairly simple, so for example while GCHandle:SetIsPinned is unprofitable and permanently no inline; is asm ends up extremely simple

```asm
Marking GCHandle:SetIsPinned():this as NOINLINE because of unprofitable inline
Successfully inlined IntPtr:op_Explicit(long):long (9 IL bytes) (depth 1) [below ALWAYS_INLINE size]
Successfully inlined IntPtr:.ctor(long):this (9 IL bytes) (depth 1) [below ALWAYS_INLINE size]
**************** Inline Tree
Inlines into 0600369E GCHandle:SetIsPinned():this
  [1 IL=0007 TR=000004 06000C06] [below ALWAYS_INLINE size] IntPtr:op_Explicit(long):long
  [2 IL=0015 TR=000017 06000BF6] [below ALWAYS_INLINE size] IntPtr:.ctor(long):this
Budget: initialTime=138, finalTime=146, initialBudget=1380, currentBudget=1380
Budget: initialSize=724, finalSize=724
; Assembly listing for method GCHandle:SetIsPinned():this
; Emitting BLENDED_CODE for X64 CPU with SSE2
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 this         [V00,T00] (  4,   4  )   byref  ->  rcx         this
;* V01 tmp0         [V01    ] (  0,   0  )    long  ->  zero-ref   
;  V02 tmp1         [V02,T01] (  2,   4  )    long  ->  rax         ld-addr-op
;  V03 tmp2         [V03,T02] (  2,   4  )    long  ->  rax        
;# V04 OutArgs      [V04    ] (  1,   1  )  lclBlk ( 0) [rsp+0x00]  
;
; Lcl frame size = 0

G_M19266_IG01:
       0F1F440000           nop      

G_M19266_IG02:
       488B01               mov      rax, qword ptr [rcx]
       4883C801             or       rax, 1
       488901               mov      qword ptr [rcx], rax

G_M19266_IG03:
       C3                   ret      

; Total bytes of code 16, prolog size 5 for method GCHandle:SetIsPinned():this
```