### PR TITLE
Correctly pass 12-byte GT_SIMD nodes on x86.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1062,6 +1062,15 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
             LclVarDsc* varDsc = &comp->lvaTable[varNum];
             type              = varDsc->lvType;
         }
+        else if (arg->OperGet() == GT_SIMD)
+        {
+            assert((arg->AsSIMD()->gtSIMDSize == 16) || (arg->AsSIMD()->gtSIMDSize == 12));
+
+            if (arg->AsSIMD()->gtSIMDSize == 12)
+            {
+                type = TYP_SIMD12;
+            }
+        }
     }
 #endif // defined(FEATURE_SIMD) && defined(_TARGET_X86_)
 

--- a/tests/src/JIT/Regression/JitBlue/CoreFX_15913/CoreFX_15913.cs
+++ b/tests/src/JIT/Regression/JitBlue/CoreFX_15913/CoreFX_15913.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+// This test ensures that we pass by-value Vector3 arguments correctly, especially on x86.
+// On x86, we must ensure that we properly treat an outgoing Vector3 as a 12-byte value
+// when pushing it onto the stack.
+
+static class CoreFX15913
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static float Sum(float v3, Vector3 v)
+    {
+        return v3 + v.X + v.Y + v.Z;
+    }
+
+    static int Main()
+    {
+        float f = 4.0f;
+        return Sum(f, Vector3.Zero) == f ? 100 : 0;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/CoreFX_15913/CoreFX_15913.csproj
+++ b/tests/src/JIT/Regression/JitBlue/CoreFX_15913/CoreFX_15913.csproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CoreFX_15913.cs" />
+  </ItemGroup>
+  <!--  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)threading+thread\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)threading+thread\project.lock.json</ProjectLockJson>
+  </PropertyGroup>-->
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
During lowering, all TYP_SIMD12 GT_SIMD nodes are retyped to TYP_SIMD16.
This is correct except in the case that the GT_SIMD node is going to be
passed by-value on x86, in which case this retyping causes us to push 16
bytes rather than 12. This change recognizes a GT_SIMD node that has
been retyped by checking the value of gtSIMDSize during LowerArg and
uses TYP_SIMD12 for the putarg instead of TYP_SIMD16 (aside from
differences in detecting retyped nodes, this is the same transformation
we already do when passing TYP_SIMD12 lclVars that are being used as
TYP_SIMD16 on x86).

Fixes https://github.com/dotnet/corefx/issues/15913.