### PR TITLE
[Local GC] Decouple the EE's usage of the generation table from the GC

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -65,7 +65,9 @@ public:
     static void DiagWalkSurvivors(void* gcContext);
     static void DiagWalkLOHSurvivors(void* gcContext);
     static void DiagWalkBGCSurvivors(void* gcContext);
-    static void StompWriteBarrier(WriteBarrierParameters* args);
+
+    // Inform the EE of changes to GC global variables.
+    static void UpdateEEGlobals(UpdateEEGlobalsParameters* args);
 
     static void EnableFinalization(bool foundFinalizers);
 };

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -2177,8 +2177,8 @@ int log2(unsigned int n)
 
 void stomp_write_barrier_resize(bool is_runtime_suspended, bool requires_upper_bounds_check)
 {
-    WriteBarrierParameters args = {};
-    args.operation = WriteBarrierOp::StompResize;
+    UpdateEEGlobalsParameters args = {};
+    args.operation = UpdateEEGlobalsOp::StompResize;
     args.is_runtime_suspended = is_runtime_suspended;
     args.requires_upper_bounds_check = requires_upper_bounds_check;
     args.card_table = g_gc_card_table;
@@ -2190,23 +2190,23 @@ void stomp_write_barrier_resize(bool is_runtime_suspended, bool requires_upper_b
         args.write_watch_table = g_gc_sw_ww_table;
     }
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    GCToEEInterface::StompWriteBarrier(&args);
+    GCToEEInterface::UpdateEEGlobals(&args);
 }
 
 void stomp_write_barrier_ephemeral(uint8_t* ephemeral_low, uint8_t* ephemeral_high)
 {
-    WriteBarrierParameters args = {};
-    args.operation = WriteBarrierOp::StompEphemeral;
+    UpdateEEGlobalsParameters args = {};
+    args.operation = UpdateEEGlobalsOp::StompEphemeral;
     args.is_runtime_suspended = true;
     args.ephemeral_low = ephemeral_low;
     args.ephemeral_high = ephemeral_high;
-    GCToEEInterface::StompWriteBarrier(&args);
+    GCToEEInterface::UpdateEEGlobals(&args);
 }
 
-void stomp_write_barrier_initialize()
+void stomp_write_barrier_initialize(uint8_t* generation_table)
 {
-    WriteBarrierParameters args = {};
-    args.operation = WriteBarrierOp::Initialize;
+    UpdateEEGlobalsParameters args = {};
+    args.operation = UpdateEEGlobalsOp::Initialize;
     args.is_runtime_suspended = true;
     args.requires_upper_bounds_check = false;
     args.card_table = g_gc_card_table;
@@ -2214,7 +2214,8 @@ void stomp_write_barrier_initialize()
     args.highest_address = g_gc_highest_address;
     args.ephemeral_low = reinterpret_cast<uint8_t*>(1);
     args.ephemeral_high = reinterpret_cast<uint8_t*>(~0);
-    GCToEEInterface::StompWriteBarrier(&args);
+    args.generation_table = generation_table;
+    GCToEEInterface::UpdateEEGlobals(&args);
 }
 
 #endif // DACCESS_COMPILE
@@ -2681,10 +2682,6 @@ BOOL        gc_heap::heap_analyze_enabled = FALSE;
 
 #ifndef MULTIPLE_HEAPS
 
-extern "C" {
-    generation generation_table[NUMBERGENERATIONS + 1];
-}
-
 alloc_list gc_heap::loh_alloc_list [NUM_LOH_ALIST-1];
 alloc_list gc_heap::gen2_alloc_list[NUM_GEN2_ALIST-1];
 
@@ -2726,9 +2723,7 @@ int         gc_heap::gen0_must_clear_bricks = 0;
 CFinalize*  gc_heap::finalize_queue = 0;
 #endif // FEATURE_PREMORTEM_FINALIZATION
 
-#ifdef MULTIPLE_HEAPS
 generation gc_heap::generation_table [NUMBERGENERATIONS + 1];
-#endif // MULTIPLE_HEAPS
 
 size_t     gc_heap::interesting_data_per_heap[max_idp_count];
 
@@ -33440,7 +33435,12 @@ HRESULT GCHeap::Initialize ()
         return E_FAIL;
     }
 
-    stomp_write_barrier_initialize();
+#ifndef MULTIPLE_HEAPS
+    uint8_t* generation_table = reinterpret_cast<uint8_t*>(&gc_heap::generation_table[0]);
+#else
+    uint8_t* generation_table = nullptr;
+#endif // MULTIPLE_HEAPS
+    stomp_write_barrier_initialize(generation_table);
 
 #ifndef FEATURE_REDHAWK // Redhawk forces relocation a different way
 #if defined (STRESS_HEAP) && !defined (MULTIPLE_HEAPS)
