### PR TITLE
[x86/Linux] Clean up pContext access

### DIFF
--- a/src/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/debug/daccess/dacdbiimplstackwalk.cpp
@@ -1152,7 +1152,7 @@ CorDebugInternalFrameType DacDbiInterfaceImpl::GetInternalFrameType(Frame * pFra
 void DacDbiInterfaceImpl::UpdateContextFromRegDisp(REGDISPLAY * pRegDisp,
                                                    T_CONTEXT *  pContext)
 {
-#if defined(_TARGET_X86_)
+#ifndef WIN64EXCEPTIONS
     // Do a partial copy first.
     pContext->ContextFlags = (CONTEXT_INTEGER | CONTEXT_CONTROL);
 

--- a/src/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/debug/daccess/dacdbiimplstackwalk.cpp
@@ -1152,7 +1152,7 @@ CorDebugInternalFrameType DacDbiInterfaceImpl::GetInternalFrameType(Frame * pFra
 void DacDbiInterfaceImpl::UpdateContextFromRegDisp(REGDISPLAY * pRegDisp,
                                                    T_CONTEXT *  pContext)
 {
-#ifndef WIN64EXCEPTIONS
+#if defined(_TARGET_X86_) && !defined(WIN64EXCEPTIONS)
     // Do a partial copy first.
     pContext->ContextFlags = (CONTEXT_INTEGER | CONTEXT_CONTROL);
 
@@ -1174,9 +1174,9 @@ void DacDbiInterfaceImpl::UpdateContextFromRegDisp(REGDISPLAY * pRegDisp,
     {
         *pContext = *pRegDisp->pContext;
     }
-#else
+#else // _TARGET_X86_ && !WIN64EXCEPTIONS
     *pContext = *pRegDisp->pCurrentContext;
-#endif
+#endif // !_TARGET_X86_ || WIN64EXCEPTIONS
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -397,7 +397,7 @@ inline LPVOID PushedRegAddr(REGDISPLAY* pRD, LPVOID pAddr)
 {
     LIMITED_METHOD_CONTRACT;
 
-#if defined(_TARGET_AMD64_)
+#ifdef WIN64EXCEPTIONS
     if ( ((UINT_PTR)(pAddr) >= (UINT_PTR)pRD->pCurrentContextPointers) &&
          ((UINT_PTR)(pAddr) <= ((UINT_PTR)pRD->pCurrentContextPointers + sizeof(_KNONVOLATILE_CONTEXT_POINTERS))) )
 #else

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -399,7 +399,7 @@ inline LPVOID PushedRegAddr(REGDISPLAY* pRD, LPVOID pAddr)
 
 #ifdef WIN64EXCEPTIONS
     if ( ((UINT_PTR)(pAddr) >= (UINT_PTR)pRD->pCurrentContextPointers) &&
-         ((UINT_PTR)(pAddr) <= ((UINT_PTR)pRD->pCurrentContextPointers + sizeof(_KNONVOLATILE_CONTEXT_POINTERS))) )
+         ((UINT_PTR)(pAddr) <= ((UINT_PTR)pRD->pCurrentContextPointers + sizeof(T_KNONVOLATILE_CONTEXT_POINTERS))) )
 #else
     if ( ((UINT_PTR)(pAddr) >= (UINT_PTR)pRD->pContext) &&
          ((UINT_PTR)(pAddr) <= ((UINT_PTR)pRD->pContext + sizeof(T_CONTEXT))) )

--- a/src/debug/ee/debugger.inl
+++ b/src/debug/ee/debugger.inl
@@ -225,7 +225,7 @@ inline void FuncEvalFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
         return;
     }
 
-#if !defined(_WIN64)
+#ifndef WIN64EXCEPTIONS
     // Reset pContext; it's only valid for active (top-most) frame.
     pRD->pContext = NULL;
 #endif // !_WIN64

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -594,9 +594,6 @@ void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     }
     CONTRACT_END;
 
-    // reset pContext; it's only valid for active (top-most) frame
-    pRD->pContext = NULL;
-
     pRD->PCTAddr = GetReturnAddressPtr();
 
 #ifdef WIN64EXCEPTIONS
@@ -618,6 +615,9 @@ void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->IsCallerSPValid = FALSE;        // Don't add usage of this field.  This is only temporary.
 
 #else // WIN64EXCEPTIONS
+
+    // reset pContext; it's only valid for active (top-most) frame
+    pRD->pContext = NULL;
 
     CalleeSavedRegisters* regs = GetCalleeSavedRegisters();
 
@@ -890,8 +890,6 @@ void TailCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     }
     CONTRACT_END;
 
-    // reset pContext; it's only valid for active (top-most) frame
-    pRD->pContext = NULL;
     pRD->PCTAddr = GetReturnAddressPtr();
 
 #ifdef WIN64EXCEPTIONS
@@ -908,6 +906,9 @@ void TailCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     SyncRegDisplayToCurrentContext(pRD);
 
 #else
+
+    // reset pContext; it's only valid for active (top-most) frame
+    pRD->pContext = NULL;
 
 #define CALLEE_SAVED_REGISTER(regname) pRD->p##regname = (DWORD*) &m_regs.regname;
     ENUM_CALLEE_SAVED_REGISTERS();


### PR DESCRIPTION
This commit cleans up pContext access inside x86/Linux.