### PR TITLE
Add stripSymbols argument; refactor symbol package build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ fi
 
 usage()
 {
-    echo "Usage: $0 [BuildArch] [BuildType] [verbose] [coverage] [cross] [clangx.y] [ninja] [configureonly] [skipconfigure] [skipnative] [skipmscorlib] [skiptests] [cmakeargs] [bindir]"
+    echo "Usage: $0 [BuildArch] [BuildType] [verbose] [coverage] [cross] [clangx.y] [ninja] [configureonly] [skipconfigure] [skipnative] [skipmscorlib] [skiptests] [stripsymbols] [cmakeargs] [bindir]"
     echo "BuildArch can be: x64, x86, arm, armel, arm64"
     echo "BuildType can be: debug, checked, release"
     echo "coverage - optional argument to enable code coverage build (currently supported only for Linux and OSX)."
@@ -44,6 +44,7 @@ usage()
 	echo "   using all processors^)."
 	echo "-officialbuildid=^<ID^>: specify the official build ID to be used by this build."
 	echo "-Rebuild: passes /t:rebuild to the build projects."
+    echo "stripSymbols - Optional argument to strip native symbols during the build."
     echo "skipgenerateversion - disable version generation even if MSBuild is supported."
     echo "cmakeargs - user-settable additional arguments passed to CMake."
     echo "bindir - output directory (defaults to $__ProjectRoot/bin)"
@@ -611,7 +612,7 @@ while :; do
             __CrossBuild=1
             ;;
             
-		portablelinux)
+        portablelinux)
             if [ "$__BuildOS" == "Linux" ]; then
                 __PortableLinux=1
             else
@@ -621,8 +622,12 @@ while :; do
             ;;
             
         verbose)
-        __VerboseBuild=1
-        ;;
+            __VerboseBuild=1
+            ;;
+
+        stripsymbols)
+            __cmakeargs="$__cmakeargs -DSTRIP_SYMBOLS=true"
+            ;;
 
         clang3.5)
             __ClangMajorVersion=3

--- a/functions.cmake
+++ b/functions.cmake
@@ -121,7 +121,7 @@ endfunction()
 
 function(strip_symbols targetName outputFilename)
   if (CLR_CMAKE_PLATFORM_UNIX)
-    if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+    if (STRIP_SYMBOLS)
 
       # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
       # generator expression doesn't work correctly returning the wrong path and on
@@ -158,7 +158,7 @@ function(strip_symbols targetName outputFilename)
       endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
       set(${outputFilename} ${strip_destination_file} PARENT_SCOPE)
-    endif(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+    endif (STRIP_SYMBOLS)
   endif(CLR_CMAKE_PLATFORM_UNIX)
 endfunction()
 

--- a/src/.nuget/Microsoft.NETCore.ILAsm/runtime.Linux.Microsoft.NETCore.ILAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/runtime.Linux.Microsoft.NETCore.ILAsm.props
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <NativeBinary Include="$(BinDir)ilasm" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/runtime.OSX.Microsoft.NETCore.ILAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/runtime.OSX.Microsoft.NETCore.ILAsm.props
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)ilasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <NativeBinary Include="$(BinDir)ilasm" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/runtime.Windows_NT.Microsoft.NETCore.ILAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/runtime.Windows_NT.Microsoft.NETCore.ILAsm.props
@@ -4,6 +4,6 @@
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
   </PropertyGroup>
   <ItemGroup>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)ilasm.exe" />
+    <NativeBinary Include="$(BinDir)ilasm.exe" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILAsm/runtime.Windows_NT.Microsoft.NETCore.ILAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/runtime.Windows_NT.Microsoft.NETCore.ILAsm.props
@@ -5,16 +5,5 @@
   </PropertyGroup>
   <ItemGroup>
     <ArchitectureSpecificNativeFile Include="$(BinDir)ilasm.exe" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
   </ItemGroup>
-  <ItemGroup>
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
-  </ItemGroup></Project>
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.Linux.Microsoft.NETCore.ILDAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.Linux.Microsoft.NETCore.ILDAsm.props
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
+    <NativeBinary Include="$(BinDir)ildasm" />
   </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
