### PR TITLE
Remove NakedThrowHelper and ifdef-out its callers

### DIFF
--- a/src/vm/amd64/unixstubs.cpp
+++ b/src/vm/amd64/unixstubs.cpp
@@ -11,11 +11,6 @@ extern "C"
         PORTABILITY_ASSERT("Implement for PAL");
     }
 
-    void NakedThrowHelper()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
     void PInvokeStubForHost()
     {
         PORTABILITY_ASSERT("Implement for PAL");

--- a/src/vm/arm/ehhelpers.S
+++ b/src/vm/arm/ehhelpers.S
@@ -75,27 +75,6 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         .endm
 
 // ------------------------------------------------------------------
-//
-// Helpers for async (NullRef, AccessViolation) exceptions
-//
-
-        NESTED_ENTRY NakedThrowHelper2,_TEXT,UnhandledExceptionHandlerUnix
-        push         {r0, lr}
-
-        // On entry:
-        //
-        // R0 = Address of FaultingExceptionFrame
-        bl C_FUNC(LinkFrameAndThrow)
-
-        // Target should not return.
-        EMIT_BREAKPOINT
-
-        NESTED_END NakedThrowHelper2, _TEXT
-
-
-        GenerateRedirectedStubWithFrame NakedThrowHelper, NakedThrowHelper2
-
-// ------------------------------------------------------------------
 
         // This helper enables us to call into a funclet after applying the non-volatiles
         NESTED_ENTRY CallEHFunclet, _TEXT, NoHandler

--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -1012,27 +1012,6 @@ NESTED_END CallEHFilterFunclet, _TEXT
 
 
 // ------------------------------------------------------------------
-//
-// Helpers for async (NullRef, AccessViolation) exceptions
-//
-
-NESTED_ENTRY NakedThrowHelper2, _TEXT ,UnhandledExceptionHandlerUnix
-    PROLOG_SAVE_REG_PAIR_INDEXED fp,lr, -16
-
-    // On entry:
-    //
-    // X0 = Address of FaultingExceptionFrame
-    bl C_FUNC(LinkFrameAndThrow)
-
-    // Target should not return.
-    EMIT_BREAKPOINT
-
-NESTED_END NakedThrowHelper2, _TEXT
-
-
-GenerateRedirectedStubWithFrame NakedThrowHelper, NakedThrowHelper2
-
-// ------------------------------------------------------------------
 // ResolveWorkerChainLookupAsmStub
 //
 // This method will perform a quick chained lookup of the entry if the


### PR DESCRIPTION
This change removes NakedThrowHelper function for Unix since it was not used.
It also ifdefs out its upstream callers.