### PR TITLE
Fix incremental build on Unix

### DIFF
--- a/src/debug/daccess/CMakeLists.txt
+++ b/src/debug/daccess/CMakeLists.txt
@@ -10,8 +10,8 @@ include_directories(${CLR_DIR}/src/debug/ee)
 include_directories(${CLR_DIR}/src/gcdump)
 
 if(CLR_CMAKE_PLATFORM_UNIX)
-    include_directories(${GENERATED_INCLUDE_DIR})
-    add_compile_options(-fPIC)
+  include_directories(${GENERATED_INCLUDE_DIR})
+  add_compile_options(-fPIC)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 set(DACCESS_SOURCES
@@ -44,5 +44,23 @@ add_precompiled_header(stdafx.h stdafx.cpp DACCESS_SOURCES)
 add_library_clr(daccess ${DACCESS_SOURCES})
 
 if(CLR_CMAKE_PLATFORM_UNIX)
-    add_dependencies(daccess coreclr)
+  add_custom_command(
+    OUTPUT  ${GENERATED_INCLUDE_DIR}/dactablerva.h
+    DEPENDS coreclr
+    VERBATIM
+    COMMAND sh ${CLR_DIR}/src/pal/tools/gen-dactable-rva.sh $<TARGET_FILE:coreclr> ${GENERATED_INCLUDE_DIR}/dactablerva.h
+    COMMENT Generating ${GENERATED_INCLUDE_DIR}/dactablerva.h
+  )
+
+  set_source_files_properties(
+    ${GENERATED_INCLUDE_DIR}/dactablerva.h
+    PROPERTIES GENERATED TRUE
+  )
+
+  add_custom_target(
+    dactablerva_header
+    DEPENDS ${GENERATED_INCLUDE_DIR}/dactablerva.h
+  )
+
+  add_dependencies(daccess coreclr dactablerva_header)
 endif(CLR_CMAKE_PLATFORM_UNIX)

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -168,14 +168,6 @@ if(WIN32)
         COMMAND ${BuildToolsDir}/InjectResource.exe /bin:${CMAKE_CURRENT_BINARY_DIR}/clrDebugResource.bin /dll:$<TARGET_FILE:coreclr> /name:CLRDEBUGINFO
         COMMENT Add dactable & debug resources to coreclr
     )
-else()
-    add_custom_command(
-        TARGET coreclr
-        POST_BUILD
-        VERBATIM 
-        COMMAND sh ${CLR_DIR}/src/pal/tools/gen-dactable-rva.sh $<TARGET_FILE:coreclr> ${GENERATED_INCLUDE_DIR}/dactablerva.h
-        COMMENT Generating ${GENERATED_INCLUDE_DIR}/dactablerva.h
-    )
 endif(WIN32)
 
 # add the install targets


### PR DESCRIPTION
This change fixes issue with dactablerva.h being generated even if the
libcoreclr.so hasn't changed. Also, the dependency of the daccess.cpp
on this header was not honored by the build system and so even if the
dactablerva.h was regenerated with a different contents, the daccess.cpp
was not rebuilt.