### PR TITLE
[x86/Linux] Fix codegen to handle GT_OBJ

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2202,6 +2202,17 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             // Do nothing; these nodes are simply markers for debug info.
             break;
 
+#if defined(_TARGET_X86_)
+        case GT_OBJ:
+        {
+            // This happens for IL_STUB_UnboxingStub
+            assert(treeNode->gtOp.gtOp1->isUsedFromReg());
+            regNumber reg = genConsumeReg(treeNode->gtOp.gtOp1);
+            emit->emitIns_R_AR(INS_mov, EA_PTRSIZE, reg, reg, 0);
+        }
+        break;
+#endif
+
         default:
         {
 #ifdef DEBUG


### PR DESCRIPTION
Add to handle GT_OBJ in genCodeForTreeNode()
- fixes unit test Loader/classloader/generics/Instantiation/Recursion/genrecur
- IL_STUB_UnboxingStub geneates GT_OBJ with register