### PR TITLE
[x86/Linux] Initial fix of arguments passing in FunctionPtrTest (WIP)

### DIFF
--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -1414,6 +1414,12 @@ VOID UMThunkMarshInfo::RunTimeInit()
 
         }
     }
+    //
+    // m_cbActualArgSize gets the number of arg bytes for the NATIVE signature
+    //
+    m_cbActualArgSize =
+        (pStubMD != NULL) ? pStubMD->AsDynamicMethodDesc()->GetNativeStackArgSize() : pMD->SizeOfArgStack();
+
 #if defined(_TARGET_X86_)
     MetaSig sig(pMD);
     ArgIterator argit(&sig);
@@ -1440,11 +1446,6 @@ VOID UMThunkMarshInfo::RunTimeInit()
             offs += StackElemSize(cbSize);
         }
     }
-    //
-    // m_cbActualArgSize gets the number of arg bytes for the NATIVE signature
-    //
-    m_cbActualArgSize =
-        (pStubMD != NULL) ? pStubMD->AsDynamicMethodDesc()->GetNativeStackArgSize() : pMD->SizeOfArgStack();
     PInvokeStaticSigInfo sigInfo;
     if (pMD != NULL)
         new (&sigInfo) PInvokeStaticSigInfo(pMD);

--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -1431,11 +1431,14 @@ VOID UMThunkMarshInfo::RunTimeInit()
         {
             if (numRegistersUsed == 1)
                 m_ecxArgOffset = offs;
-            else  if (numRegistersUsed == 2)
+            else if (numRegistersUsed == 2)
                 m_edxArgOffset = offs;
-            offs+= STACK_ELEM_SIZE;
-        } else
-            offs+=StackElemSize(cbSize);
+            offs += STACK_ELEM_SIZE;
+        }
+        else
+        {
+            offs += StackElemSize(cbSize);
+        }
     }
     //
     // m_cbActualArgSize gets the number of arg bytes for the NATIVE signature

--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -1411,13 +1411,53 @@ VOID UMThunkMarshInfo::RunTimeInit()
 
             pStubMD = GetILStubMethodDesc(pMD, &sigInfo, dwStubFlags);
             pFinalILStub = JitILStub(pStubMD);
+
         }
     }
+#if defined(_TARGET_X86_)
+    MetaSig sig(pMD);
+    ArgIterator argit(&sig);
+    int numRegistersUsed = 0;
+    m_ecxArgOffset = -1;
+    m_edxArgOffset = -1;
 
+    int offs = 0;
+    for (UINT i = 0 ; i < sig.NumFixedArgs(); i++)
+    {
+        TypeHandle thValueType;
+        CorElementType type = sig.NextArgNormalized(&thValueType);
+        int cbSize = sig.GetElemSize(type, thValueType);
+        if (ArgIterator::IsArgumentInRegister(&numRegistersUsed, type))
+        {
+            if (numRegistersUsed == 1)
+                m_ecxArgOffset = offs;
+            else  if (numRegistersUsed == 2)
+                m_edxArgOffset = offs;
+            offs+= STACK_ELEM_SIZE;
+        } else
+            offs+=StackElemSize(cbSize);
+    }
     //
     // m_cbActualArgSize gets the number of arg bytes for the NATIVE signature
     //
