### PR TITLE
Tweak SZGenericArrayEnumerator implementation

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2507,7 +2507,9 @@ namespace System {
             private T[] _array;
             private int _index;
 
-            internal static readonly SZGenericArrayEnumerator<T> Empty = new SZGenericArrayEnumerator<T>(Array.Empty<T>());
+            // Array.Empty is intentionally not used here, so we don't have to pay for generic instantiation overhead
+            // if it wouldn't have otherwise been used for that type.
+            internal static readonly SZGenericArrayEnumerator<T> Empty = new SZGenericArrayEnumerator<T>(new T[0]);
 
             internal SZGenericArrayEnumerator(T[] array)
             {

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2516,21 +2516,21 @@ namespace System {
                 _index = -1;
             }
     
-            public bool MoveNext() => ++_index < _array.Length;
+            public bool MoveNext() => _index < _array.Length && ++_index < _array.Length;
     
             public T Current
             {
                 get
                 {
-                    if ((uint)_index >= (uint)_array.Length)
+                    int index = _index;
+                    T[] array = _array;
+
+                    if ((uint)index >= (uint)array.Length)
                     {
-                        var exceptionResource = _index < 0 ?
-                            ExceptionResource.InvalidOperation_EnumNotStarted :
-                            ExceptionResource.InvalidOperation_EnumEnded;
-                        ThrowHelper.ThrowInvalidOperationException(exceptionResource);
+                        ThrowHelper.ThrowInvalidOperationException_EnumCurrent(index);
                     }
 
-                    return _array[_index];
+                    return array[index];
                 }
             }
     

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2516,7 +2516,18 @@ namespace System {
                 _index = -1;
             }
     
-            public bool MoveNext() => _index < _array.Length && ++_index < _array.Length;
+            public bool MoveNext()
+            {
+                int index = _index + 1;
+                bool result = index < _array.Length;
+                
+                if (result)
+                {
+                    _index = index;
+                }
+
+                return result;
+            }
     
             public T Current
             {

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -228,6 +228,10 @@ namespace System {
             return GetArgumentException(ExceptionResource.Argument_InvalidOffLen);
         }
 
+        internal static void ThrowInvalidOperationException_EnumCurrent(int index) {
+            throw GetInvalidOperationException_EnumCurrent(index);
+        }
+
         private static ArgumentException GetArgumentException(ExceptionResource resource) {
             return new ArgumentException(GetResourceString(resource));
         }
@@ -254,6 +258,12 @@ namespace System {
 
         private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, int paramNumber, ExceptionResource resource) {
             return new ArgumentOutOfRangeException(GetArgumentName(argument) + "[" + paramNumber.ToString() + "]", GetResourceString(resource));
+        }
+
+        private static InvalidOperationException GetInvalidOperationException_EnumCurrent(int index) {
+            if (index < 0)
+                return GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumNotStarted);
+            return GetInvalidOperationException(ExceptionResource.InvalidOperation_EnumEnded);
         }
 
         // Allow nulls for reference types and Nullable<U>, but not for value types.


### PR DESCRIPTION
- Remove the `endIndex` field. I believe accessing the Length may be slow for non-generic arrays, but it's just a simple ldlen -> pointer access for generic arrays right?
  - I just tested [with this program](https://gist.github.com/jamesqo/540268a41a54214033b24ee047a2093f) and unfortunately there's no decrease in memory usage on 64-bit, maybe the story is different for 32-bit>

- Do an unsigned cast in Current so there's only 1 branch check

- Use `Array.Empty<T>()` for the empty enumerator

- Format code

- Behavior of MoveNext is undefined after it returns false, so avoid a branch and unconditionally increment the index.
  - Can cause a breaking change if someone calls the method 2B times and then does something based on MoveNext after that?

/cc @jkotas, @benaadams 