### PR TITLE
ARM64 add previously failing tests which now pass

### DIFF
--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -1,8 +1,8 @@
 ## This list file has been produced automatically. Any changes
 ## are subject to being overwritten when reproducing this file.
 ## 
-## Last Updated: 13-Feb-2017 12:43:29
-## Commit: 28d04376fe54aea392d75d478bd468f14d134e67
+## Last Updated: 14-Feb-2017 13:45:55
+## Commit: 9759c8d4c13155c64e707989106b36b88c044579
 ## 
 [Dev10_535767.cmd_0]
 RelativePath=baseservices\compilerservices\dynamicobjectproperties\Dev10_535767\Dev10_535767.cmd
@@ -25,7 +25,7 @@ RelativePath=baseservices\compilerservices\dynamicobjectproperties\TestAPIs\Test
 WorkingDir=baseservices\compilerservices\dynamicobjectproperties\TestAPIs
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL;ISSUE_6857
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [TestGC.cmd_3]
@@ -1809,7 +1809,7 @@ RelativePath=baseservices\threading\generics\threadstart\GThread06\GThread06.cmd
 WorkingDir=baseservices\threading\generics\threadstart\GThread06
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [GThread07.cmd_226]
@@ -2761,7 +2761,7 @@ RelativePath=baseservices\threading\interlocked\compareexchange\CompareExchangeT
 WorkingDir=baseservices\threading\interlocked\compareexchange\CompareExchangeTClass
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;UNSTABLE
+Categories=NEW_PASS;UNSTABLE;EXPECTED_PASS
 HostStyle=0
 
 [CompareExchangeTClass_1.cmd_345]
@@ -3265,7 +3265,7 @@ RelativePath=baseservices\threading\paramthreadstart\ThreadStartBool\ThreadStart
 WorkingDir=baseservices\threading\paramthreadstart\ThreadStartBool
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9467
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ThreadStartBool_1.cmd_408]
@@ -3281,7 +3281,7 @@ RelativePath=baseservices\threading\paramthreadstart\ThreadStartByte\ThreadStart
 WorkingDir=baseservices\threading\paramthreadstart\ThreadStartByte
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9460
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [ThreadStartByte_1.cmd_410]
@@ -3625,7 +3625,7 @@ RelativePath=baseservices\threading\paramthreadstart\ThreadStartSByte\ThreadStar
 WorkingDir=baseservices\threading\paramthreadstart\ThreadStartSByte
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9460
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [ThreadStartSByte_1.cmd_453]
@@ -6377,7 +6377,7 @@ RelativePath=CoreMangLib\cti\system\charenumerator\CharEnumeratorIEnumeratorCurr
 WorkingDir=CoreMangLib\cti\system\charenumerator\CharEnumeratorIEnumeratorCurrent
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [CharEnumeratorIEnumgetCurrent.cmd_797]
@@ -8385,7 +8385,7 @@ RelativePath=CoreMangLib\cti\system\convert\ConvertToByte2\ConvertToByte2.cmd
 WorkingDir=CoreMangLib\cti\system\convert\ConvertToByte2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL;9464
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [ConvertToByte3.cmd_1048]
@@ -12633,7 +12633,7 @@ RelativePath=CoreMangLib\cti\system\guid\GuidToByteArray\GuidToByteArray.cmd
 WorkingDir=CoreMangLib\cti\system\guid\GuidToByteArray
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [GuidToString1.cmd_1579]
@@ -13521,7 +13521,7 @@ RelativePath=CoreMangLib\cti\system\invalidprogramexception\InvalidProgramExcept
 WorkingDir=CoreMangLib\cti\system\invalidprogramexception\InvalidProgramExceptionctor1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL;9464
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [InvalidProgramExceptionctor2.cmd_1690]
@@ -14721,7 +14721,7 @@ RelativePath=CoreMangLib\cti\system\notimplementedexception\NotImplementedExcept
 WorkingDir=CoreMangLib\cti\system\notimplementedexception\NotImplementedExceptionCtor1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [NotImplementedExceptionCtor2.cmd_1840]
@@ -15713,7 +15713,7 @@ RelativePath=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesBlt_S\OpCodes
 WorkingDir=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesBlt_S
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [OpCodesBlt_Un.cmd_1964]
@@ -16665,7 +16665,7 @@ RelativePath=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesLdlen\OpCodes
 WorkingDir=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesLdlen
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [OpCodesLdloc.cmd_2083]
@@ -16737,7 +16737,7 @@ RelativePath=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesLdnull\OpCode
 WorkingDir=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesLdnull
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [OpCodesLdobj.cmd_2092]
@@ -19713,7 +19713,7 @@ RelativePath=CoreMangLib\cti\system\string\StringCompare9\StringCompare9.cmd
 WorkingDir=CoreMangLib\cti\system\string\StringCompare9
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri1;RT;EXPECTED_FAIL
+Categories=Pri1;RT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [StringCompareOrdinal1.cmd_2464]
@@ -22977,7 +22977,7 @@ RelativePath=GC\API\GC\GetTotalMemory\GetTotalMemory.cmd
 WorkingDir=GC\API\GC\GetTotalMemory
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [KeepAlive.cmd_2874]
@@ -23345,7 +23345,7 @@ RelativePath=GC\Coverage\LargeObjectAlloc\LargeObjectAlloc.cmd
 WorkingDir=GC\Coverage\LargeObjectAlloc
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=RT;Pri0;EXPECTED_FAIL;;9464
+Categories=RT;Pri0;NEW_PASS;EXPECTED_PASS;
 HostStyle=0
 
 [LargeObjectAlloc2.cmd_2921]
@@ -23481,7 +23481,7 @@ RelativePath=GC\Features\HeapExpansion\plug\plug.cmd
 WorkingDir=GC\Features\HeapExpansion\plug
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [pluggaps.cmd_2940]
@@ -23825,7 +23825,7 @@ RelativePath=GC\Scenarios\BinTree\thdtree\thdtree.cmd
 WorkingDir=GC\Scenarios\BinTree\thdtree
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [thdtreegrowingobj.cmd_2991]
@@ -23833,7 +23833,7 @@ RelativePath=GC\Scenarios\BinTree\thdtreegrowingobj\thdtreegrowingobj.cmd
 WorkingDir=GC\Scenarios\BinTree\thdtreegrowingobj
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [thdtreelivingobj.cmd_2992]
@@ -23841,7 +23841,7 @@ RelativePath=GC\Scenarios\BinTree\thdtreelivingobj\thdtreelivingobj.cmd
 WorkingDir=GC\Scenarios\BinTree\thdtreelivingobj
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [arrcpy.cmd_2993]
@@ -23857,7 +23857,7 @@ RelativePath=GC\Scenarios\Boxing\gcvariant\gcvariant.cmd
 WorkingDir=GC\Scenarios\Boxing\gcvariant
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [gcvariant2.cmd_2995]
@@ -23865,7 +23865,7 @@ RelativePath=GC\Scenarios\Boxing\gcvariant2\gcvariant2.cmd
 WorkingDir=GC\Scenarios\Boxing\gcvariant2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [gcvariant3.cmd_2996]
@@ -23873,7 +23873,7 @@ RelativePath=GC\Scenarios\Boxing\gcvariant3\gcvariant3.cmd
 WorkingDir=GC\Scenarios\Boxing\gcvariant3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [gcvariant4.cmd_2997]
@@ -23993,7 +23993,7 @@ RelativePath=GC\Scenarios\FinalizeTimeout\FinalizeTimeout\FinalizeTimeout.cmd
 WorkingDir=GC\Scenarios\FinalizeTimeout\FinalizeTimeout
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [finalnstruct.cmd_3013]
@@ -27641,7 +27641,7 @@ RelativePath=GC\Scenarios\THDChaos\thdchaos\thdchaos.cmd
 WorkingDir=GC\Scenarios\THDChaos\thdchaos
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=9464;EXPECTED_FAIL
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [thdlist.cmd_3470]
@@ -28297,7 +28297,7 @@ RelativePath=JIT\CodeGenBringUpTests\DblVar\DblVar.cmd
 WorkingDir=JIT\CodeGenBringUpTests\DblVar
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [div1.cmd_3553]
@@ -28585,7 +28585,7 @@ RelativePath=JIT\CodeGenBringUpTests\Gcd\Gcd.cmd
 WorkingDir=JIT\CodeGenBringUpTests\Gcd
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [Ge1.cmd_3589]
@@ -31273,7 +31273,7 @@ RelativePath=JIT\Directed\leave\filter3_r\filter3_r.cmd
 WorkingDir=JIT\Directed\leave\filter3_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [try1_d.cmd_3935]
@@ -33161,7 +33161,7 @@ RelativePath=JIT\Directed\shift\nativeuint_il_r\nativeuint_il_r.cmd
 WorkingDir=JIT\Directed\shift\nativeuint_il_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [uint16_cs_d.cmd_4183]
@@ -33249,7 +33249,7 @@ RelativePath=JIT\Directed\shift\uint32_cs_r\uint32_cs_r.cmd
 WorkingDir=JIT\Directed\shift\uint32_cs_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;9464
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [uint32_cs_ro.cmd_4194]
@@ -33449,7 +33449,7 @@ RelativePath=JIT\Directed\StrAccess\straccess2_cs_ro\straccess2_cs_ro.cmd
 WorkingDir=JIT\Directed\StrAccess\straccess2_cs_ro
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;9464
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [straccess3_cs_d.cmd_4219]
@@ -35457,7 +35457,7 @@ RelativePath=JIT\Generics\Parameters\static_passing_class01\static_passing_class
 WorkingDir=JIT\Generics\Parameters\static_passing_class01
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [static_passing_struct01.cmd_4472]
@@ -38897,7 +38897,7 @@ RelativePath=JIT\jit64\eh\FinallyExec\nestedTryRegionsWithSameOffset1\nestedTryR
 WorkingDir=JIT\jit64\eh\FinallyExec\nestedTryRegionsWithSameOffset1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [nestedTryRegionsWithSameOffset1_o.cmd_4902]
@@ -39801,7 +39801,7 @@ RelativePath=JIT\jit64\hfa\main\testA\hfa_sd2A_d\hfa_sd2A_d.cmd
 WorkingDir=JIT\jit64\hfa\main\testA\hfa_sd2A_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;ISSUE_5639
 HostStyle=0
 
 [hfa_sd2A_r.cmd_5016]
@@ -39809,7 +39809,7 @@ RelativePath=JIT\jit64\hfa\main\testA\hfa_sd2A_r\hfa_sd2A_r.cmd
 WorkingDir=JIT\jit64\hfa\main\testA\hfa_sd2A_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;ISSUE_5639
 HostStyle=0
 
 [hfa_sf0A_d.cmd_5017]
@@ -39849,7 +39849,7 @@ RelativePath=JIT\jit64\hfa\main\testA\hfa_sf2A_d\hfa_sf2A_d.cmd
 WorkingDir=JIT\jit64\hfa\main\testA\hfa_sf2A_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;ISSUE_5639
 HostStyle=0
 
 [hfa_sf2A_r.cmd_5022]
@@ -39857,7 +39857,7 @@ RelativePath=JIT\jit64\hfa\main\testA\hfa_sf2A_r\hfa_sf2A_r.cmd
 WorkingDir=JIT\jit64\hfa\main\testA\hfa_sf2A_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;ISSUE_5639
 HostStyle=0
 
 [hfa_nd0B_d.cmd_5023]
@@ -39945,7 +39945,7 @@ RelativePath=JIT\jit64\hfa\main\testB\hfa_sd2B_d\hfa_sd2B_d.cmd
 WorkingDir=JIT\jit64\hfa\main\testB\hfa_sd2B_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;ISSUE_5639
 HostStyle=0
 
 [hfa_sd2B_r.cmd_5034]
@@ -39953,7 +39953,7 @@ RelativePath=JIT\jit64\hfa\main\testB\hfa_sd2B_r\hfa_sd2B_r.cmd
 WorkingDir=JIT\jit64\hfa\main\testB\hfa_sd2B_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;ISSUE_5639
 HostStyle=0
 
 [hfa_sf0B_d.cmd_5035]
@@ -39977,7 +39977,7 @@ RelativePath=JIT\jit64\hfa\main\testB\hfa_sf2B_d\hfa_sf2B_d.cmd
 WorkingDir=JIT\jit64\hfa\main\testB\hfa_sf2B_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;ISSUE_5639
 HostStyle=0
 
 [hfa_sf2B_r.cmd_5038]
@@ -39985,7 +39985,7 @@ RelativePath=JIT\jit64\hfa\main\testB\hfa_sf2B_r\hfa_sf2B_r.cmd
 WorkingDir=JIT\jit64\hfa\main\testB\hfa_sf2B_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;ISSUE_5639
 HostStyle=0
 
 [hfa_nd0C_d.cmd_5039]
@@ -40025,7 +40025,7 @@ RelativePath=JIT\jit64\hfa\main\testC\hfa_nd2C_d\hfa_nd2C_d.cmd
 WorkingDir=JIT\jit64\hfa\main\testC\hfa_nd2C_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;NATIVE_INTEROP
 HostStyle=0
 
 [hfa_nd2C_r.cmd_5044]
@@ -40033,7 +40033,7 @@ RelativePath=JIT\jit64\hfa\main\testC\hfa_nd2C_r\hfa_nd2C_r.cmd
 WorkingDir=JIT\jit64\hfa\main\testC\hfa_nd2C_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;NATIVE_INTEROP
 HostStyle=0
 
 [hfa_nf0C_d.cmd_5045]
@@ -40073,7 +40073,7 @@ RelativePath=JIT\jit64\hfa\main\testC\hfa_nf2C_d\hfa_nf2C_d.cmd
 WorkingDir=JIT\jit64\hfa\main\testC\hfa_nf2C_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;NATIVE_INTEROP
 HostStyle=0
 
 [hfa_nf2C_r.cmd_5050]
@@ -40081,7 +40081,7 @@ RelativePath=JIT\jit64\hfa\main\testC\hfa_nf2C_r\hfa_nf2C_r.cmd
 WorkingDir=JIT\jit64\hfa\main\testC\hfa_nf2C_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;NATIVE_INTEROP
 HostStyle=0
 
 [hfa_sd0C_d.cmd_5051]
@@ -40121,7 +40121,7 @@ RelativePath=JIT\jit64\hfa\main\testC\hfa_sd2C_d\hfa_sd2C_d.cmd
 WorkingDir=JIT\jit64\hfa\main\testC\hfa_sd2C_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_5639
 HostStyle=0
 
 [hfa_sd2C_r.cmd_5056]
@@ -40129,7 +40129,7 @@ RelativePath=JIT\jit64\hfa\main\testC\hfa_sd2C_r\hfa_sd2C_r.cmd
 WorkingDir=JIT\jit64\hfa\main\testC\hfa_sd2C_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_5639
 HostStyle=0
 
 [hfa_sf0C_d.cmd_5057]
@@ -40169,7 +40169,7 @@ RelativePath=JIT\jit64\hfa\main\testC\hfa_sf2C_d\hfa_sf2C_d.cmd
 WorkingDir=JIT\jit64\hfa\main\testC\hfa_sf2C_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_5639
 HostStyle=0
 
 [hfa_sf2C_r.cmd_5062]
@@ -40177,7 +40177,7 @@ RelativePath=JIT\jit64\hfa\main\testC\hfa_sf2C_r\hfa_sf2C_r.cmd
 WorkingDir=JIT\jit64\hfa\main\testC\hfa_sf2C_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;ISSUE_5639;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_4946
+Categories=Pri0;ISSUE_4946;EXPECTED_PASS;NATIVE_INTEROP;ISSUE_5639
 HostStyle=0
 
 [hfa_nd0E_d.cmd_5063]
@@ -41785,7 +41785,7 @@ RelativePath=JIT\jit64\opt\cse\fieldExprUnchecked1\fieldExprUnchecked1.cmd
 WorkingDir=JIT\jit64\opt\cse\fieldExprUnchecked1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [HugeArray.cmd_5295]
@@ -41801,7 +41801,7 @@ RelativePath=JIT\jit64\opt\cse\HugeArray1\HugeArray1.cmd
 WorkingDir=JIT\jit64\opt\cse\HugeArray1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=LONG_RUNNING;Pri0;JIT;EXPECTED_PASS
+Categories=Pri0;LONG_RUNNING;JIT;EXPECTED_PASS
 HostStyle=0
 
 [hugeexpr1.cmd_5297]
@@ -41809,7 +41809,7 @@ RelativePath=JIT\jit64\opt\cse\hugeexpr1\hugeexpr1.cmd
 WorkingDir=JIT\jit64\opt\cse\hugeexpr1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=LONG_RUNNING;Pri0;JIT;EXPECTED_PASS
+Categories=Pri0;LONG_RUNNING;JIT;EXPECTED_PASS
 HostStyle=0
 
 [HugeField1.cmd_5298]
@@ -41817,7 +41817,7 @@ RelativePath=JIT\jit64\opt\cse\HugeField1\HugeField1.cmd
 WorkingDir=JIT\jit64\opt\cse\HugeField1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=LONG_RUNNING;Pri0;JIT;EXPECTED_PASS
+Categories=Pri0;LONG_RUNNING;JIT;EXPECTED_PASS
 HostStyle=0
 
 [HugeField2.cmd_5299]
@@ -41825,7 +41825,7 @@ RelativePath=JIT\jit64\opt\cse\HugeField2\HugeField2.cmd
 WorkingDir=JIT\jit64\opt\cse\HugeField2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=LONG_RUNNING;Pri0;JIT;EXPECTED_PASS
+Categories=Pri0;LONG_RUNNING;JIT;EXPECTED_PASS
 HostStyle=0
 
 [hugeSimpleExpr1.cmd_5300]
@@ -42497,7 +42497,7 @@ RelativePath=JIT\jit64\opt\rngchk\RngchkStress3\RngchkStress3.cmd
 WorkingDir=JIT\jit64\opt\rngchk\RngchkStress3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=LONG_RUNNING;Pri0;JIT;EXPECTED_PASS
+Categories=Pri0;LONG_RUNNING;JIT;EXPECTED_PASS
 HostStyle=0
 
 [SimpleArray_01_o.cmd_5384]
@@ -43681,7 +43681,7 @@ RelativePath=JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics
 WorkingDir=JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics040
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [box-unbox-generics041.cmd_5533]
@@ -46089,7 +46089,7 @@ RelativePath=JIT\Methodical\Arrays\lcs\_speed_dbglcsvalbox\_speed_dbglcsvalbox.c
 WorkingDir=JIT\Methodical\Arrays\lcs\_speed_dbglcsvalbox
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=ISSUE_6065;9464;JIT;GCSTRESS_FAIL;Pri0;EXPECTED_FAIL
+Categories=GCSTRESS_FAIL;Pri0;JIT;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [_speed_rellcs.cmd_5834]
@@ -46113,7 +46113,7 @@ RelativePath=JIT\Methodical\Arrays\lcs\_speed_rellcsbas\_speed_rellcsbas.cmd
 WorkingDir=JIT\Methodical\Arrays\lcs\_speed_rellcsbas
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;9464
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [_speed_rellcsbox.cmd_5837]
@@ -52385,7 +52385,7 @@ RelativePath=JIT\Methodical\eh\rethrow\rethrowwithhandlerscatchingbase_do\rethro
 WorkingDir=JIT\Methodical\eh\rethrow\rethrowwithhandlerscatchingbase_do
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [rethrowwithhandlerscatchingbase_r.cmd_6633]
@@ -53785,7 +53785,7 @@ RelativePath=JIT\Methodical\explicit\coverage\expl_short_1_d\expl_short_1_d.cmd
 WorkingDir=JIT\Methodical\explicit\coverage\expl_short_1_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [expl_short_1_r.cmd_6808]
@@ -53817,7 +53817,7 @@ RelativePath=JIT\Methodical\explicit\coverage\seq_byte_1_d\seq_byte_1_d.cmd
 WorkingDir=JIT\Methodical\explicit\coverage\seq_byte_1_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [seq_byte_1_r.cmd_6812]
@@ -53825,7 +53825,7 @@ RelativePath=JIT\Methodical\explicit\coverage\seq_byte_1_r\seq_byte_1_r.cmd
 WorkingDir=JIT\Methodical\explicit\coverage\seq_byte_1_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [seq_double_1_d.cmd_6813]
@@ -54009,7 +54009,7 @@ RelativePath=JIT\Methodical\explicit\coverage\seq_long_1_d\seq_long_1_d.cmd
 WorkingDir=JIT\Methodical\explicit\coverage\seq_long_1_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;9464
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [seq_long_1_r.cmd_6836]
@@ -54233,7 +54233,7 @@ RelativePath=JIT\Methodical\explicit\misc\_opt_dbgexplicit1\_opt_dbgexplicit1.cm
 WorkingDir=JIT\Methodical\explicit\misc\_opt_dbgexplicit1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;9464
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [_opt_dbgexplicit2.cmd_6864]
@@ -54681,7 +54681,7 @@ RelativePath=JIT\Methodical\flowgraph\bug619534\moduleHandleCache\moduleHandleCa
 WorkingDir=JIT\Methodical\flowgraph\bug619534\moduleHandleCache
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [twoEndFinallys.cmd_6920]
@@ -54785,7 +54785,7 @@ RelativePath=JIT\Methodical\flowgraph\dev10_bug679008\fgloop\fgloop.cmd
 WorkingDir=JIT\Methodical\flowgraph\dev10_bug679008\fgloop
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [fgloop2.cmd_6933]
@@ -60617,7 +60617,7 @@ RelativePath=JIT\Methodical\tailcall_v4\smallFrame\smallFrame.cmd
 WorkingDir=JIT\Methodical\tailcall_v4\smallFrame
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;9462;EXPECTED_FAIL;ISSUE_6881
+Categories=ISSUE_6881;Pri0;JIT;EXPECTED_FAIL;9462
 HostStyle=0
 
 [tailcall_AV.cmd_7668]
@@ -60665,7 +60665,7 @@ RelativePath=JIT\Methodical\unsafecsharp\_dbgunsafe-4\_dbgunsafe-4.cmd
 WorkingDir=JIT\Methodical\unsafecsharp\_dbgunsafe-4
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;9464
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [_dbgunsafe-5.cmd_7674]
@@ -62905,7 +62905,7 @@ RelativePath=JIT\opt\virtualstubdispatch\bigvtbl\bigvtbl_cs_do\bigvtbl_cs_do.cmd
 WorkingDir=JIT\opt\virtualstubdispatch\bigvtbl\bigvtbl_cs_do
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;9464
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [bigvtbl_cs_r.cmd_7957]
@@ -62921,7 +62921,7 @@ RelativePath=JIT\opt\virtualstubdispatch\bigvtbl\bigvtbl_cs_ro\bigvtbl_cs_ro.cmd
 WorkingDir=JIT\opt\virtualstubdispatch\bigvtbl\bigvtbl_cs_ro
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;9464
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [ctest1_cs_d.cmd_7959]
@@ -63521,7 +63521,7 @@ RelativePath=JIT\Performance\CodeQuality\V8\DeltaBlue\DeltaBlue\DeltaBlue.cmd
 WorkingDir=JIT\Performance\CodeQuality\V8\DeltaBlue\DeltaBlue
 Expected=0
 MaxAllowedDurationSeconds=1000
-Categories=GCSTRESS_FAIL;Pri0;LONG_RUNNING;ISSUE_6065;EXPECTED_FAIL
+Categories=GCSTRESS_FAIL;Pri0;LONG_RUNNING;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [Richards.cmd_8034]
@@ -63529,7 +63529,7 @@ RelativePath=JIT\Performance\CodeQuality\V8\Richards\Richards\Richards.cmd
 WorkingDir=JIT\Performance\CodeQuality\V8\Richards\Richards
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [RunBenchmarks.cmd_8035]
@@ -64289,7 +64289,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14135\b14135\b14135.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14135\b14135
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [b14197.cmd_8132]
@@ -64857,7 +64857,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26512\b26512\b26512.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26512\b26512
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [b26558.cmd_8206]
@@ -65993,7 +65993,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b37608\b37608\b37608.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b37608\b37608
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [b37636.cmd_8356]
@@ -66177,7 +66177,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40721\b40721\b40721.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40721\b40721
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=ISSUE_2990;Pri0;JIT;EXPECTED_PASS
+Categories=Pri0;ISSUE_2990;JIT;EXPECTED_PASS
 HostStyle=0
 
 [b40725.cmd_8379]
@@ -67233,7 +67233,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b35354\b35354\b35354.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b35354\b35354
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [b35366.cmd_8516]
@@ -67481,7 +67481,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b50027\b50027\b50027.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b50027\b50027
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=ISSUE_2990;Pri0;JIT;EXPECTED_PASS
+Categories=Pri0;ISSUE_2990;JIT;EXPECTED_PASS
 HostStyle=0
 
 [b50033.cmd_8549]
@@ -67545,7 +67545,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b51420\b51420\b51420.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b51420\b51420
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=ISSUE_2990;Pri0;JIT;EXPECTED_PASS
+Categories=Pri0;ISSUE_2990;JIT;EXPECTED_PASS
 HostStyle=0
 
 [b51463.cmd_8557]
@@ -69497,7 +69497,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b91223\b91223\b91223.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b91223\b91223
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL
+Categories=NEW_PASS;Pri0;JIT;EXPECTED_PASS
 HostStyle=0
 
 [b91230.cmd_8802]
@@ -70449,7 +70449,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b425314\b425314\b425314.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b425314\b425314
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=REGRESS;Pri0;EXPECTED_FAIL;LONG_RUNNING
+Categories=REGRESS;Pri0;LONG_RUNNING;NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [b426654.cmd_8926]
@@ -72513,7 +72513,7 @@ RelativePath=JIT\Regression\VS-ia64-JIT\V1.2-M02\b28158\b28158\b28158.cmd
 WorkingDir=JIT\Regression\VS-ia64-JIT\V1.2-M02\b28158\b28158
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=LONG_RUNNING;Pri0;JIT;EXPECTED_PASS
+Categories=Pri0;LONG_RUNNING;JIT;EXPECTED_PASS
 HostStyle=0
 
 [b28158_64.cmd_9185]
