### PR TITLE
Use the correct class handle for fat calli temporary

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6432,7 +6432,6 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         eeGetSig(pResolvedToken->token, info.compScopeHnd, impTokenLookupContextHandle, &calliSig);
 
         callRetTyp = JITtype2varType(calliSig.retType);
-        clsHnd     = calliSig.retTypeClass;
 
         call = impImportIndirectCall(&calliSig, ilOffset);
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7715,7 +7715,7 @@ DONE_CALL:
                         unsigned   calliSlot  = lvaGrabTemp(true DEBUGARG("calli"));
                         LclVarDsc* varDsc     = &lvaTable[calliSlot];
                         varDsc->lvVerTypeInfo = tiRetVal;
-                        impAssignTempGen(calliSlot, call, clsHnd, (unsigned)CHECK_SPILL_NONE);
+                        impAssignTempGen(calliSlot, call, tiRetVal.GetClassHandle(), (unsigned)CHECK_SPILL_NONE);
                         // impAssignTempGen can change src arg list and return type for call that returns struct.
                         var_types type = genActualType(lvaTable[calliSlot].TypeGet());
                         call           = gtNewLclvNode(calliSlot, type);


### PR DESCRIPTION
`clsHnd` is the class handle of the type that owns the method. We need
the class handle for the method's return type though.

This is ending up with RyuJIT asking weird questions over JitInterface
(`getClassGClayout` of a reference type). I assume other things are
wrong too.