### PR TITLE
Return exit code 0 for long-running/GCSimulator tests in Helix

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -261,7 +261,7 @@ if defined __UpdateInvalidPackagesArg (
   set __up=-updateinvalidpackageversions
 )
 
-call "%__ProjectDir%\run.cmd" build -Project=%__ProjectDir%\tests\build.proj -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__up% %__RunArgs% %__unprocessedBuildArgs%
+call "%__ProjectDir%\run.cmd" build -Project=%__ProjectDir%\tests\build.proj -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__up% %__RunArgs% %__BuildAgainstPackagesArg% %__unprocessedBuildArgs%
 if errorlevel 1 (
     echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
     echo     %__BuildLog%

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -103,13 +103,17 @@ fi
 
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
-    <PropertyGroup>        
+    <PropertyGroup>
+      <!-- An exit code of 2 indicates "Skipped" for regular non-windows runs, but "Failed" in Helix -->
+      <GCBashScriptExitCode Condition="'$(BuildTestsAgainstPackages)' != 'true'">2</GCBashScriptExitCode>
+      <GCBashScriptExitCode Condition="'$(BuildTestsAgainstPackages)' == 'true'">0</GCBashScriptExitCode>
+
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(GCStressIncompatible)' == 'true'"><![CDATA[
 $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ ! -z "$COMPlus_GCStress" ]
 then
   echo SKIPPING EXECUTION BECAUSE COMPlus_GCStress IS SET
-  exit 2
+  exit $(GCBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
@@ -117,7 +121,7 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ \( ! -z "$COMPlus_JitStress" \) -o \( ! -z "$COMPlus_JitStressRegs" \) -o \( ! -z "$COMPlus_JITMinOpts" \) ]
 then
   echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts) IS SET"
-  exit 2
+  exit $(GCBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(HeapVerifyIncompatible)' == 'true'"><![CDATA[
@@ -125,7 +129,7 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ ! -z "$COMPlus_HeapVerify" ]
 then
   echo SKIPPING EXECUTION BECAUSE COMPlus_HeapVerify IS SET
-  exit 2
+  exit $(GCBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
 

--- a/tests/src/CLRTest.GC.targets
+++ b/tests/src/CLRTest.GC.targets
@@ -18,12 +18,16 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
+      <!-- An exit code of 2 indicates "Skipped" for regular non-windows runs, but "Failed" in Helix -->
+        <GCBashScriptExitCode Condition="'$(BuildTestsAgainstPackages)' != 'true'">2</GCBashScriptExitCode>
+        <GCBashScriptExitCode Condition="'$(BuildTestsAgainstPackages)' == 'true'">0</GCBashScriptExitCode>
+
         <GCLongGCTestBashScript Condition="'$(IsLongRunningGCTest)' != 'true'"><![CDATA[
 # Long GC script
 if [ ! -z $RunningLongGCTests ]
 then
     echo "Skipping execution because this is not a long-running GC test"
-    exit 2
+    exit $(GCBashScriptExitCode)
 fi
         ]]></GCLongGCTestBashScript>
         <GCLongGCTestBashScript Condition="'$(IsLongRunningGCTest)' == 'true'"><![CDATA[
@@ -31,7 +35,7 @@ fi
 if [ -z $RunningLongGCTests ]
 then
     echo "Skipping execution because long-running GC tests are not enabled"
-    exit 2
+    exit $(GCBashScriptExitCode)
 fi
         ]]></GCLongGCTestBashScript>
 
@@ -41,7 +45,7 @@ fi
 if [ ! -z $RunningGCSimulatorTests ]
 then
     echo "Skipping execution because this is not a GCSimulator test"
-    exit 2
+    exit $(GCBashScriptExitCode)
 fi
         ]]></GCSimulatorTestBashScript>
         <GCSimulatorTestBashScript Condition="'$(IsGCSimulatorTest)' == 'true'"><![CDATA[
@@ -49,7 +53,7 @@ fi
 if [ -z $RunningGCSimulatorTests ]
 then
     echo "Skipping execution because GCSimulator tests are not enabled"
-    exit 2
+    exit $(GCBashScriptExitCode)
 fi
         ]]></GCSimulatorTestBashScript>
 


### PR DESCRIPTION
Today we return '2' for skipped GC tests - this is fine in the CI, as we can interpret '2' to mean 'skipped' there. But in our xunit runs, anything non-zero means failure. I couldn't figure out an easy way to indicate to runtest.proj which tests should have their xunit facts marked for skipping, as the generation of the xunit wrappers happens after the test build, and has no knowledge of the contents of the source code for any of these tests (I could have added all 500+ to issues.targets, but that seemed like overkill). Previous to https://github.com/dotnet/coreclr/pull/9510/files, these tests were returning 0 when skipped, and still do on Windows.

I've also filed https://github.com/dotnet/coreclr/pull/9510/files against myself to fix this/issues.targets, and make it so our xunit wrappers actually find all of these tests & mark them as 'Skipped', rather than not running them at all/marking them as "succeeded"