### PR TITLE
Use CORINFO_CALLCONV to check for unmanaged calls

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6465,9 +6465,9 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         if (IsTargetAbi(CORINFO_CORERT_ABI))
         {
             bool managedCall = (((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_STDCALL) &&
-                ((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_C) &&
-                ((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_THISCALL) &&
-                ((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_FASTCALL));
+                                ((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_C) &&
+                                ((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_THISCALL) &&
+                                ((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_FASTCALL));
             if (managedCall)
             {
                 addFatPointerCandidate(call->AsCall());

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6464,7 +6464,10 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
         if (IsTargetAbi(CORINFO_CORERT_ABI))
         {
-            bool managedCall = (calliSig.callConv & GTF_CALL_UNMANAGED) == 0;
+            bool managedCall = (((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_STDCALL) &&
+                ((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_C) &&
+                ((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_THISCALL) &&
+                ((calliSig.callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_FASTCALL));
             if (managedCall)
             {
                 addFatPointerCandidate(call->AsCall());


### PR DESCRIPTION
`GTF_CALL_UNMANAGED` is a member of the wrong enum and it's something
that would be set on `call->gtFlags` except that at this point it isn't.
Check against the actual unmanaged calling conventions.