### PR TITLE
[x86/Linux] Use _X86_ instead of _TARGET_X86_

### DIFF
--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -226,11 +226,11 @@ Parameters:
     PAL_SEHException* ex - the exception to throw.
 --*/
 extern "C"
-#ifdef _TARGET_X86_
+#ifdef _X86_
 void __fastcall ThrowExceptionHelper(PAL_SEHException* ex)
-#else // _TARGET_X86_
+#else // _X86_
 void ThrowExceptionHelper(PAL_SEHException* ex)
-#endif // !_TARGET_X86_
+#endif // !_X86_
 {
     throw std::move(*ex);
 }


### PR DESCRIPTION
PAL layer uses _X86_ instead of _TARGET_X86_, and thus __fastcall ifdefed by _TARGET_X86_ has no effect.