@@ -74553,7 +74553,7 @@ RelativePath=Loader\classloader\generics\Instantiation\Recursion\RecursiveInheri
 WorkingDir=Loader\classloader\generics\Instantiation\Recursion\RecursiveInheritance
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [Struct_ImplementMscorlibGenInterface.cmd_9441]
@@ -77865,7 +77865,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_278371\DevDiv_278371\DevDiv_278371.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_278371\DevDiv_278371
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9458;NEW
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [Generated193.cmd_9855]
@@ -77873,7 +77873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest193\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest193\Generated193
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1415.cmd_9856]
@@ -77881,7 +77881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1415\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1415\Generated1415
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1246.cmd_9857]
@@ -77889,7 +77889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1246\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1246\Generated1246
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1313.cmd_9858]
@@ -77897,7 +77897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1313\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1313\Generated1313
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated80.cmd_9859]
@@ -77905,7 +77905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest80\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest80\Generated80
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1482.cmd_9860]
@@ -77913,7 +77913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1482\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1482\Generated1482
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated560.cmd_9861]
@@ -77921,7 +77921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest560\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest560\Generated560
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated864.cmd_9862]
@@ -77929,7 +77929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest864\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest864\Generated864
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated344.cmd_9863]
@@ -77937,7 +77937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest344\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest344\Generated344
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated507.cmd_9864]
@@ -77945,7 +77945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest507\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest507\Generated507
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated223.cmd_9865]
@@ -77953,7 +77953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest223\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest223\Generated223
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b410474.cmd_9866]
@@ -77961,7 +77961,7 @@ RelativePath=JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b410474\b410474\b410474.cmd
 WorkingDir=JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b410474\b410474
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated1156.cmd_9867]
@@ -77969,7 +77969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1156\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1156\Generated1156
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1330.cmd_9868]
@@ -77977,7 +77977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1330\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1330\Generated1330
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated349.cmd_9869]
@@ -77985,7 +77985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest349\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest349\Generated349
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated766.cmd_9870]
@@ -77993,7 +77993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest766\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest766\Generated766
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1222.cmd_9871]
@@ -78001,7 +78001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1222\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1222\Generated1222
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated517.cmd_9872]
@@ -78009,7 +78009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest517\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest517\Generated517
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated997.cmd_9873]
@@ -78017,7 +78017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest997\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest997\Generated997
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated88.cmd_9874]
@@ -78025,7 +78025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest88\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest88\Generated88
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated847.cmd_9875]
@@ -78033,7 +78033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest847\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest847\Generated847
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated895.cmd_9876]
@@ -78041,7 +78041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest895\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest895\Generated895
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated286.cmd_9877]
@@ -78049,7 +78049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest286\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest286\Generated286
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1302.cmd_9878]
@@ -78057,7 +78057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1302\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1302\Generated1302
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated90.cmd_9879]
@@ -78065,7 +78065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest90\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest90\Generated90
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated464.cmd_9880]
@@ -78073,7 +78073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest464\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest464\Generated464
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated679.cmd_9881]
@@ -78081,7 +78081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest679\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest679\Generated679
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated869.cmd_9882]
@@ -78089,7 +78089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest869\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest869\Generated869
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1124.cmd_9883]
@@ -78097,7 +78097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1124\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1124\Generated1124
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated559.cmd_9884]
@@ -78105,7 +78105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest559\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest559\Generated559
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b07847.cmd_9885]
@@ -78113,7 +78113,7 @@ RelativePath=JIT\Regression\CLR-x86-EJIT\v1-m10\b07847\b07847\b07847.cmd
 WorkingDir=JIT\Regression\CLR-x86-EJIT\v1-m10\b07847\b07847
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated554.cmd_9886]
@@ -78121,7 +78121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest554\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest554\Generated554
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i60.cmd_9887]
@@ -78129,7 +78129,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i60\mcc_i60.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i60
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1394.cmd_9888]
@@ -78137,7 +78137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1394\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1394\Generated1394
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated772.cmd_9889]
@@ -78145,7 +78145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest772\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest772\Generated772
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1403.cmd_9890]
@@ -78153,7 +78153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1403\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1403\Generated1403
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated610.cmd_9891]
@@ -78161,7 +78161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest610\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest610\Generated610
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated785.cmd_9892]
@@ -78169,7 +78169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest785\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest785\Generated785
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated703.cmd_9893]
@@ -78177,7 +78177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest703\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest703\Generated703
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated753.cmd_9894]
@@ -78185,7 +78185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest753\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest753\Generated753
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated146.cmd_9895]
@@ -78193,7 +78193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest146\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest146\Generated146
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated527.cmd_9896]
@@ -78201,7 +78201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest527\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest527\Generated527
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated592.cmd_9897]
@@ -78209,7 +78209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest592\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest592\Generated592
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [uint64Opt_ro.cmd_9898]
@@ -78217,7 +78217,7 @@ RelativePath=JIT\Directed\shift\uint64Opt_ro\uint64Opt_ro.cmd
 WorkingDir=JIT\Directed\shift\uint64Opt_ro
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated425.cmd_9899]
@@ -78225,7 +78225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest425\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest425\Generated425
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated885.cmd_9900]
@@ -78233,7 +78233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest885\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest885\Generated885
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1396.cmd_9901]
@@ -78241,7 +78241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1396\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1396\Generated1396
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Test7685.cmd_9902]
@@ -78249,7 +78249,7 @@ RelativePath=Regressions\coreclr\GitHub_7685\Test7685\Test7685.cmd
 WorkingDir=Regressions\coreclr\GitHub_7685\Test7685
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated921.cmd_9903]
@@ -78257,7 +78257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest921\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest921\Generated921
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_278376.cmd_9904]
@@ -78265,7 +78265,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_278376\DevDiv_278376\DevDiv_278376.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_278376\DevDiv_278376
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_dbgsin_cs_il.cmd_9905]
@@ -78273,7 +78273,7 @@ RelativePath=JIT\Methodical\Boxing\xlang\_dbgsin_cs_il\_dbgsin_cs_il.cmd
 WorkingDir=JIT\Methodical\Boxing\xlang\_dbgsin_cs_il
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated883.cmd_9906]
@@ -78281,7 +78281,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest883\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest883\Generated883
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated471.cmd_9907]
@@ -78289,7 +78289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest471\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest471\Generated471
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1015.cmd_9908]
@@ -78297,7 +78297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1015\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1015\Generated1015
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated528.cmd_9909]
@@ -78305,7 +78305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest528\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest528\Generated528
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [pinvoke-examples.cmd_9910]
@@ -78313,7 +78313,7 @@ RelativePath=JIT\Directed\pinvoke\pinvoke-examples\pinvoke-examples.cmd
 WorkingDir=JIT\Directed\pinvoke\pinvoke-examples
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DivConst.cmd_9911]
@@ -78321,7 +78321,7 @@ RelativePath=JIT\CodeGenBringUpTests\DivConst\DivConst.cmd
 WorkingDir=JIT\CodeGenBringUpTests\DivConst
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated648.cmd_9912]
@@ -78329,7 +78329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest648\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest648\Generated648
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1446.cmd_9913]
@@ -78337,7 +78337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1446\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1446\Generated1446
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1257.cmd_9914]
@@ -78345,7 +78345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1257\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1257\Generated1257
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated285.cmd_9915]
@@ -78353,7 +78353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest285\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest285\Generated285
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated971.cmd_9916]
@@ -78361,7 +78361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest971\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest971\Generated971
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1065.cmd_9917]
@@ -78369,7 +78369,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1065\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1065\Generated1065
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated435.cmd_9918]
@@ -78377,7 +78377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest435\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest435\Generated435
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated16.cmd_9919]
@@ -78385,7 +78385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest16\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest16\Generated16
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated195.cmd_9920]
@@ -78393,7 +78393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest195\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest195\Generated195
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated520.cmd_9921]
@@ -78401,7 +78401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest520\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest520\Generated520
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated143.cmd_9922]
@@ -78409,7 +78409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest143\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest143\Generated143
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1092.cmd_9923]
@@ -78417,7 +78417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1092\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1092\Generated1092
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated145.cmd_9924]
@@ -78425,7 +78425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest145\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest145\Generated145
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated649.cmd_9925]
@@ -78433,7 +78433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest649\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest649\Generated649
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated79.cmd_9926]
@@ -78441,7 +78441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest79\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest79\Generated79
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1310.cmd_9927]
@@ -78449,7 +78449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1310\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1310\Generated1310
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated911.cmd_9928]
@@ -78457,7 +78457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest911\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest911\Generated911
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated419.cmd_9929]
@@ -78465,7 +78465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest419\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest419\Generated419
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated290.cmd_9930]
@@ -78473,7 +78473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest290\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest290\Generated290
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_359733.cmd_9931]
@@ -78481,7 +78481,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_359733\DevDiv_359733\DevDiv_359733.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_359733\DevDiv_359733
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated730.cmd_9932]
@@ -78489,7 +78489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest730\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest730\Generated730
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated13.cmd_9933]
@@ -78497,7 +78497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest13\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest13\Generated13
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated750.cmd_9934]
@@ -78505,7 +78505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest750\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest750\Generated750
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1285.cmd_9935]
@@ -78513,7 +78513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1285\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1285\Generated1285
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated689.cmd_9936]
@@ -78521,7 +78521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest689\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest689\Generated689
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1395.cmd_9937]
@@ -78529,7 +78529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1395\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1395\Generated1395
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1409.cmd_9938]
@@ -78537,7 +78537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1409\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1409\Generated1409
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1010.cmd_9939]
@@ -78545,7 +78545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1010\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1010\Generated1010
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [536168.cmd_9940]
@@ -78553,7 +78553,7 @@ RelativePath=GC\Regressions\dev10bugs\536168\536168\536168.cmd
 WorkingDir=GC\Regressions\dev10bugs\536168\536168
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated1498.cmd_9941]
@@ -78561,7 +78561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1498\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1498\Generated1498
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated619.cmd_9942]
@@ -78569,7 +78569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest619\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest619\Generated619
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated240.cmd_9943]
@@ -78577,7 +78577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest240\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest240\Generated240
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_280123.cmd_9944]
@@ -78585,7 +78585,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_280123\DevDiv_280123\DevDiv_280123.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_280123\DevDiv_280123
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated405.cmd_9945]
@@ -78593,7 +78593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest405\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest405\Generated405
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated220.cmd_9946]
@@ -78601,7 +78601,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest220\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest220\Generated220
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated105.cmd_9947]
@@ -78609,7 +78609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest105\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest105\Generated105
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated867.cmd_9948]
@@ -78617,7 +78617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest867\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest867\Generated867
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1318.cmd_9949]
@@ -78625,7 +78625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1318\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1318\Generated1318
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1404.cmd_9950]
@@ -78633,7 +78633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1404\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1404\Generated1404
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated903.cmd_9951]
@@ -78641,7 +78641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest903\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest903\Generated903
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated524.cmd_9952]
@@ -78649,7 +78649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest524\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest524\Generated524
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated0.cmd_9953]
@@ -78657,7 +78657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest0\Generated0
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest0\Generated0
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated95.cmd_9954]
@@ -78665,7 +78665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest95\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest95\Generated95
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_377155.cmd_9955]
@@ -78673,7 +78673,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_377155\DevDiv_377155\DevDiv_377155.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_377155\DevDiv_377155
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated9.cmd_9956]
@@ -78681,7 +78681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest9\Generated9
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest9\Generated9
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated877.cmd_9957]
@@ -78689,7 +78689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest877\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest877\Generated877
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated175.cmd_9958]
@@ -78697,7 +78697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest175\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest175\Generated175
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated824.cmd_9959]
@@ -78705,7 +78705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest824\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest824\Generated824
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated621.cmd_9960]
@@ -78713,7 +78713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest621\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest621\Generated621
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1496.cmd_9961]
@@ -78721,7 +78721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1496\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1496\Generated1496
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated416.cmd_9962]
@@ -78729,7 +78729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest416\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest416\Generated416
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [rvastatic2.cmd_9963]
@@ -78737,7 +78737,7 @@ RelativePath=JIT\Directed\rvastatics\rvastatic2\rvastatic2.cmd
 WorkingDir=JIT\Directed\rvastatics\rvastatic2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated748.cmd_9964]
@@ -78745,7 +78745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest748\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest748\Generated748
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1354.cmd_9965]
@@ -78753,7 +78753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1354\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1354\Generated1354
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated298.cmd_9966]
@@ -78761,7 +78761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest298\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest298\Generated298
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated409.cmd_9967]
@@ -78769,7 +78769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest409\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest409\Generated409
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated976.cmd_9968]
@@ -78777,7 +78777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest976\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest976\Generated976
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated27.cmd_9969]
@@ -78785,7 +78785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest27\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest27\Generated27
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated23.cmd_9970]
@@ -78793,7 +78793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest23\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest23\Generated23
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated72.cmd_9971]
@@ -78801,7 +78801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest72\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest72\Generated72
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1137.cmd_9972]
@@ -78809,7 +78809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1137\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1137\Generated1137
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [valuetuple.cmd_9973]
@@ -78817,7 +78817,7 @@ RelativePath=JIT\Methodical\structs\valuetuple\valuetuple.cmd
 WorkingDir=JIT\Methodical\structs\valuetuple
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated618.cmd_9974]
@@ -78825,7 +78825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest618\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest618\Generated618
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated651.cmd_9975]
@@ -78833,7 +78833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest651\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest651\Generated651
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated880.cmd_9976]
@@ -78841,7 +78841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest880\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest880\Generated880
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [reregisterforfinalize.cmd_9977]
@@ -78849,7 +78849,7 @@ RelativePath=GC\LargeMemory\API\gc\reregisterforfinalize\reregisterforfinalize.c
 WorkingDir=GC\LargeMemory\API\gc\reregisterforfinalize
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1452.cmd_9978]
@@ -78857,7 +78857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1452\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1452\Generated1452
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated101.cmd_9979]
@@ -78865,7 +78865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest101\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest101\Generated101
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1281.cmd_9980]
@@ -78873,7 +78873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1281\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1281\Generated1281
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated861.cmd_9981]
@@ -78881,7 +78881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest861\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest861\Generated861
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [SeekUnroll.cmd_9982]
@@ -78889,7 +78889,7 @@ RelativePath=JIT\Performance\CodeQuality\SIMD\SeekUnroll\SeekUnroll\SeekUnroll.c
 WorkingDir=JIT\Performance\CodeQuality\SIMD\SeekUnroll\SeekUnroll
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated848.cmd_9983]
@@ -78897,7 +78897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest848\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest848\Generated848
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated860.cmd_9984]
@@ -78905,7 +78905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest860\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest860\Generated860
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1118.cmd_9985]
@@ -78913,7 +78913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1118\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1118\Generated1118
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated486.cmd_9986]
@@ -78921,7 +78921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest486\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest486\Generated486
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated367.cmd_9987]
@@ -78929,7 +78929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest367\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest367\Generated367
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_278523.cmd_9988]
@@ -78937,7 +78937,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_278523\DevDiv_278523\DevDiv_278523.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_278523\DevDiv_278523
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1479.cmd_9989]
@@ -78945,7 +78945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1479\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1479\Generated1479
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated544.cmd_9990]
@@ -78953,7 +78953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest544\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest544\Generated544
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated570.cmd_9991]
@@ -78961,7 +78961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest570\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest570\Generated570
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated153.cmd_9992]
@@ -78969,7 +78969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest153\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest153\Generated153
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated989.cmd_9993]
@@ -78977,7 +78977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest989\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest989\Generated989
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated360.cmd_9994]
@@ -78985,7 +78985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest360\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest360\Generated360
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [getgeneration.cmd_9995]
@@ -78993,7 +78993,7 @@ RelativePath=GC\LargeMemory\API\gc\getgeneration\getgeneration.cmd
 WorkingDir=GC\LargeMemory\API\gc\getgeneration
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [DevDiv_370233.cmd_9996]
@@ -79001,7 +79001,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_370233\DevDiv_370233\DevDiv_370233.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_370233\DevDiv_370233
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1432.cmd_9997]
@@ -79009,7 +79009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1432\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1432\Generated1432
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b409748.cmd_9998]
@@ -79017,7 +79017,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b409748\b409748\b409748.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b409748\b409748
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1366.cmd_9999]
@@ -79025,7 +79025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1366\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1366\Generated1366
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated645.cmd_10000]
@@ -79033,7 +79033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest645\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest645\Generated645
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated990.cmd_10001]
@@ -79041,7 +79041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest990\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest990\Generated990
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1060.cmd_10002]
@@ -79049,7 +79049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1060\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1060\Generated1060
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated709.cmd_10003]
@@ -79057,7 +79057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest709\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest709\Generated709
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated508.cmd_10004]
@@ -79065,7 +79065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest508\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest508\Generated508
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [uint64Opt_r.cmd_10005]
@@ -79073,7 +79073,7 @@ RelativePath=JIT\Directed\shift\uint64Opt_r\uint64Opt_r.cmd
 WorkingDir=JIT\Directed\shift\uint64Opt_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1078.cmd_10006]
@@ -79081,7 +79081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1078\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1078\Generated1078
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1405.cmd_10007]
@@ -79089,7 +79089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1405\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1405\Generated1405
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1192.cmd_10008]
@@ -79097,7 +79097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1192\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1192\Generated1192
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated945.cmd_10009]
@@ -79105,7 +79105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest945\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest945\Generated945
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated165.cmd_10010]
@@ -79113,7 +79113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest165\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest165\Generated165
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated792.cmd_10011]
@@ -79121,7 +79121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest792\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest792\Generated792
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1233.cmd_10012]
@@ -79129,7 +79129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1233\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1233\Generated1233
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated546.cmd_10013]
@@ -79137,7 +79137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest546\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest546\Generated546
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated61.cmd_10014]
@@ -79145,7 +79145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest61\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest61\Generated61
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated76.cmd_10015]
@@ -79153,7 +79153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest76\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest76\Generated76
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [lohfragmentation.cmd_10016]
@@ -79161,7 +79161,7 @@ RelativePath=GC\Features\LOHFragmentation\lohfragmentation\lohfragmentation.cmd
 WorkingDir=GC\Features\LOHFragmentation\lohfragmentation
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated336.cmd_10017]
@@ -79169,7 +79169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest336\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest336\Generated336
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1234.cmd_10018]
@@ -79177,7 +79177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1234\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1234\Generated1234
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated795.cmd_10019]
@@ -79185,7 +79185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest795\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest795\Generated795
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated788.cmd_10020]
@@ -79193,7 +79193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest788\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest788\Generated788
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1459.cmd_10021]
@@ -79201,7 +79201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1459\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1459\Generated1459
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated872.cmd_10022]
@@ -79209,7 +79209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest872\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest872\Generated872
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated843.cmd_10023]
@@ -79217,7 +79217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest843\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest843\Generated843
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated479.cmd_10024]
@@ -79225,7 +79225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest479\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest479\Generated479
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated889.cmd_10025]
@@ -79233,7 +79233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest889\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest889\Generated889
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated999.cmd_10026]
@@ -79241,7 +79241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest999\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest999\Generated999
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated874.cmd_10027]
@@ -79249,7 +79249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest874\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest874\Generated874
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1424.cmd_10028]
@@ -79257,7 +79257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1424\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1424\Generated1424
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Vector3Test.cmd_10029]
@@ -79265,7 +79265,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_7508\Vector3Test\Vector3Test.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_7508\Vector3Test
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated245.cmd_10030]
@@ -79273,7 +79273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest245\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest245\Generated245
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_278372.cmd_10031]
@@ -79281,7 +79281,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_278372\DevDiv_278372\DevDiv_278372.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_278372\DevDiv_278372
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated431.cmd_10032]
@@ -79289,7 +79289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest431\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest431\Generated431
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated963.cmd_10033]
@@ -79297,7 +79297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest963\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest963\Generated963
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_FAIL;9457
 HostStyle=0
 
 [Generated407.cmd_10034]
@@ -79305,7 +79305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest407\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest407\Generated407
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1143.cmd_10035]
@@ -79313,7 +79313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1143\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1143\Generated1143
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1381.cmd_10036]
@@ -79321,7 +79321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1381\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1381\Generated1381
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1028.cmd_10037]
@@ -79329,7 +79329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1028\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1028\Generated1028
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b32374.cmd_10038]
@@ -79337,7 +79337,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b32374\b32374\b32374.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b32374\b32374
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [BestFitMapping.cmd_10039]
@@ -79345,7 +79345,7 @@ RelativePath=Interop\BestFitMapping\BestFitMapping\BestFitMapping.cmd
 WorkingDir=Interop\BestFitMapping\BestFitMapping
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated21.cmd_10040]
@@ -79353,7 +79353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest21\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest21\Generated21
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated593.cmd_10041]
@@ -79361,7 +79361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest593\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest593\Generated593
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsByte.cmd_10042]
@@ -79369,7 +79369,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsByte\ConstantArgsB
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsByte
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1478.cmd_10043]
@@ -79377,7 +79377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1478\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1478\Generated1478
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated385.cmd_10044]
@@ -79385,7 +79385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest385\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest385\Generated385
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated460.cmd_10045]
@@ -79393,7 +79393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest460\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest460\Generated460
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1218.cmd_10046]
@@ -79401,7 +79401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1218\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1218\Generated1218
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1439.cmd_10047]
@@ -79409,7 +79409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1439\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1439\Generated1439
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1221.cmd_10048]
@@ -79417,7 +79417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1221\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1221\Generated1221
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated514.cmd_10049]
@@ -79425,7 +79425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest514\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest514\Generated514
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1283.cmd_10050]
@@ -79433,7 +79433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1283\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1283\Generated1283
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1278.cmd_10051]
@@ -79441,7 +79441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1278\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1278\Generated1278
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1284.cmd_10052]
@@ -79449,7 +79449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1284\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1284\Generated1284
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated978.cmd_10053]
@@ -79457,7 +79457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest978\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest978\Generated978
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated179.cmd_10054]
@@ -79465,7 +79465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest179\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest179\Generated179
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated261.cmd_10055]
@@ -79473,7 +79473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest261\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest261\Generated261
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated879.cmd_10056]
@@ -79481,7 +79481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest879\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest879\Generated879
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated355.cmd_10057]
@@ -79489,7 +79489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest355\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest355\Generated355
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1288.cmd_10058]
@@ -79497,7 +79497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1288\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1288\Generated1288
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [nonrefsdarr_il_d.cmd_10059]
@@ -79505,7 +79505,7 @@ RelativePath=JIT\Directed\coverage\importer\Desktop\nonrefsdarr_il_d\nonrefsdarr
 WorkingDir=JIT\Directed\coverage\importer\Desktop\nonrefsdarr_il_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9465;NEW
+Categories=9465;EXPECTED_FAIL
 HostStyle=0
 
 [Generated987.cmd_10060]
