### PR TITLE
[x86/Linux] Fix GetCurrentSP

### DIFF
--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -574,6 +574,7 @@ LEAF_END GetCurrentIP, _TEXT
 // LPVOID __stdcall GetCurrentSP(void);
 LEAF_ENTRY GetCurrentSP, _TEXT
     mov     eax, esp
+    add     eax, 4
     ret
 LEAF_END GetCurrentSP, _TEXT
 


### PR DESCRIPTION
This commit revises GetCurrentSP to return Caller SP of itself (instead of Initial SP).