### PR TITLE
JIT: relax assert in fgMergeFinallyChains

### DIFF
--- a/tests/src/jit/Regression/JitBlue/GitHub_9651/GitHub_9651.il
+++ b/tests/src/jit/Regression/JitBlue/GitHub_9651/GitHub_9651.il
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+.assembly a {}
+.module a.exe
+
+// Test case triggers reimportation of a leave,
+// leading to an unreachable callfinally pair.
+
+.class FinallyReimp
+{
+.method static int32 Main(class [mscorlib]System.String[]) cil managed
+{
+   .entrypoint
+   .locals init (int32 V0, native int V1)
+   .try 
+   {
+   ldarg.0
+   ldlen
+   ldc.i4 1
+   beq FOO
+   ldloca V0
+   br JOIN
+FOO:
+   ldc.i4 0
+JOIN:
+   stloc V1
+   leave AFTER
+   }
+   finally
+   {
+    ldc.i4 100
+    stloc.0
+    endfinally
+   }
+AFTER:
+   ldloc.1
+   ldind.i
+   ret
+}
+}
+

--- a/tests/src/jit/Regression/JitBlue/GitHub_9651/GitHub_9651.ilproj
+++ b/tests/src/jit/Regression/JitBlue/GitHub_9651/GitHub_9651.ilproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_9651.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
In some rare and likely IL-only cases the jit may create unreachable
callfinallys. This trips up finally chain merging since it spots a
merge opportunity but no merge actually happens.

Relax the assertion checks so that `canMerge && !didMerge` is now ok.

Closes #9651.