### PR TITLE
Support local stack unwinding on Android

### DIFF
--- a/cross/build-android-rootfs.sh
+++ b/cross/build-android-rootfs.sh
@@ -122,18 +122,23 @@ cp -R $__Android_Cross_Dir/tmp/$__AndroidArch/data/data/com.termux/files/usr/* $
 
 # Prepare libunwind
 if [ ! -d $__libunwind_Dir ]; then
-    git clone https://android.googlesource.com/platform/external/libunwind/ $__libunwind_Dir
+# Currently, we clone a fork of libunwind which adds support for Android; once this fork has been
+# merged back in, this script can be updated to use the official libunwind repository.
+# There's also an Android fork of libunwind which is currently not used.
+#   git clone https://android.googlesource.com/platform/external/libunwind/ $__libunwind_Dir
+#   git clone https://github.com/libunwind/libunwind/ $__libunwind_Dir
+   git clone https://github.com/qmfrederik/libunwind/ $__libunwind_Dir
 fi
 
 cd $__libunwind_Dir
-git checkout android-6.0.0_r26
+git checkout features/android
 git checkout -- .
 git clean -xfd
 
 # libunwind is available on Android, but not included in the NDK.
 echo Building libunwind
 autoreconf --force -v --install 2> /dev/null
-./configure CC=$__ToolchainDir/bin/$__AndroidArch-linux-android-clang --with-sysroot=$__ToolchainDir/sysroot --host=x86_64 --target=$__AndroidArch-eabi --disable-coredump --prefix=$__ToolchainDir/sysroot/usr 2> /dev/null
+./configure CC=$__ToolchainDir/bin/$__AndroidArch-linux-android-clang --with-sysroot=$__ToolchainDir/sysroot --host=$__AndroidArch-eabi --target=$__AndroidArch-eabi --disable-tests --disable-coredump --prefix=$__ToolchainDir/sysroot/usr 2> /dev/null
 make > /dev/null
 make install > /dev/null
 
@@ -141,5 +146,5 @@ make install > /dev/null
 cp include/libunwind.h $__ToolchainDir/sysroot/usr/include/
 
 echo Now run:
-echo CONFIG_DIR=\`realpath cross/android/arm64\` ROOTFS_DIR=\`realpath $__ToolchainDir/sysroot\` ./build.sh cross arm64 skipgenerateversion skipmscorlib cmakeargs -DENABLE_LLDBPLUGIN=0
+echo CONFIG_DIR=\`realpath cross/android/arm64\` ROOTFS_DIR=\`realpath $__ToolchainDir/sysroot\` ./build.sh cross arm64 skipgenerateversion skipnuget cmakeargs -DENABLE_LLDBPLUGIN=0
 

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -291,21 +291,26 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   endif()
 
   if(CLR_CMAKE_PLATFORM_ANDROID)
+    find_library(LZMA NAMES lzma)
+
+    if(LZMA STREQUAL LZMA-NOTFOUND)
+      message(FATAL_ERROR "Cannot find liblzma.")
+    endif(LZMA STREQUAL LZMA-NOTFOUND)
+
     target_link_libraries(coreclrpal
       gnustl_shared
       android-support
-      android-glob)
+      android-glob
+      ${LZMA})
   endif()
 
-  if(NOT CLR_CMAKE_PLATFORM_ANDROID)
-    find_library(UNWIND NAMES unwind)
+  find_library(UNWIND NAMES unwind)
 
-    if(UNWIND STREQUAL UNWIND-NOTFOUND)
-      message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev and libunwind8.")
-    endif(UNWIND STREQUAL UNWIND-NOTFOUND)
+  if(UNWIND STREQUAL UNWIND-NOTFOUND)
+    message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev and libunwind8.")
+  endif(UNWIND STREQUAL UNWIND-NOTFOUND)
 
-    target_link_libraries(coreclrpal ${UNWIND})
-  endif()
+  target_link_libraries(coreclrpal ${UNWIND})
 
   if(CLR_MAKE_PLATFORM_ANDROID)
     find_library(ANDROID_SUPPORT NAMES android-support)


### PR DESCRIPTION
When creating the Android RootFS, libunwind was compiled incorrectly with a different host and target architecture. This caused libunwind to support remote unwinding only.

This PR fixes the compilation of libunwind and linking with libunwind on Android.

This PR also uses the original libunwind library, instead of the Android fork, plus a patch which makes libunwind compile correctly on Android. The plan is to have that patched merged in upstream libunwind.

Because libunwind seems to take a dependency on liblzma, linking with liblzma on Android is a requirement.

With this, a sample hello world message on Android still fails but the exception message now includes a managed stack trace:

```
fcarlier@ubuntu:~$ adb shell LD_LIBRARY_PATH=/data/local/tmp/coredroid/ /data/local/tmp/coredroid/corerun /data/local/tmp/coredroid/helloworld.dll

Unhandled Exception: System.TypeLoadException
   at System.Console.WriteLine(String value)
   at ConsoleApp.Program.Main(String[] args)
Aborted
```

Fixes #9913