-  </ItemGroup></Project>
+</Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.OSX.Microsoft.NETCore.ILDAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.OSX.Microsoft.NETCore.ILDAsm.props
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)ildasm" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <NativeBinary Include="$(BinDir)ildasm" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.Windows_NT.Microsoft.NETCore.ILDAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.Windows_NT.Microsoft.NETCore.ILDAsm.props
@@ -6,17 +6,5 @@
   <ItemGroup>
     <ArchitectureSpecificNativeFile Include="$(BinDir)ildasm.exe" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)ildasmrc.dll" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup>
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.Windows_NT.Microsoft.NETCore.ILDAsm.props
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/runtime.Windows_NT.Microsoft.NETCore.ILDAsm.props
@@ -4,7 +4,7 @@
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
   </PropertyGroup>
   <ItemGroup>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)ildasm.exe" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)ildasmrc.dll" />
+    <NativeBinary Include="$(BinDir)ildasm.exe" />
+    <NativeBinary Include="$(BinDir)ildasmrc.dll" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)libclrjit.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <NativeBinary Include="$(BinDir)libclrjit.so" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.OSX.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.OSX.Microsoft.NETCore.Jit.props
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)libclrjit.dylib" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <NativeBinary Include="$(BinDir)libclrjit.dylib" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.Windows_NT.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.Windows_NT.Microsoft.NETCore.Jit.props
@@ -3,31 +3,11 @@
   <ItemGroup>
     <ArchitectureSpecificNativeFile Include="$(BinDir)clrjit.dll" />
     <ArchitectureSpecificNativeFile Condition="'$(PackagePlatform)' == 'x86'" Include="$(BinDir)compatjit.dll" />
-    <CrossArchitectureSpecificNativeFile Include="$(BinDir)$(CrossTargetComponentFolder)\clrjit.dll" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(CrossTargetComponentFolder)_$(PackagePlatform)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup>
+    <CrossArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)$(CrossTargetComponentFolder)\clrjit.dll" />
+
     <!-- prevent accidental inclusion in AOT projects. -->
     <File Include="$(PlaceholderFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)-aot/native</TargetPath>
-    </File>
-
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <CrossArchitectureSpecificNativeSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
-    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(CrossTargetComponentFolder)_$(PackagePlatform)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
     </File>
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.Windows_NT.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.Windows_NT.Microsoft.NETCore.Jit.props
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)clrjit.dll" />
-    <ArchitectureSpecificNativeFile Condition="'$(PackagePlatform)' == 'x86'" Include="$(BinDir)compatjit.dll" />
+    <NativeBinary Include="$(BinDir)clrjit.dll" />
+    <NativeBinary Condition="'$(PackagePlatform)' == 'x86'" Include="$(BinDir)compatjit.dll" />
     <CrossArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)$(CrossTargetComponentFolder)\clrjit.dll" />
 
     <!-- prevent accidental inclusion in AOT projects. -->

--- a/src/.nuget/Microsoft.NETCore.Native/runtime.Linux.Microsoft.NETCore.Native.props
+++ b/src/.nuget/Microsoft.NETCore.Native/runtime.Linux.Microsoft.NETCore.Native.props
@@ -2,21 +2,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
-    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/runtime.OSX.Microsoft.NETCore.Native.props
+++ b/src/.nuget/Microsoft.NETCore.Native/runtime.OSX.Microsoft.NETCore.Native.props
@@ -2,21 +2,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libSystem.Globalization.Native.a" />
-    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.dylib" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile);@(NativeBinary)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <NativeBinary Include="$(BinDir)System.Globalization.Native.dylib" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="Microsoft.NETCore.Runtime.CoreCLR.props" />
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup Condition="'$(PackageTargetRuntime)' == ''">

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.props
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
-  </PropertyGroup>
   <ItemGroup>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)CoreRun.exe" />
+    <!-- No reference: don't permit reference to the implementation from lib -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/netstandard1.0</TargetPath>
+    </File>
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -13,9 +13,9 @@
     <NativeBinary Include="$(BinDir)libsos.so" />
     <NativeBinary Include="$(BinDir)libsosplugin.so" />
     <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)mscorlib.ni.dll" />
