### PR TITLE
Add test coverage for ldtoken with members

### DIFF
--- a/tests/src/reflection/ldtoken/ldtokenmember.il
+++ b/tests/src/reflection/ldtoken/ldtokenmember.il
@@ -1,0 +1,247 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib
+{
+}
+
+.assembly ldtokenmember
+{
+}
+
+.method private hidebysig static int32 Main() cil managed
+{
+  .entrypoint
+  .maxstack  8
+  .locals init (class [mscorlib]System.Type nonGenericHolderType,
+                class [mscorlib]System.Reflection.FieldInfo staticField,
+                class [mscorlib]System.Reflection.MethodBase staticInt32Method,
+                class [mscorlib]System.Reflection.MethodBase staticMethodT,
+                class [mscorlib]System.Reflection.MethodBase staticMethodU,
+                class [mscorlib]System.Reflection.FieldInfo staticFieldT)
+
+  //
+  // Type nonGenericHolderType = typeof(NonGenericHolder)
+  //
+  ldtoken    class NonGenericHolder
+  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(
+                 valuetype [mscorlib]System.RuntimeTypeHandle)
+  stloc      nonGenericHolderType
+
+  //
+  // FieldInfo staticField = infoof(NonGenericHolder.StaticField)
+  //
+  ldtoken    field object NonGenericHolder::StaticField
+  call       class [mscorlib]System.Reflection.FieldInfo 
+                 [mscorlib]System.Reflection.FieldInfo::GetFieldFromHandle(
+                     valuetype [mscorlib]System.RuntimeFieldHandle)
+  stloc      staticField
+
+  //
+  // if (staticField.Name != "StaticField" || staticField.DeclaringType != nonGenericHolderType)
+  //     return 1;
+  //
+  ldloc      staticField
+  callvirt   instance string [mscorlib]System.Reflection.FieldInfo::get_Name()
+  ldstr      "StaticField"
+  callvirt   instance bool [mscorlib]System.Object::Equals(object)
+  ldloc      staticField
+  callvirt   instance class [mscorlib]System.Type [mscorlib]System.Reflection.FieldInfo::get_DeclaringType()
+  ldloc      nonGenericHolderType
+  ceq
+  and
+  brtrue     NonGenericStaticFieldOK
+  ldc.i4     1
+  ret
+NonGenericStaticFieldOK:
+
+  //
+  // MethodInfo staticInt32Method = infoof(NonGenericHolder.StaticMethod)
+  //
+  ldtoken    method int32 NonGenericHolder::StaticMethod()
+  call       class [mscorlib]System.Reflection.MethodBase 
+                 [mscorlib]System.Reflection.MethodBase::GetMethodFromHandle(
+                     valuetype [mscorlib]System.RuntimeMethodHandle)
+  stloc      staticInt32Method
+
+  //
+  // if (staticInt32Method.Name != "StaticField" || staticInt32Method.DeclaringType != nonGenericHolderType)
+  //     return 2;
+  //
+  ldloc      staticInt32Method
+  callvirt   instance string [mscorlib]System.Reflection.MethodBase::get_Name()
+  ldstr      "StaticMethod"
+  callvirt   instance bool [mscorlib]System.Object::Equals(object)
+  ldloc      staticInt32Method
+  callvirt   instance class [mscorlib]System.Type [mscorlib]System.Reflection.MethodBase::get_DeclaringType()
+  ldloc      nonGenericHolderType
+  ceq
+  and
+  brtrue     NonGenericStaticMethodOK
+  ldc.i4     2
+  ret
+NonGenericStaticMethodOK:
+
+  //
+  // if (staticInt32Method.Equals(infoof(NonGenericHolder.StaticMethod))
+  //     return 3;
+  //
+  ldtoken    method int16 NonGenericHolder::StaticMethod()
+  call       class [mscorlib]System.Reflection.MethodBase 
+                 [mscorlib]System.Reflection.MethodBase::GetMethodFromHandle(
+                     valuetype [mscorlib]System.RuntimeMethodHandle)
+  ldloc      staticInt32Method
+  callvirt   instance bool [mscorlib]System.Object::Equals(object)
+  brfalse    OverloadsOK
+  ldc.i4     3
+  ret
+OverloadsOK:
+
+  //
+  // MethodBase staticMethodT = GenericHolder<string, string>.GetInfoOfMethodT();
+  //
+  call       class [mscorlib]System.Reflection.MethodBase class GenericHolder`2<string, string>::GetInfoOfMethodT()
+  stloc      staticMethodT
+
+  //
+  // if (!staticMethodT.Equals(infoof(GenericHolder<string, string>.StaticMethod)))
+  //     return 4
+  //
+  ldtoken    method void class GenericHolder`2<string, string>::StaticMethod(!0)
+  ldtoken    class GenericHolder`2<string,string>
+  call       class [mscorlib]System.Reflection.MethodBase 
+               [mscorlib]System.Reflection.MethodBase::GetMethodFromHandle(
+                   valuetype [mscorlib]System.RuntimeMethodHandle,
+                   valuetype [mscorlib]System.RuntimeTypeHandle)
+  ldloc      staticMethodT
+  callvirt   instance bool [mscorlib]System.Object::Equals(object)
+  brtrue     MethodFromSharedContextOK
+  ldc.i4     4
+  ret
+MethodFromSharedContextOK:
+
+  //
+  // MethodBase staticMethodU = GenericHolder<string, string>.GetInfoOfMethodU();
+  //
+  call        class [mscorlib]System.Reflection.MethodBase class GenericHolder`2<string, string>::GetInfoOfMethodU()
+  stloc       staticMethodU
+
+  //
+  // if (staticMethodT.Equals(staticMethodU))
+  //     return 5;
+  //
+  ldloc      staticMethodU
+  ldloc      staticMethodT
+  callvirt   instance bool [mscorlib]System.Object::Equals(object)
+  brfalse    MethodOverloadsFromSharedContextOK
+  ldc.i4     5
+  ret
+MethodOverloadsFromSharedContextOK:
+
+  //
+  // if (staticMethodT.DeclaringType != typeof(GenericHolder<string, string>))
+  //     return 6;
+  //
+  ldloc      staticMethodT
+  callvirt   instance class [mscorlib]System.Type [mscorlib]System.Reflection.MethodBase::get_DeclaringType()
+  ldtoken    class GenericHolder`2<string,string>
+  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(
+                 valuetype [mscorlib]System.RuntimeTypeHandle)
+  ceq
+  brtrue     MethodGenericOwningTypeOK
+  ldc.i4     6
+  ret
+MethodGenericOwningTypeOK:
+
+  //
+  // FieldInfo staticFieldT = GenericHolder<string, string>.GetInfoOfFieldT();
+  //
+  call        class [mscorlib]System.Reflection.FieldInfo class GenericHolder`2<string, string>::GetInfoOfFieldT()
+  stloc       staticFieldT
+
+  //
+  // if (staticFieldT.DeclaringType != typeof(GenericHolder<string, string>))
+  //     return 7;
+  //
+  ldloc      staticFieldT
+  callvirt   instance class [mscorlib]System.Type [mscorlib]System.Reflection.FieldInfo::get_DeclaringType()
+  ldtoken    class GenericHolder`2<string,string>
+  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(
+                 valuetype [mscorlib]System.RuntimeTypeHandle)
+  ceq
+  brtrue     FieldGenericOwningTypeOK
+  ldc.i4     7
+  ret
+FieldGenericOwningTypeOK:
+
+  ldc.i4     100
+  ret
+}
+
+.class private auto ansi beforefieldinit NonGenericHolder
+       extends [mscorlib]System.Object
+{
+  .field public static object StaticField
+
+  .method public hidebysig static int32 StaticMethod()
+  {
+    ldc.i4.0
+    ret
+  }
+
+  .method public hidebysig static int16 StaticMethod()
+  {
+    ldc.i4.0
+    ret
+  }
+}
+
+.class private auto ansi beforefieldinit GenericHolder`2<T,U>
+       extends [mscorlib]System.Object
+{
+  .field public static !0 StaticFieldT;
+
+  .method public hidebysig static void StaticMethod(!0 x)
+  {
+    ret
+  }
+
+  .method public hidebysig static void StaticMethod(!1 x)
+  {
+    ret
+  }
+
+  .method public hidebysig static class [mscorlib]System.Reflection.FieldInfo GetInfoOfFieldT()
+  {
+    ldtoken    field !0 class GenericHolder`2<!T,!U>::StaticFieldT
+    ldtoken    class GenericHolder`2<!T,!U>
+    call       class [mscorlib]System.Reflection.FieldInfo
+                 [mscorlib]System.Reflection.FieldInfo::GetFieldFromHandle(
+                     valuetype [mscorlib]System.RuntimeFieldHandle,
+                     valuetype [mscorlib]System.RuntimeTypeHandle)
+    ret
+  }
+
+  .method public hidebysig static class [mscorlib]System.Reflection.MethodBase GetInfoOfMethodT()
+  {
+    ldtoken    method void class GenericHolder`2<!T,!U>::StaticMethod(!0)
+    ldtoken    class GenericHolder`2<!T,!U>
+    call       class [mscorlib]System.Reflection.MethodBase 
+                 [mscorlib]System.Reflection.MethodBase::GetMethodFromHandle(
+                     valuetype [mscorlib]System.RuntimeMethodHandle,
+                     valuetype [mscorlib]System.RuntimeTypeHandle)
+    ret
+  }
+
+  .method public hidebysig static class [mscorlib]System.Reflection.MethodBase GetInfoOfMethodU()
+  {
+    ldtoken    method void class GenericHolder`2<!T,!U>::StaticMethod(!1)
+    ldtoken    class GenericHolder`2<!T,!U>
+    call       class [mscorlib]System.Reflection.MethodBase 
+                 [mscorlib]System.Reflection.MethodBase::GetMethodFromHandle(
+                     valuetype [mscorlib]System.RuntimeMethodHandle,
+                     valuetype [mscorlib]System.RuntimeTypeHandle)
+    ret
+  }
+}

--- a/tests/src/reflection/ldtoken/ldtokenmember.ilproj
+++ b/tests/src/reflection/ldtoken/ldtokenmember.ilproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>ldtokenmember</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{F836E0D5-A909-4E8B-A77C-06B603BEFBD9}</ProjectGuid>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="ldtokenmember.il" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
The test coverage for `ldtoken field X` and `ldtoken method X` in the
repo is very small - this test tries to improve things a little.

In particular, it tests that we get the right reflection objects, and
that we can do this from shared and unshared code.