### PR TITLE
Optimize span clear

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -1,14 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <!-- Always use latest Roslyn compiler -->
   <Import Project="..\..\Tools\net45\roslyn\build\Microsoft.Net.Compilers.props" Condition="'$(OS)'=='Windows_NT'" />
-
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  
   <!-- Include common build properties -->
   <Import Project="..\..\dir.props" />
- 
   <!-- Compilation options -->
   <PropertyGroup>
     <AvailablePlatforms>amd64,x86,arm,armel,arm64</AvailablePlatforms>
@@ -19,16 +15,13 @@
     <Platform Condition=" '$(Platform)' == 'x64' ">amd64</Platform>
     <Platform Condition=" '$(Platform)' == 'armel' ">arm</Platform>
     <ProjectGuid>{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}</ProjectGuid>
-
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    
     <!-- This prevents the default MsBuild targets from referencing System.Core.dll -->
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <!-- These prevent the default MsBuild targets from referencing System.dll and mscorlib.dll -->
     <NoStdLib>true</NoStdLib>
     <NoCompilerStandardLib>true</NoCompilerStandardLib>
-    
     <SubsystemVersion>6.00</SubsystemVersion>
     <UTF8OutPut>true</UTF8OutPut>
     <HighEntropyVA>true</HighEntropyVA>
@@ -39,20 +32,16 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);618</WarningsNotAsErrors>
     <NoWarn>649,3019,414,169,3015</NoWarn>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
-
     <DefineConstants>$(DefineConstants);CORECLR;_USE_NLS_PLUS_TABLE;RESOURCE_SATELLITE_CONFIG;INSIDE_CLR;CODE_ANALYSIS_BASELINE</DefineConstants>
   </PropertyGroup>
-
   <!-- Add Serviceable attribute to the project's metadata -->
   <ItemGroup>
     <AssemblyMetadata Include="Serviceable">
-        <Value>True</Value>
+      <Value>True</Value>
     </AssemblyMetadata>
   </ItemGroup>
-
   <!-- Platform specific properties -->
   <PropertyGroup Condition="'$(Platform)' == 'amd64'">
     <PlatformTarget>x64</PlatformTarget>
@@ -73,7 +62,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DefineConstants>BIT64;ARM64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-  
   <!-- Configuration specific properties -->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Checked'">
     <DebugSymbols>true</DebugSymbols>
@@ -89,13 +77,11 @@
     <DebugType>pdbOnly</DebugType>
     <DefineConstants>TRACE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-
   <!-- Roslyn does not support writing PDBs on Unix -->
   <PropertyGroup Condition="'$(OsEnvironment)' == 'Unix'">
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
   </PropertyGroup>
-
   <!-- Assembly attributes -->
   <PropertyGroup>
     <AssemblyName>System.Private.CoreLib</AssemblyName>
@@ -109,7 +95,6 @@
     <AssemblyInfoLines Include="[assembly: System.Runtime.InteropServices.ComVisible(false)]" />
     <AssemblyInfoLines Include="[assembly: System.Resources.NeutralResourcesLanguage(&quot;en-US&quot;)]" />
   </ItemGroup>
-
   <!--
     Helper Paths
   -->
@@ -120,21 +105,17 @@
     <MscorlibDir>$(MSBuildThisFileDirectory)</MscorlibDir>
     <NlpObjDir>$(BclSourcesRoot)\System\Globalization\Tables</NlpObjDir>
   </PropertyGroup>
-  
   <!-- Msbuild variables needed to get CoreCLR features to be set properly. -->
   <PropertyGroup>
     <ClrProduct>core_clr</ClrProduct>
     <BuildForCoreSystem>true</BuildForCoreSystem>
-
     <!-- These are needed to make sure we have the right set of defines -->
     <TargetArch Condition="'$(Platform)'=='x86'">i386</TargetArch>
     <TargetArch Condition="'$(Platform)'!='x86'">$(Platform)</TargetArch>
   </PropertyGroup>
-  
   <!-- CLR Features -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\clr.coreclr.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\clr.defines.targets" />
-
   <!-- Sources -->
   <ItemGroup>
     <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\AccessedThroughPropertyAttribute.cs" />
@@ -325,15 +306,15 @@
     <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\RuntimeClass.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(FeatureCominterop)' == 'true'">
-    <MscorlibSources Include='$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\CLRIPropertyValueImpl.cs' />
-    <MscorlibSources Include='$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\CLRIReferenceImpl.cs' />
-    <MscorlibSources Include='$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\IPropertyValue.cs' />
-    <MscorlibSources Include='$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\IReference.cs' />
-    <MscorlibSources Include='$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\WindowsFoundationEventHandler.cs' />
-    <MscorlibSources Include='$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\ICustomPropertyProvider.cs' />
-    <MscorlibSources Include='$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\ICustomProperty.cs' />
-    <MscorlibSources Include='$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\CustomPropertyImpl.cs' />
-    <MscorlibSources Include='$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeBufferHelper.cs' />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\CLRIPropertyValueImpl.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\CLRIReferenceImpl.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\IPropertyValue.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\IReference.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\WindowsFoundationEventHandler.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\ICustomPropertyProvider.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\ICustomProperty.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\CustomPropertyImpl.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeBufferHelper.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(FeatureCominterop)' == 'true'">
     <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\IIterable.cs" />
@@ -761,7 +742,7 @@
     <MscorlibSources Include="$(CoreFxSourcesRoot)\System\Globalization\ThaiBuddhistCalendar.cs" />
     <MscorlibSources Include="$(CoreFxSourcesRoot)\System\Globalization\TimeSpanStyles.cs" />
     <MscorlibSources Include="$(CoreFxSourcesRoot)\System\Globalization\UmAlQuraCalendar.cs" />
-    <MscorlibSources Include="$(CoreFxSourcesRoot)\System\Globalization\UnicodeCategory.cs " /> 
+    <MscorlibSources Include="$(CoreFxSourcesRoot)\System\Globalization\UnicodeCategory.cs " />
   </ItemGroup>
   <ItemGroup Condition="'$(FeatureCoreFxGlobalization)' == 'true' and '$(TargetsUnix)' == 'true'">
     <MscorlibSources Include="$(BclSourcesRoot)\System\Globalization\EncodingTable.Unix.cs" />
