### PR TITLE
Updating codegenxarch to support single-precision CORINFO_INTRINSIC_Sqrt

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7372,11 +7372,16 @@ void CodeGen::genIntrinsic(GenTreePtr treeNode)
     switch (treeNode->gtIntrinsic.gtIntrinsicId)
     {
         case CORINFO_INTRINSIC_Sqrt:
-            noway_assert(treeNode->TypeGet() == TYP_DOUBLE);
+        {
+            // Both operand and its result must be of the same floating point type.
+            GenTreePtr srcNode = treeNode->gtOp.gtOp1;
+            assert(varTypeIsFloating(srcNode));
+            assert(srcNode->TypeGet() == treeNode->TypeGet());
+
             genConsumeOperands(treeNode->AsOp());
-            getEmitter()->emitInsBinary(ins_FloatSqrt(treeNode->TypeGet()), emitTypeSize(treeNode), treeNode,
-                                        treeNode->gtOp.gtOp1);
+            getEmitter()->emitInsBinary(ins_FloatSqrt(treeNode->TypeGet()), emitTypeSize(treeNode), treeNode, srcNode);
             break;
+        }
 
         case CORINFO_INTRINSIC_Abs:
             genSSE2BitwiseOp(treeNode);

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -3564,9 +3564,13 @@ instruction CodeGen::ins_FloatSqrt(var_types type)
     {
         ins = INS_sqrtsd;
     }
+    else if (type == TYP_FLOAT)
+    {
+        ins = INS_sqrtss;
+    }
     else
     {
-        // Right now sqrt of scalar single is not needed.
+        assert(!"ins_FloatSqrt: Unsupported type");
         unreached();
     }
 

--- a/src/jit/instrsxarch.h
+++ b/src/jit/instrsxarch.h
@@ -232,9 +232,10 @@ INST3( maxsd,  "maxsd",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEDBL(0x5F))    /
 INST3( xorpd,  "xorpd",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x57))    // XOR packed doubles
 INST3( andps,  "andps",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x54))    // AND packed singles
 INST3( andpd,  "andpd",  0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x54))    // AND packed doubles
