### PR TITLE
Use -f instead of -n when copying from Core_Root in runtest.sh

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -368,7 +368,8 @@ function create_core_overlay {
     if [ -d "$mscorlibDir/bin" ]; then
         cp -f -v "$mscorlibDir/bin/"* "$coreOverlayDir/" 2>/dev/null
     fi
-    cp -n -v "$testDependenciesDir"/* "$coreOverlayDir/" 2>/dev/null
+    cp -f -v "$testDependenciesDir/"xunit* "$coreOverlayDir/" 2>/dev/null
+    cp -n -v "$testDependenciesDir/"* "$coreOverlayDir/" 2>/dev/null
     if [ -f "$coreOverlayDir/mscorlib.ni.dll" ]; then
         # Test dependencies come from a Windows build, and mscorlib.ni.dll would be the one from Windows
         rm -f "$coreOverlayDir/mscorlib.ni.dll"

--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -26,8 +26,6 @@
       <DisabledProjects Include="JIT\superpmi\superpmicollect.csproj" Condition="'$(BuildTestsAgainstPackages)' == 'true'" />
       <DisabledProjects Include="Loader\classloader\generics\regressions\DD117522\Test.csproj" />
       <DisabledProjects Include="Loader\classloader\generics\GenericMethods\VSW491668.csproj" /> <!-- issue 5501 -->
-      <DisabledProjects Include="JIT\Performance\CodeQuality\Serialization\Deserialize.csproj" /> <!-- issue 9733 -->
-      <DisabledProjects Include="JIT\Performance\CodeQuality\Serialization\Serialize.csproj" /> <!-- issue 9733 -->
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
We should force copy everything from Core_Root when creating coreoverlay for a non-windows test run - previously, we were letting CoreFX binaries "win" over CoreCLR binaries, when we can more safely depend on the CoreCLR ones than the CoreFX ones (this caused the failures from https://github.com/dotnet/coreclr/issues/9733).