### PR TITLE
Fix System.Numerics.Vectors CoreFx test failures

### DIFF
--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -409,16 +409,25 @@ unsigned CILJit::getMaxIntrinsicSIMDVectorLength(DWORD cpuCompileFlags)
     {
         if (JitConfig.EnableAVX() != 0)
         {
-            JITDUMP("getMaxIntrinsicSIMDVectorLength: returning 32\n");
+            if (GetJitTls() != nullptr && JitTls::GetCompiler() != nullptr)
+            {
+                JITDUMP("getMaxIntrinsicSIMDVectorLength: returning 32\n");
+            }
             return 32;
         }
     }
 #endif // FEATURE_AVX_SUPPORT
-    JITDUMP("getMaxIntrinsicSIMDVectorLength: returning 16\n");
+    if (GetJitTls() != nullptr && JitTls::GetCompiler() != nullptr)
+    {
+        JITDUMP("getMaxIntrinsicSIMDVectorLength: returning 16\n");
+    }
     return 16;
 #endif // _TARGET_XARCH_
 #else  // !FEATURE_SIMD
-    JITDUMP("getMaxIntrinsicSIMDVectorLength: returning 0\n");
+    if (GetJitTls() != nullptr && JitTls::GetCompiler() != nullptr)
+    {
+        JITDUMP("getMaxIntrinsicSIMDVectorLength: returning 0\n");
+    }
     return 0;
 #endif // !FEATURE_SIMD
 }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6163,6 +6163,14 @@ GenTreePtr Compiler::fgMorphField(GenTreePtr tree, MorphAddrContext* mac)
             return newTree;
         }
     }
+    else if ((objRef != nullptr) && (objRef->OperGet() == GT_ADDR) && varTypeIsSIMD(objRef->gtGetOp1()))
+    {
+        GenTreeLclVarCommon* lcl = objRef->IsLocalAddrExpr();
+        if (lcl != nullptr)
+        {
+            lvaSetVarDoNotEnregister(lcl->gtLclNum DEBUGARG(DNER_LocalField));
+        }
+    }
 #endif
 
     /* Is this an instance data member? */


### PR DESCRIPTION
CoreFx Issue 15713 is due to a case of an Indir(Addr(Field(Vector3 local))) which for some reason has a MorphAddrContext of MACK_Ind. Although I haven't fully identified why that is the case, we should be conservative in this case and mark the address as do-not-enregister.
In addition, when attempting to debug this with a Checked JIT, I encountered an AV due to `GetJitTls` returning null in the `JITDUMP` calls in `getMaxIntrinsicSIMDVectorLength`. Again, I'm not sure why this would be the case but I have added guarding conditions.