### PR TITLE
Implement slicing APIs for ArraySegment<T>

### DIFF
--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -27,11 +27,9 @@ namespace System
     [Serializable]
     public struct ArraySegment<T> : IList<T>, IReadOnlyList<T>
     {
-        // Do not replace this with Array.Empty. We don't want to have the overhead of instantiating
-        // another generic type in addition to ArraySegment<T> for new type parameters.
-        private static readonly T[] s_emptyArray = new T[0];
-
-        public static ArraySegment<T> Empty { get; } = new ArraySegment<T>(s_emptyArray);
+        // Do not replace the array allocation with Array.Empty. We don't want to have the overhead of
+        // instantiating another generic type in addition to ArraySegment<T> for new type parameters.
+        public static ArraySegment<T> Empty { get; } = new ArraySegment<T>(new T[0]);
 
         private readonly T[] _array;
         private readonly int _offset;
@@ -112,7 +110,11 @@ namespace System
             }
         }
 
-        public ref T this[int index] => ref _array[_offset + index];
+        public T this[int index]
+        {
+            get { return _array[_offset + index]; }
+            set { _array[_offset + index] = value; }
+        }
 
         public Enumerator GetEnumerator()
         {
@@ -185,7 +187,7 @@ namespace System
 
             if (_count == 0)
             {
-                return s_emptyArray;
+                return Empty._array;
             }
 
             var array = new T[_count];

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -151,6 +151,12 @@ namespace System
         {
             ThrowInvalidOperationIfDefault();
             destination.ThrowInvalidOperationIfDefault();
+
+            if (_count > destination._count)
+            {
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            }
+
             System.Array.Copy(_array, _offset, destination._array, destination._offset, _count);
         }
 

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -168,13 +168,15 @@ namespace System
         public ArraySegment<T> Slice(int index)
         {
             ThrowInvalidOperationIfDefault();
-            return default(ArraySegment<T>);
+            // Note: `index` is allowed to be negative so the start of this ArraySegment can be moved backwards.
+            return new ArraySegment<T>(_array, _offset + index, _count - index);
         }
 
         public ArraySegment<T> Slice(int index, int count)
         {
             ThrowInvalidOperationIfDefault();
-            return default(ArraySegment<T>);
+            // Note: `index` is allowed to be negative so the start of this ArraySegment can be moved backwards.
+            return new ArraySegment<T>(_array, _offset + index, count);
         }
 
         public T[] ToArray()

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -334,8 +334,6 @@ namespace System
             return index >= 0;
         }
 
-        void ICollection<T>.CopyTo(T[] array, int arrayIndex) => CopyTo(array, arrayIndex);
-
         bool ICollection<T>.Remove(T item)
         {
             ThrowHelper.ThrowNotSupportedException();

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -192,14 +192,24 @@ namespace System
         public ArraySegment<T> Slice(int index)
         {
             ThrowInvalidOperationIfDefault();
-            // Note: `index` is allowed to be negative so the start of this ArraySegment can be moved backwards.
+            
+            if ((uint)index > (uint)_count)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
+            }
+
             return new ArraySegment<T>(_array, _offset + index, _count - index);
         }
 
         public ArraySegment<T> Slice(int index, int count)
         {
             ThrowInvalidOperationIfDefault();
-            // Note: `index` is allowed to be negative so the start of this ArraySegment can be moved backwards.
+
+            if ((uint)index > (uint)_count || (uint)count > (uint)(_count - index))
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
+            }
+
             return new ArraySegment<T>(_array, _offset + index, count);
         }
 


### PR DESCRIPTION
Progress towards https://github.com/dotnet/corefx/issues/10528.

I let `Slice` accept negative indices so the start of the `ArraySegment<T>` can backtrack to an earlier position in the array. Please let me know if you think this is a good idea or not (checking for it would involve some additional overhead).

/cc @jkotas, @KrzysztofCwalina