### PR TITLE
[x86/Linux] Fix IsIPInMarkedJitHelper to handle sigsegv

### DIFF
--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -7190,6 +7190,11 @@ bool IsIPInMarkedJitHelper(UINT_PTR uControlPc)
 
     CHECK_RANGE(JIT_WriteBarrier)
     CHECK_RANGE(JIT_CheckedWriteBarrier)
+#else
+#ifdef FEATURE_PAL
+    CHECK_RANGE(JIT_WriteBarrierGroup)
+    CHECK_RANGE(JIT_PatchedWriteBarrierGroup)
+#endif // FEATURE_PAL
 #endif // _TARGET_X86_
 
 #if defined(_TARGET_AMD64_) && defined(_DEBUG)
@@ -7215,8 +7220,8 @@ AdjustContextForWriteBarrier(
 #if defined(_TARGET_X86_) && !defined(PLATFORM_UNIX)
     void* f_IP = (void *)GetIP(pContext);
 
-    if (((f_IP >= (void *) JIT_WriteBarrierStart) && (f_IP <= (void *) JIT_WriteBarrierLast)) ||
-        ((f_IP >= (void *) JIT_PatchedWriteBarrierStart) && (f_IP <= (void *) JIT_PatchedWriteBarrierLast)))
+    if (((f_IP >= (void *) JIT_WriteBarrierGroup) && (f_IP <= (void *) JIT_WriteBarrierGroup_End)) ||
+        ((f_IP >= (void *) JIT_PatchedWriteBarrierGroup) && (f_IP <= (void *) JIT_PatchedWriteBarrierGroup_End)))
     {
         // set the exception IP to be the instruction that called the write barrier
         void* callsite = (void *)GetAdjustedCallAddress(*dac_cast<PTR_PCODE>(GetSP(pContext)));

--- a/src/vm/i386/jithelp.S
+++ b/src/vm/i386/jithelp.S
@@ -371,12 +371,12 @@ NESTED_END JIT_ByRefWriteBarrier, _TEXT
 
 .endm
 
-// WriteBarrierStart and WriteBarrierEnd are used to determine bounds of
-// WriteBarrier functions so can determine if got AV in them.
+// JIT_WriteBarrierGroup and JIT_WriteBarrierGroup_End are used
+// to determine bounds of WriteBarrier functions so can determine if got AV in them.
 //
-LEAF_ENTRY JIT_WriteBarrierStart, _TEXT
+LEAF_ENTRY JIT_WriteBarrierGroup, _TEXT
     ret
-LEAF_END JIT_WriteBarrierStart, _TEXT
+LEAF_END JIT_WriteBarrierGroup, _TEXT
 
 #ifdef FEATURE_USE_ASM_GC_WRITE_BARRIERS
 // *******************************************************************************
@@ -408,14 +408,10 @@ WriteBarrierHelper EBP
 
 ByRefWriteBarrierHelper
 
-LEAF_ENTRY JIT_WriteBarrierLast, _TEXT
-    ret
-LEAF_END JIT_WriteBarrierLast, _TEXT
-
 // This is the first function outside the "keep together range". Used by BBT scripts.
-LEAF_ENTRY JIT_WriteBarrierEnd, _TEXT
+LEAF_ENTRY JIT_WriteBarrierGroup_End, _TEXT
     ret
-LEAF_END JIT_WriteBarrierEnd, _TEXT
+LEAF_END JIT_WriteBarrierGroup_End, _TEXT
 
 // *********************************************************************/
 //  In cases where we support it we have an optimized GC Poll callback.
@@ -688,9 +684,9 @@ LEAF_END JIT_PatchedCodeStart, _TEXT
 // **********************************************************************
 // Write barriers generated at runtime
 
-LEAF_ENTRY JIT_PatchedWriteBarrierStart, _TEXT
+LEAF_ENTRY JIT_PatchedWriteBarrierGroup, _TEXT
     ret
-LEAF_END JIT_PatchedWriteBarrierStart, _TEXT
+LEAF_END JIT_PatchedWriteBarrierGroup, _TEXT
 
 .macro PatchedWriteBarrierHelper rg
 .align 8
@@ -708,15 +704,11 @@ PatchedWriteBarrierHelper ESI
 PatchedWriteBarrierHelper EDI
 PatchedWriteBarrierHelper EBP
 
-LEAF_ENTRY JIT_PatchedWriteBarrierLast, _TEXT
+// This is the first function outside the "keep together range". Used by BBT scripts.
+LEAF_ENTRY JIT_PatchedWriteBarrierGroup_End, _TEXT
     ret
-LEAF_END JIT_PatchedWriteBarrierLast, _TEXT
+LEAF_END JIT_PatchedWriteBarrierGroup_End, _TEXT
 
 LEAF_ENTRY JIT_PatchedCodeLast, _TEXT
     ret
 LEAF_END JIT_PatchedCodeLast, _TEXT
-
-// This is the first function outside the "keep together range". Used by BBT scripts.
-LEAF_ENTRY JIT_PatchedCodeEnd, _TEXT
-    ret
-LEAF_END JIT_PatchedCodeEnd, _TEXT

--- a/src/vm/i386/jithelp.asm
+++ b/src/vm/i386/jithelp.asm
@@ -439,10 +439,10 @@ ENDM
 ; WriteBarrierStart and WriteBarrierEnd are used to determine bounds of
 ; WriteBarrier functions so can determine if got AV in them. 
 ; 
-PUBLIC _JIT_WriteBarrierStart@0
-_JIT_WriteBarrierStart@0 PROC
+PUBLIC _JIT_WriteBarrierGroup@0
+_JIT_WriteBarrierGroup@0 PROC
 ret
-_JIT_WriteBarrierStart@0 ENDP
+_JIT_WriteBarrierGroup@0 ENDP
 
 ifdef FEATURE_USE_ASM_GC_WRITE_BARRIERS
 ; Only define these if we're using the ASM GC write barriers; if this flag is not defined,
@@ -460,16 +460,11 @@ WriteBarrierHelper <EBP>
 
 ByRefWriteBarrierHelper
 
-PUBLIC _JIT_WriteBarrierLast@0
-_JIT_WriteBarrierLast@0 PROC
-ret
-_JIT_WriteBarrierLast@0 ENDP
-
 ; This is the first function outside the "keep together range". Used by BBT scripts.
-PUBLIC _JIT_WriteBarrierEnd@0
-_JIT_WriteBarrierEnd@0 PROC
+PUBLIC _JIT_WriteBarrierGroup_End@0
+_JIT_WriteBarrierGroup_End@0 PROC
 ret
-_JIT_WriteBarrierEnd@0 ENDP
+_JIT_WriteBarrierGroup_End@0 ENDP
 
 ;*********************************************************************/
 ; In cases where we support it we have an optimized GC Poll callback.  Normall (when we're not trying to
@@ -2350,10 +2345,10 @@ endif
 ;**********************************************************************
 ; Write barriers generated at runtime
 
-PUBLIC _JIT_PatchedWriteBarrierStart@0
-_JIT_PatchedWriteBarrierStart@0 PROC
+PUBLIC _JIT_PatchedWriteBarrierGroup@0
+_JIT_PatchedWriteBarrierGroup@0 PROC
 ret
-_JIT_PatchedWriteBarrierStart@0 ENDP
+_JIT_PatchedWriteBarrierGroup@0 ENDP
 
 PatchedWriteBarrierHelper MACRO rg
         ALIGN 8
@@ -2372,10 +2367,10 @@ PatchedWriteBarrierHelper <ESI>
 PatchedWriteBarrierHelper <EDI>
 PatchedWriteBarrierHelper <EBP>
 
-PUBLIC _JIT_PatchedWriteBarrierLast@0
-_JIT_PatchedWriteBarrierLast@0 PROC
+PUBLIC _JIT_PatchedWriteBarrierGroup_End@0
+_JIT_PatchedWriteBarrierGroup_End@0 PROC
 ret
-_JIT_PatchedWriteBarrierLast@0 ENDP
+_JIT_PatchedWriteBarrierGroup_End@0 ENDP
 
 ;**********************************************************************
 ; PrecodeRemotingThunk is patched at runtime to activate it

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -1606,8 +1606,8 @@ void InitJITHelpers1()
 
     // All write barrier helpers should fit into one page.
     // If you hit this assert on retail build, there is most likely problem with BBT script.
-    _ASSERTE_ALL_BUILDS("clr/src/VM/i386/JITinterfaceX86.cpp", (BYTE*)JIT_WriteBarrierLast - (BYTE*)JIT_WriteBarrierStart < PAGE_SIZE);
-    _ASSERTE_ALL_BUILDS("clr/src/VM/i386/JITinterfaceX86.cpp", (BYTE*)JIT_PatchedWriteBarrierLast - (BYTE*)JIT_PatchedWriteBarrierStart < PAGE_SIZE);
+    _ASSERTE_ALL_BUILDS("clr/src/VM/i386/JITinterfaceX86.cpp", (BYTE*)JIT_WriteBarrierGroup_End - (BYTE*)JIT_WriteBarrierGroup < PAGE_SIZE);
+    _ASSERTE_ALL_BUILDS("clr/src/VM/i386/JITinterfaceX86.cpp", (BYTE*)JIT_PatchedWriteBarrierGroup_End - (BYTE*)JIT_PatchedWriteBarrierGroup < PAGE_SIZE);
 
     // Copy the write barriers to their final resting place.
     for (int iBarrier = 0; iBarrier < NUM_WRITE_BARRIERS; iBarrier++)
@@ -1787,8 +1787,8 @@ void StompWriteBarrierEphemeral(bool /* isRuntimeSuspended */)
     }
 
     if (flushICache)
-        FlushInstructionCache(GetCurrentProcess(), (void *)JIT_PatchedWriteBarrierStart,
-            (BYTE*)JIT_PatchedWriteBarrierLast - (BYTE*)JIT_PatchedWriteBarrierStart);
+        FlushInstructionCache(GetCurrentProcess(), (void *)JIT_PatchedWriteBarrierGroup,
+            (BYTE*)JIT_PatchedWriteBarrierGroup_End - (BYTE*)JIT_PatchedWriteBarrierGroup);
 }
 
 /*********************************************************************/
@@ -1924,8 +1924,8 @@ void StompWriteBarrierResize(bool isRuntimeSuspended, bool bReqUpperBoundsCheck)
     }
     else
     {
-        FlushInstructionCache(GetCurrentProcess(), (void *)JIT_PatchedWriteBarrierStart,
-            (BYTE*)JIT_PatchedWriteBarrierLast - (BYTE*)JIT_PatchedWriteBarrierStart);
+        FlushInstructionCache(GetCurrentProcess(), (void *)JIT_PatchedWriteBarrierGroup,
+            (BYTE*)JIT_PatchedWriteBarrierGroup_End - (BYTE*)JIT_PatchedWriteBarrierGroup);
     }
 
     if(bEESuspendedHere)

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -378,11 +378,11 @@ extern "C"
     void STDCALL JIT_WriteBarrierEDI();        // JIThelp.asm/JIThelp.s
     void STDCALL JIT_WriteBarrierEBP();        // JIThelp.asm/JIThelp.s
 
-    void STDCALL JIT_WriteBarrierStart();
-    void STDCALL JIT_WriteBarrierLast();
+    void STDCALL JIT_WriteBarrierGroup();
+    void STDCALL JIT_WriteBarrierGroup_End();
 
-    void STDCALL JIT_PatchedWriteBarrierStart();
-    void STDCALL JIT_PatchedWriteBarrierLast();
+    void STDCALL JIT_PatchedWriteBarrierGroup();
+    void STDCALL JIT_PatchedWriteBarrierGroup_End();
 }
 
 void ValidateWriteBarrierHelpers();


### PR DESCRIPTION
Include JIT_WriteBarrier and JIT_CheckedWriteBarrier functions
so that we can handle NullReferenceException for sigsegv from WriteBarriers.