### PR TITLE
Suppress new warnings when compiling with Clang3.9

### DIFF
--- a/compileoptions.cmake
+++ b/compileoptions.cmake
@@ -37,6 +37,7 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   # and so the compiler thinks that there is a mistake.
   add_compile_options(-Wno-constant-logical-operand)
   add_compile_options(-Wno-null-dereference)
+  add_compile_options(-Wno-deprecated-declarations)
   add_compile_options(-Wno-unknown-warning-option)
 
   #These seem to indicate real issues

--- a/compileoptions.cmake
+++ b/compileoptions.cmake
@@ -36,7 +36,7 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   # There are constants of type BOOL used in a condition. But BOOL is defined as int
   # and so the compiler thinks that there is a mistake.
   add_compile_options(-Wno-constant-logical-operand)
-
+  add_compile_options(-Wno-null-dereference)
   add_compile_options(-Wno-unknown-warning-option)
 
   #These seem to indicate real issues


### PR DESCRIPTION
I supressed these warning early on when I was compiling with Clang3.9 which is preferred for Arm64 due to the need for LLDB3.9.

At the time these warnings needed to be allowed to allow the build to complete.

I strictly cannot say whether they are still needed on the current tip

@jkotas 