### PR TITLE
Fix build-rootfs.sh to include lldb package

### DIFF
--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -108,14 +108,10 @@ for i in "$@" ; do
     esac
 done
 
-if [[ "$__BuildArch" == "arm" ]]; then
-    __UbuntuPackages+=" ${__LLDB_Package:-}"
-fi
-
 if [ "$__BuildArch" == "armel" ]; then
     __LLDB_Package="lldb-3.5-dev"
-    __UbuntuPackages+=" ${__LLDB_Package:-}"
 fi
+__UbuntuPackages+=" ${__LLDB_Package:-}"
 
 __RootfsDir="$__CrossDir/rootfs/$__BuildArch"
 


### PR DESCRIPTION
lldb package is missing for architectures other than arm and armel.

Fix #9606 