-    m_cbActualArgSize = (pStubMD != NULL) ? pStubMD->AsDynamicMethodDesc()->GetNativeStackArgSize() : pMD->SizeOfArgStack();
+    m_cbActualArgSize =
+        (pStubMD != NULL) ? pStubMD->AsDynamicMethodDesc()->GetNativeStackArgSize() : pMD->SizeOfArgStack();
+    PInvokeStaticSigInfo sigInfo;
+    if (pMD != NULL)
+        new (&sigInfo) PInvokeStaticSigInfo(pMD);
+    else
+        new (&sigInfo) PInvokeStaticSigInfo(GetSignature(), GetModule());
+    if (sigInfo.GetCallConv() == pmCallConvCdecl)
+    {
+        // caller pop
+        m_cbRetPop = 0;
+    }
+    else
+    {
+        // callee pop
+        m_cbRetPop = static_cast<UINT16>(m_cbActualArgSize);
+    }
+#endif // _TARGET_X86_
 
 #endif // _TARGET_X86_ && !FEATURE_STUBS_AS_IL
 

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -211,8 +211,8 @@ private:
                                             // On non-x86, the managed entrypoint for no-delegate no-marshal signatures
     UINT32            m_cbActualArgSize;    // caches m_pSig.SizeOfFrameArgumentArray()
 #if defined(_TARGET_X86_)
-#if defined(FEATURE_STUBS_AS_IL)
     UINT16            m_cbRetPop;           // stack bytes popped by callee (for UpdateRegDisplay)
+#if defined(FEATURE_STUBS_AS_IL)
     UINT32            m_ecxArgOffset;
     UINT32            m_edxArgOffset;
 #else

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -210,9 +210,11 @@ private:
                                             // On x86, NULL for no-marshal signatures
                                             // On non-x86, the managed entrypoint for no-delegate no-marshal signatures
     UINT32            m_cbActualArgSize;    // caches m_pSig.SizeOfFrameArgumentArray()
+    UINT16            m_cbRetPop;           // stack bytes popped by callee (for UpdateRegDisplay)
+    UINT32            m_ecxArgOffset;
+    UINT32            m_edxArgOffset;
 #if defined(_TARGET_X86_) && !defined(FEATURE_STUBS_AS_IL)
     Stub*             m_pExecStub;          // UMEntryThunk jumps directly here
-    UINT16            m_cbRetPop;           // stack bytes popped by callee (for UpdateRegDisplay)
     UINT16            m_callConv;           // unmanaged calling convention and flags (CorPinvokeMap)
 #endif
     MethodDesc *      m_pMD;                // maybe null

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -210,13 +210,17 @@ private:
                                             // On x86, NULL for no-marshal signatures
                                             // On non-x86, the managed entrypoint for no-delegate no-marshal signatures
     UINT32            m_cbActualArgSize;    // caches m_pSig.SizeOfFrameArgumentArray()
+#if defined(_TARGET_X86_)
     UINT16            m_cbRetPop;           // stack bytes popped by callee (for UpdateRegDisplay)
     UINT32            m_ecxArgOffset;
     UINT32            m_edxArgOffset;
-#if defined(_TARGET_X86_) && !defined(FEATURE_STUBS_AS_IL)
+
+#if !defined(FEATURE_STUBS_AS_IL)
     Stub*             m_pExecStub;          // UMEntryThunk jumps directly here
     UINT16            m_callConv;           // unmanaged calling convention and flags (CorPinvokeMap)
-#endif
+#endif // !FEATURE_STUBS_AS_IL
+#endif // _TARGET_X86_
+
     MethodDesc *      m_pMD;                // maybe null
     Module *          m_pModule;
     Signature         m_sig;

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -211,14 +211,14 @@ private:
                                             // On non-x86, the managed entrypoint for no-delegate no-marshal signatures
     UINT32            m_cbActualArgSize;    // caches m_pSig.SizeOfFrameArgumentArray()
 #if defined(_TARGET_X86_)
+#if defined(FEATURE_STUBS_AS_IL)
     UINT16            m_cbRetPop;           // stack bytes popped by callee (for UpdateRegDisplay)
     UINT32            m_ecxArgOffset;
     UINT32            m_edxArgOffset;
-
-#if !defined(FEATURE_STUBS_AS_IL)
+#else
     Stub*             m_pExecStub;          // UMEntryThunk jumps directly here
     UINT16            m_callConv;           // unmanaged calling convention and flags (CorPinvokeMap)
