### PR TITLE
Clean up nested WIN64EXCEPTIONS-ifdef

### DIFF
--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -777,9 +777,7 @@ private: ;
     EnclosingClauseInfo     m_EnclosingClauseInfoOfCollapsedTracker;
 };
 
-#if defined(WIN64EXCEPTIONS)
 PTR_ExceptionTracker GetEHTrackerForPreallocatedException(OBJECTREF oPreAllocThrowable, PTR_ExceptionTracker pStartingEHTracker);
-#endif // WIN64EXCEPTIONS
 
 class TrackerAllocator
 {


### PR DESCRIPTION
This commit cleans up a (unnecessary) nested WIN64EXCEPTIONS-ifdef in exceptionhandling.h.