### PR TITLE
Fix LDVIRTFTN case for GVM target methods

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -4990,22 +4990,22 @@ GenTreePtr Compiler::impImportLdvirtftn(GenTreePtr              thisPtr,
     }
 
 #if COR_JIT_EE_VERSION > 460
-	// CoreRT generic virtual method
-	if (((pCallInfo->sig.callConv & CORINFO_CALLCONV_GENERIC) != 0) && IsTargetAbi(CORINFO_CORERT_ABI))
-	{
-		GenTreePtr runtimeMethodHandle = nullptr;
-		if (pCallInfo->exactContextNeedsRuntimeLookup)
-		{
-			runtimeMethodHandle = impRuntimeLookupToTree(pResolvedToken, &pCallInfo->codePointerLookup, 
-															pCallInfo->hMethod);
-		}
-		else
-		{
-			runtimeMethodHandle = gtNewIconEmbMethHndNode(pResolvedToken->hMethod);
-		}
-		return gtNewHelperCallNode(CORINFO_HELP_GVMLOOKUP_FOR_SLOT, TYP_I_IMPL, GTF_EXCEPT, 
-									gtNewArgList(thisPtr, runtimeMethodHandle));
-	}
+    // CoreRT generic virtual method
+    if (((pCallInfo->sig.callConv & CORINFO_CALLCONV_GENERIC) != 0) && IsTargetAbi(CORINFO_CORERT_ABI))
+    {
+        GenTreePtr runtimeMethodHandle = nullptr;
+        if (pCallInfo->exactContextNeedsRuntimeLookup)
+        {
+            runtimeMethodHandle = impRuntimeLookupToTree(pResolvedToken, &pCallInfo->codePointerLookup, 
+                                                         pCallInfo->hMethod);
+        }
+        else
+        {
+            runtimeMethodHandle = gtNewIconEmbMethHndNode(pResolvedToken->hMethod);
+        }
+        return gtNewHelperCallNode(CORINFO_HELP_GVMLOOKUP_FOR_SLOT, TYP_I_IMPL, GTF_EXCEPT, 
+                                   gtNewArgList(thisPtr, runtimeMethodHandle));
+    }
 #endif // COR_JIT_EE_VERSION
 
 #ifdef FEATURE_READYTORUN_COMPILER
@@ -6791,8 +6791,8 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 GenTreePtr thisPtrCopy;
                 thisPtr = impCloneExpr(thisPtr, &thisPtrCopy, NO_CLASS_HANDLE, (unsigned)CHECK_SPILL_ALL,
                                        nullptr DEBUGARG("LDVIRTFTN this pointer"));