@@ -79513,7 +79513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest987\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest987\Generated987
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_1206929.cmd_10061]
@@ -79521,7 +79521,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_1206929\DevDiv_1206929\DevDiv_1206929
 WorkingDir=JIT\Regression\JitBlue\DevDiv_1206929\DevDiv_1206929
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1127.cmd_10062]
@@ -79529,7 +79529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1127\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1127\Generated1127
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1444.cmd_10063]
@@ -79537,7 +79537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1444\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1444\Generated1444
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated733.cmd_10064]
@@ -79545,7 +79545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest733\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest733\Generated733
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated466.cmd_10065]
@@ -79553,7 +79553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest466\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest466\Generated466
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated358.cmd_10066]
@@ -79561,7 +79561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest358\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest358\Generated358
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated896.cmd_10067]
@@ -79569,7 +79569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest896\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest896\Generated896
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated894.cmd_10068]
@@ -79577,7 +79577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest894\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest894\Generated894
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1152.cmd_10069]
@@ -79585,7 +79585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1152\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1152\Generated1152
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated129.cmd_10070]
@@ -79593,7 +79593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest129\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest129\Generated129
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_362706.cmd_10071]
@@ -79601,7 +79601,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_362706\DevDiv_362706\DevDiv_362706.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_362706\DevDiv_362706
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated606.cmd_10072]
@@ -79609,7 +79609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest606\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest606\Generated606
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_il_relseq.cmd_10073]
@@ -79617,7 +79617,7 @@ RelativePath=JIT\Methodical\refany\_il_relseq\_il_relseq.cmd
 WorkingDir=JIT\Methodical\refany\_il_relseq
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1476.cmd_10074]
@@ -79625,7 +79625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1476\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1476\Generated1476
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1073.cmd_10075]
@@ -79633,7 +79633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1073\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1073\Generated1073
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1305.cmd_10076]
@@ -79641,7 +79641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1305\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1305\Generated1305
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1464.cmd_10077]
@@ -79649,7 +79649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1464\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1464\Generated1464
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1449.cmd_10078]
@@ -79657,7 +79657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1449\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1449\Generated1449
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated111.cmd_10079]
@@ -79665,7 +79665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest111\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest111\Generated111
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1263.cmd_10080]
@@ -79673,7 +79673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1263\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1263\Generated1263
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated985.cmd_10081]
@@ -79681,7 +79681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest985\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest985\Generated985
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated535.cmd_10082]
@@ -79689,7 +79689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest535\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest535\Generated535
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1050.cmd_10083]
@@ -79697,7 +79697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1050\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1050\Generated1050
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated281.cmd_10084]
@@ -79705,7 +79705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest281\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest281\Generated281
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated951.cmd_10085]
@@ -79713,7 +79713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest951\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest951\Generated951
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1075.cmd_10086]
@@ -79721,7 +79721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1075\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1075\Generated1075
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [basefinal.cmd_10087]
@@ -79729,7 +79729,7 @@ RelativePath=GC\Scenarios\BaseFinal\basefinal\basefinal.cmd
 WorkingDir=GC\Scenarios\BaseFinal\basefinal
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1357.cmd_10088]
@@ -79737,7 +79737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1357\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1357\Generated1357
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated299.cmd_10089]
@@ -79745,7 +79745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest299\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest299\Generated299
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated624.cmd_10090]
@@ -79753,7 +79753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest624\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest624\Generated624
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated258.cmd_10091]
@@ -79761,7 +79761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest258\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest258\Generated258
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [TailcallVerifyWithPrefix.cmd_10092]
@@ -79769,7 +79769,7 @@ RelativePath=JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.
 WorkingDir=JIT\opt\Tailcall\TailcallVerifyWithPrefix
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated611.cmd_10093]
@@ -79777,7 +79777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest611\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest611\Generated611
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1375.cmd_10094]
@@ -79785,7 +79785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1375\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1375\Generated1375
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [arglist.cmd_10095]
@@ -79793,7 +79793,7 @@ RelativePath=JIT\Directed\PREFIX\unaligned\2\arglist\arglist.cmd
 WorkingDir=JIT\Directed\PREFIX\unaligned\2\arglist
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated404.cmd_10096]
@@ -79801,7 +79801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest404\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest404\Generated404
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated214.cmd_10097]
@@ -79809,7 +79809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest214\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest214\Generated214
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated799.cmd_10098]
@@ -79817,7 +79817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest799\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest799\Generated799
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated332.cmd_10099]
@@ -79825,7 +79825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest332\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest332\Generated332
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated666.cmd_10100]
@@ -79833,7 +79833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest666\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest666\Generated666
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1296.cmd_10101]
@@ -79841,7 +79841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1296\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1296\Generated1296
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated373.cmd_10102]
@@ -79849,7 +79849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest373\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest373\Generated373
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1066.cmd_10103]
@@ -79857,7 +79857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1066\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1066\Generated1066
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1005.cmd_10104]
@@ -79865,7 +79865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1005\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1005\Generated1005
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated210.cmd_10105]
@@ -79873,7 +79873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest210\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest210\Generated210
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1159.cmd_10106]
@@ -79881,7 +79881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1159\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1159\Generated1159
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b102637.cmd_10107]
@@ -79889,7 +79889,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b102637\b102637\b102637.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b102637\b102637
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [ExecuteCodeWithGuaranteedCleanup.cmd_10108]
@@ -79897,7 +79897,7 @@ RelativePath=baseservices\compilerservices\RuntimeHelpers\ExecuteCodeWithGuarant
 WorkingDir=baseservices\compilerservices\RuntimeHelpers\ExecuteCodeWithGuaranteedCleanup
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated742.cmd_10109]
@@ -79905,7 +79905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest742\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest742\Generated742
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated537.cmd_10110]
@@ -79913,7 +79913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest537\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest537\Generated537
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated759.cmd_10111]
@@ -79921,7 +79921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest759\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest759\Generated759
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1408.cmd_10112]
@@ -79929,7 +79929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1408\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1408\Generated1408
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated294.cmd_10113]
@@ -79937,7 +79937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest294\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest294\Generated294
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated312.cmd_10114]
@@ -79945,7 +79945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest312\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest312\Generated312
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated402.cmd_10115]
@@ -79953,7 +79953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest402\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest402\Generated402
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1489.cmd_10116]
@@ -79961,7 +79961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1489\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1489\Generated1489
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1326.cmd_10117]
@@ -79969,7 +79969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1326\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1326\Generated1326
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1254.cmd_10118]
@@ -79977,7 +79977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1254\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1254\Generated1254
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated668.cmd_10119]
@@ -79985,7 +79985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest668\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest668\Generated668
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated811.cmd_10120]
@@ -79993,7 +79993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest811\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest811\Generated811
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated384.cmd_10121]
@@ -80001,7 +80001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest384\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest384\Generated384
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1109.cmd_10122]
@@ -80009,7 +80009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1109\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1109\Generated1109
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1163.cmd_10123]
@@ -80017,7 +80017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1163\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1163\Generated1163
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [MarshalStructure.cmd_10124]
@@ -80025,7 +80025,7 @@ RelativePath=Interop\MarshalAPI\MarshalStructure\MarshalStructure\MarshalStructu
 WorkingDir=Interop\MarshalAPI\MarshalStructure\MarshalStructure
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i32.cmd_10125]
@@ -80033,7 +80033,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i32\mcc_i32.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i32
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated778.cmd_10126]
@@ -80041,7 +80041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest778\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest778\Generated778
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1229.cmd_10127]
@@ -80049,7 +80049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1229\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1229\Generated1229
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1376.cmd_10128]
@@ -80057,7 +80057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1376\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1376\Generated1376
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated251.cmd_10129]
@@ -80065,7 +80065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest251\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest251\Generated251
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated325.cmd_10130]
@@ -80073,7 +80073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest325\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest325\Generated325
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated222.cmd_10131]
@@ -80081,7 +80081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest222\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest222\Generated222
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated455.cmd_10132]
@@ -80089,7 +80089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest455\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest455\Generated455
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated922.cmd_10133]
@@ -80097,7 +80097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest922\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest922\Generated922
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1232.cmd_10134]
@@ -80105,7 +80105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1232\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1232\Generated1232
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated74.cmd_10135]
@@ -80113,7 +80113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest74\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest74\Generated74
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated589.cmd_10136]
@@ -80121,7 +80121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest589\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest589\Generated589
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated825.cmd_10137]
@@ -80129,7 +80129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest825\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest825\Generated825
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1043.cmd_10138]
@@ -80137,7 +80137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1043\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1043\Generated1043
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [SizeConstTest.cmd_10139]
@@ -80145,7 +80145,7 @@ RelativePath=Interop\SizeConst\SizeConstTest\SizeConstTest.cmd
 WorkingDir=Interop\SizeConst\SizeConstTest
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1186.cmd_10140]
@@ -80153,7 +80153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1186\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1186\Generated1186
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated377.cmd_10141]
@@ -80161,7 +80161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest377\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest377\Generated377
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated207.cmd_10142]
@@ -80169,7 +80169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest207\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest207\Generated207
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated932.cmd_10143]
@@ -80177,7 +80177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest932\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest932\Generated932
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1201.cmd_10144]
@@ -80185,7 +80185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1201\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1201\Generated1201
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated950.cmd_10145]
@@ -80193,7 +80193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest950\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest950\Generated950
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated25.cmd_10146]
@@ -80201,7 +80201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest25\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest25\Generated25
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated209.cmd_10147]
@@ -80209,7 +80209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest209\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest209\Generated209
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1093.cmd_10148]
@@ -80217,7 +80217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1093\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1093\Generated1093
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated719.cmd_10149]
@@ -80225,7 +80225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest719\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest719\Generated719
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1082.cmd_10150]
@@ -80233,7 +80233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1082\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1082\Generated1082
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated221.cmd_10151]
@@ -80241,7 +80241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest221\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest221\Generated221
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated501.cmd_10152]
@@ -80249,7 +80249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest501\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest501\Generated501
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b28901.cmd_10153]
@@ -80257,7 +80257,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28901\b28901\b28901.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28901\b28901
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated659.cmd_10154]
@@ -80265,7 +80265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest659\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest659\Generated659
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated60.cmd_10155]
@@ -80273,7 +80273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest60\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest60\Generated60
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1120.cmd_10156]
@@ -80281,7 +80281,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1120\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1120\Generated1120
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1304.cmd_10157]
@@ -80289,7 +80289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1304\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1304\Generated1304
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i10.cmd_10158]
@@ -80297,7 +80297,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i10\mcc_i10.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i10
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [overlap.cmd_10159]
@@ -80305,7 +80305,7 @@ RelativePath=JIT\Directed\RVAInit\overlap\overlap.cmd
 WorkingDir=JIT\Directed\RVAInit\overlap
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [b30838.cmd_10160]
@@ -80313,7 +80313,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30838\b30838\b30838.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30838\b30838
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1430.cmd_10161]
@@ -80321,7 +80321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1430\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1430\Generated1430
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated746.cmd_10162]
@@ -80329,7 +80329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest746\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest746\Generated746
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1370.cmd_10163]
@@ -80337,7 +80337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1370\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1370\Generated1370
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mutualrecurthd-tls.cmd_10164]
@@ -80345,7 +80345,7 @@ RelativePath=JIT\Directed\tls\mutualrecurthd-tls\mutualrecurthd-tls.cmd
 WorkingDir=JIT\Directed\tls\mutualrecurthd-tls
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated461.cmd_10165]
@@ -80353,7 +80353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest461\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest461\Generated461
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated457.cmd_10166]
@@ -80361,7 +80361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest457\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest457\Generated457
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1041.cmd_10167]
@@ -80369,7 +80369,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1041\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1041\Generated1041
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated661.cmd_10168]
@@ -80377,7 +80377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest661\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest661\Generated661
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated519.cmd_10169]
@@ -80385,7 +80385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest519\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest519\Generated519
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_8599.cmd_10170]
@@ -80393,7 +80393,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_8599\GitHub_8599\GitHub_8599.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_8599\GitHub_8599
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated704.cmd_10171]
@@ -80401,7 +80401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest704\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest704\Generated704
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated458.cmd_10172]
@@ -80409,7 +80409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest458\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest458\Generated458
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [arglist.cmd_10173]
@@ -80417,7 +80417,7 @@ RelativePath=JIT\Directed\PREFIX\volatile\1\arglist\arglist.cmd
 WorkingDir=JIT\Directed\PREFIX\volatile\1\arglist
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated995.cmd_10174]
@@ -80425,7 +80425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest995\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest995\Generated995
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated937.cmd_10175]
@@ -80433,7 +80433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest937\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest937\Generated937
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated51.cmd_10176]
@@ -80441,7 +80441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest51\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest51\Generated51
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated947.cmd_10177]
@@ -80449,7 +80449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest947\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest947\Generated947
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated575.cmd_10178]
@@ -80457,7 +80457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest575\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest575\Generated575
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [271010.cmd_10179]
@@ -80465,7 +80465,7 @@ RelativePath=GC\Coverage\271010\271010.cmd
 WorkingDir=GC\Coverage\271010
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated933.cmd_10180]
@@ -80473,7 +80473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest933\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest933\Generated933
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated452.cmd_10181]
@@ -80481,7 +80481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest452\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest452\Generated452
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1306.cmd_10182]
@@ -80489,7 +80489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1306\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1306\Generated1306
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1072.cmd_10183]
@@ -80497,7 +80497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1072\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1072\Generated1072
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1483.cmd_10184]
@@ -80505,7 +80505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1483\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1483\Generated1483
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1172.cmd_10185]
@@ -80513,7 +80513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1172\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1172\Generated1172
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1035.cmd_10186]
@@ -80521,7 +80521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1035\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1035\Generated1035
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [rva_rvastatic1.cmd_10187]
@@ -80529,7 +80529,7 @@ RelativePath=JIT\Directed\intrinsic\interlocked\rva_rvastatic1\rva_rvastatic1.cm
 WorkingDir=JIT\Directed\intrinsic\interlocked\rva_rvastatic1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated1145.cmd_10188]
@@ -80537,7 +80537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1145\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1145\Generated1145
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated357.cmd_10189]
@@ -80545,7 +80545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest357\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest357\Generated357
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated904.cmd_10190]
@@ -80553,7 +80553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest904\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest904\Generated904
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated888.cmd_10191]
@@ -80561,7 +80561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest888\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest888\Generated888
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1267.cmd_10192]
@@ -80569,7 +80569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1267\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1267\Generated1267
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated31.cmd_10193]
@@ -80577,7 +80577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest31\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest31\Generated31
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1481.cmd_10194]
@@ -80585,7 +80585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1481\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1481\Generated1481
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9459;NEW
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [Generated371.cmd_10195]
@@ -80593,7 +80593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest371\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest371\Generated371
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1193.cmd_10196]
@@ -80601,7 +80601,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1193\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1193\Generated1193
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated841.cmd_10197]
@@ -80609,7 +80609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest841\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest841\Generated841
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9464;NEW
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [GitHub_7906.cmd_10198]
@@ -80617,7 +80617,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_7906\GitHub_7906\GitHub_7906.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_7906\GitHub_7906
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [Generated734.cmd_10199]
@@ -80625,7 +80625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest734\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest734\Generated734
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [Generated783.cmd_10200]
@@ -80633,7 +80633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest783\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest783\Generated783
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [Generated1387.cmd_10201]
@@ -80641,7 +80641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1387\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1387\Generated1387
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1360.cmd_10202]
@@ -80649,7 +80649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1360\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1360\Generated1360
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1348.cmd_10203]
@@ -80657,7 +80657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1348\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1348\Generated1348
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated868.cmd_10204]
@@ -80665,7 +80665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest868\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest868\Generated868
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated497.cmd_10205]
@@ -80673,7 +80673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest497\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest497\Generated497
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated339.cmd_10206]
@@ -80681,7 +80681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest339\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest339\Generated339
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated612.cmd_10207]
@@ -80689,7 +80689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest612\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest612\Generated612
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated103.cmd_10208]
@@ -80697,7 +80697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest103\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest103\Generated103
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated662.cmd_10209]
@@ -80705,7 +80705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest662\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest662\Generated662
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated156.cmd_10210]
@@ -80713,7 +80713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest156\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest156\Generated156
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated82.cmd_10211]
@@ -80721,7 +80721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest82\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest82\Generated82
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated22.cmd_10212]
@@ -80729,7 +80729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest22\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest22\Generated22
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_359736_ro.cmd_10213]
@@ -80737,7 +80737,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_359736\DevDiv_359736_ro\DevDiv_359736
 WorkingDir=JIT\Regression\JitBlue\DevDiv_359736\DevDiv_359736_ro
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated1104.cmd_10214]
@@ -80745,7 +80745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1104\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1104\Generated1104
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated410.cmd_10215]
@@ -80753,7 +80753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest410\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest410\Generated410
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1149.cmd_10216]
@@ -80761,7 +80761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1149\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1149\Generated1149
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated390.cmd_10217]
@@ -80769,7 +80769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest390\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest390\Generated390
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated681.cmd_10218]
@@ -80777,7 +80777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest681\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest681\Generated681
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated754.cmd_10219]
@@ -80785,7 +80785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest754\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest754\Generated754
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1299.cmd_10220]
@@ -80793,7 +80793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1299\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1299\Generated1299
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated556.cmd_10221]
@@ -80801,7 +80801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest556\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest556\Generated556
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated133.cmd_10222]
@@ -80809,7 +80809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest133\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest133\Generated133
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1435.cmd_10223]
@@ -80817,7 +80817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1435\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1435\Generated1435
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated408.cmd_10224]
@@ -80825,7 +80825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest408\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest408\Generated408
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated637.cmd_10225]
@@ -80833,7 +80833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest637\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest637\Generated637
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated320.cmd_10226]
@@ -80841,7 +80841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest320\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest320\Generated320
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsShort.cmd_10227]
@@ -80849,7 +80849,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsShort\ConstantArgs
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsShort
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated908.cmd_10228]
@@ -80857,7 +80857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest908\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest908\Generated908
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated256.cmd_10229]
@@ -80865,7 +80865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest256\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest256\Generated256
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated491.cmd_10230]
@@ -80873,7 +80873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest491\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest491\Generated491
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated38.cmd_10231]
@@ -80881,7 +80881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest38\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest38\Generated38
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1131.cmd_10232]
@@ -80889,7 +80889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1131\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1131\Generated1131
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated713.cmd_10233]
@@ -80897,7 +80897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest713\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest713\Generated713
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated768.cmd_10234]
@@ -80905,7 +80905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest768\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest768\Generated768
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated743.cmd_10235]
@@ -80913,7 +80913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest743\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest743\Generated743
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated264.cmd_10236]
@@ -80921,7 +80921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest264\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest264\Generated264
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated567.cmd_10237]
@@ -80929,7 +80929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest567\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest567\Generated567
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated833.cmd_10238]
@@ -80937,7 +80937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest833\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest833\Generated833
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated573.cmd_10239]
@@ -80945,7 +80945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest573\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest573\Generated573
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated988.cmd_10240]
@@ -80953,7 +80953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest988\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest988\Generated988
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated805.cmd_10241]
@@ -80961,7 +80961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest805\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest805\Generated805
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated347.cmd_10242]
@@ -80969,7 +80969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest347\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest347\Generated347
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated120.cmd_10243]
@@ -80977,7 +80977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest120\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest120\Generated120
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated977.cmd_10244]
@@ -80985,7 +80985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest977\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest977\Generated977
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1342.cmd_10245]
@@ -80993,7 +80993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1342\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1342\Generated1342
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_255263.cmd_10246]
@@ -81001,7 +81001,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_255263\DevDiv_255263\DevDiv_255263.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_255263\DevDiv_255263
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated451.cmd_10247]
@@ -81009,7 +81009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest451\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest451\Generated451
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1029.cmd_10248]
@@ -81017,7 +81017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1029\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1029\Generated1029
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated84.cmd_10249]
@@ -81025,7 +81025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest84\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest84\Generated84
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated330.cmd_10250]
@@ -81033,7 +81033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest330\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest330\Generated330
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1431.cmd_10251]
@@ -81041,7 +81041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1431\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1431\Generated1431
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated420.cmd_10252]
@@ -81049,7 +81049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest420\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest420\Generated420
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated672.cmd_10253]
@@ -81057,7 +81057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest672\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest672\Generated672
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1016.cmd_10254]
@@ -81065,7 +81065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1016\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1016\Generated1016
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated994.cmd_10255]
@@ -81073,7 +81073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest994\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest994\Generated994
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1308.cmd_10256]
@@ -81081,7 +81081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1308\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1308\Generated1308
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated394.cmd_10257]
@@ -81089,7 +81089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest394\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest394\Generated394
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1100.cmd_10258]
@@ -81097,7 +81097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1100\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1100\Generated1100
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated779.cmd_10259]
@@ -81105,7 +81105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest779\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest779\Generated779
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1122.cmd_10260]
@@ -81113,7 +81113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1122\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1122\Generated1122
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated854.cmd_10261]
@@ -81121,7 +81121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest854\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest854\Generated854
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1088.cmd_10262]
@@ -81129,7 +81129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1088\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1088\Generated1088
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated340.cmd_10263]
@@ -81137,7 +81137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest340\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest340\Generated340
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated362.cmd_10264]
@@ -81145,7 +81145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest362\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest362\Generated362
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_il_dbgpointer_i.cmd_10265]
@@ -81153,7 +81153,7 @@ RelativePath=JIT\Methodical\tailcall\_il_dbgpointer_i\_il_dbgpointer_i.cmd
 WorkingDir=JIT\Methodical\tailcall\_il_dbgpointer_i
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated376.cmd_10266]
@@ -81161,7 +81161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest376\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest376\Generated376
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1059.cmd_10267]
@@ -81169,7 +81169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1059\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1059\Generated1059
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated418.cmd_10268]
@@ -81177,7 +81177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest418\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest418\Generated418
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated19.cmd_10269]
@@ -81185,7 +81185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest19\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest19\Generated19
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1134.cmd_10270]
@@ -81193,7 +81193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1134\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1134\Generated1134
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1303.cmd_10271]
@@ -81201,7 +81201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1303\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1303\Generated1303
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_relsin_cs_il.cmd_10272]
@@ -81209,7 +81209,7 @@ RelativePath=JIT\Methodical\Boxing\xlang\_relsin_cs_il\_relsin_cs_il.cmd
 WorkingDir=JIT\Methodical\Boxing\xlang\_relsin_cs_il
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b03689.cmd_10273]
@@ -81217,7 +81217,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1.2-M01\b03689\b03689\b03689.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1.2-M01\b03689\b03689
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [FixedAddressValueType.cmd_10274]
@@ -81225,7 +81225,7 @@ RelativePath=baseservices\compilerservices\FixedAddressValueType\FixedAddressVal
 WorkingDir=baseservices\compilerservices\FixedAddressValueType\FixedAddressValueType
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated529.cmd_10275]
@@ -81233,7 +81233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest529\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest529\Generated529
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1236.cmd_10276]
@@ -81241,7 +81241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1236\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1236\Generated1236
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated208.cmd_10277]
@@ -81249,7 +81249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest208\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest208\Generated208
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated63.cmd_10278]
@@ -81257,7 +81257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest63\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest63\Generated63
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated83.cmd_10279]
@@ -81265,7 +81265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest83\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest83\Generated83
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated482.cmd_10280]
@@ -81273,7 +81273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest482\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest482\Generated482
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated823.cmd_10281]
@@ -81281,7 +81281,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest823\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest823\Generated823
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [finalizertest.cmd_10282]
@@ -81289,7 +81289,7 @@ RelativePath=GC\LargeMemory\Allocation\finalizertest\finalizertest.cmd
 WorkingDir=GC\LargeMemory\Allocation\finalizertest
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1176.cmd_10283]
@@ -81297,7 +81297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1176\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1176\Generated1176
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated665.cmd_10284]
@@ -81305,7 +81305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest665\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest665\Generated665
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1168.cmd_10285]
@@ -81313,7 +81313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1168\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1168\Generated1168
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1174.cmd_10286]
@@ -81321,7 +81321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1174\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1174\Generated1174
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1210.cmd_10287]
@@ -81329,7 +81329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1210\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1210\Generated1210
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1336.cmd_10288]
@@ -81337,7 +81337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1336\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1336\Generated1336
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated69.cmd_10289]
@@ -81345,7 +81345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest69\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest69\Generated69
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1139.cmd_10290]
@@ -81353,7 +81353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1139\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1139\Generated1139
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [collect.cmd_10291]
@@ -81361,7 +81361,7 @@ RelativePath=GC\LargeMemory\API\gc\collect\collect.cmd
 WorkingDir=GC\LargeMemory\API\gc\collect
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated604.cmd_10292]
@@ -81369,7 +81369,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest604\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest604\Generated604
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1026.cmd_10293]
@@ -81377,7 +81377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1026\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1026\Generated1026
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1214.cmd_10294]
@@ -81385,7 +81385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1214\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1214\Generated1214
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated541.cmd_10295]
@@ -81393,7 +81393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest541\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest541\Generated541
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated329.cmd_10296]
@@ -81401,7 +81401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest329\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest329\Generated329
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated725.cmd_10297]
@@ -81409,7 +81409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest725\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest725\Generated725
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated562.cmd_10298]
@@ -81417,7 +81417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest562\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest562\Generated562
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated306.cmd_10299]
@@ -81425,7 +81425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest306\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest306\Generated306
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated191.cmd_10300]
@@ -81433,7 +81433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest191\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest191\Generated191
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated406.cmd_10301]
@@ -81441,7 +81441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest406\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest406\Generated406
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated551.cmd_10302]
@@ -81449,7 +81449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest551\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest551\Generated551
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1343.cmd_10303]
@@ -81457,7 +81457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1343\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1343\Generated1343
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1279.cmd_10304]
@@ -81465,7 +81465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1279\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1279\Generated1279
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated796.cmd_10305]
@@ -81473,7 +81473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest796\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest796\Generated796
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated740.cmd_10306]
@@ -81481,7 +81481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest740\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest740\Generated740
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1494.cmd_10307]
@@ -81489,7 +81489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1494\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1494\Generated1494
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated301.cmd_10308]
@@ -81497,7 +81497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest301\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest301\Generated301
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1135.cmd_10309]
@@ -81505,7 +81505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1135\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1135\Generated1135
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated953.cmd_10310]
@@ -81513,7 +81513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest953\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest953\Generated953
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b26324a.cmd_10311]
@@ -81521,7 +81521,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26324\b26324a\b26324a.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26324\b26324a
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated563.cmd_10312]
@@ -81529,7 +81529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest563\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest563\Generated563
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated516.cmd_10313]
@@ -81537,7 +81537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest516\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest516\Generated516
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1108.cmd_10314]
@@ -81545,7 +81545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1108\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1108\Generated1108
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated627.cmd_10315]
@@ -81553,7 +81553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest627\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest627\Generated627
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated821.cmd_10316]
@@ -81561,7 +81561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest821\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest821\Generated821
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated68.cmd_10317]
@@ -81569,7 +81569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest68\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest68\Generated68
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated317.cmd_10318]
@@ -81577,7 +81577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest317\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest317\Generated317
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1307.cmd_10319]
@@ -81585,7 +81585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1307\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1307\Generated1307
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [byrefs.cmd_10320]
@@ -81593,7 +81593,7 @@ RelativePath=reflection\ldtoken\byrefs\byrefs.cmd
 WorkingDir=reflection\ldtoken\byrefs
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i72.cmd_10321]
@@ -81601,7 +81601,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i72\mcc_i72.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i72
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated277.cmd_10322]
@@ -81609,7 +81609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest277\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest277\Generated277
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1161.cmd_10323]
@@ -81617,7 +81617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1161\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1161\Generated1161
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated765.cmd_10324]
@@ -81625,7 +81625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest765\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest765\Generated765
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1167.cmd_10325]
@@ -81633,7 +81633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1167\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1167\Generated1167
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated770.cmd_10326]
@@ -81641,7 +81641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest770\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest770\Generated770
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated803.cmd_10327]
@@ -81649,7 +81649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest803\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest803\Generated803
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1490.cmd_10328]
@@ -81657,7 +81657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1490\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1490\Generated1490
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated511.cmd_10329]
@@ -81665,7 +81665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest511\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest511\Generated511
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated488.cmd_10330]
@@ -81673,7 +81673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest488\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest488\Generated488
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated631.cmd_10331]
@@ -81681,7 +81681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest631\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest631\Generated631
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated196.cmd_10332]
@@ -81689,7 +81689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest196\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest196\Generated196
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated77.cmd_10333]
@@ -81697,7 +81697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest77\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest77\Generated77
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated292.cmd_10334]
@@ -81705,7 +81705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest292\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest292\Generated292
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_orelsin_cs_il.cmd_10335]
@@ -81713,7 +81713,7 @@ RelativePath=JIT\Methodical\Boxing\xlang\_orelsin_cs_il\_orelsin_cs_il.cmd
 WorkingDir=JIT\Methodical\Boxing\xlang\_orelsin_cs_il
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated64.cmd_10336]
@@ -81721,7 +81721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest64\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest64\Generated64
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated443.cmd_10337]
@@ -81729,7 +81729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest443\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest443\Generated443
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated549.cmd_10338]
@@ -81737,7 +81737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest549\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest549\Generated549
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated723.cmd_10339]
@@ -81745,7 +81745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest723\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest723\Generated723
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1125.cmd_10340]
@@ -81753,7 +81753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1125\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1125\Generated1125
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated351.cmd_10341]
@@ -81761,7 +81761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest351\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest351\Generated351
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated66.cmd_10342]
@@ -81769,7 +81769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest66\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest66\Generated66
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated379.cmd_10343]
@@ -81777,7 +81777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest379\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest379\Generated379
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated160.cmd_10344]
@@ -81785,7 +81785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest160\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest160\Generated160
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated984.cmd_10345]
@@ -81793,7 +81793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest984\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest984\Generated984
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated227.cmd_10346]
@@ -81801,7 +81801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest227\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest227\Generated227
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated901.cmd_10347]
@@ -81809,7 +81809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest901\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest901\Generated901
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated311.cmd_10348]
@@ -81817,7 +81817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest311\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest311\Generated311
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated116.cmd_10349]
@@ -81825,7 +81825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest116\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest116\Generated116
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated837.cmd_10350]
@@ -81833,7 +81833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest837\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest837\Generated837
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated650.cmd_10351]
@@ -81841,7 +81841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest650\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest650\Generated650
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1316.cmd_10352]
@@ -81849,7 +81849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1316\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1316\Generated1316
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated15.cmd_10353]
@@ -81857,7 +81857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest15\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest15\Generated15
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated566.cmd_10354]
@@ -81865,7 +81865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest566\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest566\Generated566
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated400.cmd_10355]
@@ -81873,7 +81873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest400\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest400\Generated400
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated188.cmd_10356]
@@ -81881,7 +81881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest188\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest188\Generated188
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated346.cmd_10357]
@@ -81889,7 +81889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest346\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest346\Generated346
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [bleref_il_r.cmd_10358]
@@ -81897,7 +81897,7 @@ RelativePath=JIT\Directed\coverage\importer\Desktop\bleref_il_r\bleref_il_r.cmd
 WorkingDir=JIT\Directed\coverage\importer\Desktop\bleref_il_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated1391.cmd_10359]
