### PR TITLE
[x86/linux] Implement BackPatchWorkerAsmStub

### DIFF
--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -1112,12 +1112,12 @@ NESTED_ENTRY BackPatchWorkerAsmStub, _TEXT, NoHandler
     PROLOG_PUSH edx
     PROLOG_END
 
-    push eax        //  push any indirect call address as the second arg to BackPatchWorker
-    push [ebp+8]    //  and push return address as the first arg to BackPatchWorker
-    sub esp, 4      //  for 16 bytes align
+    sub     esp, 4     //  for 16 bytes align
+    push    eax        //  push any indirect call address as the second arg to BackPatchWorker
+    push    [ebp+8]    //  and push return address as the first arg to BackPatchWorker
 
-    call C_FUNC(BackPatchWorkerStaticStub)
-    add esp, 12
+    call    C_FUNC(BackPatchWorkerStaticStub)
+    add     esp, 12
 
     EPILOG_BEG
     EPILOG_POP edx
@@ -1125,4 +1125,4 @@ NESTED_ENTRY BackPatchWorkerAsmStub, _TEXT, NoHandler
     EPILOG_POP eax
     EPILOG_END
     ret
-NESTED_END BackPatchWorkerAsmStub, _TEX
+NESTED_END BackPatchWorkerAsmStub, _TEXT

--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -1103,3 +1103,26 @@ LOCAL_LABEL(fail):
 
 NESTED_END ResolveWorkerChainLookupAsmStub, _TEXT
 #endif // CROSSGEN_COMPILE
+
+// backpatch a call site to point to a different stub
+NESTED_ENTRY BackPatchWorkerAsmStub, _TEXT, NoHandler
+    PROLOG_BEG
+    PROLOG_PUSH eax // it may contain siteAddrForRegisterIndirect
+    PROLOG_PUSH ecx
+    PROLOG_PUSH edx
+    PROLOG_END
+
+    push eax        //  push any indirect call address as the second arg to BackPatchWorker
+    push [ebp+8]    //  and push return address as the first arg to BackPatchWorker
+    sub esp, 4      //  for 16 bytes align
+
+    call C_FUNC(BackPatchWorkerStaticStub)
+    add esp, 12
+
+    EPILOG_BEG
+    EPILOG_POP edx
+    EPILOG_POP ecx
+    EPILOG_POP eax
+    EPILOG_END
+    ret
+NESTED_END BackPatchWorkerAsmStub, _TEX

--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -46,11 +46,6 @@ extern "C"
     }
 };
 
-VOID __cdecl PopSEHRecords(LPVOID pTargetSP)
-{
-    PORTABILITY_ASSERT("Implement for PAL");
-}
-
 EXTERN_C VOID JIT_TailCall()
 {
   PORTABILITY_ASSERT("JIT_TailCall");

--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -46,9 +46,9 @@ extern "C"
     }
 };
 
-EXTERN_C VOID BackPatchWorkerAsmStub()
+VOID __cdecl PopSEHRecords(LPVOID pTargetSP)
 {
-    PORTABILITY_ASSERT("BackPatchWorkerAsmStub");
+    PORTABILITY_ASSERT("Implement for PAL");
 }
 
 EXTERN_C VOID JIT_TailCall()

--- a/src/vm/virtualcallstub.cpp
+++ b/src/vm/virtualcallstub.cpp
@@ -4047,3 +4047,10 @@ BOOL VirtualCallStubManagerManager::TraceManager(
     // Forward the call to the appropriate manager.
     return pMgr->TraceManager(thread, trace, pContext, pRetAddr);
 }
+
+#ifdef _TARGET_X86_
+void BackPatchWorkerStaticStub(PCODE returnAddr, TADDR siteAddrForRegisterIndirect)
+{
+    VirtualCallStubManager::BackPatchWorkerStatic(returnAddr, siteAddrForRegisterIndirect);
+}
+#endif

--- a/src/vm/virtualcallstub.cpp
+++ b/src/vm/virtualcallstub.cpp
@@ -4048,7 +4048,7 @@ BOOL VirtualCallStubManagerManager::TraceManager(
     return pMgr->TraceManager(thread, trace, pContext, pRetAddr);
 }
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && defined(FEATURE_PAL)
 void BackPatchWorkerStaticStub(PCODE returnAddr, TADDR siteAddrForRegisterIndirect)
 {
     VirtualCallStubManager::BackPatchWorkerStatic(returnAddr, siteAddrForRegisterIndirect);

--- a/src/vm/virtualcallstub.h
+++ b/src/vm/virtualcallstub.h
@@ -551,9 +551,9 @@ private:
 #endif                            
                                    );
 
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && defined(FEATURE_PAL)
     friend void BackPatchWorkerStaticStub(PCODE returnAddr, TADDR siteAddrForRegisterIndirect);
-#endif // _TARGET_X86_
+#endif
 
     //These are the entrypoints that the stubs actually end up calling via the
     // xxxAsmStub methods above

--- a/src/vm/virtualcallstub.h
+++ b/src/vm/virtualcallstub.h
@@ -164,6 +164,7 @@ extern "C" void ResolveWorkerChainLookupAsmStub();    // for chaining of entries
 
 #ifdef _TARGET_X86_ 
 extern "C" void BackPatchWorkerAsmStub();             // backpatch a call site to point to a different stub
+extern "C" void BackPatchWorkerStaticStub(PCODE returnAddr, TADDR siteAddrForRegisterIndirect);
 #endif // _TARGET_X86_
 
 
@@ -547,6 +548,10 @@ private:
                                    , UINT_PTR flags
 #endif                            
                                    );
+
+#ifdef _TARGET_X86_
+    friend void BackPatchWorkerStaticStub(PCODE returnAddr, TADDR siteAddrForRegisterIndirect);
+#endif // _TARGET_X86_
 
     //These are the entrypoints that the stubs actually end up calling via the
     // xxxAsmStub methods above

--- a/src/vm/virtualcallstub.h
+++ b/src/vm/virtualcallstub.h
@@ -164,7 +164,9 @@ extern "C" void ResolveWorkerChainLookupAsmStub();    // for chaining of entries
 
 #ifdef _TARGET_X86_ 
 extern "C" void BackPatchWorkerAsmStub();             // backpatch a call site to point to a different stub
+#ifdef FEATURE_PAL
 extern "C" void BackPatchWorkerStaticStub(PCODE returnAddr, TADDR siteAddrForRegisterIndirect);
+#endif // FEATURE_PAL
 #endif // _TARGET_X86_
 
 


### PR DESCRIPTION
This implementation is ported from BackPatchWorkerAsmStub in vm/i386/virtualcallstubcpu.hpp