@@ -891,8 +872,8 @@
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\BinaryReader.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\BinaryWriter.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\Directory.cs" />
-    <MscorlibSources Include="$(BclSourcesRoot)\System\IO\SearchOption.cs" />    
-    <MscorlibSources Include="$(BclSourcesRoot)\System\IO\DirectoryNotFoundException.cs" />  
+    <MscorlibSources Include="$(BclSourcesRoot)\System\IO\SearchOption.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\IO\DirectoryNotFoundException.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\DriveNotFoundException.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\EncodingCache.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\EndOfStreamException.cs" />
@@ -911,7 +892,7 @@
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\SeekOrigin.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\Stream.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\StreamHelpers.CopyValidation.cs" />
-    <MscorlibSources Include="$(BclSourcesRoot)\System\IO\TextReader.cs" Condition="'$(TargetsUnix)' == 'true'" />    
+    <MscorlibSources Include="$(BclSourcesRoot)\System\IO\TextReader.cs" Condition="'$(TargetsUnix)' == 'true'" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\StreamReader.cs" Condition="'$(TargetsUnix)' == 'true'" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\UnmanagedMemoryAccessor.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\IO\UnmanagedMemoryStream.cs" />
@@ -1016,7 +997,7 @@
   </ItemGroup>
   <ItemGroup>
     <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\Versioning\TargetFrameworkAttribute.cs" />
-    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\Versioning\CompatibilitySwitch.cs" Condition="'$(TargetsUnix)' == 'true'" />   
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\Versioning\CompatibilitySwitch.cs" Condition="'$(TargetsUnix)' == 'true'" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Runtime\Versioning\NonVersionableAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -1047,7 +1028,7 @@
     <MscorlibSources Include="$(BclSourcesRoot)\System\Text\EncodingProvider.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Text\Latin1Encoding.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Text\Normalization.cs" />
-    <MscorlibSources Include="$(BclSourcesRoot)\System\Text\Normalization.Windows.cs" Condition="'$(TargetsUnix)' != 'true'"/>
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Text\Normalization.Windows.cs" Condition="'$(TargetsUnix)' != 'true'" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Text\UnicodeEncoding.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Text\UTF7Encoding.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Text\UTF8Encoding.cs" />
@@ -1206,32 +1187,27 @@
   <ItemGroup>
     <MscorlibSources Include="$(CoreFxSourcesRoot)\Debug.cs" />
   </ItemGroup>
-
   <!-- Include additional sources shared files in the compilation -->
   <ItemGroup>
     <!-- These are files are preprocessed  -->
     <MscorlibSources Include="$(CommonPath)\Preprocessed\AssemblyRefs.g.cs" />
-
     <!-- These files are shared with other framework components and don't live the same folder as the rest of them-->
     <MscorlibSources Include="$(CommonPath)\PinnableBufferCache.cs" />
-
     <!-- Include Internals visible to file in the compilation -->
     <MscorlibSources Include="$(BclSourcesRoot)\mscorlib.Friends.cs" />
-
     <!-- TODO list of types to be cleaned up from CoreLib -->
     <MscorlibSources Include="$(BclSourcesRoot)\CleanupToDoList.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <!-- We want the sources to show up nicely in VS-->
     <Compile Include="@(MscorlibSources)">
     </Compile>
     <Compile Include="src\System\Runtime\CompilerServices\ITuple.cs" />
     <Compile Include="src\System\Runtime\CompilerServices\TupleElementNamesAttribute.cs" />
+    <Compile Include="src\System\Runtime\RuntimeImports.cs" />
     <Compile Include="src\System\TupleExtensions.cs" />
     <Compile Include="src\System\ValueTuple.cs" />
   </ItemGroup>
-  
   <!-- Resources -->
   <ItemGroup>
     <SplitTextStringResource Include="$(BclSourcesRoot)\System.Private.CoreLib.txt">
@@ -1239,11 +1215,9 @@
       <ResGenDefines>$(DefineConstants)</ResGenDefines>
     </SplitTextStringResource>
   </ItemGroup>
-
   <PropertyGroup>
     <CheckCDefines Condition="'$(CheckCDefines)'==''">true</CheckCDefines>
   </PropertyGroup>
-
   <Target Name="CDefineChecker" BeforeTargets="Build" Condition="'$(CheckCDefines)'=='true'">
     <!-- Compiler Definition Verification -->
     <Message Importance="High" Text="============" />
@@ -1251,46 +1225,37 @@
       <IgnoreDefineConstants>FEATURE_IMPLICIT_TLS;FEATURE_HIJACK</IgnoreDefineConstants>
       <CMakeDefinitionSaveFile>$(IntermediateOutputPath)\cmake.definitions</CMakeDefinitionSaveFile>
     </PropertyGroup>
-    <Exec Command='python $(MSBuildThisFileDirectory)..\scripts\check-definitions.py "$(CMakeDefinitionSaveFile)" "$(DefineConstants)" "$(IgnoreDefineConstants)" ' />
+    <Exec Command="python $(MSBuildThisFileDirectory)..\scripts\check-definitions.py &quot;$(CMakeDefinitionSaveFile)&quot; &quot;$(DefineConstants)&quot; &quot;$(IgnoreDefineConstants)&quot; " />
     <Message Importance="High" Text="============" />
   </Target>
-
   <ItemGroup>
     <EmbeddedResource Include="$(NlpObjDir)\charinfo.nlp">
       <LogicalName>charinfo.nlp</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-
   <PropertyGroup Condition="'$(BuildOS)' == 'Windows_NT'">
     <EnableDotnetAnalyzers Condition="'$(EnableDotnetAnalyzers)'==''">true</EnableDotnetAnalyzers>
     <UseWin32Apis>true</UseWin32Apis>
     <OSGroup>Windows_NT</OSGroup>
   </PropertyGroup>
   <Import Project="$(ToolsDir)\codeAnalysis.targets" />
-
   <Import Project="$(ToolsDir)\Microsoft.CSharp.Targets" />
-
   <PropertyGroup>
     <StrongNameSig>Silverlight</StrongNameSig>
   </PropertyGroup>
-
   <!-- Import signing tools -->
   <Import Condition="Exists('$(ToolsDir)\sign.targets')" Project="$(ToolsDir)\sign.targets" />
-
   <!-- Overwrite the key that we are going to use for signing -->
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Tools\Signing\mscorlib.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-
-  <Import Project="$(MSBuildThisFileDirectory)Tools\Versioning\GenerateVersionInfo.targets"/>
+  <Import Project="$(MSBuildThisFileDirectory)Tools\Versioning\GenerateVersionInfo.targets" />
   <!-- Override versioning targets -->
   <Import Condition="Exists('$(ToolsDir)versioning.targets')" Project="$(ToolsDir)versioning.targets" />