@@ -81905,7 +81905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1391\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1391\Generated1391
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_8231.cmd_10360]
@@ -81913,7 +81913,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_8231\GitHub_8231\GitHub_8231.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_8231\GitHub_8231
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated219.cmd_10361]
@@ -81921,7 +81921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest219\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest219\Generated219
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsInt.cmd_10362]
@@ -81929,7 +81929,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsInt\ConstantArgsIn
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsInt
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1297.cmd_10363]
@@ -81937,7 +81937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1297\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1297\Generated1297
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated387.cmd_10364]
@@ -81945,7 +81945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest387\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest387\Generated387
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1399.cmd_10365]
@@ -81953,7 +81953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1399\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1399\Generated1399
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [global_il_d.cmd_10366]
@@ -81961,7 +81961,7 @@ RelativePath=JIT\Methodical\cctor\misc\global_il_d\global_il_d.cmd
 WorkingDir=JIT\Methodical\cctor\misc\global_il_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated229.cmd_10367]
@@ -81969,7 +81969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest229\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest229\Generated229
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated510.cmd_10368]
@@ -81977,7 +81977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest510\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest510\Generated510
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated284.cmd_10369]
@@ -81985,7 +81985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest284\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest284\Generated284
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i51.cmd_10370]
@@ -81993,7 +81993,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i51\mcc_i51.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i51
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1179.cmd_10371]
@@ -82001,7 +82001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1179\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1179\Generated1179
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1440.cmd_10372]
@@ -82009,7 +82009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1440\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1440\Generated1440
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated250.cmd_10373]
@@ -82017,7 +82017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest250\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest250\Generated250
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1196.cmd_10374]
@@ -82025,7 +82025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1196\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1196\Generated1196
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated538.cmd_10375]
@@ -82033,7 +82033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest538\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest538\Generated538
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated436.cmd_10376]
@@ -82041,7 +82041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest436\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest436\Generated436
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated875.cmd_10377]
@@ -82049,7 +82049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest875\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest875\Generated875
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated121.cmd_10378]
@@ -82057,7 +82057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest121\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest121\Generated121
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated86.cmd_10379]
@@ -82065,7 +82065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest86\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest86\Generated86
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated186.cmd_10380]
@@ -82073,7 +82073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest186\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest186\Generated186
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [arglist.cmd_10381]
@@ -82081,7 +82081,7 @@ RelativePath=JIT\Directed\PREFIX\unaligned\1\arglist\arglist.cmd
 WorkingDir=JIT\Directed\PREFIX\unaligned\1\arglist
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated413.cmd_10382]
@@ -82089,7 +82089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest413\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest413\Generated413
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1264.cmd_10383]
@@ -82097,7 +82097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1264\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1264\Generated1264
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated849.cmd_10384]
@@ -82105,7 +82105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest849\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest849\Generated849
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1155.cmd_10385]
@@ -82113,7 +82113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1155\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1155\Generated1155
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated338.cmd_10386]
@@ -82121,7 +82121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest338\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest338\Generated338
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated673.cmd_10387]
@@ -82129,7 +82129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest673\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest673\Generated673
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1106.cmd_10388]
@@ -82137,7 +82137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1106\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1106\Generated1106
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1077.cmd_10389]
@@ -82145,7 +82145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1077\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1077\Generated1077
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1128.cmd_10390]
@@ -82153,7 +82153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1128\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1128\Generated1128
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1249.cmd_10391]
@@ -82161,7 +82161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1249\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1249\Generated1249
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1194.cmd_10392]
@@ -82169,7 +82169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1194\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1194\Generated1194
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated426.cmd_10393]
@@ -82177,7 +82177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest426\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest426\Generated426
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [revcomp.cmd_10394]
@@ -82185,7 +82185,7 @@ RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\revcomp\revcomp\revcomp.
 WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\revcomp\revcomp
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [DevDiv_216571.cmd_10395]
@@ -82193,7 +82193,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_216571\DevDiv_216571\DevDiv_216571.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_216571\DevDiv_216571
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_simpleoddpower_il_d.cmd_10396]
@@ -82201,7 +82201,7 @@ RelativePath=JIT\Methodical\delegate\_simpleoddpower_il_d\_simpleoddpower_il_d.c
 WorkingDir=JIT\Methodical\delegate\_simpleoddpower_il_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated45.cmd_10397]
@@ -82209,7 +82209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest45\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest45\Generated45
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated472.cmd_10398]
@@ -82217,7 +82217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest472\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest472\Generated472
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated484.cmd_10399]
@@ -82225,7 +82225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest484\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest484\Generated484
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated576.cmd_10400]
@@ -82233,7 +82233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest576\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest576\Generated576
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated609.cmd_10401]
@@ -82241,7 +82241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest609\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest609\Generated609
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated834.cmd_10402]
@@ -82249,7 +82249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest834\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest834\Generated834
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated961.cmd_10403]
@@ -82257,7 +82257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest961\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest961\Generated961
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1406.cmd_10404]
@@ -82265,7 +82265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1406\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1406\Generated1406
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1382.cmd_10405]
@@ -82273,7 +82273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1382\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1382\Generated1382
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [verify01_small.cmd_10406]
@@ -82281,7 +82281,7 @@ RelativePath=JIT\jit64\localloc\verify\verify01_small\verify01_small.cmd
 WorkingDir=JIT\jit64\localloc\verify\verify01_small
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated962.cmd_10407]
@@ -82289,7 +82289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest962\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest962\Generated962
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated453.cmd_10408]
@@ -82297,7 +82297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest453\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest453\Generated453
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated498.cmd_10409]
@@ -82305,7 +82305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest498\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest498\Generated498
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1189.cmd_10410]
@@ -82313,7 +82313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1189\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1189\Generated1189
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated616.cmd_10411]
@@ -82321,7 +82321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest616\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest616\Generated616
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated952.cmd_10412]
@@ -82329,7 +82329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest952\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest952\Generated952
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated581.cmd_10413]
@@ -82337,7 +82337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest581\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest581\Generated581
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_odbgsin_cs_il.cmd_10414]
@@ -82345,7 +82345,7 @@ RelativePath=JIT\Methodical\Boxing\xlang\_odbgsin_cs_il\_odbgsin_cs_il.cmd
 WorkingDir=JIT\Methodical\Boxing\xlang\_odbgsin_cs_il
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated203.cmd_10415]
@@ -82353,7 +82353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest203\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest203\Generated203
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1090.cmd_10416]
@@ -82361,7 +82361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1090\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1090\Generated1090
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_6318.cmd_10417]
@@ -82369,7 +82369,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_6318\GitHub_6318\GitHub_6318.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_6318\GitHub_6318
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [badcodeafterfinally_d.cmd_10418]
@@ -82377,7 +82377,7 @@ RelativePath=JIT\Methodical\eh\deadcode\badcodeafterfinally_d\badcodeafterfinall
 WorkingDir=JIT\Methodical\eh\deadcode\badcodeafterfinally_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1238.cmd_10419]
@@ -82385,7 +82385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1238\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1238\Generated1238
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1454.cmd_10420]
@@ -82393,7 +82393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1454\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1454\Generated1454
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated608.cmd_10421]
@@ -82401,7 +82401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest608\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest608\Generated608
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated676.cmd_10422]
@@ -82409,7 +82409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest676\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest676\Generated676
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1277.cmd_10423]
@@ -82417,7 +82417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1277\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1277\Generated1277
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated71.cmd_10424]
@@ -82425,7 +82425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest71\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest71\Generated71
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated259.cmd_10425]
@@ -82433,7 +82433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest259\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest259\Generated259
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1044.cmd_10426]
@@ -82441,7 +82441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1044\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1044\Generated1044
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1291.cmd_10427]
@@ -82449,7 +82449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1291\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1291\Generated1291
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1129.cmd_10428]
@@ -82457,7 +82457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1129\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1129\Generated1129
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1486.cmd_10429]
@@ -82465,7 +82465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1486\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1486\Generated1486
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_CoreRT_2073.cmd_10430]
@@ -82473,7 +82473,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_CoreRT_2073\GitHub_CoreRT_2073\GitHub
 WorkingDir=JIT\Regression\JitBlue\GitHub_CoreRT_2073\GitHub_CoreRT_2073
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_255294.cmd_10431]
@@ -82481,7 +82481,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_255294\DevDiv_255294\DevDiv_255294.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_255294\DevDiv_255294
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated543.cmd_10432]
@@ -82489,7 +82489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest543\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest543\Generated543
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated206.cmd_10433]
@@ -82497,7 +82497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest206\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest206\Generated206
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated530.cmd_10434]
@@ -82505,7 +82505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest530\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest530\Generated530
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated969.cmd_10435]
@@ -82513,7 +82513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest969\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest969\Generated969
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_5047.cmd_10436]
@@ -82521,7 +82521,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_5047\GitHub_5047\GitHub_5047.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_5047\GitHub_5047
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1465.cmd_10437]
@@ -82529,7 +82529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1465\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1465\Generated1465
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b49644.cmd_10438]
@@ -82537,7 +82537,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b49644\b49644\b49644.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b49644\b49644
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [global_il_r.cmd_10439]
@@ -82545,7 +82545,7 @@ RelativePath=JIT\Methodical\cctor\misc\global_il_r\global_il_r.cmd
 WorkingDir=JIT\Methodical\cctor\misc\global_il_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [dev10_865840.cmd_10440]
@@ -82553,7 +82553,7 @@ RelativePath=JIT\Regression\Dev11\dev10_865840\dev10_865840\dev10_865840.cmd
 WorkingDir=JIT\Regression\Dev11\dev10_865840\dev10_865840
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9461;NEW
+Categories=EXPECTED_FAIL;9461
 HostStyle=0
 
 [Generated728.cmd_10441]
@@ -82561,7 +82561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest728\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest728\Generated728
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated902.cmd_10442]
@@ -82569,7 +82569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest902\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest902\Generated902
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [muldimjagary.cmd_10443]
@@ -82577,7 +82577,7 @@ RelativePath=GC\Scenarios\muldimjagary\muldimjagary\muldimjagary.cmd
 WorkingDir=GC\Scenarios\muldimjagary\muldimjagary
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated140.cmd_10444]
@@ -82585,7 +82585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest140\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest140\Generated140
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1314.cmd_10445]
@@ -82593,7 +82593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1314\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1314\Generated1314
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1142.cmd_10446]
@@ -82601,7 +82601,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1142\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1142\Generated1142
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1367.cmd_10447]
@@ -82609,7 +82609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1367\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1367\Generated1367
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated6.cmd_10448]
@@ -82617,7 +82617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest6\Generated6
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest6\Generated6
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1095.cmd_10449]
@@ -82625,7 +82625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1095\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1095\Generated1095
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_278365.cmd_10450]
@@ -82633,7 +82633,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_278365\DevDiv_278365\DevDiv_278365.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_278365\DevDiv_278365
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated555.cmd_10451]
@@ -82641,7 +82641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest555\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest555\Generated555
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1212.cmd_10452]
@@ -82649,7 +82649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1212\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1212\Generated1212
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated660.cmd_10453]
@@ -82657,7 +82657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest660\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest660\Generated660
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_279396.cmd_10454]
@@ -82665,7 +82665,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_279396\DevDiv_279396\DevDiv_279396.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_279396\DevDiv_279396
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i82.cmd_10455]
@@ -82673,7 +82673,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i82\mcc_i82.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i82
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1333.cmd_10456]
@@ -82681,7 +82681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1333\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1333\Generated1333
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated149.cmd_10457]
@@ -82689,7 +82689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest149\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest149\Generated149
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated334.cmd_10458]
@@ -82697,7 +82697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest334\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest334\Generated334
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated243.cmd_10459]
@@ -82705,7 +82705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest243\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest243\Generated243
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated279.cmd_10460]
@@ -82713,7 +82713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest279\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest279\Generated279
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated515.cmd_10461]
@@ -82721,7 +82721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest515\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest515\Generated515
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [rvastatic4.cmd_10462]
@@ -82729,7 +82729,7 @@ RelativePath=JIT\Directed\rvastatics\rvastatic4\rvastatic4.cmd
 WorkingDir=JIT\Directed\rvastatics\rvastatic4
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated944.cmd_10463]
@@ -82737,7 +82737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest944\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest944\Generated944
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1206.cmd_10464]
@@ -82745,7 +82745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1206\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1206\Generated1206
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1471.cmd_10465]
@@ -82753,7 +82753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1471\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1471\Generated1471
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1309.cmd_10466]
@@ -82761,7 +82761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1309\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1309\Generated1309
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b16423.cmd_10467]
@@ -82769,7 +82769,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16423\b16423\b16423.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16423\b16423
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [DevDiv_279829.cmd_10468]
@@ -82777,7 +82777,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_279829\DevDiv_279829\DevDiv_279829.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_279829\DevDiv_279829
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated741.cmd_10469]
@@ -82785,7 +82785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest741\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest741\Generated741
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1116.cmd_10470]
@@ -82793,7 +82793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1116\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1116\Generated1116
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated714.cmd_10471]
@@ -82801,7 +82801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest714\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest714\Generated714
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b26323.cmd_10472]
@@ -82809,7 +82809,7 @@ RelativePath=JIT\Regression\CLR-x86-EJIT\V1-M12-Beta2\b26323\b26323\b26323.cmd
 WorkingDir=JIT\Regression\CLR-x86-EJIT\V1-M12-Beta2\b26323\b26323
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [smalloom.cmd_10473]
@@ -82817,7 +82817,7 @@ RelativePath=GC\Coverage\smalloom\smalloom.cmd
 WorkingDir=GC\Coverage\smalloom
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated583.cmd_10474]
@@ -82825,7 +82825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest583\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest583\Generated583
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1368.cmd_10475]
@@ -82833,7 +82833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1368\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1368\Generated1368
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated737.cmd_10476]
@@ -82841,7 +82841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest737\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest737\Generated737
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1358.cmd_10477]
@@ -82849,7 +82849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1358\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1358\Generated1358
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated197.cmd_10478]
@@ -82857,7 +82857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest197\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest197\Generated197
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated114.cmd_10479]
@@ -82865,7 +82865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest114\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest114\Generated114
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated112.cmd_10480]
@@ -82873,7 +82873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest112\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest112\Generated112
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_284785.cmd_10481]
@@ -82881,7 +82881,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_284785\DevDiv_284785\DevDiv_284785.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_284785\DevDiv_284785
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1255.cmd_10482]
@@ -82889,7 +82889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1255\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1255\Generated1255
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1184.cmd_10483]
@@ -82897,7 +82897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1184\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1184\Generated1184
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [Generated40.cmd_10484]
@@ -82905,7 +82905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest40\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest40\Generated40
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated986.cmd_10485]
@@ -82913,7 +82913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest986\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest986\Generated986
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1158.cmd_10486]
@@ -82921,7 +82921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1158\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1158\Generated1158
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated991.cmd_10487]
@@ -82929,7 +82929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest991\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest991\Generated991
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated762.cmd_10488]
@@ -82937,7 +82937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest762\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest762\Generated762
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_il_rellocalloc.cmd_10489]
@@ -82945,7 +82945,7 @@ RelativePath=JIT\Methodical\xxobj\operand\_il_rellocalloc\_il_rellocalloc.cmd
 WorkingDir=JIT\Methodical\xxobj\operand\_il_rellocalloc
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1025.cmd_10490]
@@ -82953,7 +82953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1025\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1025\Generated1025
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated233.cmd_10491]
@@ -82961,7 +82961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest233\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest233\Generated233
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated11.cmd_10492]
@@ -82969,7 +82969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest11\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest11\Generated11
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated262.cmd_10493]
@@ -82977,7 +82977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest262\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest262\Generated262
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b37646.cmd_10494]
@@ -82985,7 +82985,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b37646\b37646\b37646.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b37646\b37646
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1223.cmd_10495]
@@ -82993,7 +82993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1223\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1223\Generated1223
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated658.cmd_10496]
@@ -83001,7 +83001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest658\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest658\Generated658
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated132.cmd_10497]
@@ -83009,7 +83009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest132\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest132\Generated132
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_il_dbgpointer.cmd_10498]
@@ -83017,7 +83017,7 @@ RelativePath=JIT\Methodical\tailcall\_il_dbgpointer\_il_dbgpointer.cmd
 WorkingDir=JIT\Methodical\tailcall\_il_dbgpointer
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated910.cmd_10499]
@@ -83025,7 +83025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest910\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest910\Generated910
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1103.cmd_10500]
@@ -83033,7 +83033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1103\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1103\Generated1103
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i52.cmd_10501]
@@ -83041,7 +83041,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i52\mcc_i52.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i52
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1380.cmd_10502]
@@ -83049,7 +83049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1380\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1380\Generated1380
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated247.cmd_10503]
@@ -83057,7 +83057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest247\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest247\Generated247
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1011.cmd_10504]
@@ -83065,7 +83065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1011\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1011\Generated1011
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1369.cmd_10505]
@@ -83073,7 +83073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1369\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1369\Generated1369
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated166.cmd_10506]
@@ -83081,7 +83081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest166\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest166\Generated166
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1160.cmd_10507]
@@ -83089,7 +83089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1160\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1160\Generated1160
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsLong.cmd_10508]
@@ -83097,7 +83097,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsLong\ConstantArgsL
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsLong
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1013.cmd_10509]
@@ -83105,7 +83105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1013\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1013\Generated1013
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated761.cmd_10510]
@@ -83113,7 +83113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest761\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest761\Generated761
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated870.cmd_10511]
@@ -83121,7 +83121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest870\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest870\Generated870
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated7.cmd_10512]
@@ -83129,7 +83129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest7\Generated7
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest7\Generated7
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated752.cmd_10513]
@@ -83137,7 +83137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest752\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest752\Generated752
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated213.cmd_10514]
@@ -83145,7 +83145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest213\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest213\Generated213
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated183.cmd_10515]
@@ -83153,7 +83153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest183\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest183\Generated183
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated246.cmd_10516]
@@ -83161,7 +83161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest246\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest246\Generated246
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [foregroundgc.cmd_10517]
@@ -83169,7 +83169,7 @@ RelativePath=GC\Features\BackgroundGC\foregroundgc\foregroundgc.cmd
 WorkingDir=GC\Features\BackgroundGC\foregroundgc
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated701.cmd_10518]
@@ -83177,7 +83177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest701\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest701\Generated701
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated685.cmd_10519]
@@ -83185,7 +83185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest685\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest685\Generated685
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated835.cmd_10520]
@@ -83193,7 +83193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest835\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest835\Generated835
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [verify01_large.cmd_10521]
@@ -83201,7 +83201,7 @@ RelativePath=JIT\jit64\localloc\verify\verify01_large\verify01_large.cmd
 WorkingDir=JIT\jit64\localloc\verify\verify01_large
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated202.cmd_10522]
@@ -83209,7 +83209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest202\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest202\Generated202
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1121.cmd_10523]
@@ -83217,7 +83217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1121\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1121\Generated1121
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1327.cmd_10524]
@@ -83225,7 +83225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1327\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1327\Generated1327
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1393.cmd_10525]
@@ -83233,7 +83233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1393\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1393\Generated1393
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1425.cmd_10526]
@@ -83241,7 +83241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1425\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1425\Generated1425
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated266.cmd_10527]
@@ -83249,7 +83249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest266\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest266\Generated266
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated318.cmd_10528]
@@ -83257,7 +83257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest318\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest318\Generated318
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated594.cmd_10529]
@@ -83265,7 +83265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest594\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest594\Generated594
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1219.cmd_10530]
@@ -83273,7 +83273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1219\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1219\Generated1219
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_359737.cmd_10531]
@@ -83281,7 +83281,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_359737\DevDiv_359737\DevDiv_359737.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_359737\DevDiv_359737
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_6649.cmd_10532]
@@ -83289,7 +83289,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_6649\GitHub_6649\GitHub_6649.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_6649\GitHub_6649
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1290.cmd_10533]
@@ -83297,7 +83297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1290\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1290\Generated1290
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated131.cmd_10534]
@@ -83305,7 +83305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest131\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest131\Generated131
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [NoThrowInline.cmd_10535]
@@ -83313,7 +83313,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\NoThrowInline\NoThrowInline.cm
 WorkingDir=JIT\Performance\CodeQuality\Inlining\NoThrowInline
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated632.cmd_10536]
@@ -83321,7 +83321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest632\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest632\Generated632
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated801.cmd_10537]
@@ -83329,7 +83329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest801\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest801\Generated801
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated884.cmd_10538]
@@ -83337,7 +83337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest884\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest884\Generated884
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated98.cmd_10539]
@@ -83345,7 +83345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest98\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest98\Generated98
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1009.cmd_10540]
@@ -83353,7 +83353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1009\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1009\Generated1009
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1428.cmd_10541]
@@ -83361,7 +83361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1428\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1428\Generated1428
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_278375.cmd_10542]
@@ -83369,7 +83369,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_278375\DevDiv_278375\DevDiv_278375.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_278375\DevDiv_278375
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated736.cmd_10543]
@@ -83377,7 +83377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest736\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest736\Generated736
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated793.cmd_10544]
@@ -83385,7 +83385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest793\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest793\Generated793
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1386.cmd_10545]
@@ -83393,7 +83393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1386\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1386\Generated1386
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1076.cmd_10546]
@@ -83401,7 +83401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1076\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1076\Generated1076
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated238.cmd_10547]
@@ -83409,7 +83409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest238\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest238\Generated238
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated295.cmd_10548]
@@ -83417,7 +83417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest295\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest295\Generated295
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b31746.cmd_10549]
@@ -83425,7 +83425,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31746\b31746\b31746.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31746\b31746
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated158.cmd_10550]
@@ -83433,7 +83433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest158\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest158\Generated158
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated942.cmd_10551]
@@ -83441,7 +83441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest942\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest942\Generated942
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated430.cmd_10552]
@@ -83449,7 +83449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest430\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest430\Generated430
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated644.cmd_10553]
@@ -83457,7 +83457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest644\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest644\Generated644
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated462.cmd_10554]
@@ -83465,7 +83465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest462\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest462\Generated462
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated182.cmd_10555]
@@ -83473,7 +83473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest182\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest182\Generated182
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated767.cmd_10556]
@@ -83481,7 +83481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest767\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest767\Generated767
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsULong.cmd_10557]
@@ -83489,7 +83489,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsULong\ConstantArgs
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsULong
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated331.cmd_10558]
@@ -83497,7 +83497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest331\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest331\Generated331
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated218.cmd_10559]
@@ -83505,7 +83505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest218\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest218\Generated218
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated297.cmd_10560]
@@ -83513,7 +83513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest297\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest297\Generated297
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated587.cmd_10561]
@@ -83521,7 +83521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest587\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest587\Generated587
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated481.cmd_10562]
@@ -83529,7 +83529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest481\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest481\Generated481
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_simpleoddpower_il_r.cmd_10563]
@@ -83537,7 +83537,7 @@ RelativePath=JIT\Methodical\delegate\_simpleoddpower_il_r\_simpleoddpower_il_r.c
 WorkingDir=JIT\Methodical\delegate\_simpleoddpower_il_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1132.cmd_10564]
