### PR TITLE
Cleanup tests/runtest.sh script.

### DIFF
--- a/Documentation/building/unix-test-instructions.md
+++ b/Documentation/building/unix-test-instructions.md
@@ -33,7 +33,6 @@ Run tests (`Debug` may be replaced with `Release` or `Checked`, depending on whi
 > ```bash
 > ~/coreclr$ tests/runtest.sh
 >     --testRootDir=~/test/Windows_NT.x64.Debug
->     --testNativeBinDir=~/coreclr/bin/obj/Linux.x64.Debug/tests
 >     --coreClrBinDir=~/coreclr/bin/Product/Linux.x64.Debug
 >     --mscorlibDir=/media/coreclr/bin/Product/Linux.x64.Debug
 >     --coreFxBinDir=~/corefx/bin/runtime/netcoreapp-Linux-Debug-x64
@@ -41,13 +40,12 @@ Run tests (`Debug` may be replaced with `Release` or `Checked`, depending on whi
 
 The method above will copy dependencies from the set of directories provided to create an 'overlay' directory.
 If you already have an overlay directory prepared with the dependencies you need, you can specify `--coreOverlayDir`
-instead of `--coreClrBinDir`, `--mscorlibDir`, `--coreFxBinDir`, and `--coreFxNativeBinDir`. It would look something like:
+instead of `--coreClrBinDir`, `--mscorlibDir`, and `--coreFxBinDir`. It would look something like:
 
 
 > ```bash
 > ~/coreclr$ tests/runtest.sh
 >     --testRootDir=~/test/Windows_NT.x64.Debug
->     --testNativeBinDir=~/coreclr/bin/obj/Linux.x64.Debug/tests
 >     --coreOverlayDir=/path/to/directory/containing/overlay
 > ```
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -2853,7 +2853,6 @@ combinedScenarios.each { scenario ->
                                 // Run coreclr tests w/ workstation GC
                                 shell("""./clr/tests/runtest.sh \\
                 --testRootDir=\"\$(pwd)/clr/bin/tests/Windows_NT.${architecture}.${configuration}\" \\
-                --testNativeBinDir=\"\$(pwd)/clr/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
                 --coreClrBinDir=\"\$(pwd)/clr/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --mscorlibDir=\"\$(pwd)/clr/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --coreFxBinDir=\"\$(pwd)/fx/bin/runtime/netcoreapp-${osGroup}-Release-${architecture}\" \\
@@ -2862,14 +2861,12 @@ combinedScenarios.each { scenario ->
                                 // Run coreclr tests w/ server GC & HeapVerify enabled
                                 shell("""./clr/tests/runtest.sh \\
                 --testRootDir=\"\$(pwd)/clr/bin/tests/Windows_NT.${architecture}.${configuration}\" \\
-                --testNativeBinDir=\"\$(pwd)/clr/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
                 --coreOverlayDir=\"\$(pwd)/clr/bin/tests/Windows_NT.${architecture}.${configuration}/Tests/coreoverlay\" \\
                 --useServerGC ${testEnvOpt}""")
 
                                  // Run long-running coreclr GC tests & produce coverage reports
                                 shell("""./clr/tests/runtest.sh \\
                 --testRootDir=\"\$(pwd)/clr/bin/tests/Windows_NT.${architecture}.${configuration}\" \\
-                --testNativeBinDir=\"\$(pwd)/clr/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
                 --coreOverlayDir=\"\$(pwd)/clr/bin/tests/Windows_NT.${architecture}.${configuration}/Tests/coreoverlay\" \\
                 --long-gc --playlist=\"\$(pwd)/clr/tests/longRunningGcTests.txt\" --coreclr-coverage\\
                 --coreclr-objs=\"\$(pwd)/clr/bin/obj/${osGroup}.${architecture}.${configuration}\" \\
@@ -2922,7 +2919,6 @@ combinedScenarios.each { scenario ->
 
                                 shell("""./tests/runtest.sh \\
                 --testRootDir=\"\${WORKSPACE}/bin/tests/Windows_NT.${architecture}.${configuration}\" \\
-                --testNativeBinDir=\"\${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
                 --coreClrBinDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --mscorlibDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --coreFxBinDir=\"\${WORKSPACE}/bin/CoreFxBinDir\" \\

--- a/perf.groovy
+++ b/perf.groovy
@@ -138,7 +138,6 @@ def static getOSGroup(def os) {
 				"python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type " + runType)
                 shell("""sudo -E bash ./tests/scripts/run-xunit-perf.sh \\
                 --testRootDir=\"\${WORKSPACE}/bin/tests/Windows_NT.${architecture}.${configuration}\" \\
-                --testNativeBinDir=\"\${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
                 --coreClrBinDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --mscorlibDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --coreFxBinDir=\"\${WORKSPACE}/corefx\" \\

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -954,6 +954,10 @@ do
         --testRootDir=*)
             testRootDir=${i#*=}
             ;;
+        --testNativeBinDir=*)
+            testNativeBinDir=${i#*=}
+            echo "--testNativeBinDir no more required"
+            ;;
         --coreOverlayDir=*)
             coreOverlayDir=${i#*=}
             ;;

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -8,14 +8,12 @@ function print_usage {
     echo ''
     echo 'coreclr/tests/runtest.sh'
     echo '    --testRootDir="temp/Windows_NT.x64.Debug"'
-    echo '    --testNativeBinDir="coreclr/bin/obj/Linux.x64.Debug/tests"'
     echo '    --coreClrBinDir="coreclr/bin/Product/Linux.x64.Debug"'
     echo '    --mscorlibDir="windows/coreclr/bin/Product/Linux.x64.Debug"'
     echo '    --coreFxBinDir="corefx/bin/runtime/netcoreapp-Linux-Debug-x64'
     echo ''
     echo 'Required arguments:'
     echo '  --testRootDir=<path>             : Root directory of the test build (e.g. coreclr/bin/tests/Windows_NT.x64.Debug).'
-    echo '  --testNativeBinDir=<path>        : Directory of the native CoreCLR test build (e.g. coreclr/bin/obj/Linux.x64.Debug/tests).'
     echo '  (Also required: Either --coreOverlayDir, or all of the switches --coreOverlayDir overrides)'
     echo ''
     echo 'Optional arguments:'
@@ -94,29 +92,6 @@ countSkippedTests=0
 # Variables for xUnit-style XML output. XML format: https://xunit.github.io/docs/format-xml-v2.html
 xunitOutputPath=
 xunitTestOutputPath=
-
-# libExtension determines extension for dynamic library files
-# runtimeName determines where CoreFX Runtime files will be located
-OSName=$(uname -s)
-libExtension=
-case $OSName in
-    Darwin)
-        libExtension="dylib"
-        ;;
-
-    Linux)
-        libExtension="so"
-        ;;
-
-    NetBSD)
-        libExtension="so"
-        ;;
-
-    *)
-        echo "Unsupported OS $OSName detected, configuring as if for Linux"
-        libExtension="so"
-        ;;
-esac
 
 # clean up any existing dumpling remnants from previous runs.
 dumplingsListPath="$PWD/dumplings.txt"
@@ -338,6 +313,7 @@ function create_core_overlay {
     # Check inputs to make sure we have enough information to create the core layout. $testRootDir/Tests/Core_Root should
     # already exist and contain test dependencies that are not built.
     local testDependenciesDir=$testRootDir/Tests/Core_Root
+    local testNativeBinDir=$coreClrBinDir/bin
     if [ ! -d "$testDependenciesDir" ]; then
         exit_with_error "$errorSource" "Did not find the test dependencies directory: $testDependenciesDir"
     fi
@@ -349,6 +325,9 @@ function create_core_overlay {
     fi
     if [ ! -f "$mscorlibDir/mscorlib.dll" ]; then
         exit_with_error "$errorSource" "mscorlib.dll was not found in: $mscorlibDir"
+    fi
+    if [ ! -d "$testNativeBinDir" ]; then
+        exit_with_error "$errorSource" "Directory, contains test native libraries: $testNativeBinDir does not exist."
     fi
     if [ -z "$coreFxBinDir" ]; then
         exit_with_error "$errorSource" "One of --coreOverlayDir or --coreFxBinDir must be specified." "$printUsage"
@@ -365,11 +344,9 @@ function create_core_overlay {
     cp -f -v "$coreFxBinDir/"* "$coreOverlayDir/" 2>/dev/null
     cp -f -v "$coreClrBinDir/"* "$coreOverlayDir/" 2>/dev/null
     cp -f -v "$mscorlibDir/mscorlib.dll" "$coreOverlayDir/" 2>/dev/null
-    if [ -d "$mscorlibDir/bin" ]; then
-        cp -f -v "$mscorlibDir/bin/"* "$coreOverlayDir/" 2>/dev/null
-    fi
     cp -f -v "$testDependenciesDir/"xunit* "$coreOverlayDir/" 2>/dev/null
     cp -n -v "$testDependenciesDir/"* "$coreOverlayDir/" 2>/dev/null
+    cp -f -v "$testNativeBinDir/"* "$coreOverlayDir/" 2>/dev/null
     if [ -f "$coreOverlayDir/mscorlib.ni.dll" ]; then
         # Test dependencies come from a Windows build, and mscorlib.ni.dll would be the one from Windows
         rm -f "$coreOverlayDir/mscorlib.ni.dll"
@@ -378,7 +355,6 @@ function create_core_overlay {
         # Test dependencies come from a Windows build, and System.Private.CoreLib.ni.dll would be the one from Windows
         rm -f "$coreOverlayDir/System.Private.CoreLib.ni.dll"
     fi
-    copy_test_native_bin_to_test_root
 }
 
 function precompile_overlay_assemblies {
@@ -417,29 +393,6 @@ function precompile_overlay_assemblies {
     else
         echo Skipping crossgen of FX assemblies.
     fi
-}
-
-function copy_test_native_bin_to_test_root {
-    local errorSource='copy_test_native_bin_to_test_root'
-
-    if [ -z "$testNativeBinDir" ]; then
-        exit_with_error "$errorSource" "--testNativeBinDir is required."
-    fi
-    testNativeBinDir=$testNativeBinDir/src
-    if [ ! -d "$testNativeBinDir" ]; then
-        exit_with_error "$errorSource" "Directory specified by --testNativeBinDir does not exist: $testNativeBinDir"
-    fi
-
-    # Copy native test components from the native test build into the respective test directory in the test root directory
-    find "$testNativeBinDir" -type f -iname '*.$libExtension' |
-        while IFS='' read -r filePath || [ -n "$filePath" ]; do
-            local dirPath=$(dirname "$filePath")
-            local destinationDirPath=${testRootDir}${dirPath:${#testNativeBinDir}}
-            if [ ! -d "$destinationDirPath" ]; then
-                exit_with_error "$errorSource" "Cannot copy native test bin '$filePath' to '$destinationDirPath/', as the destination directory does not exist."
-            fi
-            cp -f "$filePath" "$destinationDirPath/"
-        done
 }
 
 # Variables for unsupported and failing tests
@@ -946,7 +899,6 @@ readonly EXIT_CODE_TEST_FAILURE=2  # Script completed successfully, but one or m
 
 # Argument variables
 testRootDir=
-testNativeBinDir=
 coreOverlayDir=
 coreClrBinDir=
 mscorlibDir=
@@ -1001,9 +953,6 @@ do
             ;;
         --testRootDir=*)
             testRootDir=${i#*=}
-            ;;
-        --testNativeBinDir=*)
-            testNativeBinDir=${i#*=}
             ;;
         --coreOverlayDir=*)
             coreOverlayDir=${i#*=}
@@ -1109,8 +1058,6 @@ if [ ! -d "$testRootDir" ]; then
     exit $EXIT_CODE_EXCEPTION
 fi
 
-# Copy native interop test libraries over to the mscorlib path in
-# order for interop tests to run on linux.
 if [ -z "$mscorlibDir" ]; then
     mscorlibDir=$coreClrBinDir
 fi

--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -242,9 +242,6 @@ function copy_to_emulator {
     sudo cp -R "$__testRootDir" "$__ARMRootfsCoreclrPath/$testRootDirBase"
     __testRootDirBase="$__ARMEmulCoreclr/$testRootDirBase"
 
-    sudo cp -R "./$__testNativeBinDirBase" "$__ARMRootfsCoreclrPath/$__testNativeBinDirBase"
-    __testNativeBinDirBase="$__ARMEmulCoreclr/$__testNativeBinDirBase"
-
     sudo cp -R "./$__coreClrBinDirBase" "$__ARMRootfsCoreclrPath/$__coreClrBinDirBase"
     if [ ! -z "$__mscorlibDir" ]; then
         sudo cp "$__mscorlibDir/mscorlib.dll" "$__ARMRootfsCoreclrPath/$__coreClrBinDirBase/"
@@ -292,7 +289,6 @@ function run_tests {
                            --coreFxNativeBinDir=$__coreFxNativeBinDirBase \
                            --coreFxBinDir="$__coreFxBinDirBase" \
                            --testDirFile=$__testDirFileBase \
-                           --testNativeBinDir=$__testNativeBinDirBase \
                            --coreClrBinDir=$__coreClrBinDirBase
 EOF
 }
@@ -425,7 +421,6 @@ __mscorlibDirBase=
 __coreFxNativeBinDirBase=
 __coreFxBinDirBase=
 __testDirFileBase=
-__testNativeBinDirBase="bin/obj/$__buildDirName/tests"
 __coreClrBinDirBase="bin/Product/$__buildDirName"
 
 set -x

--- a/tests/src/JIT/superpmi/runtests.sh
+++ b/tests/src/JIT/superpmi/runtests.sh
@@ -28,7 +28,6 @@ UNIXARCHFLAVOR=OSX.x64.Debug
 
 ARGS="\
 --testRootDir=${TESTROOT}/${WINDOWSFLAVOR} \
---testNativeBinDir=${CORECLRROOT}/bin/obj/${UNIXARCHFLAVOR}/tests \
 --coreClrBinDir=${CORECLRROOT}/bin/Product/${UNIXARCHFLAVOR} \
 --mscorlibDir=${WINDOWSCORECLRROOT}/bin/Product/${UNIXARCHFLAVOR} \
 --coreFxBinDir=${COREFXROOT}/bin/${UNIXANYFLAVOR};${COREFXROOT}/bin/Unix.AnyCPU.Debug;${COREFXROOT}/bin/AnyOS.AnyCPU.Debug \


### PR DESCRIPTION
This PR fixed issue #9632

I've tried to recreate copying of test native libraries as it was made in 'copy_test_native_bin_to_test_root' function.
But several tests from different folders can use the same native library.
So I decided to stay it as it working now, but removed 'testNativeBinDir' argument with related code and made copying of these libraries more clearly.

CC @danmosemsft 