### PR TITLE
Delay Random allocation in ConcurrentStack

### DIFF
--- a/src/mscorlib/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/mscorlib/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -328,7 +328,7 @@ namespace System.Collections.Concurrent
             Node head;
             Node next;
             int backoff = 1;
-            Random r = new Random(Environment.TickCount & Int32.MaxValue); // avoid the case where TickCount could return Int32.MinValue
+            Random r = null;
             while (true)
             {
                 head = m_head;
@@ -359,7 +359,18 @@ namespace System.Collections.Concurrent
                     spin.SpinOnce();
                 }
 
-                backoff = spin.NextSpinWillYield ? r.Next(1, BACKOFF_MAX_YIELDS) : backoff * 2;
+                if (spin.NextSpinWillYield)
+                {
+                    if (r == null)
+                    {
+                        r = new Random();
+                    }
+                    backoff = r.Next(1, BACKOFF_MAX_YIELDS);
+                }
+                else
+                {
+                    backoff *= 2;
+                }
             }
         }
 


### PR DESCRIPTION
Port of https://github.com/dotnet/corefx/pull/16295

This is showing up in traces of code heavily using overlapped, as overlapped pools some objects using ConcurrentStack.  There is a larger allocation issue here to think through regarding ConcurrentStack itself and the Node objects it uses, but this at least reduces some cost in heavily contended scenarios.

cc: @geoffkizer, @kouvel, @alexperovich 