### PR TITLE
Separate nullable/enum Comparer and EqualityComparer creation logic into new methods

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -1085,6 +1085,7 @@
   <ItemGroup>
     <MscorlibSources Include="$(BclSourcesRoot)\System\Nullable.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\Comparer.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\ComparerHelpers.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\Dictionary.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\EqualityComparer.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\DebugView.cs" />
@@ -1101,7 +1102,6 @@
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\KeyNotFoundException.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\KeyValuePair.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\List.cs" />
-    <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\RareComparers.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\ArraySortHelper.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\ObjectModel\Collection.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\ObjectModel\ReadOnlyCollection.cs" />

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -1101,6 +1101,7 @@
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\KeyNotFoundException.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\KeyValuePair.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\List.cs" />
+    <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\RareComparers.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\Generic\ArraySortHelper.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\ObjectModel\Collection.cs" />
     <MscorlibSources Include="$(BclSourcesRoot)\System\Collections\ObjectModel\ReadOnlyCollection.cs" />

--- a/src/mscorlib/src/System/Collections/Generic/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Comparer.cs
@@ -20,14 +20,9 @@ namespace System.Collections.Generic
     [TypeDependencyAttribute("System.Collections.Generic.ObjectComparer`1")] 
     public abstract class Comparer<T> : IComparer, IComparer<T>
     {
-        static readonly Comparer<T> defaultComparer = (Comparer<T>)ComparerHelpers.CreateDefaultComparer(typeof(T));
-
-        public static Comparer<T> Default {
-            get {
-                Contract.Ensures(Contract.Result<Comparer<T>>() != null);
-                return defaultComparer;
-            }
-        }
+        // To minimize generic instantiation overhead of creating the comparer per type, we keep the generic portion of the code as small
+        // as possible and define most of the creation logic in a non-generic class.
+        public static Comparer<T> Default { get; } = (Comparer<T>)ComparerHelpers.CreateDefaultComparer(typeof(T));
 
         public static Comparer<T> Create(Comparison<T> comparison)
         {

--- a/src/mscorlib/src/System/Collections/Generic/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Comparer.cs
@@ -45,83 +45,32 @@ namespace System.Collections.Generic
         //
         private static Comparer<T> CreateComparer()
         {
+            object result = null;
             var type = (RuntimeType)typeof(T);
 
             // If T implements IComparable<T> return a GenericComparer<T>
             if (typeof(IComparable<T>).IsAssignableFrom(type))
             {
-                return (Comparer<T>)RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericComparer<int>), type);
+                result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericComparer<int>), type);
             }
-
-            if (default(T) == null)
+            else if (default(T) == null)
             {
                 // Nullable does not implement IComparable<T?> directly because that would add an extra interface call per comparison.
                 // Instead, it relies on Comparer<T?>.Default to specialize for nullables and do the lifted comparisons if T implements IComparable.
                 if (type.IsValueType)
                 {
-                    return CreateNullableComparer();
+                    // Nullable/enum comparers are less common than IComparable comparers.
+                    // Their creation logic is put in a separate, non-generic class to minimize the cost of generic instantiations of this method
+                    // for the more-common codepath.
+                    result = RareComparers.TryCreateNullableComparer(type);
                 }
             }
             else if (type.IsEnum)
             {
                 // The comparer for enums is specialized to avoid boxing.
-                return CreateEnumComparer();
-            }
-            
-            return new ObjectComparer<T>();
-        }
-
-        private static Comparer<T> CreateNullableComparer()
-        {
-            Debug.Assert(default(T) == null && typeof(T).IsValueType);
-            Debug.Assert(typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>));
-            
-            var nullableType = (RuntimeType)typeof(T);
-            var embeddedType = (RuntimeType)nullableType.GetGenericArguments()[0];
-
-            if (typeof(IComparable<>).MakeGenericType(embeddedType).IsAssignableFrom(embeddedType))
-            {
-                return (Comparer<T>)RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(NullableComparer<int>), embeddedType);
+                result = RareComparers.TryCreateEnumComparer(type);
             }
 