-
   <PropertyGroup>
     <!-- Use a different nativeresource file to avoid conflicts with mscorlib-->
     <Win32Resource Condition="'$(GenerateNativeVersionInfo)'=='true'">$(IntermediateOutputPath)\System.Private.CoreLib.res</Win32Resource>
   </PropertyGroup>
-
-  <Import Project="GenerateSplitStringResources.targets"/>
-  <Import Project="GenerateCompilerResponseFile.targets"/>
+  <Import Project="GenerateSplitStringResources.targets" />
+  <Import Project="GenerateCompilerResponseFile.targets" />
 </Project>

--- a/src/mscorlib/System.Private.CoreLib.sln
+++ b/src/mscorlib/System.Private.CoreLib.sln
@@ -21,14 +21,14 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|amd64.ActiveCfg = Checked|amd64
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|amd64.Build.0 = Checked|amd64
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm.ActiveCfg = Checked|arm
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm.Build.0 = Checked|arm
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm64.ActiveCfg = Checked|arm64
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm64.Build.0 = Checked|arm64
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|x86.ActiveCfg = Checked|x86
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|x86.Build.0 = Checked|x86
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|amd64.ActiveCfg = Release|amd64
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|amd64.Build.0 = Release|amd64
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm.ActiveCfg = Release|arm
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm.Build.0 = Release|arm
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm64.ActiveCfg = Release|arm64
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm64.Build.0 = Release|arm64
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|x86.ActiveCfg = Release|x86
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|x86.Build.0 = Release|x86
 		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Debug|amd64.ActiveCfg = Debug|amd64
 		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Debug|amd64.Build.0 = Debug|amd64
 		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Debug|arm.ActiveCfg = Debug|arm

--- a/src/mscorlib/System.Private.CoreLib.sln
+++ b/src/mscorlib/System.Private.CoreLib.sln
@@ -1,5 +1,4 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -21,14 +20,14 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|amd64.ActiveCfg = Release|amd64
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|amd64.Build.0 = Release|amd64
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm.ActiveCfg = Release|arm
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm.Build.0 = Release|arm
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm64.ActiveCfg = Release|arm64
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm64.Build.0 = Release|arm64
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|x86.ActiveCfg = Release|x86
-		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|x86.Build.0 = Release|x86
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|amd64.ActiveCfg = Checked|amd64
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|amd64.Build.0 = Checked|amd64
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm.ActiveCfg = Checked|arm
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm.Build.0 = Checked|arm
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm64.ActiveCfg = Checked|arm64
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|arm64.Build.0 = Checked|arm64
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|x86.ActiveCfg = Checked|x86
+		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Checked|x86.Build.0 = Checked|x86
 		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Debug|amd64.ActiveCfg = Debug|amd64
 		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Debug|amd64.Build.0 = Debug|amd64
 		{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}.Debug|arm.ActiveCfg = Debug|arm

--- a/src/mscorlib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -76,11 +76,10 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ref T AddNative<T>(ref T source, nuint elementOffset)
+        public static ref T AddByteOffset<T>(ref T source, nuint byteOffset)
         {
             // The body of this function will be replaced by the EE with unsafe code!!!
             // See getILIntrinsicImplementationForUnsafe for how this happens.
-            typeof(T).ToString(); // Type used by the actual method body
             throw new InvalidOperationException();
         }
 

--- a/src/mscorlib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -4,6 +4,12 @@
 
 using System.Runtime.Versioning;
 
+#if BIT64
+using nuint = System.UInt64;
+#else
+using nuint = System.UInt32;
+#endif
+
 namespace System.Runtime.CompilerServices
 {
     //
@@ -58,6 +64,19 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref T Add<T>(ref T source, int elementOffset)
+        {
+            // The body of this function will be replaced by the EE with unsafe code!!!
+            // See getILIntrinsicImplementationForUnsafe for how this happens.
+            typeof(T).ToString(); // Type used by the actual method body
+            throw new InvalidOperationException();
+        }
+
+        /// <summary>
+        /// Adds an element offset to the given reference.
+        /// </summary>
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref T AddNative<T>(ref T source, nuint elementOffset)
         {
             // The body of this function will be replaced by the EE with unsafe code!!!
             // See getILIntrinsicImplementationForUnsafe for how this happens.

--- a/src/mscorlib/src/System/Runtime/RuntimeImports.cs
+++ b/src/mscorlib/src/System/Runtime/RuntimeImports.cs
@@ -27,6 +27,6 @@ namespace System.Runtime
         }
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        extern internal unsafe static void RhZeroMemory(byte* b, nuint byteLength);
+        extern private unsafe static void RhZeroMemory(byte* b, nuint byteLength);
     }
 }

--- a/src/mscorlib/src/System/Runtime/RuntimeImports.cs
+++ b/src/mscorlib/src/System/Runtime/RuntimeImports.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#if BIT64
+using nuint = System.UInt64;
+#else
+    using nuint = System.UInt32;
+#endif
+
+namespace System.Runtime
+{
+    public class RuntimeImports
+    {
+        // Non-inlinable wrapper around the QCall that avoids poluting the fast path
+        // with P/Invoke prolog/epilog.
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        internal unsafe static void RhZeroMemory(ref byte b, nuint byteLength)
+        {
+            fixed (byte* bytePointer = &b)
+            {
+                RhZeroMemory(bytePointer, byteLength);
+            }
+        }
+
+        [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
+        extern internal unsafe static void RhZeroMemory(byte* b, nuint byteLength);
+    }
+}

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -849,12 +849,12 @@ namespace System
             {
                 if ((Unsafe.As<byte, int>(ref b) & 1) != 0)
                 {
-                    Unsafe.AddNative<byte>(ref b, i) = 0;
+                    Unsafe.AddByteOffset<byte>(ref b, i) = 0;
                     i += 1;
                     if ((Unsafe.As<byte, int>(ref b) & 2) != 0)
                         goto IntAligned;
                 }
-                Unsafe.As<byte, short>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, short>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
                 i += 2;
             }
 
@@ -870,7 +870,7 @@ namespace System
 
             if (((Unsafe.As<byte, int>(ref b) - 1) & 4) == 0)
             {
-                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
                 i += 4;
             }
 
@@ -899,13 +899,13 @@ namespace System
                 // we save on writes to b.
 
 #if BIT64
-                Unsafe.As<byte, long>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
-                Unsafe.As<byte, long>(ref Unsafe.AddNative<byte>(ref b, i + 8)) = 0;
+                Unsafe.As<byte, long>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, long>(ref Unsafe.AddByteOffset<byte>(ref b, i + 8)) = 0;
 #else
-                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
-                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i + 4)) = 0;
-                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i + 8)) = 0;
-                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i + 12)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i + 4)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i + 8)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i + 12)) = 0;
 #endif
 
                 i = counter;
