### PR TITLE
Exclude ni files from linux arm32 builds

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_PlatformDoesntSupportNiFiles Condition="'$(Platform)' == 'armel'">true</_PlatformDoesntSupportNiFiles>
+    <_PlatformDoesntSupportNiFiles Condition="'$(PackageTargetRuntime)' == 'ubuntu.14.04-arm'">true</_PlatformDoesntSupportNiFiles>
+    <_PlatformDoesntSupportNiFiles Condition="'$(PackageTargetRuntime)' == 'ubuntu.16.04-arm'">true</_PlatformDoesntSupportNiFiles>
+  </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so" />
-    <NativeSplittableBinary Condition="'$(Platform)' != 'armel'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
+    <NativeSplittableBinary Condition="'$(_PlatformDoesntSupportNiFiles)' != 'true'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.so" />
     <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so" />
     <NativeSplittableBinary Include="$(BinDir)libmscordbi.so" />
@@ -10,8 +15,8 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Condition="'$(Platform)' != 'armel'" Include="$(BinDir)mscorlib.ni.dll" />
-    <ArchitectureSpecificNativeFile Condition="'$(Platform)' != 'armel'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesntSupportNiFiles)' != 'true'" Include="$(BinDir)mscorlib.ni.dll" />
+    <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesntSupportNiFiles)' != 'true'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_PlatformDoesntSupportNiFiles Condition="'$(Platform)' == 'armel'">true</_PlatformDoesntSupportNiFiles>
-    <_PlatformDoesntSupportNiFiles Condition="'$(PackageTargetRuntime)' == 'ubuntu.14.04-arm'">true</_PlatformDoesntSupportNiFiles>
-    <_PlatformDoesntSupportNiFiles Condition="'$(PackageTargetRuntime)' == 'ubuntu.16.04-arm'">true</_PlatformDoesntSupportNiFiles>
+    <_PlatformDoesNotSupportNiFiles Condition="'$(Platform)' == 'armel'">true</_PlatformDoesNotSupportNiFiles>
+    <_PlatformDoesNotSupportNiFiles Condition="'$(PackageTargetRuntime)' == 'ubuntu.14.04-arm'">true</_PlatformDoesNotSupportNiFiles>
+    <_PlatformDoesNotSupportNiFiles Condition="'$(PackageTargetRuntime)' == 'ubuntu.16.04-arm'">true</_PlatformDoesNotSupportNiFiles>
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so" />
-    <NativeSplittableBinary Condition="'$(_PlatformDoesntSupportNiFiles)' != 'true'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
+    <NativeSplittableBinary Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.so" />
     <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so" />
     <NativeSplittableBinary Include="$(BinDir)libmscordbi.so" />
@@ -15,8 +15,8 @@
     <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
     <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesntSupportNiFiles)' != 'true'" Include="$(BinDir)mscorlib.ni.dll" />
-    <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesntSupportNiFiles)' != 'true'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)mscorlib.ni.dll" />
+    <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <_PlatformDoesNotSupportNiFiles Condition="'$(Platform)' == 'arm'">true</_PlatformDoesNotSupportNiFiles>
     <_PlatformDoesNotSupportNiFiles Condition="'$(Platform)' == 'armel'">true</_PlatformDoesNotSupportNiFiles>
-    <_PlatformDoesNotSupportNiFiles Condition="'$(PackageTargetRuntime)' == 'ubuntu.14.04-arm'">true</_PlatformDoesNotSupportNiFiles>
-    <_PlatformDoesNotSupportNiFiles Condition="'$(PackageTargetRuntime)' == 'ubuntu.16.04-arm'">true</_PlatformDoesNotSupportNiFiles>
   </PropertyGroup>
   <ItemGroup>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so" />

--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -102,9 +102,6 @@
       <Platform>arm</Platform>
     </OfficialBuildRID>
     <OfficialBuildRID Include="ubuntu.16.04-x64" />
-    <OfficialBuildRID Include="ubuntu.16.10-arm">
-      <Platform>arm</Platform>
-    </OfficialBuildRID>
     <OfficialBuildRID Include="ubuntu.16.10-x64" />
   </ItemGroup>
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';OSX;'))">


### PR DESCRIPTION
/cc @gkhanna79 @ericstj 

@gkhanna79, is there a plan to add one of the Ubuntu arm builds to CI to prevent this type of break?  It seems useful given that it has unique packaging requirements. 