@@ -83545,7 +83545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1132\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1132\Generated1132
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1493.cmd_10565]
@@ -83553,7 +83553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1493\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1493\Generated1493
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [scenario.cmd_10566]
@@ -83561,7 +83561,7 @@ RelativePath=GC\Features\SustainedLowLatency\scenario\scenario.cmd
 WorkingDir=GC\Features\SustainedLowLatency\scenario
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated1205.cmd_10567]
@@ -83569,7 +83569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1205\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1205\Generated1205
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_7907.cmd_10568]
@@ -83577,7 +83577,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_7907\GitHub_7907\GitHub_7907.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_7907\GitHub_7907
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated852.cmd_10569]
@@ -83585,7 +83585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest852\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest852\Generated852
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1150.cmd_10570]
@@ -83593,7 +83593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1150\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1150\Generated1150
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated167.cmd_10571]
@@ -83601,7 +83601,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest167\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest167\Generated167
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1488.cmd_10572]
@@ -83609,7 +83609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1488\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1488\Generated1488
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated981.cmd_10573]
@@ -83617,7 +83617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest981\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest981\Generated981
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated128.cmd_10574]
@@ -83625,7 +83625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest128\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest128\Generated128
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated421.cmd_10575]
@@ -83633,7 +83633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest421\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest421\Generated421
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated322.cmd_10576]
@@ -83641,7 +83641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest322\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest322\Generated322
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1312.cmd_10577]
@@ -83649,7 +83649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1312\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1312\Generated1312
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated827.cmd_10578]
@@ -83657,7 +83657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest827\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest827\Generated827
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated780.cmd_10579]
@@ -83665,7 +83665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest780\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest780\Generated780
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated862.cmd_10580]
@@ -83673,7 +83673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest862\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest862\Generated862
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1057.cmd_10581]
@@ -83681,7 +83681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1057\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1057\Generated1057
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1426.cmd_10582]
@@ -83689,7 +83689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1426\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1426\Generated1426
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated257.cmd_10583]
@@ -83697,7 +83697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest257\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest257\Generated257
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1468.cmd_10584]
@@ -83705,7 +83705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1468\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1468\Generated1468
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated941.cmd_10585]
@@ -83713,7 +83713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest941\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest941\Generated941
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated523.cmd_10586]
@@ -83721,7 +83721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest523\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest523\Generated523
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1215.cmd_10587]
@@ -83729,7 +83729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1215\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1215\Generated1215
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated890.cmd_10588]
@@ -83737,7 +83737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest890\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest890\Generated890
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated368.cmd_10589]
@@ -83745,7 +83745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest368\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest368\Generated368
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated829.cmd_10590]
@@ -83753,7 +83753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest829\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest829\Generated829
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated85.cmd_10591]
@@ -83761,7 +83761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest85\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest85\Generated85
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1359.cmd_10592]
@@ -83769,7 +83769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1359\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1359\Generated1359
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated348.cmd_10593]
@@ -83777,7 +83777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest348\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest348\Generated348
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated190.cmd_10594]
@@ -83785,7 +83785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest190\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest190\Generated190
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [arglist_pos.cmd_10595]
@@ -83793,7 +83793,7 @@ RelativePath=JIT\Methodical\Coverage\arglist_pos\arglist_pos.cmd
 WorkingDir=JIT\Methodical\Coverage\arglist_pos
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [mcc_i03.cmd_10596]
@@ -83801,7 +83801,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i03\mcc_i03.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i03
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated126.cmd_10597]
@@ -83809,7 +83809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest126\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest126\Generated126
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated48.cmd_10598]
@@ -83817,7 +83817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest48\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest48\Generated48
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated417.cmd_10599]
@@ -83825,7 +83825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest417\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest417\Generated417
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated5.cmd_10600]
@@ -83833,7 +83833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest5\Generated5
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest5\Generated5
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated925.cmd_10601]
@@ -83841,7 +83841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest925\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest925\Generated925
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated857.cmd_10602]
@@ -83849,7 +83849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest857\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest857\Generated857
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated979.cmd_10603]
@@ -83857,7 +83857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest979\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest979\Generated979
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated807.cmd_10604]
@@ -83865,7 +83865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest807\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest807\Generated807
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated280.cmd_10605]
@@ -83873,7 +83873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest280\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest280\Generated280
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1433.cmd_10606]
@@ -83881,7 +83881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1433\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1433\Generated1433
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated157.cmd_10607]
@@ -83889,7 +83889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest157\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest157\Generated157
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Shift.cmd_10608]
@@ -83897,7 +83897,7 @@ RelativePath=JIT\CodeGenBringUpTests\Shift\Shift.cmd
 WorkingDir=JIT\CodeGenBringUpTests\Shift
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated656.cmd_10609]
@@ -83905,7 +83905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest656\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest656\Generated656
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated477.cmd_10610]
@@ -83913,7 +83913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest477\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest477\Generated477
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated881.cmd_10611]
@@ -83921,7 +83921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest881\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest881\Generated881
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1049.cmd_10612]
@@ -83929,7 +83929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1049\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1049\Generated1049
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated73.cmd_10613]
@@ -83937,7 +83937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest73\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest73\Generated73
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1062.cmd_10614]
@@ -83945,7 +83945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1062\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1062\Generated1062
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [rvastatic3.cmd_10615]
@@ -83953,7 +83953,7 @@ RelativePath=JIT\Directed\rvastatics\rvastatic3\rvastatic3.cmd
 WorkingDir=JIT\Directed\rvastatics\rvastatic3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated1268.cmd_10616]
@@ -83961,7 +83961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1268\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1268\Generated1268
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated248.cmd_10617]
@@ -83969,7 +83969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest248\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest248\Generated248
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated503.cmd_10618]
@@ -83977,7 +83977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest503\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest503\Generated503
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1273.cmd_10619]
@@ -83985,7 +83985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1273\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1273\Generated1273
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated381.cmd_10620]
@@ -83993,7 +83993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest381\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest381\Generated381
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1224.cmd_10621]
@@ -84001,7 +84001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1224\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1224\Generated1224
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1081.cmd_10622]
@@ -84009,7 +84009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1081\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1081\Generated1081
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [regexdna.cmd_10623]
@@ -84017,7 +84017,7 @@ RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\regexdna\regexdna\regexd
 WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\regexdna\regexdna
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated504.cmd_10624]
@@ -84025,7 +84025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest504\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest504\Generated504
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1260.cmd_10625]
@@ -84033,7 +84033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1260\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1260\Generated1260
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated47.cmd_10626]
@@ -84041,7 +84041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest47\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest47\Generated47
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated313.cmd_10627]
@@ -84049,7 +84049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest313\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest313\Generated313
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated682.cmd_10628]
@@ -84057,7 +84057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest682\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest682\Generated682
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated614.cmd_10629]
@@ -84065,7 +84065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest614\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest614\Generated614
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1046.cmd_10630]
@@ -84073,7 +84073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1046\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1046\Generated1046
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1499.cmd_10631]
@@ -84081,7 +84081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1499\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1499\Generated1499
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1265.cmd_10632]
@@ -84089,7 +84089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1265\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1265\Generated1265
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1170.cmd_10633]
@@ -84097,7 +84097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1170\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1170\Generated1170
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated437.cmd_10634]
@@ -84105,7 +84105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest437\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest437\Generated437
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated415.cmd_10635]
@@ -84113,7 +84113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest415\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest415\Generated415
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated267.cmd_10636]
@@ -84121,7 +84121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest267\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest267\Generated267
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1133.cmd_10637]
@@ -84129,7 +84129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1133\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1133\Generated1133
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated692.cmd_10638]
@@ -84137,7 +84137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest692\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest692\Generated692
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1248.cmd_10639]
@@ -84145,7 +84145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1248\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1248\Generated1248
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated595.cmd_10640]
@@ -84153,7 +84153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest595\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest595\Generated595
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1334.cmd_10641]
@@ -84161,7 +84161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1334\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1334\Generated1334
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated414.cmd_10642]
@@ -84169,7 +84169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest414\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest414\Generated414
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated702.cmd_10643]
@@ -84177,7 +84177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest702\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest702\Generated702
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated293.cmd_10644]
@@ -84185,7 +84185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest293\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest293\Generated293
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_il_relpointer.cmd_10645]
@@ -84193,7 +84193,7 @@ RelativePath=JIT\Methodical\tailcall\_il_relpointer\_il_relpointer.cmd
 WorkingDir=JIT\Methodical\tailcall\_il_relpointer
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated1472.cmd_10646]
@@ -84201,7 +84201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1472\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1472\Generated1472
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated386.cmd_10647]
@@ -84209,7 +84209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest386\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest386\Generated386
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1287.cmd_10648]
@@ -84217,7 +84217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1287\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1287\Generated1287
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated162.cmd_10649]
@@ -84225,7 +84225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest162\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest162\Generated162
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated32.cmd_10650]
@@ -84233,7 +84233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest32\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest32\Generated32
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated729.cmd_10651]
@@ -84241,7 +84241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest729\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest729\Generated729
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated776.cmd_10652]
@@ -84249,7 +84249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest776\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest776\Generated776
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated212.cmd_10653]
@@ -84257,7 +84257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest212\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest212\Generated212
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated93.cmd_10654]
@@ -84265,7 +84265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest93\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest93\Generated93
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated878.cmd_10655]
@@ -84273,7 +84273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest878\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest878\Generated878
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated242.cmd_10656]
@@ -84281,7 +84281,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest242\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest242\Generated242
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated361.cmd_10657]
@@ -84289,7 +84289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest361\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest361\Generated361
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated198.cmd_10658]
@@ -84297,7 +84297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest198\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest198\Generated198
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated710.cmd_10659]
@@ -84305,7 +84305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest710\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest710\Generated710
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated603.cmd_10660]
@@ -84313,7 +84313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest603\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest603\Generated603
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1182.cmd_10661]
@@ -84321,7 +84321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1182\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1182\Generated1182
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated393.cmd_10662]
@@ -84329,7 +84329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest393\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest393\Generated393
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated487.cmd_10663]
@@ -84337,7 +84337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest487\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest487\Generated487
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1289.cmd_10664]
@@ -84345,7 +84345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1289\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1289\Generated1289
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated913.cmd_10665]
@@ -84353,7 +84353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest913\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest913\Generated913
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated502.cmd_10666]
@@ -84361,7 +84361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest502\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest502\Generated502
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_359736_d.cmd_10667]
@@ -84369,7 +84369,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_359736\DevDiv_359736_d\DevDiv_359736_
 WorkingDir=JIT\Regression\JitBlue\DevDiv_359736\DevDiv_359736_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated817.cmd_10668]
@@ -84377,7 +84377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest817\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest817\Generated817
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated512.cmd_10669]
@@ -84385,7 +84385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest512\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest512\Generated512
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated124.cmd_10670]
@@ -84393,7 +84393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest124\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest124\Generated124
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1199.cmd_10671]
@@ -84401,7 +84401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1199\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1199\Generated1199
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated244.cmd_10672]
@@ -84409,7 +84409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest244\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest244\Generated244
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i01.cmd_10673]
@@ -84417,7 +84417,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i01\mcc_i01.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i01
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1017.cmd_10674]
@@ -84425,7 +84425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1017\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1017\Generated1017
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1226.cmd_10675]
@@ -84433,7 +84433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1226\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1226\Generated1226
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated967.cmd_10676]
@@ -84441,7 +84441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest967\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest967\Generated967
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated598.cmd_10677]
@@ -84449,7 +84449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest598\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest598\Generated598
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1448.cmd_10678]
@@ -84457,7 +84457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1448\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1448\Generated1448
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated260.cmd_10679]
@@ -84465,7 +84465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest260\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest260\Generated260
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated836.cmd_10680]
@@ -84473,7 +84473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest836\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest836\Generated836
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1038.cmd_10681]
@@ -84481,7 +84481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1038\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1038\Generated1038
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_6239.cmd_10682]
@@ -84489,7 +84489,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_6239\GitHub_6239\GitHub_6239.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_6239\GitHub_6239
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated151.cmd_10683]
@@ -84497,7 +84497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest151\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest151\Generated151
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_142976.cmd_10684]
@@ -84505,7 +84505,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_142976\DevDiv_142976\DevDiv_142976.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_142976\DevDiv_142976
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1241.cmd_10685]
@@ -84513,7 +84513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1241\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1241\Generated1241
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1271.cmd_10686]
@@ -84521,7 +84521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1271\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1271\Generated1271
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated278.cmd_10687]
@@ -84529,7 +84529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest278\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest278\Generated278
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated800.cmd_10688]
@@ -84537,7 +84537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest800\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest800\Generated800
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1364.cmd_10689]
@@ -84545,7 +84545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1364\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1364\Generated1364
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated34.cmd_10690]
@@ -84553,7 +84553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest34\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest34\Generated34
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1220.cmd_10691]
@@ -84561,7 +84561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1220\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1220\Generated1220
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i70.cmd_10692]
@@ -84569,7 +84569,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i70\mcc_i70.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i70
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated335.cmd_10693]
@@ -84577,7 +84577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest335\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest335\Generated335
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1340.cmd_10694]
@@ -84585,7 +84585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1340\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1340\Generated1340
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1392.cmd_10695]
@@ -84593,7 +84593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1392\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1392\Generated1392
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_283795.cmd_10696]
@@ -84601,7 +84601,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_283795\DevDiv_283795\DevDiv_283795.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_283795\DevDiv_283795
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated720.cmd_10697]
@@ -84609,7 +84609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest720\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest720\Generated720
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1274.cmd_10698]
@@ -84617,7 +84617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1274\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1274\Generated1274
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated20.cmd_10699]
@@ -84625,7 +84625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest20\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest20\Generated20
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated844.cmd_10700]
@@ -84633,7 +84633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest844\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest844\Generated844
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1485.cmd_10701]
@@ -84641,7 +84641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1485\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1485\Generated1485
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated383.cmd_10702]
@@ -84649,7 +84649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest383\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest383\Generated383
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated480.cmd_10703]
@@ -84657,7 +84657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest480\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest480\Generated480
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated773.cmd_10704]
@@ -84665,7 +84665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest773\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest773\Generated773
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1361.cmd_10705]
@@ -84673,7 +84673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1361\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1361\Generated1361
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsSByte.cmd_10706]
@@ -84681,7 +84681,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsSByte\ConstantArgs
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsSByte
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated806.cmd_10707]
@@ -84689,7 +84689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest806\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest806\Generated806
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated37.cmd_10708]
@@ -84697,7 +84697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest37\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest37\Generated37
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1457.cmd_10709]
@@ -84705,7 +84705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1457\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1457\Generated1457
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1373.cmd_10710]
@@ -84713,7 +84713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1373\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1373\Generated1373
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1402.cmd_10711]
@@ -84721,7 +84721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1402\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1402\Generated1402
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated395.cmd_10712]
@@ -84729,7 +84729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest395\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest395\Generated395
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated622.cmd_10713]
@@ -84737,7 +84737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest622\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest622\Generated622
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated873.cmd_10714]
@@ -84745,7 +84745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest873\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest873\Generated873
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated891.cmd_10715]
@@ -84753,7 +84753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest891\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest891\Generated891
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1280.cmd_10716]
@@ -84761,7 +84761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1280\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1280\Generated1280
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1420.cmd_10717]
@@ -84769,7 +84769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1420\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1420\Generated1420
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated705.cmd_10718]
@@ -84777,7 +84777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest705\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest705\Generated705
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated315.cmd_10719]
@@ -84785,7 +84785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest315\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest315\Generated315
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated639.cmd_10720]
@@ -84793,7 +84793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest639\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest639\Generated639
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated912.cmd_10721]
@@ -84801,7 +84801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest912\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest912\Generated912
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [structfieldparam_r.cmd_10722]
@@ -84809,7 +84809,7 @@ RelativePath=JIT\Directed\StructABI\structfieldparam_r\structfieldparam_r.cmd
 WorkingDir=JIT\Directed\StructABI\structfieldparam_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1014.cmd_10723]
@@ -84817,7 +84817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1014\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1014\Generated1014
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated3.cmd_10724]
@@ -84825,7 +84825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest3\Generated3
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest3\Generated3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated909.cmd_10725]
@@ -84833,7 +84833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest909\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest909\Generated909
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated522.cmd_10726]
@@ -84841,7 +84841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest522\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest522\Generated522
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated580.cmd_10727]
@@ -84849,7 +84849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest580\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest580\Generated580
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1056.cmd_10728]
@@ -84857,7 +84857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1056\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1056\Generated1056
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b21220.cmd_10729]
@@ -84865,7 +84865,7 @@ RelativePath=JIT\jit64\regress\ndpw\21220\b21220\b21220.cmd
 WorkingDir=JIT\jit64\regress\ndpw\21220\b21220
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated1054.cmd_10730]
@@ -84873,7 +84873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1054\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1054\Generated1054
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1052.cmd_10731]
@@ -84881,7 +84881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1052\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1052\Generated1052
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_278526.cmd_10732]
@@ -84889,7 +84889,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_278526\DevDiv_278526\DevDiv_278526.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_278526\DevDiv_278526
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated936.cmd_10733]
@@ -84897,7 +84897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest936\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest936\Generated936
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1445.cmd_10734]
@@ -84905,7 +84905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1445\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1445\Generated1445
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated633.cmd_10735]
@@ -84913,7 +84913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest633\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest633\Generated633
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated432.cmd_10736]
@@ -84921,7 +84921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest432\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest432\Generated432
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated447.cmd_10737]
@@ -84929,7 +84929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest447\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest447\Generated447
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated446.cmd_10738]
@@ -84937,7 +84937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest446\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest446\Generated446
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated319.cmd_10739]
@@ -84945,7 +84945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest319\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest319\Generated319
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated791.cmd_10740]
@@ -84953,7 +84953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest791\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest791\Generated791
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated863.cmd_10741]
@@ -84961,7 +84961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest863\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest863\Generated863
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated438.cmd_10742]
@@ -84969,7 +84969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest438\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest438\Generated438
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated350.cmd_10743]
@@ -84977,7 +84977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest350\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest350\Generated350
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1301.cmd_10744]
@@ -84985,7 +84985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1301\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1301\Generated1301
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated958.cmd_10745]
@@ -84993,7 +84993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest958\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest958\Generated958
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1419.cmd_10746]
@@ -85001,7 +85001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1419\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1419\Generated1419
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated178.cmd_10747]
@@ -85009,7 +85009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest178\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest178\Generated178
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated775.cmd_10748]
@@ -85017,7 +85017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest775\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest775\Generated775
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated236.cmd_10749]
@@ -85025,7 +85025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest236\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest236\Generated236
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated625.cmd_10750]
@@ -85033,7 +85033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest625\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest625\Generated625
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [UDivConst.cmd_10751]
@@ -85041,7 +85041,7 @@ RelativePath=JIT\CodeGenBringUpTests\UDivConst\UDivConst.cmd
 WorkingDir=JIT\CodeGenBringUpTests\UDivConst
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1070.cmd_10752]
@@ -85049,7 +85049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1070\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1070\Generated1070
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1110.cmd_10753]
@@ -85057,7 +85057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1110\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1110\Generated1110
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated465.cmd_10754]
@@ -85065,7 +85065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest465\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest465\Generated465
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated605.cmd_10755]
@@ -85073,7 +85073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest605\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest605\Generated605
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated687.cmd_10756]
@@ -85081,7 +85081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest687\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest687\Generated687
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1456.cmd_10757]
@@ -85089,7 +85089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1456\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1456\Generated1456
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated392.cmd_10758]
@@ -85097,7 +85097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest392\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest392\Generated392
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1324.cmd_10759]
@@ -85105,7 +85105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1324\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1324\Generated1324
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1275.cmd_10760]
@@ -85113,7 +85113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1275\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1275\Generated1275
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1071.cmd_10761]
@@ -85121,7 +85121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1071\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1071\Generated1071
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1146.cmd_10762]
@@ -85129,7 +85129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1146\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1146\Generated1146
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1413.cmd_10763]
@@ -85137,7 +85137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1413\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1413\Generated1413
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated55.cmd_10764]
@@ -85145,7 +85145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest55\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest55\Generated55
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated965.cmd_10765]
@@ -85153,7 +85153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest965\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest965\Generated965
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated130.cmd_10766]
@@ -85161,7 +85161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest130\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest130\Generated130
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated217.cmd_10767]
@@ -85169,7 +85169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest217\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest217\Generated217
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated774.cmd_10768]
@@ -85177,7 +85177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest774\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest774\Generated774
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated164.cmd_10769]
@@ -85185,7 +85185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest164\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest164\Generated164
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1451.cmd_10770]
@@ -85193,7 +85193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1451\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1451\Generated1451
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated982.cmd_10771]
@@ -85201,7 +85201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest982\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest982\Generated982
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1037.cmd_10772]
@@ -85209,7 +85209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1037\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1037\Generated1037
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated797.cmd_10773]
@@ -85217,7 +85217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest797\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest797\Generated797
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1181.cmd_10774]
@@ -85225,7 +85225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1181\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1181\Generated1181
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1390.cmd_10775]
@@ -85233,7 +85233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1390\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1390\Generated1390
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated970.cmd_10776]
@@ -85241,7 +85241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest970\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest970\Generated970
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1022.cmd_10777]
@@ -85249,7 +85249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1022\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1022\Generated1022
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1006.cmd_10778]
@@ -85257,7 +85257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1006\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1006\Generated1006
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1328.cmd_10779]
@@ -85265,7 +85265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1328\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1328\Generated1328
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated56.cmd_10780]
@@ -85273,7 +85273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest56\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest56\Generated56
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated585.cmd_10781]
@@ -85281,7 +85281,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest585\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest585\Generated585
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1034.cmd_10782]
@@ -85289,7 +85289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1034\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1034\Generated1034
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated596.cmd_10783]
@@ -85297,7 +85297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest596\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest596\Generated596
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1024.cmd_10784]
@@ -85305,7 +85305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1024\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1024\Generated1024
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated996.cmd_10785]
@@ -85313,7 +85313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest996\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest996\Generated996
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1495.cmd_10786]
@@ -85321,7 +85321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1495\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1495\Generated1495
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated695.cmd_10787]
@@ -85329,7 +85329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest695\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest695\Generated695
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated304.cmd_10788]
@@ -85337,7 +85337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest304\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest304\Generated304
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated30.cmd_10789]
@@ -85345,7 +85345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest30\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest30\Generated30
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated412.cmd_10790]
@@ -85353,7 +85353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest412\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest412\Generated412
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated819.cmd_10791]
@@ -85361,7 +85361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest819\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest819\Generated819
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated138.cmd_10792]
@@ -85369,7 +85369,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest138\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest138\Generated138
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1042.cmd_10793]
@@ -85377,7 +85377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1042\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1042\Generated1042
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i53.cmd_10794]
@@ -85385,7 +85385,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i53\mcc_i53.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i53
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [b37598.cmd_10795]
@@ -85393,7 +85393,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b37598\b37598\b37598.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b37598\b37598
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated647.cmd_10796]
@@ -85401,7 +85401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest647\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest647\Generated647
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated521.cmd_10797]
@@ -85409,7 +85409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest521\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest521\Generated521
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated181.cmd_10798]
@@ -85417,7 +85417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest181\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest181\Generated181
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1069.cmd_10799]
@@ -85425,7 +85425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1069\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1069\Generated1069
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1319.cmd_10800]
@@ -85433,7 +85433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1319\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1319\Generated1319
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated70.cmd_10801]
@@ -85441,7 +85441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest70\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest70\Generated70
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [RuntimeWrappedException.cmd_10802]
@@ -85449,7 +85449,7 @@ RelativePath=baseservices\compilerservices\RuntimeWrappedException\RuntimeWrappe
 WorkingDir=baseservices\compilerservices\RuntimeWrappedException\RuntimeWrappedException
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated493.cmd_10803]
@@ -85457,7 +85457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest493\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest493\Generated493
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated914.cmd_10804]
@@ -85465,7 +85465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest914\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest914\Generated914
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated789.cmd_10805]
@@ -85473,7 +85473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest789\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest789\Generated789
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i71.cmd_10806]
@@ -85481,7 +85481,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i71\mcc_i71.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i71
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated790.cmd_10807]
@@ -85489,7 +85489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest790\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest790\Generated790
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1180.cmd_10808]
@@ -85497,7 +85497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1180\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1180\Generated1180
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1140.cmd_10809]
@@ -85505,7 +85505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1140\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1140\Generated1140
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1462.cmd_10810]
@@ -85513,7 +85513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1462\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1462\Generated1462
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated992.cmd_10811]
@@ -85521,7 +85521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest992\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest992\Generated992
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated964.cmd_10812]
@@ -85529,7 +85529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest964\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest964\Generated964
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated831.cmd_10813]
@@ -85537,7 +85537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest831\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest831\Generated831
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated147.cmd_10814]
@@ -85545,7 +85545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest147\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest147\Generated147
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [uint64Opt_d.cmd_10815]
@@ -85553,7 +85553,7 @@ RelativePath=JIT\Directed\shift\uint64Opt_d\uint64Opt_d.cmd
 WorkingDir=JIT\Directed\shift\uint64Opt_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [bleref_il_d.cmd_10816]
@@ -85561,7 +85561,7 @@ RelativePath=JIT\Directed\coverage\importer\Desktop\bleref_il_d\bleref_il_d.cmd
 WorkingDir=JIT\Directed\coverage\importer\Desktop\bleref_il_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated113.cmd_10817]
