### PR TITLE
Build cross-compile altjits for arm32 and arm64

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -12,6 +12,8 @@ if (CLR_CMAKE_TARGET_ARCH_AMD64 OR (CLR_CMAKE_TARGET_ARCH_I386 AND NOT CLR_CMAKE
   add_definitions(-DFEATURE_AVX_SUPPORT)
 endif ()
 
+# JIT_BUILD disables certain PAL_TRY debugging features
+add_definitions(-DJIT_BUILD=1)
 
 if(WIN32)
   set(JIT_RESOURCES Native.rc)
@@ -76,86 +78,93 @@ set( JIT_SOURCES
   valuenum.cpp
 )
 
-if(CLR_CMAKE_TARGET_ARCH_AMD64)
-  set( ARCH_SOURCES
-    codegenxarch.cpp
-    emitxarch.cpp
-    lowerxarch.cpp
-    lsraxarch.cpp
-    simd.cpp
-    simdcodegenxarch.cpp
-    targetamd64.cpp
-    unwindamd64.cpp
-  )
-elseif(CLR_CMAKE_TARGET_ARCH_ARM)
-  set( ARCH_SOURCES
-    codegenarm.cpp
-    decomposelongs.cpp
-    emitarm.cpp
-    lowerarm.cpp
-    lsraarm.cpp
-    targetarm.cpp
-    unwindarm.cpp
-  )
-elseif(CLR_CMAKE_TARGET_ARCH_I386)
-  set( ARCH_SOURCES
-    codegenxarch.cpp
-    decomposelongs.cpp
-    emitxarch.cpp
-    lowerxarch.cpp
-    lsraxarch.cpp
-    simd.cpp
-    simdcodegenxarch.cpp
-    targetx86.cpp
-    unwindx86.cpp
-  )
-elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
-  set( ARCH_SOURCES
-    codegenarm64.cpp
-    emitarm64.cpp
-    lowerarm64.cpp
-    lsraarm64.cpp
-    targetarm64.cpp
-    unwindarm.cpp
-    unwindarm64.cpp
-  )
-else()
-  clr_unknown_arch()
-endif()
-
 # The following defines all the source files used by the "legacy" back-end (#ifdef LEGACY_BACKEND).
 # It is always safe to include both legacy and non-legacy files in the build, as everything is properly
 # #ifdef'ed, though it makes the build slightly slower to do so. Note there is only a legacy backend for
 # x86 and ARM.
 
-if(CLR_CMAKE_TARGET_ARCH_AMD64)
-  set( ARCH_LEGACY_SOURCES
-  )
-elseif(CLR_CMAKE_TARGET_ARCH_ARM)
-  set( ARCH_LEGACY_SOURCES
+set(JIT_ARM_LEGACY_SOURCES
     codegenlegacy.cpp
     registerfp.cpp
-  )
-elseif(CLR_CMAKE_TARGET_ARCH_I386)
-  set( ARCH_LEGACY_SOURCES
+)
+set(JIT_I386_LEGACY_SOURCES
     codegenlegacy.cpp
     stackfp.cpp
-  )
+)
+
+# Define all the architecture-specific source files
+
+set( JIT_AMD64_SOURCES
+  codegenxarch.cpp
+  emitxarch.cpp
+  lowerxarch.cpp
+  lsraxarch.cpp
+  simd.cpp
+  simdcodegenxarch.cpp
+  targetamd64.cpp
+  unwindamd64.cpp
+)
+
+set( JIT_ARM_SOURCES
+  ${JIT_ARM_LEGACY_SOURCES}
+  codegenarm.cpp
+  decomposelongs.cpp
+  emitarm.cpp
+  lowerarm.cpp
+  lsraarm.cpp
+  targetarm.cpp
+  unwindarm.cpp
+)
+
+set( JIT_I386_SOURCES
+  ${JIT_I386_LEGACY_SOURCES}
+  codegenxarch.cpp
+  decomposelongs.cpp
+  emitxarch.cpp
+  lowerxarch.cpp
+  lsraxarch.cpp
+  simd.cpp
+  simdcodegenxarch.cpp
+  targetx86.cpp
+  unwindx86.cpp
+)
+
+set( JIT_ARM64_SOURCES
+  codegenarm64.cpp
+  emitarm64.cpp
+  lowerarm64.cpp
+  lsraarm64.cpp
+  targetarm64.cpp
+  unwindarm.cpp
+  unwindarm64.cpp
+)
+
+if(CLR_CMAKE_TARGET_ARCH_AMD64)
+  set(JIT_ARCH_SOURCES ${JIT_AMD64_SOURCES})
+elseif(CLR_CMAKE_TARGET_ARCH_ARM)
+  set(JIT_ARCH_SOURCES ${JIT_ARM_SOURCES})
+elseif(CLR_CMAKE_TARGET_ARCH_I386)
+  set(JIT_ARCH_SOURCES ${JIT_I386_SOURCES})
 elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
-  set( ARCH_LEGACY_SOURCES
-  )
+  set(JIT_ARCH_SOURCES ${JIT_ARM64_SOURCES})
 else()
   clr_unknown_arch()
 endif()
 
 set( SOURCES
   ${JIT_SOURCES}
-  ${ARCH_SOURCES}
-  ${ARCH_LEGACY_SOURCES}
   ${JIT_RESOURCES}
 )
 
 convert_to_absolute_path(SOURCES ${SOURCES})
+convert_to_absolute_path(JIT_ARCH_SOURCES ${JIT_ARCH_SOURCES})
+
+# Also convert the per-architecture sources to absolute paths, if the subdirs want to use them.
+
+convert_to_absolute_path(JIT_AMD64_SOURCES ${JIT_AMD64_SOURCES})
+convert_to_absolute_path(JIT_ARM_SOURCES ${JIT_ARM_SOURCES})
+convert_to_absolute_path(JIT_I386_SOURCES ${JIT_I386_SOURCES})
+convert_to_absolute_path(JIT_ARM64_SOURCES ${JIT_ARM64_SOURCES})
 
 if(WIN32)
   add_precompiled_header(jitpch.h ../jitpch.cpp SOURCES)
@@ -211,6 +220,12 @@ add_subdirectory(standalone)
 if (CLR_CMAKE_PLATFORM_ARCH_ARM)
     add_subdirectory(protojit)
 endif (CLR_CMAKE_PLATFORM_ARCH_ARM)
+
+if ((CLR_CMAKE_PLATFORM_ARCH_I386 OR CLR_CMAKE_PLATFORM_ARCH_AMD64) AND WIN32)
+    # On x86, build RyuJIT/ARM32 cross-compiling altjit.
+    # On amd64, build RyuJIT/ARM64 cross-compiling altjit.
+    add_subdirectory(protononjit)
+endif ()
 
 if (CLR_CMAKE_PLATFORM_ARCH_I386 AND WIN32)
     add_subdirectory(legacyjit)

--- a/src/jit/compatjit/CMakeLists.txt
+++ b/src/jit/compatjit/CMakeLists.txt
@@ -22,6 +22,7 @@ endif(WIN32)
 add_library_clr(compatjit
    SHARED
    ${SHARED_LIB_SOURCES}
+   ${JIT_ARCH_SOURCES}
 )
 
 add_dependencies(compatjit jit_exports)

--- a/src/jit/crossgen/CMakeLists.txt
+++ b/src/jit/crossgen/CMakeLists.txt
@@ -4,4 +4,4 @@ if(CLR_CMAKE_TARGET_ARCH_ARM)
   add_definitions(-DLEGACY_BACKEND)
 endif()
 
-add_library_clr(clrjit_crossgen ${SOURCES})
+add_library_clr(clrjit_crossgen ${SOURCES} ${JIT_ARCH_SOURCES})

--- a/src/jit/dll/CMakeLists.txt
+++ b/src/jit/dll/CMakeLists.txt
@@ -11,11 +11,13 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     add_library_clr(clrjit_static
       STATIC
       ${SHARED_LIB_SOURCES}
+      ${JIT_ARCH_SOURCES}
     )
     add_dependencies(clrjit_static coreclrpal gcinfo)
 else()
     add_library_clr(clrjit_static
-       ${SOURCES}
+      ${SHARED_LIB_SOURCES}
+      ${JIT_ARCH_SOURCES}
     )
 # Disable up to here (see above) the following for UNIX altjit on Windows 
 # Enable the following for UNIX altjit on Windows

--- a/src/jit/protojit/CMakeLists.txt
+++ b/src/jit/protojit/CMakeLists.txt
@@ -13,6 +13,7 @@ endif(WIN32)
 add_library_clr(protojit
    SHARED
    ${SHARED_LIB_SOURCES}
+   ${JIT_ARCH_SOURCES}
 )
 
 add_dependencies(protojit jit_exports)

--- a/src/jit/protononjit/CMakeLists.txt
+++ b/src/jit/protononjit/CMakeLists.txt
@@ -1,30 +1,40 @@
-project(legacyjit)
+project(protononjit)
 
-add_definitions(-DLEGACY_BACKEND)
 add_definitions(-DALT_JIT)
 add_definitions(-DFEATURE_NO_HOST)
 add_definitions(-DSELF_NO_HOST)
 add_definitions(-DFEATURE_READYTORUN_COMPILER)
 remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
-# No SIMD in legacy back-end.
 remove_definitions(-DFEATURE_SIMD)
 remove_definitions(-DFEATURE_AVX_SUPPORT)
 
+if (CLR_CMAKE_PLATFORM_ARCH_I386)
+    remove_definitions(-D_TARGET_X86_=1)
+    add_definitions(-D_TARGET_ARM_)
+    set(JIT_ARCH_ALTJIT_SOURCES ${JIT_ARM_SOURCES})
+elseif(CLR_CMAKE_PLATFORM_ARCH_AMD64)
+    remove_definitions(-D_TARGET_AMD64_=1)
+    add_definitions(-D_TARGET_ARM64_)
+    set(JIT_ARCH_ALTJIT_SOURCES ${JIT_ARM64_SOURCES})
+else()
+    clr_unknown_arch()
+endif()
+
 if(WIN32)
-  add_definitions(-DFX_VER_INTERNALNAME_STR=legacyjit.dll)
+  add_definitions(-DFX_VER_INTERNALNAME_STR=protononjit.dll)
 endif(WIN32)
 
-add_library_clr(legacyjit
+add_library_clr(protononjit
    SHARED
    ${SHARED_LIB_SOURCES}
-   ${JIT_ARCH_SOURCES}
+   ${JIT_ARCH_ALTJIT_SOURCES}
 )
 
-add_dependencies(legacyjit jit_exports)
+add_dependencies(protononjit jit_exports)
 
-set_property(TARGET legacyjit APPEND_STRING PROPERTY LINK_FLAGS ${JIT_EXPORTS_LINKER_OPTION})
-set_property(TARGET legacyjit APPEND_STRING PROPERTY LINK_DEPENDS ${JIT_EXPORTS_FILE})
+set_property(TARGET protononjit APPEND_STRING PROPERTY LINK_FLAGS ${JIT_EXPORTS_LINKER_OPTION})
+set_property(TARGET protononjit APPEND_STRING PROPERTY LINK_DEPENDS ${JIT_EXPORTS_FILE})
 
 set(RYUJIT_LINK_LIBRARIES
    utilcodestaticnohost
@@ -55,9 +65,9 @@ else()
     )
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-target_link_libraries(legacyjit
+target_link_libraries(protononjit
    ${RYUJIT_LINK_LIBRARIES}
 )
 
 # add the install targets
-install_clr(legacyjit)
+install_clr(protononjit)

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -16,6 +16,7 @@ endif(WIN32)
 add_library_clr(clrjit
    SHARED
    ${SHARED_LIB_SOURCES}
+   ${JIT_ARCH_SOURCES}
 )
 
 add_dependencies(clrjit jit_exports)


### PR DESCRIPTION
On x86, build an x86-host, arm32-target altjit.
On amd64, build an amd64-host, arm64-target altjit.

Each are named protononjit.dll, using our existing naming
convention (proto for "prototype", nonjit meaning the code
won't be executed).

Use these via:
```
set COMPlus_AltJit=*
set COMPlus_AltJitName=protononjit.dll
```
Of course, instead of `*`, you can use any function name.

They are very useful for debugging the JIT in a "nicer" environment
than the full native environment, especially if the full native
environment isn't complete, or if the tools (such as debuggers, editors)
are better in the cross environment than the native environment.