### PR TITLE
[x86/Linux] Clean up PopSEHRecords

### DIFF
--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -52,11 +52,6 @@ extern "C"
     }
 };
 
-VOID __cdecl PopSEHRecords(LPVOID pTargetSP)
-{
-    PORTABILITY_ASSERT("Implement for PAL");
-}
-
 EXTERN_C VOID BackPatchWorkerAsmStub()
 {
     PORTABILITY_ASSERT("BackPatchWorkerAsmStub");


### PR DESCRIPTION
PopSEHRecords is introduced while x86/Linux bring up, but no longer used.

This commit cleans up PopSEHRecords from x86/Linux codebase.