### PR TITLE
Enable promotion of structs containing fields of structs with a single pointer-sized scalar type field.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -971,6 +971,43 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
                 assert(!varTypeIsSIMD(arg));
                 numRefs = comp->info.compCompHnd->getClassGClayout(arg->gtObj.gtClass, gcLayout);
                 putArg->AsPutArgStk()->setGcPointers(numRefs, gcLayout);
+
+#ifdef _TARGET_X86_
+                // On x86 VM lies about the type of a struct containing a pointer sized
+                // integer field by returning the type of its field as the type of struct.
+                // Such struct can be passed in a register depending its position in
+                // parameter list.  VM does this unwrapping only one level and therefore
+                // a type like Struct Foo { Struct Bar { int f}} awlays needs to be
+                // passed on stack.  Also, VM doesn't lie about type of such a struct
+                // when it is a field of another struct.  That is VM doesn't lie about
+                // the type of Foo.Bar
+                //
+                // We now support the promotion of fields that are of type struct.
+                // However we only support a limited case where the struct field has a
+                // single field and that single field must be a scalar type. Say Foo.Bar
+                // field is getting passed as a parameter to a call, Since it is a TYP_STRUCT,
+                // as per x86 ABI it should always be passed on stack.  Therefore GenTree
+                // node under a PUTARG_STK could be GT_OBJ(GT_LCL_VAR_ADDR(v1)), where
+                // local v1 could be a promoted field standing for Foo.Bar.  Note that
+                // the type of v1 will be the type of field of Foo.Bar.f when Foo is
+                // promoted.  That is v1 will be a scalar type.  In this case we need to
+                // pass v1 on stack instead of in a register.
+                //
+                // TODO-PERF: replace GT_OBJ(GT_LCL_VAR_ADDR(v1)) with v1 if v1 is
+                // a scalar type and the width of GT_OBJ matches the type size of v1.
+                // Note that this cannot be done till call node arguments are morphed
+                // because we should not lose the fact that the type of argument is
+                // a struct so that the arg gets correctly marked to be passed on stack.
+                GenTree* objOp1 = arg->gtGetOp1();
+                if (objOp1->OperGet() == GT_LCL_VAR_ADDR)
+                {
+                    unsigned lclNum = objOp1->AsLclVarCommon()->GetLclNum();
+                    if (comp->lvaTable[lclNum].lvType != TYP_STRUCT)
+                    {
+                        comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_VMNeedsStackAddr));
+                    }
+                }
+#endif // _TARGET_X86_
             }
         }
 #endif // FEATURE_PUT_STRUCT_ARG_STK

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -732,6 +732,35 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
             {
                 RewriteSIMDOperand(use, false);
             }
+            else
+            {
+                // Due to promotion of structs containing fields of type struct with a
+                // single scalar type field, we could potentially see IR nodes of the
+                // form GT_IND(GT_ADD(lclvarAddr, 0)) where 0 is an offset representing
+                // a field-seq. These get folded here.
+                //
+                // TODO: This code can be removed once JIT implements recursive struct
+                // promotion instead of lying about the type of struct field as the type
+                // of its single scalar field.
+                GenTree* addr = node->AsIndir()->Addr();
+                if (addr->OperGet() == GT_ADD && addr->gtGetOp1()->OperGet() == GT_LCL_VAR_ADDR &&
+                    addr->gtGetOp2()->IsIntegralConst(0))
+                {
+                    GenTreeLclVarCommon* lclVarNode = addr->gtGetOp1()->AsLclVarCommon();
+                    unsigned             lclNum     = lclVarNode->GetLclNum();
+                    LclVarDsc*           varDsc     = comp->lvaTable + lclNum;
+                    if (node->TypeGet() == varDsc->TypeGet())
+                    {
+                        JITDUMP("Rewriting GT_IND(GT_ADD(LCL_VAR_ADDR,0)) to LCL_VAR\n");
+                        lclVarNode->SetOper(GT_LCL_VAR);
+                        lclVarNode->gtType = node->TypeGet();
+                        use.ReplaceWith(comp, lclVarNode);
+                        BlockRange().Remove(addr);
+                        BlockRange().Remove(addr->gtGetOp2());
+                        BlockRange().Remove(node);
+                    }
+                }
+            }
             break;
 
         case GT_NOP:


### PR DESCRIPTION
Re-instating this optimization addressing gc-hole caused by initial implementation.