-    <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <NativeBinary Include="$(BinDir)sosdocsunix.txt" />
+    <NativeBinary Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)mscorlib.ni.dll" />
+    <NativeBinary Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -5,14 +5,14 @@
     <_PlatformDoesNotSupportNiFiles Condition="'$(Platform)' == 'armel'">true</_PlatformDoesNotSupportNiFiles>
   </PropertyGroup>
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)libcoreclr.so" />
-    <NativeSplittableBinary Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
-    <NativeSplittableBinary Include="$(BinDir)libdbgshim.so" />
-    <NativeSplittableBinary Include="$(BinDir)libmscordaccore.so" />
-    <NativeSplittableBinary Include="$(BinDir)libmscordbi.so" />
-    <NativeSplittableBinary Include="$(BinDir)libsos.so" />
-    <NativeSplittableBinary Include="$(BinDir)libsosplugin.so" />
-    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.so" />
+    <NativeBinary Include="$(BinDir)libcoreclr.so" />
+    <NativeBinary Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
+    <NativeBinary Include="$(BinDir)libdbgshim.so" />
+    <NativeBinary Include="$(BinDir)libmscordaccore.so" />
+    <NativeBinary Include="$(BinDir)libmscordbi.so" />
+    <NativeBinary Include="$(BinDir)libsos.so" />
+    <NativeBinary Include="$(BinDir)libsosplugin.so" />
+    <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
     <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)mscorlib.ni.dll" />
     <ArchitectureSpecificNativeFile Condition="'$(_PlatformDoesNotSupportNiFiles)' != 'true'" Include="$(BinDir)System.Private.CoreLib.ni.dll" />
@@ -20,33 +20,5 @@
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)libcoreclr.dylib" />
-    <NativeSplittableBinary Include="$(BinDir)libdbgshim.dylib" />
-    <NativeSplittableBinary Include="$(BinDir)libmscordaccore.dylib" />
-    <NativeSplittableBinary Include="$(BinDir)libmscordbi.dylib" />
-    <NativeSplittableBinary Include="$(BinDir)libsos.dylib" />
-    <NativeSplittableBinary Include="$(BinDir)System.Globalization.Native.dylib" />
+    <NativeBinary Include="$(BinDir)libcoreclr.dylib" />
+    <NativeBinary Include="$(BinDir)libdbgshim.dylib" />
+    <NativeBinary Include="$(BinDir)libmscordaccore.dylib" />
+    <NativeBinary Include="$(BinDir)libmscordbi.dylib" />
+    <NativeBinary Include="$(BinDir)libsos.dylib" />
+    <NativeBinary Include="$(BinDir)System.Globalization.Native.dylib" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll" />
     <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
@@ -14,34 +14,5 @@
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
   </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\sosdocsunix.txt" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\crossgen" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
-  </ItemGroup>
-
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -7,9 +7,9 @@
     <NativeBinary Include="$(BinDir)libmscordbi.dylib" />
     <NativeBinary Include="$(BinDir)libsos.dylib" />
     <NativeBinary Include="$(BinDir)System.Globalization.Native.dylib" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <NativeBinary Include="$(BinDir)sosdocsunix.txt" />
+    <NativeBinary Include="$(BinDir)mscorlib.ni.dll" />
+    <NativeBinary Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -11,22 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <LongNameFiles Include="mscordaccore.dll"/>
-    <LongNameFiles Include="sos.dll"/>
-  </ItemGroup>
-
-  <Target Name="CopyLongNamedBinaries" BeforeTargets="CreatePackage">
-    <Copy
-      SourceFiles="@(LongNameFiles -> '$(BinDir)%(Identity)')"
-      DestinationFiles="@(LongNameFiles -> '$(BinDir)%(FileName)$(LongNameSuffix)%(Extension)')">
-    </Copy>
-    <Copy Condition="'$(HasCrossTargetComponents)' == 'true'"
-      SourceFiles="@(LongNameFiles -> '$(BinDir)$(CrossTargetComponentFolder)\%(Identity)')"
-      DestinationFiles="@(LongNameFiles -> '$(BinDir)$(CrossTargetComponentFolder)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')">
-    </Copy>
-  </Target>
-
-  <ItemGroup>
     <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)clretwrc.dll" />
     <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)coreclr.dll" />
     <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)dbgshim.dll" />
@@ -45,20 +29,7 @@
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\mscordaccore.dll" />
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\mscordbi.dll" />
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\sos.dll" />
-    <ArchitectureSpecificNativeFile Include="@(ArchitectureSpecificNativeFileAndSymbol)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath> 
-    </File>
-    <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
-    <File Include="@(ArchitectureSpecificLibFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
-    </File>
-    <File Include="@(ArchitectureSpecificToolFile)">
-      <TargetPath>tools</TargetPath>
-    </File>
-    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificToolFile)">
-      <TargetPath>tools/$(CrossTargetComponentFolder)_$(PackagePlatform)</TargetPath>
-    </File>
+
     <!-- prevent accidental inclusion in AOT projects. -->
     <File Include="$(PlaceholderFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)-aot/lib/netstandard1.0</TargetPath>
