### PR TITLE
Directly support Min/Max intrinsic for Vector<T> on SSE3_4 and above targets 

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -81,9 +81,11 @@ bool emitter::IsThreeOperandBinaryAVXInstruction(instruction ins)
             ins == INS_minsd || ins == INS_divps || ins == INS_divpd || ins == INS_maxps || ins == INS_maxpd ||
             ins == INS_maxss || ins == INS_maxsd || ins == INS_andnps || ins == INS_andnpd || ins == INS_paddb ||
             ins == INS_paddw || ins == INS_paddd || ins == INS_paddq || ins == INS_psubb || ins == INS_psubw ||
-            ins == INS_psubd || ins == INS_psubq || ins == INS_pmuludq || ins == INS_pxor || ins == INS_pmaxub ||
-            ins == INS_pminub || ins == INS_pmaxsw || ins == INS_pminsw || ins == INS_insertps ||
-            ins == INS_vinsertf128 || ins == INS_punpckldq || ins == INS_phaddd);
+            ins == INS_psubd || ins == INS_psubq || ins == INS_pmuludq || ins == INS_pxor || ins == INS_insertps ||
+            ins == INS_vinsertf128 || ins == INS_punpckldq || ins == INS_phaddd || ins == INS_pminub ||
+            ins == INS_pminsw || ins == INS_pminsb || ins == INS_pminsd || ins == INS_pminuw || ins == INS_pminud ||
+            ins == INS_pmaxub || ins == INS_pmaxsw || ins == INS_pmaxsb || ins == INS_pmaxsd || ins == INS_pmaxuw ||
+            ins == INS_pmaxud);
 }
 
 // Returns true if the AVX instruction is a move operator that requires 3 operands.
@@ -115,7 +117,9 @@ bool emitter::Is4ByteAVXInstruction(instruction ins)
            (ins == INS_dpps || ins == INS_dppd || ins == INS_insertps || ins == INS_pcmpeqq || ins == INS_pcmpgtq ||
             ins == INS_vbroadcastss || ins == INS_vbroadcastsd || ins == INS_vpbroadcastb || ins == INS_vpbroadcastw ||
             ins == INS_vpbroadcastd || ins == INS_vpbroadcastq || ins == INS_vextractf128 || ins == INS_vinsertf128 ||
-            ins == INS_pmulld || ins == INS_ptest || ins == INS_phaddd);
+            ins == INS_pmulld || ins == INS_ptest || ins == INS_phaddd || ins == INS_pminsb || ins == INS_pminsd ||
+            ins == INS_pminuw || ins == INS_pminud || ins == INS_pmaxsb || ins == INS_pmaxsd || ins == INS_pmaxuw ||
+            ins == INS_pmaxud);
 }
 #endif // FEATURE_AVX_SUPPORT
 
@@ -135,7 +139,9 @@ bool emitter::Is4ByteSSE4Instruction(instruction ins)
     return false;
 #else
     return UseSSE3_4() && (ins == INS_dpps || ins == INS_dppd || ins == INS_insertps || ins == INS_pcmpeqq ||
-                           ins == INS_pcmpgtq || ins == INS_pmulld || ins == INS_ptest || ins == INS_phaddd);
+                           ins == INS_pcmpgtq || ins == INS_pmulld || ins == INS_ptest || ins == INS_phaddd ||
+                           ins == INS_pminsb || ins == INS_pminsd || ins == INS_pminuw || ins == INS_pminud ||
+                           ins == INS_pmaxsb || ins == INS_pmaxsd || ins == INS_pmaxuw || ins == INS_pmaxud);
 #endif
 }
 

--- a/src/jit/instrsxarch.h
+++ b/src/jit/instrsxarch.h
@@ -323,6 +323,14 @@ INST3( phaddd,       "phaddd"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SS
 INST3( pabsb,        "pabsb"       , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x1C))   // Packed absolute value of bytes
 INST3( pabsw,        "pabsw"       , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x1D))   // Packed absolute value of 16-bit integers
 INST3( pabsd,        "pabsd"       , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x1E))   // Packed absolute value of 32-bit integers