@@ -36811,7 +36811,7 @@ void PopulateDacVars(GcDacVars *gcDacVars)
     gcDacVars->next_sweep_obj = &gc_heap::next_sweep_obj;
     gcDacVars->oom_info = &gc_heap::oom_info;
     gcDacVars->finalize_queue = reinterpret_cast<dac_finalize_queue**>(&gc_heap::finalize_queue);
-    gcDacVars->generation_table = reinterpret_cast<dac_generation**>(&generation_table);
+    gcDacVars->generation_table = reinterpret_cast<dac_generation**>(&gc_heap::generation_table);
 #ifdef GC_CONFIG_DRIVEN
     gcDacVars->gc_global_mechanisms = reinterpret_cast<size_t**>(&gc_global_mechanisms);
     gcDacVars->interesting_data_per_heap = reinterpret_cast<size_t**>(&gc_heap::interesting_data_per_heap);

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -195,10 +195,10 @@ ALWAYS_INLINE void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
     return g_theGCToCLR->DiagWalkBGCSurvivors(gcContext);
 }
 
-ALWAYS_INLINE void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
+ALWAYS_INLINE void GCToEEInterface::UpdateEEGlobals(UpdateEEGlobalsParameters* args)
 {
     assert(g_theGCToCLR != nullptr);
-    g_theGCToCLR->StompWriteBarrier(args);
+    g_theGCToCLR->UpdateEEGlobals(args);
 }
 
 ALWAYS_INLINE void GCToEEInterface::EnableFinalization(bool foundFinalizers)

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -124,10 +124,10 @@ public:
     virtual
     void DiagWalkBGCSurvivors(void* gcContext) = 0;
 
-    // Informs the EE of changes to the location of the card table, potentially updating the write
-    // barrier if it needs to be updated.
+    // Informs the EE of changes to GC global variables. Depending on the operation,
+    // the EE may need to take action by e.g. stomping the current write barrier.
     virtual
-    void StompWriteBarrier(WriteBarrierParameters* args) = 0;
+    void UpdateEEGlobals(UpdateEEGlobalsParameters* args) = 0;
 
     // Signals to the finalizer thread that there are objects ready to
     // be finalized.

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -2801,11 +2801,9 @@ public:
     PER_HEAP
     BOOL heap_analyze_success;
 
-#ifdef MULTIPLE_HEAPS
     // The generation table. Must always be last.
     PER_HEAP
     generation generation_table [NUMBERGENERATIONS + 1];
-#endif // MULTIPLE_HEAPS
 
     // End DAC zone
 

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -253,7 +253,7 @@ void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
 {
 }
 
-void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
+void GCToEEInterface::UpdateEEGlobals(UpdateEEGlobalsParameters* args)
 {
 }
 

--- a/src/gc/softwarewritewatch.h
+++ b/src/gc/softwarewritewatch.h
@@ -201,11 +201,11 @@ inline void SoftwareWriteWatch::EnableForGCHeap()
     assert(!IsEnabledForGCHeap());
     g_gc_sw_ww_enabled_for_gc_heap = true;
 
-    WriteBarrierParameters args = {};
-    args.operation = WriteBarrierOp::SwitchToWriteWatch;
+    UpdateEEGlobalsParameters args = {};
+    args.operation = UpdateEEGlobalsOp::SwitchToWriteWatch;
     args.write_watch_table = g_gc_sw_ww_table;
     args.is_runtime_suspended = true;
-    GCToEEInterface::StompWriteBarrier(&args);
+    GCToEEInterface::UpdateEEGlobals(&args);
 }
 
 inline void SoftwareWriteWatch::DisableForGCHeap()
@@ -215,12 +215,12 @@ inline void SoftwareWriteWatch::DisableForGCHeap()
 
     VerifyCreated();
     assert(IsEnabledForGCHeap());
-    g_gc_sw_ww_enabled_for_gc_heap = false;     
+    g_gc_sw_ww_enabled_for_gc_heap = false;
 
-    WriteBarrierParameters args = {};
-    args.operation = WriteBarrierOp::SwitchToNonWriteWatch;
+    UpdateEEGlobalsParameters args = {};
+    args.operation = UpdateEEGlobalsOp::SwitchToNonWriteWatch;
     args.is_runtime_suspended = true;
-    GCToEEInterface::StompWriteBarrier(&args);
+    GCToEEInterface::UpdateEEGlobals(&args);
 }
 
 inline void *SoftwareWriteWatch::GetHeapStartAddress()

