### PR TITLE
Tweak OrdinalComparer for OrdinalIgnoreCase

### DIFF
--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -29,11 +29,12 @@ namespace System
             {
                 char* a = ap;
                 char* b = bp;
+                int charA = 0, charB = 0;
 
                 while (length != 0)
                 {
-                    int charA = *a;
-                    int charB = *b;
+                    charA = *a;
+                    charB = *b;
 
                     Debug.Assert((charA | charB) <= 0x7F, "strings have to be ASCII");
 
@@ -43,7 +44,7 @@ namespace System
 
                     //Return the (case-insensitive) difference between them.
                     if (charA != charB)
-                        return charA - charB;
+                        goto ReturnCharAMinusCharB; // TODO: Workaround for https://github.com/dotnet/coreclr/issues/9692
 
                     // Next char
                     a++; b++;
@@ -51,6 +52,9 @@ namespace System
                 }
 
                 return strA.Length - strB.Length;
+
+                ReturnCharAMinusCharB:
+                return charA - charB;
             }
         }
 

--- a/src/mscorlib/src/System/StringComparer.cs
+++ b/src/mscorlib/src/System/StringComparer.cs
@@ -249,22 +249,15 @@ namespace System
 
     }
 
-    // Provide a more optimal implementation of ordinal comparison.
     [Serializable]
     internal sealed class OrdinalComparer : StringComparer 
 #if FEATURE_RANDOMIZED_STRING_HASHING           
         , IWellKnownStringEqualityComparer
 #endif
     {
-        public override int Compare(string x, string y) =>
-            object.ReferenceEquals(x, y) ? 0 :
-            x == null ? -1 :
-            y == null ? 1 :
-            string.CompareOrdinal(x, y);
+        public override int Compare(string x, string y) => string.CompareOrdinal(x, y);
 
-        public override bool Equals(string x, string y) =>
-            object.ReferenceEquals(x, y) ||
-            (x != null && x.Equals(y));
+        public override bool Equals(string x, string y) => string.Equals(x, y);
 
         public override int GetHashCode(string obj)
         {
@@ -276,7 +269,7 @@ namespace System
         }
 
         // Equals/GetHashCode methods for the comparer itself. 
-        public override bool Equals(Object obj) => obj is OrdinalComparer;
+        public override bool Equals(object obj) => obj is OrdinalComparer;
         public override int GetHashCode() => nameof(OrdinalComparer).GetHashCode();
 
 #if FEATURE_RANDOMIZED_STRING_HASHING           
@@ -284,22 +277,15 @@ namespace System
 #endif
     }
 
-    // Provide a more optimal implementation of ordinal ignore-case comparison.
     [Serializable]
     internal sealed class OrdinalIgnoreCaseComparer : StringComparer
 #if FEATURE_RANDOMIZED_STRING_HASHING
         , IWellKnownStringEqualityComparer
 #endif
     {
-        public override int Compare(string x, string y) =>
-            object.ReferenceEquals(x, y) ? 0 :
-            x == null ? -1 :
-            y == null ? 1 :
-            string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+        public override int Compare(string x, string y) => string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
 
-        public override bool Equals(string x, string y) =>
-            object.ReferenceEquals(x, y) ||
-            (x != null && x.Equals(y, StringComparison.OrdinalIgnoreCase));
+        public override bool Equals(string x, string y) => string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
 
         public override int GetHashCode(string obj)
         {
@@ -311,7 +297,7 @@ namespace System
         }
 
         // Equals/GetHashCode methods for the comparer itself. 
-        public override bool Equals(Object obj) => obj is OrdinalIgnoreCaseComparer;
+        public override bool Equals(object obj) => obj is OrdinalIgnoreCaseComparer;
         public override int GetHashCode() => nameof(OrdinalIgnoreCaseComparer).GetHashCode();
 
 #if FEATURE_RANDOMIZED_STRING_HASHING

--- a/src/mscorlib/src/System/StringComparer.cs
+++ b/src/mscorlib/src/System/StringComparer.cs
@@ -16,10 +16,10 @@ namespace System
     [Serializable]
     public abstract class StringComparer : IComparer, IEqualityComparer, IComparer<string>, IEqualityComparer<string>
     {
-        private static readonly StringComparer _invariantCulture = new CultureAwareComparer(CultureInfo.InvariantCulture, false);
-        private static readonly StringComparer _invariantCultureIgnoreCase = new CultureAwareComparer(CultureInfo.InvariantCulture, true);
-        private static readonly StringComparer _ordinal = new OrdinalComparer();
-        private static readonly StringComparer _ordinalIgnoreCase = new OrdinalIgnoreCaseComparer();        
+        private static readonly CultureAwareComparer _invariantCulture = new CultureAwareComparer(CultureInfo.InvariantCulture, false);
+        private static readonly CultureAwareComparer _invariantCultureIgnoreCase = new CultureAwareComparer(CultureInfo.InvariantCulture, true);
+        private static readonly OrdinalComparer _ordinal = new OrdinalComparer();
+        private static readonly OrdinalIgnoreCaseComparer _ordinalIgnoreCase = new OrdinalIgnoreCaseComparer();        
 
         public static StringComparer InvariantCulture
         {


### PR DESCRIPTION
- OrdinalComparer was parameterized by ignoreCase, meaning every call to it switched on _ignoreCase and took a path based on whether StringComparer.Ordinal or StringComparer.OrdinalIgnoreCase was used.  As both of these are so commonly used, I've split the type into one sealed class for each, and simplified the code for each.  Even with the split, total lines of C# code decreased.
- https://github.com/dotnet/coreclr/pull/9213 added a special path to string.Equal(string, StringComparison) for OrdinalIgnoreCase.  I switched StringComparer.OrdinalIgnoreCase to use that rather than string.Compare(..., StringComparison.OrdinalIgnoreCase) == 0.  I also then removed a couple of null checks that were optimizing for comparing a non-null string against a null string, which shouldn't be the common case.
- Strongly-typed the various static readonly comparer fields on StringComparer
- Applied the same workaround used in https://github.com/dotnet/coreclr/pull/9213 that moves the return out of the loop.  In some microbenchmarks, it had no effect.  On a few, e.g. comparing "abcdefghijklmno" to "AbCdEfGhIjKlMnz" or "ssssssssss" to "SSSSSSSSSS", it had upwards of a 30% improvement.  I tagged it with a comment with the associated issue number (https://github.com/dotnet/coreclr/issues/9692) to undo if/when the JIT is better able to optimize this.