### PR TITLE
Update CoreCLR to use xunit perf api

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -27,7 +27,7 @@ def static getOSGroup(def os) {
 // Setup perflab tests runs
 [true, false].each { isPR ->
     ['Windows_NT'].each { os ->
-		['x64', 'x86', 'x86jit32'].each { arch ->
+        ['x64', 'x86', 'x86jit32'].each { arch ->
             def architecture = arch
             def testEnv = ''
 
@@ -41,39 +41,39 @@ def static getOSGroup(def os) {
                 testEnv = '-testEnv %WORKSPACE%\\tests\\x86\\ryujit_x86_testenv.cmd'
             }
 
-			def newJob = job(Utilities.getFullJobName(project, "perf_perflab_${os}_${arch}", isPR)) {
-				// Set the label.
-				label('windows_clr_perf')
-				wrappers {
-					credentialsBinding {
-						string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
-					}
-				}
+            def newJob = job(Utilities.getFullJobName(project, "perf_perflab_${os}_${arch}", isPR)) {
+                // Set the label.
+                label('windows_clr_perf')
+                wrappers {
+                    credentialsBinding {
+                        string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
+                    }
+                }
 
-			if (isPR)
-			{
-				parameters
-				{
-					stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-				}
-			}
-			def configuration = 'Release'
-			def runType = isPR ? 'private' : 'rolling'
-			def benchViewName = isPR ? 'coreclr private %BenchviewCommitName%' : 'coreclr rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
-				
-				steps {
-					// Batch
+            if (isPR)
+            {
+                parameters
+                {
+                    stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+                }
+            }
+            def configuration = 'Release'
+            def runType = isPR ? 'private' : 'rolling'
+            def benchViewName = isPR ? 'coreclr private %BenchviewCommitName%' : 'coreclr rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
+                
+                steps {
+                    // Batch
 
-					batchFile("if exist \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\" rmdir /s /q \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\"")
-					batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory \"%WORKSPACE%\" -Prerelease -ExcludeVersion")
-					//Do this here to remove the origin but at the front of the branch name as this is a problem for BenchView
-					//we have to do it all as one statement because cmd is called each time and we lose the set environment variable
-					batchFile("if [%GIT_BRANCH:~0,7%] == [origin/] (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH:origin/=%) else (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH%)\n" +
-					"py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"${benchViewName}\" --user \"dotnet-bot@microsoft.com\"\n" +
-					"py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type ${runType}")
-					batchFile("py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
-					batchFile("set __TestIntermediateDir=int&&build.cmd ${configuration} ${architecture}")
-					batchFile("tests\\runtest.cmd ${configuration} ${architecture} GenerateLayoutOnly")
+                    batchFile("if exist \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\" rmdir /s /q \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\"")
+                    batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory \"%WORKSPACE%\" -Prerelease -ExcludeVersion")
+                    //Do this here to remove the origin but at the front of the branch name as this is a problem for BenchView
+                    //we have to do it all as one statement because cmd is called each time and we lose the set environment variable
+                    batchFile("if [%GIT_BRANCH:~0,7%] == [origin/] (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH:origin/=%) else (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH%)\n" +
+                    "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"${benchViewName}\" --user \"dotnet-bot@microsoft.com\"\n" +
+                    "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type ${runType}")
+                    batchFile("py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
+                    batchFile("set __TestIntermediateDir=int&&build.cmd ${configuration} ${architecture}")
+                    batchFile("tests\\runtest.cmd ${configuration} ${architecture} GenerateLayoutOnly")
 
                     if (arch == 'x86jit32')
                     {
@@ -82,40 +82,48 @@ def static getOSGroup(def os) {
                         "xcopy \"%WORKSPACE%\\runtime.win7-x86.Microsoft.NETCore.Jit\\runtimes\\win7-x86\\native\\compatjit.dll\" \"%WORKSPACE%\\bin\\Product\\${os}.${architecture}.${configuration}\" /Y")
                     }
 
-					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${arch} -configuration ${configuration} ${testEnv} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\performance\\perflab\\Perflab -library -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype ${runType}")
-					batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${arch} -configuration ${configuration} ${testEnv} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\Jit\\Performance\\CodeQuality -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype ${runType}")
-				}
-			}
+                    batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${arch} -configuration ${configuration} ${testEnv} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\performance\\perflab\\Perflab -library -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype ${runType}")
+                    batchFile("tests\\scripts\\run-xunit-perf.cmd -arch ${arch} -configuration ${configuration} ${testEnv} -testBinLoc bin\\tests\\${os}.${architecture}.${configuration}\\Jit\\Performance\\CodeQuality -uploadToBenchview \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -runtype ${runType}")
+                }
+            }
 
-			// Save machinedata.json to /artifact/bin/ Jenkins dir
-			def archiveSettings = new ArchivalSettings()
-			archiveSettings.addFiles('Perf-*.xml')
-			archiveSettings.addFiles('Perf-*.etl')
-			Utilities.addArchival(newJob, archiveSettings)
+            // Save machinedata.json to /artifact/bin/ Jenkins dir
+            def archiveSettings = new ArchivalSettings()
+            archiveSettings.addFiles('Perf-*.xml')
+            archiveSettings.addFiles('Perf-*.etl')
+            Utilities.addArchival(newJob, archiveSettings)
 
-			Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-
-			if (isPR) {
-				TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
-				builder.setGithubContext("${os} ${arch} CoreCLR Perf Tests")
-				builder.triggerOnlyOnComment()
-				builder.setCustomTriggerPhrase("(?i).*test\\W+${os}\\W+${arch}\\W+perf.*")
-				builder.triggerForBranch(branch)
-				builder.emitTrigger(newJob)
-			}
-			else {
-				// Set a push trigger
-				TriggerBuilder builder = TriggerBuilder.triggerOnCommit()
-				builder.emitTrigger(newJob)
-			}
-		}
+            Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+            
+            newJob.with {
+                wrappers {
+                    timeout {
+                        absolute(240)
+                    }
+                }
+            }
+            
+            if (isPR) {
+                TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
+                builder.setGithubContext("${os} ${arch} CoreCLR Perf Tests")
+                builder.triggerOnlyOnComment()
+                builder.setCustomTriggerPhrase("(?i).*test\\W+${os}\\W+${arch}\\W+perf.*")
+                builder.triggerForBranch(branch)
+                builder.emitTrigger(newJob)
+            }
+            else {
+                // Set a push trigger
+                TriggerBuilder builder = TriggerBuilder.triggerOnCommit()
+                builder.emitTrigger(newJob)
+            }
+        }
     }
 }
 
 // Setup throughput perflab tests runs
 [true, false].each { isPR ->
     ['Windows_NT'].each { os ->
-		['x64', 'x86', 'x86jit32'].each { arch ->
+        ['x64', 'x86', 'x86jit32'].each { arch ->
             def architecture = arch
 
             if (arch == 'x86jit32')
@@ -123,72 +131,72 @@ def static getOSGroup(def os) {
                 architecture = 'x86'
             }
 
-			def newJob = job(Utilities.getFullJobName(project, "perf_throughput_perflab_${os}_${arch}", isPR)) {
-				// Set the label.
-				label('windows_clr_perf')
-				wrappers {
-					credentialsBinding {
-						string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
-					}
-				}
+            def newJob = job(Utilities.getFullJobName(project, "perf_throughput_perflab_${os}_${arch}", isPR)) {
+                // Set the label.
+                label('windows_clr_perf')
+                wrappers {
+                    credentialsBinding {
+                        string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
+                    }
+                }
 
-			if (isPR)
-			{
-				parameters
-				{
-					stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-				}
-			}
-			def configuration = 'Release'
-			def runType = isPR ? 'private' : 'rolling'
-			def benchViewName = isPR ? 'coreclr-throughput private %BenchviewCommitName%' : 'coreclr-throughput rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
-				
-				steps {
-					// Batch
+            if (isPR)
+            {
+                parameters
+                {
+                    stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+                }
+            }
+            def configuration = 'Release'
+            def runType = isPR ? 'private' : 'rolling'
+            def benchViewName = isPR ? 'coreclr-throughput private %BenchviewCommitName%' : 'coreclr-throughput rolling %GIT_BRANCH_WITHOUT_ORIGIN% %GIT_COMMIT%'
+                
+                steps {
+                    // Batch
 
-					batchFile("if exist \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\" rmdir /s /q \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\"")
-					batchFile("if exist \"%WORKSPACE%\\Microsoft.BenchView.ThroughputBenchmarks.${architecture}.${os}\" rmdir /s /q \"%WORKSPACE%\\Microsoft.BenchView.ThroughputBenchmarks.${architecture}.${os}\"")
-					batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory \"%WORKSPACE%\" -Prerelease -ExcludeVersion")
-					batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.ThroughputBenchmarks.${architecture}.${os} -Source https://dotnet.myget.org/F/dotnet-core -OutputDirectory \"%WORKSPACE%\" -Prerelease -ExcludeVersion")
-					//Do this here to remove the origin but at the front of the branch name as this is a problem for BenchView
-					//we have to do it all as one statement because cmd is called each time and we lose the set environment variable
-					batchFile("if [%GIT_BRANCH:~0,7%] == [origin/] (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH:origin/=%) else (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH%)\n" +
-					"py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"${benchViewName}\" --user \"dotnet-bot@microsoft.com\"\n" +
-					"py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type ${runType}")
-					batchFile("py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
-					batchFile("set __TestIntermediateDir=int&&build.cmd ${configuration} ${architecture} skiptests")
-					batchFile("tests\\runtest.cmd ${configuration} ${architecture} GenerateLayoutOnly")
+                    batchFile("if exist \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\" rmdir /s /q \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\"")
+                    batchFile("if exist \"%WORKSPACE%\\Microsoft.BenchView.ThroughputBenchmarks.${architecture}.${os}\" rmdir /s /q \"%WORKSPACE%\\Microsoft.BenchView.ThroughputBenchmarks.${architecture}.${os}\"")
+                    batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory \"%WORKSPACE%\" -Prerelease -ExcludeVersion")
+                    batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.ThroughputBenchmarks.${architecture}.${os} -Source https://dotnet.myget.org/F/dotnet-core -OutputDirectory \"%WORKSPACE%\" -Prerelease -ExcludeVersion")
+                    //Do this here to remove the origin but at the front of the branch name as this is a problem for BenchView
+                    //we have to do it all as one statement because cmd is called each time and we lose the set environment variable
+                    batchFile("if [%GIT_BRANCH:~0,7%] == [origin/] (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH:origin/=%) else (set GIT_BRANCH_WITHOUT_ORIGIN=%GIT_BRANCH%)\n" +
+                    "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\submission-metadata.py\" --name \"${benchViewName}\" --user \"dotnet-bot@microsoft.com\"\n" +
+                    "py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\build.py\" git --branch %GIT_BRANCH_WITHOUT_ORIGIN% --type ${runType}")
+                    batchFile("py \"%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools\\machinedata.py\"")
+                    batchFile("set __TestIntermediateDir=int&&build.cmd ${configuration} ${architecture} skiptests")
+                    batchFile("tests\\runtest.cmd ${configuration} ${architecture} GenerateLayoutOnly")
                     if (arch == 'x86jit32')
                     {
                         // Download package and copy compatjit into Core_Root
                         batchFile("C:\\Tools\\nuget.exe install runtime.win7-${architecture}.Microsoft.NETCore.Jit -Source https://dotnet.myget.org/F/dotnet-core -OutputDirectory \"%WORKSPACE%\" -Prerelease -ExcludeVersion\n" +
                         "xcopy \"%WORKSPACE%\\runtime.win7-x86.Microsoft.NETCore.Jit\\runtimes\\win7-x86\\native\\compatjit.dll\" \"%WORKSPACE%\\bin\\Product\\${os}.${architecture}.${configuration}\" /Y")
                     }
-					batchFile("py -u tests\\scripts\\run-throughput-perf.py -arch ${arch} -os ${os} -configuration ${configuration} -clr_root \"%WORKSPACE%\" -assembly_root \"%WORKSPACE%\\Microsoft.BenchView.ThroughputBenchmarks.${architecture}.${os}\\lib\" -benchview_path \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -run_type ${runType}")
-				}
-			}
+                    batchFile("py -u tests\\scripts\\run-throughput-perf.py -arch ${arch} -os ${os} -configuration ${configuration} -clr_root \"%WORKSPACE%\" -assembly_root \"%WORKSPACE%\\Microsoft.BenchView.ThroughputBenchmarks.${architecture}.${os}\\lib\" -benchview_path \"%WORKSPACE%\\Microsoft.Benchview.JSONFormat\\tools\" -run_type ${runType}")
+                }
+            }
 
-			// Save machinedata.json to /artifact/bin/ Jenkins dir
-			def archiveSettings = new ArchivalSettings()
-			archiveSettings.addFiles('throughput-*.csv')
-			Utilities.addArchival(newJob, archiveSettings)
+            // Save machinedata.json to /artifact/bin/ Jenkins dir
+            def archiveSettings = new ArchivalSettings()
+            archiveSettings.addFiles('throughput-*.csv')
+            Utilities.addArchival(newJob, archiveSettings)
 
-			Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+            Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
 
-			if (isPR) {
-				TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
-				builder.setGithubContext("${os} ${arch} CoreCLR Throughput Perf Tests")
-				builder.triggerOnlyOnComment()
-				builder.setCustomTriggerPhrase("(?i).*test\\W+${os}\\W+${arch}\\W+throughput.*")
-				builder.triggerForBranch(branch)
-				builder.emitTrigger(newJob)
-			}
-			else {
-				// Set a push trigger
-				TriggerBuilder builder = TriggerBuilder.triggerOnCommit()
-				builder.emitTrigger(newJob)
-			}
-		}
+            if (isPR) {
+                TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
+                builder.setGithubContext("${os} ${arch} CoreCLR Throughput Perf Tests")
+                builder.triggerOnlyOnComment()
+                builder.setCustomTriggerPhrase("(?i).*test\\W+${os}\\W+${arch}\\W+throughput.*")
+                builder.triggerForBranch(branch)
+                builder.emitTrigger(newJob)
+            }
+            else {
+                // Set a push trigger
+                TriggerBuilder builder = TriggerBuilder.triggerOnCommit()
+                builder.emitTrigger(newJob)
+            }
+        }
     }
 }
 
