### PR TITLE
Fix exception catch clause off by one error

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -3993,7 +3993,7 @@ BOOL ExceptionTracker::ClauseCoversPC(
     // of the method so we can just compare them to the offset returned
     // by JitCodeToMethodInfo.
     //
-    return ((pEHClause->TryStartPC <= dwOffset) && (dwOffset < pEHClause->TryEndPC));
+    return ((pEHClause->TryStartPC <= dwOffset) && (dwOffset <= pEHClause->TryEndPC));
 }
 
 #if defined(DEBUGGING_SUPPORTED)


### PR DESCRIPTION
Debug log shows "considering %s clause [%x,%x], ControlPc..."

This patches fixes the mismatch.

Fix resolved observed catch misses on Arm64
No additonal failures observed on amd64/unix

@janvorli 