### PR TITLE
[Linux][GDB-JIT] Fix lldb type displaying issues

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -89,8 +89,11 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle, NotifyGdb::PTK_TypeInfoMap pTyp
 
                 pTypeMap->Add(refTypeInfo->GetTypeKey(), refTypeInfo);
             }
+            else
+            {
+                pTypeMap->Add(typeInfo->GetTypeKey(), typeInfo);
+            }
 
-            pTypeMap->Add(typeInfo->GetTypeKey(), typeInfo);
             typeInfo->CalculateName();
 
             //

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1009,6 +1009,11 @@ void TypeDefInfo::DumpStrings(char *ptr, int &offset)
 
 void TypeDefInfo::DumpDebugInfo(char *ptr, int &offset)
 {
+    if (m_typedef_type_offset != 0)
+    {
+        return;
+    }
+
     if (ptr != nullptr)
     {
         DebugInfoTypeDef buf;

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1033,15 +1033,18 @@ void TypeDefInfo::DumpDebugInfo(char *ptr, int &offset)
 void ByteTypeInfo::DumpStrings(char* ptr, int& offset)
 {
     PrimitiveTypeInfo::DumpStrings(ptr, offset);
-    m_typedef_info->m_typedef_name = new (nothrow) char[strlen(m_type_name) + 1];
-    if (strcmp(m_type_name, "System.Byte") == 0)
-        strcpy(m_typedef_info->m_typedef_name, "byte");
-    else if (strcmp(m_type_name, "System.SByte") == 0)
-        strcpy(m_typedef_info->m_typedef_name, "sbyte");
-    else if (strcmp(m_type_name, "char16_t") == 0)
-        strcpy(m_typedef_info->m_typedef_name, "char");
-    else
-        strcpy(m_typedef_info->m_typedef_name, m_type_name);
+    if (!m_typedef_info->m_typedef_name)
+    {
+        m_typedef_info->m_typedef_name = new (nothrow) char[strlen(m_type_name) + 1];
+        if (strcmp(m_type_name, "System.Byte") == 0)
+            strcpy(m_typedef_info->m_typedef_name, "byte");
+        else if (strcmp(m_type_name, "System.SByte") == 0)
+            strcpy(m_typedef_info->m_typedef_name, "sbyte");
+        else if (strcmp(m_type_name, "char16_t") == 0)
+            strcpy(m_typedef_info->m_typedef_name, "char");
+        else
+            strcpy(m_typedef_info->m_typedef_name, m_type_name);
+    }
     m_typedef_info->DumpStrings(ptr, offset);
 }
 

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -952,7 +952,13 @@ void TypeInfoBase::CalculateName()
 {
     // name the type
     SString sName;
-    typeHandle.GetName(sName);
+
+    const TypeString::FormatFlags formatFlags = static_cast<TypeString::FormatFlags>(
+        TypeString::FormatNamespace |
+        TypeString::FormatAngleBrackets);
+
+    TypeString::AppendType(sName, typeHandle, formatFlags);
+
     StackScratchBuffer buffer;
     const UTF8 *utf8 = sName.GetUTF8(buffer);
     if (typeHandle.IsValueType())
@@ -965,6 +971,13 @@ void TypeInfoBase::CalculateName()
         m_type_name = new char[strlen(utf8) + 1 + 2];
         strcpy(m_type_name, "__");
         strcpy(m_type_name + 2, utf8);
+    }
+
+    // Fix nested names
+    for (char *p = m_type_name; *p; ++p)
+    {
+        if (*p == '+')
+            *p = '.';
     }
 }
 

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -69,7 +69,10 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle, NotifyGdb::PTK_TypeInfoMap pTyp
             if (typeInfo == nullptr)
                 return nullptr;
 
-            typeInfo->m_type_size = typeHandle.AsMethodTable()->GetClass()->GetSize();
+            if (pMT->IsValueType())
+                typeInfo->m_type_size = typeHandle.GetSize();
+            else
+                typeInfo->m_type_size = typeHandle.AsMethodTable()->GetClass()->GetSize();
 
             RefTypeInfo* refTypeInfo = nullptr;
             if (!typeHandle.IsValueType())

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -190,7 +190,7 @@ class TypeDefInfo : public DwarfDumpable
 {
 public:
     TypeDefInfo(char *typedef_name,int typedef_type):
-    m_typedef_name(typedef_name), m_typedef_type(typedef_type) {}
+    m_typedef_name(typedef_name), m_typedef_type(typedef_type), m_typedef_type_offset(0) {}
     void DumpStrings(char* ptr, int& offset) override;
     void DumpDebugInfo(char* ptr, int& offset) override;
     virtual ~TypeDefInfo()

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -284,9 +284,9 @@ public:
 class ArrayTypeInfo: public TypeInfoBase
 {
 public:
-    ArrayTypeInfo(TypeHandle typeHandle, int countOffset, TypeInfoBase* elemType)
+    ArrayTypeInfo(TypeHandle typeHandle, int count, TypeInfoBase* elemType)
         : TypeInfoBase(typeHandle),
-          m_count_offset(countOffset),
+          m_count(count),
           m_elem_type(elemType)
     {
     }
@@ -301,7 +301,7 @@ public:
 
     void DumpDebugInfo(char* ptr, int& offset) override;
 
-    int m_count_offset;
+    int m_count;
     TypeInfoBase *m_elem_type;
 };
 

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -236,6 +236,16 @@ public:
     TypeInfoBase *m_value_type;
 };
 
+class NamedRefTypeInfo: public RefTypeInfo
+{
+public:
+    NamedRefTypeInfo(TypeHandle typeHandle, TypeInfoBase *value_type)
+        : RefTypeInfo(typeHandle, value_type)
+    {
+    }
+    void DumpDebugInfo(char* ptr, int& offset) override;
+};
+
 class ClassTypeInfo: public TypeInfoBase
 {
 public:


### PR DESCRIPTION
This PR introduces fixes in GDB-JIT to help LLDB display primitive types, structs, classes and arrays.

Highlights:

* fix incorrect value type size when it is embedded in other types

* fix reference types duplication

* fix memory leak in ByteTypeInfo::DumpStrings

* use array of 1 element instead of lenght expression in DWARF (because LLDB calculates array length incorrectly)

* use C# type names for built-in types (float instead of System.Single etc.)

* use full names (with namespaces) for classes and structures

* add typedef for reference types (example: make MyClass a typedef for __MyClass *)

* add bounds field in array structure for multi-dimensional arrays

@mikem8361, @janvorli PTAL

cc @Dmitri-Botcharnikov @chunseoklee @seanshpark @lucenticus
