### PR TITLE
Remove useless message from runtest output.

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -1218,7 +1218,6 @@ finish_remaining_tests
 
 print_results
 
-echo "constructing $dumplingsListPath"
 find . -type f -name "local_dumplings.txt" -exec cat {} \; > $dumplingsListPath
 
 if [ -s $dumplingsListPath ]; then


### PR DESCRIPTION
This message is shown after every run, regardless of whether dumps were generated or whether dump generation was even enabled. It is at best noise, and at worst misleading.