### PR TITLE
[x86/Linux] Emit proper frame for ArrayOpStub

### DIFF
--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -263,6 +263,7 @@ LEAF_ENTRY ArrayOpStubNullException, _TEXT
     // them anyway for consistency and to avoid future bugs.
     pop     esi
     pop     edi
+    pop     ebp
     mov     ecx, CORINFO_NullReferenceException_ASM
     jmp     C_FUNC(InternalExceptionWorker)
 LEAF_END ArrayOpStubNullException, _TEXT
@@ -274,6 +275,7 @@ LEAF_ENTRY ArrayOpStubRangeException, _TEXT
     // them anyway for consistency and to avoid future bugs.
     pop     esi
     pop     edi
+    pop     ebp
     mov     ecx, CORINFO_IndexOutOfRangeException_ASM
     jmp     C_FUNC(InternalExceptionWorker)
 LEAF_END ArrayOpStubRangeException, _TEXT
@@ -285,6 +287,7 @@ LEAF_ENTRY ArrayOpStubTypeMismatchException, _TEXT
     // them anyway for consistency and to avoid future bugs.
     pop     esi
     pop     edi
+    pop     ebp
     mov     ecx, CORINFO_ArrayTypeMismatchException_ASM
     jmp     C_FUNC(InternalExceptionWorker)
 LEAF_END ArrayOpStubTypeMismatchException, _TEXT

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -5079,6 +5079,11 @@ VOID StubLinkerCPU::EmitArrayOpStub(const ArrayOpScript* pArrayOpScript)
         }
     }
 #else
+    // Emit frame
+    X86EmitPushEBPframe();
+
+    ofsadjust += sizeof(void*);
+
     // Preserve the callee-saved registers
     // NOTE: if you change the sequence of these pushes, you must also update:
     //  ArrayOpStubNullException
@@ -5716,6 +5721,9 @@ COPY_VALUE_CLASS:
     // Restore the callee-saved registers
     X86EmitPopReg(kFactorReg);
     X86EmitPopReg(kTotalReg);
+
+    // Restore EBP
+    X86EmitPopReg(kEBP);
 
     // ret N
     X86EmitReturn(pArrayOpScript->m_cbretpop);

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -5079,10 +5079,12 @@ VOID StubLinkerCPU::EmitArrayOpStub(const ArrayOpScript* pArrayOpScript)
         }
     }
 #else
+#ifdef FEATURE_PAL
     // Emit frame
     X86EmitPushEBPframe();
 
     ofsadjust += sizeof(void*);
+#endif // FEATURE_PAL
 
     // Preserve the callee-saved registers
     // NOTE: if you change the sequence of these pushes, you must also update:
@@ -5722,8 +5724,10 @@ COPY_VALUE_CLASS:
     X86EmitPopReg(kFactorReg);
     X86EmitPopReg(kTotalReg);
 
+#ifdef FEATURE_PAL
     // Restore EBP
     X86EmitPopReg(kEBP);
+#endif // FEATURE_PAL
 
     // ret N
     X86EmitReturn(pArrayOpScript->m_cbretpop);


### PR DESCRIPTION
In x86/Linux, C++ unwinder failed to unwind the frame by ArrayOpStub as the current implementation does not emit a proper frame (discussed in #9687).

This commit revises ArrayOpStub to have a ebp frame to fix #9687.