### PR TITLE
Fix `JitTimeLog::PrintCsvHeader`.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -7807,6 +7807,9 @@ void JitTimer::PrintCsvHeader()
     FILE* fp = _wfopen(jitTimeLogCsv, W("a"));
     if (fp != nullptr)
     {
+        // Seek to the end of the file s.t. `ftell` doesn't lie to us on Windows
+        fseek(fp, 0, SEEK_END);
+
         // Write the header if the file is empty
         if (ftell(fp) == 0)
         {


### PR DESCRIPTION
This function attempts to suppress its output if the JIT time log is not
empty. Unfortunately, the method it uses to do this detection gives
incorrect results on Windows: as documented on MSDN, `ftell` will return
`0` for a file opened for appending until the first I/O operation on
that file occurs. This change fixes this by seeking to the end of the
file prior to `ftell`.