-            return new ObjectComparer<T>();
-        }
-
-        private static Comparer<T> CreateEnumComparer()
-        {
-            Debug.Assert(typeof(T).IsEnum);
-
-            object result = null;
-            var enumType = (RuntimeType)typeof(T);
-
-            // Explicitly call Enum.GetUnderlyingType here. Although GetTypeCode
-            // ends up doing this anyway, we end up avoiding an unnecessary P/Invoke
-            // and virtual method call.
-            TypeCode underlyingTypeCode = Type.GetTypeCode(Enum.GetUnderlyingType(enumType));
-            
-            // Depending on the enum type, we need to special case the comparers so that we avoid boxing.
-            // Specialize differently for signed/unsigned types so we avoid problems with large numbers.
-            switch (underlyingTypeCode)
-            {
-                case TypeCode.SByte:
-                case TypeCode.Int16:
-                case TypeCode.Int32:
-                    result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(Int32EnumComparer<int>), enumType);
-                    break;
-                case TypeCode.Byte:
-                case TypeCode.UInt16:
-                case TypeCode.UInt32:
-                    result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(UInt32EnumComparer<uint>), enumType);
-                    break;
-                // 64-bit enums: use UnsafeEnumCastLong
-                case TypeCode.Int64:
-                    result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(Int64EnumComparer<long>), enumType);
-                    break;
-                case TypeCode.UInt64:
-                    result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(UInt64EnumComparer<ulong>), enumType);
-                    break;
-            }
-            
             return result != null ? (Comparer<T>)result : new ObjectComparer<T>();
         }
 

