### PR TITLE
ARM64 Modify genCodeForInitBlk assert

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3378,7 +3378,14 @@ void CodeGen::genCodeForInitBlk(GenTreeBlk* initBlkNode)
 
     assert(!dstAddr->isContained());
     assert(!initVal->isContained());
-    assert(initBlkNode->gtRsvdRegs == RBM_ARG_2);
+    if (initBlkNode->gtOper == GT_STORE_DYN_BLK)
+    {
+        assert(initBlkNode->AsDynBlk()->gtDynamicSize->gtRegNum == REG_ARG_2);
+    }
+    else
+    {
+        assert(initBlkNode->gtRsvdRegs == RBM_ARG_2);
+    }
 
 // TODO-ARM64-CQ: When initblk loop unrolling is implemented
 //                put this assert back on.


### PR DESCRIPTION
Assert in codegenarm64 was incorrect for the GT_STORE_DYN_BLK oper.
If it is that oper then there will not be a temp reg used and instead
the size is computed and stored into REG_2. Add an assert to assert
this is done.

@briansull @CarolEidt ptal
/cc @dotnet/jit-contrib 