### PR TITLE
Increase the length of allowed parameters in ilasm

### DIFF
--- a/src/ilasm/main.cpp
+++ b/src/ilasm/main.cpp
@@ -106,7 +106,7 @@ extern "C" int _cdecl wmain(int argc, __in WCHAR **argv)
 {
     int         i, NumFiles = 0, NumDeltaFiles = 0;
     bool        IsDLL = false, IsOBJ = false;
-    char        szOpt[128];
+    char        szOpt[1024];
     Assembler   *pAsm;
     MappedFileStream *pIn;
     AsmParse    *pParser;


### PR DESCRIPTION
The way this code is structured prevents parameters longer than 128 characters from being passed. This change simply increases that to 1024 characters, although a more robust change could be made in the future to account for platform differences.

Related to https://github.com/dotnet/coreclr/issues/9757

@RussKeldorph 