--- a/src/mscorlib/src/System/Collections/Generic/Comparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Comparer.cs
@@ -222,7 +222,7 @@ namespace System.Collections.Generic
     {
         public Int32EnumComparer()
         {
-            Debug.Assert(typeof(T).IsEnum, "This type is only intended to be used to compare enums!");
+            Debug.Assert(typeof(T).IsEnum);
         }
         
         // Used by the serialization engine.
@@ -257,7 +257,7 @@ namespace System.Collections.Generic
     {
         public UInt32EnumComparer()
         {
-            Debug.Assert(typeof(T).IsEnum, "This type is only intended to be used to compare enums!");
+            Debug.Assert(typeof(T).IsEnum);
         }
         
         // Used by the serialization engine.
@@ -288,7 +288,7 @@ namespace System.Collections.Generic
     {
         public Int64EnumComparer()
         {
-            Debug.Assert(typeof(T).IsEnum, "This type is only intended to be used to compare enums!");
+            Debug.Assert(typeof(T).IsEnum);
         }
         
         public override int Compare(T x, T y)
@@ -316,7 +316,7 @@ namespace System.Collections.Generic
     {
         public UInt64EnumComparer()
         {
-            Debug.Assert(typeof(T).IsEnum, "This type is only intended to be used to compare enums!");
+            Debug.Assert(typeof(T).IsEnum);
         }
         
         // Used by the serialization engine.

--- a/src/mscorlib/src/System/Collections/Generic/ComparerHelpers.cs
+++ b/src/mscorlib/src/System/Collections/Generic/ComparerHelpers.cs
@@ -55,6 +55,10 @@ namespace System.Collections.Generic
             return result ?? CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(ObjectComparer<object>), runtimeType);
         }
 
+        /// <summary>
+        /// Creates the default <see cref="Comparer{T}"/> for a nullable type.
+        /// </summary>
+        /// <param name="nullableType">The nullable type to create the default comparer for.</param>
         private static object TryCreateNullableComparer(RuntimeType nullableType)
         {
             Debug.Assert(nullableType != null);
@@ -70,6 +74,10 @@ namespace System.Collections.Generic
             return null;
         }
 
+        /// <summary>
+        /// Creates the default <see cref="Comparer{T}"/> for an enum type.
+        /// </summary>
+        /// <param name="enumType">The enum type to create the default comparer for.</param>
         private static object TryCreateEnumComparer(RuntimeType enumType)
         {
             Debug.Assert(enumType != null);
@@ -144,6 +152,10 @@ namespace System.Collections.Generic
             return result ?? CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(ObjectEqualityComparer<object>), runtimeType);
         }
 
+        /// <summary>
+        /// Creates the default <see cref="EqualityComparer{T}"/> for a nullable type.
+        /// </summary>
+        /// <param name="nullableType">The nullable type to create the default equality comparer for.</param>
         private static object TryCreateNullableEqualityComparer(RuntimeType nullableType)
         {
             Debug.Assert(nullableType != null);
@@ -159,6 +171,10 @@ namespace System.Collections.Generic
             return null;
         }
 
+        /// <summary>
+        /// Creates the default <see cref="EqualityComparer{T}"/> for an enum type.
+        /// </summary>
+        /// <param name="enumType">The enum type to create the default equality comparer for.</param>
         private static object TryCreateEnumEqualityComparer(RuntimeType enumType)
         {
             Debug.Assert(enumType != null);

--- a/src/mscorlib/src/System/Collections/Generic/ComparerHelpers.cs
+++ b/src/mscorlib/src/System/Collections/Generic/ComparerHelpers.cs
@@ -7,9 +7,24 @@ using static System.RuntimeTypeHandle;
 
 namespace System.Collections.Generic
 {
+    /// <summary>
+    /// Helper class for creating the default <see cref="Comparer{T}"/> and <see cref="EqualityComparer{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// This class is intentionally type-unsafe and non-generic to minimize the generic instantiation overhead of creating
+    /// the default comparer/equality comparer for a new type parameter. Efficiency of the methods in here does not matter too
+    /// much since they will only be run once per type parameter, but generic code involved in creating the comparers needs to be
+    /// kept to a minimum.
+    /// </remarks>
     internal static class ComparerHelpers
     {
-        // Note: The logic in this method is replicated in vm/compile.cpp to ensure that NGen saves the right instantiations.
+        /// <summary>
+        /// Creates the default <see cref="Comparer{T}"/>.
+        /// </summary>
+        /// <param name="type">The type to create the default comparer for.</param>
+        /// <remarks>
+        /// The logic in this method is replicated in vm/compile.cpp to ensure that NGen saves the right instantiations.
+        /// </remarks>
         internal static object CreateDefaultComparer(Type type)
         {
             Debug.Assert(type != null && type is RuntimeType);
@@ -87,7 +102,13 @@ namespace System.Collections.Generic
             return null;
         }
 
-        // Note: The logic in this method is replicated in vm/compile.cpp to ensure that NGen saves the right instantiations.
+        /// <summary>
+        /// Creates the default <see cref="EqualityComparer{T}"/>.
+        /// </summary>
+        /// <param name="type">The type to create the default equality comparer for.</param>
+        /// <remarks>
+        /// The logic in this method is replicated in vm/compile.cpp to ensure that NGen saves the right instantiations.
+        /// </remarks>
         internal static object CreateDefaultEqualityComparer(Type type)
         {
             Debug.Assert(type != null && type is RuntimeType);

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -18,14 +18,9 @@ namespace System.Collections.Generic
     [TypeDependencyAttribute("System.Collections.Generic.ObjectEqualityComparer`1")]
     public abstract class EqualityComparer<T> : IEqualityComparer, IEqualityComparer<T>
     {
-        static readonly EqualityComparer<T> defaultComparer = (EqualityComparer<T>)ComparerHelpers.CreateDefaultEqualityComparer(typeof(T));
-
-        public static EqualityComparer<T> Default {
-            get {
-                Contract.Ensures(Contract.Result<EqualityComparer<T>>() != null);
-                return defaultComparer;
-            }
-        }
+        // To minimize generic instantiation overhead of creating the comparer per type, we keep the generic portion of the code as small
+        // as possible and define most of the creation logic in a non-generic class.
+        public static EqualityComparer<T> Default { get; } = (EqualityComparer<T>)ComparerHelpers.CreateDefaultEqualityComparer(typeof(T));
 
         [Pure]
         public abstract bool Equals(T x, T y);

--- a/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/mscorlib/src/System/Collections/Generic/EqualityComparer.cs
@@ -35,87 +35,37 @@ namespace System.Collections.Generic
         {
             Contract.Ensures(Contract.Result<EqualityComparer<T>>() != null);
             
+            object result = null;
             var type = (RuntimeType)typeof(T);
             
             // Specialize for byte so Array.IndexOf is faster.
             if (type == typeof(byte))
             {
-                return (EqualityComparer<T>)(object)new ByteEqualityComparer();
+                result = new ByteEqualityComparer();
             }
             // If T implements IEquatable<T> return a GenericEqualityComparer<T>
-            if (typeof(IEquatable<T>).IsAssignableFrom(type))
+            else if (typeof(IEquatable<T>).IsAssignableFrom(type))
             {
-                return (EqualityComparer<T>)RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericEqualityComparer<int>), type);
+                result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericEqualityComparer<int>), type);
             }
-            if (default(T) == null) // Reference type/Nullable
+            else if (default(T) == null) // Reference type/Nullable
             {
                 // Nullable does not implement IEquatable<T?> directly because that would add an extra interface call per comparison.
                 // Instead, it relies on EqualityComparer<T?>.Default to specialize for nullables and do the lifted comparisons if T implements IEquatable.
                 if (type.IsValueType)
                 {
-                    return CreateNullableComparer();
+                    // Nullable/enum equality comparers are less common than IEquatable equality comparers.
+                    // Their creation logic is put in a separate, non-generic class to minimize the cost of generic instantiations of this method
+                    // for the more-common codepath.
+                    result = RareComparers.TryCreateNullableEqualityComparer(type);
                 }
             }
             else if (type.IsEnum)
             {
                 // The equality comparer for enums is specialized to avoid boxing.
-                return CreateEnumComparer();
+                result = RareComparers.TryCreateEnumEqualityComparer(type);
             }
             
-            return new ObjectEqualityComparer<T>();
-        }
-
-        private static EqualityComparer<T> CreateNullableComparer()
-        {
-            Debug.Assert(default(T) == null && typeof(T).IsValueType);
-            Debug.Assert(typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>));
-
-            var nullableType = (RuntimeType)typeof(T);
-            var embeddedType = (RuntimeType)nullableType.GetGenericArguments()[0];
-
-            if (typeof(IEquatable<>).MakeGenericType(embeddedType).IsAssignableFrom(embeddedType))
-            {
-                return (EqualityComparer<T>)RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(NullableEqualityComparer<int>), embeddedType);
-            }
-
-            return new ObjectEqualityComparer<T>();
-        }
-
-        private static EqualityComparer<T> CreateEnumComparer()
-        {
-            Debug.Assert(typeof(T).IsEnum);
-
-            // See the METHOD__JIT_HELPERS__UNSAFE_ENUM_CAST and METHOD__JIT_HELPERS__UNSAFE_ENUM_CAST_LONG cases in getILIntrinsicImplementation
-            // for how we cast the enum types to integral values in the comparer without boxing.
-
-            object result = null;
-            var enumType = (RuntimeType)typeof(T);
-
-            TypeCode underlyingTypeCode = Type.GetTypeCode(Enum.GetUnderlyingType(enumType));
-
-            // Depending on the enum type, we need to special case the comparers so that we avoid boxing.
-            // Note: We have different comparers for short and sbyte, since for those types GetHashCode does not simply return the value.
-            // We need to preserve what they would return.
-            switch (underlyingTypeCode)
-            {
-                case TypeCode.Int16:
-                    result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(ShortEnumEqualityComparer<short>), enumType);
-                    break;
-                case TypeCode.SByte:
-                    result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(SByteEnumEqualityComparer<sbyte>), enumType);
-                    break;
-                case TypeCode.Int32:
-                case TypeCode.UInt32:
-                case TypeCode.Byte:
-                case TypeCode.UInt16:
-                    result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(EnumEqualityComparer<int>), enumType);
-                    break;
-                case TypeCode.Int64:
-                case TypeCode.UInt64:
-                    result = RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(LongEnumEqualityComparer<long>), enumType);
-                    break;
-            }
-
             return result != null ? (EqualityComparer<T>)result : new ObjectEqualityComparer<T>();
         }
 