-
-				GenTreePtr fptr = impImportLdvirtftn(thisPtr, pResolvedToken, callInfo);
+                
+                GenTreePtr fptr = impImportLdvirtftn(thisPtr, pResolvedToken, callInfo);
 
                 if (compDonotInline())
                 {
@@ -6815,7 +6815,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
                 if (((sig->callConv & CORINFO_CALLCONV_GENERIC) != 0) && IsTargetAbi(CORINFO_CORERT_ABI))
                 {
-					// CoreRT generic virtual method: need to handle potential fat function pointers
+                    // CoreRT generic virtual method: need to handle potential fat function pointers
                     addFatPointerCandidate(call->AsCall());
                 }
 #ifdef FEATURE_READYTORUN_COMPILER

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -4996,14 +4996,14 @@ GenTreePtr Compiler::impImportLdvirtftn(GenTreePtr              thisPtr,
         GenTreePtr runtimeMethodHandle = nullptr;
         if (pCallInfo->exactContextNeedsRuntimeLookup)
         {
-            runtimeMethodHandle = impRuntimeLookupToTree(pResolvedToken, &pCallInfo->codePointerLookup, 
-                                                         pCallInfo->hMethod);
+            runtimeMethodHandle =
+                impRuntimeLookupToTree(pResolvedToken, &pCallInfo->codePointerLookup, pCallInfo->hMethod);
         }
         else
         {
             runtimeMethodHandle = gtNewIconEmbMethHndNode(pResolvedToken->hMethod);
         }
-        return gtNewHelperCallNode(CORINFO_HELP_GVMLOOKUP_FOR_SLOT, TYP_I_IMPL, GTF_EXCEPT, 
+        return gtNewHelperCallNode(CORINFO_HELP_GVMLOOKUP_FOR_SLOT, TYP_I_IMPL, GTF_EXCEPT,
                                    gtNewArgList(thisPtr, runtimeMethodHandle));
     }
 #endif // COR_JIT_EE_VERSION
@@ -6791,7 +6791,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 GenTreePtr thisPtrCopy;
                 thisPtr = impCloneExpr(thisPtr, &thisPtrCopy, NO_CLASS_HANDLE, (unsigned)CHECK_SPILL_ALL,
                                        nullptr DEBUGARG("LDVIRTFTN this pointer"));
-                
+
                 GenTreePtr fptr = impImportLdvirtftn(thisPtr, pResolvedToken, callInfo);
 
                 if (compDonotInline())

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -4989,6 +4989,25 @@ GenTreePtr Compiler::impImportLdvirtftn(GenTreePtr              thisPtr,
         NO_WAY("Virtual call to a function added via EnC is not supported");
     }
 
+#if COR_JIT_EE_VERSION > 460
+	// CoreRT generic virtual method
+	if (((pCallInfo->sig.callConv & CORINFO_CALLCONV_GENERIC) != 0) && IsTargetAbi(CORINFO_CORERT_ABI))
+	{
+		GenTreePtr runtimeMethodHandle = nullptr;
+		if (pCallInfo->exactContextNeedsRuntimeLookup)
+		{
+			runtimeMethodHandle = impRuntimeLookupToTree(pResolvedToken, &pCallInfo->codePointerLookup, 
+															pCallInfo->hMethod);
+		}
+		else
+		{
+			runtimeMethodHandle = gtNewIconEmbMethHndNode(pResolvedToken->hMethod);
+		}
+		return gtNewHelperCallNode(CORINFO_HELP_GVMLOOKUP_FOR_SLOT, TYP_I_IMPL, GTF_EXCEPT, 
+									gtNewArgList(thisPtr, runtimeMethodHandle));
+	}
+#endif // COR_JIT_EE_VERSION
+
 #ifdef FEATURE_READYTORUN_COMPILER
     if (opts.IsReadyToRun())
     {
@@ -6773,30 +6792,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 thisPtr = impCloneExpr(thisPtr, &thisPtrCopy, NO_CLASS_HANDLE, (unsigned)CHECK_SPILL_ALL,
                                        nullptr DEBUGARG("LDVIRTFTN this pointer"));
 
-                GenTreePtr fptr = nullptr;
-                bool       coreRTGenericVirtualMethod =
-                    ((sig->callConv & CORINFO_CALLCONV_GENERIC) != 0) && IsTargetAbi(CORINFO_CORERT_ABI);
-#if COR_JIT_EE_VERSION > 460
-                if (coreRTGenericVirtualMethod)
-                {
-                    GenTreePtr runtimeMethodHandle = nullptr;
-                    if (callInfo->exactContextNeedsRuntimeLookup)
-                    {
-                        runtimeMethodHandle =
-                            impRuntimeLookupToTree(pResolvedToken, &callInfo->codePointerLookup, methHnd);
-                    }
-                    else
-                    {
-                        runtimeMethodHandle = gtNewIconEmbMethHndNode(pResolvedToken->hMethod);
-                    }
-                    fptr = gtNewHelperCallNode(CORINFO_HELP_GVMLOOKUP_FOR_SLOT, TYP_I_IMPL, GTF_EXCEPT,
-                                               gtNewArgList(thisPtr, runtimeMethodHandle));
-                }
-                else
-#endif // COR_JIT_EE_VERSION
-                {
-                    fptr = impImportLdvirtftn(thisPtr, pResolvedToken, callInfo);
-                }
+				GenTreePtr fptr = impImportLdvirtftn(thisPtr, pResolvedToken, callInfo);
 
                 if (compDonotInline())
                 {
@@ -6817,8 +6813,9 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 call->gtCall.gtCallObjp = thisPtrCopy;
                 call->gtFlags |= GTF_EXCEPT | (fptr->gtFlags & GTF_GLOB_EFFECT);
 
-                if (coreRTGenericVirtualMethod)
+                if (((sig->callConv & CORINFO_CALLCONV_GENERIC) != 0) && IsTargetAbi(CORINFO_CORERT_ABI))
                 {
+					// CoreRT generic virtual method: need to handle potential fat function pointers
                     addFatPointerCandidate(call->AsCall());
                 }
 #ifdef FEATURE_READYTORUN_COMPILER


### PR DESCRIPTION
Fix for issue https://github.com/dotnet/corert/issues/2796
We were handling the GVM case correctly for the callvirt scenarios, but not for the ldvirtftn opcodes.
This fix moves the GVM handling logic for CoreRT into the impImportLdvirtftn helper to fix both cases.