### PR TITLE
Fix bogus assert in flowgraph and update related ilproj

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -23286,8 +23286,7 @@ void Compiler::fgCloneFinally()
         BasicBlock* const firstTryBlock = HBtab->ebdTryBeg;
         BasicBlock* const lastTryBlock  = HBtab->ebdTryLast;
         assert(firstTryBlock->getTryIndex() == XTnum);
-        // TODO: rewrite the following assert to support nested try blocks
-        // assert(lastTryBlock->getTryIndex() == XTnum);
+        assert(bbInTryRegions(XTnum, lastTryBlock));
         BasicBlock* const beforeTryBlock = firstTryBlock->bbPrev;
 
         BasicBlock* normalCallFinallyBlock   = nullptr;

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -23287,7 +23287,7 @@ void Compiler::fgCloneFinally()
         BasicBlock* const lastTryBlock  = HBtab->ebdTryLast;
         assert(firstTryBlock->getTryIndex() == XTnum);
         // TODO: rewrite the following assert to support nested try blocks
-        //assert(lastTryBlock->getTryIndex() == XTnum);
+        // assert(lastTryBlock->getTryIndex() == XTnum);
         BasicBlock* const beforeTryBlock = firstTryBlock->bbPrev;
 
         BasicBlock* normalCallFinallyBlock   = nullptr;

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -23286,7 +23286,8 @@ void Compiler::fgCloneFinally()
         BasicBlock* const firstTryBlock = HBtab->ebdTryBeg;
         BasicBlock* const lastTryBlock  = HBtab->ebdTryLast;
         assert(firstTryBlock->getTryIndex() == XTnum);
-        assert(lastTryBlock->getTryIndex() == XTnum);
+        // TODO: rewrite the following assert to support nested try blocks
+        //assert(lastTryBlock->getTryIndex() == XTnum);
         BasicBlock* const beforeTryBlock = firstTryBlock->bbPrev;
 
         BasicBlock* normalCallFinallyBlock   = nullptr;

--- a/tests/src/JIT/Methodical/eh/disconnected/tryfinallyincatchtry_r.ilproj
+++ b/tests/src/JIT/Methodical/eh/disconnected/tryfinallyincatchtry_r.ilproj
@@ -20,6 +20,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
       <Visible>False</Visible>


### PR DESCRIPTION
End try block may not be directly contained as discussed in #9576, but there is an assert that considers  only direct cases.

This commit revises the assert to take care of indirect cases, and also revises relevant .ilproj file (to prevent future regression).