### PR TITLE
[x86/Linux] Correct GetStackParameterSize on Funclet (WIP)

### DIFF
--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5913,6 +5913,14 @@ ULONG32 EECodeManager::GetStackParameterSize(EECodeInfo * pCodeInfo)
     } CONTRACTL_END;
 
 #if defined(_TARGET_X86_)
+#if defined(WIN64EXCEPTIONS)
+    if (pCodeInfo->IsFunclet())
+    {
+        // Funclet has no stack argument
+        return 0;
+    }
+#endif // WIN64EXCEPTIONS
+
     GCInfoToken gcInfoToken = pCodeInfo->GetGCInfoToken();
     unsigned    dwOffset = pCodeInfo->GetRelOffset();
 


### PR DESCRIPTION
The current implementation returns the funtion's stack parameter size even for funclet, which results in #9847.

This commit revises GetStackParameterSize to take care of funclets correctly.