### PR TITLE
Handle contained nodes earlier in buildRefPositionsForNode.

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -744,6 +744,9 @@ private:
         TreeNodeInfo& info = tree->gtLsraInfo;
         info.srcCount      = 0;
         info.dstCount      = 0;
+
+        info.internalIntCount   = 0;
+        info.internalFloatCount = 0;
     }
 
     inline bool isLocalDefUse(GenTree* tree)


### PR DESCRIPTION
These nodes never produce ref positions. Handling them earlier in this function
avoids a rather large amount of unnecessary work (e.g. this decreases overall
compile time by about 0.5% for `crossgen System.Private.CoreLib`).