### PR TITLE
SpinWait - always spin once

### DIFF
--- a/src/mscorlib/src/System/Threading/SpinWait.cs
+++ b/src/mscorlib/src/System/Threading/SpinWait.cs
@@ -146,6 +146,11 @@ namespace System.Threading
                     Thread.Yield();
                 }
             }
+            else if (m_count == 0)
+            {
+                // Not spun yet, single cpu PAUSE, bitshift below would result in 0 PAUSEs
+                Thread.SpinWait(1);
+            }
             else
             {
                 //

--- a/src/mscorlib/src/System/Threading/SpinWait.cs
+++ b/src/mscorlib/src/System/Threading/SpinWait.cs
@@ -71,6 +71,7 @@ namespace System.Threading
     /// </remarks>
     public struct SpinWait
     {
+        private const int MAX_COUNT = int.MaxValue >> 4;
 
         // These constants determine the frequency of yields versus spinning. The
         // numbers may seem fairly arbitrary, but were derived with at least some
@@ -168,7 +169,7 @@ namespace System.Threading
             }
 
             // Finally, increment our spin counter.
-            m_count = (m_count == int.MaxValue ? YIELD_THRESHOLD : m_count + 1);
+            m_count = (m_count == MAX_COUNT ? YIELD_THRESHOLD : m_count + 1);
         }
 
         /// <summary>


### PR DESCRIPTION
When `m_count == 0` `SpinOnce()` calls through to [`ThreadNative::SpinWait`](https://github.com/dotnet/coreclr/blob/master/src/vm/comsynchronizable.cpp#L1886-L1915) but doesn't actually issue a pause as iterations are zero.

/cc @stephentoub PTAL