@@ -196,43 +204,43 @@ def static getOSGroup(def os) {
 [true, false].each { isPR ->
     ['Ubuntu14.04'].each { os ->
         def newJob = job(Utilities.getFullJobName(project, "perf_${os}", isPR)) {
-			
-			label('linux_clr_perf')
-				wrappers {
-					credentialsBinding {
-						string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
-					}
-				}
-			
-			if (isPR)
-			{
-				parameters
-				{
-					stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-				}
-			}
-			def osGroup = getOSGroup(os)
-			def architecture = 'x64'
-			def configuration = 'Release'
-			def runType = isPR ? 'private' : 'rolling'
-			def benchViewName = isPR ? 'coreclr private \$BenchviewCommitName' : 'coreclr rolling \$GIT_BRANCH_WITHOUT_ORIGIN \$GIT_COMMIT'
-			
+            
+            label('linux_clr_perf')
+                wrappers {
+                    credentialsBinding {
+                        string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
+                    }
+                }
+            
+            if (isPR)
+            {
+                parameters
+                {
+                    stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+                }
+            }
+            def osGroup = getOSGroup(os)
+            def architecture = 'x64'
+            def configuration = 'Release'
+            def runType = isPR ? 'private' : 'rolling'
+            def benchViewName = isPR ? 'coreclr private \$BenchviewCommitName' : 'coreclr rolling \$GIT_BRANCH_WITHOUT_ORIGIN \$GIT_COMMIT'
+            
             steps {
                 shell("bash ./tests/scripts/perf-prep.sh")
                 shell("./init-tools.sh")
-				shell("./build.sh ${architecture} ${configuration}")
-				shell("GIT_BRANCH_WITHOUT_ORIGIN=\$(echo \$GIT_BRANCH | sed \"s/[^/]*\\/\\(.*\\)/\\1 /\")\n" +
-				"python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission-metadata.py\" --name \" ${benchViewName} \" --user \"dotnet-bot@microsoft.com\"\n" +
-				"python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type ${runType}")
+                shell("./build.sh ${architecture} ${configuration}")
+                shell("GIT_BRANCH_WITHOUT_ORIGIN=\$(echo \$GIT_BRANCH | sed \"s/[^/]*\\/\\(.*\\)/\\1 /\")\n" +
+                "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission-metadata.py\" --name \" ${benchViewName} \" --user \"dotnet-bot@microsoft.com\"\n" +
+                "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type ${runType}")
                 shell("""sudo -E bash ./tests/scripts/run-xunit-perf.sh \\
                 --testRootDir=\"\${WORKSPACE}/bin/tests/Windows_NT.${architecture}.${configuration}\" \\
                 --testNativeBinDir=\"\${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\
                 --coreClrBinDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --mscorlibDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --coreFxBinDir=\"\${WORKSPACE}/corefx\" \\
-				--runType=\"${runType}\" \\
-				--benchViewOS=\"${os}\" \\
-				--uploadToBenchview""")
+                --runType=\"${runType}\" \\
+                --benchViewOS=\"${os}\" \\
+                --uploadToBenchview""")
             }
         }
 
@@ -274,42 +282,42 @@ def static getOSGroup(def os) {
 [true, false].each { isPR ->
     ['Ubuntu14.04'].each { os ->
         def newJob = job(Utilities.getFullJobName(project, "perf_throughput_${os}", isPR)) {
-			
-			label('linux_clr_perf')
-				wrappers {
-					credentialsBinding {
-						string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
-					}
-				}
-			
-			if (isPR)
-			{
-				parameters
-				{
-					stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
-				}
-			}
-			def osGroup = getOSGroup(os)
-			def architecture = 'x64'
-			def configuration = 'Release'
-			def runType = isPR ? 'private' : 'rolling'
-			def benchViewName = isPR ? 'coreclr private \$BenchviewCommitName' : 'coreclr rolling \$GIT_BRANCH_WITHOUT_ORIGIN \$GIT_COMMIT'
-			
+            
+            label('linux_clr_perf')
+                wrappers {
+                    credentialsBinding {
+                        string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
+                    }
+                }
+            
+            if (isPR)
+            {
+                parameters
+                {
+                    stringParam('BenchviewCommitName', '\${ghprbPullTitle}', 'The name that you will be used to build the full title of a run in Benchview.  The final name will be of the form <branch> private BenchviewCommitName')
+                }
+            }
+            def osGroup = getOSGroup(os)
+            def architecture = 'x64'
+            def configuration = 'Release'
+            def runType = isPR ? 'private' : 'rolling'
+            def benchViewName = isPR ? 'coreclr private \$BenchviewCommitName' : 'coreclr rolling \$GIT_BRANCH_WITHOUT_ORIGIN \$GIT_COMMIT'
+            
             steps {
                 shell("bash ./tests/scripts/perf-prep.sh --throughput")
                 shell("./init-tools.sh")
-				shell("./build.sh ${architecture} ${configuration}")
-				shell("GIT_BRANCH_WITHOUT_ORIGIN=\$(echo \$GIT_BRANCH | sed \"s/[^/]*\\/\\(.*\\)/\\1 /\")\n" +
-				"python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission-metadata.py\" --name \" ${benchViewName} \" --user \"dotnet-bot@microsoft.com\"\n" +
-				"python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type ${runType}")
+                shell("./build.sh ${architecture} ${configuration}")
+                shell("GIT_BRANCH_WITHOUT_ORIGIN=\$(echo \$GIT_BRANCH | sed \"s/[^/]*\\/\\(.*\\)/\\1 /\")\n" +
+                "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/submission-metadata.py\" --name \" ${benchViewName} \" --user \"dotnet-bot@microsoft.com\"\n" +
+                "python3.5 \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools/build.py\" git --branch \$GIT_BRANCH_WITHOUT_ORIGIN --type ${runType}")
                 shell("""sudo -E python3.5 ./tests/scripts/run-throughput-perf.py \\
                 -arch \"${architecture}\" \\
                 -os \"${os}\" \\
                 -configuration \"${configuration}\" \\
                 -clr_root \"\${WORKSPACE}\" \\
                 -assembly_root \"\${WORKSPACE}/_/fx/bin/runtime/netcoreapp-${osGroup}-${configuration}-${architecture}\" \\
-				-run_type \"${runType}\" \\
-				-benchview_path \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools\"""")
+                -run_type \"${runType}\" \\
+                -benchview_path \"\${WORKSPACE}/tests/scripts/Microsoft.BenchView.JSONFormat/tools\"""")
             }
         }
 

--- a/perf.groovy
+++ b/perf.groovy
@@ -89,8 +89,8 @@ def static getOSGroup(def os) {
 
 			// Save machinedata.json to /artifact/bin/ Jenkins dir
 			def archiveSettings = new ArchivalSettings()
-			archiveSettings.addFiles('perf-*.xml')
-			archiveSettings.addFiles('perf-*.etl')
+			archiveSettings.addFiles('Perf-*.xml')
+			archiveSettings.addFiles('Perf-*.etl')
 			Utilities.addArchival(newJob, archiveSettings)
 
 			Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")

--- a/tests/src/Common/PerfHarness/PerfHarness.cs
+++ b/tests/src/Common/PerfHarness/PerfHarness.cs
@@ -1,0 +1,16 @@
+﻿using System.IO;
+using System.Reflection;
+using System.Collections.Generic;
+using Microsoft.Xunit.Performance.Api;
+
+public class PerfHarness
+{
+    public static void Main(string[] args)
+    {
+        string assemblyName = args[0];
+        using (XunitPerformanceHarness harness = new XunitPerformanceHarness(args))
+        {
+            harness.RunBenchmarks(assemblyName);
+        }
+    }
+}

--- a/tests/src/Common/PerfHarness/project.json
+++ b/tests/src/Common/PerfHarness/project.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true
+  },
+  "dependencies": {},
+  "frameworks": {
+    "netcoreapp1.1": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.1.0"
+        },
+        "xunit.performance.api": "1.0.0-alpha-build0049"
+      }
+    }
+  }
+}