-#endif // !FEATURE_STUBS_AS_IL
+#endif // FEATURE_STUBS_AS_IL
 #endif // _TARGET_X86_
 
     MethodDesc *      m_pMD;                // maybe null

--- a/src/vm/i386/asmconstants.h
+++ b/src/vm/i386/asmconstants.h
@@ -438,6 +438,16 @@ ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_pILStub == offsetof(UMThunkMarshInfo, 
 #define               UMThunkMarshInfo__m_cbActualArgSize   0x04
 ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_cbActualArgSize == offsetof(UMThunkMarshInfo, m_cbActualArgSize))
 
+#define               UMThunkMarshInfo__m_cbRetPop   0x08
+ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_cbRetPop == offsetof(UMThunkMarshInfo, m_cbRetPop))
+
+#define               UMThunkMarshInfo__m_ecxArgOffset   0xc
+ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_ecxArgOffset == offsetof(UMThunkMarshInfo, m_ecxArgOffset))
+
+#define               UMThunkMarshInfo__m_edxArgOffset  0x10
+ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_edxArgOffset == offsetof(UMThunkMarshInfo, m_edxArgOffset))
+
+
 #ifndef CROSSGEN_COMPILE
 #define               Thread__m_pDomain                     0x14
 ASMCONSTANTS_C_ASSERT(Thread__m_pDomain == offsetof(Thread, m_pDomain));

--- a/src/vm/i386/asmconstants.h
+++ b/src/vm/i386/asmconstants.h
@@ -438,7 +438,7 @@ ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_pILStub == offsetof(UMThunkMarshInfo, 
 #define               UMThunkMarshInfo__m_cbActualArgSize   0x04
 ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_cbActualArgSize == offsetof(UMThunkMarshInfo, m_cbActualArgSize))
 
-#ifdef FEATURE_PAL
+#ifdef FEATURE_STUBS_AS_IL
 #define               UMThunkMarshInfo__m_cbRetPop   0x08
 ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_cbRetPop == offsetof(UMThunkMarshInfo, m_cbRetPop))
 
@@ -447,7 +447,7 @@ ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_ecxArgOffset == offsetof(UMThunkMarshI
 
 #define               UMThunkMarshInfo__m_edxArgOffset  0x10
 ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_edxArgOffset == offsetof(UMThunkMarshInfo, m_edxArgOffset))
-#endif //FEATURE_PAL
+#endif //FEATURE_STUBS_AS_IL
 
 #ifndef CROSSGEN_COMPILE
 #define               Thread__m_pDomain                     0x14

--- a/src/vm/i386/asmconstants.h
+++ b/src/vm/i386/asmconstants.h
@@ -438,6 +438,7 @@ ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_pILStub == offsetof(UMThunkMarshInfo, 
 #define               UMThunkMarshInfo__m_cbActualArgSize   0x04
 ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_cbActualArgSize == offsetof(UMThunkMarshInfo, m_cbActualArgSize))
 
+#ifdef FEATURE_PAL
 #define               UMThunkMarshInfo__m_cbRetPop   0x08
 ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_cbRetPop == offsetof(UMThunkMarshInfo, m_cbRetPop))
 
@@ -446,7 +447,7 @@ ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_ecxArgOffset == offsetof(UMThunkMarshI
 
 #define               UMThunkMarshInfo__m_edxArgOffset  0x10
 ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_edxArgOffset == offsetof(UMThunkMarshInfo, m_edxArgOffset))
-
+#endif //FEATURE_PAL
 
 #ifndef CROSSGEN_COMPILE
 #define               Thread__m_pDomain                     0x14

--- a/src/vm/i386/umthunkstub.S
+++ b/src/vm/i386/umthunkstub.S
@@ -173,25 +173,20 @@ LOCAL_LABEL(UMThunkStub_CopyStackArgs):
 LOCAL_LABEL(InitCopyStack):
     push    ecx
     push    edx