--- a/src/mscorlib/src/System/Collections/Generic/RareComparers.cs
+++ b/src/mscorlib/src/System/Collections/Generic/RareComparers.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Collections.Generic
+{
+    internal static class RareComparers
+    {
+        internal static object TryCreateNullableComparer(RuntimeType nullableType)
+        {
+            Debug.Assert(nullableType != null);
+            Debug.Assert(nullableType.IsGenericType && nullableType.GetGenericTypeDefinition() == typeof(Nullable<>));
+            
+            var embeddedType = (RuntimeType)nullableType.GetGenericArguments()[0];
+
+            if (typeof(IComparable<>).MakeGenericType(embeddedType).IsAssignableFrom(embeddedType))
+            {
+                return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(NullableComparer<int>), embeddedType);
+            }
+
+            return null;
+        }
+
+        internal static object TryCreateEnumComparer(RuntimeType enumType)
+        {
+            Debug.Assert(enumType != null);
+            Debug.Assert(enumType.IsEnum);
+
+            // Explicitly call Enum.GetUnderlyingType here. Although GetTypeCode
+            // ends up doing this anyway, we end up avoiding an unnecessary P/Invoke
+            // and virtual method call.
+            TypeCode underlyingTypeCode = Type.GetTypeCode(Enum.GetUnderlyingType(enumType));
+            
+            // Depending on the enum type, we need to special case the comparers so that we avoid boxing.
+            // Specialize differently for signed/unsigned types so we avoid problems with large numbers.
+            switch (underlyingTypeCode)
+            {
+                case TypeCode.SByte:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                    return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(Int32EnumComparer<int>), enumType);
+                case TypeCode.Byte:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                    return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(UInt32EnumComparer<uint>), enumType);
+                // 64-bit enums: Use `UnsafeEnumCastLong`
+                case TypeCode.Int64:
+                    return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(Int64EnumComparer<long>), enumType);
+                case TypeCode.UInt64:
+                    return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(UInt64EnumComparer<ulong>), enumType);
+            }
+            
+            return null;
+        }
+
+        internal static object TryCreateNullableEqualityComparer(RuntimeType nullableType)
+        {
+            Debug.Assert(nullableType != null);
+            Debug.Assert(nullableType.IsGenericType && nullableType.GetGenericTypeDefinition() == typeof(Nullable<>));
+
+            var embeddedType = (RuntimeType)nullableType.GetGenericArguments()[0];
+
+            if (typeof(IEquatable<>).MakeGenericType(embeddedType).IsAssignableFrom(embeddedType))
+            {
+                return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(NullableEqualityComparer<int>), embeddedType);
+            }
+            
+            return null;
+        }
+
+        internal static object TryCreateEnumEqualityComparer(RuntimeType enumType)
+        {
+            Debug.Assert(enumType != null);
+            Debug.Assert(enumType.IsEnum);
+
+            // See the METHOD__JIT_HELPERS__UNSAFE_ENUM_CAST and METHOD__JIT_HELPERS__UNSAFE_ENUM_CAST_LONG cases in getILIntrinsicImplementation
+            // for how we cast the enum types to integral values in the comparer without boxing.
+
+            TypeCode underlyingTypeCode = Type.GetTypeCode(Enum.GetUnderlyingType(enumType));
+
+            // Depending on the enum type, we need to special case the comparers so that we avoid boxing.
+            // Note: We have different comparers for short and sbyte, since for those types GetHashCode does not simply return the value.
+            // We need to preserve what they would return.
+            switch (underlyingTypeCode)
+            {
+                case TypeCode.Int16:
+                    return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(ShortEnumEqualityComparer<short>), enumType);
+                case TypeCode.SByte:
+                    return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(SByteEnumEqualityComparer<sbyte>), enumType);
+                case TypeCode.Int32:
+                case TypeCode.UInt32:
+                case TypeCode.Byte:
+                case TypeCode.UInt16:
+                    return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(EnumEqualityComparer<int>), enumType);
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
+                    return RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(LongEnumEqualityComparer<long>), enumType);
+            }
+            
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
For `Comparer<T>.Default` or `EqualityComparer<T>.Default`, most `T`s will down the path that returns a comparer based on IComparable/IEquatable respectively. If `T` is not a nullable/enum, all of the stuff to handle nullables/enums in `CreateComparer` is dead code for that instantiation. The JIT does not yet recognize reflection code such as `typeof(T).IsValueType` et al. however (https://github.com/dotnet/coreclr/issues/2591) so it will not be able to eliminate this dead code.

This PR moves the creation of nullable/enum comparers into a new method, and cleans up the code in `CreateComparer` for both classes.

/cc @jkotas, @omariom, @benaadams 