### PR TITLE
Remove OSX FileStream Lock/Unlock

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -858,6 +858,12 @@
     <MscorlibSources Include="$(CoreFxSourcesRoot)\Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs" />
     <MscorlibSources Include="$(CoreFxSourcesRoot)\System\IO\FileStream.Unix.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true' and '$(TargetsOSX)' == 'true'">
+    <MscorlibSources Include="$(CoreFxSourcesRoot)\System\IO\FileStream.OSX.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true' and '$(TargetsOSX)' != 'true'">
+    <MscorlibSources Include="$(CoreFxSourcesRoot)\System\IO\FileStream.Linux.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' != 'true'">
     <MscorlibSources Include="$(CoreFxSourcesRoot)\Microsoft\Win32\SafeHandles\SafeFileHandle.Windows.cs" />
     <MscorlibSources Include="$(CoreFxSourcesRoot)\System\IO\FileStream.Win32.cs" />

--- a/src/mscorlib/corefx/System/IO/FileStream.Linux.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.Linux.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    public partial class FileStream : Stream
+    {
+        /// <summary>Prevents other processes from reading from or writing to the FileStream.</summary>
+        /// <param name="position">The beginning of the range to lock.</param>
+        /// <param name="length">The range to be locked.</param>
+        private void LockInternal(long position, long length)
+        {
+            CheckFileCall(Interop.Sys.LockFileRegion(_fileHandle, position, length, Interop.Sys.LockType.F_WRLCK));
+        }
+
+        /// <summary>Allows access by other processes to all or part of a file that was previously locked.</summary>
+        /// <param name="position">The beginning of the range to unlock.</param>
+        /// <param name="length">The range to be unlocked.</param>
+        private void UnlockInternal(long position, long length)
+        {
+            CheckFileCall(Interop.Sys.LockFileRegion(_fileHandle, position, length, Interop.Sys.LockType.F_UNLCK));
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/IO/FileStream.OSX.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.OSX.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    public partial class FileStream : Stream
+    {
+        private void LockInternal(long position, long length)
+        {
+            throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_OSXFileLocking"));
+        }
+
+        private void UnlockInternal(long position, long length)
+        {
+            throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_OSXFileLocking"));
+        }
+    }
+}

--- a/src/mscorlib/corefx/System/IO/FileStream.Unix.cs
+++ b/src/mscorlib/corefx/System/IO/FileStream.Unix.cs
@@ -796,22 +796,6 @@ namespace System.IO
             }
         }
 
-        /// <summary>Prevents other processes from reading from or writing to the FileStream.</summary>
-        /// <param name="position">The beginning of the range to lock.</param>
-        /// <param name="length">The range to be locked.</param>
-        private void LockInternal(long position, long length)
-        {
-            CheckFileCall(Interop.Sys.LockFileRegion(_fileHandle, position, length, Interop.Sys.LockType.F_WRLCK));
-        }
-
-        /// <summary>Allows access by other processes to all or part of a file that was previously locked.</summary>
-        /// <param name="position">The beginning of the range to unlock.</param>
-        /// <param name="length">The range to be unlocked.</param>
-        private void UnlockInternal(long position, long length)
-        {
-            CheckFileCall(Interop.Sys.LockFileRegion(_fileHandle, position, length, Interop.Sys.LockType.F_UNLCK));
-        }
-
         /// <summary>Sets the current position of this stream to the given value.</summary>
         /// <param name="offset">The point relative to origin from which to begin seeking. </param>
         /// <param name="origin">

--- a/src/mscorlib/src/System.Private.CoreLib.txt
+++ b/src/mscorlib/src/System.Private.CoreLib.txt
@@ -1720,7 +1720,7 @@ event_Barrier_PhaseFinished=Barrier finishing phase {1}.
 PlatformNotSupported_NamedSynchronizationPrimitives=The named version of this synchronization primitive is not supported on this platform.
 PlatformNotSupported_NamedSyncObjectWaitAnyWaitAll=Wait operations on multiple wait handles including a named synchronization primitive are not supported on this platform.
 ; OSX File locking
-PlatformNotSupported_OSXFileLocking=Locking/unlocking file regions is not supported. Use FileShare on the entire file instead.
+PlatformNotSupported_OSXFileLocking=Locking/unlocking file regions is not supported on this platform. Use FileShare on the entire file instead.
 #endif
 
 ;

--- a/src/mscorlib/src/System.Private.CoreLib.txt
+++ b/src/mscorlib/src/System.Private.CoreLib.txt
@@ -1719,6 +1719,8 @@ event_Barrier_PhaseFinished=Barrier finishing phase {1}.
 ; Unix threading
 PlatformNotSupported_NamedSynchronizationPrimitives=The named version of this synchronization primitive is not supported on this platform.
 PlatformNotSupported_NamedSyncObjectWaitAnyWaitAll=Wait operations on multiple wait handles including a named synchronization primitive are not supported on this platform.
+; OSX File locking
+PlatformNotSupported_OSXFileLocking=Locking/unlocking file regions is not supported. Use FileShare on the entire file instead.
 #endif
 
 ;


### PR DESCRIPTION
OSX doesn't support usage of both fcntl and flock. Since we're already using one in FileShare for the entire file, we cannot enable partial file locking like we do on other Unix platforms. The alternative is to throw a PNSE and suggest using FileShare on the whole file instead.

resolves https://github.com/dotnet/corefx/issues/5964

@stephentoub @JeremyKuhne 