### PR TITLE
Fix x86 perf testing

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -74,8 +74,8 @@ def static getOSGroup(def os) {
 					batchFile("py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
 					batchFile("set __TestIntermediateDir=int&&build.cmd ${configuration} ${architecture}")
 					batchFile("tests\\runtest.cmd ${configuration} ${architecture} GenerateLayoutOnly")
-					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${architecture} -configuration ${configuration} ${testEnv} -testBinLoc bin\\tests\\Windows_NT.${architecture}.${configuration}\\performance\\perflab\\Perflab -library -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype ${runType}")
-					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${architecture} -configuration ${configuration} ${testEnv} -testBinLoc bin\\tests\\Windows_NT.${architecture}.${configuration}\\Jit\\Performance\\CodeQuality -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype ${runType}")
+					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${arch} -configuration ${configuration} ${testEnv} -testBinLoc bin\\tests\\Windows_NT.${architecture}.${configuration}\\performance\\perflab\\Perflab -library -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype ${runType}")
+					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${arch} -configuration ${configuration} ${testEnv} -testBinLoc bin\\tests\\Windows_NT.${architecture}.${configuration}\\Jit\\Performance\\CodeQuality -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype ${runType}")
 				}
 			}
 


### PR DESCRIPTION
We did not use a different architecture in run-xunit-perf.cmd, so all the
x86 runs were uploading to the same architecture. This change fixes it so
x86jit32 runs upload to their own architecture. Also fixes the delayed
expansion issue for testenv.