--- a/tests/src/Common/external/external.depproj
+++ b/tests/src/Common/external/external.depproj
@@ -27,6 +27,11 @@
     <PackageToInclude Include="Microsoft.DotNet.xunit.performance"/>
     <PackageToInclude Include="Microsoft.DotNet.xunit.performance.analysis"/>
     <PackageToInclude Include="Microsoft.DotNet.xunit.performance.runner.Windows"/>
+    <PackageToInclude Include="xunit.performance.api"/>
+    <PackageToInclude Include="xunit.performance.core"/>
+    <PackageToInclude Include="xunit.performance.execution"/>
+    <PackageToInclude Include="xunit.performance.metrics"/>
+    <PackageToInclude Include="Microsoft.Diagnostics.Tracing.TraceEvent"/>
     <PackageToInclude Include="Newtonsoft.Json"/>
     <PackageToInclude Include="Microsoft.CodeAnalysis.Analyzers"/>
     <PackageToInclude Include="Microsoft.CodeAnalysis.Common"/>

--- a/tests/src/Common/external/project.json
+++ b/tests/src/Common/external/project.json
@@ -1,9 +1,11 @@
 {
   "dependencies": {
     "Microsoft.CodeAnalysis.Compilers": "1.1.1",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040",
+    "xunit.performance.api": "1.0.0-alpha-build0049",
+    "xunit.performance.core": "1.0.0-alpha-build0049",
+    "xunit.performance.execution": "1.0.0-alpha-build0049",
+    "xunit.performance.metrics": "1.0.0-alpha-build0049",
+    "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Newtonsoft.Json": "9.0.1",
     "xunit": "2.2.0-beta2-build3300",
     "xunit.console.netcore": "1.0.2-prerelease-00177",

--- a/tests/src/JIT/config/benchmark+roslyn/project.json
+++ b/tests/src/JIT/config/benchmark+roslyn/project.json
@@ -1,9 +1,11 @@
 {
   "dependencies": {
     "Microsoft.CodeAnalysis.Compilers": "1.1.1",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040",
+    "xunit.performance.api": "1.0.0-alpha-build0049",
+    "xunit.performance.core": "1.0.0-alpha-build0049",
+    "xunit.performance.execution": "1.0.0-alpha-build0049",
+    "xunit.performance.metrics": "1.0.0-alpha-build0049",
+    "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Microsoft.NETCore.Platforms": "2.0.0-beta-25122-01",
     "System.Console": "4.4.0-beta-24913-02",
     "System.Dynamic.Runtime": "4.4.0-beta-24913-02",

--- a/tests/src/JIT/config/benchmark+serialize/project.json
+++ b/tests/src/JIT/config/benchmark+serialize/project.json
@@ -1,8 +1,10 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040",
+    "xunit.performance.api": "1.0.0-alpha-build0049",
+    "xunit.performance.core": "1.0.0-alpha-build0049",
+    "xunit.performance.execution": "1.0.0-alpha-build0049",
+    "xunit.performance.metrics": "1.0.0-alpha-build0049",
+    "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Microsoft.NETCore.Platforms": "2.0.0-beta-25122-01",
     "Newtonsoft.Json": "7.0.1",
     "System.Console": "4.4.0-beta-24913-02",

--- a/tests/src/JIT/config/benchmark/project.json
+++ b/tests/src/JIT/config/benchmark/project.json
@@ -1,8 +1,10 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040",
+    "xunit.performance.api": "1.0.0-alpha-build0049",
+    "xunit.performance.core": "1.0.0-alpha-build0049",
+    "xunit.performance.execution": "1.0.0-alpha-build0049",
+    "xunit.performance.metrics": "1.0.0-alpha-build0049",
+    "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Microsoft.NETCore.Platforms": "2.0.0-beta-25122-01",
     "System.Collections.NonGeneric": "4.4.0-beta-24913-02",
     "System.Console": "4.4.0-beta-24913-02",

--- a/tests/src/performance/project.json
+++ b/tests/src/performance/project.json
@@ -1,8 +1,10 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0040",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0040",
+    "xunit.performance.api": "1.0.0-alpha-build0049",
+    "xunit.performance.core": "1.0.0-alpha-build0049",
+    "xunit.performance.execution": "1.0.0-alpha-build0049",
+    "xunit.performance.metrics": "1.0.0-alpha-build0049",
+    "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Microsoft.NETCore.Platforms": "2.0.0-beta-25122-01",
     "System.Collections.NonGeneric": "4.4.0-beta-24913-02",
     "System.Console": "4.4.0-beta-24913-02",


### PR DESCRIPTION
This updates the CoreCLR performance runs to use the new xunit
performance api.  This will unblock several people who were wanting to
move tests forward from netstandard1.4 which is were we have been locked
because of using the old desktop runner.