### PR TITLE
JIT: keep ref count for runtime generic context lookups

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5663,8 +5663,6 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
     info.compCallUnmanaged   = 0;
     info.compLvFrameListRoot = BAD_VAR_NUM;
 
-    lvaGenericsContextUsed = false;
-
     info.compInitMem = ((methodInfo->options & CORINFO_OPT_INIT_LOCALS) != 0);
 
     /* Allocate the local variable table */

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2435,7 +2435,7 @@ public:
     unsigned lvaCallEspCheck;   // confirms ESP not corrupted after a call
 #endif
 
-    bool lvaGenericsContextUsed;
+    unsigned lvaGenericsContextUseCount;
 
     bool lvaKeepAliveAndReportThis(); // Synchronized instance method of a reference type, or
                                       // CORINFO_GENERICS_CTXT_FROM_THIS?
@@ -3322,7 +3322,10 @@ private:
                                                             GenTreePtr  variableBeingDereferenced,
                                                             InlArgInfo* inlArgInfo);
 
-    void impMarkInlineCandidate(GenTreePtr call, CORINFO_CONTEXT_HANDLE exactContextHnd, CORINFO_CALL_INFO* callInfo);
+    void impMarkInlineCandidate(GenTreePtr             call,
+                                CORINFO_CONTEXT_HANDLE exactContextHnd,
+                                bool                   exactContextNeedsRuntimeLookup,
+                                CORINFO_CALL_INFO*     callInfo);
 
     bool impTailCallRetTypeCompatible(var_types            callerRetType,
                                       CORINFO_CLASS_HANDLE callerRetTypeClass,

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6376,7 +6376,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     GenTreeArgList*        args                           = nullptr;
     CORINFO_THIS_TRANSFORM constraintCallThisTransform    = CORINFO_NO_THIS_TRANSFORM;
     CORINFO_CONTEXT_HANDLE exactContextHnd                = nullptr;
-    BOOL                   exactContextNeedsRuntimeLookup = FALSE;
+    bool                   exactContextNeedsRuntimeLookup = false;
     bool                   canTailCall                    = true;
     const char*            szCanTailCallFailReason        = nullptr;
     int                    tailCall                       = prefixFlags & PREFIX_TAILCALL;
@@ -6634,10 +6634,9 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         // Work out what sort of call we're making.
         // Dispense with virtual calls implemented via LDVIRTFTN immediately.
 
-        constraintCallThisTransform = callInfo->thisTransform;
-
+        constraintCallThisTransform    = callInfo->thisTransform;
         exactContextHnd                = callInfo->contextHandle;
-        exactContextNeedsRuntimeLookup = callInfo->exactContextNeedsRuntimeLookup;
+        exactContextNeedsRuntimeLookup = callInfo->exactContextNeedsRuntimeLookup == TRUE;
 
         // Recursive call is treaded as a loop to the begining of the method.
         if (methHnd == info.compMethodHnd)
@@ -7401,7 +7400,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 
                 // Is it an inline candidate?
-                impMarkInlineCandidate(call, exactContextHnd, exactContextNeedsRuntimeLookup == TRUE, callInfo);
+                impMarkInlineCandidate(call, exactContextHnd, exactContextNeedsRuntimeLookup, callInfo);
             }
 
             // append the call node.
@@ -7625,7 +7624,7 @@ DONE:
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 
         // Is it an inline candidate?
-        impMarkInlineCandidate(call, exactContextHnd, exactContextNeedsRuntimeLookup == TRUE, callInfo);
+        impMarkInlineCandidate(call, exactContextHnd, exactContextNeedsRuntimeLookup, callInfo);
     }
 
 DONE_CALL:

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -506,6 +506,7 @@ struct InlineCandidateInfo
     var_types              fncRetType;
     CORINFO_METHOD_HANDLE  ilCallerHandle; // the logical IL caller of this inlinee.
     CORINFO_CONTEXT_HANDLE exactContextHnd;
+    bool                   exactContextNeedsRuntimeLookup;
     CorInfoInitClassResult initClassResult;
 };
 
@@ -570,7 +571,8 @@ struct InlineInfo
         return numberOfGcRefLocals > 0;
     }
 
-    bool thisDereferencedFirst;
+    bool     thisDereferencedFirst;
+    unsigned typeContextArg;
 
 #ifdef FEATURE_SIMD
     bool hasSIMDTypeArgLocalOrReturn;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -38,6 +38,8 @@ void Compiler::lvaInit()
     lvaRefCountingStarted = false;
     lvaLocalVarRefCounted = false;
 
+    lvaGenericsContextUseCount = 0;
+
     lvaSortAgain    = false; // false: We don't need to call lvaSortOnly()
     lvaTrackedFixed = false; // false: We can still add new tracked variables
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16305,7 +16305,7 @@ GenTreePtr Compiler::fgInitThisClass()
         // Collectible types requires that for shared generic code, if we use the generic context paramter
         // that we report it. (This is a conservative approach, we could detect some cases particularly when the
         // context parameter is this that we don't need the eager reporting logic.)
-        lvaGenericsContextUsed = true;
+        lvaGenericsContextUseCount++;
 
         switch (kind.runtimeLookupKind)
         {


### PR DESCRIPTION
Keep a ref count for runtime generic context lookups, and track when
an inlinee requires a runtime lookup but then ignores the resulting
context. Only report/keep the context alive if there are known uses.

This pattern happens frequently in inlined generic code that uses
type tests to extract properties of types.

Addresses #1691.