@@ -85569,7 +85569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest113\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest113\Generated113
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated316.cmd_10818]
@@ -85577,7 +85577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest316\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest316\Generated316
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1461.cmd_10819]
@@ -85585,7 +85585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1461\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1461\Generated1461
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1191.cmd_10820]
@@ -85593,7 +85593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1191\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1191\Generated1191
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated448.cmd_10821]
@@ -85601,7 +85601,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest448\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest448\Generated448
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated928.cmd_10822]
@@ -85609,7 +85609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest928\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest928\Generated928
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_FAIL;9457
 HostStyle=0
 
 [DevDiv_367099.cmd_10823]
@@ -85617,7 +85617,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_367099\DevDiv_367099\DevDiv_367099.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_367099\DevDiv_367099
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_8170.cmd_10824]
@@ -85625,7 +85625,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_8170\GitHub_8170\GitHub_8170.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_8170\GitHub_8170
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [extended.cmd_10825]
@@ -85633,7 +85633,7 @@ RelativePath=JIT\Directed\RVAInit\extended\extended.cmd
 WorkingDir=JIT\Directed\RVAInit\extended
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated255.cmd_10826]
@@ -85641,7 +85641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest255\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest255\Generated255
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1102.cmd_10827]
@@ -85649,7 +85649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1102\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1102\Generated1102
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1322.cmd_10828]
@@ -85657,7 +85657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1322\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1322\Generated1322
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [InlineGCStruct.cmd_10829]
@@ -85665,7 +85665,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\InlineGCStruct\InlineGCStruct.
 WorkingDir=JIT\Performance\CodeQuality\Inlining\InlineGCStruct
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1429.cmd_10830]
@@ -85673,7 +85673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1429\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1429\Generated1429
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated252.cmd_10831]
@@ -85681,7 +85681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest252\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest252\Generated252
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsFloat.cmd_10832]
@@ -85689,7 +85689,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsFloat\ConstantArgs
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsFloat
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated716.cmd_10833]
@@ -85697,7 +85697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest716\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest716\Generated716
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1148.cmd_10834]
@@ -85705,7 +85705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1148\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1148\Generated1148
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated342.cmd_10835]
@@ -85713,7 +85713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest342\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest342\Generated342
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1209.cmd_10836]
@@ -85721,7 +85721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1209\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1209\Generated1209
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1068.cmd_10837]
@@ -85729,7 +85729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1068\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1068\Generated1068
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated578.cmd_10838]
@@ -85737,7 +85737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest578\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest578\Generated578
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated674.cmd_10839]
@@ -85745,7 +85745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest674\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest674\Generated674
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated401.cmd_10840]
@@ -85753,7 +85753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest401\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest401\Generated401
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated354.cmd_10841]
@@ -85761,7 +85761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest354\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest354\Generated354
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated291.cmd_10842]
@@ -85769,7 +85769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest291\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest291\Generated291
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1374.cmd_10843]
@@ -85777,7 +85777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1374\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1374\Generated1374
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1293.cmd_10844]
@@ -85785,7 +85785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1293\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1293\Generated1293
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated818.cmd_10845]
@@ -85793,7 +85793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest818\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest818\Generated818
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b46867.cmd_10846]
@@ -85801,7 +85801,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b46867\b46867\b46867.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b46867\b46867
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated635.cmd_10847]
@@ -85809,7 +85809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest635\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest635\Generated635
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1030.cmd_10848]
@@ -85817,7 +85817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1030\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1030\Generated1030
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1027.cmd_10849]
@@ -85825,7 +85825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1027\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1027\Generated1027
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated845.cmd_10850]
@@ -85833,7 +85833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest845\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest845\Generated845
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated81.cmd_10851]
@@ -85841,7 +85841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest81\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest81\Generated81
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated798.cmd_10852]
@@ -85849,7 +85849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest798\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest798\Generated798
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_288222.cmd_10853]
@@ -85857,7 +85857,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_288222\DevDiv_288222\DevDiv_288222.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_288222\DevDiv_288222
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated363.cmd_10854]
@@ -85865,7 +85865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest363\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest363\Generated363
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated17.cmd_10855]
@@ -85873,7 +85873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest17\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest17\Generated17
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_6238.cmd_10856]
@@ -85881,7 +85881,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_6238\GitHub_6238\GitHub_6238.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_6238\GitHub_6238
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated784.cmd_10857]
@@ -85889,7 +85889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest784\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest784\Generated784
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1300.cmd_10858]
@@ -85897,7 +85897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1300\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1300\Generated1300
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1298.cmd_10859]
@@ -85905,7 +85905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1298\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1298\Generated1298
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated478.cmd_10860]
@@ -85913,7 +85913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest478\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest478\Generated478
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated700.cmd_10861]
@@ -85921,7 +85921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest700\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest700\Generated700
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated892.cmd_10862]
@@ -85929,7 +85929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest892\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest892\Generated892
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1130.cmd_10863]
@@ -85937,7 +85937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1130\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1130\Generated1130
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated638.cmd_10864]
@@ -85945,7 +85945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest638\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest638\Generated638
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ldelemnullarr1_il_d.cmd_10865]
@@ -85953,7 +85953,7 @@ RelativePath=JIT\Directed\coverage\importer\Desktop\ldelemnullarr1_il_d\ldelemnu
 WorkingDir=JIT\Directed\coverage\importer\Desktop\ldelemnullarr1_il_d
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9465;NEW
+Categories=9465;EXPECTED_FAIL
 HostStyle=0
 
 [Generated1080.cmd_10866]
@@ -85961,7 +85961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1080\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1080\Generated1080
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated427.cmd_10867]
@@ -85969,7 +85969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest427\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest427\Generated427
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated670.cmd_10868]
@@ -85977,7 +85977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest670\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest670\Generated670
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b91248.cmd_10869]
@@ -85985,7 +85985,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b91248\b91248\b91248.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b91248\b91248
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated42.cmd_10870]
@@ -85993,7 +85993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest42\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest42\Generated42
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i33.cmd_10871]
@@ -86001,7 +86001,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i33\mcc_i33.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i33
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated830.cmd_10872]
@@ -86009,7 +86009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest830\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest830\Generated830
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated473.cmd_10873]
@@ -86017,7 +86017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest473\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest473\Generated473
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1019.cmd_10874]
@@ -86025,7 +86025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1019\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1019\Generated1019
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated669.cmd_10875]
@@ -86033,7 +86033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest669\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest669\Generated669
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated756.cmd_10876]
@@ -86041,7 +86041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest756\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest756\Generated756
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated442.cmd_10877]
@@ -86049,7 +86049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest442\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest442\Generated442
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1315.cmd_10878]
@@ -86057,7 +86057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1315\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1315\Generated1315
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated65.cmd_10879]
@@ -86065,7 +86065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest65\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest65\Generated65
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated898.cmd_10880]
@@ -86073,7 +86073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest898\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest898\Generated898
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated653.cmd_10881]
@@ -86081,7 +86081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest653\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest653\Generated653
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1001.cmd_10882]
@@ -86089,7 +86089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1001\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1001\Generated1001
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1332.cmd_10883]
@@ -86097,7 +86097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1332\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1332\Generated1332
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated136.cmd_10884]
@@ -86105,7 +86105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest136\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest136\Generated136
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated804.cmd_10885]
@@ -86113,7 +86113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest804\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest804\Generated804
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated654.cmd_10886]
@@ -86121,7 +86121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest654\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest654\Generated654
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1123.cmd_10887]
@@ -86129,7 +86129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1123\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1123\Generated1123
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated454.cmd_10888]
@@ -86137,7 +86137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest454\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest454\Generated454
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1113.cmd_10889]
@@ -86145,7 +86145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1113\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1113\Generated1113
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated440.cmd_10890]
@@ -86153,7 +86153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest440\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest440\Generated440
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1477.cmd_10891]
@@ -86161,7 +86161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1477\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1477\Generated1477
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1421.cmd_10892]
@@ -86169,7 +86169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1421\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1421\Generated1421
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated171.cmd_10893]
@@ -86177,7 +86177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest171\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest171\Generated171
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i63.cmd_10894]
@@ -86185,7 +86185,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i63\mcc_i63.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i63
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated582.cmd_10895]
@@ -86193,7 +86193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest582\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest582\Generated582
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated946.cmd_10896]
@@ -86201,7 +86201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest946\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest946\Generated946
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated569.cmd_10897]
@@ -86209,7 +86209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest569\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest569\Generated569
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsString.cmd_10898]
@@ -86217,7 +86217,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsString\ConstantArg
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsString
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i02.cmd_10899]
@@ -86225,7 +86225,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i02\mcc_i02.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i02
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1004.cmd_10900]
@@ -86233,7 +86233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1004\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1004\Generated1004
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1096.cmd_10901]
@@ -86241,7 +86241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1096\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1096\Generated1096
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1266.cmd_10902]
@@ -86249,7 +86249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1266\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1266\Generated1266
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated980.cmd_10903]
@@ -86257,7 +86257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest980\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest980\Generated980
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated954.cmd_10904]
@@ -86265,7 +86265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest954\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest954\Generated954
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated375.cmd_10905]
@@ -86273,7 +86273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest375\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest375\Generated375
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated106.cmd_10906]
@@ -86281,7 +86281,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest106\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest106\Generated106
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated547.cmd_10907]
@@ -86289,7 +86289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest547\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest547\Generated547
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated876.cmd_10908]
@@ -86297,7 +86297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest876\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest876\Generated876
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated468.cmd_10909]
@@ -86305,7 +86305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest468\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest468\Generated468
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1031.cmd_10910]
@@ -86313,7 +86313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1031\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1031\Generated1031
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated810.cmd_10911]
@@ -86321,7 +86321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest810\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest810\Generated810
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1185.cmd_10912]
@@ -86329,7 +86329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1185\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1185\Generated1185
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated763.cmd_10913]
@@ -86337,7 +86337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest763\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest763\Generated763
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_FAIL;9457
 HostStyle=0
 
 [Generated1349.cmd_10914]
@@ -86345,7 +86345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1349\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1349\Generated1349
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated927.cmd_10915]
@@ -86353,7 +86353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest927\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest927\Generated927
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated43.cmd_10916]
@@ -86361,7 +86361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest43\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest43\Generated43
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1190.cmd_10917]
@@ -86369,7 +86369,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1190\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1190\Generated1190
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1261.cmd_10918]
@@ -86377,7 +86377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1261\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1261\Generated1261
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1351.cmd_10919]
@@ -86385,7 +86385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1351\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1351\Generated1351
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated423.cmd_10920]
@@ -86393,7 +86393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest423\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest423\Generated423
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated429.cmd_10921]
@@ -86401,7 +86401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest429\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest429\Generated429
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i00.cmd_10922]
@@ -86409,7 +86409,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i00\mcc_i00.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i00
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1389.cmd_10923]
@@ -86417,7 +86417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1389\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1389\Generated1389
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_278369.cmd_10924]
@@ -86425,7 +86425,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_278369\DevDiv_278369\DevDiv_278369.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_278369\DevDiv_278369
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated882.cmd_10925]
@@ -86433,7 +86433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest882\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest882\Generated882
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1239.cmd_10926]
@@ -86441,7 +86441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1239\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1239\Generated1239
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated374.cmd_10927]
@@ -86449,7 +86449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest374\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest374\Generated374
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated226.cmd_10928]
@@ -86457,7 +86457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest226\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest226\Generated226
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated328.cmd_10929]
@@ -86465,7 +86465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest328\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest328\Generated328
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated943.cmd_10930]
@@ -86473,7 +86473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest943\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest943\Generated943
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated189.cmd_10931]
@@ -86481,7 +86481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest189\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest189\Generated189
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated467.cmd_10932]
@@ -86489,7 +86489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest467\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest467\Generated467
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [structfieldparam_ro.cmd_10933]
@@ -86497,7 +86497,7 @@ RelativePath=JIT\Directed\StructABI\structfieldparam_ro\structfieldparam_ro.cmd
 WorkingDir=JIT\Directed\StructABI\structfieldparam_ro
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1325.cmd_10934]
@@ -86505,7 +86505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1325\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1325\Generated1325
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated366.cmd_10935]
@@ -86513,7 +86513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest366\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest366\Generated366
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated302.cmd_10936]
@@ -86521,7 +86521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest302\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest302\Generated302
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated591.cmd_10937]
@@ -86529,7 +86529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest591\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest591\Generated591
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated509.cmd_10938]
@@ -86537,7 +86537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest509\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest509\Generated509
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated2.cmd_10939]
@@ -86545,7 +86545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest2\Generated2
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest2\Generated2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated655.cmd_10940]
@@ -86553,7 +86553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest655\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest655\Generated655
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b36472.cmd_10941]
@@ -86561,7 +86561,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b36472\b36472\b36472.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b36472\b36472
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [mcc_i31.cmd_10942]
@@ -86569,7 +86569,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i31\mcc_i31.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i31
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated572.cmd_10943]
@@ -86577,7 +86577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest572\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest572\Generated572
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1230.cmd_10944]
@@ -86585,7 +86585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1230\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1230\Generated1230
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated949.cmd_10945]
@@ -86593,7 +86593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest949\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest949\Generated949
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated641.cmd_10946]
@@ -86601,7 +86601,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest641\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest641\Generated641
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1345.cmd_10947]
@@ -86609,7 +86609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1345\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1345\Generated1345
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated235.cmd_10948]
@@ -86617,7 +86617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest235\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest235\Generated235
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated476.cmd_10949]
@@ -86625,7 +86625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest476\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest476\Generated476
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated540.cmd_10950]
@@ -86633,7 +86633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest540\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest540\Generated540
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated634.cmd_10951]
@@ -86641,7 +86641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest634\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest634\Generated634
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [funclet.cmd_10952]
@@ -86649,7 +86649,7 @@ RelativePath=JIT\jit64\gc\misc\funclet\funclet.cmd
 WorkingDir=JIT\jit64\gc\misc\funclet
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated671.cmd_10953]
@@ -86657,7 +86657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest671\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest671\Generated671
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ldelemnullarr1_il_r.cmd_10954]
@@ -86665,7 +86665,7 @@ RelativePath=JIT\Directed\coverage\importer\Desktop\ldelemnullarr1_il_r\ldelemnu
 WorkingDir=JIT\Directed\coverage\importer\Desktop\ldelemnullarr1_il_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9465;NEW
+Categories=9465;EXPECTED_FAIL
 HostStyle=0
 
 [ConstantArgsUInt.cmd_10955]
@@ -86673,7 +86673,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsUInt\ConstantArgsU
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsUInt
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1228.cmd_10956]
@@ -86681,7 +86681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1228\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1228\Generated1228
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1423.cmd_10957]
@@ -86689,7 +86689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1423\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1423\Generated1423
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated100.cmd_10958]
@@ -86697,7 +86697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest100\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest100\Generated100
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1388.cmd_10959]
@@ -86705,7 +86705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1388\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1388\Generated1388
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated296.cmd_10960]
@@ -86713,7 +86713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest296\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest296\Generated296
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1353.cmd_10961]
@@ -86721,7 +86721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1353\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1353\Generated1353
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated816.cmd_10962]
@@ -86729,7 +86729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest816\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest816\Generated816
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated485.cmd_10963]
@@ -86737,7 +86737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest485\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest485\Generated485
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated270.cmd_10964]
@@ -86745,7 +86745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest270\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest270\Generated270
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated905.cmd_10965]
@@ -86753,7 +86753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest905\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest905\Generated905
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated826.cmd_10966]
@@ -86761,7 +86761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest826\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest826\Generated826
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1055.cmd_10967]
@@ -86769,7 +86769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1055\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1055\Generated1055
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated439.cmd_10968]
@@ -86777,7 +86777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest439\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest439\Generated439
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1350.cmd_10969]
@@ -86785,7 +86785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1350\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1350\Generated1350
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated108.cmd_10970]
@@ -86793,7 +86793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest108\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest108\Generated108
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated161.cmd_10971]
@@ -86801,7 +86801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest161\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest161\Generated161
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1173.cmd_10972]
@@ -86809,7 +86809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1173\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1173\Generated1173
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated33.cmd_10973]
@@ -86817,7 +86817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest33\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest33\Generated33
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated686.cmd_10974]
@@ -86825,7 +86825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest686\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest686\Generated686
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated398.cmd_10975]
@@ -86833,7 +86833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest398\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest398\Generated398
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated309.cmd_10976]
@@ -86841,7 +86841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest309\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest309\Generated309
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated850.cmd_10977]
@@ -86849,7 +86849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest850\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest850\Generated850
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_359736_do.cmd_10978]
@@ -86857,7 +86857,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_359736\DevDiv_359736_do\DevDiv_359736
 WorkingDir=JIT\Regression\JitBlue\DevDiv_359736\DevDiv_359736_do
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [nonrefsdarr_il_r.cmd_10979]
@@ -86865,7 +86865,7 @@ RelativePath=JIT\Directed\coverage\importer\Desktop\nonrefsdarr_il_r\nonrefsdarr
 WorkingDir=JIT\Directed\coverage\importer\Desktop\nonrefsdarr_il_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9465;NEW
+Categories=9465;EXPECTED_FAIL
 HostStyle=0
 
 [Generated107.cmd_10980]
@@ -86873,7 +86873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest107\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest107\Generated107
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1085.cmd_10981]
@@ -86881,7 +86881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1085\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1085\Generated1085
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated495.cmd_10982]
@@ -86889,7 +86889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest495\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest495\Generated495
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsUShort.cmd_10983]
@@ -86897,7 +86897,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsUShort\ConstantArg
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsUShort
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1165.cmd_10984]
@@ -86905,7 +86905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1165\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1165\Generated1165
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated8.cmd_10985]
@@ -86913,7 +86913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest8\Generated8
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest8\Generated8
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated62.cmd_10986]
@@ -86921,7 +86921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest62\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest62\Generated62
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated150.cmd_10987]
@@ -86929,7 +86929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest150\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest150\Generated150
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1002.cmd_10988]
@@ -86937,7 +86937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1002\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1002\Generated1002
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated24.cmd_10989]
@@ -86945,7 +86945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest24\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest24\Generated24
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1292.cmd_10990]
@@ -86953,7 +86953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1292\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1292\Generated1292
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b26324b.cmd_10991]
@@ -86961,7 +86961,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26324\b26324b\b26324b.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26324\b26324b
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [b41391.cmd_10992]
@@ -86969,7 +86969,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41391\b41391\b41391.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41391\b41391
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated814.cmd_10993]
@@ -86977,7 +86977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest814\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest814\Generated814
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1474.cmd_10994]
@@ -86985,7 +86985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1474\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1474\Generated1474
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1337.cmd_10995]
@@ -86993,7 +86993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1337\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1337\Generated1337
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated176.cmd_10996]
@@ -87001,7 +87001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest176\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest176\Generated176
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated956.cmd_10997]
@@ -87009,7 +87009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest956\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest956\Generated956
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated382.cmd_10998]
@@ -87017,7 +87017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest382\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest382\Generated382
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1371.cmd_10999]
@@ -87025,7 +87025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1371\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1371\Generated1371
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1207.cmd_11000]
@@ -87033,7 +87033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1207\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1207\Generated1207
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1216.cmd_11001]
@@ -87041,7 +87041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1216\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1216\Generated1216
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated615.cmd_11002]
@@ -87049,7 +87049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest615\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest615\Generated615
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1365.cmd_11003]
@@ -87057,7 +87057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1365\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1365\Generated1365
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated557.cmd_11004]
@@ -87065,7 +87065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest557\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest557\Generated557
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b08046.cmd_11005]
@@ -87073,7 +87073,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1.2-M01\b08046\b08046\b08046.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1.2-M01\b08046\b08046
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated1045.cmd_11006]
@@ -87081,7 +87081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1045\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1045\Generated1045
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1099.cmd_11007]
@@ -87089,7 +87089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1099\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1099\Generated1099
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1084.cmd_11008]
@@ -87097,7 +87097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1084\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1084\Generated1084
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated607.cmd_11009]
@@ -87105,7 +87105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest607\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest607\Generated607
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated940.cmd_11010]
@@ -87113,7 +87113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest940\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest940\Generated940
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated41.cmd_11011]
@@ -87121,7 +87121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest41\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest41\Generated41
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated28.cmd_11012]
@@ -87129,7 +87129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest28\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest28\Generated28
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated855.cmd_11013]
@@ -87137,7 +87137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest855\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest855\Generated855
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1259.cmd_11014]
@@ -87145,7 +87145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1259\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1259\Generated1259
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1447.cmd_11015]
@@ -87153,7 +87153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1447\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1447\Generated1447
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated934.cmd_11016]
@@ -87161,7 +87161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest934\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest934\Generated934
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated626.cmd_11017]
@@ -87169,7 +87169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest626\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest626\Generated626
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated173.cmd_11018]
@@ -87177,7 +87177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest173\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest173\Generated173
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1231.cmd_11019]
@@ -87185,7 +87185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1231\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1231\Generated1231
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated760.cmd_11020]
@@ -87193,7 +87193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest760\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest760\Generated760
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated192.cmd_11021]
@@ -87201,7 +87201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest192\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest192\Generated192
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1466.cmd_11022]
@@ -87209,7 +87209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1466\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1466\Generated1466
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated104.cmd_11023]
@@ -87217,7 +87217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest104\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest104\Generated104
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1171.cmd_11024]
@@ -87225,7 +87225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1171\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1171\Generated1171
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated230.cmd_11025]
@@ -87233,7 +87233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest230\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest230\Generated230
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated731.cmd_11026]
@@ -87241,7 +87241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest731\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest731\Generated731
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1021.cmd_11027]
@@ -87249,7 +87249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1021\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1021\Generated1021
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated142.cmd_11028]
@@ -87257,7 +87257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest142\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest142\Generated142
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1377.cmd_11029]
@@ -87265,7 +87265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1377\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1377\Generated1377
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated601.cmd_11030]
@@ -87273,7 +87273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest601\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest601\Generated601
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated677.cmd_11031]
@@ -87281,7 +87281,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest677\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest677\Generated677
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated561.cmd_11032]
@@ -87289,7 +87289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest561\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest561\Generated561
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated718.cmd_11033]
@@ -87297,7 +87297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest718\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest718\Generated718
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated623.cmd_11034]
@@ -87305,7 +87305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest623\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest623\Generated623
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated693.cmd_11035]
@@ -87313,7 +87313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest693\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest693\Generated693
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_FAIL;9457
 HostStyle=0
 
 [Generated500.cmd_11036]
@@ -87321,7 +87321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest500\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest500\Generated500
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1183.cmd_11037]
@@ -87329,7 +87329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1183\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1183\Generated1183
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1253.cmd_11038]
@@ -87337,7 +87337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1253\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1253\Generated1253
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1039.cmd_11039]
@@ -87345,7 +87345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1039\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1039\Generated1039
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1203.cmd_11040]
@@ -87353,7 +87353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1203\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1203\Generated1203
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated887.cmd_11041]
@@ -87361,7 +87361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest887\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest887\Generated887
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1023.cmd_11042]
@@ -87369,7 +87369,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1023\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1023\Generated1023
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1098.cmd_11043]
@@ -87377,7 +87377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1098\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1098\Generated1098
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1114.cmd_11044]
@@ -87385,7 +87385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1114\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1114\Generated1114
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1208.cmd_11045]
@@ -87393,7 +87393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1208\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1208\Generated1208
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated957.cmd_11046]
@@ -87401,7 +87401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest957\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest957\Generated957
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated839.cmd_11047]
@@ -87409,7 +87409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest839\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest839\Generated839
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated141.cmd_11048]
@@ -87417,7 +87417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest141\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest141\Generated141
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated49.cmd_11049]
@@ -87425,7 +87425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest49\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest49\Generated49
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated254.cmd_11050]
@@ -87433,7 +87433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest254\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest254\Generated254
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i81.cmd_11051]
@@ -87441,7 +87441,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i81\mcc_i81.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i81
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated273.cmd_11052]
@@ -87449,7 +87449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest273\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest273\Generated273
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated744.cmd_11053]
@@ -87457,7 +87457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest744\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest744\Generated744
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1401.cmd_11054]
@@ -87465,7 +87465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1401\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1401\Generated1401
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated699.cmd_11055]
@@ -87473,7 +87473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest699\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest699\Generated699
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1020.cmd_11056]
@@ -87481,7 +87481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1020\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1020\Generated1020
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1138.cmd_11057]
@@ -87489,7 +87489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1138\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1138\Generated1138
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b31745.cmd_11058]
@@ -87497,7 +87497,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31745\b31745\b31745.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31745\b31745
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated463.cmd_11059]
@@ -87505,7 +87505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest463\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest463\Generated463
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated444.cmd_11060]
@@ -87513,7 +87513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest444\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest444\Generated444
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1012.cmd_11061]
@@ -87521,7 +87521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1012\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1012\Generated1012
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated97.cmd_11062]
@@ -87529,7 +87529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest97\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest97\Generated97
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i73.cmd_11063]
@@ -87537,7 +87537,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i73\mcc_i73.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i73
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1198.cmd_11064]
@@ -87545,7 +87545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1198\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1198\Generated1198
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated548.cmd_11065]
@@ -87553,7 +87553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest548\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest548\Generated548
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1048.cmd_11066]
@@ -87561,7 +87561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1048\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1048\Generated1048
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated492.cmd_11067]
@@ -87569,7 +87569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest492\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest492\Generated492
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated122.cmd_11068]
@@ -87577,7 +87577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest122\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest122\Generated122
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1323.cmd_11069]
@@ -87585,7 +87585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1323\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1323\Generated1323
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated276.cmd_11070]
@@ -87593,7 +87593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest276\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest276\Generated276
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b30864.cmd_11071]
@@ -87601,7 +87601,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30864\b30864\b30864.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30864\b30864
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated738.cmd_11072]
@@ -87609,7 +87609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest738\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest738\Generated738
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated707.cmd_11073]
@@ -87617,7 +87617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest707\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest707\Generated707
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated590.cmd_11074]
@@ -87625,7 +87625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest590\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest590\Generated590
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated846.cmd_11075]
@@ -87633,7 +87633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest846\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest846\Generated846
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated434.cmd_11076]
@@ -87641,7 +87641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest434\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest434\Generated434
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated966.cmd_11077]
@@ -87649,7 +87649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest966\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest966\Generated966
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated586.cmd_11078]
@@ -87657,7 +87657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest586\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest586\Generated586
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated489.cmd_11079]
@@ -87665,7 +87665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest489\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest489\Generated489
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1467.cmd_11080]
@@ -87673,7 +87673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1467\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1467\Generated1467
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated929.cmd_11081]
@@ -87681,7 +87681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest929\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest929\Generated929
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1177.cmd_11082]
@@ -87689,7 +87689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1177\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1177\Generated1177
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1053.cmd_11083]
@@ -87697,7 +87697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1053\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1053\Generated1053
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1000.cmd_11084]
@@ -87705,7 +87705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1000\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1000\Generated1000
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated808.cmd_11085]
@@ -87713,7 +87713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest808\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest808\Generated808
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1225.cmd_11086]
@@ -87721,7 +87721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1225\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1225\Generated1225
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated628.cmd_11087]
@@ -87729,7 +87729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest628\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest628\Generated628
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1256.cmd_11088]
@@ -87737,7 +87737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1256\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1256\Generated1256
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated600.cmd_11089]
@@ -87745,7 +87745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest600\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest600\Generated600
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1492.cmd_11090]
@@ -87753,7 +87753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1492\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1492\Generated1492
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1126.cmd_11091]
@@ -87761,7 +87761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1126\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1126\Generated1126
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated10.cmd_11092]
@@ -87769,7 +87769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest10\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest10\Generated10
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_359734.cmd_11093]
@@ -87777,7 +87777,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_359734\DevDiv_359734\DevDiv_359734.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_359734\DevDiv_359734
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [badcodeafterfinally_r.cmd_11094]
@@ -87785,7 +87785,7 @@ RelativePath=JIT\Methodical\eh\deadcode\badcodeafterfinally_r\badcodeafterfinall
 WorkingDir=JIT\Methodical\eh\deadcode\badcodeafterfinally_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated180.cmd_11095]