@@ -66,29 +37,16 @@
     <File Include="$(PlaceholderFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)-aot/native</TargetPath>
     </File>
-    <!-- No reference: don't permit reference to the implementation from lib -->
-    <File Include="$(PlaceholderFile)">
-      <TargetPath>ref/netstandard1.0</TargetPath>
-    </File>
-    <!-- Symbols -->
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificNativeFileAndSymbol -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificLibFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <ArchitectureSpecificNativeSymbol Include="@(ArchitectureSpecificToolFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <ArchitectureSpecificNativeSymbol Include="@(LongNameFiles -> '$(BinDir)%(FileName)$(LongNameSuffix)%(Extension)')" />
-    <AdditionalLibPackageExcludes Include="@(LongNameFiles -> 'runtimes\$(PackageTargetRuntime)\native\%(FileName)$(LongNameSuffix)%(Extension)')" />
-    <CrossArchitectureSpecificNativeSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" 
-                                           Include="@(CrossArchitectureSpecificToolFile -> '%(RelativeDir)PDB\%(FileName).pdb')" />
-    <CrossArchitectureSpecificNativeSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" 
-                                           Include="@(LongNameFiles -> '$(BinDir)$(CrossTargetComponentFolder)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')" />
-    <AdditionalLibPackageExcludes Condition="'$(HasCrossTargetComponents)' == 'true'" 
-                                  Include="@(LongNameFiles -> 'tools\$(CrossTargetComponentFolder)_$(PackagePlatform)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)')" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes\$(PackageTargetRuntime)\native</TargetPath> 
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
-    <File Condition="'$(HasCrossTargetComponents)' == 'true'" Include="@(CrossArchitectureSpecificNativeSymbol)">
-      <TargetPath>tools\$(CrossTargetComponentFolder)_$(PackagePlatform)</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+
+    <!-- Create long-name files by including the same files again with a different target path. -->
+    <LongNameFile Include="$(BinDir)mscordaccore.dll;
+                           $(BinDir)sos.dll">
+      <TargetPath>runtimes\$(PackageTargetRuntime)\native\%(FileName)$(LongNameSuffix)%(Extension)</TargetPath>
+    </LongNameFile>
+    <LongNameFile Include="$(BinDir)$(CrossTargetComponentFolder)\mscordaccore.dll;
+                           $(BinDir)$(CrossTargetComponentFolder)\sos.dll"
+                  Condition="'$(HasCrossTargetComponents)'=='true'">
+      <TargetPath>tools\$(CrossTargetComponentFolder)_$(PackagePlatform)\%(FileName)$(CrossTargetLongNameSuffix)%(Extension)</TargetPath>
+    </LongNameFile>
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -11,16 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)clretwrc.dll" />
-    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)coreclr.dll" />
-    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)dbgshim.dll" />
-    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)mscordaccore.dll" />
-    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)mscordbi.dll" />
-    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)mscorrc.debug.dll" />
-    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)mscorrc.dll" />
-    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)sos.dll" />
-    <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll" />
-    <ArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <NativeBinary Include="$(BinDir)clretwrc.dll" />
+    <NativeBinary Include="$(BinDir)coreclr.dll" />
+    <NativeBinary Include="$(BinDir)dbgshim.dll" />
+    <NativeBinary Include="$(BinDir)mscordaccore.dll" />
+    <NativeBinary Include="$(BinDir)mscordbi.dll" />
+    <NativeBinary Include="$(BinDir)mscorrc.debug.dll" />
+    <NativeBinary Include="$(BinDir)mscorrc.dll" />
+    <NativeBinary Include="$(BinDir)sos.dll" />
+    <NativeBinary Include="$(BinDir)mscorlib.ni.dll" />
+    <NativeBinary Include="$(BinDir)System.Private.CoreLib.ni.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />

--- a/src/.nuget/Microsoft.NETCore.TestHost/runtime.Linux.Microsoft.NETCore.TestHost.props
+++ b/src/.nuget/Microsoft.NETCore.TestHost/runtime.Linux.Microsoft.NETCore.TestHost.props
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dbg')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dbg" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.so" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <NativeBinary Include="$(BinDir)corerun" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/runtime.OSX.Microsoft.NETCore.TestHost.props
+++ b/src/.nuget/Microsoft.NETCore.TestHost/runtime.OSX.Microsoft.NETCore.TestHost.props
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeSplittableBinary Include="$(BinDir)corerun" />
-    <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)" />
-    <File Include="@(ArchitectureSpecificNativeFile)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-    </File>
-  </ItemGroup>
-  <ItemGroup Condition="'$(__BuildType)' == 'Release'">
-    <ArchitectureSpecificNativeSymbol Include="@(NativeSplittableBinary -> '%(Identity).dwarf')" />
-    <AdditionalLibPackageExcludes Include="%2A%2A\%2A.dwarf" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dylib" />
-    <AdditionalSymbolPackageExcludes Include="%2A%2A\%2A.dll" />
-    <ArchitectureSpecificNativeSymbol Include="..\_.pdb" />
-    <File Include="@(ArchitectureSpecificNativeSymbol)">
-      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      <IsSymbolFile>true</IsSymbolFile>
-    </File>
+    <NativeBinary Include="$(BinDir)corerun" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/runtime.Windows_NT.Microsoft.NETCore.TestHost.props
+++ b/src/.nuget/Microsoft.NETCore.TestHost/runtime.Windows_NT.Microsoft.NETCore.TestHost.props
@@ -4,6 +4,6 @@
     <PackageTargetRuntime>$(MinOSForArch)-$(PackagePlatform)</PackageTargetRuntime>
   </PropertyGroup>
   <ItemGroup>
-    <ArchitectureSpecificNativeFile Include="$(BinDir)CoreRun.exe" />
+    <NativeBinary Include="$(BinDir)CoreRun.exe" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -80,6 +80,23 @@
     </Otherwise>
   </Choose>
 
+  <!-- Determine per-platform native binary extensions. -->
+  <Choose>
+    <When Condition="'$(_runtimeOSFamily)' == 'win'" />
+    <When Condition="'$(_runtimeOSFamily)' == 'osx'">
+      <PropertyGroup>
+        <LibraryFileExtension>.dylib</LibraryFileExtension>
+        <SymbolFileExtension>.dwarf</SymbolFileExtension>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <LibraryFileExtension>.so</LibraryFileExtension>
+        <SymbolFileExtension>.dbg</SymbolFileExtension>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';Linux;'))">
     <OfficialBuildRID Include="alpine.3.4.3-x64" />
     <OfficialBuildRID Include="debian.8-armel">

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    Finds symbol files and injects them into the package build.
+  -->
+  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
+    <ItemGroup Condition="'$(SymbolFileExtension)' != ''">
+      <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolFileExtension)"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <AdditionalLibPackageExcludes Include="@(LongNameFile -> '%(TargetPath)')" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <NativeWithSymbolFile Include="@(NativeBinary);
+                                     @(ArchitectureSpecificNativeFile);
+                                     @(ArchitectureSpecificNativeFileAndSymbol)">
+        <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      </NativeWithSymbolFile>
+      <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->
+      <NativeWithSymbolFile Include="@(ArchitectureSpecificLibFile)">
+        <TargetPath>runtimes/$(PackageTargetRuntime)/lib/netstandard1.0</TargetPath>
+      </NativeWithSymbolFile>
+      <NativeWithSymbolFile Include="@(ArchitectureSpecificToolFile)">
+        <TargetPath>tools</TargetPath>
+      </NativeWithSymbolFile>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(HasCrossTargetComponents)'=='true'">
+      <NativeWithSymbolFile Include="@(CrossArchitectureSpecificNativeFileAndSymbol)">
+        <TargetPath>runtimes/$(CrossTargetComponentFolder)_$(PackagePlatform)/native</TargetPath>
+      </NativeWithSymbolFile>
+      <NativeWithSymbolFile Include="@(CrossArchitectureSpecificToolFile)">
+        <TargetPath>tools/$(CrossTargetComponentFolder)_$(PackagePlatform)</TargetPath>
+      </NativeWithSymbolFile>
+    </ItemGroup>
+
+    <ItemGroup>
+      <File Include="@(NativeWithSymbolFile)" />
+      <File Include="@(LongNameFile)">
+        <IsSymbolFile>true</IsSymbolFile>
+      </File>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- On Windows, trim ".dll" before adding ".pdb". -->
+      <WindowsNativeFile Include="@(NativeWithSymbolFile)"
+                         Condition="'%(NativeWithSymbolFile.Extension)'=='.dll' OR '%(NativeWithSymbolFile.Extension)'=='.exe'" />
+      <NativeDllFileWithoutExtension Include="@(WindowsNativeFile -> '%(RootDir)%(Directory)PDB\%(Filename)')" />
+      <WindowsSymbolFile Include="@(NativeDllFileWithoutExtension -> '%(Identity).pdb')" />
+
+      <!--
+        Search for all xplat symbol file extensions on every xplat native binary. Some binaries have
+        no ".so" or ".dylib" extension, so we can't tell which convention its symbol files would
+        use. On xplat, the symbol extension is simply appended. 
+      -->
+      <NonWindowsNativeFile Include="@(NativeWithSymbolFile)"
+                            Exclude="@(WindowsNativeFile)" />
+
+      <NonWindowsSymbolFile Include="@(NonWindowsNativeFile -> '%(Identity)$(SymbolFileExtension)')" />
+
+      <ExistingWindowsSymbolFile Include="@(WindowsSymbolFile)" Condition="Exists('%(Identity)')" />
+      <ExistingNonWindowsSymbolFile Include="@(NonWindowsSymbolFile)" Condition="Exists('%(Identity)') AND '$(SkipPackagingXplatSymbols)'!='true'" />
+
+      <!-- Include all found symbols. -->
+      <File Include="@(ExistingWindowsSymbolFile);@(ExistingNonWindowsSymbolFile)">
+        <IsSymbolFile>true</IsSymbolFile>
+      </File>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <NeedsPlaceholderPdb Condition="'@(ExistingNonWindowsSymbolFile)'!='' AND '@(ExistingWindowsSymbolFile)'==''">true</NeedsPlaceholderPdb>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <File Include="$(MSBuildThisFileDirectory)\_.pdb"
+            Condition="'$(NeedsPlaceholderPdb)'=='true' AND '$(PackageTargetRuntime)'!=''">
+        <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+        <IsSymbolFile>true</IsSymbolFile>
+      </File>
+    </ItemGroup>
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -46,8 +46,7 @@
       <!-- On Windows, trim ".dll" before adding ".pdb". -->
       <WindowsNativeFile Include="@(NativeWithSymbolFile)"
                          Condition="'%(NativeWithSymbolFile.Extension)'=='.dll' OR '%(NativeWithSymbolFile.Extension)'=='.exe'" />
