### PR TITLE
Clean up ClrUnwindEx

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -8139,8 +8139,7 @@ LONG Debugger::NotifyOfCHFFilter(EXCEPTION_POINTERS* pExceptionPointers, PVOID p
     pExState->GetFlags()->SetDebugCatchHandlerFound();
 
 #ifdef DEBUGGING_SUPPORTED
-
-
+#ifdef DEBUGGER_INTERCEPTION_SUPPORTED
     if ( (pThread != NULL) &&
          (pThread->IsExceptionInProgress()) &&
          (pThread->GetExceptionState()->GetFlags()->DebuggerInterceptInfo()) )
@@ -8151,6 +8150,7 @@ LONG Debugger::NotifyOfCHFFilter(EXCEPTION_POINTERS* pExceptionPointers, PVOID p
         //
         ClrDebuggerDoUnwindAndIntercept(X86_FIRST_ARG(EXCEPTION_CHAIN_END) pExceptionPointers->ExceptionRecord);
     }
+#endif // DEBUGGER_INTERCEPTION_SUPPORTED
 #endif // DEBUGGING_SUPPORTED
 
     return EXCEPTION_CONTINUE_SEARCH;

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -8139,7 +8139,7 @@ LONG Debugger::NotifyOfCHFFilter(EXCEPTION_POINTERS* pExceptionPointers, PVOID p
     pExState->GetFlags()->SetDebugCatchHandlerFound();
 
 #ifdef DEBUGGING_SUPPORTED
-#ifdef DEBUGGER_INTERCEPTION_SUPPORTED
+#ifdef DEBUGGER_EXCEPTION_INTERCEPTION_SUPPORTED
     if ( (pThread != NULL) &&
          (pThread->IsExceptionInProgress()) &&
          (pThread->GetExceptionState()->GetFlags()->DebuggerInterceptInfo()) )
@@ -8150,7 +8150,7 @@ LONG Debugger::NotifyOfCHFFilter(EXCEPTION_POINTERS* pExceptionPointers, PVOID p
         //
         ClrDebuggerDoUnwindAndIntercept(X86_FIRST_ARG(EXCEPTION_CHAIN_END) pExceptionPointers->ExceptionRecord);
     }
-#endif // DEBUGGER_INTERCEPTION_SUPPORTED
+#endif // DEBUGGER_EXCEPTION_INTERCEPTION_SUPPORTED
 #endif // DEBUGGING_SUPPORTED
 
     return EXCEPTION_CONTINUE_SEARCH;

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -4031,6 +4031,7 @@ LONG NotifyDebuggerLastChance(Thread *pThread,
 
     UNINSTALL_NESTED_EXCEPTION_HANDLER();
 
+#ifdef DEBUGGER_INTERCEPTION_SUPPORTED
     EX_TRY
     {
         // if the debugger wants to intercept the unhandled exception then we immediately unwind without returning
@@ -4050,6 +4051,7 @@ LONG NotifyDebuggerLastChance(Thread *pThread,
     {
     }
     EX_END_CATCH(SwallowAllExceptions);
+#endif // DEBUGGER_INTERCEPTION_SUPPORTED
 
     return retval;
 }

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -4031,7 +4031,7 @@ LONG NotifyDebuggerLastChance(Thread *pThread,
 
     UNINSTALL_NESTED_EXCEPTION_HANDLER();
 
-#ifdef DEBUGGER_INTERCEPTION_SUPPORTED
+#ifdef DEBUGGER_EXCEPTION_INTERCEPTION_SUPPORTED
     EX_TRY
     {
         // if the debugger wants to intercept the unhandled exception then we immediately unwind without returning
@@ -4051,7 +4051,7 @@ LONG NotifyDebuggerLastChance(Thread *pThread,
     {
     }
     EX_END_CATCH(SwallowAllExceptions);
-#endif // DEBUGGER_INTERCEPTION_SUPPORTED
+#endif // DEBUGGER_EXCEPTION_INTERCEPTION_SUPPORTED
 
     return retval;
 }

--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -745,9 +745,16 @@ bool IsInterceptableException(Thread *pThread);
 // perform simple checking to see if the current exception is intercepted
 bool CheckThreadExceptionStateForInterception();
 
+#ifndef FEATURE_PAL
+// Currently, only Windows supports ClrUnwindEx (used inside ClrDebuggerDoUnwindAndIntercept)
+#define DEBUGGER_INTERCEPTION_SUPPORTED
+#endif // !FEATURE_PAL
+
+#ifdef DEBUGGER_INTERCEPTION_SUPPORTED
 // Intercept the current exception and start an unwind.  This function may never return.
 EXCEPTION_DISPOSITION ClrDebuggerDoUnwindAndIntercept(X86_FIRST_ARG(EXCEPTION_REGISTRATION_RECORD *pEstablisherFrame)
                                                       EXCEPTION_RECORD *pExceptionRecord);
+#endif // DEBUGGER_INTERCEPTION_SUPPORTED
 
 LONG NotifyDebuggerLastChance(Thread *pThread,
                               EXCEPTION_POINTERS *pExceptionInfo,

--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -747,14 +747,14 @@ bool CheckThreadExceptionStateForInterception();
 
 #ifndef FEATURE_PAL
 // Currently, only Windows supports ClrUnwindEx (used inside ClrDebuggerDoUnwindAndIntercept)
-#define DEBUGGER_INTERCEPTION_SUPPORTED
+#define DEBUGGER_EXCEPTION_INTERCEPTION_SUPPORTED
 #endif // !FEATURE_PAL
 
-#ifdef DEBUGGER_INTERCEPTION_SUPPORTED
+#ifdef DEBUGGER_EXCEPTION_INTERCEPTION_SUPPORTED
 // Intercept the current exception and start an unwind.  This function may never return.
 EXCEPTION_DISPOSITION ClrDebuggerDoUnwindAndIntercept(X86_FIRST_ARG(EXCEPTION_REGISTRATION_RECORD *pEstablisherFrame)
                                                       EXCEPTION_RECORD *pExceptionRecord);
-#endif // DEBUGGER_INTERCEPTION_SUPPORTED
+#endif // DEBUGGER_EXCEPTION_INTERCEPTION_SUPPORTED
 
 LONG NotifyDebuggerLastChance(Thread *pThread,
                               EXCEPTION_POINTERS *pExceptionInfo,

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -75,12 +75,6 @@ static void DoEHLog(DWORD lvl, __in_z const char *fmt, ...);
 
 TrackerAllocator    g_theTrackerAllocator;
 
-void __declspec(noinline)
-ClrUnwindEx(EXCEPTION_RECORD* pExceptionRecord,
-                 UINT_PTR ReturnValue,
-                 UINT_PTR TargetIP,
-                 UINT_PTR TargetFrameSp);
-
 bool FixNonvolatileRegisters(UINT_PTR  uOriginalSP,
                              Thread*   pThread,
                              CONTEXT*  pContextRecord,
@@ -4128,6 +4122,7 @@ void ExceptionTracker::MakeCallbacksRelatedToHandler(
     }
 }
 
+#ifdef DEBUGGER_INTERCEPTION_SUPPORTED
 //---------------------------------------------------------------------------------------
 //
 // This function is called by DefaultCatchHandler() to intercept an exception and start an unwind.
@@ -4164,6 +4159,7 @@ EXCEPTION_DISPOSITION ClrDebuggerDoUnwindAndIntercept(X86_FIRST_ARG(EXCEPTION_RE
 
     UNREACHABLE();
 }
+#endif // DEBUGGER_INTERCEPTION_SUPPORTED
 #endif // DEBUGGING_SUPPORTED
 
 #ifdef _DEBUG
@@ -5151,9 +5147,9 @@ BOOL HandleHardwareException(PAL_SEHException* ex)
 
 #endif // FEATURE_PAL
 
+#ifndef FEATURE_PAL
 void ClrUnwindEx(EXCEPTION_RECORD* pExceptionRecord, UINT_PTR ReturnValue, UINT_PTR TargetIP, UINT_PTR TargetFrameSp)
 {
-#ifndef FEATURE_PAL
     PVOID TargetFrame = (PVOID)TargetFrameSp;
 
     CONTEXT ctx;
@@ -5164,13 +5160,10 @@ void ClrUnwindEx(EXCEPTION_RECORD* pExceptionRecord, UINT_PTR ReturnValue, UINT_
                 &ctx,
                 NULL);      // HistoryTable
 
-#else // !FEATURE_PAL
-    PORTABILITY_ASSERT("UNIXTODO: Implement unwinding for PAL");
-#endif // !FEATURE_PAL
-                
     // doesn't return
     UNREACHABLE();
 }
+#endif // !FEATURE_PAL
 
 void TrackerAllocator::Init()
 {

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4122,7 +4122,7 @@ void ExceptionTracker::MakeCallbacksRelatedToHandler(
     }
 }
 
-#ifdef DEBUGGER_INTERCEPTION_SUPPORTED
+#ifdef DEBUGGER_EXCEPTION_INTERCEPTION_SUPPORTED
 //---------------------------------------------------------------------------------------
 //
 // This function is called by DefaultCatchHandler() to intercept an exception and start an unwind.
@@ -4159,7 +4159,7 @@ EXCEPTION_DISPOSITION ClrDebuggerDoUnwindAndIntercept(X86_FIRST_ARG(EXCEPTION_RE
 
     UNREACHABLE();
 }
-#endif // DEBUGGER_INTERCEPTION_SUPPORTED
+#endif // DEBUGGER_EXCEPTION_INTERCEPTION_SUPPORTED
 #endif // DEBUGGING_SUPPORTED
 
 #ifdef _DEBUG

--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -26,11 +26,13 @@ ProcessCLRException(IN     PEXCEPTION_RECORD     pExceptionRecord
                     IN OUT PT_DISPATCHER_CONTEXT pDispatcherContext);
 
 
+#ifndef FEATURE_PAL
 void __declspec(noinline)
 ClrUnwindEx(EXCEPTION_RECORD* pExceptionRecord,
                  UINT_PTR          ReturnValue,
                  UINT_PTR          TargetIP,
                  UINT_PTR          TargetFrameSp);
+#endif // !FEATURE_PAL
 
 typedef DWORD_PTR   (HandlerFn)(UINT_PTR uStackFrame, Object* pExceptionObj);
 


### PR DESCRIPTION
ClrUnwindEx is currently valid only for Windows (which ClrDebuggerDoUnwindAndIntercept uses).

This commit cleans up ClrUnwindEx.