-    mov     eax, 0  // Offset in edi
-    mov     ebx, 0  // Offset in esi
-LOCAL_LABEL(CopyStack):
     mov     edx, dword ptr [ebp - UMThunkStub_UMENTRYTHUNK_OFFSET]
     mov     edx, dword ptr [edx + UMEntryThunk__m_pUMThunkMarshInfo]
-    mov     ecx, dword ptr [edx + UMThunkMarshInfo__m_ecxArgOffset]
-    cmp     ecx, ebx
+    mov     ebx, [edx + UMThunkMarshInfo__m_cbActualArgSize]
+LOCAL_LABEL(CopyStack):
+    cmp     ebx, dword ptr [edx + UMThunkMarshInfo__m_ecxArgOffset]
     je      LOCAL_LABEL(IncreaseOffset)
-    mov     ecx, dword ptr [edx + UMThunkMarshInfo__m_edxArgOffset]
-    cmp     ecx, ebx
+    cmp     ebx, dword ptr [edx + UMThunkMarshInfo__m_edxArgOffset]
     je      LOCAL_LABEL(IncreaseOffset)
-    mov     ecx, dword ptr [esi + ebx]
-    mov     dword ptr [edi + eax], ecx
-    add     eax, 4
+    mov     ecx, dword ptr [esi + ebx - 4]
+    mov     dword ptr [edi + eax - 4], ecx
+    add     eax, -4
 LOCAL_LABEL(IncreaseOffset):
-    add     ebx, 4
-    mov     ecx, [edx + UMThunkMarshInfo__m_cbActualArgSize]
-    cmp     ecx, ebx
-    jne     LOCAL_LABEL(CopyStack)
+    add     ebx, -4
+    jnz     LOCAL_LABEL(CopyStack)
 
     pop     edx
     pop     ecx

--- a/src/vm/i386/umthunkstub.S
+++ b/src/vm/i386/umthunkstub.S
@@ -176,17 +176,18 @@ LOCAL_LABEL(InitCopyStack):
     mov     edx, dword ptr [ebp - UMThunkStub_UMENTRYTHUNK_OFFSET]
     mov     edx, dword ptr [edx + UMEntryThunk__m_pUMThunkMarshInfo]
     mov     ebx, [edx + UMThunkMarshInfo__m_cbActualArgSize]
+    add     ebx, -4
 LOCAL_LABEL(CopyStack):
     cmp     ebx, dword ptr [edx + UMThunkMarshInfo__m_ecxArgOffset]
     je      LOCAL_LABEL(IncreaseOffset)
     cmp     ebx, dword ptr [edx + UMThunkMarshInfo__m_edxArgOffset]
     je      LOCAL_LABEL(IncreaseOffset)
-    mov     ecx, dword ptr [esi + ebx - 4]
-    mov     dword ptr [edi + eax - 4], ecx
     add     eax, -4
+    mov     ecx, dword ptr [esi + ebx]
+    mov     dword ptr [edi + eax], ecx
 LOCAL_LABEL(IncreaseOffset):
     add     ebx, -4
-    jnz     LOCAL_LABEL(CopyStack)
+    jc      LOCAL_LABEL(CopyStack)
 
     pop     edx
     pop     ecx

--- a/src/vm/i386/umthunkstub.S
+++ b/src/vm/i386/umthunkstub.S
@@ -40,7 +40,6 @@ NESTED_ENTRY UMThunkStub, _TEXT, UnhandledExceptionHandlerUnix
 // dummy 4 byte for 16 byte stack alignment
 // {optional stack args passed to callee}   <-- new esp
 
-
     PROLOG_BEG
     PROLOG_PUSH ebx
     PROLOG_PUSH esi
@@ -154,34 +153,48 @@ LOCAL_LABEL(UMThunkStub_CopyStackArgs):
     and     esp, -16    // align with 16 byte
     lea     edi, [esp]
 