-INST3( sqrtsd, "sqrtsd", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEDBL(0x51))    // Sqrt of a scalar double
-INST3( sqrtps, "sqrtps", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x51))    // Sqrt of a packed float
-INST3( sqrtpd, "sqrtpd", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x51))    // Sqrt of a packed double
+INST3( sqrtps, "sqrtps", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x51))    // Sqrt of packed singles
+INST3( sqrtss, "sqrtss", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEFLT(0x51))    // Sqrt of scalar single
+INST3( sqrtpd, "sqrtpd", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x51))    // Sqrt of packed doubles
+INST3( sqrtsd, "sqrtsd", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, SSEDBL(0x51))    // Sqrt of scalar double
 INST3( andnps, "andnps", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x55))    // And-Not packed singles
 INST3( andnpd, "andnpd", 0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKDBL(0x55))    // And-Not packed doubles
 INST3( orps,   "orps",   0, IUM_WR, 0, 0, BAD_CODE, BAD_CODE, PCKFLT(0x56))    // Or packed singles

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFAbs.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFAbs.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{753E20EC-61C7-4BF3-92EE-4519A55FA4B5}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfabs.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFAcos.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFAcos.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{68E081B5-2C96-4105-B01B-34C7C746FDC8}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfacos.cs" />
+    <Compile Include="mathftestlib.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFAtan.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFAtan.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A1A8A825-38A2-4B8C-BD81-12494482AE26}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfatan.cs" />
+    <Compile Include="mathftestlib.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFAtan2.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFAtan2.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{89EDC6AB-FDB9-4A19-A4E8-0DA10B59AE5E}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfatan2.cs" />
+    <Compile Include="mathftestlib.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFCeiling.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFCeiling.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{003D9B58-D8CA-4D5C-A3BB-2C36B166F3F2}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfceiling.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFCos.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFCos.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{D5D37943-62D6-4579-8AD9-6EC793534C31}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfcos.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFCosh.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFCosh.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{381997D1-75E4-46D4-8663-EE60183BAD60}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfcosh.cs" />
+    <Compile Include="mathftestlib.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFE.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFE.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{F5F42C53-AC5D-4140-82C7-A441C50726C8}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfe.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFExp.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFExp.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{3332C473-8FCF-4BC8-8A4A-EEA791A77C0D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfexp.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFFloor.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFFloor.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{E7916B4D-47B3-4F8D-B5C9-437318A10C69}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathffloor.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFIEEERemainder.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFIEEERemainder.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{C288A75E-FCA5-41F4-80A2-3546920487F7}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfieeeremainder.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFLog.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFLog.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{25B363C9-3059-4071-8B63-8AD56BEFB169}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathflog.cs" />
+    <Compile Include="mathftestlib.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFLog10.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFLog10.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BB3AD81D-7036-49BC-A0C3-318FC89F00FD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathflog10.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj">
+      <Project>{C8C0DC74-FAC4-45B1-81FE-70C4808366E0}</Project>
+      <Name>CoreCLRTestLibrary</Name>
+    </ProjectReference>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFMax.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFMax.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8CFA48E4-0F16-4B70-841A-A276E55B2536}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfmax.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFMin.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFMin.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{78BFB69A-326B-4BCE-9913-E5CBA473FC94}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfmin.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFPI.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFPI.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{6FD7CFCB-9BE3-46D9-9AA1-F15574084F22}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfpi.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFPow.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFPow.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{AF3C5F7A-51BC-4B3B-A12A-068765B390D6}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfpow.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFRound1.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFRound1.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DE4C7ADC-AC3D-4555-9E3B-F9C3C5542A1E}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfround1.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFRound2.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFRound2.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{ABFDE127-D0A5-4202-8320-E1B0B52B218D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfround2.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFSign.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFSign.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{D030C47B-3942-4B1F-800D-28863DDB6F0D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfsign.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFSin.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFSin.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8B5F12CB-20BC-472D-BE8F-EC289FD8D85B}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfsin.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFSinh.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFSinh.csproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9340A0ED-9EA3-4B36-8C15-43FBB22C640E}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfsinh.cs" />
+    <Compile Include="mathftestlib.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFSqrt.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFSqrt.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{5F8BCFB3-581B-455C-AA69-F1434DB4948A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathfsqrt.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFTan.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFTan.csproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{12FAA70F-51FD-49C3-A3BE-48254AEB9354}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathftan.cs" />
+    <Compile Include="mathftestlib.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/MathFTanh.csproj
+++ b/tests/src/CoreMangLib/cti/system/mathf/MathFTanh.csproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{EFC1E11C-BA0F-44A5-AC95-7572BE852F37}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="mathftanh.cs" />
+    <Compile Include="mathftestlib.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfabs.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfabs.cs
@@ -1,0 +1,183 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Abs(System.Single)
+/// </summary>
+public class MathFAbs
+{
+    public static int Main(string[] args)
+    {
+        MathFAbs abs = new MathFAbs();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Abs(System.Single)...");
+
+        if (abs.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the max value of float should be equal to its Abs value");
+
+        try
+        {
+            float max = float.MaxValue;
+            if (MathF.Abs(max) != max)
+            {
+                TestLibrary.TestFramework.LogError("001", "The Abs of max value should be equal to itself!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the min value of float should be equal to its Abs value");
+
+        try
+        {
+            float min = float.MinValue;
+            if (MathF.Abs(min) != -min)
+            {
+                TestLibrary.TestFramework.LogError("003", "The Abs of max value should be equal to it's contrary!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the NegativeInfinity of float should be equal to its contrary...");
+
+        try
+        {
+            float negInfinit = float.NegativeInfinity;
+            if (MathF.Abs(negInfinit) != -negInfinit)
+            {
+                TestLibrary.TestFramework.LogError("005", "The Abs of max value should be equal to it's contrary!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the PositiveInfinity of float should be equal to its Abs value");
+
+        try
+        {
+            float posInfinit = float.PositiveInfinity;
+            if (MathF.Abs(posInfinit) != posInfinit)
+            {
+                TestLibrary.TestFramework.LogError("007", "The Abs of max value should be equal to itself!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify Abs value of zero should be equal to both itself and its contrary value...");
+
+        try
+        {
+            float zero = 0;
+            if (MathF.Abs(zero) != zero || MathF.Abs(zero) != -zero)
+            {
+                TestLibrary.TestFramework.LogError("009", "Abs value of zero should be equal to both itself and its contrary value!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify Abs value of Epsilon ");
+
+        try
+        {
+            float epsilon = float.Epsilon;
+            if (MathF.Abs(epsilon) != epsilon)
+            {
+                TestLibrary.TestFramework.LogError("011", "Abs value of epsilon should be equal to itself...");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfacos.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfacos.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Acos(System.Single)
+/// </summary>
+public class MathFAcos
+{
+    public static int Main(string[] args)
+    {
+        MathFAcos Acos = new MathFAcos();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Acos(System.Single)...");
+
+        if (Acos.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+
+        //TestLibrary.TestFramework.LogInformation("[Negtive]");
+        //retVal = NegTest1() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the value of Arccos(-1) is MathF.PI...");
+
+        try
+        {
+            float angle = MathF.Acos(-1);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, MathF.PI))
+            {
+                TestLibrary.TestFramework.LogError("001", "Expected MathF.Acos(-1) = " + MathF.PI.ToString() + ", received " +
+            angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the value of Arccos(0) is MathF.PI/2...");
+
+        try
+        {
+            float angle = MathF.Acos(0);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, MathF.PI / 2))
+            {
+                TestLibrary.TestFramework.LogError("003", "Expected pi/2, got " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the value of Arccos(1) is 0...");
+
+        try
+        {
+            float angle = MathF.Acos(1);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, 0))
+            {
+                TestLibrary.TestFramework.LogError("005", "Expected 1, got " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the value of Arccos(0.5) is MathF.PI/3...");
+
+        try
+        {
+            float angle = MathF.Acos(0.5f);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, 1.04719755f))
+            {
+                TestLibrary.TestFramework.LogError("007", "Expected 1.04719755, got " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify the value of Arccos(-0.5) is 2*MathF.PI/3...");
+
+        try
+        {
+            float angle = MathF.Acos(-0.5f);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, 2.09439510f))
+            {
+                TestLibrary.TestFramework.LogError("009", "Expected: 2.09439510, actual: " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify the value of Arccos(MathF.Sqrt(3)/2) is MathF.PI/6...");
+
+        try
+        {
+            float angle = MathF.Acos(MathF.Sqrt(3) / 2);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, 0.523598776f))
+            {
+                TestLibrary.TestFramework.LogError("011", "Expected: 0.523598776, actual: " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest7: Verify the value of Arccos(-MathF.Sqrt(3)/2) is 5*MathF.PI/6...");
+
+        try
+        {
+            float angle = MathF.Acos(-MathF.Sqrt(3) / 2);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, 2.61799388f))
+            {
+                TestLibrary.TestFramework.LogError("013", "Expected: 2.61799388, actual: " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("014", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfatan.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfatan.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Atan(System.Single)
+/// </summary>
+public class MathFAtan
+{
+    public static int Main(string[] args)
+    {
+        MathFAtan arctan = new MathFAtan();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Atan(System.Single)...");
+
+        if (arctan.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the value of arctan(NegativeInfinity) is -MathF.PI/2...");
+
+        try
+        {
+            float angle = MathF.Atan(float.NegativeInfinity);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, -MathF.PI / 2))
+            {
+                TestLibrary.TestFramework.LogError("001", "Expected: -pi/2, actual: " +
+                    angle.ToString() + " diff>epsilon= " + MathFTestLib.Epsilon.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the value of arctan(PositiveInfinity) is MathF.PI/2...");
+
+        try
+        {
+            float angle = MathF.Atan(float.PositiveInfinity);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, MathF.PI / 2))
+            {
+                TestLibrary.TestFramework.LogError("003", "Expected: pi/2, actual: " +
+                    angle.ToString() + " diff>epsilon= " + MathFTestLib.Epsilon.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the value of arctan(0) is zero...");
+
+        try
+        {
+            float angle = MathF.Atan(0);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, 0))
+            {
+                TestLibrary.TestFramework.LogError("005", "Expected: 0, actual: " +
+                    angle.ToString() + " diff>epsilon= " + MathFTestLib.Epsilon.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the value of atn(inf+1)=atn(inf)");
+
+        try
+        {
+            float angle = MathF.Atan(float.PositiveInfinity + 1);
+            float baseline = MathF.Atan(float.PositiveInfinity);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, baseline))
+            {
+                TestLibrary.TestFramework.LogError("007", "Expected: " + baseline.ToString() + ", actual: " +
+                    angle.ToString() + " diff>epsilon= " + MathFTestLib.Epsilon.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify atn(-inf -1)=atn(-inf)");
+
+        try
+        {
+            float angle = MathF.Atan(float.NegativeInfinity - 1);
+            float baseline = MathF.Atan(float.NegativeInfinity);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, baseline))
+            {
+                TestLibrary.TestFramework.LogError("009", "Expected " + baseline.ToString() + ", actual: " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfatan2.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfatan2.cs
@@ -1,0 +1,272 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Atan2(System.Single, System.Single)
+/// </summary>
+public class MathFAtan2
+{
+    public static int Main(string[] args)
+    {
+        MathFAtan2 arctan2 = new MathFAtan2();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Atan2(System.Single,System.Single)...");
+
+        if (arctan2.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the angle of arctan(x,y) when the point in quadrant one...");
+
+        try
+        {
+            float x = TestLibrary.Generator.GetSingle(-55);
+            while (x <= 0)
+            {
+                x = TestLibrary.Generator.GetSingle(-55);
+            }
+            float y = TestLibrary.Generator.GetSingle(-55);
+            while (y <= 0)
+            {
+                y = TestLibrary.Generator.GetSingle(-55);
+            }
+
+            float angle = MathF.Atan2(y, x);
+            if (angle > MathF.PI / 2 || angle < 0)
+            {
+                TestLibrary.TestFramework.LogError("001", "The angle should be between 0 and MathF.PI/2, actual: " +
+                    angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the angle of arctan(x,y) when the point in quadrant four...");
+
+        try
+        {
+            float x = TestLibrary.Generator.GetSingle(-55);
+            while (x <= 0)
+            {
+                x = TestLibrary.Generator.GetSingle(-55);
+            }
+            float y = TestLibrary.Generator.GetSingle(-55);
+            while (y >= 0)
+            {
+                y = -TestLibrary.Generator.GetSingle(-55);
+            }
+
+            float angle = MathF.Atan2(y, x);
+            if (angle > 0 || angle < -MathF.PI / 2)
+            {
+                TestLibrary.TestFramework.LogError("003", "The angle should be between 0 and -MathF.PI/2, actual: " +
+                    angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the angle of arctan(x,y) when the point in forward direction of X axis...");
+
+        try
+        {
+            float x = TestLibrary.Generator.GetSingle(-55);
+            while (x <= 0)
+            {
+                x = TestLibrary.Generator.GetSingle(-55);
+            }
+
+            float y = 0;
+            float angle = MathF.Atan2(y, x);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, 0.0f))
+            {
+                TestLibrary.TestFramework.LogError("005", "The angle should be zero,actual: " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the angle of arctan(x,y) when the point in forward direction of Y axis...");
+
+        try
+        {
+            float x = 0;
+            float y = TestLibrary.Generator.GetSingle(-55);
+            while (y <= 0)
+            {
+                y = TestLibrary.Generator.GetSingle(-55);
+            }
+            float angle = MathF.Atan2(y, x);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, MathF.PI / 2))
+            {
+                TestLibrary.TestFramework.LogError("007", "The angle should be pi/2, actual:" + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify the angle of arctan(x,y) when the point in negative direction of Y axis...");
+
+        try
+        {
+            float x = 0;
+            float y = TestLibrary.Generator.GetSingle(-55);
+            while (y >= 0)
+            {
+                y = -TestLibrary.Generator.GetSingle(-55);
+            }
+            float angle = MathF.Atan2(y, x);
+            if (!MathFTestLib.SingleIsWithinEpsilon(angle, -MathF.PI / 2))
+            {
+                TestLibrary.TestFramework.LogError("009", "The angle should be -pi/2, actual: " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify the angle of arctan(x,y) when the point in quadrant two...");
+
+        try
+        {
+            float x = TestLibrary.Generator.GetSingle(-55);
+            while (x >= 0)
+            {
+                x = -TestLibrary.Generator.GetSingle(-55);
+            }
+            float y = TestLibrary.Generator.GetSingle(-55);
+            while (y <= 0)
+            {
+                y = TestLibrary.Generator.GetSingle(-55);
+            }
+
+            float angle = MathF.Atan2(y, x);
+            if (angle < MathF.PI / 2 || angle > MathF.PI)
+            {
+                TestLibrary.TestFramework.LogError("011", "The angle should be between 0 and MathF.PI/2, actual: " + angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest7: Verify the angle of arctan(x,y) when the point in quadrant three...");
+
+        try
+        {
+            float x = TestLibrary.Generator.GetSingle(-55);
+            while (x >= 0)
+            {
+                x = -TestLibrary.Generator.GetSingle(-55);
+            }
+            float y = TestLibrary.Generator.GetSingle(-55);
+            while (y >= 0)
+            {
+                y = -TestLibrary.Generator.GetSingle(-55);
+            }
+
+            float angle = MathF.Atan2(y, x);
+            if (angle > -MathF.PI / 2 || angle < -MathF.PI)
+            {
+                TestLibrary.TestFramework.LogError("013", "The angle should be between 0 and MathF.PI/2, actual: " +
+                    angle.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("014", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfceiling.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfceiling.cs
@@ -1,0 +1,206 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Ceiling(System.Single)
+/// </summary>
+public class MathFCeiling
+{
+    public static int Main(string[] args)
+    {
+        MathFCeiling ceiling = new MathFCeiling();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Ceiling(System.Single)...");
+
+        if (ceiling.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify Ceiling number should be equal to the integer part of negative number...");
+
+        try
+        {
+            float number = TestLibrary.Generator.GetSingle(-55);
+            while (number >= 0)
+            {
+                number = (-TestLibrary.Generator.GetSingle(-55)) * 100;
+            }
+
+            float ceilingNumber = MathF.Ceiling(number);
+            if (ceilingNumber < number || ceilingNumber > number + 1)
+            {
+                TestLibrary.TestFramework.LogError("001", "The Ceiling number should be equal to the integer part of negative number!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify Ceiling number should be equal to itself when number is negative integer");
+
+        try
+        {
+            float number = TestLibrary.Generator.GetSingle(-55);
+            while (number >= 0)
+            {
+                number = (-TestLibrary.Generator.GetSingle(-55)) * 100;
+            }
+
+            float ceilingNumber = MathF.Ceiling(number);
+            if (ceilingNumber != MathF.Ceiling(ceilingNumber))
+            {
+                TestLibrary.TestFramework.LogError("003", "The Ceiling number should be equal to itself when number is negative integer...");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify Ceiling number should be equal to the integer part plus one of positive number...");
+
+        try
+        {
+            float number = TestLibrary.Generator.GetSingle(-55);
+            while (number <= 0)
+            {
+                number = (TestLibrary.Generator.GetSingle(-55)) * 100;
+            }
+
+            float ceilingNumber = MathF.Ceiling(number);
+            if (ceilingNumber < number || ceilingNumber > number + 1)
+            {
+                TestLibrary.TestFramework.LogError("005", "The Ceiling number should be equal to the integer part plus one of positive number!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify Ceiling number should be equal to itself when number is positive integer");
+
+        try
+        {
+            float number = TestLibrary.Generator.GetSingle(-55);
+            while (number <= 0)
+            {
+                number = (TestLibrary.Generator.GetSingle(-55)) * 100;
+            }
+
+            float ceilingNumber = MathF.Ceiling(number);
+            if (ceilingNumber != MathF.Ceiling(ceilingNumber))
+            {
+                TestLibrary.TestFramework.LogError("007", "The Ceiling number should be equal to itself when number is positive integer...");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify Ceiling number should be equal to itself when number is maxvalue...");
+
+        try
+        {
+            float ceilingMax = MathF.Ceiling(float.MaxValue);
+            if (ceilingMax != float.MaxValue)
+            {
+                TestLibrary.TestFramework.LogError("009", "The Ceiling number should be equal to itself when number is maxvalue!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify Ceiling number should be equal to itself when number is minvalue...");
+
+        try
+        {
+            float ceilingMax = MathF.Ceiling(float.MinValue);
+            if (ceilingMax != float.MinValue)
+            {
+                TestLibrary.TestFramework.LogError("011", "The Ceiling number should be equal to itself when number is minvalue!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfcos.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfcos.cs
@@ -1,0 +1,184 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Cos(System.Single)
+/// </summary>
+public class MathFCos
+{
+    public static int Main(string[] args)
+    {
+        MathFCos cos = new MathFCos();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Cos(System.Single)...");
+
+        if (cos.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the value of cosine(0)...");
+
+        try
+        {
+            float value = MathF.Cos(0);
+            if (value != 1)
+            {
+                TestLibrary.TestFramework.LogError("001", "cosine(0) should be 1!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the value of cosine(MathF.PI/2)...");
+
+        try
+        {
+            float value = MathF.Cos(MathF.PI / 2);
+            if (MathF.Abs(1000000 * value) >= 0.1)
+            {
+                TestLibrary.TestFramework.LogError("003", "cosine(MathF.PI/2) should be 0!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the value of cosine(MathF.PI)...");
+
+        try
+        {
+            float value = MathF.Cos(MathF.PI);
+            if (value != -1)
+            {
+                TestLibrary.TestFramework.LogError("005", "cosine(MathF.PI) should be -1!");
+                retVal = false;
+            }
+
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the value of cosine(3*MathF.PI/2)...");
+
+        try
+        {
+            float value = MathF.Cos(3 * MathF.PI / 2);
+            if (MathF.Abs(1000000 * value) >= 0.1)
+            {
+                TestLibrary.TestFramework.LogError("007", "cosine(3*MathF.PI/2) should be 0!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify the value of cosine(2*MathF.PI) is equal to cosine(0)...");
+
+        try
+        {
+            float value1 = MathF.Cos(0);
+            float value2 = MathF.Cos(2 * MathF.PI);
+            if (value1 != value2)
+            {
+                TestLibrary.TestFramework.LogError("009", "cosine(3*MathF.PI/2) should be 0!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify the value of cosine(number) is between -1 and 1...");
+
+        try
+        {
+            float coefficient = TestLibrary.Generator.GetSingle(-55);
+            if (MathF.Cos(2 * coefficient * MathF.PI) > 1 || MathF.Cos(2 * coefficient * MathF.PI) < -1)
+            {
+                TestLibrary.TestFramework.LogError("011", "The scale of cosine is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfcosh.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfcosh.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Cosh(System.Single)
+/// </summary>
+public class MathFCosh
+{
+    public static int Main(string[] args)
+    {
+        MathFCosh cosh = new MathFCosh();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Cosh(System.Single)...");
+
+        if (cosh.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the monotonicity of cosh function...");
+
+        try
+        {
+            float variable = TestLibrary.Generator.GetSingle(-55);
+            float value1 = MathF.Cosh(variable);
+            float positiveoffset = MathF.Exp(-15);
+            float value2 = MathF.Cosh(variable + positiveoffset);
+
+            if (value2 <= value1)
+            {
+                TestLibrary.TestFramework.LogError("001", "the monotonicity of cosh function [x>=y -> cosh(x)>=cosh(y)]");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the evenness of cosh function [cosh(x)=cosh(-x)]");
+
+        try
+        {
+            float variable = TestLibrary.Generator.GetSingle(-55);
+            float value1 = MathF.Cosh(variable);
+            float value2 = MathF.Cosh(-variable);
+
+            if (!MathFTestLib.SingleIsWithinEpsilon(value1, value2))
+            {
+                TestLibrary.TestFramework.LogError("003", "The parity of cosh should be even function!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the value of cosh(0) = 1...");
+
+        try
+        {
+            float zero = 0;
+            float value = MathF.Cosh(zero);
+            if (!MathFTestLib.SingleIsWithinEpsilon(value, 1))
+            {
+                TestLibrary.TestFramework.LogError("005", "The value of cosh(0) should be 1, actual: " + value.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the cosh(+inf)=+inf...");
+
+        try
+        {
+            float variable = float.MaxValue;
+            float value = MathF.Cosh(variable);
+            if (value != float.PositiveInfinity)
+            {
+                TestLibrary.TestFramework.LogError("007", "The value should be float.PositiveInfinity, actual: " + value.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify the value of cosh(float.MinValue)=+inf");
+
+        try
+        {
+            float variable = float.MinValue;
+            float value = MathF.Cosh(variable);
+            if (value != float.PositiveInfinity)
+            {
+                TestLibrary.TestFramework.LogError("009", "The value should be float.PositiveInfinity, actual: " +
+                    value.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfe.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfe.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.E
+/// </summary>
+public class MathFE
+{
+    public static int Main(string[] args)
+    {
+        MathFE mathE = new MathFE();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.E...");
+
+        if (mathE.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the value of MathF.E...");
+
+        try
+        {
+            float constantE = MathF.E;
+            if (constantE != 2.71828183f)
+            {
+                TestLibrary.TestFramework.LogError("001", "The value of E is not correct!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfexp.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfexp.cs
@@ -1,0 +1,171 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Exp(System.Single)
+/// </summary>
+public class MathFExp
+{
+    public static int Main(string[] args)
+    {
+        MathFExp exp = new MathFExp();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Exp(System.Single)...");
+
+        if (exp.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify monotonicity of Exp function");
+
+        try
+        {
+            float variable = TestLibrary.Generator.GetSingle(-55);
+            float value1 = MathF.Exp(variable);
+            float positiveoffset = MathF.Exp(-15);
+            float value2 = MathF.Exp(variable + positiveoffset);
+
+            if (value2 <= value1)
+            {
+                TestLibrary.TestFramework.LogError("001", "The monotonicity of chx function should be increase by degree!");
+                retVal = false;
+            }
+
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify Exp is neither odd function nor even function...");
+
+        try
+        {
+            float variable = TestLibrary.Generator.GetSingle(-55);
+            float value1 = MathF.Exp(variable);
+            float value2 = MathF.Exp(-variable);
+
+            if (value1 == value2 || value1 == -value2)
+            {
+                TestLibrary.TestFramework.LogError("003", "The exp function should not be symmetry!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the value of Exp(0) is 1...");
+
+        try
+        {
+            float value = MathF.Exp(0);
+
+            if (value != 1)
+            {
+                TestLibrary.TestFramework.LogError("005", "The value of Exp(0) is 1!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the value of Exp(float.MaxValue)...");
+
+        try
+        {
+            float variable = float.MaxValue;
+            float value = MathF.Exp(variable);
+
+            if (value != float.PositiveInfinity)
+            {
+                TestLibrary.TestFramework.LogError("007", "The value of Exp(float.MaxValue) should be PositiveInfinity!");
+                retVal = true;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify the value of Exp(float.MaxValue)");
+
+        try
+        {
+            float variable = float.MinValue;
+            float value = MathF.Exp(variable);
+
+            if (value != 0)
+            {
+                TestLibrary.TestFramework.LogError("009", "The value of Exp(float.MaxValue) should be PositiveInfinity!");
+                retVal = true;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathffloor.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathffloor.cs
@@ -1,0 +1,206 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Floor(System.Single)
+/// </summary>
+public class MathFFloor
+{
+    public static int Main(string[] args)
+    {
+        MathFFloor floor = new MathFFloor();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Floor(System.Single)...");
+
+        if (floor.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify floor number should be equal to intefer part subtract one of negative number...");
+
+        try
+        {
+            float number = TestLibrary.Generator.GetSingle(-55);
+            while (number >= 0)
+            {
+                number = (-TestLibrary.Generator.GetSingle(-55)) * 100;
+            }
+
+            float floorNumber = MathF.Floor(number);
+            if (floorNumber < number - 1 || floorNumber > number)
+            {
+                TestLibrary.TestFramework.LogError("001", "The Ceiling number should be equal to the integer part of negative number!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify floor number should be equal to itself when number is negative integer...");
+
+        try
+        {
+            float number = TestLibrary.Generator.GetSingle(-55);
+            while (number >= 0)
+            {
+                number = (-TestLibrary.Generator.GetSingle(-55)) * 100;
+            }
+
+            float floorNumber = MathF.Floor(number);
+            if (floorNumber != MathF.Floor(floorNumber))
+            {
+                TestLibrary.TestFramework.LogError("003", "The floor number should be equal to itself when number is negative integer...");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify floor number should be equal to the integer part of positive number...");
+
+        try
+        {
+            float number = TestLibrary.Generator.GetSingle(-55);
+            while (number <= 0)
+            {
+                number = (TestLibrary.Generator.GetSingle(-55)) * 100;
+            }
+
+            float floorNumber = MathF.Floor(number);
+            if (floorNumber < number - 1 || floorNumber > number)
+            {
+                TestLibrary.TestFramework.LogError("005", "The floor number should be equal to the integer part plus one of positive number!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify floor number should be equal to itself when number is positive integer...");
+
+        try
+        {
+            float number = TestLibrary.Generator.GetSingle(-55);
+            while (number <= 0)
+            {
+                number = (TestLibrary.Generator.GetSingle(-55)) * 100;
+            }
+
+            float floorNumber = MathF.Floor(number);
+            if (floorNumber != MathF.Floor(floorNumber))
+            {
+                TestLibrary.TestFramework.LogError("007", "The floor number should be equal to itself when number is positive integer...");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify floor number should be equal to itself when number is maxvalue...");
+
+        try
+        {
+            float floorMax = MathF.Floor(float.MaxValue);
+            if (floorMax != float.MaxValue)
+            {
+                TestLibrary.TestFramework.LogError("009", "The floor number should be equal to itself when number is maxvalue!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify floor number should be equal to itself when number is minvalue...");
+
+        try
+        {
+            float floorMin = MathF.Floor(float.MinValue);
+            if (floorMin != float.MinValue)
+            {
+                TestLibrary.TestFramework.LogError("011", "The floor number should be equal to itself when number is minvalue!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfieeeremainder.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfieeeremainder.cs
@@ -1,0 +1,148 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.IEEERemainder(System.Single, System.Single)
+/// </summary>
+public class MathFIEEERemainder
+{
+    public static int Main(string[] args)
+    {
+        MathFIEEERemainder ieeeRemainder = new MathFIEEERemainder();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.IEEERemainder(System.Single,System.Single)...");
+
+        if (ieeeRemainder.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify  x / y fails halfway between two integer,the even integer is less than odd integer...");
+
+        try
+        {
+            float x = 5;
+            float y = 2;
+            float remainder = MathF.IEEERemainder(x, y);
+
+            // When x=5,y=2,the quotient should be equal to the even nember 2, therefore the IEEERemainder is positive
+            if (remainder != x - MathF.Floor(x / y) * y)
+            {
+                TestLibrary.TestFramework.LogError("001", "The remainder should be x - (y*quotient)!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify x/y fails halfway between two integer,the add integer is less than even integer...");
+
+        try
+        {
+            float x = 7;
+            float y = 2;
+            float remainder = MathF.IEEERemainder(x, y);
+
+            //When x=7,y=2,the quotient should be equal to the even number 4,therefore the IEEERemainder is negative
+            if (remainder != x - MathF.Ceiling(x / y) * y)
+            {
+                TestLibrary.TestFramework.LogError("003", "The remainder should be x - (y*quotient)!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify divisor is zero...");
+
+        try
+        {
+            float x = TestLibrary.Generator.GetSingle(-55);
+            float y = 0;
+            float remainder = MathF.IEEERemainder(x, y);
+
+            if (!float.IsNaN(remainder))
+            {
+                TestLibrary.TestFramework.LogError("005", "The value should be float.NaN!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the value 0 is returned when x - (y*quotient) is zero...");
+
+        try
+        {
+            float x = 6;
+            float y = 2;
+            float remainder = MathF.IEEERemainder(x, y);
+
+            if (remainder != 0)
+            {
+                TestLibrary.TestFramework.LogError("007", "The value should be zero!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathflog.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathflog.cs
@@ -1,0 +1,246 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Log(System.Single)
+/// </summary>
+public class MathFLog
+{
+    public static int Main(string[] args)
+    {
+        MathFLog log = new MathFLog();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Log(System.Single)...");
+
+        if (log.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the monotonicity of ln(f)...");
+
+        try
+        {
+            float var1 = 100.1f * TestLibrary.Generator.GetSingle(-55);
+            float var2 = 100.1f * TestLibrary.Generator.GetSingle(-55);
+
+            if (var1 < var2)
+            {
+                if (MathF.Log(var1) >= MathF.Log(var2))
+                {
+                    TestLibrary.TestFramework.LogError("001", "The value of ln(var1)=" + MathF.Log(var1).ToString() +
+                        " should be less than ln(var2)=" + MathF.Log(var2).ToString());
+                    retVal = false;
+                }
+            }
+            else if (var1 > var2)
+            {
+                if (MathF.Log(var1) <= MathF.Log(var2))
+                {
+                    TestLibrary.TestFramework.LogError("002", "The value of ln(var1)=" + MathF.Log(var1).ToString() +
+                        " should be larger than ln(var2)=" + MathF.Log(var2).ToString());
+                    retVal = false;
+                }
+            }
+            else
+            {
+                if (!MathFTestLib.SingleIsWithinEpsilon(MathF.Log(var1), MathF.Log(var2)))
+                {
+                    TestLibrary.TestFramework.LogError("003", "The value of ln(var1)=" + MathF.Log(var1).ToString() +
+                        " should be equal to ln(var2)=" + MathF.Log(var2).ToString());
+                    retVal = false;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the value is negative when var is between o and 1...");
+
+        try
+        {
+            float var = 0;
+            while (var <= 0 && var >= 1)
+            {
+                var = TestLibrary.Generator.GetSingle(-55);
+            }
+
+            if (MathF.Log(var) >= 0)
+            {
+                TestLibrary.TestFramework.LogError("005", "The value should be negative, is " + MathF.Log(var).ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the value of ln(1) is 0...");
+
+        try
+        {
+            float var = 1;
+            if (!MathFTestLib.SingleIsWithinEpsilon(MathF.Log(var), 0))
+            {
+                TestLibrary.TestFramework.LogError("007", "The value of ln(1) should be zero, is " + MathF.Log(var).ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the value of ln(var) is larger than zero...");
+
+        try
+        {
+            float var = TestLibrary.Generator.GetSingle(-55);
+            while (var <= 1)
+            {
+                var *= 10;
+            }
+
+            if (MathF.Log(var) < 0)
+            {
+                TestLibrary.TestFramework.LogError("009", "The value should be larger than zero, is " + MathF.Log(var).ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify the value of ln(0)...");
+
+        try
+        {
+            float var = 0;
+            if (!float.IsNegativeInfinity(MathF.Log(var)))
+            {
+                TestLibrary.TestFramework.LogError("011", "the value of ln(0) should be negativeInfinity, is " +
+                    MathF.Log(var).ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify the value of ln(var) when var is negative...");
+
+        try
+        {
+            float var = -TestLibrary.Generator.GetSingle(-55);
+            while (var >= 0)
+            {
+                var = TestLibrary.Generator.GetSingle(-55);
+            }
+
+            if (!float.IsNaN(MathF.Log(var)))
+            {
+                TestLibrary.TestFramework.LogError("013", "The value should be NaN, is " + MathF.Log(var).ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("014", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest7: Verify the value of ln(e)...");
+
+        try
+        {
+            float var = MathF.E;
+            if (!MathFTestLib.SingleIsWithinEpsilon(MathF.Log(var), 1))
+            {
+                TestLibrary.TestFramework.LogError("015", "The value should be equal to 1, is " + MathF.Log(var).ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("016", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathflog10.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathflog10.cs
@@ -1,0 +1,242 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Log10(System.Single)
+/// </summary>
+public class MathFLog10
+{
+    public static int Main(string[] args)
+    {
+        MathFLog10 log10 = new MathFLog10();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Log10(System.Single)...");
+
+        if (log10.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the monotonicity of Log10(var)...");
+
+        try
+        {
+            float var1 = 100.1f * TestLibrary.Generator.GetSingle(-55);
+            float var2 = 100.1f * TestLibrary.Generator.GetSingle(-55);
+
+            if (var1 < var2)
+            {
+                if (MathF.Log10(var1) >= MathF.Log10(var2))
+                {
+                    TestLibrary.TestFramework.LogError("001", "The value of Log10(var1) should be less than In(var2)...");
+                    retVal = false;
+                }
+            }
+            else if (var1 > var2)
+            {
+                if (MathF.Log10(var1) <= MathF.Log10(var2))
+                {
+                    TestLibrary.TestFramework.LogError("002", "The value of Log10(var1) should be larger than In(var2)...");
+                    retVal = false;
+                }
+            }
+            else
+            {
+                if (MathF.Log10(var1) != MathF.Log10(var2))
+                {
+                    TestLibrary.TestFramework.LogError("003", "The value of Log10(var1) should be equal to In(var2)...");
+                    retVal = false;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the value is negative when var is between o and 1...");
+
+        try
+        {
+            float var = 0;
+            while (var <= 0 && var >= 1)
+            {
+                var = TestLibrary.Generator.GetSingle(-55);
+            }
+
+            if (MathF.Log10(var) >= 0)
+            {
+                TestLibrary.TestFramework.LogError("005", "The value should be negative!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the value of Log10(1) is 0...");
+
+        try
+        {
+            float var = 1;
+            if (MathF.Log10(var) != 0)
+            {
+                TestLibrary.TestFramework.LogError("007", "The value of Log10(1) should be zero!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the value of Log10(var) is larger than zero...");
+
+        try
+        {
+            float var = TestLibrary.Generator.GetSingle(-55);
+            while (var <= 1)
+            {
+                var *= 10;
+            }
+
+            if (MathF.Log10(var) < 0)
+            {
+                TestLibrary.TestFramework.LogError("009", "The value should be larger than zero!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify the value of Log10(0)...");
+
+        try
+        {
+            float var = 0;
+            if (!float.IsNegativeInfinity(MathF.Log10(var)))
+            {
+                TestLibrary.TestFramework.LogError("011", "the value of Log10(0) should be negativeInfinity!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify the value of Log10(var) when var is negative...");
+
+        try
+        {
+            float var = -TestLibrary.Generator.GetSingle(-55);
+            while (var >= 0)
+            {
+                var = TestLibrary.Generator.GetSingle(-55);
+            }
+
+            if (!float.IsNaN(MathF.Log10(var)))
+            {
+                TestLibrary.TestFramework.LogError("013", "The value should be NaN!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("014", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest7: Verify the value of Log10(10)...");
+
+        try
+        {
+            float var = 10;
+            if (MathF.Log10(var) != 1)
+            {
+                TestLibrary.TestFramework.LogError("015", "the value should be equal to 1!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("016", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfmax.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfmax.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Max(System.Single, System.Single)
+/// </summary>
+public class MathFMax8
+{
+    public static int Main(string[] args)
+    {
+        MathFMax8 max8 = new MathFMax8();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Max(System.Single,System.Single)...");
+
+        if (max8.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the return value of max function...");
+
+        try
+        {
+            float var1 = TestLibrary.Generator.GetSingle(-55);
+            float var2 = TestLibrary.Generator.GetSingle(-55);
+
+            if (var1 > var2 && !float.IsNaN(var1) && !float.IsNaN(var2))
+            {
+                if (MathF.Max(var1, var2) != var1)
+                {
+                    TestLibrary.TestFramework.LogError("001", "The return value should be var1!");
+                    retVal = false;
+                }
+            }
+            else if (!float.IsNaN(var1) && !float.IsNaN(var2))
+            {
+                if (MathF.Max(var1, var2) != var2)
+                {
+                    TestLibrary.TestFramework.LogError("002", "The return value should be var2!");
+                    retVal = false;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("003", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the max value of float.NaN and float.PositiveInfinity...");
+
+        try
+        {
+            float var1 = float.NaN;
+            float var2 = float.PositiveInfinity;
+
+            if (!float.IsNaN(MathF.Max(var1, var2)))
+            {
+                TestLibrary.TestFramework.LogError("004", "The return value should be single.NaN!");
+                retVal = false;
+            }
+
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("005", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfmin.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfmin.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Min(System.Single, System.Single)
+/// </summary>
+public class MathFMin8
+{
+    public static int Main(string[] args)
+    {
+        MathFMin8 min8 = new MathFMin8();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Min(System.Single,System.Single)...");
+
+        if (min8.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the return value of min function...");
+
+        try
+        {
+            float var1 = TestLibrary.Generator.GetSingle(-55);
+            float var2 = TestLibrary.Generator.GetSingle(-55);
+
+            if (var1 < var2 && !float.IsNaN(var1) && !float.IsNaN(var2))
+            {
+                if (MathF.Min(var1, var2) != var1)
+                {
+                    TestLibrary.TestFramework.LogError("001", "The return value should be var1!");
+                    retVal = false;
+                }
+            }
+            else if (!float.IsNaN(var1) && !float.IsNaN(var2))
+            {
+                if (MathF.Min(var1, var2) != var2)
+                {
+                    TestLibrary.TestFramework.LogError("002", "The return value should be var2!");
+                    retVal = false;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("003", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the min value of float.NaN and float.NegativeInfinity...");
+
+        try
+        {
+            float var1 = float.NaN;
+            float var2 = float.NegativeInfinity;
+
+            if (!float.IsNaN(MathF.Min(var1, var2)))
+            {
+                TestLibrary.TestFramework.LogError("004", "The return value should be float.NaN!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("005", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfpi.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfpi.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.PI
+/// </summary>
+public class MathFPI
+{
+    public static int Main(string[] args)
+    {
+        MathFPI mathPI = new MathFPI();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.PI...");
+
+        if (mathPI.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the value of MathF.PI...");
+
+        try
+        {
+            float mathPI = MathF.PI;
+            if (mathPI != 3.14159265f)
+            {
+                TestLibrary.TestFramework.LogError("001", "The value of MathF.PI is not correct!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfpow.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfpow.cs
@@ -1,0 +1,523 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Pow(System.Single, System.Single)
+/// </summary>
+public class MathFPow
+{
+    #region Public Methods
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+        retVal = PosTest8() && retVal;
+        retVal = PosTest9() && retVal;
+        retVal = PosTest10() && retVal;
+        retVal = PosTest11() && retVal;
+        retVal = PosTest12() && retVal;
+        retVal = PosTest13() && retVal;
+        retVal = PosTest14() && retVal;
+        retVal = PosTest15() && retVal;
+        retVal = PosTest16() && retVal;
+
+
+        //
+        // TODO: Add your negative test cases here
+        //
+        // TestLibrary.TestFramework.LogInformation("[Negative]");
+        // retVal = NegTest1() && retVal;
+
+        return retVal;
+    }
+
+    #region Positive Test Cases
+    public bool PosTest1()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify Pow when one of args is NaN .");
+
+        try
+        {
+            float f = MathF.Pow(float.NaN, TestLibrary.Generator.GetByte(-55));
+
+            if (!float.IsNaN(f))
+            {
+                TestLibrary.TestFramework.LogError("001.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("001.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify Pow when second arg is zero .");
+
+        try
+        {
+            float f = MathF.Pow(TestLibrary.Generator.GetByte(-55), 0);
+
+            if (f != 1)
+            {
+                TestLibrary.TestFramework.LogError("002.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify Pow(NegativeInfinity, < 0) .");
+
+        try
+        {
+            float f = MathF.Pow(float.NegativeInfinity, -TestLibrary.Generator.GetSingle(-55));
+
+            if (f != 0)
+            {
+                TestLibrary.TestFramework.LogError("003.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("003.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify Pow(NegativeInfinity, positive odd int) .");
+
+        try
+        {
+            float f = MathF.Pow(float.NegativeInfinity, TestLibrary.Generator.GetByte(-55) * 2 + 1);
+
+            if (f != float.NegativeInfinity)
+            {
+                TestLibrary.TestFramework.LogError("004.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify Pow(NegativeInfinity, positive non-odd int) .");
+
+        try
+        {
+            int e = (TestLibrary.Generator.GetByte(-55) + 1) * 2;
+            float f = MathF.Pow(float.NegativeInfinity, e);
+
+            if (f != float.PositiveInfinity)
+            {
+                TestLibrary.TestFramework.LogError("005.1", "Return value is wrong: expected float.PositiveInfinity, actual: " +
+                    f.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("005.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify Pow(< 0, non-int) .");
+
+        try
+        {
+            float f = MathF.Pow(-TestLibrary.Generator.GetByte(-55) - 1, TestLibrary.Generator.GetSingle() + 0.1f);
+
+            if (!float.IsNaN(f))
+            {
+                TestLibrary.TestFramework.LogError("006.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest7: Verify Pow(-1, NegativeInfinity) .");
+
+        try
+        {
+            float f = MathF.Pow(-1, float.NegativeInfinity);
+
+            if (!float.IsNaN(f))
+            {
+                TestLibrary.TestFramework.LogError("007.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("007.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest8()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest8: Verify Pow(-1<x<1, NegativeInfinity) .");
+
+        try
+        {
+            float f = MathF.Pow(TestLibrary.Generator.GetSingle(-55), float.NegativeInfinity);
+
+            if (!float.IsPositiveInfinity(f))
+            {
+                TestLibrary.TestFramework.LogError("008.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest9()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest9: Verify Pow(-1<x<1, PositiveInfinity) .");
+
+        try
+        {
+            float f = MathF.Pow(TestLibrary.Generator.GetSingle(-55), float.PositiveInfinity);
+
+            if (f != 0)
+            {
+                TestLibrary.TestFramework.LogError("009.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("009.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest10()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest10: Verify Pow(>1, NegativeInfinity) .");
+
+        try
+        {
+            float f = MathF.Pow(TestLibrary.Generator.GetSingle(-55) + 1, float.NegativeInfinity);
+
+            if (f != 0)
+            {
+                TestLibrary.TestFramework.LogError("010.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest11()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest11: Verify Pow(>1, PositiveInfinity) .");
+
+        try
+        {
+            float f = MathF.Pow(TestLibrary.Generator.GetSingle(-55) + 1, float.PositiveInfinity);
+
+            if (!float.IsPositiveInfinity(f))
+            {
+                TestLibrary.TestFramework.LogError("011.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("011.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest12()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest12: Verify Pow( 0, < 0) .");
+
+        try
+        {
+            float f = MathF.Pow(0, -TestLibrary.Generator.GetSingle(-55) - 0.1f);
+
+            if (!float.IsPositiveInfinity(f))
+            {
+                TestLibrary.TestFramework.LogError("012.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest13()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest13: Verify Pow( 0, > 0) .");
+
+        try
+        {
+            float f = MathF.Pow(0, TestLibrary.Generator.GetSingle(-55) + 0.1f);
+
+            if (f != 0)
+            {
+                TestLibrary.TestFramework.LogError("013.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("013.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest14()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest14: Verify Pow( 1, any value) .");
+
+        try
+        {
+            float f = MathF.Pow(1, TestLibrary.Generator.GetSingle(-55));
+
+            if (f != 1)
+            {
+                TestLibrary.TestFramework.LogError("014.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("014.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest15()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest15: Verify Pow( PositiveInfinity, < 0) .");
+
+        try
+        {
+            float f = MathF.Pow(float.PositiveInfinity, -TestLibrary.Generator.GetSingle(-55) - 0.1f);
+
+            if (f != 0)
+            {
+                TestLibrary.TestFramework.LogError("015.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("015.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest16()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest16: Verify Pow( PositiveInfinity, > 0) .");
+
+        try
+        {
+            float f = MathF.Pow(float.PositiveInfinity, TestLibrary.Generator.GetSingle(-55) + 0.1f);
+
+            if (!float.IsPositiveInfinity(f))
+            {
+                TestLibrary.TestFramework.LogError("015.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("015.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+    #endregion
+
+    #region Nagetive Test Cases
+    //public bool NegTest1()
+    //{
+    //    bool retVal = true;
+
+    //    TestLibrary.TestFramework.BeginScenario("NegTest1: ");
+
+    //    try
+    //    {
+    //          //
+    //          // Add your test logic here
+    //          //
+    //    }
+    //    catch (Exception e)
+    //    {
+    //        TestLibrary.TestFramework.LogError("101", "Unexpected exception: " + e);
+    //        TestLibrary.TestFramework.LogInformation(e.StackTrace);
+    //        retVal = false;
+    //    }
+
+    //    return retVal;
+    //}
+    #endregion
+    #endregion
+
+    public static int Main()
+    {
+        MathFPow test = new MathFPow();
+
+        TestLibrary.TestFramework.BeginTestCase("MathFPow");
+
+        if (test.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfround1.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfround1.cs
@@ -1,0 +1,145 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Round(System.Single)
+/// </summary>
+public class MathFRound1
+{
+    #region Public Methods
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+
+        retVal = NegTest1() && retVal;
+
+        return retVal;
+    }
+
+    #region Positive Test Cases
+    public bool PosTest1()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify Round(System.Single) when decimal part of arg f <= 0.5 .");
+
+        try
+        {
+            int tempIntVar = TestLibrary.Generator.GetInt32(-55);
+
+            float tempSingleVar;
+            do
+                tempSingleVar = TestLibrary.Generator.GetSingle(-55);
+            while (tempSingleVar > 0.5);
+
+            float f = tempIntVar + tempSingleVar;
+
+            if (MathF.Round(f) != tempIntVar)
+            {
+                Console.WriteLine("actual value = " + tempIntVar);
+                Console.WriteLine("expected value = " + MathF.Round(f));
+                TestLibrary.TestFramework.LogError("001.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("001.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify Round(System.Single) when decimal part of arg f > 0.5 .");
+
+        try
+        {
+            int tempIntVar = TestLibrary.Generator.GetInt32(-55);
+
+            float tempSingleVar;
+            do
+                tempSingleVar = TestLibrary.Generator.GetSingle(-55);
+            while (tempSingleVar <= 0.5);
+
+            float f = tempIntVar + tempSingleVar;
+
+            if (MathF.Round(f) != tempIntVar + 1)
+            {
+                Console.WriteLine("actual value = " + (tempIntVar + 1));
+                Console.WriteLine("expected value = " + MathF.Round(f));
+                TestLibrary.TestFramework.LogError("001.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("001.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+    #endregion
+
+    #region Nagetive Test Cases
+    public bool NegTest1()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.BeginScenario("NegTest1: OverflowException is not thrown.");
+
+        try
+        {
+            float result = MathF.Round(float.Parse(float.MaxValue.ToString() + "1"));
+            TestLibrary.TestFramework.LogError("101.1", " OverflowException is not thrown.");
+            retVal = false;
+        }
+        catch (OverflowException)
+        { }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("101.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+    #endregion
+    #endregion
+
+    public static int Main()
+    {
+        MathFRound1 test = new MathFRound1();
+
+        TestLibrary.TestFramework.BeginTestCase("MathFRound1");
+
+        if (test.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfround2.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfround2.cs
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Pow(System.Single, System.Int32)
+/// </summary>
+public class MathFRound2
+{
+    #region Public Methods
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+
+        retVal = NegTest1() && retVal;
+        retVal = NegTest2() && retVal;
+
+        return retVal;
+    }
+
+    #region Positive Test Cases
+    public bool PosTest1()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify Round(f, 0)");
+
+        try
+        {
+            int i = 0;
+            if (MathF.Round(3.4f, i) != 3 || MathF.Round(3.5f, i) != 4 || MathF.Round(3.6f, i) != 4)
+            {
+                TestLibrary.TestFramework.LogError("001.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("001.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify Round(f, 1)");
+
+        try
+        {
+            if (MathF.Round(3.44f, 1) != 3.4f || MathF.Round(3.45f, 1) != 3.4f || MathF.Round(3.46f, 1) != 3.5f)
+            {
+                TestLibrary.TestFramework.LogError("002.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+
+        // Add your scenario description here
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify Round(f, 6)");
+
+        try
+        {
+            float f1 = 1234.56784f;
+            float expectedResult1 = 1234.5678f;
+
+            float f2 = 1234.56785f;
+            float expectedResult2 = 1234.5679f;
+
+            float f3 = 1234.56786f;
+            float expectedResult3 = 1234.5679f;
+
+            int i = 6;
+
+            if (MathF.Round(f1, i).ToString() != expectedResult1.ToString()
+             || MathF.Round(f2, i).ToString() != expectedResult2.ToString()
+             || MathF.Round(f3, i).ToString() != expectedResult3.ToString())
+            {
+                TestLibrary.TestFramework.LogError("003.1", "Return value is wrong!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("003.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+    #endregion
+
+    #region Nagetive Test Cases
+    public bool NegTest1()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.BeginScenario("NegTest1: ArgumentOutOfRangeException is not thrown.");
+
+        try
+        {
+            float f = MathF.Round(3.45f, -1);
+            TestLibrary.TestFramework.LogError("101.1", " OverflowException is not thrown.");
+            retVal = false;
+        }
+        catch (ArgumentOutOfRangeException)
+        { }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("101.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool NegTest2()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.BeginScenario("NegTest2: ArgumentOutOfRangeException is not thrown.");
+
+        try
+        {
+            float f = MathF.Round(12345.6789f, 8);
+            TestLibrary.TestFramework.LogError("102.1", " OverflowException is not thrown.");
+            retVal = false;
+        }
+        catch (ArgumentOutOfRangeException)
+        { }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("102.2", "Unexpected exception: " + e);
+            TestLibrary.TestFramework.LogInformation(e.StackTrace);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+    #endregion
+    #endregion
+
+    public static int Main()
+    {
+        MathFRound2 test = new MathFRound2();
+
+        TestLibrary.TestFramework.BeginTestCase("MathFRound4");
+
+        if (test.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfsign.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfsign.cs
@@ -1,0 +1,270 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Sign(System.Single)
+/// </summary>
+public class MathFSign
+{
+    public static int Main(string[] args)
+    {
+        MathFSign test = new MathFSign();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Sign(System.Single).");
+
+        if (test.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+        retVal = PosTest8() && retVal;
+
+        TestLibrary.TestFramework.LogInformation("[Negtive]");
+        retVal = NegTest1() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify float.MaxValue is a positive number.");
+
+        try
+        {
+            float s = float.MaxValue;
+            if (MathF.Sign(s) != 1)
+            {
+                TestLibrary.TestFramework.LogError("P01.1", "float.MaxValue is not a positive number!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P01.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify float.MinValue is a negative number.");
+
+        try
+        {
+            float s = float.MinValue;
+            if (MathF.Sign(s) != -1)
+            {
+                TestLibrary.TestFramework.LogError("P02.1", "float.MinValue is not a negative number!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P02.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify float.PositiveInfinity is a positive number.");
+
+        try
+        {
+            float s = float.PositiveInfinity;
+            if (MathF.Sign(s) != 1)
+            {
+                TestLibrary.TestFramework.LogError("P03.1", "float.PositiveInfinity is not a positive number!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P03.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify float.NegativeInfinity is a negative number.");
+
+        try
+        {
+            float s = float.NegativeInfinity;
+            if (MathF.Sign(s) != -1)
+            {
+                TestLibrary.TestFramework.LogError("P04.1", "float.NegativeInfinity is not a negative number!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P04.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify float.Epsilon is a positive number.");
+
+        try
+        {
+            float s = float.Epsilon;
+            if (MathF.Sign(s) != 1)
+            {
+                TestLibrary.TestFramework.LogError("P05.1", "float.Epsilon is not a positive number!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P05.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify the return value should be 1 when the float is positive.");
+
+        try
+        {
+            float s = TestLibrary.Generator.GetSingle(-55);
+            while (s <= 0)
+            {
+                s = TestLibrary.Generator.GetSingle(-55);
+            }
+
+            if (MathF.Sign(s) != 1)
+            {
+                TestLibrary.TestFramework.LogError("P06.1", "The return value is not 1 when the float is positive!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P06.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest7: Verify the return value should be -1 when the float is negative.");
+
+        try
+        {
+            float s = TestLibrary.Generator.GetSingle(-55);
+            while (s <= 0)
+            {
+                s = TestLibrary.Generator.GetSingle(-55);
+            }
+
+            if (MathF.Sign(-s) != -1)
+            {
+                TestLibrary.TestFramework.LogError("P07.1", "The return value is not -1 when the float is negative!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P07.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest8()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest8: Verify the return value should be 0 when the float is zero.");
+
+        try
+        {
+            float s = 0.0f;
+
+            if (MathF.Sign(s) != 0)
+            {
+                TestLibrary.TestFramework.LogError("P08.1", "The return value is not -1 when the float is negative!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P08.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool NegTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("NegTest1: ArithmeticException should be thrown when value is equal to NaN.");
+
+        try
+        {
+            float s = float.NaN;
+            MathF.Sign(s);
+
+            TestLibrary.TestFramework.LogError("N01.1", "ArithmeticException is not thrown when value is equal to NaN!");
+            retVal = false;
+
+        }
+        catch (ArithmeticException)
+        {
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("N01.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfsin.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfsin.cs
@@ -1,0 +1,230 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Sin(System.Single)
+/// </summary>
+public class MathFSin
+{
+    public static int Main(string[] args)
+    {
+        MathFSin test = new MathFSin();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Sin(System.Single).");
+
+        if (test.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+        retVal = PosTest8() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the result when radian is 0.");
+
+        try
+        {
+            float f = MathF.Sin(0);
+            if (f != 0)
+            {
+                TestLibrary.TestFramework.LogError("P01.1", "The result is error when radian is 0!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P01.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the result is 1 when radian is MathF.PI/2.");
+
+        try
+        {
+            float f = MathF.Sin(MathF.PI / 2);
+            if (f != 1)
+            {
+                TestLibrary.TestFramework.LogError("P02.1", "The result is error when radian is MathF.PI/2!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P02.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the result is -1 when radian is -MathF.PI/2.");
+
+        try
+        {
+            float f = MathF.Sin(-MathF.PI / 2);
+            if (f != -1)
+            {
+                TestLibrary.TestFramework.LogError("P03.1", "The result is error when radian is -MathF.PI/2!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P03.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the result is 1/2 when radian is MathF.PI/6.");
+
+        try
+        {
+            float f = MathF.Round(MathF.Sin(MathF.PI / 6), 2);
+            if (f != 0.5d)
+            {
+                TestLibrary.TestFramework.LogError("P04.1", "The result is error when radian is MathF.PI/6!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P04.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify the result is -1/2 when radian is -MathF.PI/6.");
+
+        try
+        {
+            float f = MathF.Round(MathF.Sin(-MathF.PI / 6), 2);
+            if (f != -0.5d)
+            {
+                TestLibrary.TestFramework.LogError("P05.1", "The result is error when radian is -MathF.PI/6!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P05.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify the result is NaN when radian is PositiveInfinity.");
+
+        try
+        {
+            float f = MathF.Sin(float.PositiveInfinity);
+            if (f.CompareTo(float.NaN) != 0)
+            {
+                TestLibrary.TestFramework.LogError("P06.1", "The result is error when radian is PositiveInfinity!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P06.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest7: Verify the result is NaN when radian is NegativeInfinity.");
+
+        try
+        {
+            float f = MathF.Sin(float.NegativeInfinity);
+            if (f.CompareTo(float.NaN) != 0)
+            {
+                TestLibrary.TestFramework.LogError("P07.1", "The result is error when radian is NegativeInfinity!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P07.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest8()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest8: Verify the result is NaN when radian is NaN.");
+
+        try
+        {
+            float f = MathF.Sin(float.NaN);
+            if (f.CompareTo(float.NaN) != 0)
+            {
+                TestLibrary.TestFramework.LogError("P08.1", "The result is error when radian is NaN!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P08.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfsinh.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfsinh.cs
@@ -1,0 +1,230 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Sinh(System.Single)
+/// </summary>
+public class MathFSinh
+{
+    public static int Main(string[] args)
+    {
+        MathFSinh test = new MathFSinh();
+        TestLibrary.TestFramework.BeginTestCase("Testing System.MathF.Sinh(System.Single).");
+
+        if (test.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+        retVal = PosTest8() && retVal;
+
+        return retVal;
+    }
+
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Verify the result when radian is 0.");
+
+        try
+        {
+            float f = MathF.Sinh(0);
+            if (!MathFTestLib.SingleIsWithinEpsilon(f, 0))
+            {
+                TestLibrary.TestFramework.LogError("P01.1", "The result is error when radian is 0!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P01.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Verify the result when radian is MathF.PI/2.");
+
+        try
+        {
+            float f = MathF.Sinh(MathF.PI / 2);
+            if (!MathFTestLib.SingleIsWithinEpsilon(f, 2.30129890f))
+            {
+                TestLibrary.TestFramework.LogError("P02.1", "The result is error when radian is MathF.PI/2!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P02.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Verify the result when radian is -MathF.PI/2.");
+
+        try
+        {
+            float f = MathF.Sinh(-MathF.PI / 2);
+            if (!MathFTestLib.SingleIsWithinEpsilon(f, -2.30129890f))
+            {
+                TestLibrary.TestFramework.LogError("P03.1", "The result is error when radian is -MathF.PI/2!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P03.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Verify the result when radian is MathF.PI/6.");
+
+        try
+        {
+            float f = MathF.Sinh(MathF.PI / 6);
+            if (!MathFTestLib.SingleIsWithinEpsilon(f, 0.547853474f))
+            {
+                TestLibrary.TestFramework.LogError("P04.1", "The result is error when radian is MathF.PI/6!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P04.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: Verify the result when radian is -MathF.PI/6.");
+
+        try
+        {
+            float f = MathF.Sinh(-MathF.PI / 6);
+            if (!MathFTestLib.SingleIsWithinEpsilon(f, -0.547853474f))
+            {
+                TestLibrary.TestFramework.LogError("P05.1", "The result is error when radian is -MathF.PI/6!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P05.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: Verify the result is PositiveInfinity when radian is PositiveInfinity.");
+
+        try
+        {
+            float f = MathF.Sinh(float.PositiveInfinity);
+            if (f.CompareTo(float.PositiveInfinity) != 0)
+            {
+                TestLibrary.TestFramework.LogError("P06.1", "The result is error when radian is PositiveInfinity!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P06.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest7: Verify the result is NegativeInfinity when radian is NegativeInfinity.");
+
+        try
+        {
+            float f = MathF.Sinh(float.NegativeInfinity);
+            if (f.CompareTo(float.NegativeInfinity) != 0)
+            {
+                TestLibrary.TestFramework.LogError("P07.1", "The result is error when radian is NegativeInfinity!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P07.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+
+    public bool PosTest8()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest8: Verify the result is NaN when radian is NaN.");
+
+        try
+        {
+            float f = MathF.Sinh(float.NaN);
+            if (f.CompareTo(float.NaN) != 0)
+            {
+                TestLibrary.TestFramework.LogError("P08.1", "The result is error when radian is NaN!");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("P08.2", "Unexpected exception occurs: " + e);
+            retVal = false;
+        }
+
+        return retVal;
+    }
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathfsqrt.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathfsqrt.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Sqrt(float)
+/// </summary>
+public class MathFSqrt
+{
+    public static int Main()
+    {
+        MathFSqrt mathSqrt = new MathFSqrt();
+        TestLibrary.TestFramework.BeginTestCase("MathFSqrt");
+        if (mathSqrt.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        return retVal;
+    }
+
+    #region PositiveTest
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1:Calculate the zero sqrt");
+        try
+        {
+            float source = 0;
+            float des = MathF.Sqrt(source);
+            if (des != 0)
+            {
+                TestLibrary.TestFramework.LogError("001", "the ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpect exception:" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2:Calculate the positive number sqrt");
+        try
+        {
+            float source = 100;
+            float des = MathF.Sqrt(source);
+            if (des != 10)
+            {
+                TestLibrary.TestFramework.LogError("003", "the ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpect exception:" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3:Calculate the negative number sqrt");
+        try
+        {
+            float source = -1;
+            float des = MathF.Sqrt(source);
+            if (!float.IsNaN(des))
+            {
+                TestLibrary.TestFramework.LogError("005", "the ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpect exception:" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4:Calculate the float NaN sqrt");
+        try
+        {
+            float source = float.NaN;
+            float des = MathF.Sqrt(source);
+            if (!float.IsNaN(des))
+            {
+                TestLibrary.TestFramework.LogError("007", "the ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpect exception:" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5:Calculate the float PositiveInfinity sqrt");
+        try
+        {
+            float source = float.PositiveInfinity;
+            float des = MathF.Sqrt(source);
+            if (!float.IsPositiveInfinity(des))
+            {
+                TestLibrary.TestFramework.LogError("009", "the ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpect exception:" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6:Calculate the float NegativeInfinity sqrt");
+        try
+        {
+            float source = float.NegativeInfinity;
+            float des = MathF.Sqrt(source);
+            if (!float.IsNaN(des))
+            {
+                TestLibrary.TestFramework.LogError("011", "the ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpect exception:" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+    #endregion
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathftan.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathftan.cs
@@ -1,0 +1,200 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Tan(float)
+/// </summary>
+public class MathFTan
+{
+    private const float c_DELTA = 0.000005f;
+
+    public static int Main()
+    {
+        MathFTan mathTan = new MathFTan();
+        TestLibrary.TestFramework.BeginTestCase("MathFTan");
+        if (mathTan.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+        return retVal;
+    }
+
+    #region PositiveTest
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Caculate the tangent of 0 degrees");
+        try
+        {
+            float sourceA = (float)0;
+            float desA = MathF.Tan(sourceA);
+            if (!MathFTestLib.SingleIsWithinEpsilon(desA, (float)0))
+            {
+                TestLibrary.TestFramework.LogError("001", "Expected: 0, actual: " + desA.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Calculate the tangent of 90 degrees");
+        try
+        {
+            float sourceA = 90;
+            float desA = MathF.Tan(sourceA * (MathF.PI / 180));
+            if ((desA - 16331778728383844.0) > c_DELTA)
+            {
+                TestLibrary.TestFramework.LogError("003", "the ExpectResult is not the ActualResult: Expected(" + 16331778728383844.0 + ") Actual(" + desA + ")");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Calculate the tangent of 180 degrees");
+        try
+        {
+            float sourceA = 180;
+            float desA = MathF.Tan(sourceA * (MathF.PI / 180));
+            if ((desA + 0.00000000000000012246063538223773) > c_DELTA)
+            {
+                TestLibrary.TestFramework.LogError("005", "Expected: 0.00000000000000012246063538223773, actual: " + desA.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Calculate the tangent of 45 degrees");
+        try
+        {
+            float sourceA = 45.0f;
+            float desA = MathF.Tan(sourceA * (MathF.PI / 180));
+            if (!MathFTestLib.SingleIsWithinEpsilon(desA, 1.0f))
+            {
+                TestLibrary.TestFramework.LogError("007", "Expected: 1.0, actual: " + desA.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: The float is float NaN");
+        try
+        {
+            float sourceA = float.NaN;
+            float desA = MathF.Tan(sourceA);
+            if (!float.IsNaN(desA))
+            {
+                TestLibrary.TestFramework.LogError("009", "the ExpectResult is not the ActualResult: Expected(NaN) Actual(" + desA + ")");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: The float is float NegativeInfinity");
+        try
+        {
+            float sourceA = float.NegativeInfinity;
+            float desA = MathF.Tan(sourceA);
+            if (!float.IsNaN(desA))
+            {
+                TestLibrary.TestFramework.LogError("011", "Expected: NaN, actual: " + desA.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest7: The float is float PositiveInfinity");
+        try
+        {
+            float sourceA = float.PositiveInfinity;
+            float desA = MathF.Tan(sourceA);
+            if (!float.IsNaN(desA))
+            {
+                TestLibrary.TestFramework.LogError("013", "Expected: NaN, actual: " + desA.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("014", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+    #endregion
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathftanh.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathftanh.cs
@@ -1,0 +1,202 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// System.MathF.Tanh(bouble)
+/// </summary>
+public class MathFTanh
+{
+    public static int Main()
+    {
+        MathFTanh mathTanh = new MathFTanh();
+        TestLibrary.TestFramework.BeginTestCase("MathFTanh");
+        if (mathTanh.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+
+    public bool RunTests()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
+        retVal = PosTest5() && retVal;
+        retVal = PosTest6() && retVal;
+        retVal = PosTest7() && retVal;
+        return retVal;
+    }
+
+    #region PositiveTest
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1: Caculate the tanh of 0 degrees");
+        try
+        {
+            float sourceA = 0;
+            float desA = MathF.Tanh(sourceA);
+            if (!MathFTestLib.SingleIsWithinEpsilon(desA, sourceA))
+            {
+                TestLibrary.TestFramework.LogError("001", "Expected: 0, actual: " + desA.ToString() + "; diff > epsilon = " +
+                    MathFTestLib.Epsilon.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2: Calculate the tanh of 90 degrees");
+        try
+        {
+            float sourceA = 90;
+            float desA = MathF.Tanh(sourceA * (MathF.PI / 180));
+            if (!MathFTestLib.SingleIsWithinEpsilon(desA, 0.917152336f))
+            {
+                TestLibrary.TestFramework.LogError("003", "Expected: 0.917152336, actual: " + desA.ToString() + "; diff > epsilon = " +
+                    MathFTestLib.Epsilon.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3: Calculate the tanh of 180 degrees");
+        try
+        {
+            float sourceA = 180;
+            float desA = MathF.Tan(sourceA * (MathF.PI / 180));
+            if (!MathFTestLib.SingleIsWithinEpsilon(desA, -0.0f))
+            {
+                TestLibrary.TestFramework.LogError("005", "Expected: -0.0, actual: " + desA.ToString() + "; diff > epsilon = " +
+                    MathFTestLib.Epsilon.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("006", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest4()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest4: Calculate the tanh of 45 degrees");
+        try
+        {
+            float sourceA = 45.0f;
+            float desA = MathF.Tanh(sourceA * (MathF.PI / 180));
+            if (!MathFTestLib.SingleIsWithinEpsilon(desA, 0.655794203f))
+            {
+                TestLibrary.TestFramework.LogError("007", "Expected: 0.655794203, actual: " + desA.ToString() + "; diff > epsilon = " +
+                    MathFTestLib.Epsilon.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("008", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest5()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest5: tanh(NaN)=NaN");
+        try
+        {
+            float sourceA = float.NaN;
+            float desA = MathF.Tanh(sourceA);
+            if (!float.IsNaN(desA))
+            {
+                TestLibrary.TestFramework.LogError("009", "Expected: NaN, actual: " + desA.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("010", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest6()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest6: tanh(-inf)=-1");
+        try
+        {
+            float sourceA = float.NegativeInfinity;
+            float desA = MathF.Tanh(sourceA);
+            if (!MathFTestLib.SingleIsWithinEpsilon(desA, -1))
+            {
+                TestLibrary.TestFramework.LogError("011", "Expected: -1, actual: " + desA.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("012", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+
+    public bool PosTest7()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest7: tanh(+inf) = 1");
+        try
+        {
+            float sourceA = float.PositiveInfinity;
+            float desA = MathF.Tanh(sourceA);
+            if (!MathFTestLib.SingleIsWithinEpsilon(desA, 1))
+            {
+                TestLibrary.TestFramework.LogError("013", "Expected 1, actual: " + desA.ToString());
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("014", "Unexpected exception" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+    #endregion
+}

--- a/tests/src/CoreMangLib/cti/system/mathf/mathftestlib.cs
+++ b/tests/src/CoreMangLib/cti/system/mathf/mathftestlib.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+/// <summary>
+/// Summary description for Class1
+/// </summary>
+public class MathFTestLib
+{
+    private static decimal epsilon = new decimal(0.000001D);
+
+    public static decimal Epsilon
+    {
+        get
+        {
+            return epsilon;
+        }
+
+        set
+        {
+            epsilon = Convert.ToDecimal(value);
+        }
+    }
+
+    public static bool SingleIsWithinEpsilon(float x, float y)
+    {
+        decimal dx = new decimal(x);
+        decimal dy = new decimal(y);
+
+        decimal diff = Math.Abs(decimal.Subtract(dx, dy));
+        return diff.CompareTo(Epsilon) <= 0;
+    }
+}


### PR DESCRIPTION
This resolves an assert that occurs because `codegenxarch` asserted that `CORINFO_INTRINSIC_Sqrt` could only ever be `TYP_DOUBLE`:
```
Assert failure(PID 58004 [0x0000e294], Thread: 58004 [0xe294]): Assertion failed 'treeNode->TypeGet() == TYP_DOUBLE' in 'Functions.MathTests:SqrtSingleTest()' (IL size 99)
```