### PR TITLE
[x86/Linux] Initial filter support

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1794,6 +1794,15 @@ typedef struct _CONTEXT {
 // support any other values in the ExtendedRegisters) but we might as well be as accurate as we can.
 #define CONTEXT_EXREG_XMM_OFFSET 160
 
+typedef struct _KNONVOLATILE_CONTEXT {
+
+    DWORD Edi;
+    DWORD Esi;
+    DWORD Ebx;
+    DWORD Ebp;
+
+} KNONVOLATILE_CONTEXT, *PKNONVOLATILE_CONTEXT;
+
 typedef struct _KNONVOLATILE_CONTEXT_POINTERS {
 
     // The ordering of these fields should be aligned with that

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1502,6 +1502,7 @@ typedef struct _DISPATCHER_CONTEXT {
     PRUNTIME_FUNCTION FunctionEntry;
     DWORD EstablisherFrame;
     DWORD TargetIp;
+    PCONTEXT CurrentRecord;
     PCONTEXT ContextRecord;
     PEXCEPTION_ROUTINE LanguageHandler;
     PVOID HandlerData;

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1502,7 +1502,7 @@ typedef struct _DISPATCHER_CONTEXT {
     PRUNTIME_FUNCTION FunctionEntry;
     DWORD EstablisherFrame;
     DWORD TargetIp;
-    PCONTEXT CurrentRecord;
+    PKNONVOLATILE_CONTEXT CurrentRecord;
     PCONTEXT ContextRecord;
     PEXCEPTION_ROUTINE LanguageHandler;
     PVOID HandlerData;

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1502,7 +1502,7 @@ typedef struct _DISPATCHER_CONTEXT {
     PRUNTIME_FUNCTION FunctionEntry;
     DWORD EstablisherFrame;
     DWORD TargetIp;
-    PKNONVOLATILE_CONTEXT CurrentRecord;
+    PKNONVOLATILE_CONTEXT CurrentNonVolatileContextRecord;
     PCONTEXT ContextRecord;
     PEXCEPTION_ROUTINE LanguageHandler;
     PVOID HandlerData;

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -1306,7 +1306,7 @@ void ExceptionTracker::InitializeCurrentContextForCrawlFrame(CrawlFrame* pcfThis
         // Ensure that clients can tell the current context isn't valid.
         SetIP(pRD->pCurrentContext, 0);
 #else // !USE_CURRENT_CONTEXT_IN_FILTER
-        RestoreNonvolatileRegisters(pRD->pCurrentContext, pDispatcherContext->CurrentRecord);
+        RestoreNonvolatileRegisters(pRD->pCurrentContext, pDispatcherContext->CurrentNonVolatileContextRecord);
 #endif // USE_CURRENT_CONTEXT_IN_FILTER
 
         *(pRD->pCallerContext)      = *(pDispatcherContext->ContextRecord);
@@ -4540,8 +4540,8 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex, CONTEXT
         if (dispatcherContext.FunctionEntry != NULL)
         {
 #ifdef USE_CURRENT_CONTEXT_IN_FILTER
-            KNONVOLATILE_CONTEXT currentContext;
-            CaptureNonvolatileRegisters(&currentContext, frameContext);
+            KNONVOLATILE_CONTEXT currentNonVolatileContext;
+            CaptureNonvolatileRegisters(&currentNonVolatileContext, frameContext);
 #endif // USE_CURRENT_CONTEXT_IN_FILTER
 
             RtlVirtualUnwind(UNW_FLAG_EHANDLER,
@@ -4563,7 +4563,7 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex, CONTEXT
 
             dispatcherContext.EstablisherFrame = establisherFrame;
 #ifdef USE_CURRENT_CONTEXT_IN_FILTER
-            dispatcherContext.CurrentRecord = &currentContext;
+            dispatcherContext.CurrentNonVolatileContextRecord = &currentNonVolatileContext;
 #endif // USE_CURRENT_CONTEXT_IN_FILTER
             dispatcherContext.ContextRecord = frameContext;
 


### PR DESCRIPTION
Filters in x86/Linux require EE to set frame pointer before EE calls them, but it is impossible to pass correct frame pointer in the current implementation.

This commit revises EH subsystem to pass correct context for the first pass.