### PR TITLE
[x86/Linux] Clean up unused NakedThrowHelper stub

### DIFF
--- a/src/vm/i386/unixstubs.cpp
+++ b/src/vm/i386/unixstubs.cpp
@@ -11,11 +11,6 @@ extern "C"
         PORTABILITY_ASSERT("Implement for PAL");
     }
 
-    void NakedThrowHelper()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
     void ProfileEnterNaked(FunctionIDOrClientID functionIDOrClientID)    
     {
         PORTABILITY_ASSERT("Implement for PAL");


### PR DESCRIPTION
This commit cleans up NakedThrowHelper stub from x86/Linux (similarly as #9771).