### PR TITLE
Promote struct containing fields of struct of a single pointer-size field

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1522,15 +1522,8 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE    typeHnd,
             pFieldInfo->fldOffset  = (BYTE)fldOffset;
             pFieldInfo->fldOrdinal = ordinal;
             CorInfoType corType    = info.compCompHnd->getFieldType(pFieldInfo->fldHnd, &pFieldInfo->fldTypeHnd);
-            var_types   varType    = JITtype2varType(corType);
-            pFieldInfo->fldType    = varType;
-            unsigned size          = genTypeSize(varType);
-            pFieldInfo->fldSize    = size;
-
-            if (varTypeIsGC(varType))
-            {
-                containsGCpointers = true;
-            }
+            pFieldInfo->fldType    = JITtype2varType(corType);
+            pFieldInfo->fldSize    = genTypeSize(pFieldInfo->fldType);
 
 #ifdef FEATURE_SIMD
             // Check to see if this is a SIMD type.
@@ -1542,8 +1535,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE    typeHnd,
                 var_types simdBaseType = getBaseTypeAndSizeOfSIMDType(pFieldInfo->fldTypeHnd, &simdSize);
                 if (simdBaseType != TYP_UNKNOWN)
                 {
-                    varType             = getSIMDTypeForSize(simdSize);
-                    pFieldInfo->fldType = varType;
+                    pFieldInfo->fldType = getSIMDTypeForSize(simdSize);
                     pFieldInfo->fldSize = simdSize;
                 }
             }
@@ -1551,8 +1543,60 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE    typeHnd,
 
             if (pFieldInfo->fldSize == 0)
             {
-                // Non-primitive struct field. Don't promote.
-                return;
+                // Size of TYP_BLK, TYP_FUNC, TYP_VOID and TYP_STRUCT is zero.
+                // Early out if field type is other than TYP_STRUCT.
+                // This is a defensive check as we don't expect a struct to have
+                // fields of TYP_BLK, TYP_FUNC or TYP_VOID.
+                if (pFieldInfo->fldType != TYP_STRUCT)
+                {
+                    return;
+                }
+
+                // Non-primitive struct field.
+                // Try to promote structs of single field of scalar types aligned at their
+                // natural boundary.
+
+                // Do Not promote if the struct field in turn has more than one field.
+                if (info.compCompHnd->getClassNumInstanceFields(pFieldInfo->fldTypeHnd) != 1)
+                {
+                    return;
+                }
+
+                // Do not promote if the single field is not aligned at its natural boundary within
+                // the struct field.
+                CORINFO_FIELD_HANDLE fHnd    = info.compCompHnd->getFieldInClass(pFieldInfo->fldTypeHnd, 0);
+                unsigned             fOffset = info.compCompHnd->getFieldOffset(fHnd);
+                if (fOffset != 0)
+                {
+                    return;
+                }
+
+                CORINFO_CLASS_HANDLE cHnd;
+                CorInfoType          fieldCorType = info.compCompHnd->getFieldType(fHnd, &cHnd);
+                var_types            fieldVarType = JITtype2varType(fieldCorType);
+                unsigned             fieldSize    = genTypeSize(fieldVarType);
+
+                // Do not promote if either not a primitive type or size equal to ptr size on
+                // target or a struct containing a single floating-point field.
+                //
+                // TODO-PERF: Structs containing a single floating-point field on Amd64
+                // needs to be passed in integer registers. Right now LSRA doesn't support
+                // passing of floating-point LCL_VARS in integer registers.  Enabling promotion
+                // of such structs results in an assert in lsra right now.
+                //
+                // TODO-PERF: Right now promotion is confined to struct containing a ptr sized
+                // field (int/uint/ref/byref on 32-bits and long/ulong/ref/byref on 64-bits).
+                // Though this would serve the purpose of promoting Span<T> containing ByReference<T>,
+                // this can be extended to other primitive types as long as they are aligned at their
+                // natural boundary.
+                if (fieldSize == 0 || fieldSize != TARGET_POINTER_SIZE || varTypeIsFloating(fieldVarType))
+                {
+                    return;
+                }
+
+                // Retype the field as the type of the single field of the struct
+                pFieldInfo->fldType = fieldVarType;
+                pFieldInfo->fldSize = fieldSize;
             }
 
             if ((pFieldInfo->fldOffset % pFieldInfo->fldSize) != 0)
