### PR TITLE
Jit: fix gtIsRecursiveCall

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2138,9 +2138,10 @@ public:
     bool gtIsStaticFieldPtrToBoxedStruct(var_types fieldNodeType, CORINFO_FIELD_HANDLE fldHnd);
 
     // Return true if call is a recursive call; return false otherwise.
+    // Note when inlining, this looks for calls back to the root method.
     bool gtIsRecursiveCall(GenTreeCall* call)
     {
-        return (call->gtCallMethHnd == info.compMethodHnd);
+        return (call->gtCallMethHnd == impInlineRoot()->info.compMethodHnd);
     }
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
When called from the inline compiler, this needs to look at the root
method's handle, not the inlined method's handle.

Fixes #9568.