--- a/src/vm/amd64/JitHelpers_Slow.asm
+++ b/src/vm/amd64/JitHelpers_Slow.asm
@@ -473,7 +473,7 @@ NESTED_END JIT_NewArr1OBJ_MP, _TEXT
 
 M_GCLOCK equ ?m_GCLock@@3HC
 extern M_GCLOCK:dword
-extern generation_table:qword
+extern g_generation_table:qword
 
 LEAF_ENTRY JIT_TrialAllocSFastSP, _TEXT
 
@@ -484,15 +484,15 @@ LEAF_ENTRY JIT_TrialAllocSFastSP, _TEXT
         inc     [M_GCLOCK]
         jnz     JIT_NEW
 
-        mov     rax, [generation_table + 0]     ; alloc_ptr
-        mov     r10, [generation_table + 8]     ; limit_ptr
+        mov     rax, [g_generation_table + 0]     ; alloc_ptr
+        mov     r10, [g_generation_table + 8]     ; limit_ptr
 
         add     r8, rax
 
         cmp     r8, r10
         ja      AllocFailed
 
-        mov     qword ptr [generation_table + 0], r8     ; update the alloc ptr
+        mov     qword ptr [g_generation_table + 0], r8     ; update the alloc ptr
         mov     [rax], rcx
         mov     [M_GCLOCK], -1
 
@@ -523,8 +523,8 @@ NESTED_ENTRY JIT_BoxFastUP, _TEXT
         inc     [M_GCLOCK]
         jnz     JIT_Box
 
-        mov     rax, [generation_table + 0]     ; alloc_ptr
-        mov     r10, [generation_table + 8]     ; limit_ptr
+        mov     rax, [g_generation_table + 0]     ; alloc_ptr
+        mov     r10, [g_generation_table + 8]     ; limit_ptr
 
         add     r8, rax
 
@@ -532,7 +532,7 @@ NESTED_ENTRY JIT_BoxFastUP, _TEXT
         ja      NoAlloc
 
 
-        mov     qword ptr [generation_table + 0], r8     ; update the alloc ptr
+        mov     qword ptr [g_generation_table + 0], r8     ; update the alloc ptr
         mov     [rax], rcx
         mov     [M_GCLOCK], -1
 
@@ -605,15 +605,15 @@ LEAF_ENTRY AllocateStringFastUP, _TEXT
         inc     [M_GCLOCK]
         jnz     FramedAllocateString
 
-        mov     rax, [generation_table + 0]     ; alloc_ptr
-        mov     r10, [generation_table + 8]     ; limit_ptr
+        mov     rax, [g_generation_table + 0]     ; alloc_ptr
+        mov     r10, [g_generation_table + 8]     ; limit_ptr
 
         add     r8, rax
 
         cmp     r8, r10
         ja      AllocFailed
 
-        mov     qword ptr [generation_table + 0], r8     ; update the alloc ptr
+        mov     qword ptr [g_generation_table + 0], r8     ; update the alloc ptr
         mov     [rax], r11
         mov     [M_GCLOCK], -1
 
@@ -671,8 +671,8 @@ LEAF_ENTRY JIT_NewArr1VC_UP, _TEXT
         inc     [M_GCLOCK]
         jnz     JIT_NewArr1
 
-        mov     rax, [generation_table + 0]     ; alloc_ptr
-        mov     r10, [generation_table + 8]     ; limit_ptr
+        mov     rax, [g_generation_table + 0]     ; alloc_ptr
+        mov     r10, [g_generation_table + 8]     ; limit_ptr
 
         add     r8, rax
         jc      AllocFailed
@@ -680,7 +680,7 @@ LEAF_ENTRY JIT_NewArr1VC_UP, _TEXT
         cmp     r8, r10
         ja      AllocFailed
 
-        mov     qword ptr [generation_table + 0], r8     ; update the alloc ptr
+        mov     qword ptr [g_generation_table + 0], r8     ; update the alloc ptr
         mov     [rax], r9
         mov     [M_GCLOCK], -1
 
@@ -734,15 +734,15 @@ LEAF_ENTRY JIT_NewArr1OBJ_UP, _TEXT
         inc     [M_GCLOCK]
         jnz     JIT_NewArr1
 
-        mov     rax, [generation_table + 0]     ; alloc_ptr
-        mov     r10, [generation_table + 8]     ; limit_ptr
+        mov     rax, [g_generation_table + 0]     ; alloc_ptr
+        mov     r10, [g_generation_table + 8]     ; limit_ptr
 
         add     r8, rax
 
         cmp     r8, r10
         ja      AllocFailed
 
