### PR TITLE
[Windows/Arm32] Fix a build break

### DIFF
--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -2597,15 +2597,6 @@ AGAIN:
                 constVal = (ssize_t)(tree->gtLngCon.gtLconVal >> 32);
                 size     = EA_4BYTE;
             }
-#if defined(_TARGET_ARM_) && CPU_LONG_USES_REGPAIR
-            if ((ins != INS_mov) && !arm_Valid_Imm_For_Instr(ins, constVal, flags))
-            {
-                regNumber constReg = (offs == 0) ? genRegPairLo(tree->gtRegPair) : genRegPairHi(tree->gtRegPair);
-                instGen_Set_Reg_To_Imm(size, constReg, constVal);
-                getEmitter()->emitIns_R_R(ins, size, reg, constReg, flags);
-                break;
-            }
-#endif // _TARGET_ARM_ && CPU_LONG_USES_REGPAIR
 
             inst_RV_IV(ins, reg, constVal, size, flags);
             break;


### PR DESCRIPTION
Fix for #9536.

In #9085 I missed `#ifndef LEGACY_BACKEND` at [instr.cpp#L2598](https://github.com/dotnet/coreclr/blob/cacb79692c4db6c4dded4d8f6a55e7fd8fa11d3a/src/jit/instr.cpp#L2598):
```c++
#ifndef LEGACY_BACKEND
#ifdef _TARGET_ARM_
            if ((ins != INS_mov) && !arm_Valid_Imm_For_Instr(ins, constVal, flags))
            {
                regNumber constReg = (offs == 0) ? genRegPairLo(tree->gtRegPair) : genRegPairHi(tree->gtRegPair);
                instGen_Set_Reg_To_Imm(size, constReg, constVal);
                getEmitter()->emitIns_R_R(ins, size, reg, constReg, flags);
                break;
            }
#endif // _TARGET_ARM_
#endif // !LEGACY_BACKEND
```
and incorrectly changed it to
```c++
#if defined(_TARGET_ARM_) && CPU_LONG_USES_REGPAIR
           if ((ins != INS_mov) && !arm_Valid_Imm_For_Instr(ins, constVal, flags))
           {
               regNumber constReg = (offs == 0) ? genRegPairLo(tree->gtRegPair) : genRegPairHi(tree->gtRegPair);
               instGen_Set_Reg_To_Imm(size, constReg, constVal);
               getEmitter()->emitIns_R_R(ins, size, reg, constReg, flags);
               break;
           }
#endif // _TARGET_ARM_ && CPU_LONG_USES_REGPAIR
```
Since the RyuJIT backend doesn't use register pairs, this entire fragment should be removed.