### PR TITLE
Remove  `this == null` checks from string.Equals

### DIFF
--- a/src/mscorlib/src/System/String.Comparison.cs
+++ b/src/mscorlib/src/System/String.Comparison.cs
@@ -850,9 +850,6 @@ namespace System
         // Determines whether two strings match.
         public override bool Equals(Object obj)
         {
-            if (this == null)                        // this is necessary to guard against reverse-pinvokes and
-                throw new NullReferenceException();  // other callers who do not use the callvirt instruction
-
             if (object.ReferenceEquals(this, obj))
                 return true;
 
@@ -870,9 +867,6 @@ namespace System
         [Pure]
         public bool Equals(String value)
         {
-            if (this == null)                        // this is necessary to guard against reverse-pinvokes and
-                throw new NullReferenceException();  // other callers who do not use the callvirt instruction
-
             if (object.ReferenceEquals(this, value))
                 return true;
 


### PR DESCRIPTION
Separated from https://github.com/dotnet/coreclr/pull/9744

Are these checks still needed in .NET Core? The comments mention 2 things: 1) people using reverse P/Invoke, and 2) people using call instead of callvirt, the latter of which is emitted by C#/VB compilers for all classes. Both of these seem like they would be pretty rare.

/cc @jkotas