### PR TITLE
[Arm64] Enable building ForeignThreadExceptionsNative

### DIFF
--- a/tests/src/Exceptions/ForeignThread/CMakeLists.txt
+++ b/tests/src/Exceptions/ForeignThread/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required (VERSION 2.6)
 
-if(NOT (CLR_CMAKE_TARGET_ARCH STREQUAL arm64))
-
 project (ForeignThreadExceptionsNative)
 
 include_directories(${INC_PLATFORM_DIR})
@@ -13,5 +11,3 @@ add_library (ForeignThreadExceptionsNative SHARED ${SOURCES})
 
 # add the install targets
 install (TARGETS ForeignThreadExceptionsNative DESTINATION bin)
-
-endif()

--- a/tests/src/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
+++ b/tests/src/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
@@ -13,7 +13,6 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <DisableProjectBuild Condition=" '$(Platform)' == 'arm64' ">true</DisableProjectBuild> 
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
@jkotas @janvorli Can you mention the correct person.  Not sure why this was disabled.  It fixes a broken test on [Arm64/Unix] .  May need to be tested on Windows.