### PR TITLE
[Unix] Skipped tests should report exit code 2

### DIFF
--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -109,7 +109,7 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ ! -z "$COMPlus_GCStress" ]
 then
   echo SKIPPING EXECUTION BECAUSE COMPlus_GCStress IS SET
-  exit 0
+  exit 2
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
@@ -117,7 +117,7 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ \( ! -z "$COMPlus_JitStress" \) -o \( ! -z "$COMPlus_JitStressRegs" \) -o \( ! -z "$COMPlus_JITMinOpts" \) ]
 then
   echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts) IS SET"
-  exit 0
+  exit 2
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(HeapVerifyIncompatible)' == 'true'"><![CDATA[
@@ -125,7 +125,7 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ ! -z "$COMPlus_HeapVerify" ]
 then
   echo SKIPPING EXECUTION BECAUSE COMPlus_HeapVerify IS SET
-  exit 0
+  exit 2
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
 

--- a/tests/src/CLRTest.GC.targets
+++ b/tests/src/CLRTest.GC.targets
@@ -23,7 +23,7 @@ WARNING:   When setting properties based on their current state (for example:
 if [ ! -z $RunningLongGCTests ]
 then
     echo "Skipping execution because this is not a long-running GC test"
-    exit 0
+    exit 2
 fi
         ]]></GCLongGCTestBashScript>
         <GCLongGCTestBashScript Condition="'$(IsLongRunningGCTest)' == 'true'"><![CDATA[
@@ -31,7 +31,7 @@ fi
 if [ -z $RunningLongGCTests ]
 then
     echo "Skipping execution because long-running GC tests are not enabled"
-    exit 0
+    exit 2
 fi
         ]]></GCLongGCTestBashScript>
 
@@ -41,7 +41,7 @@ fi
 if [ ! -z $RunningGCSimulatorTests ]
 then
     echo "Skipping execution because this is not a GCSimulator test"
-    exit 0
+    exit 2
 fi
         ]]></GCSimulatorTestBashScript>
         <GCSimulatorTestBashScript Condition="'$(IsGCSimulatorTest)' == 'true'"><![CDATA[
@@ -49,7 +49,7 @@ fi
 if [ -z $RunningGCSimulatorTests ]
 then
     echo "Skipping execution because GCSimulator tests are not enabled"
-    exit 0
+    exit 2
 fi
         ]]></GCSimulatorTestBashScript>
 


### PR DESCRIPTION
Whle debugging catastrophic failures on Arm64, 542 tests were reported as passed.  This was traced to this bug in the test code where unsupported tests were being reported as passed instead of skipped.

Windows side needs a similar patch, but I do not have the knowledge to write such a patch

@jkotas