### PR TITLE
[ARM,ARM64/Linux] Fix undefined FixContextHandler reference

### DIFF
--- a/src/vm/arm/ehhelpers.S
+++ b/src/vm/arm/ehhelpers.S
@@ -79,7 +79,7 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
 // Helpers for async (NullRef, AccessViolation) exceptions
 //
 
-        NESTED_ENTRY NakedThrowHelper2,_TEXT,FixContextHandler
+        NESTED_ENTRY NakedThrowHelper2,_TEXT,UnhandledExceptionHandlerUnix
         push         {r0, lr}
 
         // On entry:

--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -1016,7 +1016,7 @@ NESTED_END CallEHFilterFunclet, _TEXT
 // Helpers for async (NullRef, AccessViolation) exceptions
 //
 
-NESTED_ENTRY NakedThrowHelper2, _TEXT ,FixContextHandler
+NESTED_ENTRY NakedThrowHelper2, _TEXT ,UnhandledExceptionHandlerUnix
     PROLOG_SAVE_REG_PAIR_INDEXED fp,lr, -16
 
     // On entry:


### PR DESCRIPTION
#9685 cleans up FixContextHandler from Linux, but FixContextHandler is used as a personality routine in ARM/Linux and ARM64/Linux, which results in undefined reference issue.

This commit replaces it with UnhandledExceptionHandlerUnix to fix undefined reference issue (FixContextHandler seems to be Windows-specific personality routine).