### PR TITLE
Better ArraySegment .ctor validation

### DIFF
--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -45,8 +45,9 @@ namespace System
         public ArraySegment(T[] array, int offset, int count)
         {
             // Validate arguments, check is minimal instructions with reduced branching for inlinable fast-path
+            // Negative values discovered though conversion to high values when converted to unsigned
             // Failure should be rare and location determination and message is delegated to failure functions
-            if (array == null || (offset | count) < 0 || (array.Length - offset < count))
+            if (array == null || (uint)offset > (uint)array.Length || (uint)count > (uint)(array.Length - offset))
                 ThrowHelper.ThrowArraySegmentCtorValidationFailedExceptions(array, offset, count);
             Contract.EndContractBlock();
 


### PR DESCRIPTION
Same il count; however the unsigned test produces better asm than the bitwise combine (87 vs 91)

Before
```asm
**************** Inline Tree
Inlines into 060002C8 ArraySegment`1:.ctor(ref,int,int):this
  [0 IL=0020 TR=000010 0600030D] [FAILED: does not return] ThrowHelper:ThrowArraySegmentCtorValidationFailedExceptions(ref,int,int)
Budget: initialTime=201, finalTime=201, initialBudget=2010, currentBudget=2010
Budget: initialSize=1202, finalSize=1202
; Assembly listing for method ArraySegment`1:.ctor(ref,int,int):this
; Emitting BLENDED_CODE for X64 CPU with SSE2
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 this         [V00,T02] (  5,   5  )   byref  ->  rdi         this
;* V01 TypeCtx      [V01    ] (  0,   0  )    long  ->  zero-ref   
;  V02 arg1         [V02,T00] (  6,   5  )     ref  ->   r8        
;  V03 arg2         [V03,T01] (  6,   5  )     int  ->  rsi        
;  V04 arg3         [V04,T03] (  4,   3  )     int  ->  rbx        
;  V05 loc0         [V05    ] (  1,   1  )  lclBlk (32) [rsp+0x00]  
;
; Lcl frame size = 32

G_M41507_IG01:
       57                   push     rdi
       56                   push     rsi
       53                   push     rbx
       4883EC20             sub      rsp, 32
       488BF9               mov      rdi, rcx
       418BF1               mov      esi, r9d
       8B5C2460             mov      ebx, dword ptr [rsp+60H]

G_M41507_IG02:
       4D85C0               test     r8, r8
       0F8400000000         je       G_M41507_IG05
       8BD6                 mov      edx, esi
       0BD3                 or       edx, ebx
       85D2                 test     edx, edx
       0F8C00000000         jl       G_M41507_IG05
       418B5008             mov      edx, dword ptr [r8+8]
       2BD6                 sub      edx, esi
       3BD3                 cmp      edx, ebx
       0F8C00000000         jl       G_M41507_IG05

G_M41507_IG03:
       488BCF               mov      rcx, rdi
       498BD0               mov      rdx, r8
       E800000000           call     CORINFO_HELP_CHECKED_ASSIGN_REF
       897708               mov      dword ptr [rdi+8], esi
       895F0C               mov      dword ptr [rdi+12], ebx

G_M41507_IG04:
       4883C420             add      rsp, 32
       5B                   pop      rbx
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      

************** Beginning of cold code **************

G_M41507_IG05:
       498BC8               mov      rcx, r8
       8BD6                 mov      edx, esi
       448BC3               mov      r8d, ebx
       E800000000           call     ThrowHelper:ThrowArraySegmentCtorValidationFailedExceptions(ref,int,int)
       CC                   int3     

; Total bytes of code 91, prolog size 7 for method ArraySegment`1:.ctor(ref,int,int):this
; ============================================================
```
After
```asm
**************** Inline Tree
Inlines into 060002C8 ArraySegment`1:.ctor(ref,int,int):this
  [0 IL=0020 TR=000010 0600030D] [FAILED: does not return] ThrowHelper:ThrowArraySegmentCtorValidationFailedExceptions(ref,int,int)
Budget: initialTime=201, finalTime=201, initialBudget=2010, currentBudget=2010
Budget: initialSize=1202, finalSize=1202
; Assembly listing for method ArraySegment`1:.ctor(ref,int,int):this
; Emitting BLENDED_CODE for X64 CPU with SSE2
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 this         [V00,T02] (  5,   5  )   byref  ->  rdi         this
;* V01 TypeCtx      [V01    ] (  0,   0  )    long  ->  zero-ref   
;  V02 arg1         [V02,T01] (  7,   6  )     ref  ->   r8        
;  V03 arg2         [V03,T00] (  8,   7  )     int  ->  rsi        
;  V04 arg3         [V04,T04] (  4,   3  )     int  ->  rbx        
;  V05 loc0         [V05    ] (  1,   1  )  lclBlk (32) [rsp+0x00]  
;  V06 cse0         [V06,T03] (  6,   6  )     int  ->  rdx        
;
; Lcl frame size = 32

G_M41507_IG01:
       57                   push     rdi
       56                   push     rsi
       53                   push     rbx
       4883EC20             sub      rsp, 32
       488BF9               mov      rdi, rcx
       418BF1               mov      esi, r9d
       8B5C2460             mov      ebx, dword ptr [rsp+60H]

G_M41507_IG02:
       4D85C0               test     r8, r8
       0F8400000000         je       G_M41507_IG05
       418B5008             mov      edx, dword ptr [r8+8]
       3BD6                 cmp      edx, esi
       0F8200000000         jb       G_M41507_IG05
       2BD6                 sub      edx, esi
       3BD3                 cmp      edx, ebx
       0F8200000000         jb       G_M41507_IG05

G_M41507_IG03:
       488BCF               mov      rcx, rdi
       498BD0               mov      rdx, r8
       E800000000           call     CORINFO_HELP_CHECKED_ASSIGN_REF
       897708               mov      dword ptr [rdi+8], esi
       895F0C               mov      dword ptr [rdi+12], ebx

G_M41507_IG04:
       4883C420             add      rsp, 32
       5B                   pop      rbx
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      

************** Beginning of cold code **************

G_M41507_IG05:
       498BC8               mov      rcx, r8
       8BD6                 mov      edx, esi
       448BC3               mov      r8d, ebx
       E800000000           call     ThrowHelper:ThrowArraySegmentCtorValidationFailedExceptions(ref,int,int)
       CC                   int3     

; Total bytes of code 87, prolog size 7 for method ArraySegment`1:.ctor(ref,int,int):this
; ============================================================
```
