### PR TITLE
Remove OpenSuse13.2 from runtime section in all Project.Jsons

### DIFF
--- a/tests/src/Common/build_against_pkg_dependencies/project.json
+++ b/tests/src/Common/build_against_pkg_dependencies/project.json
@@ -26,7 +26,6 @@
     "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }
 }

--- a/tests/src/Common/empty/project.json
+++ b/tests/src/Common/empty/project.json
@@ -14,7 +14,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "fedora.23-x64": {}
   }
 }

--- a/tests/src/Common/targeting_pack_ref/project.json
+++ b/tests/src/Common/targeting_pack_ref/project.json
@@ -20,7 +20,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "fedora.23-x64": {}
   }
 }

--- a/tests/src/Common/test_dependencies/project.json
+++ b/tests/src/Common/test_dependencies/project.json
@@ -88,7 +88,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "fedora.23-x64": {}
   }
 }

--- a/tests/src/Common/test_runtime/project.json
+++ b/tests/src/Common/test_runtime/project.json
@@ -24,7 +24,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "fedora.23-x64": {}
   }
 }

--- a/tests/src/JIT/config/extra/project.json
+++ b/tests/src/JIT/config/extra/project.json
@@ -30,7 +30,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "fedora.23-x64": {}
   }
 }

--- a/tests/src/JIT/config/minimal/project.json
+++ b/tests/src/JIT/config/minimal/project.json
@@ -19,7 +19,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "fedora.23-x64": {}
   }
 }

--- a/tests/src/JIT/config/threading+thread/project.json
+++ b/tests/src/JIT/config/threading+thread/project.json
@@ -21,7 +21,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "fedora.23-x64": {}
   }
 }

--- a/tests/src/JIT/config/threading/project.json
+++ b/tests/src/JIT/config/threading/project.json
@@ -19,7 +19,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "fedora.23-x64": {}
   }
 }

--- a/tests/src/TestWrappersConfig/project.json
+++ b/tests/src/TestWrappersConfig/project.json
@@ -27,7 +27,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "fedora.23-x64": {}
   }
 }


### PR DESCRIPTION
Since we are deprecating support for OpenSuse13.2, we should no longer restore packages for it.