### PR TITLE
List Clear+Remove

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -292,13 +292,21 @@ namespace System.Collections.Generic
         // Clears the contents of List.
         public void Clear()
         {
-            if (JitHelpers.ContainsReferences<T>() && _size > 0)
+            if (JitHelpers.ContainsReferences<T>())
             {
-                Array.Clear(_items, 0, _size); // Clear the elements so that the gc can reclaim the references.
+                int size = _size;
+                _size = 0;
+                _version++;
+                if (size > 0)
+                {
+                    Array.Clear(_items, 0, size); // Clear the elements so that the gc can reclaim the references.
+                }
             }
-
-            _size = 0;
-            _version++;
+            else
+            {
+                _size = 0;
+                _version++;
+            }
         }
     
         // Contains returns true if the specified element is in the List.

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -861,9 +861,13 @@ namespace System.Collections.Generic
                     // copy item to the free slot.
                     _items[freeIndex++] = _items[current++];
                 }
-            }                       
-            
-            Array.Clear(_items, freeIndex, _size - freeIndex);
+            }
+
+            if (JitHelpers.ContainsReferences<T>())
+            {
+                Array.Clear(_items, freeIndex, _size - freeIndex); // Clear the elements so that the gc can reclaim the references.
+            }
+
             int result = _size - freeIndex;
             _size = freeIndex;
             _version++;
@@ -911,8 +915,12 @@ namespace System.Collections.Generic
                 if (index < _size) {
                     Array.Copy(_items, index + count, _items, index, _size - index);
                 }
-                Array.Clear(_items, _size, count);
+
                 _version++;
+                if (JitHelpers.ContainsReferences<T>())
+                {
+                    Array.Clear(_items, _size, count);
+                }
             }
         }
     

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -12,14 +12,13 @@
 **
 ** 
 ===========================================================*/
-namespace System.Collections.Generic {
-
+namespace System.Collections.Generic
+{
     using System;
-    using System.Runtime;
-    using System.Runtime.Versioning;
     using System.Diagnostics;
     using System.Diagnostics.Contracts;
     using System.Collections.ObjectModel;
+    using Runtime.CompilerServices;
 
     // Implements a variable-size List that uses an array of objects to store the
     // elements. A List has a capacity, which is the allocated length
@@ -291,12 +290,14 @@ namespace System.Collections.Generic {
 
     
         // Clears the contents of List.
-        public void Clear() {
-            if (_size > 0)
+        public void Clear()
+        {
+            if (JitHelpers.ContainsReferences<T>() && _size > 0)
             {
-                Array.Clear(_items, 0, _size); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
-                _size = 0;
+                Array.Clear(_items, 0, _size); // Clear the elements so that the gc can reclaim the references.
             }
+
+            _size = 0;
             _version++;
         }
     
@@ -870,10 +871,14 @@ namespace System.Collections.Generic {
             }
             Contract.EndContractBlock();
             _size--;
-            if (index < _size) {
+            if (index < _size)
+            {
                 Array.Copy(_items, index + 1, _items, index, _size - index);
             }
-            _items[_size] = default(T);
+            if (JitHelpers.ContainsReferences<T>())
+            {
+                _items[_size] = default(T);
+            }
             _version++;
         }
     


### PR DESCRIPTION
Struct based Clear trims to
```asm
Marking List`1:Clear():this as NOINLINE because of unprofitable inline
Successfully inlined JitHelpers:ContainsReferences():bool (2 IL bytes) (depth 1) [below ALWAYS_INLINE size]
**************** Inline Tree
Inlines into 060034D8 List`1:Clear():this
  [1 IL=0000 TR=000001 06003B02] [below ALWAYS_INLINE size] JitHelpers:ContainsReferences():bool
  [0 IL=0029 TR=000037 06000248] [FAILED: noinline per IL/cached result] Array:Clear(ref,int,int)
Budget: initialTime=228, finalTime=218, initialBudget=2280, currentBudget=2280
Budget: initialSize=1408, finalSize=1408
; Assembly listing for method List`1:Clear():this
; Emitting BLENDED_CODE for X64 CPU with SSE2
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 this         [V00,T00] (  7,   7  )     ref  ->  rcx         this
;  V01 OutArgs      [V01    ] (  1,   1  )  lclBlk (32) [rsp+0x00]  
;
; Lcl frame size = 40

G_M33881_IG01:
       4883EC28             sub      rsp, 40
       90                   nop      

G_M33881_IG02:
       33C0                 xor      eax, eax
       894118               mov      dword ptr [rcx+24], eax
       FF411C               inc      dword ptr [rcx+28]

G_M33881_IG03:
       4883C428             add      rsp, 40
       C3                   ret      

; Total bytes of code 18, prolog size 5 for method List`1:Clear():this
```
Shame about the no-inline...

For remove I was looking to swap `Array.Copy` for `Buffer.Memmove` or similar, however the Span code for getting a pointer to a `T[]` element in an array is a little exotic