### PR TITLE
Do not report FP restores in x86 epilogs.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -9450,6 +9450,13 @@ void CodeGen::genFnEpilog(BasicBlock* block)
     genRestoreCalleeSavedFltRegs(compiler->compLclFrameSize);
 #endif // !FEATURE_STACK_FP_X87
 
+#ifdef JIT32_GCENCODER
+    // On IA32, we start the OS-reported portion of the epilog after restoring any callee-saved
+    // floating-point registers. This avoids the need to update the x86 unwinder and retains binary
+    // compatibility between later versions of the JIT and earlier versions of the runtime.
+    getEmitter()->emitStartEpilog();
+#endif
+
     /* Compute the size in bytes we've pushed/popped */
 
     if (!doubleAlignOrFramePointerUsed())

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1983,9 +1983,9 @@ void emitter::emitEndFnEpilog()
 #ifdef JIT32_GCENCODER
     assert(emitEpilogLast != nullptr);
 
-    UNATIVE_OFFSET epilogBegCodeOffset = emitEpilogLast->elLoc.CodeOffset(this);
+    UNATIVE_OFFSET epilogBegCodeOffset          = emitEpilogLast->elLoc.CodeOffset(this);
     UNATIVE_OFFSET epilogExitSeqStartCodeOffset = emitExitSeqBegLoc.CodeOffset(this);
-    UNATIVE_OFFSET newSize = epilogExitSeqStartCodeOffset - epilogBegCodeOffset;
+    UNATIVE_OFFSET newSize                      = epilogExitSeqStartCodeOffset - epilogBegCodeOffset;
 
     /* Compute total epilog size */
     assert(emitEpilogSize == 0 || emitEpilogSize == newSize); // All epilogs must be identical
@@ -2056,7 +2056,6 @@ void emitter::emitEndFuncletEpilog()
 }
 
 #endif // FEATURE_EH_FUNCLETS
-
 
 #ifdef JIT32_GCENCODER
 

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1983,22 +1983,14 @@ void emitter::emitEndFnEpilog()
 #ifdef JIT32_GCENCODER
     assert(emitEpilogLast != nullptr);
 
-    UNATIVE_OFFSET newSize;
     UNATIVE_OFFSET epilogBegCodeOffset = emitEpilogLast->elLoc.CodeOffset(this);
-#ifdef _TARGET_XARCH_
     UNATIVE_OFFSET epilogExitSeqStartCodeOffset = emitExitSeqBegLoc.CodeOffset(this);
-#else
-    UNATIVE_OFFSET epilogExitSeqStartCodeOffset = emitCodeOffset(emitCurIG, emitCurOffset());
-#endif
-
-    newSize = epilogExitSeqStartCodeOffset - epilogBegCodeOffset;
-
-#ifdef _TARGET_X86_
+    UNATIVE_OFFSET newSize = epilogExitSeqStartCodeOffset - epilogBegCodeOffset;
 
     /* Compute total epilog size */
-
     assert(emitEpilogSize == 0 || emitEpilogSize == newSize); // All epilogs must be identical
-    emitEpilogSize                     = newSize;
+    emitEpilogSize = newSize;
+
     UNATIVE_OFFSET epilogEndCodeOffset = emitCodeOffset(emitCurIG, emitCurOffset());
     assert(epilogExitSeqStartCodeOffset != epilogEndCodeOffset);
 
@@ -2018,8 +2010,6 @@ void emitter::emitEndFnEpilog()
                );
         emitExitSeqSize = newSize;
     }
-
-#endif // _TARGET_X86_
 #endif // JIT32_GCENCODER
 }
 

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1518,14 +1518,21 @@ protected:
     // IG of the epilog, and use it to find the epilog offset at the end of code generation.
     struct EpilogList
     {
-        EpilogList* elNext;
-        insGroup*   elIG;
+        EpilogList*  elNext;
+        emitLocation elLoc;
+
+        EpilogList()
+            : elNext(nullptr), elLoc()
+        {
+        }
     };
 
     EpilogList* emitEpilogList; // per method epilog list - head
     EpilogList* emitEpilogLast; // per method epilog list - tail
 
 public:
+    void emitStartEpilog();
+
     bool emitHasEpilogEnd();
 
     size_t emitGenEpilogLst(size_t (*fp)(void*, unsigned), void* cp);
@@ -1534,8 +1541,6 @@ public:
 
     void emitBegPrologEpilog(insGroup* igPh);
     void emitEndPrologEpilog();
-
-    emitLocation emitEpilogBegLoc;
 
     void emitBegFnEpilog(insGroup* igPh);
     void emitEndFnEpilog();

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1521,8 +1521,7 @@ protected:
         EpilogList*  elNext;
         emitLocation elLoc;
 
-        EpilogList()
-            : elNext(nullptr), elLoc()
+        EpilogList() : elNext(nullptr), elLoc()
         {
         }
     };

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2321,11 +2321,8 @@ void emitter::emitIns(instruction ins)
     }
 
 #ifndef LEGACY_BACKEND
-    // Account for 2-byte VEX prefix in case of vzeroupper
-    if (ins == INS_vzeroupper)
-    {
-        sz += 2;
-    }
+    // vzeroupper includes its 2-byte VEX prefix in its MR code.
+    assert((ins != INS_vzeroupper) || (sz == 3));
 #endif
 
     insFormat fmt = IF_NONE;


### PR DESCRIPTION
The x86 unwinder neither needs nor expects to see these restores (which
right now consist solely of a `vzeroupper` instruction that is emitted
to eliminate AVX <-> SSE transition penalties), which was causing unwind
failures under GC stress. This change stops reporting these restores as
part of a function epilog.

Fixes #9452.