@@ -918,26 +918,26 @@ namespace System
             if ((byteLength & 8) != 0)
             {
 #if BIT64
-                Unsafe.As<byte, long>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, long>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
 #else
-                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
-                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i + 4)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i + 4)) = 0;
 #endif
                 i += 8;
             }
             if ((byteLength & 4) != 0)
             {
-                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
                 i += 4;
             }
             if ((byteLength & 2) != 0)
             {
-                Unsafe.As<byte, short>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, short>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
                 i += 2;
             }
             if ((byteLength & 1) != 0)
             {
-                Unsafe.AddNative<byte>(ref b, i) = 0;
+                Unsafe.AddByteOffset<byte>(ref b, i) = 0;
                 // We're not using i after this, so not needed
                 // i += 1;
             }
@@ -959,33 +959,33 @@ namespace System
             nuint n = 0;
             while ((n = i + 8) <= (pointerSizeLength))
             {
-                Unsafe.AddNative<IntPtr>(ref ip, i + 0) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 1) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 2) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 3) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 4) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 5) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 6) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 7) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 0) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 1) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 2) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 3) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 4) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 5) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 6) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 7) * (nuint)sizeof(IntPtr)) = default(IntPtr);
                 i = n;
             }
             if ((n = i + 4) <= (pointerSizeLength))
             {
-                Unsafe.AddNative<IntPtr>(ref ip, i + 0) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 1) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 2) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 3) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 0) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 1) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 2) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 3) * (nuint)sizeof(IntPtr)) = default(IntPtr);
                 i = n;
             }
             if ((n = i + 2) <= (pointerSizeLength))
             {
-                Unsafe.AddNative<IntPtr>(ref ip, i + 0) = default(IntPtr);
-                Unsafe.AddNative<IntPtr>(ref ip, i + 1) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 0) * (nuint)sizeof(IntPtr)) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 1) * (nuint)sizeof(IntPtr)) = default(IntPtr);
                 i = n;
             }
             if ((i + 1) <= (pointerSizeLength))
             {
-                Unsafe.AddNative<IntPtr>(ref ip, i) = default(IntPtr);
+                Unsafe.AddByteOffset<IntPtr>(ref ip, (i + 0) * (nuint)sizeof(IntPtr)) = default(IntPtr);
             }
         }
     }

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -849,19 +849,19 @@ namespace System
             {
                 if ((Unsafe.As<byte, int>(ref b) & 1) != 0)
                 {
-                    Unsafe.Add<byte>(ref b, (int)i) = 0;
+                    Unsafe.AddNative<byte>(ref b, i) = 0;
                     i += 1;
                     if ((Unsafe.As<byte, int>(ref b) & 2) != 0)
                         goto IntAligned;
                 }
-                Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                Unsafe.As<byte, short>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
                 i += 2;
             }
 
             IntAligned:
 
             // On 64-bit IntPtr.Size == 8, so we want to advance to the next 8-aligned address. If
-            // (int)bytePointer % 8 is 0, 5, 6, or 7, we will already have advanced by 0, 3, 2, or 1
+            // (int)b % 8 is 0, 5, 6, or 7, we will already have advanced by 0, 3, 2, or 1
             // bytes to the next aligned address (respectively), so do nothing. On the other hand,
             // if it is 1, 2, 3, or 4 we will want to copy-and-advance another 4 bytes until
             // we're aligned.
@@ -870,7 +870,7 @@ namespace System
 
             if (((Unsafe.As<byte, int>(ref b) - 1) & 4) == 0)
             {
-                Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
                 i += 4;
             }
 
@@ -896,10 +896,17 @@ namespace System
                 // these to use memory addressing operands.
 
                 // So the only cost is a bit of code size, which is made up for by the fact that
-                // we save on writes to bytePointer.
+                // we save on writes to b.
 
-                Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
-                Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, (int)i + 8)) = 0;
+#if BIT64
+                Unsafe.As<byte, long>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, long>(ref Unsafe.AddNative<byte>(ref b, i + 8)) = 0;
+#else
+                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i + 4)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i + 8)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i + 12)) = 0;
+#endif
 
                 i = counter;
 
@@ -910,22 +917,27 @@ namespace System
 
             if ((byteLength & 8) != 0)
             {
-                Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+#if BIT64
+                Unsafe.As<byte, long>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
+#else
+                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i + 4)) = 0;
+#endif
                 i += 8;
             }
             if ((byteLength & 4) != 0)
             {
-                Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                Unsafe.As<byte, int>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
                 i += 4;
             }
             if ((byteLength & 2) != 0)
             {
-                Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                Unsafe.As<byte, short>(ref Unsafe.AddNative<byte>(ref b, i)) = 0;
                 i += 2;
             }
             if ((byteLength & 1) != 0)
             {
-                Unsafe.Add<byte>(ref b, (int)i) = 0;
+                Unsafe.AddNative<byte>(ref b, i) = 0;
                 // We're not using i after this, so not needed
                 // i += 1;
             }

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -642,211 +642,207 @@ namespace System
             if (byteLength == 0)
                 return;
 
-            fixed (byte* bytePointer = &b)
+            // Note: It's important that this switch handles lengths at least up to 22.
+            // See notes below near the main loop for why.
+
+            // The switch will be very fast since it can be implemented using a jump
+            // table in assembly. See http://stackoverflow.com/a/449297/4077294 for more info.
+
+            switch (byteLength)
             {
-                // Note: It's important that this switch handles lengths at least up to 22.
-                // See notes below near the main loop for why.
+                case 1:
+                    b = 0;
+                    return;
+                case 2:
+                    Unsafe.As<byte, short>(ref b) = 0;
+                    return;
+                case 3:
+                    Unsafe.As<byte, short>(ref b) = 0;
+                    Unsafe.Add<byte>(ref b, 2) = 0;
+                    return;
+                case 4:
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    return;
+                case 5:
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.Add<byte>(ref b, 4) = 0;
+                    return;
+                case 6:
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+                    return;
+                case 7:
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+                    Unsafe.Add<byte>(ref b, 6) = 0;
+                    return;
+                case 8:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    return;
+                case 9:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.Add<byte>(ref b, 8) = 0;
+                    return;
+                case 10:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    return;
+                case 11:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.Add<byte>(ref b, 10) = 0;
+                    return;
+                case 12:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    return;
+                case 13:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.Add<byte>(ref b, 12) = 0;
+                    return;
+                case 14:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
+                    return;
+                case 15:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
+                    Unsafe.Add<byte>(ref b, 14) = 0;
+                    return;
+                case 16:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    return;
+                case 17:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.Add<byte>(ref b, 16) = 0;
+                    return;
+                case 18:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
+                    return;
+                case 19:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
+                    Unsafe.Add<byte>(ref b, 18) = 0;
+                    return;
+                case 20:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
+                    return;
+                case 21:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
+                    Unsafe.Add<byte>(ref b, 20) = 0;
+                    return;
+                case 22:
+                    Unsafe.As<byte, long>(ref b) = 0;
+                    Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
+                    Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 20)) = 0;
+                    return;
+            }
 
