### PR TITLE
Re-Remove ComVisible On Lazy as per #9371

### DIFF
--- a/src/mscorlib/shared/System/Lazy.cs
+++ b/src/mscorlib/shared/System/Lazy.cs
@@ -183,7 +183,6 @@ namespace System
     /// </para>
     /// </remarks>
     [Serializable]
-    [ComVisible(false)]
     [DebuggerTypeProxy(typeof(System_LazyDebugView<>))]
     [DebuggerDisplay("ThreadSafetyMode={Mode}, IsValueCreated={IsValueCreated}, IsValueFaulted={IsValueFaulted}, Value={ValueForDebugDisplay}")]
     public class Lazy<T>


### PR DESCRIPTION
During a merge that occured on the branch working on alternative lazy implementation #8963, the ComVisible attribute which had been removed in #9371 was reinstanted. This minor PR is to re-remove the attribute.