### PR TITLE
Enable delay signing in ilasm

### DIFF
--- a/src/ilasm/assembler.h
+++ b/src/ilasm/assembler.h
@@ -1051,6 +1051,8 @@ public:
                           PermissionSetDecl*pPermissionSets);
     BinStr* EncodeSecAttr(__in __nullterminated char* szReflName, BinStr* pbsSecAttrBlob, unsigned nProps);
 
+    HRESULT AllocateStrongNameSignature();
+
     // Custom values paraphernalia:
 public:
     mdToken m_tkCurrentCVOwner;


### PR DESCRIPTION
Corefx needs the .Net Core version of ilasm to create delay signable
assemblies. This change brings back AllocateStrongNameSignature that was
deleted in 2efbb92 and modifies it to use similar logic from Roslyn to
determine the size of the signature that we need to allocate space for.

Fixes #9292.