-                // The switch will be very fast since it can be implemented using a jump
-                // table in assembly. See http://stackoverflow.com/a/449297/4077294 for more info.
-
-                switch (byteLength)
-                {
-                    case 1:
-                        *bytePointer = (byte)0;
-                        return;
-                    case 2:
-                        *(short*)bytePointer = (short)0;
-                        return;
-                    case 3:
-                        *(short*)bytePointer = (short)0;
-                        *(bytePointer + 2) = (byte)0;
-                        return;
-                    case 4:
-                        *(int*)bytePointer = (int)0;
-                        return;
-                    case 5:
-                        *(int*)bytePointer = (int)0;
-                        *(bytePointer + 4) = (byte)0;
-                        return;
-                    case 6:
-                        *(int*)bytePointer = (int)0;
-                        *(short*)(bytePointer + 4) = (short)0;
-                        return;
-                    case 7:
-                        *(int*)bytePointer = (int)0;
-                        *(short*)(bytePointer + 4) = (short)0;
-                        *(bytePointer + 6) = (byte)0;
-                        return;
-                    case 8:
-                        *(long*)bytePointer = (long)0;
-                        return;
-                    case 9:
-                        *(long*)bytePointer = (long)0;
-                        *(bytePointer + 8) = (byte)0;
-                        return;
-                    case 10:
-                        *(long*)bytePointer = (long)0;
-                        *(short*)(bytePointer + 8) = (short)0;
-                        return;
-                    case 11:
-                        *(long*)bytePointer = (long)0;
-                        *(short*)(bytePointer + 8) = (short)0;
-                        *(bytePointer + 10) = (byte)0;
-                        return;
-                    case 12:
-                        *(long*)bytePointer = (long)0;
-                        *(int*)(bytePointer + 8) = (int)0;
-                        return;
-                    case 13:
-                        *(long*)bytePointer = (long)0;
-                        *(int*)(bytePointer + 8) = (int)0;
-                        *(bytePointer + 12) = (byte)0;
-                        return;
-                    case 14:
-                        *(long*)bytePointer = (long)0;
-                        *(int*)(bytePointer + 8) = (int)0;
-                        *(short*)(bytePointer + 12) = (short)0;
-                        return;
-                    case 15:
-                        *(long*)bytePointer = (long)0;
-                        *(int*)(bytePointer + 8) = (int)0;
-                        *(short*)(bytePointer + 12) = (short)0;
-                        *(bytePointer + 14) = (byte)0;
-                        return;
-                    case 16:
-                        *(long*)bytePointer = (long)0;
-                        *(long*)(bytePointer + 8) = (long)0;
-                        return;
-                    case 17:
-                        *(long*)bytePointer = (long)0;
-                        *(long*)(bytePointer + 8) = (long)0;
-                        *(bytePointer + 16) = (byte)0;
-                        return;
-                    case 18:
-                        *(long*)bytePointer = (long)0;
-                        *(long*)(bytePointer + 8) = (long)0;
-                        *(short*)(bytePointer + 16) = (short)0;
-                        return;
-                    case 19:
-                        *(long*)bytePointer = (long)0;
-                        *(long*)(bytePointer + 8) = (long)0;
-                        *(short*)(bytePointer + 16) = (short)0;
-                        *(bytePointer + 18) = (byte)0;
-                        return;
-                    case 20:
-                        *(long*)bytePointer = (long)0;
-                        *(long*)(bytePointer + 8) = (long)0;
-                        *(int*)(bytePointer + 16) = (int)0;
-                        return;
-                    case 21:
-                        *(long*)bytePointer = (long)0;
-                        *(long*)(bytePointer + 8) = (long)0;
-                        *(int*)(bytePointer + 16) = (int)0;
-                        *(bytePointer + 20) = (byte)0;
-                        return;
-                    case 22:
-                        *(long*)bytePointer = (long)0;
-                        *(long*)(bytePointer + 8) = (long)0;
-                        *(int*)(bytePointer + 16) = (int)0;
-                        *(short*)(bytePointer + 20) = (short)0;
-                        return;
-                }
-
-                // P/Invoke into the native version for large lengths
-                if (byteLength >= 512) goto PInvoke;
-
-                nuint i = 0; // byte offset at which we're copying
-
-                if (((int)bytePointer & 3) != 0)
-                {
-                    if (((int)bytePointer & 1) != 0)
-                    {
-                        *(bytePointer + i) = (byte)0;
-                        i += 1;
-                        if (((int)bytePointer & 2) != 0)
-                            goto IntAligned;
-                    }
-                    *(short*)(bytePointer + i) = (short)0;
-                    i += 2;
-                }
-
-                IntAligned:
-
-                // On 64-bit IntPtr.Size == 8, so we want to advance to the next 8-aligned address. If
-                // (int)bytePointer % 8 is 0, 5, 6, or 7, we will already have advanced by 0, 3, 2, or 1
-                // bytes to the next aligned address (respectively), so do nothing. On the other hand,
-                // if it is 1, 2, 3, or 4 we will want to copy-and-advance another 4 bytes until
-                // we're aligned.
-                // The thing 1, 2, 3, and 4 have in common that the others don't is that if you
-                // subtract one from them, their 3rd lsb will not be set. Hence, the below check.
-
-                if ((((int)bytePointer - 1) & 4) == 0)
-                {
-                    *(int*)(bytePointer + i) = (int)0;
-                    i += 4;
-                }
-
-                nuint end = byteLength - 16;
-                byteLength -= i; // lower 4 bits of byteLength represent how many bytes are left *after* the unrolled loop
-
-                // We know due to the above switch-case that this loop will always run 1 iteration; max
-                // bytes we clear before checking is 23 (7 to align the pointers, 16 for 1 iteration) so
-                // the switch handles lengths 0-22.
-                Debug.Assert(end >= 7 && i <= end);
-
-                // This is separated out into a different variable, so the i + 16 addition can be
-                // performed at the start of the pipeline and the loop condition does not have
-                // a dependency on the writes.
-                nuint counter;
-
-                do
-                {
-                    counter = i + 16;
-
-                    // This loop looks very costly since there appear to be a bunch of temporary values
-                    // being created with the adds, but the jit (for x86 anyways) will convert each of
-                    // these to use memory addressing operands.
-
-                    // So the only cost is a bit of code size, which is made up for by the fact that
-                    // we save on writes to bytePointer.
-
-                    *(long*)(bytePointer + i) = (long)0;
-                    *(long*)(bytePointer + i + 8) = (long)0;
-
-                    i = counter;
-
-                    // See notes above for why this wasn't used instead
-                    // i += 16;
-                }
-                while (counter <= end);
-
-                if ((byteLength & 8) != 0)
-                {
-                    *(long*)(bytePointer + i) = (long)0;
-                    i += 8;
-                }
-                if ((byteLength & 4) != 0)
-                {
-                    *(int*)(bytePointer + i) = (int)0;
-                    i += 4;
-                }
-                if ((byteLength & 2) != 0)
-                {
-                    *(short*)(bytePointer + i) = (short)0;
-                    i += 2;
-                }
-                if ((byteLength & 1) != 0)
-                {
-                    *(bytePointer + i) = (byte)0;
-                    // We're not using i after this, so not needed
-                    // i += 1;
-                }
-
-                return;
-
-                PInvoke:
+            // P/Invoke into the native version for large lengths
+            if (byteLength >= 512)
+            {
                 RuntimeImports.RhZeroMemory(ref b, byteLength);
+                return;
+            }
+
+            nuint i = 0; // byte offset at which we're copying
+
+            if ((Unsafe.As<byte, int>(ref b) & 3) != 0)
+            {
+                if ((Unsafe.As<byte, int>(ref b) & 1) != 0)
+                {
+                    Unsafe.Add<byte>(ref b, (int)i) = 0;
+                    i += 1;
+                    if ((Unsafe.As<byte, int>(ref b) & 2) != 0)
+                        goto IntAligned;
+                }
+                Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                i += 2;
+            }
+
+            IntAligned:
+
+            // On 64-bit IntPtr.Size == 8, so we want to advance to the next 8-aligned address. If
+            // (int)bytePointer % 8 is 0, 5, 6, or 7, we will already have advanced by 0, 3, 2, or 1
+            // bytes to the next aligned address (respectively), so do nothing. On the other hand,
+            // if it is 1, 2, 3, or 4 we will want to copy-and-advance another 4 bytes until
+            // we're aligned.
+            // The thing 1, 2, 3, and 4 have in common that the others don't is that if you
+            // subtract one from them, their 3rd lsb will not be set. Hence, the below check.
+
+            if (((Unsafe.As<byte, int>(ref b) - 1) & 4) == 0)
+            {
+                Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                i += 4;
+            }
+
+            nuint end = byteLength - 16;
+            byteLength -= i; // lower 4 bits of byteLength represent how many bytes are left *after* the unrolled loop
+
+            // We know due to the above switch-case that this loop will always run 1 iteration; max
+            // bytes we clear before checking is 23 (7 to align the pointers, 16 for 1 iteration) so
+            // the switch handles lengths 0-22.
+            Debug.Assert(end >= 7 && i <= end);
+
+            // This is separated out into a different variable, so the i + 16 addition can be
+            // performed at the start of the pipeline and the loop condition does not have
+            // a dependency on the writes.
+            nuint counter;
+
+            do
+            {
+                counter = i + 16;
+
+                // This loop looks very costly since there appear to be a bunch of temporary values
+                // being created with the adds, but the jit (for x86 anyways) will convert each of
+                // these to use memory addressing operands.
+
+                // So the only cost is a bit of code size, which is made up for by the fact that
+                // we save on writes to bytePointer.
+
+                Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, (int)i + 8)) = 0;
+
+                i = counter;
+
+                // See notes above for why this wasn't used instead
+                // i += 16;
+            }
+            while (counter <= end);
+
+            if ((byteLength & 8) != 0)
+            {
+                Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                i += 8;
+            }
+            if ((byteLength & 4) != 0)
+            {
+                Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                i += 4;
+            }
+            if ((byteLength & 2) != 0)
+            {
+                Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, (int)i)) = 0;
+                i += 2;
+            }
+            if ((byteLength & 1) != 0)
+            {
+                Unsafe.Add<byte>(ref b, (int)i) = 0;
+                // We're not using i after this, so not needed
+                // i += 1;
             }
         }
 

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -752,11 +752,7 @@ namespace System
             }
 
             // P/Invoke into the native version for large lengths