-      <NativeDllFileWithoutExtension Include="@(WindowsNativeFile -> '%(RootDir)%(Directory)PDB\%(Filename)')" />
-      <WindowsSymbolFile Include="@(NativeDllFileWithoutExtension -> '%(Identity).pdb')" />
+      <WindowsSymbolFile Include="@(WindowsNativeFile -> '%(RootDir)%(Directory)PDB\%(Filename).pdb')" />
 
       <!--
         Search for all xplat symbol file extensions on every xplat native binary. Some binaries have

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -14,9 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <NativeWithSymbolFile Include="@(NativeBinary);
-                                     @(ArchitectureSpecificNativeFile);
-                                     @(ArchitectureSpecificNativeFileAndSymbol)">
+      <NativeWithSymbolFile Include="@(NativeBinary)">
         <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       </NativeWithSymbolFile>
       <!-- Using lib/netstandard1.0 here.  There is no TFM for this since it is a runtime itself. -->


### PR DESCRIPTION
This adds a `stripSymbols` build arg to explicitly opt in to symbol stripping and applies a package refactor to avoid breaking when symbols don't exist.

Replaces my previous PR: https://github.com/dotnet/coreclr/pull/9326.

Package content diff between this PR and 25017-03, (`alpine`, `osx`, `win10-arm64`, `win7-x64` builds):
https://gist.github.com/dagood/8590cf9a13bc0c58a77736b068987870

Differences:

 * Cross-arch files are `AnyCPU` rather than `arm64`. This is existing behavior in the master branch right now, unrelated to these changes. @chcosta @ericstj was this intentional?
 * All symbol packages include `dll`/`so`/`dylib`. This follows symbol package convention more closely, and concretely means that indexing infra won't need to first merge the lib/sym packages together.
 * Files in `runtimes/win10-arm64/lib/netstandard1.0` now have their symbols placed in the same folder in the symbol package, rather than `runtimes/win10-arm64/native`.

PTAL, @chcosta @ericstj @gkhanna79 
FYI @ellismg 