### PR TITLE
[Arm64] Correct CORINFO_HELP_ASSIGN_BYREF killed mask

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3626,8 +3626,14 @@ void CodeGen::genCodeForCpObj(GenTreeObj* cpObjNode)
                     break;
 
                 default:
-                    // We have a GC pointer, call the memory barrier.
+                    // In the case of a GC-Pointer we'll call the ByRef write barrier helper
                     genEmitHelperCall(CORINFO_HELP_ASSIGN_BYREF, 0, EA_PTRSIZE);
+
+                    // genEmitHelperCall(CORINFO_HELP_ASSIGN_BYREF...) killed these registers.
+                    // However they are still live references to the structures we are copying.
+                    gcInfo.gcMarkRegPtrVal(REG_WRITE_BARRIER_SRC_BYREF, TYP_BYREF);
+                    gcInfo.gcMarkRegPtrVal(REG_WRITE_BARRIER_DST_BYREF, TYP_BYREF);
+
                     gcPtrCount--;
                     break;
             }


### PR DESCRIPTION
The assign by ref helper is intended to copy GC live references
from src to dest.

It is supposed to be the functional equivalent to

  *dst = *src; ++dst; ++src

The src and dst registers are live entering the helper, incremented
but live exiting the function.

It is the callers responsibility to mark these references dead.

@jashook This is the third commit from #9498 rebased to tip with a better commit message