### PR TITLE
[Arm64/Unix] Revert fix stack unwinding in CallDescrWorkerInternal

### DIFF
--- a/src/pal/inc/unixasmmacrosarm64.inc
+++ b/src/pal/inc/unixasmmacrosarm64.inc
@@ -43,6 +43,7 @@ C_FUNC(\Name\()_End):
 
 .macro PROLOG_STACK_ALLOC Size
         sub sp, sp, \Size
+        .cfi_adjust_cfa_offset \Size
 .endm
 
 .macro EPILOG_STACK_FREE Size
@@ -66,7 +67,6 @@ C_FUNC(\Name\()_End):
         .cfi_rel_offset \reg2, \ofs + 8
         .ifc \reg1, fp
         mov fp, sp
-        .cfi_def_cfa_register fp
         .endif
 .endm
 
@@ -77,7 +77,6 @@ C_FUNC(\Name\()_End):
         .cfi_rel_offset \reg2, 8
         .ifc \reg1, fp
         mov fp, sp
-        .cfi_def_cfa_register fp
         .endif
 .endm
 

--- a/src/pal/src/arch/arm64/callsignalhandlerwrapper.S
+++ b/src/pal/src/arch/arm64/callsignalhandlerwrapper.S
@@ -17,7 +17,6 @@ C_FUNC(SignalHandlerWorkerReturnOffset\Alignment):
 NESTED_ENTRY CallSignalHandlerWrapper\Alignment, _TEXT, NoHandler
 __StackAllocationSize = (128 + 8 + 8 + \Alignment) // red zone + fp + lr + alignment 
     PROLOG_STACK_ALLOC __StackAllocationSize
-    .cfi_adjust_cfa_offset __StackAllocationSize
     PROLOG_SAVE_REG_PAIR fp, lr, 0
     bl      EXTERNAL_C_FUNC(signal_handler_worker)
 LOCAL_LABEL(SignalHandlerWorkerReturn\Alignment):


### PR DESCRIPTION
@janvorli This fixes a significant part of the regressions being investigated in #9860.
It reverts a small part of the change in #9650.

This fixed at least 99 tests when applied immediately after #9650.  On tip is is fixing 98 of those 99 tests.



