### PR TITLE
Fix race condition building System.Private.CoreLib.dll and SOS.NETCore.dll 

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -83,7 +83,7 @@
   <!-- Output paths -->
   <PropertyGroup>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RootBinDir)obj\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseIntermediateOutputPath)$(BuildOS).$(BuildArch).$(BuildType)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseIntermediateOutputPath)\$(BuildOS).$(BuildArch).$(BuildType)\$(MSBuildProjectName)</IntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)' == ''">$(BinDir)</OutputPath>
   </PropertyGroup>
 

--- a/dir.props
+++ b/dir.props
@@ -83,7 +83,7 @@
   <!-- Output paths -->
   <PropertyGroup>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RootBinDir)obj\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseIntermediateOutputPath)\$(BuildOS).$(BuildArch).$(BuildType)\$(MSBuildProjectName)</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseIntermediateOutputPath)$(BuildOS).$(BuildArch).$(BuildType)\$(MSBuildProjectName)</IntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)' == ''">$(BinDir)</OutputPath>
   </PropertyGroup>
 

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -121,13 +121,6 @@
     <NlpObjDir>$(BclSourcesRoot)\System\Globalization\Tables</NlpObjDir>
   </PropertyGroup>
   
-  <!-- Output paths -->
-  <PropertyGroup>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RootBinDir)obj</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseIntermediateOutputPath)\$(BuildOS).$(BuildArch).$(Configuration)</IntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)' == ''">$(BinDir)</OutputPath>
-  </PropertyGroup>
-  
   <!-- Msbuild variables needed to get CoreCLR features to be set properly. -->
   <PropertyGroup>
     <ClrProduct>core_clr</ClrProduct>


### PR DESCRIPTION
There's a race condition building System.Private.Corelib.dll and SOS.NETCore.dll.  Because they shared an intermediate directory, the assembly version would either be that of System.Private.CoreLib (4.0.0.0), or SOS.NETCore (1.0.0.0).  It looks like our official builds stamped both assemblies as 4.0.0.0, my private build was generating them both as 1.0.0.0.  This change creates separate intermediates folders for the assemblies and ensures they are versioned as they are specified.

It's not clear to me if there will be fallout anywhere now that SOS.NETCore has been published with assembly version 4.0.0.0 and if we should update that assembly version.  Was that intentional?  It was probably fine because we were just rolling forward when trying to load that assembly.  It is clear that System.Private.CoreLib versioned 1.0.0.0 causes downstream breaks because CoreFx has a dependency on version 4.0.0.0 and won't load it.

/cc @ellismg @AlexGhiondea @weshaggard