### PR TITLE
Fix error in dumpling text file cleanup

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -118,14 +118,6 @@ case $OSName in
         ;;
 esac
 
-# clean up any existing dumpling remnants from previous runs.
-dumplingsListPath="$PWD/dumplings.txt"
-if [ -f "$dumplingsListPath" ]; then
-    rm "$dumplingsListPath"
-fi
-
-find . -type f -name "local_dumplings.txt" -exec rm {} \;
-
 function xunit_output_begin {
     xunitOutputPath=$testRootDir/coreclrtests.xml
     xunitTestOutputPath=${xunitOutputPath}.test
@@ -1198,6 +1190,13 @@ fi
 export __TestEnv=$testEnv
 
 cd "$testRootDir"
+
+dumplingsListPath="$testRootDir/dumplings.txt"
+
+# clean up any existing dumpling remnants from previous runs.
+rm -f "$dumplingsListPath"
+find $testRootDir -type f -name "local_dumplings.txt" -exec rm {} \;
+
 time_start=$(date +"%s")
 if [ -z "$testDirectories" ]
 then
@@ -1219,7 +1218,7 @@ finish_remaining_tests
 
 print_results
 
-find . -type f -name "local_dumplings.txt" -exec cat {} \; > $dumplingsListPath
+find $testRootDir -type f -name "local_dumplings.txt" -exec cat {} \; > $dumplingsListPath
 
 if [ -s $dumplingsListPath ]; then
     cat $dumplingsListPath


### PR DESCRIPTION
https://github.com/dotnet/coreclr/commit/85358db35ac3f37d5c3eb541984fe3a27b7a1175 added some logic for creating and cleaning up text files which contain dump information.

Both the creation and the clean up code were using the current directory as the location where the files should be. However, because the clean up code was just inserted near the beginning of the script, the current directory at that time is wherever the script is run from, and it can be different from `$testRootDir`, under which the files are created.

This change moves the cleanup code close to the creation code and uses the `$testRootDir` path explicitly rather than just the current directory.

@bryanar 