@@ -87793,7 +87793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest180\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest180\Generated180
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated118.cmd_11096]
@@ -87801,7 +87801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest118\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest118\Generated118
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated948.cmd_11097]
@@ -87809,7 +87809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest948\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest948\Generated948
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated44.cmd_11098]
@@ -87817,7 +87817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest44\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest44\Generated44
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1295.cmd_11099]
@@ -87825,7 +87825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1295\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1295\Generated1295
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated271.cmd_11100]
@@ -87833,7 +87833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest271\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest271\Generated271
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated201.cmd_11101]
@@ -87841,7 +87841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest201\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest201\Generated201
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [test-tls.cmd_11102]
@@ -87849,7 +87849,7 @@ RelativePath=JIT\Directed\tls\test-tls\test-tls.cmd
 WorkingDir=JIT\Directed\tls\test-tls
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated1227.cmd_11103]
@@ -87857,7 +87857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1227\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1227\Generated1227
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated282.cmd_11104]
@@ -87865,7 +87865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest282\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest282\Generated282
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=NEW_PASS;EXPECTED_PASS
 HostStyle=0
 
 [Generated1101.cmd_11105]
@@ -87873,7 +87873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1101\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1101\Generated1101
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated526.cmd_11106]
@@ -87881,7 +87881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest526\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest526\Generated526
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated853.cmd_11107]
@@ -87889,7 +87889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest853\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest853\Generated853
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1417.cmd_11108]
@@ -87897,7 +87897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1417\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1417\Generated1417
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated96.cmd_11109]
@@ -87905,7 +87905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest96\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest96\Generated96
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated588.cmd_11110]
@@ -87913,7 +87913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest588\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest588\Generated588
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated525.cmd_11111]
@@ -87921,7 +87921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest525\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest525\Generated525
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1487.cmd_11112]
@@ -87929,7 +87929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1487\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1487\Generated1487
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated326.cmd_11113]
@@ -87937,7 +87937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest326\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest326\Generated326
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated726.cmd_11114]
@@ -87945,7 +87945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest726\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest726\Generated726
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsChar.cmd_11115]
@@ -87953,7 +87953,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsChar\ConstantArgsC
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsChar
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated553.cmd_11116]
@@ -87961,7 +87961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest553\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest553\Generated553
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated283.cmd_11117]
@@ -87969,7 +87969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest283\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest283\Generated283
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1383.cmd_11118]
@@ -87977,7 +87977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1383\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1383\Generated1383
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1175.cmd_11119]
@@ -87985,7 +87985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1175\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1175\Generated1175
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated456.cmd_11120]
@@ -87993,7 +87993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest456\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest456\Generated456
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1250.cmd_11121]
@@ -88001,7 +88001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1250\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1250\Generated1250
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated840.cmd_11122]
@@ -88009,7 +88009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest840\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest840\Generated840
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i11.cmd_11123]
@@ -88017,7 +88017,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i11\mcc_i11.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i11
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated715.cmd_11124]
@@ -88025,7 +88025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest715\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest715\Generated715
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated300.cmd_11125]
@@ -88033,7 +88033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest300\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest300\Generated300
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated998.cmd_11126]
@@ -88041,7 +88041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest998\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest998\Generated998
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1258.cmd_11127]
@@ -88049,7 +88049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1258\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1258\Generated1258
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated459.cmd_11128]
@@ -88057,7 +88057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest459\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest459\Generated459
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated815.cmd_11129]
@@ -88065,7 +88065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest815\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest815\Generated815
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [uint64Opt_do.cmd_11130]
@@ -88073,7 +88073,7 @@ RelativePath=JIT\Directed\shift\uint64Opt_do\uint64Opt_do.cmd
 WorkingDir=JIT\Directed\shift\uint64Opt_do
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated369.cmd_11131]
@@ -88081,7 +88081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest369\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest369\Generated369
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated269.cmd_11132]
@@ -88089,7 +88089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest269\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest269\Generated269
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated683.cmd_11133]
@@ -88097,7 +88097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest683\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest683\Generated683
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated449.cmd_11134]
@@ -88105,7 +88105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest449\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest449\Generated449
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1311.cmd_11135]
@@ -88113,7 +88113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1311\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1311\Generated1311
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated26.cmd_11136]
@@ -88121,7 +88121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest26\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest26\Generated26
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1032.cmd_11137]
@@ -88129,7 +88129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1032\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1032\Generated1032
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated930.cmd_11138]
@@ -88137,7 +88137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest930\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest930\Generated930
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1040.cmd_11139]
@@ -88145,7 +88145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1040\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1040\Generated1040
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1107.cmd_11140]
@@ -88153,7 +88153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1107\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1107\Generated1107
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1067.cmd_11141]
@@ -88161,7 +88161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1067\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1067\Generated1067
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b41852.cmd_11142]
@@ -88169,7 +88169,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b41852\b41852\b41852.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b41852\b41852
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated78.cmd_11143]
@@ -88177,7 +88177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest78\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest78\Generated78
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GetGenerationWR2.cmd_11144]
@@ -88185,7 +88185,7 @@ RelativePath=GC\API\GC\GetGenerationWR2\GetGenerationWR2.cmd
 WorkingDir=GC\API\GC\GetGenerationWR2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated749.cmd_11145]
@@ -88193,7 +88193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest749\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest749\Generated749
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated148.cmd_11146]
@@ -88201,7 +88201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest148\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest148\Generated148
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated813.cmd_11147]
@@ -88209,7 +88209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest813\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest813\Generated813
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated194.cmd_11148]
@@ -88217,7 +88217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest194\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest194\Generated194
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated234.cmd_11149]
@@ -88225,7 +88225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest234\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest234\Generated234
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated57.cmd_11150]
@@ -88233,7 +88233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest57\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest57\Generated57
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated469.cmd_11151]
@@ -88241,7 +88241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest469\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest469\Generated469
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated755.cmd_11152]
@@ -88249,7 +88249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest755\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest755\Generated755
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated787.cmd_11153]
@@ -88257,7 +88257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest787\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest787\Generated787
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated241.cmd_11154]
@@ -88265,7 +88265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest241\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest241\Generated241
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated690.cmd_11155]
@@ -88273,7 +88273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest690\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest690\Generated690
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [binarytrees3.cmd_11156]
@@ -88281,7 +88281,7 @@ RelativePath=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees3
 WorkingDir=JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated781.cmd_11157]
@@ -88289,7 +88289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest781\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest781\Generated781
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1119.cmd_11158]
@@ -88297,7 +88297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1119\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1119\Generated1119
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated513.cmd_11159]
@@ -88305,7 +88305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest513\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest513\Generated513
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated343.cmd_11160]
@@ -88313,7 +88313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest343\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest343\Generated343
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated809.cmd_11161]
@@ -88321,7 +88321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest809\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest809\Generated809
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated617.cmd_11162]
@@ -88329,7 +88329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest617\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest617\Generated617
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated532.cmd_11163]
@@ -88337,7 +88337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest532\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest532\Generated532
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated441.cmd_11164]
@@ -88345,7 +88345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest441\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest441\Generated441
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated751.cmd_11165]
@@ -88353,7 +88353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest751\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest751\Generated751
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1414.cmd_11166]
@@ -88361,7 +88361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1414\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1414\Generated1414
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated388.cmd_11167]
@@ -88369,7 +88369,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest388\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest388\Generated388
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated722.cmd_11168]
@@ -88377,7 +88377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest722\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest722\Generated722
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated542.cmd_11169]
@@ -88385,7 +88385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest542\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest542\Generated542
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_8460.cmd_11170]
@@ -88393,7 +88393,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_8460\GitHub_8460\GitHub_8460.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_8460\GitHub_8460
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated688.cmd_11171]
@@ -88401,7 +88401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest688\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest688\Generated688
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_FAIL;9457
 HostStyle=0
 
 [Generated169.cmd_11172]
@@ -88409,7 +88409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest169\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest169\Generated169
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated584.cmd_11173]
@@ -88417,7 +88417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest584\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest584\Generated584
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated558.cmd_11174]
@@ -88425,7 +88425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest558\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest558\Generated558
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated771.cmd_11175]
@@ -88433,7 +88433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest771\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest771\Generated771
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [arglist.cmd_11176]
@@ -88441,7 +88441,7 @@ RelativePath=JIT\Directed\PREFIX\unaligned\4\arglist\arglist.cmd
 WorkingDir=JIT\Directed\PREFIX\unaligned\4\arglist
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1384.cmd_11177]
@@ -88449,7 +88449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1384\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1384\Generated1384
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1441.cmd_11178]
@@ -88457,7 +88457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1441\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1441\Generated1441
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b35784.cmd_11179]
@@ -88465,7 +88465,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b35784\b35784\b35784.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b35784\b35784
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated445.cmd_11180]
@@ -88473,7 +88473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest445\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest445\Generated445
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated424.cmd_11181]
@@ -88481,7 +88481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest424\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest424\Generated424
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated200.cmd_11182]
@@ -88489,7 +88489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest200\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest200\Generated200
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated916.cmd_11183]
@@ -88497,7 +88497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest916\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest916\Generated916
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated820.cmd_11184]
@@ -88505,7 +88505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest820\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest820\Generated820
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1262.cmd_11185]
@@ -88513,7 +88513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1262\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1262\Generated1262
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated717.cmd_11186]
@@ -88521,7 +88521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest717\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest717\Generated717
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1086.cmd_11187]
@@ -88529,7 +88529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1086\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1086\Generated1086
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1213.cmd_11188]
@@ -88537,7 +88537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1213\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1213\Generated1213
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1061.cmd_11189]
@@ -88545,7 +88545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1061\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1061\Generated1061
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated110.cmd_11190]
@@ -88553,7 +88553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest110\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest110\Generated110
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated871.cmd_11191]
@@ -88561,7 +88561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest871\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest871\Generated871
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated12.cmd_11192]
@@ -88569,7 +88569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest12\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest12\Generated12
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1244.cmd_11193]
@@ -88577,7 +88577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1244\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1244\Generated1244
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [runmoduleconstructor.cmd_11194]
@@ -88585,7 +88585,7 @@ RelativePath=baseservices\compilerservices\modulector\runmoduleconstructor\runmo
 WorkingDir=baseservices\compilerservices\modulector\runmoduleconstructor
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated117.cmd_11195]
@@ -88593,7 +88593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest117\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest117\Generated117
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1240.cmd_11196]
@@ -88601,7 +88601,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1240\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1240\Generated1240
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1341.cmd_11197]
@@ -88609,7 +88609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1341\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1341\Generated1341
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated39.cmd_11198]
@@ -88617,7 +88617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest39\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest39\Generated39
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1443.cmd_11199]
@@ -88625,7 +88625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1443\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1443\Generated1443
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated727.cmd_11200]
@@ -88633,7 +88633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest727\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest727\Generated727
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [doublinknoleak.cmd_11201]
@@ -88641,7 +88641,7 @@ RelativePath=GC\Scenarios\DoublinkList\doublinknoleak\doublinknoleak.cmd
 WorkingDir=GC\Scenarios\DoublinkList\doublinknoleak
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated411.cmd_11202]
@@ -88649,7 +88649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest411\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest411\Generated411
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated663.cmd_11203]
@@ -88657,7 +88657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest663\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest663\Generated663
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated391.cmd_11204]
@@ -88665,7 +88665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest391\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest391\Generated391
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1347.cmd_11205]
@@ -88673,7 +88673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1347\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1347\Generated1347
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated918.cmd_11206]
@@ -88681,7 +88681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest918\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest918\Generated918
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated696.cmd_11207]
@@ -88689,7 +88689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest696\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest696\Generated696
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1211.cmd_11208]
@@ -88697,7 +88697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1211\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1211\Generated1211
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated577.cmd_11209]
@@ -88705,7 +88705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest577\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest577\Generated577
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated91.cmd_11210]
@@ -88713,7 +88713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest91\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest91\Generated91
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated640.cmd_11211]
@@ -88721,7 +88721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest640\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest640\Generated640
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated308.cmd_11212]
@@ -88729,7 +88729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest308\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest308\Generated308
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1453.cmd_11213]
@@ -88737,7 +88737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1453\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1453\Generated1453
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1450.cmd_11214]
@@ -88745,7 +88745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1450\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1450\Generated1450
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1473.cmd_11215]
@@ -88753,7 +88753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1473\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1473\Generated1473
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_8220.cmd_11216]
@@ -88761,7 +88761,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_8220\GitHub_8220\GitHub_8220.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_8220\GitHub_8220
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1018.cmd_11217]
@@ -88769,7 +88769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1018\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1018\Generated1018
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated187.cmd_11218]
@@ -88777,7 +88777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest187\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest187\Generated187
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated506.cmd_11219]
@@ -88785,7 +88785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest506\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest506\Generated506
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated769.cmd_11220]
@@ -88793,7 +88793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest769\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest769\Generated769
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1247.cmd_11221]
@@ -88801,7 +88801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1247\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1247\Generated1247
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated533.cmd_11222]
@@ -88809,7 +88809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest533\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest533\Generated533
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated307.cmd_11223]
@@ -88817,7 +88817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest307\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest307\Generated307
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated102.cmd_11224]
@@ -88825,7 +88825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest102\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest102\Generated102
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1036.cmd_11225]
@@ -88833,7 +88833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1036\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1036\Generated1036
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated579.cmd_11226]
@@ -88841,7 +88841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest579\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest579\Generated579
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated288.cmd_11227]
@@ -88849,7 +88849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest288\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest288\Generated288
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated786.cmd_11228]
@@ -88857,7 +88857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest786\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest786\Generated786
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated620.cmd_11229]
@@ -88865,7 +88865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest620\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest620\Generated620
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1410.cmd_11230]
@@ -88873,7 +88873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1410\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1410\Generated1410
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated574.cmd_11231]
@@ -88881,7 +88881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest574\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest574\Generated574
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [superpmicollect.cmd_11232]
@@ -88889,7 +88889,7 @@ RelativePath=JIT\superpmi\superpmicollect\superpmicollect.cmd
 WorkingDir=JIT\superpmi\superpmicollect
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated483.cmd_11233]
@@ -88897,7 +88897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest483\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest483\Generated483
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated228.cmd_11234]
@@ -88905,7 +88905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest228\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest228\Generated228
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated564.cmd_11235]
@@ -88913,7 +88913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest564\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest564\Generated564
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated399.cmd_11236]
@@ -88921,7 +88921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest399\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest399\Generated399
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated137.cmd_11237]
@@ -88929,7 +88929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest137\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest137\Generated137
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1003.cmd_11238]
@@ -88937,7 +88937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1003\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1003\Generated1003
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [rva_rvastatic2.cmd_11239]
@@ -88945,7 +88945,7 @@ RelativePath=JIT\Directed\intrinsic\interlocked\rva_rvastatic2\rva_rvastatic2.cm
 WorkingDir=JIT\Directed\intrinsic\interlocked\rva_rvastatic2
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated993.cmd_11240]
@@ -88953,7 +88953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest993\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest993\Generated993
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated851.cmd_11241]
@@ -88961,7 +88961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest851\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest851\Generated851
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1197.cmd_11242]
@@ -88969,7 +88969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1197\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1197\Generated1197
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1187.cmd_11243]
@@ -88977,7 +88977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1187\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1187\Generated1187
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated225.cmd_11244]
@@ -88985,7 +88985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest225\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest225\Generated225
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated365.cmd_11245]
@@ -88993,7 +88993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest365\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest365\Generated365
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1338.cmd_11246]
@@ -89001,7 +89001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1338\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1338\Generated1338
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated571.cmd_11247]
@@ -89009,7 +89009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest571\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest571\Generated571
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated838.cmd_11248]
@@ -89017,7 +89017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest838\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest838\Generated838
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated115.cmd_11249]
@@ -89025,7 +89025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest115\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest115\Generated115
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated856.cmd_11250]
@@ -89033,7 +89033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest856\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest856\Generated856
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1115.cmd_11251]
@@ -89041,7 +89041,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1115\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1115\Generated1115
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1217.cmd_11252]
@@ -89049,7 +89049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1217\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1217\Generated1217
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ModConst.cmd_11253]
@@ -89057,7 +89057,7 @@ RelativePath=JIT\CodeGenBringUpTests\ModConst\ModConst.cmd
 WorkingDir=JIT\CodeGenBringUpTests\ModConst
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated475.cmd_11254]
@@ -89065,7 +89065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest475\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest475\Generated475
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1320.cmd_11255]
@@ -89073,7 +89073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1320\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1320\Generated1320
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated378.cmd_11256]
@@ -89081,7 +89081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest378\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest378\Generated378
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_il_relpointer_i.cmd_11257]
@@ -89089,7 +89089,7 @@ RelativePath=JIT\Methodical\tailcall\_il_relpointer_i\_il_relpointer_i.cmd
 WorkingDir=JIT\Methodical\tailcall\_il_relpointer_i
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated955.cmd_11258]
@@ -89097,7 +89097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest955\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest955\Generated955
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated721.cmd_11259]
@@ -89105,7 +89105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest721\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest721\Generated721
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated215.cmd_11260]
@@ -89113,7 +89113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest215\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest215\Generated215
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated531.cmd_11261]
@@ -89121,7 +89121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest531\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest531\Generated531
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1153.cmd_11262]
@@ -89129,7 +89129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1153\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1153\Generated1153
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated59.cmd_11263]
@@ -89137,7 +89137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest59\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest59\Generated59
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated711.cmd_11264]
@@ -89145,7 +89145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest711\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest711\Generated711
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1434.cmd_11265]
@@ -89153,7 +89153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1434\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1434\Generated1434
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1058.cmd_11266]
@@ -89161,7 +89161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1058\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1058\Generated1058
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated125.cmd_11267]
@@ -89169,7 +89169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest125\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest125\Generated125
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated959.cmd_11268]
@@ -89177,7 +89177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest959\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest959\Generated959
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated184.cmd_11269]
@@ -89185,7 +89185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest184\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest184\Generated184
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1105.cmd_11270]
@@ -89193,7 +89193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1105\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1105\Generated1105
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated67.cmd_11271]
@@ -89201,7 +89201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest67\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest67\Generated67
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated842.cmd_11272]
@@ -89209,7 +89209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest842\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest842\Generated842
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated231.cmd_11273]
@@ -89217,7 +89217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest231\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest231\Generated231
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated782.cmd_11274]
@@ -89225,7 +89225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest782\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest782\Generated782
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1470.cmd_11275]
@@ -89233,7 +89233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1470\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1470\Generated1470
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1166.cmd_11276]
@@ -89241,7 +89241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1166\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1166\Generated1166
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [rvastatic1.cmd_11277]
@@ -89249,7 +89249,7 @@ RelativePath=JIT\Directed\rvastatics\rvastatic1\rvastatic1.cmd
 WorkingDir=JIT\Directed\rvastatics\rvastatic1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [Generated708.cmd_11278]
@@ -89257,7 +89257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest708\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest708\Generated708
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1242.cmd_11279]
@@ -89265,7 +89265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1242\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1242\Generated1242
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1362.cmd_11280]
@@ -89273,7 +89273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1362\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1362\Generated1362
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated396.cmd_11281]
@@ -89281,7 +89281,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest396\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest396\Generated396
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated758.cmd_11282]
@@ -89289,7 +89289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest758\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest758\Generated758
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1339.cmd_11283]
@@ -89297,7 +89297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1339\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1339\Generated1339
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated352.cmd_11284]
@@ -89305,7 +89305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest352\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest352\Generated352
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1276.cmd_11285]
@@ -89313,7 +89313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1276\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1276\Generated1276
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated265.cmd_11286]
@@ -89321,7 +89321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest265\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest265\Generated265
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_il_dbgseq.cmd_11287]
@@ -89329,7 +89329,7 @@ RelativePath=JIT\Methodical\refany\_il_dbgseq\_il_dbgseq.cmd
 WorkingDir=JIT\Methodical\refany\_il_dbgseq
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [mcc_i61.cmd_11288]
@@ -89337,7 +89337,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i61\mcc_i61.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i61
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1500.cmd_11289]
@@ -89345,7 +89345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1500\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1500\Generated1500
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1154.cmd_11290]
@@ -89353,7 +89353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1154\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1154\Generated1154
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1418.cmd_11291]
@@ -89361,7 +89361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1418\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1418\Generated1418
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated630.cmd_11292]
@@ -89369,7 +89369,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest630\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest630\Generated630
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1491.cmd_11293]
@@ -89377,7 +89377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1491\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1491\Generated1491
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i13.cmd_11294]
@@ -89385,7 +89385,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i13\mcc_i13.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i13
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated568.cmd_11295]
@@ -89393,7 +89393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest568\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest568\Generated568
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated364.cmd_11296]
@@ -89401,7 +89401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest364\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest364\Generated364
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated536.cmd_11297]
@@ -89409,7 +89409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest536\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest536\Generated536
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated428.cmd_11298]
@@ -89417,7 +89417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest428\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest428\Generated428
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1188.cmd_11299]
@@ -89425,7 +89425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1188\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1188\Generated1188
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated802.cmd_11300]
@@ -89433,7 +89433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest802\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest802\Generated802
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated52.cmd_11301]
@@ -89441,7 +89441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest52\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest52\Generated52
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1346.cmd_11302]
@@ -89449,7 +89449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1346\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1346\Generated1346
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated664.cmd_11303]
@@ -89457,7 +89457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest664\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest664\Generated664
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1455.cmd_11304]
@@ -89465,7 +89465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1455\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1455\Generated1455
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated926.cmd_11305]
@@ -89473,7 +89473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest926\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest926\Generated926
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated172.cmd_11306]
@@ -89481,7 +89481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest172\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest172\Generated172
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1144.cmd_11307]
@@ -89489,7 +89489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1144\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1144\Generated1144
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated974.cmd_11308]
@@ -89497,7 +89497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest974\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest974\Generated974
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated155.cmd_11309]
@@ -89505,7 +89505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest155\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest155\Generated155
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated886.cmd_11310]
@@ -89513,7 +89513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest886\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest886\Generated886
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated274.cmd_11311]
@@ -89521,7 +89521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest274\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest274\Generated274
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1169.cmd_11312]
@@ -89529,7 +89529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1169\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1169\Generated1169
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1294.cmd_11313]
@@ -89537,7 +89537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1294\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1294\Generated1294
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_280127.cmd_11314]
@@ -89545,7 +89545,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_280127\DevDiv_280127\DevDiv_280127.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_280127\DevDiv_280127
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1243.cmd_11315]
@@ -89553,7 +89553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1243\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1243\Generated1243
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1321.cmd_11316]
@@ -89561,7 +89561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1321\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1321\Generated1321
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated177.cmd_11317]
@@ -89569,7 +89569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest177\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest177\Generated177
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1411.cmd_11318]
@@ -89577,7 +89577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1411\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1411\Generated1411
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_FAIL;9457
 HostStyle=0
 
 [Generated303.cmd_11319]
