### PR TITLE
Up the timeout for arm64 jobs that run tests.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2033,6 +2033,9 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                        buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture} toolset_dir C:\\ats2"
                     }
                     else {
+                       // Up the timeout for arm64 testing.
+                       Utilities.setJobTimeout(newJob, 240)
+
                        buildCommands += "set __TestIntermediateDir=int&&build.cmd skiptests ${lowerConfiguration} ${architecture} toolset_dir C:\\ats2"
                        // Test build and run are launched together.
                        buildCommands += "python tests\\scripts\\arm64_post_build.py -repo_root %WORKSPACE% -arch ${architecture} -build_type ${lowerConfiguration} -scenario ${scenario} -key_location C:\\tools\\key.txt"


### PR DESCRIPTION
With the new test update arm64 jobs run too long to fit into the default 120 minutes.