### PR TITLE
[x86/Linux] Ignore fake jump while checking funclet branches

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -4233,7 +4233,7 @@ void emitter::emitCheckFuncletBranch(instrDesc* jmp, insGroup* jmpIG)
     // meets one of those criteria...
     assert(jmp->idIsBound());
 
-#ifdef _TARGET_AMD64_
+#ifdef _TARGET_XARCH_
     // An lea of a code address (for constant data stored with the code)
     // is treated like a jump for emission purposes but is not really a jump so
     // we don't have to check anything here.


### PR DESCRIPTION
For both x86/x64, CLR emits a fake jump using lea, but this fake jump is ignored inside emitCheckFuncletBranch only for x64, which results in the assert failure discussed in #9545.

This commit ports the relevant workaround into x86 to fix #9545.