-            if (byteLength >= 512)
-            {
-                RuntimeImports.RhZeroMemory(ref b, byteLength);
-                return;
-            }
+            if (byteLength >= 512) goto PInvoke;
 
             nuint i = 0; // byte offset at which we're copying
 
@@ -844,6 +840,11 @@ namespace System
                 // We're not using i after this, so not needed
                 // i += 1;
             }
+
+            return;
+            
+            PInvoke:
+            RuntimeImports.RhZeroMemory(ref b, byteLength);
         }
 
         internal static unsafe void ClearWithReferences(ref IntPtr ip, nuint pointerSizeLength)
@@ -857,41 +858,34 @@ namespace System
             nuint n = 0;
             while ((n = i + 8) <= (pointerSizeLength))
             {
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 0) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 1) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 2) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 3) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 4) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 5) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 6) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 7) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 0) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 1) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 2) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 3) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 4) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 5) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 6) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 7) = default(IntPtr);
                 i = n;
             }
             if ((n = i + 4) <= (pointerSizeLength))
             {
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 0) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 1) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 2) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 3) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 0) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 1) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 2) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 3) = default(IntPtr);
                 i = n;
             }
             if ((n = i + 2) <= (pointerSizeLength))
             {
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 0) = default(IntPtr);
-                Unsafe.Add<IntPtr>(ref ip, (int)i + 1) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 0) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i + 1) = default(IntPtr);
                 i = n;
             }
             if ((i + 1) <= (pointerSizeLength))
             {
-                Unsafe.Add<IntPtr>(ref ip, (int)i) = default(IntPtr);
+                Unsafe.AddNative<IntPtr>(ref ip, i) = default(IntPtr);
             }
         }