+    // First, we copy arguments to ecx and edx registers (if needed).
     mov     edx, dword ptr [ebp - UMThunkStub_UMENTRYTHUNK_OFFSET]
     mov     edx, dword ptr [edx + UMEntryThunk__m_pUMThunkMarshInfo]
     mov     ebx, dword ptr [edx + UMThunkMarshInfo__m_ecxArgOffset]
     cmp     ebx, -1
-    je      LOCAL_LABEL(CopyStack)
+    je      LOCAL_LABEL(InitCopyStack)
     mov     ecx, dword ptr [esi + ebx]
     add     eax, -4
     jz      LOCAL_LABEL(UMThunkStub_ArgumentsSetup)
 
     mov     ebx, dword ptr [edx + UMThunkMarshInfo__m_edxArgOffset]
     cmp     ebx, -1
-    je      LOCAL_LABEL(CopyStack)
+    je      LOCAL_LABEL(InitCopyStack)
     mov     edx, dword ptr [esi + ebx]
     add     eax, -4
     jz      LOCAL_LABEL(UMThunkStub_ArgumentsSetup)
 
-
-LOCAL_LABEL(CopyStack):
+LOCAL_LABEL(InitCopyStack):
     push    ecx
-    mov     ebx, dword ptr [ebp - UMThunkStub_UMENTRYTHUNK_OFFSET]
-    mov     ebx, dword ptr [ebx + UMEntryThunk__m_pUMThunkMarshInfo]
-    mov     ebx, [ebx + UMThunkMarshInfo__m_cbActualArgSize]
-    sub     ebx, eax
+    push    edx
+    mov     eax, 0  // Offset in edi
+    mov     ebx, 0  // Offset in esi
+LOCAL_LABEL(CopyStack):
+    mov     edx, dword ptr [ebp - UMThunkStub_UMENTRYTHUNK_OFFSET]
+    mov     edx, dword ptr [edx + UMEntryThunk__m_pUMThunkMarshInfo]
+    mov     ecx, dword ptr [edx + UMThunkMarshInfo__m_ecxArgOffset]
+    cmp     ecx, ebx
+    je      LOCAL_LABEL(IncreaseOffset)
+    mov     ecx, dword ptr [edx + UMThunkMarshInfo__m_edxArgOffset]
+    cmp     ecx, ebx
+    je      LOCAL_LABEL(IncreaseOffset)
     mov     ecx, dword ptr [esi + ebx]
-    mov     dword ptr [edi + ebx], ecx
+    mov     dword ptr [edi + eax], ecx
+    add     eax, 4
+LOCAL_LABEL(IncreaseOffset):
+    add     ebx, 4
+    mov     ecx, [edx + UMThunkMarshInfo__m_cbActualArgSize]
+    cmp     ecx, ebx
+    jne     LOCAL_LABEL(CopyStack)
+
+    pop     edx
     pop     ecx
-    add     eax, -4
-    jnz     LOCAL_LABEL(CopyStack)
     jmp     LOCAL_LABEL(UMThunkStub_ArgumentsSetup)
 
 #if _DEBUG

--- a/src/vm/i386/umthunkstub.S
+++ b/src/vm/i386/umthunkstub.S
@@ -40,6 +40,7 @@ NESTED_ENTRY UMThunkStub, _TEXT, UnhandledExceptionHandlerUnix
 // dummy 4 byte for 16 byte stack alignment
 // {optional stack args passed to callee}   <-- new esp
 
+
     PROLOG_BEG
     PROLOG_PUSH ebx
     PROLOG_PUSH esi
@@ -103,12 +104,20 @@ LOCAL_LABEL(PostCall):
     mov     dword ptr [ebx + Thread_m_fPreemptiveGCDisabled], 0
 
     lea     esp, [ebp - UMThunkStub_SAVEDREG]  // deallocate arguments
