### PR TITLE
[x86/Linux] Clean up EXCEPTION_REGISTRATION_RECORD

### DIFF
--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1491,11 +1491,6 @@ typedef struct _DISPATCHER_CONTEXT {
 
 #elif defined(_X86_)
 
-typedef struct _EXCEPTION_REGISTRATION_RECORD {
-    struct _EXCEPTION_REGISTRATION_RECORD *Next;
-    PEXCEPTION_ROUTINE Handler;
-} EXCEPTION_REGISTRATION_RECORD;
-
 typedef struct _DISPATCHER_CONTEXT {
     DWORD ControlPc;
     DWORD ImageBase;

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -2846,7 +2846,7 @@ protected:
 };
 #endif // _TARGET_X86_ && !FEATURE_PAL
 
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) && defined(FEATURE_COMINTEROP)
 //-------------------------------------------------------------------------
 // Exception handler for COM to managed frame
 //  and the layout of the exception registration record structure in the stack
@@ -2866,7 +2866,7 @@ struct ComToManagedExRecord
         return &m_frame;
     }
 };
-#endif // _TARGET_X86_
+#endif // _TARGET_X86_ && FEATURE_COMINTEROP
 
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
EXCEPTION_REGISTRATION_RECORD is introduces as a workaround while x86/Linux bring up, but it is not used any more.

This commit cleans up EXCEPTION_REGISTRATION_RECORD from x86/Linux PAL.