### PR TITLE
Turn segfauts into asserts in debug build

### DIFF
--- a/src/inc/stdmacros.h
+++ b/src/inc/stdmacros.h
@@ -277,7 +277,7 @@ inline ULONG RoundUpToPower2(ULONG x)
 
 
 #define DBG_GET_CLASS_NAME(pMT)        \
-        (pMT)->GetClass()->GetDebugClassName()
+        (((pMT) == NULL)  ? NULL : (pMT)->GetClass()->GetDebugClassName())
 
 #define DBG_CLASS_NAME_MT(pMT)         \
         (DBG_GET_CLASS_NAME(pMT) == NULL) ? "<null-class>" : DBG_GET_CLASS_NAME(pMT) 

--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -1737,9 +1737,10 @@ VOID Object::ValidateInner(BOOL bDeep, BOOL bVerifyNextHeader, BOOL bVerifySyncB
         AVInRuntimeImplOkayHolder avOk;
 
         MethodTable *pMT = GetGCSafeMethodTable();
+
         lastTest = 1;
 
-        CHECK_AND_TEAR_DOWN(pMT->Validate());
+        CHECK_AND_TEAR_DOWN(pMT && pMT->Validate());
         lastTest = 2;
 
         bool noRangeChecks =


### PR DESCRIPTION
This is two patches to turn segfaults into asserts.  This only matters while debugging GC holes on previously unstable platforms like Arm64

@jkotas