### PR TITLE
[x86/Linux] Revise VirtualMethodFixupStub

### DIFF
--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -836,14 +836,12 @@ NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
     // Set frame pointer
     PROLOG_END
 
-    push    eax
-    sub     esp, 4
+    sub     esp, 8
     push    eax         // address of the thunk
     push    ecx         // this ptr
     CHECK_STACK_ALIGNMENT
     call    C_FUNC(VirtualMethodFixupWorker)
-    add     esp, 4
-    pop     eax
+    add     esp, 8
 
     // Restore stack pointer
     EPILOG_BEG

--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -822,9 +822,9 @@ NESTED_END DelayLoad_MethodCall, _TEXT
 //
 NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
     // Get the return address. It points right after the call instruction in the thunk.
-    mov     ebx, esp
+    mov     eax, [esp]
     // Calculate the address of the thunk
-    sub     ebx, 5
+    sub     eax, 5
 
     // Push ebp frame to get good callstack under debugger
     PROLOG_BEG
@@ -836,13 +836,14 @@ NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
     // Set frame pointer
     PROLOG_END
 
-    sub     esp, 8
-    push    ebx         // address of the thunk
+    push    eax
+    sub     esp, 4
+    push    eax         // address of the thunk
     push    ecx         // this ptr
-
     CHECK_STACK_ALIGNMENT
     call    C_FUNC(VirtualMethodFixupWorker)
-    add     esp, 8
+    add     esp, 4
+    pop     eax
 
     // Restore stack pointer
     EPILOG_BEG
@@ -856,7 +857,6 @@ NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
 
     // Pop return address
     add   esp, 4
-    mov   eax, ebx
 
 PATCH_LABEL VirtualMethodFixupPatchLabel
     // Proceed to execute the actual method.

--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -821,10 +821,10 @@ NESTED_END DelayLoad_MethodCall, _TEXT
 //  to optionally patch the target of the jump so that we do not take this slow path again.
 //
 NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
-    // Pop the return address. It points right after the call instruction in the thunk.
-    pop     eax
+    // Get the return address. It points right after the call instruction in the thunk.
+    mov     ebx, esp
     // Calculate the address of the thunk
-    sub     eax, 5
+    sub     ebx, 5
 
     // Push ebp frame to get good callstack under debugger
     PROLOG_BEG
@@ -836,9 +836,13 @@ NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
     // Set frame pointer
     PROLOG_END
 
-    push    eax         // address of the thunk
+    sub     esp, 8
+    push    ebx         // address of the thunk
     push    ecx         // this ptr
+
+    CHECK_STACK_ALIGNMENT
     call    C_FUNC(VirtualMethodFixupWorker)
+    add     esp, 8
 
     // Restore stack pointer
     EPILOG_BEG
@@ -849,6 +853,10 @@ NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
 
     // Pop ebp frame
     EPILOG_END
+
+    // Pop return address
+    add   esp, 4
+    mov   eax, ebx
 
 PATCH_LABEL VirtualMethodFixupPatchLabel
     // Proceed to execute the actual method.


### PR DESCRIPTION
This commit revises VirtualMethodFixupStub to emit 16-byte aligned stack frame.