### PR TITLE
Fix SpanBench

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -17,7 +17,7 @@ using Xunit;
 namespace Span
 {
 
-public class Tests
+public class SpanBench
 {
 
 #if DEBUG
@@ -31,7 +31,6 @@ public class Tests
 #endif
 
     const int Size = 1024;
-
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static void TestFillAllSpan(Span<byte> span)
@@ -452,7 +451,7 @@ public class Tests
 
     static Action LookupFunc(object o)
     {
-        TypeInfo t = typeof(Tests).GetTypeInfo();
+        TypeInfo t = typeof(SpanBench).GetTypeInfo();
         MethodInfo m = t.GetDeclaredMethod((string) o);
         return m.CreateDelegate(typeof(Action)) as Action;
     }

--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -17,7 +17,7 @@ using Xunit;
 namespace Span
 {
 
-public class Benchmark
+public class SpanBench
 {
 
 #if DEBUG
@@ -451,7 +451,7 @@ public class Benchmark
 
     static Action LookupFunc(object o)
     {
-        TypeInfo t = typeof(Benchmark).GetTypeInfo();
+        TypeInfo t = typeof(SpanBench).GetTypeInfo();
         MethodInfo m = t.GetDeclaredMethod((string) o);
         return m.CreateDelegate(typeof(Action)) as Action;
     }

--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -17,7 +17,7 @@ using Xunit;
 namespace Span
 {
 
-public class SpanBench
+public class Bench
 {
 
 #if DEBUG
@@ -451,7 +451,7 @@ public class SpanBench
 
     static Action LookupFunc(object o)
     {
-        TypeInfo t = typeof(SpanBench).GetTypeInfo();
+        TypeInfo t = typeof(Bench).GetTypeInfo();
         MethodInfo m = t.GetDeclaredMethod((string) o);
         return m.CreateDelegate(typeof(Action)) as Action;
     }

--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -17,7 +17,7 @@ using Xunit;
 namespace Span
 {
 
-public class Bench
+public class Benchmark
 {
 
 #if DEBUG
@@ -451,7 +451,7 @@ public class Bench
 
     static Action LookupFunc(object o)
     {
-        TypeInfo t = typeof(Bench).GetTypeInfo();
+        TypeInfo t = typeof(Benchmark).GetTypeInfo();
         MethodInfo m = t.GetDeclaredMethod((string) o);
         return m.CreateDelegate(typeof(Action)) as Action;
     }

--- a/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Span/SpanBench.cs
@@ -14,13 +14,20 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-class Tests
+namespace Span
+{
+
+public class Tests
 {
 
 #if DEBUG
-    const int Iterations = 1;
+    const int BubbleSortIterations = 1;
+    const int QuickSortIterations = 1;
+    const int FillAllIterations = 1;
 #else
-    const int Iterations = 10000;
+    const int BubbleSortIterations = 1000;
+    const int QuickSortIterations = 10000;
+    const int FillAllIterations = 1000000;
 #endif
 
     const int Size = 1024;
@@ -198,7 +205,7 @@ class Tests
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < FillAllIterations; i++)
                 {
                     TestFillAllSpan(s);
                 }
@@ -214,7 +221,7 @@ class Tests
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < FillAllIterations; i++)
                 {
                     TestFillAllArray(a);
                 }
@@ -231,7 +238,7 @@ class Tests
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < FillAllIterations; i++)
                 {
                     TestFillAllReverseSpan(s);
                 }
@@ -247,7 +254,7 @@ class Tests
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < FillAllIterations; i++)
                 {
                     TestFillAllReverseArray(a);
                 }
@@ -266,7 +273,7 @@ class Tests
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < QuickSortIterations; i++)
                 {
                     Array.Copy(unsortedData, data, Size);
                     TestQuickSortSpan(span);
@@ -286,7 +293,7 @@ class Tests
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < BubbleSortIterations; i++)
                 {
                     Array.Copy(unsortedData, data, Size);
                     TestBubbleSortSpan(span);
@@ -305,7 +312,7 @@ class Tests
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < QuickSortIterations; i++)
                 {
                     Array.Copy(unsortedData, data, Size);
                     TestQuickSortArray(data);
@@ -324,7 +331,7 @@ class Tests
         {
             using (iteration.StartMeasurement())
             {
-                for (int i = 0; i < Iterations; i++)
+                for (int i = 0; i < BubbleSortIterations; i++)
                 {
                     Array.Copy(unsortedData, data, Size);
                     TestBubbleSortArray(data);
@@ -339,7 +346,7 @@ class Tests
     {
         byte[] a = new byte[Size];
         Span<byte> s = new Span<byte>(a);
-        for (int i = 0; i < Iterations; i++)
+        for (int i = 0; i < FillAllIterations; i++)
         {
             TestFillAllSpan(s);
         }
@@ -348,7 +355,7 @@ class Tests
     static void FillAllArrayBase()
     {
         byte[] a = new byte[Size];
-        for (int i = 0; i < Iterations; i++)
+        for (int i = 0; i < FillAllIterations; i++)
         {
             TestFillAllArray(a);
         }
@@ -358,7 +365,7 @@ class Tests
     {
         byte[] a = new byte[Size];
         Span<byte> s = new Span<byte>(a);
-        for (int i = 0; i < Iterations; i++)
+        for (int i = 0; i < FillAllIterations; i++)
         {
             TestFillAllReverseSpan(s);
         }
@@ -367,7 +374,7 @@ class Tests
     static void FillAllReverseArrayBase()
     {
         byte[] a = new byte[Size];
-        for (int i = 0; i < Iterations; i++)
+        for (int i = 0; i < FillAllIterations; i++)
         {
             TestFillAllReverseArray(a);
         }
@@ -379,7 +386,7 @@ class Tests
         int[] unsortedData = GetUnsortedData();
         Span<int> span = new Span<int>(data);
 
-        for (int i = 0; i < Iterations; i++)
+        for (int i = 0; i < QuickSortIterations; i++)
         {
             Array.Copy(unsortedData, data, Size);
             TestQuickSortSpan(span);
@@ -392,7 +399,7 @@ class Tests
         int[] unsortedData = GetUnsortedData();
         Span<int> span = new Span<int>(data);
 
-        for (int i = 0; i < Iterations; i++)
+        for (int i = 0; i < BubbleSortIterations; i++)
         {
             Array.Copy(unsortedData, data, Size);
             TestBubbleSortSpan(span);
@@ -404,7 +411,7 @@ class Tests
         int[] data = new int[Size];
         int[] unsortedData = GetUnsortedData();
 
-        for (int i = 0; i < Iterations; i++)
+        for (int i = 0; i < QuickSortIterations; i++)
         {
             Array.Copy(unsortedData, data, Size);
             TestQuickSortArray(data);
@@ -416,7 +423,7 @@ class Tests
         int[] data = new int[Size];
         int[] unsortedData = GetUnsortedData();
 
-        for (int i = 0; i < Iterations; i++)
+        for (int i = 0; i < BubbleSortIterations; i++)
         {
             Array.Copy(unsortedData, data, Size);
             TestBubbleSortArray(data);
@@ -466,3 +473,4 @@ class Tests
     }
 }
 
+}


### PR DESCRIPTION
Make benchmark class public, add namespace. Tweak iteration counts
to very roughly 1 second per xunit-perf iteration.