### PR TITLE
Fix GC hole when exception filter throws unhandled exception

### DIFF
--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -653,6 +653,11 @@ public:
     {
         return !m_ExceptionFlags.UnwindHasStarted();
     }
+
+    EHClauseInfo* GetEHClauseInfo()
+    {
+        return &m_EHClauseInfo;
+    }
     
 private: ;
 


### PR DESCRIPTION
The extra Unix specific piece of code in the StackFrameIterator::Filter that
handles the difference in the exception stack unwinding on Unix was not
skipping exception trackers belonging to filter clauses. But that was not
right, since filter funclet stack frames behave the same way on Windows and
Unix. They can be present on the stack when we reach their parent frame if
the filter hasn't finished running yet or they can be gone if the filter
completed running, either succesfully or with unhandled exception.

This change adds skipping of filter funclet related exception trackers at
that place so that the common code processes them.

This fixes the GC hole mentioned in the title.