### PR TITLE
[Arm64/Unix] Fix gdbjit support

### DIFF
--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -473,6 +473,8 @@ public:
         m_sub_loc[1] = DW_OP_reg6;
 #elif defined(_TARGET_X86_)
         m_sub_loc[1] = DW_OP_reg5;
+#elif defined(_TARGET_ARM64_)
+        m_sub_loc[1] = DW_OP_reg29;
 #elif defined(_TARGET_ARM_)
         m_sub_loc[1] = DW_OP_reg11;
 #else


### PR DESCRIPTION
Most ARM64 GDBJIT support was added to tip after I wrote the origianl version of this patch.

This is the small bit that is still missing from the tip

@jkotas