### PR TITLE
Value number TypeHandleToRuntimeType helper

### DIFF
--- a/src/jit/utils.cpp
+++ b/src/jit/utils.cpp
@@ -1358,6 +1358,7 @@ void HelperCallProperties::init()
             case CORINFO_HELP_ISINSTANCEOFCLASS:
             case CORINFO_HELP_ISINSTANCEOFANY:
             case CORINFO_HELP_READYTORUN_ISINSTANCEOF:
+            case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE:
 
                 isPure  = true;
                 noThrow = true; // These return null for a failing cast

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -7466,6 +7466,10 @@ VNFunc Compiler::fgValueNumberHelperMethVNFunc(CorInfoHelpFunc helpFunc)
             vnf = VNF_IsInstanceOf;
             break;
 
+        case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE:
+            vnf = VNF_TypeHandleToRuntimeType;
+            break;
+
         case CORINFO_HELP_READYTORUN_ISINSTANCEOF:
             vnf = VNF_ReadyToRunIsInstanceOf;
             break;

--- a/src/jit/valuenumfuncs.h
+++ b/src/jit/valuenumfuncs.h
@@ -34,6 +34,7 @@ ValueNumFuncDef(CastClass, 2, false, false, false)          // Args: 0: Handle o
 ValueNumFuncDef(IsInstanceOf, 2, false, false, false)       // Args: 0: Handle of class being queried, 1: object being queried.
 ValueNumFuncDef(ReadyToRunCastClass, 2, false, false, false)          // Args: 0: Helper stub address, 1: object being cast.
 ValueNumFuncDef(ReadyToRunIsInstanceOf, 2, false, false, false)       // Args: 0: Helper stub address, 1: object being queried.
+ValueNumFuncDef(TypeHandleToRuntimeType, 1, false, false, false)      // Args: 0: TypeHandle to translate
 
 ValueNumFuncDef(LdElemA, 3, false, false, false)            // Args: 0: array value; 1: index value; 2: type handle of element.
 


### PR DESCRIPTION
This is a pure helper w/o side-effects, so add it to the lists of
tractable helpers in value-numbering; this allows redundant calls to be
CSEd, and fixes #9552 so we can again optimize away type checks on type
parameters in generic code (a not-infrequent pattern).