+
+    mov     ecx, dword ptr [ebp - UMThunkStub_UMENTRYTHUNK_OFFSET]
+    mov     edx, dword ptr [ecx + UMEntryThunk__m_pUMThunkMarshInfo]
+    mov     edx, dword ptr [edx + UMThunkMarshInfo__m_cbRetPop]
+
     EPILOG_BEG
     EPILOG_POP edi
     EPILOG_POP esi
     EPILOG_POP ebx
     EPILOG_END
-    ret
+
+    pop     ecx  // pop return address
+    add     esp, edx // adjust ESP
+    jmp     ecx // return to caller
 
 LOCAL_LABEL(DoThreadSetup):
 
@@ -139,30 +148,40 @@ LOCAL_LABEL(UMThunkStub_CopyStackArgs):
     // esi = src
     // edi = dest
     // ebx = scratch
-    lea     esi, [ebp + 0x08]
-
-    // first [esi] goes to ecx, in LTR
-    add     eax, -4
-    mov     ecx, dword ptr [esi]
-    jz      LOCAL_LABEL(UMThunkStub_ArgumentsSetup)
-
-    // second [esi+04] goes to edx
-    add     eax, -4
-    mov     edx, dword ptr [esi + 0x04]
-    jz      LOCAL_LABEL(UMThunkStub_ArgumentsSetup)
+    lea     esi, [ebp + 0x8]
 
     sub     esp, eax
     and     esp, -16    // align with 16 byte
     lea     edi, [esp]
 
-LOCAL_LABEL(CopyLoop):
-
-    // copy rest of the arguments to [esp+08+n], in RTL
+    mov     edx, dword ptr [ebp - UMThunkStub_UMENTRYTHUNK_OFFSET]
+    mov     edx, dword ptr [edx + UMEntryThunk__m_pUMThunkMarshInfo]
+    mov     ebx, dword ptr [edx + UMThunkMarshInfo__m_ecxArgOffset]
+    cmp     ebx, -1
+    je      LOCAL_LABEL(CopyStack)
+    mov     ecx, dword ptr [esi + ebx]
     add     eax, -4
-    mov     ebx, dword ptr [esi + 0x08 + eax]
-    mov     dword ptr [edi + eax], ebx
-    jnz     LOCAL_LABEL(CopyLoop)
+    jz      LOCAL_LABEL(UMThunkStub_ArgumentsSetup)
 
+    mov     ebx, dword ptr [edx + UMThunkMarshInfo__m_edxArgOffset]
+    cmp     ebx, -1
+    je      LOCAL_LABEL(CopyStack)
+    mov     edx, dword ptr [esi + ebx]
+    add     eax, -4
+    jz      LOCAL_LABEL(UMThunkStub_ArgumentsSetup)
+
+
+LOCAL_LABEL(CopyStack):
+    push    ecx
+    mov     ebx, dword ptr [ebp - UMThunkStub_UMENTRYTHUNK_OFFSET]
+    mov     ebx, dword ptr [ebx + UMEntryThunk__m_pUMThunkMarshInfo]
+    mov     ebx, [ebx + UMThunkMarshInfo__m_cbActualArgSize]
+    sub     ebx, eax
+    mov     ecx, dword ptr [esi + ebx]
+    mov     dword ptr [edi + ebx], ecx
+    pop     ecx
+    add     eax, -4
+    jnz     LOCAL_LABEL(CopyStack)
     jmp     LOCAL_LABEL(UMThunkStub_ArgumentsSetup)
 
 #if _DEBUG


### PR DESCRIPTION
This PR implements initial fix of arguments passing in UMThunkStub.
Fix for issue #9357
This PR also fixes following Interop tests:
Interop/BestFitMapping/BestFitMapping/BestFitMapping.sh
Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest/MarshalBoolArrayTest.sh
Interop/RefInt/RefIntTest/RefIntTest.sh
Interop/RefCharArray/RefCharArrayTest/RefCharArrayTest.sh
Interop/StringMarshalling/LPTSTR/LPTSTRTest/LPTSTRTest.sh
@janvorli @parjong @seanshpark PTAL
\CC: @Dmitri-Botcharnikov 