-
-        [StructLayout(LayoutKind.Sequential, Size = 64)]
-        private struct Reg64 { }
-        [StructLayout(LayoutKind.Sequential, Size = 32)]
-        private struct Reg32 { }
-        [StructLayout(LayoutKind.Sequential, Size = 16)]
-        private struct Reg16 { }
     }
 }

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -677,75 +677,164 @@ namespace System
                     Unsafe.Add<byte>(ref b, 6) = 0;
                     return;
                 case 8:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+#endif
                     return;
                 case 9:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+#endif
                     Unsafe.Add<byte>(ref b, 8) = 0;
                     return;
                 case 10:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+#endif
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
                     return;
                 case 11:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+#endif
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
                     Unsafe.Add<byte>(ref b, 10) = 0;
                     return;
                 case 12:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+#endif
                     Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
                     return;
                 case 13:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+#endif
                     Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
                     Unsafe.Add<byte>(ref b, 12) = 0;
                     return;
                 case 14:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+#endif
                     Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
                     return;
                 case 15:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+#endif
                     Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
                     Unsafe.Add<byte>(ref b, 14) = 0;
                     return;
                 case 16:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
+#endif
                     return;
                 case 17:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
+#endif
                     Unsafe.Add<byte>(ref b, 16) = 0;
                     return;
                 case 18:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
+#endif
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
                     return;
                 case 19:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
+#endif
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
                     Unsafe.Add<byte>(ref b, 18) = 0;
                     return;
                 case 20:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
+#endif
                     Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
                     return;
                 case 21:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
+#endif
                     Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
                     Unsafe.Add<byte>(ref b, 20) = 0;
                     return;
                 case 22:
+#if BIT64
                     Unsafe.As<byte, long>(ref b) = 0;
                     Unsafe.As<byte, long>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+#else
+                    Unsafe.As<byte, int>(ref b) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 4)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 8)) = 0;
+                    Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 12)) = 0;
+#endif
                     Unsafe.As<byte, int>(ref Unsafe.Add<byte>(ref b, 16)) = 0;
                     Unsafe.As<byte, short>(ref Unsafe.Add<byte>(ref b, 20)) = 0;
                     return;

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -449,23 +449,6 @@ namespace System
         public static Span<T> Empty => default(Span<T>);
     }
 
