### PR TITLE
[x86/Linux] Emit proper frame for FastGetSharedStaticBase

### DIFF
--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -1397,6 +1397,10 @@ void EmitFastGetSharedStaticBase(CPUSTUBLINKER *psl, CodeLabel *init, bool bCCto
         // DoInit:
         psl->EmitLabel(DoInit);
 
+#ifdef FEATURE_PAL
+        psl->X86EmitPushEBPframe();
+#endif // FEATURE_PAL
+
 #if defined(UNIX_X86_ABI)
         // sub esp, 8 ; to align the stack
         psl->X86EmitSubEsp(8);
@@ -1413,6 +1417,10 @@ void EmitFastGetSharedStaticBase(CPUSTUBLINKER *psl, CodeLabel *init, bool bCCto
 #if defined(UNIX_X86_ABI)
         // add esp, 8
         psl->X86EmitAddEsp(8);
+#endif
+
+#ifdef FEATURE_PAL
+        psl->X86EmitPopReg(kEBP);
 #endif
         // ret
         psl->X86EmitReturn(0);

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -1397,7 +1397,6 @@ void EmitFastGetSharedStaticBase(CPUSTUBLINKER *psl, CodeLabel *init, bool bCCto
         // DoInit:
         psl->EmitLabel(DoInit);
 
-#ifdef FEATURE_PAL
         psl->X86EmitPushEBPframe();
 
 #ifdef UNIX_X86_ABI
@@ -1405,7 +1404,6 @@ void EmitFastGetSharedStaticBase(CPUSTUBLINKER *psl, CodeLabel *init, bool bCCto
         // sub esp, STACK_ALIGN_PADDING; to align the stack
         psl->X86EmitSubEsp(STACK_ALIGN_PADDING);
 #endif // UNIX_X86_ABI
-#endif // FEATURE_PAL
 
         // push edx (must be preserved)
         psl->X86EmitPushReg(kEDX);
@@ -1416,7 +1414,6 @@ void EmitFastGetSharedStaticBase(CPUSTUBLINKER *psl, CodeLabel *init, bool bCCto
         // pop edx
         psl->X86EmitPopReg(kEDX);
 
-#ifdef FEATURE_PAL
 #ifdef UNIX_X86_ABI
         // add esp, STACK_ALIGN_PADDING
         psl->X86EmitAddEsp(STACK_ALIGN_PADDING);
@@ -1424,7 +1421,6 @@ void EmitFastGetSharedStaticBase(CPUSTUBLINKER *psl, CodeLabel *init, bool bCCto
 #endif // UNIX_X86_ABI
 
         psl->X86EmitPopReg(kEBP);
-#endif // FEATURE_PAL
 
         // ret
         psl->X86EmitReturn(0);

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -1399,12 +1399,14 @@ void EmitFastGetSharedStaticBase(CPUSTUBLINKER *psl, CodeLabel *init, bool bCCto
 
 #ifdef FEATURE_PAL
         psl->X86EmitPushEBPframe();
+
+#ifdef UNIX_X86_ABI
+#define STACK_ALIGN_PADDING 4
+        // sub esp, STACK_ALIGN_PADDING; to align the stack
+        psl->X86EmitSubEsp(STACK_ALIGN_PADDING);
+#endif // UNIX_X86_ABI
 #endif // FEATURE_PAL
 
-#if defined(UNIX_X86_ABI)
-        // sub esp, 8 ; to align the stack
-        psl->X86EmitSubEsp(8);
-#endif
         // push edx (must be preserved)
         psl->X86EmitPushReg(kEDX);
 
@@ -1414,14 +1416,16 @@ void EmitFastGetSharedStaticBase(CPUSTUBLINKER *psl, CodeLabel *init, bool bCCto
         // pop edx
         psl->X86EmitPopReg(kEDX);
 
-#if defined(UNIX_X86_ABI)
-        // add esp, 8
-        psl->X86EmitAddEsp(8);
-#endif
-
 #ifdef FEATURE_PAL
+#ifdef UNIX_X86_ABI
+        // add esp, STACK_ALIGN_PADDING
+        psl->X86EmitAddEsp(STACK_ALIGN_PADDING);
+#undef STACK_ALIGN_PADDING
+#endif // UNIX_X86_ABI
+
         psl->X86EmitPopReg(kEBP);
-#endif
+#endif // FEATURE_PAL
+
         // ret
         psl->X86EmitReturn(0);
     }


### PR DESCRIPTION
The stub generated by EmitFastGetSharedStaticBase currently does not create a proper frame in slow code path.

C++ unwinder fails to unwind this frame, which results in unwind failure in 2nd pass when the callee in the slow path throws a managed exception.

This commit creates a minimal frame for slow code path.