### PR TITLE
Reduce code in StubHelpers.SafeHandleAddRef

### DIFF
--- a/src/mscorlib/src/System/StubHelpers.cs
+++ b/src/mscorlib/src/System/StubHelpers.cs
@@ -1618,13 +1618,11 @@ namespace  System.StubHelpers {
         {
             if (pHandle == null)
             {
-                throw new ArgumentNullException(nameof(pHandle), Environment.GetResourceString("ArgumentNull_SafeHandle"));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.pHandle, ExceptionResource.ArgumentNull_SafeHandle);
             }
-            Contract.EndContractBlock();
 
             pHandle.DangerousAddRef(ref success);
-
-            return (success ? pHandle.DangerousGetHandle() : IntPtr.Zero);
+            return pHandle.DangerousGetHandle();
         }
 
         // Releases the SH (to be called from finally block).
@@ -1632,9 +1630,8 @@ namespace  System.StubHelpers {
         {
             if (pHandle == null)
             {
-                throw new ArgumentNullException(nameof(pHandle), Environment.GetResourceString("ArgumentNull_SafeHandle"));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.pHandle, ExceptionResource.ArgumentNull_SafeHandle);
             }
-            Contract.EndContractBlock();
 
             try
             {

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -136,6 +136,11 @@ namespace System {
             throw new ArgumentNullException(GetResourceString(resource));
         }
 
+        internal static void ThrowArgumentNullException(ExceptionArgument argument, ExceptionResource resource)
+        {
+            throw new ArgumentNullException(GetArgumentName(argument), GetResourceString(resource));
+        }
+
         internal static void ThrowArgumentOutOfRangeException(ExceptionArgument argument) {
             throw new ArgumentOutOfRangeException(GetArgumentName(argument));
         }
@@ -363,6 +368,7 @@ namespace System {
         callBack,
         type,
         stateMachine,
+        pHandle,
     }
 
     //
@@ -469,6 +475,7 @@ namespace System {
         ArgumentOutOfRange_Enum,
         InvalidOperation_HandleIsNotInitialized,
         AsyncMethodBuilder_InstanceNotInitialized,
+        ArgumentNull_SafeHandle,
     }
 }
 


### PR DESCRIPTION
If DangerousAddRef returns rather than throws, its argument will be true, so there's no need to branch on it.

Also changed its throws to use ThrowHelper.