### PR TITLE
Fix Linux Arm Build break from package refactoring

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so" />
-    <NativeSplittableBinary Condition="'$(Platform)' != 'armel'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
+    <NativeSplittableBinary Condition="'$(Platform)' != 'armel' and '$(Platform)' != 'arm'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.so" />
     <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so" />
     <NativeSplittableBinary Include="$(BinDir)libmscordbi.so" />
@@ -10,8 +10,8 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Condition="'$(Platform)' != 'armel'" Include="$(BinDir)mscorlib.ni.dll" />
-    <ArchitectureSpecificNativeFile Condition="'$(Platform)' != 'armel'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFile Condition="'$(Platform)' != 'armel' and '$(Platform)' != 'arm'" Include="$(BinDir)mscorlib.ni.dll" />
+    <ArchitectureSpecificNativeFile Condition="'$(Platform)' != 'armel' and '$(Platform)' != 'arm'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />


### PR DESCRIPTION
Fixes Linux Arm32 build break introduced by https://github.com/dotnet/coreclr/commit/6a54a4405aa4bc795cbd7c95ac9e5dd66fecdf97#diff-db6c934e3fc9f3fef2ac8eda683192e5.

@chcosta @ericstj PTAL