### PR TITLE
Fix _our_GetThreadCycles for clang/xarch.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -73,9 +73,9 @@ inline bool _our_GetThreadCycles(unsigned __int64* cycleOut)
 
 inline bool _our_GetThreadCycles(unsigned __int64* cycleOut)
 {
-    uint64_t cycles;
-    asm volatile("rdtsc" : "=A"(cycles));
-    *cycleOut = cycles;
+    uint32_t hi, lo;
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+    *cycleOut = (static_cast<unsigned __int64>(hi) << 32) | static_cast<unsigned __int64>(lo);
     return true;
 }
 


### PR DESCRIPTION
The `"=A"` constraint in `asm volatile("rdtsc" : "=A"(cycles))` does not work as expected
on AMD64. Instead, the assembly must use an output constraint for both `eax` and `edx`
(i.e. `=a"(lo), "=d"(hi)`).