The reason for gc-hole is that since struct promotion logic lies about the type of struct field as the type of its underlying single field, IR could have

GT_IND(GT_ADD(lclvarAddr, 0)) = value

where 0 is the field offset representing a fieldseq.  But lclVarAddr type is not struct but a scalar (due to retyping of struct as its underlying field).

Say the single field is a gc-type (ref/byref). In such a case lclVar type would be ref/bref and it is getting updated through an addr mode.  Emitter won't be able to recognize that the addr mode is actually assigning to a localvar and doesn't emit gc-info indicating that the stack slot of lclVar is going live with gc-ref/byref.

As a short term fix, the above IR gets folded into 
lclvar = value 

in rationalizer.   Surprisingly , rationalizer logic alone resulted in an asm diff imrovement for one of the PInvoke stubs in mscorlib.

I have verified that fast span Slice benchmark also benefits due to rationalizer change.

```
Here is ngen asm diff of mscorlib on desktop:
08.31:     Code Size improvements (code sizes in bytes):
08.31:     <filename>                                            baseline        diff improvement  %improvement    #funcs
08.31:     mscorlib.dasm                                          6392330     6391095        1235          0.02     42246
08.32:        52 functions improved (1439 total bytes improvement)
08.32:           Improvement # 1 goes from   107 to    45, diff of    62 (57.94%) :: ValueCollection[Int32,DateTime][System.Int32,System.DateTime]:GetEnumerator():struct:this
08.32:           Improvement # 2 goes from   107 to    45, diff of    62 (57.94%) :: ValueCollection[DateTime,TimeSpan][System.DateTime,System.TimeSpan]:GetEnumerator():struct:this
08.32:           Improvement # 3 goes from   107 to    45, diff of    62 (57.94%) :: KeyCollection[DateTime,TimeSpan][System.DateTime,System.TimeSpan]:GetEnumerator():struct:this
08.32:           Improvement # 4 goes from   103 to    54, diff of    49 (47.57%) :: System.Collections.Generic.List`1[DateTime][System.DateTime]:GetEnumerator():struct:this
08.32:           Improvement # 5 goes from   103 to    54, diff of    49 (47.57%) :: System.Collections.Generic.List`1[GCHandle][System.Runtime.InteropServices.GCHandle]:GetEnumerator():struct:this
08.32:           Improvement # 6 goes from   103 to    54, diff of    49 (47.57%) :: System.Collections.Generic.List`1[EventRegistrationToken][System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken]:GetEnumerator():struct:this
08.32:           Improvement # 7 goes from   103 to    54, diff of    49 (47.57%) :: System.Collections.Generic.List`1[TimeSpan][System.TimeSpan]:GetEnumerator():struct:this
08.32:           Improvement # 8 goes from   117 to    65, diff of    52 (44.44%) :: KeyCollection[EventRegistrationToken,__Canon][System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken,System.__Canon]:GetEnumerator():struct:this
08.32:           Improvement # 9 goes from   117 to    78, diff of    39 (33.33%) :: System.Collections.Generic.Dictionary`2[__Canon,EventRegistrationTokenList][System.__Canon,System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal+EventRegistrationTokenList]:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(struct):this
08.32:           Improvement #10 goes from   118 to    81, diff of    37 (31.36%) :: ValueCollection[Int32,DateTime][System.Int32,System.DateTime]:System.Collections.IEnumerable.GetEnumerator():ref:this
08.32:        10 aggregated functions improved (155 total bytes improvement)
08.32:           Improvement # 1 goes from   540 to   505, diff of    35 ( 6.48%) ::  3 x Enumerator[EventRegistrationToken,__Canon][System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken,System.__Canon]:MoveNext():bool:this
08.32:           Improvement # 2 goes from  1214 to  1162, diff of    52 ( 4.28%) ::  5 x System.Internal:NullableHelper():struct
08.32:           Improvement # 3 goes from   428 to   403, diff of    25 ( 5.84%) ::  3 x Enumerator[EventRegistrationToken,__Canon][System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken,System.__Canon]:System.Collections.IEnumerator.get_Current():ref:this
08.32:           Improvement # 4 goes from   383 to   371, diff of    12 ( 3.13%) ::  3 x Enumerator[DateTime,TimeSpan][System.DateTime,System.TimeSpan]:System.Collections.IEnumerator.get_Current():ref:this
08.32:           Improvement # 5 goes from   527 to   515, diff of    12 ( 2.28%) ::  3 x Enumerator[DateTime,TimeSpan][System.DateTime,System.TimeSpan]:MoveNext():bool:this
08.32:           Improvement # 6 goes from   472 to   465, diff of     7 ( 1.48%) ::  3 x Enumerator[__Canon,EventRegistrationTokenList][System.__Canon,System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal+EventRegistrationTokenList]:System.Collections.IEnumerator.get_Current():ref:this
08.32:           Improvement # 7 goes from   256 to   253, diff of     3 ( 1.17%) ::  2 x DomainNeutralILStubClass:IL_STUB_ReversePInvoke(long):long
08.32:           Improvement # 8 goes from   374 to   371, diff of     3 ( 0.80%) ::  3 x Enumerator[Int32,DateTime][System.Int32,System.DateTime]:System.Collections.IEnumerator.get_Current():ref:this
08.32:           Improvement # 9 goes from   520 to   517, diff of     3 ( 0.58%) ::  3 x Enumerator[Int32,DateTime][System.Int32,System.DateTime]:MoveNext():bool:this
08.32:           Improvement #10 goes from 17457 to 17454, diff of     3 ( 0.02%) :: 76 x DomainNeutralILStubClass:IL_STUB_WinRTtoCLR(long):int:this
08.32:        20 functions regressed (313 total bytes regression)
08.32:           Regression # 1 goes from    61 to    85, diff of    24 (28.24%) :: System.Collections.Generic.List`1[DateTimeOffset][System.DateTimeOffset]:IsCompatibleObject(ref):bool
08.32:           Regression # 2 goes from    65 to    89, diff of    24 (26.97%) :: System.Collections.ObjectModel.ReadOnlyCollection`1[DateTimeOffset][System.DateTimeOffset]:IsCompatibleObject(ref):bool
08.32:           Regression # 3 goes from   149 to   174, diff of    25 (14.37%) :: System.Collections.Generic.List`1[DateTimeOffset][System.DateTimeOffset]:RemoveAt(int):this
08.32:           Regression # 4 goes from   595 to   641, diff of    46 ( 7.18%) :: System.Collections.Generic.ArraySortHelper`1[DateTimeOffset][System.DateTimeOffset]:PickPivotAndPartition(ref,int,int,ref):int
08.32:           Regression # 5 goes from   509 to   551, diff of    42 ( 7.62%) :: System.Collections.Generic.GenericArraySortHelper`1[DateTimeOffset][System.DateTimeOffset]:PickPivotAndPartition(ref,int,int):int
08.32:           Regression # 6 goes from   178 to   203, diff of    25 (12.32%) :: System.Collections.Generic.List`1[DateTimeOffset][System.DateTimeOffset]:FindLast(ref):struct:this
08.32:           Regression # 7 goes from   179 to   204, diff of    25 (12.25%) :: System.Collections.Generic.List`1[DateTimeOffset][System.DateTimeOffset]:Find(ref):struct:this
08.32:           Regression # 8 goes from   207 to   228, diff of    21 ( 9.21%) :: System.Collections.Generic.GenericArraySortHelper`1[DateTimeOffset][System.DateTimeOffset]:Heapsort(ref,int,int)
08.32:           Regression # 9 goes from   230 to   251, diff of    21 ( 8.37%) :: System.Collections.Generic.ArraySortHelper`1[DateTimeOffset][System.DateTimeOffset]:Heapsort(ref,int,int,ref)
08.32:           Regression #10 goes from   140 to   154, diff of    14 ( 9.09%) :: System.Diagnostics.Tracing.TraceLoggingTypeInfo`1[DateTimeOffset][System.DateTimeOffset]:WriteObjectData(ref,ref):this
08.32:        2 aggregated functions regressed (46 total bytes regression)
08.32:           Regression # 1 goes from   604 to   626, diff of    22 ( 3.51%) ::  3 x Enumerator[__Canon,EventRegistrationTokenList][System.__Canon,System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal+EventRegistrationTokenList]:MoveNext():bool:this
08.32:           Regression # 2 goes from   982 to  1006, diff of    24 ( 2.39%) :: 34 x System.ThrowHelper:IfNullAndNullsAreIllegalThenThrow(ref,int)
08.32:     TOTAL                                                  6392330     6391095        1235          0.02     42246
```