### PR TITLE
Ignore binder context for corelib when performing binding cache lookup

### DIFF
--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -1276,7 +1276,14 @@ AssemblySpecBindingCache::AssemblyBinding* AssemblySpecBindingCache::GetAssembly
     
     // Check if the AssemblySpec already has specified its binding context. This will be set for assemblies that are
     // attempted to be explicitly bound using AssemblyLoadContext LoadFrom* methods.
-    pBinderContextForLookup = pSpec->GetBindingContext();
+    if(!pSpec->IsAssemblySpecForMscorlib())
+        pBinderContextForLookup = pSpec->GetBindingContext();
+    else
+    {
+        // For System.Private.Corelib Binding context is either not set or if set then it should be TPA
+        _ASSERTE(pSpec->GetBindingContext() == NULL || pSpec->GetBindingContext() == pSpecDomain->GetFusionContext());
+    }
+
     if (pBinderContextForLookup != NULL)
     {
         // We are working with the actual binding context in which the assembly was expected to be loaded.


### PR DESCRIPTION
corelib is always loaded in default context. When performing a lookup for corelib in binding cache no binderid is used to modify the key. However in function AssemblySpecBindingCache::GetAssemblyBindingEntryForAssemblySpec we were using binderid to modify the key even for corelib. This is different from implementation in AssemblySpecBindingCache::StoreAssembly. This was causing the POST condition at https://github.com/dotnet/coreclr/blob/master/src/vm/assemblyspec.cpp#L1509 to fail.
