### PR TITLE
Fix compilation on macOS with case sensitive FS

### DIFF
--- a/src/pal/src/locale/unicode.cpp
+++ b/src/pal/src/locale/unicode.cpp
@@ -42,7 +42,7 @@ Revision History:
 #endif // __APPLE__
 #include <errno.h>
 #if HAVE_COREFOUNDATION
-#include <corefoundation/corefoundation.h>
+#include <CoreFoundation/CoreFoundation.h>
 #endif // HAVE_COREFOUNDATION
 
 #include <debugmacrosext.h>


### PR DESCRIPTION
If I compile coreclr on macOS with case-sensitive fs, one header file not found. I fix it.