@@ -1561,6 +1605,11 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE    typeHnd,
                 // struct values on the stack from promoted fields expects
                 // those fields to be at their natural alignment.
                 return;
+            }
+
+            if (varTypeIsGC(pFieldInfo->fldType))
+            {
+                containsGCpointers = true;
             }
 
             // The end offset for this field should never be larger than our structSize.

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -971,6 +971,42 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
                 assert(!varTypeIsSIMD(arg));
                 numRefs = comp->info.compCompHnd->getClassGClayout(arg->gtObj.gtClass, gcLayout);
                 putArg->AsPutArgStk()->setGcPointers(numRefs, gcLayout);
+
+#ifdef _TARGET_X86_
+                // On x86 VM lies about the type of a struct containing a pointer sized
+                // integer field by returning the type of its field as the type of struct.
+                // Such struct can be passed in a register depending its position in
+                // parameter list.  VM does this unwrapping only one level and therefore
+                // a type like Struct Foo { Struct Bar { int f}} awlays needs to be
+                // passed on stack.  Also, VM doesn't lie about type of such a struct
+                // when it is a field of another struct.  That is VM doesn't lie about
+                // the type of Foo.Bar
+                //
+                // Promotion of structs containing structs of single field can promote
+                // such a struct.  Say Foo.Bar field is getting passed as a parameter
+                // to a call, Since it is a TYP_STRUCT, as per x86 ABI it should always
+                // be passed on stack.  Therefore GenTree node under a PUTARG_STK could
+                // be GT_OBJ(GT_LCL_VAR_ADDR(v1)), where local v1 could be a promoted
+                // field standing for Foo.Bar.  Note that the type of v1 will be the
+                // type of field of Foo.Bar.f when Foo is promoted.  That is v1
+                // will be a scalar type.  In this case we need to pass v1 on stack
+                // instead of in a register.
+                //
+                // TODO-PERF: replace GT_OBJ(GT_LCL_VAR_ADDR(v1)) with v1 if v1 is
+                // a scalar type and the width of GT_OBJ matches the type size of v1.
+                // Note that this cannot be done till call node arguments are morphed
+                // because we should not lose the fact that the type of argument is
+                // a struct so that the arg gets correctly marked to be passed on stack.
+                GenTree* objOp1 = arg->gtGetOp1();
+                if (objOp1->OperGet() == GT_LCL_VAR_ADDR)
+                {
+                    unsigned lclNum = objOp1->AsLclVarCommon()->GetLclNum();
+                    if (comp->lvaTable[lclNum].lvType != TYP_STRUCT)
+                    {
+                        comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_VMNeedsStackAddr));
+                    }
+                }
+#endif // _TARGET_X86_
             }
         }
 #endif // FEATURE_PUT_STRUCT_ARG_STK


### PR DESCRIPTION
This work is meant to struct promote Fast `Span<T>` struct which is currently not promoted because one of its fields is a `ByReference<T>` struct containing a single pointer sized field.

lvaCanPromoteStructType() - if a field is a struct type further checks to see whether it has a single pointer sized field aligned at its natural boundary.  If so then such a struct field is typed as the type of its single field.  This is done up to one level only.

With this change Slice micro-benchmark on fast Span is in perf parity with slow Span.  

Ngen asm diff on mscorlib show a net size win.  

