### PR TITLE
Speed up JIT builds

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -200,8 +200,12 @@ endif()
 
 add_custom_target(jit_exports DEPENDS ${JIT_EXPORTS_FILE})
 
-add_subdirectory(dll)
-add_subdirectory(crossgen)
+if (FEATURE_MERGE_JIT_AND_ENGINE)
+  # Despite the directory being named "dll", it creates a static library "clrjit_static" to link into the VM.
+  add_subdirectory(dll)
+  add_subdirectory(crossgen)
+endif (FEATURE_MERGE_JIT_AND_ENGINE)
+
 add_subdirectory(standalone)
 
 if (CLR_CMAKE_PLATFORM_ARCH_ARM)


### PR DESCRIPTION
We don't need to build the static lib and crossgen static lib
versions of the JIT unless FEATURE_MERGE_JIT_AND_ENGINE is set.
And, since we currently don't set it, this means doing two
fewer JIT builds.