### PR TITLE
Updating the build scripts to support VS2017.

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -11,13 +11,20 @@ You must install several components to build the CoreCLR and CoreFX repos. These
 ## Visual Studio
 
 Visual Studio must be installed. Supported versions:
-- [Visual Studio 2015](https://www.visualstudio.com/downloads/visual-studio-2015-downloads-vs) (Community, Professional, Enterprise).  The community version is completely free.  
+- [Visual Studio 2015](https://www.visualstudio.com/vs/older-downloads/) (Community, Professional, Enterprise).  The community version is completely free.  
+- [Visual Studio 2017](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise).  The community version is completely free.  
 
-To debug managed code, ensure you have installed at least [Visual Studio 2015 Update 3](https://www.visualstudio.com/en-us/news/releasenotes/vs2015-update3-vs).
+For Visual Studio 2015:
+* To debug managed code, ensure you have installed at least [Visual Studio 2015 Update 3](https://www.visualstudio.com/en-us/news/releasenotes/vs2015-update3-vs).
+* Make sure that you install "VC++ Tools". By default, they will not be installed.
+* To build for Arm32, Make sure that you have the Windows SDK for Windows 10 installed (or selected to be installed as part of VS installation). To explicitly install Windows SDK, download it from here: [Windows SDK for Windows 10](https://developer.microsoft.com/en-us/windows/downloads)
 
-Make sure that you install "VC++ Tools". By default, they will not be installed.
-
-To build for Arm32, you need to have [Windows SDK for Windows 10](https://developer.microsoft.com/en-us/windows/downloads) installed. 
+For Visual Studio 2017:
+* Make sure that you install the ".NET Core Cross-Platform Development" workload.
+* Make sure that you install the "Desktop Development with C++" workload.
+ * Make sure that the "VC++ 2017 v141 toolset (x86,x64)" component is selected in list of Optional components
+ * To build for Arm32, Make sure that you have the Windows SDK for Windows 10 installed (or selected to be installed as part of VS installation). To explicitly install Windows SDK, download it from here: [Windows SDK for Windows 10](https://developer.microsoft.com/en-us/windows/downloads)
+* Ensure you are running from the "Developer Command Prompt for VS2017"; Otherwise, the build will attempt to locate and use the VS2015 toolset.
 
 Visual Studio Express is not supported.
 
@@ -117,4 +124,3 @@ Build has a number of options that you can learn about using build -?.   Some of
 See [Using Your Build](../workflow/UsingYourBuild.md) for instructions on running code with your build.  
 
 See [Running Tests](../workflow/RunningTests.md) for instructions on running the tests.  
-

--- a/build-test.cmd
+++ b/build-test.cmd
@@ -6,8 +6,17 @@ set __BuildArch=x64
 set __VCBuildArch=x86_amd64
 set __BuildType=Debug
 set __BuildOS=Windows_NT
-set __VSVersion=vs2015
-set __VSToolsRoot=%VS140COMNTOOLS%
+
+:: Default to highest Visual Studio version available
+if defined VS150COMNTOOLS (
+  set "__VSToolsRoot=%VS150COMNTOOLS%"
+  set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"
+  set __VSVersion=vs2017
+) else (
+  set "__VSToolsRoot=%VS140COMNTOOLS%"
+  set "__VCToolsRoot=%VS140COMNTOOLS%\..\..\VC"
+  set __VSVersion=vs2015
+)
 
 :: Define a prefix for most output progress messages that come from this script. That makes
 :: it easier to see where these are coming from. Note that there is a trailing space here.
@@ -137,8 +146,8 @@ if defined __ToolsetDir (
 )
 
 :: Set the environment for the native build
-echo %__MsgPrefix%Using environment: "%__VSToolsRoot%\..\..\VC\vcvarsall.bat" %__VCBuildArch%
-call                                 "%__VSToolsRoot%\..\..\VC\vcvarsall.bat" %__VCBuildArch%
+echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" %__VCBuildArch%
+call                                 "%__VCToolsRoot%\vcvarsall.bat" %__VCBuildArch%
 @if defined _echo @echo on
 
 if not defined VSINSTALLDIR (
@@ -397,8 +406,8 @@ This is due to a bug in the Visual Studio installer. It does not install DIA SDK
 at the install location of previous Visual Studio version. The workaround is to copy the DIA SDK folder from the Visual Studio install location ^
 of the previous version to "%VSINSTALLDIR%" and then build.
 :: DIA SDK not included in Express editions
-echo Visual Studio 2013 Express does not include the DIA SDK. ^
-You need Visual Studio 2013+ (Community is free).
+echo Visual Studio Express does not include the DIA SDK. ^
+You need Visual Studio 2015 or 2017 (Community is free).
 echo See: https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md#prerequisites
 exit /b 1
 

--- a/build-test.cmd
+++ b/build-test.cmd
@@ -8,6 +8,20 @@ set __BuildType=Debug
 set __BuildOS=Windows_NT
 
 :: Default to highest Visual Studio version available
+::
+:: For VS2015 (and prior), only a single instance is allowed to be installed on a box
+:: and VS140COMNTOOLS is set as a global environment variable by the installer. This
+:: allows users to locate where the instance of VS2015 is installed.
+::
+:: For VS2017, multiple instances can be installed on the same box SxS and VS150COMNTOOLS
+:: is no longer set as a global environment variable and is instead only set if the user
+:: has launched the VS2017 Developer Command Prompt.
+::
+:: Following this logic, we will default to the VS2017 toolset if VS150COMNTOOLS tools is
+:: set, as this indicates the user is running from the VS2017 Developer Command Prompt and
+:: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
+:: toolset if it is installed. Finally, we will fail the script if no supported VS instance
+:: can be found.
 if defined VS150COMNTOOLS (
   set "__VSToolsRoot=%VS150COMNTOOLS%"
   set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"

--- a/build.cmd
+++ b/build.cmd
@@ -5,6 +5,20 @@ echo Starting Build at %TIME%
 set __ThisScriptFull="%~f0"
 
 :: Default to highest Visual Studio version available
+::
+:: For VS2015 (and prior), only a single instance is allowed to be installed on a box
+:: and VS140COMNTOOLS is set as a global environment variable by the installer. This
+:: allows users to locate where the instance of VS2015 is installed.
+::
+:: For VS2017, multiple instances can be installed on the same box SxS and VS150COMNTOOLS
+:: is no longer set as a global environment variable and is instead only set if the user
+:: has launched the VS2017 Developer Command Prompt.
+::
+:: Following this logic, we will default to the VS2017 toolset if VS150COMNTOOLS tools is
+:: set, as this indicates the user is running from the VS2017 Developer Command Prompt and
+:: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
+:: toolset if it is installed. Finally, we will fail the script if no supported VS instance
+:: can be found.
 if defined VS150COMNTOOLS (
   set "__VSToolsRoot=%VS150COMNTOOLS%"
   set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"

--- a/build.cmd
+++ b/build.cmd
@@ -3,7 +3,18 @@ setlocal EnableDelayedExpansion EnableExtensions
 
 echo Starting Build at %TIME%
 set __ThisScriptFull="%~f0"
-set __VSToolsRoot=%VS140COMNTOOLS%
+
+:: Default to highest Visual Studio version available
+if defined VS150COMNTOOLS (
+  set "__VSToolsRoot=%VS150COMNTOOLS%"
+  set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"
+  set __VSVersion=vs2017
+) else (
+  set "__VSToolsRoot=%VS140COMNTOOLS%"
+  set "__VCToolsRoot=%VS140COMNTOOLS%\..\..\VC"
+  set __VSVersion=vs2015
+)
+
 :: Note that the msbuild project files (specifically, dir.proj) will use the following variables, if set:
 ::      __BuildArch         -- default: x64
 ::      __BuildType         -- default: Debug
@@ -23,9 +34,6 @@ set __VSToolsRoot=%VS140COMNTOOLS%
 set __BuildArch=x64
 set __BuildType=Debug
 set __BuildOS=Windows_NT
-
-:: Default to highest Visual Studio version available
-set __VSVersion=vs2015
 
 :: Define a prefix for most output progress messages that come from this script. That makes
 :: it easier to see where these are coming from. Note that there is a trailing space here.
@@ -235,8 +243,8 @@ if %__BuildNative% EQU 1 (
         set ___SDKVersion="-DCMAKE_SYSTEM_VERSION=10.0"
     )
 
-    echo %__MsgPrefix%Using environment: "%__VSToolsRoot%\..\..\VC\vcvarsall.bat" !__VCBuildArch!
-    call                                 "%__VSToolsRoot%\..\..\VC\vcvarsall.bat" !__VCBuildArch!
+    echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
+    call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
 	@if defined _echo @echo on
 
     if not defined VSINSTALLDIR (
@@ -296,7 +304,7 @@ if /i "%__DoCrossArchBuild%"=="1" (
     :: Set the environment for the native build
     set __VCBuildArch=x86_amd64
     if /i "%__CrossArch%" == "x86" ( set __VCBuildArch=x86 )
-    @call "%__VSToolsRoot%\..\..\VC\vcvarsall.bat" !__VCBuildArch!
+    @call "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
     @if defined _echo @echo on
 
     if not exist "%__CrossCompIntermediatesDir%" md "%__CrossCompIntermediatesDir%"
@@ -622,7 +630,7 @@ at the install location of previous Visual Studio version. The workaround is to 
 of the previous version to "%VSINSTALLDIR%" and then build.
 :: DIA SDK not included in Express editions
 echo Visual Studio Express does not include the DIA SDK. ^
-You need Visual Studio 2015+ (Community is free).
+You need Visual Studio 2015 or 2017 (Community is free).
 echo See: https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md#prerequisites
 exit /b 1
 

--- a/run.cmd
+++ b/run.cmd
@@ -2,7 +2,13 @@
 setlocal
 
 if not defined VisualStudioVersion (
-  if defined VS140COMNTOOLS (
+  if defined VS150COMNTOOLS (
+	 if not exist "%VS150COMNTOOLS%\..\IDE\devenv.exe"      goto NoVS
+	 if not exist "%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build\vcvarsall.bat" goto NoVS
+	 if not exist "%VS150COMNTOOLS%\VsDevCmd.bat" 			  goto NoVS
+    call "%VS150COMNTOOLS%\VsDevCmd.bat"
+    goto :Run
+  ) else if defined VS140COMNTOOLS (
 	 if not exist "%VS140COMNTOOLS%\..\IDE\devenv.exe"      goto NoVS
 	 if not exist "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" goto NoVS
 	 if not exist "%VS140COMNTOOLS%\VsDevCmd.bat" 			  goto NoVS
@@ -11,7 +17,7 @@ if not defined VisualStudioVersion (
   )
 
   :NoVS
-  echo Error: Visual Studio 2015 required.
+  echo Error: Visual Studio 2015 or 2017 required.
   echo        https://github.com/dotnet/coreclr/blob/master/Documentation/building/windows-instructions.md for build instructions.
   exit /b 1
 )

--- a/run.cmd
+++ b/run.cmd
@@ -1,6 +1,21 @@
 @if not defined _echo @echo off
 setlocal
 
+:: Default to highest Visual Studio version available
+::
+:: For VS2015 (and prior), only a single instance is allowed to be installed on a box
+:: and VS140COMNTOOLS is set as a global environment variable by the installer. This
+:: allows users to locate where the instance of VS2015 is installed.
+::
+:: For VS2017, multiple instances can be installed on the same box SxS and VS150COMNTOOLS
+:: is no longer set as a global environment variable and is instead only set if the user
+:: has launched the VS2017 Developer Command Prompt.
+::
+:: Following this logic, we will default to the VS2017 toolset if VS150COMNTOOLS tools is
+:: set, as this indicates the user is running from the VS2017 Developer Command Prompt and
+:: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
+:: toolset if it is installed. Finally, we will fail the script if no supported VS instance
+:: can be found.
 if not defined VisualStudioVersion (
   if defined VS150COMNTOOLS (
 	 if not exist "%VS150COMNTOOLS%\..\IDE\devenv.exe"      goto NoVS

--- a/src/pal/tools/gen-buildsys-win.bat
+++ b/src/pal/tools/gen-buildsys-win.bat
@@ -19,6 +19,7 @@ set __SourceDir=%1
 set __VSVersion=%2
 set __Arch=%3
 set __CmakeGenerator=Visual Studio
+if /i "%__VSVersion%" == "vs2017" (set __CmakeGenerator=%__CmakeGenerator% 15 2017)
 if /i "%__VSVersion%" == "vs2015" (set __CmakeGenerator=%__CmakeGenerator% 14 2015)
 if /i "%__Arch%" == "x64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
 if /i "%__Arch%" == "arm64" (set __CmakeGenerator=%__CmakeGenerator% Win64)
@@ -47,7 +48,7 @@ GOTO :DONE
   echo "Usage..."
   echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion>"
   echo "Specify the path to the top level CMake file - <ProjectK>/src/NDP"
-  echo "Specify the VSVersion to be used - VS2015"
+  echo "Specify the VSVersion to be used - VS2015 or VS2017"
   EXIT /B 1
 
 :DONE

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -8,6 +8,20 @@ set __BuildOS=Windows_NT
 set __MSBuildBuildArch=x64
 
 :: Default to highest Visual Studio version available
+::
+:: For VS2015 (and prior), only a single instance is allowed to be installed on a box
+:: and VS140COMNTOOLS is set as a global environment variable by the installer. This
+:: allows users to locate where the instance of VS2015 is installed.
+::
+:: For VS2017, multiple instances can be installed on the same box SxS and VS150COMNTOOLS
+:: is no longer set as a global environment variable and is instead only set if the user
+:: has launched the VS2017 Developer Command Prompt.
+::
+:: Following this logic, we will default to the VS2017 toolset if VS150COMNTOOLS tools is
+:: set, as this indicates the user is running from the VS2017 Developer Command Prompt and
+:: is already configured to use that toolset. Otherwise, we will fallback to using the VS2015
+:: toolset if it is installed. Finally, we will fail the script if no supported VS instance
+:: can be found.
 set __VSVersion=vs2017
 
 if defined VS140COMNTOOLS set __VSVersion=vs2015

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -8,10 +8,10 @@ set __BuildOS=Windows_NT
 set __MSBuildBuildArch=x64
 
 :: Default to highest Visual Studio version available
-set __VSVersion=vs2015
+set __VSVersion=vs2017
 
-if defined VS120COMNTOOLS set __VSVersion=vs2013
 if defined VS140COMNTOOLS set __VSVersion=vs2015
+if defined VS150COMNTOOLS set __VSVersion=vs2017
 
 :: Define a prefix for most output progress messages that come from this script. That makes
 :: it easier to see where these are coming from. Note that there is a trailing space here.
@@ -49,8 +49,8 @@ if /i "%1" == "debug"                 (set __BuildType=Debug&shift&goto Arg_Loop
 if /i "%1" == "release"               (set __BuildType=Release&shift&goto Arg_Loop)
 if /i "%1" == "checked"               (set __BuildType=Checked&shift&goto Arg_Loop)
 
-if /i "%1" == "vs2013"                (set __VSVersion=%1&shift&goto Arg_Loop)
 if /i "%1" == "vs2015"                (set __VSVersion=%1&shift&goto Arg_Loop)
+if /i "%1" == "vs2017"                (set __VSVersion=%1&shift&goto Arg_Loop)
 
 if /i "%1" == "TestEnv"               (set __TestEnv=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "AgainstPackages"       (set __AgainstPackages=1&shift&goto Arg_Loop)
@@ -95,30 +95,26 @@ if not defined XunitTestReportDirBase set  XunitTestReportDirBase=%XunitTestBinB
 
 if not exist %__LogsDir% md %__LogsDir%
 
-set __VSProductVersion=
-if /i "%__VSVersion%" == "vs2013" set __VSProductVersion=120
-if /i "%__VSVersion%" == "vs2015" set __VSProductVersion=140
+set _msbuildexe=
+if /i "%__VSVersion%" == "vs2017" (
+  set "__VSToolsRoot=%VS150COMNTOOLS%"
+  set "__VCToolsRoot=%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build"
 
-:: Check presence of VS
-if not defined VS%__VSProductVersion%COMNTOOLS goto NoVS
+  set _msbuildexe="%VS150COMNTOOLS%\..\..\MSBuild\15.0\Bin\MSBuild.exe"
+) else if /i "%__VSVersion%" == "vs2015" (
+  set "__VSToolsRoot=%VS140COMNTOOLS%"
+  set "__VCToolsRoot=%VS140COMNTOOLS%\..\..\VC"
 
-set __VSToolsRoot=!VS%__VSProductVersion%COMNTOOLS!
-if %__VSToolsRoot:~-1%==\ set "__VSToolsRoot=%__VSToolsRoot:~0,-1%"
+  set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+  if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
+)
 
 :: Does VS really exist?
 if not exist "%__VSToolsRoot%\..\IDE\devenv.exe"      goto NoVS
-if not exist "%__VSToolsRoot%\..\..\VC\vcvarsall.bat" goto NoVS
+if not exist "%__VCToolsRoot%\vcvarsall.bat"          goto NoVS
 if not exist "%__VSToolsRoot%\VsDevCmd.bat"           goto NoVS
 
-if /i "%__VSVersion%" =="vs2015" goto MSBuild14
-set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
-goto :CheckMSBuild14
-:MSBuild14
-set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
-:CheckMSBuild14
-if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
+:: Does MSBuild really exist?
 if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md for build instructions. && exit /b 1
 
 :: Set the environment for the  build- VS cmd prompt
@@ -386,7 +382,7 @@ echo./? -? /h -h /help -help: view this message.
 echo BuildArch- Optional parameter - x64 or x86 ^(default: x64^).
 echo BuildType- Optional parameter - Debug, Release, or Checked ^(default: Debug^).
 echo TestEnv- Optional parameter - this will run a custom script to set custom test environment settings.
-echo VSVersion- Optional parameter - VS2013 or VS2015 ^(default: VS2015^)
+echo VSVersion- Optional parameter - VS2015 or VS2017 ^(default: VS2017^)
 echo AgainstPackages - Optional parameter - this indicates that we are running tests that were built against packages
 echo GenerateLayoutOnly - If specified will not run the tests and will only create the Runtime Dependency Layout
 echo RunCrossgenTests   - Runs ReadytoRun tests
@@ -403,6 +399,6 @@ echo CORE_ROOT The path to the runtime
 exit /b 1
 
 :NoVS
-echo Visual Studio 2013+ ^(Community is free^) is a prerequisite to build this repository.
+echo Visual Studio 2015 or 2017 (Community is free) is a prerequisite to build this repository.
 echo See: https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md#prerequisites
 exit /b 1


### PR DESCRIPTION
This updates the build scripts to support VS 2017, provided you are running from a developer command prompt.

This does not support locating VS 2017 dynamically. There are two parts to this:
1. The installation environment variables we used previously no longer exist globally
2. In order to locate an instance of VS 2017, you need to use the Managed Query APIs (http://www.nuget.org/packages/Microsoft.VisualStudio.Setup.Configuration.Interop/1.7.13-rc). Adding support for this would take quite a bit more work, and supporting running from an existing DevCmd Prompt instance is at least significantly better than what we have today.

This also drops support for VS 2013 from the RunTest script. Given that we don't support building from VS 2013, it doesn't make sense to have this support here (let me know if there is some reason we do actually still need this).