```
07.97:     Code Size improvements (code sizes in bytes):
07.97:     <filename>                                            baseline        diff improvement  %improvement    #funcs
07.97:     mscorlib.dasm                                          6395975     6394810        1165          0.02     42246
07.98:        48 functions improved (1396 total bytes improvement)
07.98:           Improvement # 1 goes from   107 to    45, diff of    62 (57.94%) :: ValueCollection[Int32,DateTime][System.Int32,System.DateTime]:GetEnumerator():struct:this
07.98:           Improvement # 2 goes from   107 to    45, diff of    62 (57.94%) :: ValueCollection[DateTime,TimeSpan][System.DateTime,System.TimeSpan]:GetEnumerator():struct:this
07.98:           Improvement # 3 goes from   107 to    45, diff of    62 (57.94%) :: KeyCollection[DateTime,TimeSpan][System.DateTime,System.TimeSpan]:GetEnumerator():struct:this
07.98:           Improvement # 4 goes from   103 to    54, diff of    49 (47.57%) :: System.Collections.Generic.List`1[DateTime][System.DateTime]:GetEnumerator():struct:this
07.98:           Improvement # 5 goes from   103 to    54, diff of    49 (47.57%) :: System.Collections.Generic.List`1[GCHandle][System.Runtime.InteropServices.GCHandle]:GetEnumerator():struct:this
07.98:           Improvement # 6 goes from   103 to    54, diff of    49 (47.57%) :: System.Collections.Generic.List`1[EventRegistrationToken][System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken]:GetEnumerator():struct:this
07.98:           Improvement # 7 goes from   103 to    54, diff of    49 (47.57%) :: System.Collections.Generic.List`1[TimeSpan][System.TimeSpan]:GetEnumerator():struct:this
07.98:           Improvement # 8 goes from   117 to    65, diff of    52 (44.44%) :: KeyCollection[EventRegistrationToken,__Canon][System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken,System.__Canon]:GetEnumerator():struct:this
07.98:           Improvement # 9 goes from   117 to    78, diff of    39 (33.33%) :: System.Collections.Generic.Dictionary`2[__Canon,EventRegistrationTokenList][System.__Canon,System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal+EventRegistrationTokenList]:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(struct):this
07.98:           Improvement #10 goes from   118 to    81, diff of    37 (31.36%) :: ValueCollection[Int32,DateTime][System.Int32,System.DateTime]:System.Collections.IEnumerable.GetEnumerator():ref:this
07.98:        7 aggregated functions improved (128 total bytes improvement)
07.98:           Improvement # 1 goes from  1214 to  1162, diff of    52 ( 4.28%) ::  5 x System.Internal:NullableHelper():struct
07.98:           Improvement # 2 goes from   540 to   508, diff of    32 ( 5.93%) ::  3 x Enumerator[EventRegistrationToken,__Canon][System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken,System.__Canon]:MoveNext():bool:this
07.98:           Improvement # 3 goes from   428 to   406, diff of    22 ( 5.14%) ::  3 x Enumerator[EventRegistrationToken,__Canon][System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken,System.__Canon]:System.Collections.IEnumerator.get_Current():ref:this
07.98:           Improvement # 4 goes from   472 to   465, diff of     7 ( 1.48%) ::  3 x Enumerator[__Canon,EventRegistrationTokenList][System.__Canon,System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal+EventRegistrationTokenList]:System.Collections.IEnumerator.get_Current():ref:this
07.98:           Improvement # 5 goes from   383 to   377, diff of     6 ( 1.57%) ::  3 x Enumerator[DateTime,TimeSpan][System.DateTime,System.TimeSpan]:System.Collections.IEnumerator.get_Current():ref:this
07.98:           Improvement # 6 goes from   527 to   521, diff of     6 ( 1.14%) ::  3 x Enumerator[DateTime,TimeSpan][System.DateTime,System.TimeSpan]:MoveNext():bool:this
07.98:           Improvement # 7 goes from 17457 to 17454, diff of     3 ( 0.02%) :: 76 x DomainNeutralILStubClass:IL_STUB_WinRTtoCLR(long):int:this
07.98:        20 functions regressed (313 total bytes regression)
07.98:           Regression # 1 goes from    61 to    85, diff of    24 (28.24%) :: System.Collections.Generic.List`1[DateTimeOffset][System.DateTimeOffset]:IsCompatibleObject(ref):bool
07.98:           Regression # 2 goes from    65 to    89, diff of    24 (26.97%) :: System.Collections.ObjectModel.ReadOnlyCollection`1[DateTimeOffset][System.DateTimeOffset]:IsCompatibleObject(ref):bool
07.98:           Regression # 3 goes from   149 to   174, diff of    25 (14.37%) :: System.Collections.Generic.List`1[DateTimeOffset][System.DateTimeOffset]:RemoveAt(int):this
07.98:           Regression # 4 goes from   595 to   641, diff of    46 ( 7.18%) :: System.Collections.Generic.ArraySortHelper`1[DateTimeOffset][System.DateTimeOffset]:PickPivotAndPartition(ref,int,int,ref):int
07.98:           Regression # 5 goes from   509 to   551, diff of    42 ( 7.62%) :: System.Collections.Generic.GenericArraySortHelper`1[DateTimeOffset][System.DateTimeOffset]:PickPivotAndPartition(ref,int,int):int
07.98:           Regression # 6 goes from   178 to   203, diff of    25 (12.32%) :: System.Collections.Generic.List`1[DateTimeOffset][System.DateTimeOffset]:FindLast(ref):struct:this
07.98:           Regression # 7 goes from   179 to   204, diff of    25 (12.25%) :: System.Collections.Generic.List`1[DateTimeOffset][System.DateTimeOffset]:Find(ref):struct:this
07.98:           Regression # 8 goes from   207 to   228, diff of    21 ( 9.21%) :: System.Collections.Generic.GenericArraySortHelper`1[DateTimeOffset][System.DateTimeOffset]:Heapsort(ref,int,int)
07.98:           Regression # 9 goes from   230 to   251, diff of    21 ( 8.37%) :: System.Collections.Generic.ArraySortHelper`1[DateTimeOffset][System.DateTimeOffset]:Heapsort(ref,int,int,ref)
07.98:           Regression #10 goes from   140 to   154, diff of    14 ( 9.09%) :: System.Diagnostics.Tracing.TraceLoggingTypeInfo`1[DateTimeOffset][System.DateTimeOffset]:WriteObjectData(ref,ref):this
07.98:        2 aggregated functions regressed (46 total bytes regression)
07.98:           Regression # 1 goes from   604 to   626, diff of    22 ( 3.51%) ::  3 x Enumerator[__Canon,EventRegistrationTokenList][System.__Canon,System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal+EventRegistrationTokenList]:MoveNext():bool:this
07.98:           Regression # 2 goes from   982 to  1006, diff of    24 ( 2.39%) :: 34 x System.ThrowHelper:IfNullAndNullsAreIllegalThenThrow(ref,int)
```

There are a couple of more minor CQ issues that needs to be addressed but given that CoreFX team wants Kestrel to switch over to fast Span as early as possible, I intend to merge this work by opening issues for outstanding minor CQ issues.

I will be filing git issues for the following issues that were uncovered in this work:
1.  Right now a struct containing a single float/double field is not struct promoted.  This is already an existing issue - see TODOs in fgPromoteStructs().   Enabling such a struct promotion leads to asserts in LSRA.   See isssues https://github.com/dotnet/coreclr/issues/1161 and https://github.com/dotnet/coreclr/issues/8828
2. On x86, a struct field containing a single pointer field still needs to be passed on stack.   That is IR could have `GT_PUTARG_STK(GT_OBJ(GT_LCL_VAR_ADDR(v1)))`, where v1 is a promoted local of scalar type.  For correct codegen v1 needs to be on stack.  Ideally we should be able to morph this into GT_PUTARG_STK(v1) if the width of GT_OBJ's read matches the size of v1.  Note that this cannot be done prior to morphing of arguments.  For now v1 is marked as do-not-enregister for correctness.
3. IR of the form `GT_OBJ(GT_LCL_VAR_ADDR(v1)) = v2`, where v1 and v2 are promoted struct locals of scalar type.  This IR gets morphed by `fgMorphCopyBlkock()` into `GT_IND(GT_ADD(GT_LCL_VAR_ADDR(v1) + 0)) = v2` and also marks v1 as addr-exposed.  Instead this could be morphed into v1 = v2 i.e. a scalar assignment without marking v1 as addr-exposed.
4. Asm diffs indicate that if a struct gets promoted as P-DEP, then if it is unused it won't be eliminated because its P-DEP fields are marked as untracked.