-    /*public static class RuntimeImports
-    {
-        // Non-inlinable wrapper around the QCall that avoids poluting the fast path
-        // with P/Invoke prolog/epilog.
-        [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        internal unsafe static void RhZeroMemory(ref byte b, nuint byteLength)
-        {
-            fixed (byte* bytePointer = &b)
-            {
-                RhZeroMemory(bytePointer, byteLength);
-            }
-        }
-
-        [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        extern internal unsafe static void RhZeroMemory(byte* b, nuint byteLength);
-    }*/
-
     public static class Span
     {
         /// <summary>

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -857,8 +857,8 @@ namespace System
 
             // TODO: Perhaps do switch casing to improve small size perf
 
-            var i = (nuint)0;
-            var n = (nuint)0;
+            nuint i = 0;
+            nuint n = 0;
             while ((n = i + 8) <= (pointerSizeLength))
             {
                 Unsafe.Add<IntPtr>(ref ip, (int)i + 0) = default(IntPtr);

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1494,6 +1494,13 @@ FCIMPL5(VOID, Buffer::InternalBlockCopy, ArrayBase *src, int srcOffset, ArrayBas
 }
 FCIMPLEND
 
+void QCALLTYPE SpanNative::SpanClear(void *dst, size_t length)
+{
+    QCALL_CONTRACT;
+
+    memset(dst, 0, length);
+}
+
 void QCALLTYPE Buffer::MemMove(void *dst, void *src, size_t length)
 {
     QCALL_CONTRACT;

--- a/src/vm/comutilnative.h
+++ b/src/vm/comutilnative.h
@@ -112,6 +112,14 @@ public:
 
 
 //
+// SpanNative
+//
+class SpanNative {
+public:
+    static void QCALLTYPE SpanClear(void *dst, size_t length);
+};
+
+//
 // Buffer
 //
 class Buffer {

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -1659,7 +1659,7 @@ FCClassElement("RuntimeEnvironment", "System.Runtime.InteropServices", gRuntimeE
 FCClassElement("RuntimeFieldHandle", "System", gCOMFieldHandleNewFuncs)
 FCClassElement("RuntimeHelpers", "System.Runtime.CompilerServices", gCompilerFuncs)
 #ifdef FEATURE_SPAN_OF_T
-FCClassElement("RuntimeImports", "System", gRuntimeImportsFuncs)
+FCClassElement("RuntimeImports", "System.Runtime", gRuntimeImportsFuncs)
 #endif// FEATURE_SPAN_OF_T
 FCClassElement("RuntimeMethodHandle", "System", gRuntimeMethodHandle)
 FCClassElement("RuntimeModule", "System.Reflection", gCOMModuleFuncs)

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -1465,11 +1465,9 @@ FCFuncStart(gRuntimeClassFuncs)
 FCFuncEnd()
 #endif // ifdef FEATURE_COMINTEROP
 
-#ifdef FEATURE_SPAN_OF_T
 FCFuncStart(gRuntimeImportsFuncs)
     QCFuncElement("RhZeroMemory", SpanNative::SpanClear)
 FCFuncEnd()
-#endif // ifdef FEATURE_SPAN_OF_T
 
 FCFuncStart(gWeakReferenceFuncs)
     FCFuncElement("Create", WeakReferenceNative::Create)
@@ -1658,9 +1656,7 @@ FCClassElement("RuntimeClass", "System.Runtime.InteropServices.WindowsRuntime", 
 FCClassElement("RuntimeEnvironment", "System.Runtime.InteropServices", gRuntimeEnvironmentFuncs)
 FCClassElement("RuntimeFieldHandle", "System", gCOMFieldHandleNewFuncs)
 FCClassElement("RuntimeHelpers", "System.Runtime.CompilerServices", gCompilerFuncs)
-#ifdef FEATURE_SPAN_OF_T
 FCClassElement("RuntimeImports", "System.Runtime", gRuntimeImportsFuncs)
-#endif// FEATURE_SPAN_OF_T
 FCClassElement("RuntimeMethodHandle", "System", gRuntimeMethodHandle)
 FCClassElement("RuntimeModule", "System.Reflection", gCOMModuleFuncs)
 FCClassElement("RuntimeThread", "Internal.Runtime.Augments", gRuntimeThreadFuncs)

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -1464,6 +1464,13 @@ FCFuncStart(gRuntimeClassFuncs)
     FCFuncElement("RedirectEquals", ComObject::RedirectEquals)
 FCFuncEnd()
 #endif // ifdef FEATURE_COMINTEROP
+
+#ifdef FEATURE_SPAN_OF_T
+FCFuncStart(gRuntimeImportsFuncs)
+    QCFuncElement("RhZeroMemory", SpanNative::SpanClear)
+FCFuncEnd()
+#endif // ifdef FEATURE_SPAN_OF_T
+
 FCFuncStart(gWeakReferenceFuncs)
     FCFuncElement("Create", WeakReferenceNative::Create)
     FCFuncElement("Finalize", WeakReferenceNative::Finalize)
@@ -1651,6 +1658,9 @@ FCClassElement("RuntimeClass", "System.Runtime.InteropServices.WindowsRuntime", 
 FCClassElement("RuntimeEnvironment", "System.Runtime.InteropServices", gRuntimeEnvironmentFuncs)
 FCClassElement("RuntimeFieldHandle", "System", gCOMFieldHandleNewFuncs)
 FCClassElement("RuntimeHelpers", "System.Runtime.CompilerServices", gCompilerFuncs)
+#ifdef FEATURE_SPAN_OF_T
+FCClassElement("RuntimeImports", "System", gRuntimeImportsFuncs)
+#endif// FEATURE_SPAN_OF_T
 FCClassElement("RuntimeMethodHandle", "System", gRuntimeMethodHandle)
 FCClassElement("RuntimeModule", "System.Reflection", gCOMModuleFuncs)
 FCClassElement("RuntimeThread", "Internal.Runtime.Augments", gRuntimeThreadFuncs)

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -7060,24 +7060,13 @@ bool getILIntrinsicImplementationForUnsafe(MethodDesc * ftn,
         methInfo->options = (CorInfoOptions)0;
         return true;
     }
-    else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_ADD_NATIVE)->GetMemberDef())
+    else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_ADD_BYTE_OFFSET)->GetMemberDef())
     {
-        mdToken tokGenericArg = FindGenericMethodArgTypeSpec(MscorlibBinder::GetModule()->GetMDImport());
-        
-        static BYTE ilcode[] = { CEE_LDARG_0, CEE_LDARG_1,
-            CEE_PREFIX1, (CEE_SIZEOF & 0xFF), 0,0,0,0,
-            CEE_MUL,
-            CEE_ADD,
-            CEE_RET };
-
-        ilcode[4] = (BYTE)(tokGenericArg);
-        ilcode[5] = (BYTE)(tokGenericArg >> 8);
-        ilcode[6] = (BYTE)(tokGenericArg >> 16);
-        ilcode[7] = (BYTE)(tokGenericArg >> 24);
+        static BYTE ilcode[] = { CEE_LDARG_0, CEE_LDARG_1, CEE_ADD, CEE_RET };
 
         methInfo->ILCode = const_cast<BYTE*>(ilcode);
         methInfo->ILCodeSize = sizeof(ilcode);
-        methInfo->maxStack = 3;
+        methInfo->maxStack = 2;
         methInfo->EHcount = 0;
         methInfo->options = (CorInfoOptions)0;
         return true;

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -7060,6 +7060,28 @@ bool getILIntrinsicImplementationForUnsafe(MethodDesc * ftn,
         methInfo->options = (CorInfoOptions)0;
         return true;
     }
+    else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_ADD_NATIVE)->GetMemberDef())
+    {
+        mdToken tokGenericArg = FindGenericMethodArgTypeSpec(MscorlibBinder::GetModule()->GetMDImport());
+        
+        static BYTE ilcode[] = { CEE_LDARG_0, CEE_LDARG_1,
+            CEE_PREFIX1, (CEE_SIZEOF & 0xFF), 0,0,0,0,
+            CEE_MUL,
+            CEE_ADD,
+            CEE_RET };
+
+        ilcode[4] = (BYTE)(tokGenericArg);
+        ilcode[5] = (BYTE)(tokGenericArg >> 8);
+        ilcode[6] = (BYTE)(tokGenericArg >> 16);
+        ilcode[7] = (BYTE)(tokGenericArg >> 24);
+
+        methInfo->ILCode = const_cast<BYTE*>(ilcode);
+        methInfo->ILCodeSize = sizeof(ilcode);
+        methInfo->maxStack = 3;
+        methInfo->EHcount = 0;
+        methInfo->options = (CorInfoOptions)0;
+        return true;
+    }
     else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_ARE_SAME)->GetMemberDef())
     {
         // Compare the two arguments

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -1109,6 +1109,7 @@ DEFINE_METHOD(UNSAFE,               AS_POINTER,             AsPointer, NoSig)
 DEFINE_METHOD(UNSAFE,               SIZEOF,                 SizeOf, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_AS,               As, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_ADD,              Add, NoSig)
+DEFINE_METHOD(UNSAFE,               BYREF_ADD_NATIVE,              AddNative, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_ARE_SAME,         AreSame, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_INIT_BLOCK_UNALIGNED, InitBlockUnaligned, NoSig)
 

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -1109,7 +1109,7 @@ DEFINE_METHOD(UNSAFE,               AS_POINTER,             AsPointer, NoSig)
 DEFINE_METHOD(UNSAFE,               SIZEOF,                 SizeOf, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_AS,               As, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_ADD,              Add, NoSig)
-DEFINE_METHOD(UNSAFE,               BYREF_ADD_NATIVE,              AddNative, NoSig)
+DEFINE_METHOD(UNSAFE,               BYREF_ADD_BYTE_OFFSET,  AddByteOffset, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_ARE_SAME,         AreSame, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_INIT_BLOCK_UNALIGNED, InitBlockUnaligned, NoSig)
 


### PR DESCRIPTION
For issue #9161

Basic performance test (similar to smoke tests) just to get a general idea on performance comparing the two:
![image](https://cloud.githubusercontent.com/assets/6527137/22956933/ffbfcec6-f2d9-11e6-8b3e-a9a547fce680.png)


The test is just measuring:
```C#
        const int Iterations = 100000;
        
        static void Main(string[] args)
        {
            Stopwatch stopWatch = new Stopwatch();
            byte[] byteArray = new byte[1000000];
            Span<byte> byteSpan = new Span<byte>(byteArray);
            Console.WriteLine("Iterations: " + Iterations);
            Console.WriteLine("Span Length: " + byteSpan.Length);

            stopWatch.Restart();
            PerfTestClear(byteSpan);
            stopWatch.Stop();
            Output(stopWatch.Elapsed);
        }


        private static void PerfTestClear(Span<byte> byteSpan)
        {
            int count = 0;
            for (int j = 0; j < Iterations; j++)
            {
                count = 0;
                byteSpan.Clear();
            }
        }
```