### PR TITLE
Fix x64 perf run break

### DIFF
--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -10,6 +10,7 @@ set CORECLR_REPO=%CD%
 set TEST_FILE_EXT=exe
 set TEST_ARCH=x64
 set TEST_CONFIG=Release
+set TEST_ENV=thisfilewillnotexist
 
 goto :ARGLOOP
 


### PR DESCRIPTION
After the checkin to add legacy JIT testing support for x86 we broke x64
runs.  THe issue is that we do not pass anything in to the TEST_ENV
variable on x64 and when a variable is empty and you attempt to use the
if exists syntax you fail.  I have added a nonsense file name that we
set this to before we go through the args loop. I was not able to find a
better solution and want to get the lab unblocked, but any batch masters
feel free to solve this the right way.