### PR TITLE
Android: workaround absence of getcontext/setcontext

### DIFF
--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -47,6 +47,14 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 
 #include "pal/context.h"
 
+#ifdef __ANDROID__
+int setcontext(const ucontext_t *ucp)
+{
+    // Not implemented on Android
+    return -1;
+}
+#endif
+
 using namespace CorUnix;
 
 #ifdef SIGRTMIN

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -48,10 +48,29 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 #include "pal/context.h"
 
 #ifdef __ANDROID__
+// getcontext and setcontext are not available natively on Android
+int getcontext(ucontext_t *ucp)
+{
+    CONTEXT context;
+    RtlCaptureContext(&context);
+    CONTEXTToNativeContext(&context, ucp);
+
+    return 0;
+}
+
 int setcontext(const ucontext_t *ucp)
 {
-    // Not implemented on Android
-    return -1;
+    CONTEXT context;
+    ULONG contextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT;
+
+#if defined(_AMD64_)
+    contextFlags |= CONTEXT_XSTATE;
+#endif
+
+    CONTEXTFromNativeContext(ucp, &context, contextFlags);
+    RtlRestoreContext(&context, NULL);
+
+    return 0;
 }
 #endif
 

--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -29,6 +29,14 @@ extern "C"
 #include <signal.h>
 #include <pthread.h>
 
+#ifdef __ANDROID__
+// There's no getcontext in Android, but we can use getcontext from libunwind;
+// there's no setcontext implementation.
+#include "libunwind.h"
+#define getcontext unw_tdep_getcontext
+int setcontext(const ucontext_t *ucp);
+#endif
+
 #if !HAVE_MACH_EXCEPTIONS
 /* A type to wrap the native context type, which is ucontext_t on some
  * platforms and another type elsewhere. */

--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -30,11 +30,9 @@ extern "C"
 #include <pthread.h>
 
 #ifdef __ANDROID__
-// There's no getcontext in Android, but we can use getcontext from libunwind;
-// there's no setcontext implementation.
-#include "libunwind.h"
-#define getcontext unw_tdep_getcontext
+// getcontext and setcontext are not available natively on Android
 int setcontext(const ucontext_t *ucp);
+int getcontext(ucontext_t* ucp);
 #endif
 
 #if !HAVE_MACH_EXCEPTIONS


### PR DESCRIPTION
#9650 added dependencies on getcontext and setcontext, which are not available on Android.

This PR implements getcontext and setcontext using RtlCaptureContext and RtlRestoreContext.