### PR TITLE
Guard a use of a possibly-uninitialized BitSet.

### DIFF
--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -869,10 +869,13 @@ Range RangeCheck::ComputeRangeForLocalDef(
         case GT_ASG:
         {
             Range range = GetRange(loc->block, loc->stmt, asg->gtGetOp2(), path, monotonic DEBUGARG(indent));
-            JITDUMP("Merge assertions from BB%02d:%s for assignment about %p\n", block->bbNum,
-                    BitVecOps::ToString(m_pCompiler->apTraits, block->bbAssertionIn), dspPtr(asg->gtGetOp1()));
-            MergeEdgeAssertions(asg->gtGetOp1(), block->bbAssertionIn, &range);
-            JITDUMP("done merging\n");
+            if (!BitVecOps::MayBeUninit(block->bbAssertionIn))
+            {
+                JITDUMP("Merge assertions from BB%02d:%s for assignment about %p\n", block->bbNum,
+                        BitVecOps::ToString(m_pCompiler->apTraits, block->bbAssertionIn), dspPtr(asg->gtGetOp1()));
+                MergeEdgeAssertions(asg->gtGetOp1(), block->bbAssertionIn, &range);
+                JITDUMP("done merging\n");
+            }
             return range;
         }
 


### PR DESCRIPTION
Part of the range check optimization pass was not checking to ensure that a bitset
was initialized before attempting to access it. This was causing one of the new
tests for Vector.Narrow to fail with an AV.