### PR TITLE
[x86/Linux] Clean up CallRtlUnwind

### DIFF
--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -44,12 +44,6 @@ extern "C"
     void STDCALL JIT_ProfilerEnterLeaveTailcallStub(UINT_PTR ProfilerHandle)
     {
     }
-
-    BOOL CallRtlUnwind()
-    {
-        PORTABILITY_ASSERT("CallRtlUnwind");
-        return FALSE;
-    }
 };
 
 VOID __cdecl PopSEHRecords(LPVOID pTargetSP)


### PR DESCRIPTION
CallRtlUnwind is added as a stub while x86/Linux bring up, but no longer used.

This commit cleans up unused CallRtlUnwind.