### PR TITLE
Remove CLRThreadpoolHosted as it always returns false.

### DIFF
--- a/src/vm/threadpoolrequest.cpp
+++ b/src/vm/threadpoolrequest.cpp
@@ -368,11 +368,8 @@ void UnManagedPerAppDomainTPCount::SetAppDomainRequestsActive()
         LONG prevCount = FastInterlockCompareExchange(&m_outstandingThreadRequestCount, count+1, count);
         if (prevCount == count)
         {
-            if (!CLRThreadpoolHosted())
-            {
-                ThreadpoolMgr::MaybeAddWorkingWorker();
-                ThreadpoolMgr::EnsureGateThreadRunning();
-            }
+            ThreadpoolMgr::MaybeAddWorkingWorker();
+            ThreadpoolMgr::EnsureGateThreadRunning();
             break;
         }
         count = prevCount;
@@ -608,11 +605,8 @@ void ManagedPerAppDomainTPCount::SetAppDomainRequestsActive()
             LONG prev = FastInterlockCompareExchange(&m_numRequestsPending, count+1, count);
             if (prev == count)
             {
-                if (!CLRThreadpoolHosted())
-                {
-                    ThreadpoolMgr::MaybeAddWorkingWorker();
-                    ThreadpoolMgr::EnsureGateThreadRunning();
-                }
+                ThreadpoolMgr::MaybeAddWorkingWorker();
+                ThreadpoolMgr::EnsureGateThreadRunning();
                 break;
             }
             count = prev;
@@ -688,7 +682,7 @@ void ManagedPerAppDomainTPCount::ClearAppDomainUnloading()
     // AD.
     //
     VolatileStore(&m_numRequestsPending, (LONG)ThreadpoolMgr::NumberOfProcessors);
-    if (!CLRThreadpoolHosted() && ThreadpoolMgr::IsInitialized())
+    if (ThreadpoolMgr::IsInitialized())
     {
         ThreadpoolMgr::MaybeAddWorkingWorker();
         ThreadpoolMgr::EnsureGateThreadRunning();

--- a/src/vm/util.hpp
+++ b/src/vm/util.hpp
@@ -708,12 +708,6 @@ inline BOOL CLRSyncHosted()
     return FALSE;
 }
 
-inline BOOL CLRThreadpoolHosted()
-{
-    LIMITED_METHOD_CONTRACT;
-    return FALSE;
-}
-
 inline BOOL CLRIoCompletionHosted()
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -1122,19 +1122,13 @@ public:
     static void NotifyWorkItemCompleted()
     {
         WRAPPER_NO_CONTRACT;
-        if (!CLRThreadpoolHosted())
-        {
-            Thread::IncrementThreadPoolCompletionCount();
-            UpdateLastDequeueTime();
-        }
+        Thread::IncrementThreadPoolCompletionCount();
+        UpdateLastDequeueTime();
     }
 
     static bool ShouldAdjustMaxWorkersActive()
     {
         WRAPPER_NO_CONTRACT;
-
-        if (CLRThreadpoolHosted())
-            return false;
 
         DWORD priorTime = PriorCompletedWorkRequestsTime;
         MemoryBarrier(); // read fresh value for NextCompletedWorkRequestsTime below


### PR DESCRIPTION
When commit 1476776a3989817bf5378d583b5cf61dd5957925, as part of #9603, removed all the code under `FEATURE_INCLUDE_ALL_INTERFACES`, it left behind several functions in src/vm/util.hpp that just return `false`. `CLRThreadpoolHosted` is one of them.

While the compiler is probably able to able to see that these methods always return `false` and remove dead code accordingly, some of these `CLR*Hosted` functions make parts of the coreclr more complicated than they need to be and harder for humans to understand. Would it be valuable to have all of these functions removed?