### PR TITLE
Fix bytemark benchmark

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
@@ -1350,14 +1350,14 @@ public class ByteMark
         }
     }
 
-    const int EmFloatIterations = 8;
+    const int EmFloatIterations = 10;
 
     [Benchmark]
     public static void BenchEmFloat()
     {
         Setup();
         EmFloatStruct t = new EMFloat();
-        t.loops = 100;
+        t.loops = 50;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1379,7 +1379,7 @@ public class ByteMark
     {
         Setup();
         EmFloatStruct t = new EMFloatClass();
-        t.loops = 20;
+        t.loops = 50;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1415,7 +1415,7 @@ public class ByteMark
         }
     }
 
-    const int AssignJaggedIterations = 5;
+    const int AssignJaggedIterations = 2;
 
     [Benchmark]
     public static void BenchAssignJagged()
@@ -1503,7 +1503,7 @@ public class ByteMark
         }
     }
 
-    const int NeuralIterations = 10;
+    const int NeuralIterations = 20;
 
     [Benchmark]
     public static void BenchNeural()

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
@@ -1263,7 +1263,7 @@ public class ByteMark
         global.write_to_file = false;
     }
 
-    const int NumericSortJaggedIterations = 20;
+    const int NumericSortJaggedIterations = 10;
 
     [Benchmark]
     public static void BenchNumericSortJagged()
@@ -1285,7 +1285,7 @@ public class ByteMark
         }
     }
 
-    const int NumericSortRectangularIterations = 20;
+    const int NumericSortRectangularIterations = 5;
 
     [Benchmark]
     public static void BenchNumericSortRectangular()
@@ -1329,7 +1329,7 @@ public class ByteMark
         }
     }
 
-    const int BitOpsIterations = 60000;
+    const int BitOpsIterations = 100000;
 
     [Benchmark]
     public static void BenchBitOps()
@@ -1372,7 +1372,7 @@ public class ByteMark
         }
     }
 
-    const int EmFloatClassIterations = 8;
+    const int EmFloatClassIterations = 2;
 
     [Benchmark]
     public static void BenchEmFloatClass()
@@ -1422,7 +1422,7 @@ public class ByteMark
     {
         Setup();
         AssignStruct t = new AssignJagged();
-        t.numarrays = 50;
+        t.numarrays = 25;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1444,7 +1444,7 @@ public class ByteMark
     {
         Setup();
         AssignStruct t = new AssignRect();
-        t.numarrays = 50;
+        t.numarrays = 10;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1459,7 +1459,7 @@ public class ByteMark
         }
     }
 
-    const int IDEAEncryptionIterations = 200;
+    const int IDEAEncryptionIterations = 50;
 
     [Benchmark]
     public static void BenchIDEAEncryption()
@@ -1532,7 +1532,7 @@ public class ByteMark
     {
         Setup();
         LUStruct t = new LUDecomp();
-        t.numarrays = 500;
+        t.numarrays = 250;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
@@ -120,10 +120,12 @@ internal class global
     public const int LUARRAYROWS = 101;
     public const int LUARRAYCOLS = 101;
 
-
     // EMFLOAT constants
     public const int CPUEMFLOATLOOPMAX = 50000;
     public const int EMFARRAYSIZE = 3000;
+
+    // FOURIER constants
+    public const int FOURIERARRAYSIZE = 100;
 }
 
 /*
@@ -183,7 +185,7 @@ public abstract class HuffStruct : HarnessTest
 
 public abstract class FourierStruct : HarnessTest
 {
-    public int arraysize;                       /* Size of coeff. arrays */
+    public int arraysize = global.FOURIERARRAYSIZE;
     public override void ShowStats()
     {
         ByteMark.OutputString(
@@ -1268,7 +1270,7 @@ public class ByteMark
     {
         Setup();
         NumericSortJagged t = new NumericSortJagged();
-        t.numarrays = 1000;
+        t.numarrays = 200;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1290,7 +1292,7 @@ public class ByteMark
     {
         Setup();
         NumericSortRect t = new NumericSortRect();
-        t.numarrays = 1000;
+        t.numarrays = 200;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1312,7 +1314,7 @@ public class ByteMark
     {
         Setup();
         StringSort t = new StringSort();
-        t.numarrays = 1000;
+        t.numarrays = 40;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1326,7 +1328,8 @@ public class ByteMark
             }
         }
     }
-    const int BitOpsIterations = 15;
+
+    const int BitOpsIterations = 60000;
 
     [Benchmark]
     public static void BenchBitOps()
@@ -1376,7 +1379,7 @@ public class ByteMark
     {
         Setup();
         EmFloatStruct t = new EMFloatClass();
-        t.loops = 100;
+        t.loops = 20;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1391,7 +1394,7 @@ public class ByteMark
         }
     }
 
-    const int FourierIterations = 20;
+    const int FourierIterations = 300;
 
     [Benchmark]
     public static void BenchFourier()
@@ -1412,14 +1415,14 @@ public class ByteMark
         }
     }
 
