### PR TITLE
Report bytes allocated in the JIT time log.

### DIFF
--- a/src/inc/switches.h
+++ b/src/inc/switches.h
@@ -198,12 +198,10 @@
 // This is just for convenience in doing performance investigations in a checked-out enlistment.
 // #define FEATURE_ENABLE_NO_RANGE_CHECKS
 
-#ifndef FEATURE_CORECLR
 // This controls whether a compilation-timing feature that relies on Windows APIs, if available, else direct
 // hardware instructions (rdtsc), for accessing high-resolution hardware timers is enabled. This is disabled
 // in Silverlight (just to avoid thinking about whether the extra code space is worthwhile).
 #define FEATURE_JIT_TIMER
-#endif // FEATURE_CORECLR
 
 // This feature in RyuJIT supersedes the FEATURE_JIT_TIMER. In addition to supporting the time log file, this
 // feature also supports using COMPlus_JitTimeLogCsv=a.csv, which will dump method-level and phase-level timing

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -7863,7 +7863,7 @@ void JitTimer::PrintCsvMethodStats(Compiler* comp)
 
     comp->m_inlineStrategy->DumpCsvData(fp);
 
-    fprintf(fp, "%I64u,", (unsigned __int64)comp->compGetAllocator()->getTotalBytesAllocated());
+    fprintf(fp, "%Iu,", comp->compGetAllocator()->getTotalBytesAllocated());
     fprintf(fp, "%I64u,", m_info.m_totalCycles);
     fprintf(fp, "%f\n", CycleTimer::CyclesPerSecond());
     fclose(fp);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -7812,6 +7812,7 @@ void JitTimer::PrintCsvHeader()
 
             InlineStrategy::DumpCsvHeader(fp);
 
+            fprintf(fp, "\"Total Bytes Allocated\",");
             fprintf(fp, "\"Total Cycles\",");
             fprintf(fp, "\"CPS\"\n");
         }
@@ -7862,6 +7863,7 @@ void JitTimer::PrintCsvMethodStats(Compiler* comp)
 
     comp->m_inlineStrategy->DumpCsvData(fp);
 
+    fprintf(fp, "%I64u,", (unsigned __int64)comp->compGetAllocator()->getTotalBytesAllocated());
     fprintf(fp, "%I64u,", m_info.m_totalCycles);
     fprintf(fp, "%f\n", CycleTimer::CyclesPerSecond());
     fclose(fp);


### PR DESCRIPTION
This adds a new column, "Total Bytes Allocated", to the JIT time log.
This column reports the total number of bytes requested from the host by
the JIT's arena allocator.

This change also enables `FEATURE_JIT_TIMER` by default (which only
affects JIT32).