-        mov     qword ptr [generation_table + 0], r8     ; update the alloc ptr
+        mov     qword ptr [g_generation_table + 0], r8     ; update the alloc ptr
         mov     [rax], r9
         mov     [M_GCLOCK], -1
 

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -41,7 +41,7 @@ public:
     void DiagWalkSurvivors(void* gcContext);
     void DiagWalkLOHSurvivors(void* gcContext);
     void DiagWalkBGCSurvivors(void* gcContext);
-    void StompWriteBarrier(WriteBarrierParameters* args);
+    void UpdateEEGlobals(UpdateEEGlobalsParameters* args);
 
     void EnableFinalization(bool foundFinalizers);
 };

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -14,6 +14,7 @@ GPTR_IMPL_INIT(uint8_t,  g_lowest_address,  nullptr);
 GPTR_IMPL_INIT(uint8_t,  g_highest_address, nullptr);
 uint8_t* g_ephemeral_low  = (uint8_t*)1;
 uint8_t* g_ephemeral_high = (uint8_t*)~0;
+uint8_t* g_generation_table = nullptr;
 
 // This is the global GC heap, maintained by the VM.
 GPTR_IMPL(IGCHeap, g_pGCHeap);

--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -22,6 +22,7 @@ GPTR_DECL(uint32_t,g_card_table);
 
 extern "C" uint8_t* g_ephemeral_low;
 extern "C" uint8_t* g_ephemeral_high;
+extern "C" uint8_t* g_generation_table;
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -35,7 +35,6 @@
 #endif
 
 class generation;
-extern "C" generation generation_table[];
 
 extern "C" void STDCALL JIT_WriteBarrierReg_PreGrow();// JIThelp.asm/JIThelp.s
 extern "C" void STDCALL JIT_WriteBarrierReg_PostGrow();// JIThelp.asm/JIThelp.s
@@ -580,9 +579,9 @@ void JIT_TrialAlloc::EmitCore(CPUSTUBLINKER *psl, CodeLabel *noLock, CodeLabel *
             psl->X86EmitIndexRegLoad(kEDX, kECX, offsetof(MethodTable, m_BaseSize));
         }
 
-        // mov             eax, dword ptr [generation_table]
+        // mov             eax, dword ptr [g_generation_table]
         psl->Emit8(0xA1);
-        psl->Emit32((int)(size_t)&generation_table);
+        psl->Emit32((int)(size_t)&g_generation_table);
 
         // Try the allocation.
         // add             edx, eax
@@ -591,17 +590,17 @@ void JIT_TrialAlloc::EmitCore(CPUSTUBLINKER *psl, CodeLabel *noLock, CodeLabel *
         if (flags & (ALIGN8 | ALIGN8OBJ))
             EmitAlignmentRoundup(psl, kEAX, kEDX, flags);      // bump up EDX size by 12 if EAX unaligned (so that we are aligned)
 
-        // cmp             edx, dword ptr [generation_table+4]
+        // cmp             edx, dword ptr [g_generation_table+4]
         psl->Emit16(0x153b);
-        psl->Emit32((int)(size_t)&generation_table + 4);
+        psl->Emit32((int)(size_t)&g_generation_table + 4);
 
         // ja              noAlloc
         psl->X86EmitCondJump(noAlloc, X86CondCode::kJA);
 
         // Fill in the allocation and get out.
-        // mov             dword ptr [generation_table], edx
+        // mov             dword ptr [g_generation_table], edx
         psl->Emit16(0x1589);
-        psl->Emit32((int)(size_t)&generation_table);
+        psl->Emit32((int)(size_t)&g_generation_table);
 
         if (flags & (ALIGN8 | ALIGN8OBJ))
             EmitDummyObject(psl, kEAX, flags);


### PR DESCRIPTION
This addresses an issue that arose in my last PR (https://github.com/dotnet/coreclr/pull/9255), in that the EE uses the GC's generation table directly when not using allocation contexts (which, today, means running on a single-proc Windows machine). The offsets that the assembly allocation helpers are using into the generation table are the `alloc_ptr` and `alloc_limit` fields of the Gen 0 allocation context.

The approach of this PR is similar to that of the other PRs that detangle EE and GC globals - upon initialization, the GC calls `stomp_write_barrier_initialize`, which in turn passes the value of the `generation_table` global to the EE, which records it in `g_generation_table` and uses it in allocation helpers.

Of note in this PR is that I named the `GCToEEInterface` function `StompWriteBarrier` to `UpdateEEGlobals`, since the latter name is more indicative of its purpose now that non-write-barrier globals are updated using it as well. If anyone has a better name, I'd be happy to use it instead.

I've tested this locally on a single-proc Windows VM and the tests (that don't timeout) look clean.