### PR TITLE
[Unix] Assume 8M cache reported as 0

### DIFF
--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -343,5 +343,8 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
     cacheSize = max(cacheSize, sysconf(_SC_LEVEL4_CACHE_SIZE));
 #endif
 
+    if(cacheSize == 0)
+      cacheSize = 8ULL << 20;  // sysconf currently only reports cache size info for x86.
+
     return cacheSize;
 }


### PR DESCRIPTION
glibc does not currently support cache size info for
platforms other than Amd64.

Set 8M as a reaonable cache size guess

This may be an interim fix, perhaps the better long term fix would be a cmake config option.

@jkotas 