-    const int AssignJaggedIterations = 15;
+    const int AssignJaggedIterations = 5;
 
     [Benchmark]
     public static void BenchAssignJagged()
     {
         Setup();
         AssignStruct t = new AssignJagged();
-        t.numarrays = 1000;
+        t.numarrays = 50;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1434,14 +1437,14 @@ public class ByteMark
         }
     }
 
-    const int AssignRectangularIterations = 20;
+    const int AssignRectangularIterations = 5;
 
     [Benchmark]
     public static void BenchAssignRectangular()
     {
         Setup();
         AssignStruct t = new AssignRect();
-        t.numarrays = 1000;
+        t.numarrays = 50;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1456,7 +1459,7 @@ public class ByteMark
         }
     }
 
-    const int IDEAEncryptionIterations = 20;
+    const int IDEAEncryptionIterations = 200;
 
     [Benchmark]
     public static void BenchIDEAEncryption()
@@ -1478,14 +1481,14 @@ public class ByteMark
         }
     }
 
-    const int NeuralJaggedIterations = 20;
+    const int NeuralJaggedIterations = 10;
 
     [Benchmark]
     public static void BenchNeuralJagged()
     {
         Setup();
         NNetStruct t = new NeuralJagged();
-        t.loops = 100;
+        t.loops = 3;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1500,14 +1503,14 @@ public class ByteMark
         }
     }
 
-    const int NeuralIterations = 12;
+    const int NeuralIterations = 10;
 
     [Benchmark]
     public static void BenchNeural()
     {
         Setup();
         NNetStruct t = new Neural();
-        t.loops = 100;
+        t.loops = 1;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -1522,14 +1525,14 @@ public class ByteMark
         }
     }
 
-    const int LUDecompIterations = 20;
+    const int LUDecompIterations = 10;
 
     [Benchmark]
     public static void BenchLUDecomp()
     {
         Setup();
         LUStruct t = new LUDecomp();
-        t.numarrays = 1000;
+        t.numarrays = 500;
         t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
@@ -1269,7 +1269,7 @@ public class ByteMark
         Setup();
         NumericSortJagged t = new NumericSortJagged();
         t.numarrays = 1000;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1291,7 +1291,7 @@ public class ByteMark
         Setup();
         NumericSortRect t = new NumericSortRect();
         t.numarrays = 1000;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1313,7 +1313,7 @@ public class ByteMark
         Setup();
         StringSort t = new StringSort();
         t.numarrays = 1000;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1333,7 +1333,7 @@ public class ByteMark
     {
         Setup();
         BitOps t = new BitOps();
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1355,7 +1355,7 @@ public class ByteMark
         Setup();
         EmFloatStruct t = new EMFloat();
         t.loops = 100;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1377,7 +1377,7 @@ public class ByteMark
         Setup();
         EmFloatStruct t = new EMFloatClass();
         t.loops = 100;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1398,7 +1398,7 @@ public class ByteMark
     {
         Setup();
         FourierStruct t = new Fourier();
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1420,7 +1420,7 @@ public class ByteMark
         Setup();
         AssignStruct t = new AssignJagged();
         t.numarrays = 1000;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1442,7 +1442,7 @@ public class ByteMark
         Setup();
         AssignStruct t = new AssignRect();
         t.numarrays = 1000;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1464,7 +1464,7 @@ public class ByteMark
         Setup();
         IDEAStruct t = new IDEAEncryption();
         t.loops = 100;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1486,7 +1486,7 @@ public class ByteMark
         Setup();
         NNetStruct t = new NeuralJagged();
         t.loops = 100;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1508,7 +1508,7 @@ public class ByteMark
         Setup();
         NNetStruct t = new Neural();
         t.loops = 100;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {
@@ -1530,7 +1530,7 @@ public class ByteMark
         Setup();
         LUStruct t = new LUDecomp();
         t.numarrays = 1000;
-        t.adjust = 0;
+        t.adjust = 1;
 
         foreach (var iteration in Benchmark.Iterations)
         {


### PR DESCRIPTION
I misunderstood how bytemark uses the `adjust` parameter and inadvertently
enabled self-adjustment for the xunit-perf versions of these tests. Not
surprisingly the results showed crazy run to run variations.

Update these tests to set `adjust = 1` to stop the self-adjustment.