@@ -89585,7 +89585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest303\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest303\Generated303
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated36.cmd_11320]
@@ -89593,7 +89593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest36\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest36\Generated36
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1437.cmd_11321]
@@ -89601,7 +89601,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1437\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1437\Generated1437
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated960.cmd_11322]
@@ -89609,7 +89609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest960\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest960\Generated960
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated321.cmd_11323]
@@ -89617,7 +89617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest321\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest321\Generated321
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1436.cmd_11324]
@@ -89625,7 +89625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1436\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1436\Generated1436
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated333.cmd_11325]
@@ -89633,7 +89633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest333\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest333\Generated333
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated915.cmd_11326]
@@ -89641,7 +89641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest915\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest915\Generated915
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1378.cmd_11327]
@@ -89649,7 +89649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1378\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1378\Generated1378
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated680.cmd_11328]
@@ -89657,7 +89657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest680\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest680\Generated680
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated747.cmd_11329]
@@ -89665,7 +89665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest747\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest747\Generated747
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1237.cmd_11330]
@@ -89673,7 +89673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1237\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1237\Generated1237
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1074.cmd_11331]
@@ -89681,7 +89681,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1074\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1074\Generated1074
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated712.cmd_11332]
@@ -89689,7 +89689,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest712\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest712\Generated712
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated735.cmd_11333]
@@ -89697,7 +89697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest735\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest735\Generated735
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i83.cmd_11334]
@@ -89705,7 +89705,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i83\mcc_i83.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i83
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated858.cmd_11335]
@@ -89713,7 +89713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest858\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest858\Generated858
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated272.cmd_11336]
@@ -89721,7 +89721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest272\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest272\Generated272
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated239.cmd_11337]
@@ -89729,7 +89729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest239\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest239\Generated239
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated777.cmd_11338]
@@ -89737,7 +89737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest777\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest777\Generated777
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1480.cmd_11339]
@@ -89745,7 +89745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1480\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1480\Generated1480
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated499.cmd_11340]
@@ -89753,7 +89753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest499\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest499\Generated499
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1111.cmd_11341]
@@ -89761,7 +89761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1111\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1111\Generated1111
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated35.cmd_11342]
@@ -89769,7 +89769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest35\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest35\Generated35
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated127.cmd_11343]
@@ -89777,7 +89777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest127\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest127\Generated127
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated433.cmd_11344]
@@ -89785,7 +89785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest433\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest433\Generated433
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated403.cmd_11345]
@@ -89793,7 +89793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest403\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest403\Generated403
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated224.cmd_11346]
@@ -89801,7 +89801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest224\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest224\Generated224
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated920.cmd_11347]
@@ -89809,7 +89809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest920\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest920\Generated920
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated906.cmd_11348]
@@ -89817,7 +89817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest906\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest906\Generated906
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1033.cmd_11349]
@@ -89825,7 +89825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1033\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1033\Generated1033
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1136.cmd_11350]
@@ -89833,7 +89833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1136\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1136\Generated1136
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated232.cmd_11351]
@@ -89841,7 +89841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest232\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest232\Generated232
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1497.cmd_11352]
@@ -89849,7 +89849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1497\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1497\Generated1497
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated199.cmd_11353]
@@ -89857,7 +89857,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest199\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest199\Generated199
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1363.cmd_11354]
@@ -89865,7 +89865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1363\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1363\Generated1363
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i30.cmd_11355]
@@ -89873,7 +89873,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i30\mcc_i30.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i30
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated597.cmd_11356]
@@ -89881,7 +89881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest597\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest597\Generated597
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated356.cmd_11357]
@@ -89889,7 +89889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest356\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest356\Generated356
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1063.cmd_11358]
@@ -89897,7 +89897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1063\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1063\Generated1063
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated675.cmd_11359]
@@ -89905,7 +89905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest675\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest675\Generated675
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1352.cmd_11360]
@@ -89913,7 +89913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1352\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1352\Generated1352
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated496.cmd_11361]
@@ -89921,7 +89921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest496\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest496\Generated496
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1484.cmd_11362]
@@ -89929,7 +89929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1484\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1484\Generated1484
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated897.cmd_11363]
@@ -89937,7 +89937,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest897\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest897\Generated897
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1235.cmd_11364]
@@ -89945,7 +89945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1235\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1235\Generated1235
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated636.cmd_11365]
@@ -89953,7 +89953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest636\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest636\Generated636
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1079.cmd_11366]
@@ -89961,7 +89961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1079\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1079\Generated1079
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated89.cmd_11367]
@@ -89969,7 +89969,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest89\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest89\Generated89
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated159.cmd_11368]
@@ -89977,7 +89977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest159\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest159\Generated159
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated828.cmd_11369]
@@ -89985,7 +89985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest828\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest828\Generated828
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated275.cmd_11370]
@@ -89993,7 +89993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest275\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest275\Generated275
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1422.cmd_11371]
@@ -90001,7 +90001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1422\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1422\Generated1422
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated359.cmd_11372]
@@ -90009,7 +90009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest359\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest359\Generated359
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated50.cmd_11373]
@@ -90017,7 +90017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest50\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest50\Generated50
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated975.cmd_11374]
@@ -90025,7 +90025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest975\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest975\Generated975
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated216.cmd_11375]
@@ -90033,7 +90033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest216\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest216\Generated216
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [verify01_dynamic.cmd_11376]
@@ -90041,7 +90041,7 @@ RelativePath=JIT\jit64\localloc\verify\verify01_dynamic\verify01_dynamic.cmd
 WorkingDir=JIT\jit64\localloc\verify\verify01_dynamic
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated1094.cmd_11377]
@@ -90049,7 +90049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1094\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1094\Generated1094
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated697.cmd_11378]
@@ -90057,7 +90057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest697\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest697\Generated697
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1412.cmd_11379]
@@ -90065,7 +90065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1412\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1412\Generated1412
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_FAIL;9457
 HostStyle=0
 
 [Generated1272.cmd_11380]
@@ -90073,7 +90073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1272\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1272\Generated1272
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated657.cmd_11381]
@@ -90081,7 +90081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest657\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest657\Generated657
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated865.cmd_11382]
@@ -90089,7 +90089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest865\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest865\Generated865
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated94.cmd_11383]
@@ -90097,7 +90097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest94\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest94\Generated94
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [UModConst.cmd_11384]
@@ -90105,7 +90105,7 @@ RelativePath=JIT\CodeGenBringUpTests\UModConst\UModConst.cmd
 WorkingDir=JIT\CodeGenBringUpTests\UModConst
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated99.cmd_11385]
@@ -90113,7 +90113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest99\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest99\Generated99
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated237.cmd_11386]
@@ -90121,7 +90121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest237\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest237\Generated237
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated109.cmd_11387]
@@ -90129,7 +90129,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest109\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest109\Generated109
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated263.cmd_11388]
@@ -90137,7 +90137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest263\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest263\Generated263
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated832.cmd_11389]
@@ -90145,7 +90145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest832\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest832\Generated832
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1469.cmd_11390]
@@ -90153,7 +90153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1469\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1469\Generated1469
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1400.cmd_11391]
@@ -90161,7 +90161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1400\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1400\Generated1400
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated75.cmd_11392]
@@ -90169,7 +90169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest75\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest75\Generated75
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1397.cmd_11393]
@@ -90177,7 +90177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1397\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1397\Generated1397
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated732.cmd_11394]
@@ -90185,7 +90185,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest732\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest732\Generated732
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated643.cmd_11395]
@@ -90193,7 +90193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest643\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest643\Generated643
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated893.cmd_11396]
@@ -90201,7 +90201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest893\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest893\Generated893
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1097.cmd_11397]
@@ -90209,7 +90209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1097\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1097\Generated1097
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated174.cmd_11398]
@@ -90217,7 +90217,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest174\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest174\Generated174
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated123.cmd_11399]
@@ -90225,7 +90225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest123\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest123\Generated123
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i62.cmd_11400]
@@ -90233,7 +90233,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i62\mcc_i62.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i62
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1398.cmd_11401]
@@ -90241,7 +90241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1398\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1398\Generated1398
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [_il_dbglocalloc.cmd_11402]
@@ -90249,7 +90249,7 @@ RelativePath=JIT\Methodical\xxobj\operand\_il_dbglocalloc\_il_dbglocalloc.cmd
 WorkingDir=JIT\Methodical\xxobj\operand\_il_dbglocalloc
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [mcc_i50.cmd_11403]
@@ -90257,7 +90257,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i50\mcc_i50.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i50
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated341.cmd_11404]
@@ -90265,7 +90265,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest341\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest341\Generated341
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated253.cmd_11405]
@@ -90273,7 +90273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest253\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest253\Generated253
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated211.cmd_11406]
@@ -90281,7 +90281,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest211\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest211\Generated211
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated46.cmd_11407]
@@ -90289,7 +90289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest46\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest46\Generated46
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated494.cmd_11408]
@@ -90297,7 +90297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest494\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest494\Generated494
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated972.cmd_11409]
@@ -90305,7 +90305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest972\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest972\Generated972
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated163.cmd_11410]
@@ -90313,7 +90313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest163\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest163\Generated163
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated324.cmd_11411]
@@ -90321,7 +90321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest324\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest324\Generated324
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1157.cmd_11412]
@@ -90329,7 +90329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1157\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1157\Generated1157
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1007.cmd_11413]
@@ -90337,7 +90337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1007\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1007\Generated1007
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated92.cmd_11414]
@@ -90345,7 +90345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest92\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest92\Generated92
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated613.cmd_11415]
@@ -90353,7 +90353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest613\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest613\Generated613
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated602.cmd_11416]
@@ -90361,7 +90361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest602\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest602\Generated602
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GetGenerationWR.cmd_11417]
@@ -90369,7 +90369,7 @@ RelativePath=GC\API\GC\GetGenerationWR\GetGenerationWR.cmd
 WorkingDir=GC\API\GC\GetGenerationWR
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1286.cmd_11418]
@@ -90377,7 +90377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1286\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1286\Generated1286
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1141.cmd_11419]
@@ -90385,7 +90385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1141\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1141\Generated1141
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1475.cmd_11420]
@@ -90393,7 +90393,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1475\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1475\Generated1475
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated684.cmd_11421]
@@ -90401,7 +90401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest684\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest684\Generated684
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated935.cmd_11422]
@@ -90409,7 +90409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest935\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest935\Generated935
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated866.cmd_11423]
@@ -90417,7 +90417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest866\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest866\Generated866
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated53.cmd_11424]
@@ -90425,7 +90425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest53\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest53\Generated53
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1178.cmd_11425]
@@ -90433,7 +90433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1178\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1178\Generated1178
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated691.cmd_11426]
@@ -90441,7 +90441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest691\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest691\Generated691
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated305.cmd_11427]
@@ -90449,7 +90449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest305\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest305\Generated305
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_5696.cmd_11428]
@@ -90457,7 +90457,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_5696\GitHub_5696\GitHub_5696.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_5696\GitHub_5696
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated204.cmd_11429]
@@ -90465,7 +90465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest204\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest204\Generated204
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated698.cmd_11430]
@@ -90473,7 +90473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest698\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest698\Generated698
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated154.cmd_11431]
@@ -90481,7 +90481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest154\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest154\Generated154
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1151.cmd_11432]
@@ -90489,7 +90489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1151\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1151\Generated1151
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1427.cmd_11433]
@@ -90497,7 +90497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1427\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1427\Generated1427
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1147.cmd_11434]
@@ -90505,7 +90505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1147\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1147\Generated1147
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1117.cmd_11435]
@@ -90513,7 +90513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1117\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1117\Generated1117
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated170.cmd_11436]
@@ -90521,7 +90521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest170\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest170\Generated170
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated144.cmd_11437]
@@ -90529,7 +90529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest144\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest144\Generated144
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated152.cmd_11438]
@@ -90537,7 +90537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest152\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest152\Generated152
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated642.cmd_11439]
@@ -90545,7 +90545,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest642\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest642\Generated642
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated470.cmd_11440]
@@ -90553,7 +90553,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest470\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest470\Generated470
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated4.cmd_11441]
@@ -90561,7 +90561,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest4\Generated4
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest4\Generated4
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1355.cmd_11442]
@@ -90569,7 +90569,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1355\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1355\Generated1355
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated983.cmd_11443]
@@ -90577,7 +90577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest983\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest983\Generated983
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated310.cmd_11444]
@@ -90585,7 +90585,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest310\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest310\Generated310
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated185.cmd_11445]
@@ -90593,7 +90593,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest185\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest185\Generated185
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated667.cmd_11446]
@@ -90601,7 +90601,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest667\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest667\Generated667
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1112.cmd_11447]
@@ -90609,7 +90609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1112\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1112\Generated1112
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated54.cmd_11448]
@@ -90617,7 +90617,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest54\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest54\Generated54
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1047.cmd_11449]
@@ -90625,7 +90625,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1047\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1047\Generated1047
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated917.cmd_11450]
@@ -90633,7 +90633,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest917\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest917\Generated917
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated899.cmd_11451]
@@ -90641,7 +90641,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest899\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest899\Generated899
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1200.cmd_11452]
@@ -90649,7 +90649,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1200\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1200\Generated1200
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1416.cmd_11453]
@@ -90657,7 +90657,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1416\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1416\Generated1416
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1356.cmd_11454]
@@ -90665,7 +90665,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1356\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1356\Generated1356
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated337.cmd_11455]
@@ -90673,7 +90673,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest337\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest337\Generated337
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [rvastatic5.cmd_11456]
@@ -90681,7 +90681,7 @@ RelativePath=JIT\Directed\rvastatics\rvastatic5\rvastatic5.cmd
 WorkingDir=JIT\Directed\rvastatics\rvastatic5
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9468;NEW
+Categories=EXPECTED_FAIL;9468
 HostStyle=0
 
 [pinvoke-bug.cmd_11457]
@@ -90689,7 +90689,7 @@ RelativePath=JIT\Directed\pinvoke\pinvoke-bug\pinvoke-bug.cmd
 WorkingDir=JIT\Directed\pinvoke\pinvoke-bug
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated323.cmd_11458]
@@ -90697,7 +90697,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest323\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest323\Generated323
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1064.cmd_11459]
@@ -90705,7 +90705,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1064\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1064\Generated1064
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated931.cmd_11460]
@@ -90713,7 +90713,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest931\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest931\Generated931
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated327.cmd_11461]
@@ -90721,7 +90721,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest327\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest327\Generated327
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated380.cmd_11462]
@@ -90729,7 +90729,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest380\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest380\Generated380
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated545.cmd_11463]
@@ -90737,7 +90737,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest545\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest545\Generated545
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated629.cmd_11464]
@@ -90745,7 +90745,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest629\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest629\Generated629
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated907.cmd_11465]
@@ -90753,7 +90753,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest907\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest907\Generated907
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated87.cmd_11466]
@@ -90761,7 +90761,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest87\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest87\Generated87
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated370.cmd_11467]
@@ -90769,7 +90769,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest370\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest370\Generated370
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1460.cmd_11468]
@@ -90777,7 +90777,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1460\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1460\Generated1460
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated372.cmd_11469]
@@ -90785,7 +90785,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest372\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest372\Generated372
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated550.cmd_11470]
@@ -90793,7 +90793,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest550\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest550\Generated550
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated919.cmd_11471]
@@ -90801,7 +90801,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest919\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest919\Generated919
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1344.cmd_11472]
@@ -90809,7 +90809,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1344\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1344\Generated1344
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1087.cmd_11473]
@@ -90817,7 +90817,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1087\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1087\Generated1087
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated18.cmd_11474]
@@ -90825,7 +90825,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest18\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest18\Generated18
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated14.cmd_11475]
@@ -90833,7 +90833,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest14\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest14\Generated14
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1463.cmd_11476]
@@ -90841,7 +90841,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1463\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1463\Generated1463
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated119.cmd_11477]
@@ -90849,7 +90849,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest119\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest119\Generated119
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [preemptive_cooperative.cmd_11478]
@@ -90857,7 +90857,7 @@ RelativePath=JIT\Directed\pinvoke\preemptive_cooperative\preemptive_cooperative.
 WorkingDir=JIT\Directed\pinvoke\preemptive_cooperative
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1089.cmd_11479]
@@ -90865,7 +90865,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1089\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1089\Generated1089
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1442.cmd_11480]
@@ -90873,7 +90873,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1442\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1442\Generated1442
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated353.cmd_11481]
@@ -90881,7 +90881,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest353\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest353\Generated353
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated724.cmd_11482]
@@ -90889,7 +90889,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest724\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest724\Generated724
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated599.cmd_11483]
@@ -90897,7 +90897,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest599\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest599\Generated599
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated859.cmd_11484]
@@ -90905,7 +90905,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest859\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest859\Generated859
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated389.cmd_11485]
@@ -90913,7 +90913,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest389\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest389\Generated389
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated422.cmd_11486]
@@ -90921,7 +90921,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest422\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest422\Generated422
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated565.cmd_11487]
@@ -90929,7 +90929,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest565\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest565\Generated565
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [SpanBench.cmd_11488]
@@ -90937,7 +90937,7 @@ RelativePath=JIT\Performance\CodeQuality\Span\SpanBench\SpanBench.cmd
 WorkingDir=JIT\Performance\CodeQuality\Span\SpanBench
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1202.cmd_11489]
@@ -90945,7 +90945,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1202\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1202\Generated1202
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated518.cmd_11490]
@@ -90953,7 +90953,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest518\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest518\Generated518
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated397.cmd_11491]
@@ -90961,7 +90961,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest397\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest397\Generated397
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [rva_rvastatic4.cmd_11492]
@@ -90969,7 +90969,7 @@ RelativePath=JIT\Directed\intrinsic\interlocked\rva_rvastatic4\rva_rvastatic4.cm
 WorkingDir=JIT\Directed\intrinsic\interlocked\rva_rvastatic4
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated249.cmd_11493]
@@ -90977,7 +90977,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest249\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest249\Generated249
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated939.cmd_11494]
@@ -90985,7 +90985,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest939\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest939\Generated939
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated900.cmd_11495]
@@ -90993,7 +90993,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest900\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest900\Generated900
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1379.cmd_11496]
@@ -91001,7 +91001,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1379\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1379\Generated1379
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1385.cmd_11497]
@@ -91009,7 +91009,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1385\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1385\Generated1385
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1051.cmd_11498]
@@ -91017,7 +91017,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1051\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1051\Generated1051
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated923.cmd_11499]
@@ -91025,7 +91025,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest923\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest923\Generated923
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated490.cmd_11500]
@@ -91033,7 +91033,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest490\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest490\Generated490
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [rva_rvastatic3.cmd_11501]
@@ -91041,7 +91041,7 @@ RelativePath=JIT\Directed\intrinsic\interlocked\rva_rvastatic3\rva_rvastatic3.cm
 WorkingDir=JIT\Directed\intrinsic\interlocked\rva_rvastatic3
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;NEW
+Categories=EXPECTED_FAIL
 HostStyle=0
 
 [Generated968.cmd_11502]
@@ -91049,7 +91049,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest968\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest968\Generated968
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1.cmd_11503]
@@ -91057,7 +91057,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1\Generated1
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1\Generated1
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated757.cmd_11504]
@@ -91065,7 +91065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest757\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest757\Generated757
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated739.cmd_11505]
@@ -91073,7 +91073,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest739\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest739\Generated739
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated268.cmd_11506]
@@ -91081,7 +91081,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest268\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest268\Generated268
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1204.cmd_11507]
@@ -91089,7 +91089,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1204\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1204\Generated1204
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated135.cmd_11508]
@@ -91097,7 +91097,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest135\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest135\Generated135
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated973.cmd_11509]
@@ -91105,7 +91105,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest973\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest973\Generated973
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated822.cmd_11510]
@@ -91113,7 +91113,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest822\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest822\Generated822
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1164.cmd_11511]
@@ -91121,7 +91121,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1164\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1164\Generated1164
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [b88793.cmd_11512]
@@ -91129,7 +91129,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b88793\b88793\b88793.cmd
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b88793\b88793
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated58.cmd_11513]
@@ -91137,7 +91137,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest58\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest58\Generated58
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated552.cmd_11514]
@@ -91145,7 +91145,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest552\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest552\Generated552
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1251.cmd_11515]
@@ -91153,7 +91153,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1251\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1251\Generated1251
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated694.cmd_11516]
@@ -91161,7 +91161,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest694\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest694\Generated694
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated764.cmd_11517]
@@ -91169,7 +91169,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest764\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest764\Generated764
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated646.cmd_11518]
@@ -91177,7 +91177,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest646\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest646\Generated646
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i12.cmd_11519]
@@ -91185,7 +91185,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i12\mcc_i12.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i12
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated1282.cmd_11520]
@@ -91193,7 +91193,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1282\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1282\Generated1282
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated205.cmd_11521]
@@ -91201,7 +91201,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest205\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest205\Generated205
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated745.cmd_11522]
@@ -91209,7 +91209,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest745\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest745\Generated745
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_359736_r.cmd_11523]
@@ -91217,7 +91217,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_359736\DevDiv_359736_r\DevDiv_359736_
 WorkingDir=JIT\Regression\JitBlue\DevDiv_359736\DevDiv_359736_r
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated29.cmd_11524]
@@ -91225,7 +91225,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest29\Generated
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest29\Generated29
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1407.cmd_11525]
@@ -91233,7 +91233,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1407\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1407\Generated1407
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated287.cmd_11526]
@@ -91241,7 +91241,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest287\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest287\Generated287
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1195.cmd_11527]
@@ -91249,7 +91249,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1195\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1195\Generated1195
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated924.cmd_11528]
@@ -91257,7 +91257,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest924\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest924\Generated924
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [DevDiv_280120.cmd_11529]
@@ -91265,7 +91265,7 @@ RelativePath=JIT\Regression\JitBlue\DevDiv_280120\DevDiv_280120\DevDiv_280120.cm
 WorkingDir=JIT\Regression\JitBlue\DevDiv_280120\DevDiv_280120
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1162.cmd_11530]
@@ -91273,7 +91273,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1162\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1162\Generated1162
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [ConstantArgsDouble.cmd_11531]
@@ -91281,7 +91281,7 @@ RelativePath=JIT\Performance\CodeQuality\Inlining\ConstantArgsDouble\ConstantArg
 WorkingDir=JIT\Performance\CodeQuality\Inlining\ConstantArgsDouble
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated539.cmd_11532]
@@ -91289,7 +91289,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest539\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest539\Generated539
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [GitHub_8133.cmd_11533]
@@ -91297,7 +91297,7 @@ RelativePath=JIT\Regression\JitBlue\GitHub_8133\GitHub_8133\GitHub_8133.cmd
 WorkingDir=JIT\Regression\JitBlue\GitHub_8133\GitHub_8133
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1329.cmd_11534]
@@ -91305,7 +91305,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1329\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1329\Generated1329
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated289.cmd_11535]
@@ -91313,7 +91313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest289\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest289\Generated289
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated938.cmd_11536]
@@ -91321,7 +91321,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest938\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest938\Generated938
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated678.cmd_11537]
@@ -91329,7 +91329,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest678\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest678\Generated678
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated505.cmd_11538]
@@ -91337,7 +91337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest505\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest505\Generated505
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated812.cmd_11539]
@@ -91345,7 +91345,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest812\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest812\Generated812
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1372.cmd_11540]
@@ -91353,7 +91353,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1372\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1372\Generated1372
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated706.cmd_11541]
@@ -91361,7 +91361,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest706\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest706\Generated706
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1331.cmd_11542]
@@ -91369,7 +91369,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1331\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1331\Generated1331
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated450.cmd_11543]
@@ -91377,7 +91377,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest450\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest450\Generated450
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1335.cmd_11544]
@@ -91385,7 +91385,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1335\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1335\Generated1335
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [mcc_i80.cmd_11545]
@@ -91393,7 +91393,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i80\mcc_i80.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i80
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9462;NEW
+Categories=EXPECTED_FAIL;9462
 HostStyle=0
 
 [Generated652.cmd_11546]
@@ -91401,7 +91401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest652\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest652\Generated652
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated134.cmd_11547]
@@ -91409,7 +91409,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest134\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest134\Generated134
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1091.cmd_11548]
@@ -91417,7 +91417,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1091\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1091\Generated1091
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated474.cmd_11549]
@@ -91425,7 +91425,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest474\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest474\Generated474
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated314.cmd_11550]
@@ -91433,7 +91433,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest314\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest314\Generated314
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1252.cmd_11551]
@@ -91441,7 +91441,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1252\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1252\Generated1252
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1438.cmd_11552]
@@ -91449,7 +91449,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1438\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1438\Generated1438
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1270.cmd_11553]
@@ -91457,7 +91457,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1270\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1270\Generated1270
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1458.cmd_11554]
@@ -91465,7 +91465,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1458\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1458\Generated1458
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated794.cmd_11555]
@@ -91473,7 +91473,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest794\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest794\Generated794
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated168.cmd_11556]
@@ -91481,7 +91481,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest168\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest168\Generated168
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1245.cmd_11557]
@@ -91489,7 +91489,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1245\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1245\Generated1245
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated139.cmd_11558]
@@ -91497,7 +91497,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest139\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest139\Generated139
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1317.cmd_11559]
@@ -91505,7 +91505,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1317\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1317\Generated1317
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1008.cmd_11560]
@@ -91513,7 +91513,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1008\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1008\Generated1008
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated534.cmd_11561]
@@ -91521,7 +91521,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest534\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest534\Generated534
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1269.cmd_11562]
@@ -91529,7 +91529,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1269\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1269\Generated1269
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated345.cmd_11563]
@@ -91537,7 +91537,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest345\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest345\Generated345
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 
 [Generated1083.cmd_11564]
@@ -91545,6 +91545,6 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1083\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1083\Generated1083
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_PASS;NEW
+Categories=EXPECTED_PASS
 HostStyle=0
 


### PR DESCRIPTION
Many tests have been excluded but fixed for long periods of time. After auditing the open issues and running all failing tests, this marks tests that should pass even though they were marked to fail.