### PR TITLE
[RyuJIT/ARM32] P/Invoke support

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1513,7 +1513,13 @@ void CodeGen::genCallInstruction(GenTreePtr node)
         }
         else
         {
-            if (varTypeIsFloating(returnType))
+            if (call->IsHelperCall(compiler, CORINFO_HELP_INIT_PINVOKE_FRAME))
+            {
+                // The CORINFO_HELP_INIT_PINVOKE_FRAME helper uses a custom calling convention that returns with
+                // TCB in REG_PINVOKE_TCB. fgMorphCall() sets the correct argument registers.
+                returnReg = REG_PINVOKE_TCB;
+            }
+            else if (varTypeIsFloating(returnType))
             {
                 returnReg = REG_FLOATRET;
             }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2758,6 +2758,8 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
                     needFloatTmpForFPCall = true;
                 }
             }
+#endif // _TARGET_X86_
+#if defined(_TARGET_X86_) || defined(_TARGET_ARM_)
             if (tree->IsHelperCall())
             {
                 GenTreeCall*    call     = tree->AsCall();
@@ -2765,7 +2767,7 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
                 killMask                 = compiler->compHelperCallKillSet(helpFunc);
             }
             else
-#endif // _TARGET_X86_
+#endif // defined(_TARGET_X86_) || defined(_TARGET_ARM_)
             {
                 // if there is no FP used, we can ignore the FP kills
                 if (compiler->compFloatingPointUsed)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2881,9 +2881,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
         CLANG_FORMAT_COMMENT_ANCHOR;
 
 #if !defined(LEGACY_BACKEND)
-#if defined(_TARGET_X86_)
-        // The x86 CORINFO_HELP_INIT_PINVOKE_FRAME helper has a custom calling convention. Set the argument registers
-        // correctly here.
+#if defined(_TARGET_X86_) || defined(_TARGET_ARM_)
+        // The x86 and arm32 CORINFO_HELP_INIT_PINVOKE_FRAME helpers has a custom calling convention.
+        // Set the argument registers correctly here.
         if (call->IsHelperCall(this, CORINFO_HELP_INIT_PINVOKE_FRAME))
         {
             GenTreeArgList* args = call->gtCallArgs;
@@ -2891,6 +2891,8 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
             assert(arg1 != nullptr);
             nonStandardArgs.Add(arg1, REG_PINVOKE_FRAME);
         }
+#endif // defined(_TARGET_X86_) || defined(_TARGET_ARM_)
+#if defined(_TARGET_X86_)
         // The x86 shift helpers have custom calling conventions and expect the lo part of the long to be in EAX and the
         // hi part to be in EDX. This sets the argument registers up correctly.
         else if (call->IsHelperCall(this, CORINFO_HELP_LLSH) || call->IsHelperCall(this, CORINFO_HELP_LRSH) ||

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1446,7 +1446,7 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_STOP_FOR_GC_TRASH     (RBM_CALLEE_TRASH & ~(RBM_FLOATRET | RBM_INTRET))
 
   // The registers trashed by the CORINFO_HELP_INIT_PINVOKE_FRAME helper.
-  #define RBM_INIT_PINVOKE_FRAME_TRASH  RBM_CALLEE_TRASH
+  #define RBM_INIT_PINVOKE_FRAME_TRASH (RBM_CALLEE_TRASH | RBM_PINVOKE_TCB | RBM_PINVOKE_SCRATCH)
 
   #define REG_FPBASE               REG_R11
   #define RBM_FPBASE               RBM_R11


### PR DESCRIPTION
This PR enables p/invoke support in lowering, regalloc and codegen. It's almost a copy of #5939.

Tested in both chk/rel modes on the family of `DomainNeutralILStubClass:IL_STUB_PInvoke` methods from CoreLib, as well as on some of the `JIT/Directed/pinvoke` tests. 

(This is a part of #8496.)