### PR TITLE
[Arm64/Unix] Remove aarch64 unsupported message

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -475,7 +475,6 @@ case $CPUName in
         ;;
 
     aarch64)
-        echo "Unsupported CPU $CPUName detected, build might not succeed!"
         __BuildArch=arm64
         __HostArch=arm64
         ;;


### PR DESCRIPTION
My intention is to make a Arm64 on Unix a fully supported platform.

I am not sure when the appropriate time to remove this message, but the tree will be very stable when my patches are merged

@RussKeldorph 