+INST3( pminsb,       "pminsb"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x38))   // packed minimum signed bytes
+INST3( pminsd,       "pminsd"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x39))   // packed minimum 32-bit signed integers
+INST3( pminuw,       "pminuw"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x3A))   // packed minimum 16-bit unsigned integers
+INST3( pminud,       "pminud"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x3B))   // packed minimum 32-bit unsigned integers
+INST3( pmaxsb,       "pmaxsb"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x3C))   // packed maximum signed bytes
+INST3( pmaxsd,       "pmaxsd"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x3D))   // packed maximum 32-bit signed integers
+INST3( pmaxuw,       "pmaxuw"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x3E))   // packed maximum 16-bit unsigned integers
+INST3( pmaxud,       "pmaxud"      , 0, IUM_WR, 0, 0, BAD_CODE,     BAD_CODE, SSE38(0x3F))   // packed maximum 32-bit unsigned integers
 INST3(LAST_SSE4_INSTRUCTION, "LAST_SSE4_INSTRUCTION",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, BAD_CODE)
 
 INST3(FIRST_AVX_INSTRUCTION, "FIRST_AVX_INSTRUCTION",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, BAD_CODE)

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -1374,20 +1374,22 @@ GenTreePtr Compiler::impSIMDMinMax(SIMDIntrinsicID      intrinsicId,
 
 #ifdef _TARGET_XARCH_
     // SSE2 has direct support for float/double/signed word/unsigned byte.
+    // SSE4.1 has direct support for int32/uint32/signed byte/unsigned word.
     // For other integer types we compute min/max as follows
     //
-    // int32/uint32/int64/uint64:
+    // int32/uint32 (SSE2)
+    // int64/uint64 (SSE2&SSE3_4):
     //       compResult        = (op1 < op2) in case of Min
     //                           (op1 > op2) in case of Max
     //       Min/Max(op1, op2) = Select(compResult, op1, op2)
     //
-    // unsigned word:
+    // unsigned word (SSE2):
     //        op1 = op1 - 2^15  ; to make it fit within a signed word
     //        op2 = op2 - 2^15  ; to make it fit within a signed word
     //        result = SSE2 signed word Min/Max(op1, op2)
     //        result = result + 2^15  ; readjust it back
     //
-    // signed byte:
+    // signed byte (SSE2):
     //        op1 = op1 + 2^7  ; to make it unsigned
     //        op1 = op1 + 2^7  ; to make it unsigned
     //        result = SSE2 unsigned byte Min/Max(op1, op2)
@@ -1395,13 +1397,16 @@ GenTreePtr Compiler::impSIMDMinMax(SIMDIntrinsicID      intrinsicId,
 
     GenTree* simdTree = nullptr;
 
-    if (varTypeIsFloating(baseType) || baseType == TYP_SHORT || baseType == TYP_UBYTE)
+    if (varTypeIsFloating(baseType) || baseType == TYP_SHORT || baseType == TYP_UBYTE ||
+        (getSIMDInstructionSet() >= InstructionSet_SSE3_4 &&
+         (baseType == TYP_BYTE || baseType == TYP_INT || baseType == TYP_UINT || baseType == TYP_CHAR)))
     {
-        // SSE2 has direct support
+        // SSE2 or SSE4.1 has direct support
         simdTree = gtNewSIMDNode(simdType, op1, op2, intrinsicId, baseType, size);
     }
     else if (baseType == TYP_CHAR || baseType == TYP_BYTE)
     {
+        assert(getSIMDInstructionSet() == InstructionSet_SSE2);
         int             constVal;
         SIMDIntrinsicID operIntrinsic;
         SIMDIntrinsicID adjustIntrinsic;

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -243,6 +243,25 @@ instruction CodeGen::getOpForSIMDIntrinsic(SIMDIntrinsicID intrinsicId, var_type
             {
                 result = INS_pminsw;
             }
+            else if (compiler->getSIMDInstructionSet() >= InstructionSet_SSE3_4)
+            {
+                if (baseType == TYP_BYTE)
+                {
+                    result = INS_pminsb;
+                }
+                else if (baseType == TYP_CHAR)
+                {
+                    result = INS_pminuw;
+                }
+                else if (baseType == TYP_INT)
+                {
+                    result = INS_pminsd;
+                }
+                else if (baseType == TYP_UINT)
+                {
+                    result = INS_pminud;
+                }
+            }
             else
             {
                 unreached();
@@ -265,6 +284,25 @@ instruction CodeGen::getOpForSIMDIntrinsic(SIMDIntrinsicID intrinsicId, var_type
             else if (baseType == TYP_SHORT)
             {
                 result = INS_pmaxsw;
+            }
+            else if (compiler->getSIMDInstructionSet() >= InstructionSet_SSE3_4)
+            {
+                if (baseType == TYP_BYTE)
+                {
+                    result = INS_pmaxsb;
+                }
+                else if (baseType == TYP_CHAR)
+                {
+                    result = INS_pmaxuw;
+                }
+                else if (baseType == TYP_INT)
+                {
+                    result = INS_pmaxsd;
+                }
+                else if (baseType == TYP_UINT)
+                {
+                    result = INS_pmaxud;
+                }
             }
             else
             {


### PR DESCRIPTION
This PR implements the direct support of Min/Max intrinsic for `Vector<T>` on Int32, UInt32, Uint16, and Sbyte by pminsd/pminsb/pminuw/pminud/pmaxsd/pmaxsb/pmaxuw/pmaxud from SSE4.1. 
Fixed #9312 , fixed #9311 

For example, originally, RyuJIT compiles
```csharp
var a = Vector<uint>.One;
var b = new Vector<uint>(2);
var c = Vector.Min(a, b);
```
to  
```
IN0005: 000030 mov      ecx, 1
IN0006: 000035 movd     xmm0, ecx
IN0007: 000039 pshufd   xmm0, xmm0, 0
IN0008: 00003E movaps   xmmword ptr [V04 rbp-60H], xmm0
IN0009: 000042 movaps   xmm0, xmmword ptr [V04 rbp-60H]
IN000a: 000046 movaps   xmmword ptr [V00 rbp-20H], xmm0
IN000b: 00004A mov      ecx, 2
IN000c: 00004F movd     xmm0, ecx
IN000d: 000053 pshufd   xmm0, xmm0, 0
IN000e: 000058 movaps   xmmword ptr [V01 rbp-30H], xmm0
IN000f: 00005C movaps   xmm0, xmmword ptr [V01 rbp-30H]
IN0010: 000060 mov      ecx, 0x80000000
IN0011: 000065 movd     xmm1, ecx
IN0012: 000069 pshufd   xmm1, xmm1, 0
IN0013: 00006E movaps   xmmword ptr [V05 rbp-70H], xmm1
IN0014: 000072 movaps   xmm1, xmmword ptr [V05 rbp-70H]
IN0015: 000076 psubd    xmm0, xmm1
IN0016: 00007A movaps   xmm1, xmmword ptr [V00 rbp-20H]
IN0017: 00007E movaps   xmm2, xmmword ptr [V05 rbp-70H]
IN0018: 000082 psubd    xmm1, xmm2
IN0019: 000086 pcmpgtd  xmm0, xmm1
IN001a: 00008A movaps   xmmword ptr [V06 rbp-80H], xmm0
IN001b: 00008E movaps   xmm0, xmmword ptr [V00 rbp-20H]
IN001c: 000092 movaps   xmm1, xmmword ptr [V06 rbp-80H]
IN001d: 000096 pand     xmm0, xmm1
IN001e: 00009A movaps   xmm1, xmmword ptr [V06 rbp-80H]
IN001f: 00009E movaps   xmm2, xmmword ptr [V01 rbp-30H]
IN0020: 0000A2 pandn    xmm1, xmm2
IN0021: 0000A6 por      xmm0, xmm1
IN0022: 0000AA movaps   xmmword ptr [V07 rbp-90H], xmm0
IN0023: 0000B1 movaps   xmm0, xmmword ptr [V07 rbp-90H]
IN0024: 0000B8 movaps   xmmword ptr [V02 rbp-40H], xmm0
```
With SSE 4.1 direct support, we can JIT compile the code segment to:
```
IN0005: 00002D mov      ecx, 1
IN0006: 000032 movd     xmm0, ecx
IN0007: 000036 pshufd   xmm0, xmm0, 0
IN0008: 00003B movaps   xmmword ptr [V04 rbp-60H], xmm0
IN0009: 00003F movaps   xmm0, xmmword ptr [V04 rbp-60H]
IN000a: 000043 movaps   xmmword ptr [V00 rbp-20H], xmm0
IN000b: 000047 mov      ecx, 2
IN000c: 00004C movd     xmm0, ecx
IN000d: 000050 pshufd   xmm0, xmm0, 0
IN000e: 000055 movaps   xmmword ptr [V01 rbp-30H], xmm0
IN000f: 000059 movaps   xmm0, xmmword ptr [V00 rbp-20H]
IN0010: 00005D movaps   xmm1, xmmword ptr [V01 rbp-30H]
IN0011: 000061 pminud   xmm0, xmm1
IN0012: 000066 movaps   xmmword ptr [V05 rbp-70H], xmm0
IN0013: 00006A movaps   xmm0, xmmword ptr [V05 rbp-70H]
IN0014: 00006E movaps   xmmword ptr [V02 rbp-40H], xmm0
```
This produces more efficient code generation using SSE 4.1. Here is the summary of code size reduction (number of instructions) on the related types:

|  Type  |  Before  |  SSE 4.1 Direct Support  |  Instructions Reduced   |
|--------|:---------|:---------------------------|:--------------------------|
|UInt32|   31        |                 16                   |           48.4%                   |
|   Int32|   31        |                 16                   |           48.4%                  |
|UInt16|   25        |                 14                   |           44.0%                  |
|SByte  |   27        |                 17                   |           37.0%                  |


The above JIT dump is generated on a `Intel® Core™ i7-6700K` processor with `COMPlus_EnableAVX=0` and debug build.