### PR TITLE
Refactor some of fgPromoteStruct() checks into lvaCanPromoteStructVar() and lvaShouldPromoteStructVar()

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2669,6 +2669,7 @@ public:
                                  lvaStructPromotionInfo* StructPromotionInfo,
                                  bool                    sortFields);
     void lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* StructPromotionInfo);
+    bool lvaShouldPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
     void lvaPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* StructPromotionInfo);
 #if !defined(_TARGET_64BIT_)
     void lvaPromoteLongVars();


### PR DESCRIPTION
Code changes are mostly self-explanatory.

These changes have no SPMI diffs.