### PR TITLE
Don't generate a runtime lookup for static base if not needed

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16289,18 +16289,19 @@ GenTreePtr Compiler::fgInitThisClass()
         // Only CoreRT understands CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE. Don't do this on CoreCLR.
         if (opts.IsReadyToRun() && IsTargetAbi(CORINFO_CORERT_ABI))
         {
-            // We might be in a shared method body, but maybe we don't need a runtime lookup after all.
+            CORINFO_RESOLVED_TOKEN resolvedToken;
+            memset(&resolvedToken, 0, sizeof(resolvedToken));
+
+            // We are in a shared method body, but maybe we don't need a runtime lookup after all.
             // This covers the case of a generic method on a non-generic type.
             DWORD classAttribs = info.compCompHnd->getClassAttribs(info.compClassHnd);
             if (!(classAttribs & CORINFO_FLG_SHAREDINST))
             {
-                return fgGetSharedCCtor(info.compClassHnd);
+                resolvedToken.hClass = info.compClassHnd;
+                return impReadyToRunHelperToTree(&resolvedToken, CORINFO_HELP_READYTORUN_STATIC_BASE, TYP_BYREF);
             }
 
-            // We need a runtime lookup for the static base of the type that owns the method.
-            CORINFO_RESOLVED_TOKEN resolvedToken;
-            memset(&resolvedToken, 0, sizeof(resolvedToken));
-
+            // We need a runtime lookup.
             GenTreePtr ctxTree = getRuntimeContextTree(kind.runtimeLookupKind);
 
             // CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE with a zeroed out resolvedToken means "get the static

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16294,8 +16294,7 @@ GenTreePtr Compiler::fgInitThisClass()
 
             // We are in a shared method body, but maybe we don't need a runtime lookup after all.
             // This covers the case of a generic method on a non-generic type.
-            DWORD classAttribs = info.compCompHnd->getClassAttribs(info.compClassHnd);
-            if (!(classAttribs & CORINFO_FLG_SHAREDINST))
+            if (!(info.compClassAttr & CORINFO_FLG_SHAREDINST))
             {
                 resolvedToken.hClass = info.compClassHnd;
                 return impReadyToRunHelperToTree(&resolvedToken, CORINFO_HELP_READYTORUN_STATIC_BASE, TYP_BYREF);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16289,6 +16289,15 @@ GenTreePtr Compiler::fgInitThisClass()
         // Only CoreRT understands CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE. Don't do this on CoreCLR.
         if (opts.IsReadyToRun() && IsTargetAbi(CORINFO_CORERT_ABI))
         {
+            // We might be in a shared method body, but maybe we don't need a runtime lookup after all.
+            // This covers the case of a generic method on a non-generic type.
+            DWORD classAttribs = info.compCompHnd->getClassAttribs(info.compClassHnd);
+            if (!(classAttribs & CORINFO_FLG_SHAREDINST))
+            {
+                return fgGetSharedCCtor(info.compClassHnd);
+            }
+
+            // We need a runtime lookup for the static base of the type that owns the method.
             CORINFO_RESOLVED_TOKEN resolvedToken;
             memset(&resolvedToken, 0, sizeof(resolvedToken));
 


### PR DESCRIPTION
`fgInitThisClass` makes sure that the type initializer for the type that
owns the method being compiled has run. On CoreCLR, the fallthrough code
somehow ends up not doing a runtime lookup if the owning type is not
canonical. We need to avoid it on CoreRT as well.

The other option would be to move the check a bit up (so that we don't
duplicate the call to `fgGetSharedCCtor`, but that would be a change in
behavior on CoreCLR too and I don't know if it's safe.