### PR TITLE
[x86/Linux] Fix clang 3.9 build error

### DIFF
--- a/src/pal/tests/palsuite/threading/CreateMutexA_ReleaseMutex/test1/CreateMutexA.cpp
+++ b/src/pal/tests/palsuite/threading/CreateMutexA_ReleaseMutex/test1/CreateMutexA.cpp
@@ -169,8 +169,7 @@ FillBuffer()
 /* 
  * Producer thread function.  
  */
-DWORD 
-Producer(LPVOID lpParam)
+DWORD PALAPI Producer(LPVOID lpParam)
 {
     int n = 0;
     int ret;
@@ -202,7 +201,7 @@ Producer(LPVOID lpParam)
 /* 
  * Consumer thread function. 
  */
-DWORD Consumer( LPVOID lpParam )
+DWORD PALAPI Consumer( LPVOID lpParam )
 {
     int n = 0;
     int ret;

--- a/src/pal/tests/palsuite/threading/CreateMutexW_ReleaseMutex/test1/CreateMutexW.cpp
+++ b/src/pal/tests/palsuite/threading/CreateMutexW_ReleaseMutex/test1/CreateMutexW.cpp
@@ -169,8 +169,7 @@ FillBuffer()
 /* 
  * Producer thread function.  
  */
-DWORD 
-Producer(LPVOID lpParam)
+DWORD PALAPI Producer(LPVOID lpParam)
 {
     int n = 0;
     int ret;
@@ -202,7 +201,7 @@ Producer(LPVOID lpParam)
 /* 
  * Consumer thread function. 
  */
-DWORD Consumer( LPVOID lpParam )
+DWORD PALAPI Consumer( LPVOID lpParam )
 {
     int n = 0;
     int ret;

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -759,7 +759,7 @@ struct BackgroundThreadStubArgs
     bool hasStarted;
 };
 
-DWORD BackgroundThreadStub(void* arg)
+DWORD WINAPI BackgroundThreadStub(void* arg)
 {
     BackgroundThreadStubArgs* stubArgs = (BackgroundThreadStubArgs*)arg;
     assert (stubArgs->thread != NULL);


### PR DESCRIPTION
This commit fixes several incompatible function pointer castings detected by clang 3.9.