### PR TITLE
[x86/Linux] Explicitly Set P/Invoke Interop Calling Convention

### DIFF
--- a/src/mscorlib/shared/Interop/Unix/Interop.Errors.cs
+++ b/src/mscorlib/shared/Interop/Unix/Interop.Errors.cs
@@ -179,13 +179,13 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi((IntPtr)message);
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConvertErrorPlatformToPal")]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_ConvertErrorPlatformToPal")]
         internal static extern Error ConvertErrorPlatformToPal(int platformErrno);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConvertErrorPalToPlatform")]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_ConvertErrorPalToPlatform")]
         internal static extern int ConvertErrorPalToPlatform(Error error);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_StrErrorR")]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_StrErrorR")]
         private static unsafe extern byte* StrErrorR(int platformErrno, byte* buffer, int bufferSize);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Close.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Close.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Close", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_Close", SetLastError = true)]
         internal static extern int Close(IntPtr fd);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.FLock.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.FLock.cs
@@ -18,14 +18,14 @@ internal static partial class Interop
             LOCK_UN = 8,    /* unlock */
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FLock", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_FLock", SetLastError = true)]
         internal static extern int FLock(SafeFileHandle fd, LockOperations operation);
 
         /// <summary>
         /// Exposing this for SafeFileHandle.ReleaseHandle() to call.
         /// Normal callers should use FLock(SafeFileHandle fd).
         /// </summary>
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FLock", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_FLock", SetLastError = true)]
         internal static extern int FLock(IntPtr fd, LockOperations operation);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.FSync.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.FSync.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FSync", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_FSync", SetLastError = true)]
         internal static extern int FSync(SafeFileHandle fd);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.FTruncate.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.FTruncate.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FTruncate", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_FTruncate", SetLastError = true)]
         internal static extern int FTruncate(SafeFileHandle fd, long length);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.GetCwd.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.GetCwd.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetCwd", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_GetCwd", SetLastError = true)]
         private static unsafe extern byte* GetCwd(byte* buffer, int bufferLength);
 
         internal static unsafe string GetCwd()

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.LSeek.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.LSeek.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
             SEEK_END = 2
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LSeek", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_LSeek", SetLastError = true)]
         internal static extern long LSeek(SafeFileHandle fd, long offset, SeekWhence whence);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.LockFileRegion.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.LockFileRegion.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
             F_UNLCK = 2     // unlock
         }
         
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LockFileRegion", SetLastError=true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_LockFileRegion", SetLastError=true)]
         internal static extern int LockFileRegion(SafeHandle fd, long offset, long length, LockType lockType);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.MksTemps.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.MksTemps.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MksTemps", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_MksTemps", SetLastError = true)]
         internal static extern IntPtr MksTemps(
             byte[] template, 
             int suffixlen);

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Open.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Open.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Open", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_Open", SetLastError = true)]
         internal static extern SafeFileHandle Open(string filename, OpenFlags flags, int mode);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.PathConf.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.PathConf.cs
@@ -64,10 +64,10 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PathConf", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_PathConf", SetLastError = true)]
         private static extern int PathConf(string path, PathConfName name);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetMaximumPath")]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_GetMaximumPath")]
         private static extern long GetMaximumPath();
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.PosixFAdvise.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.PosixFAdvise.cs
@@ -30,7 +30,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns 0 on success; otherwise, the error code is returned
         /// </returns>
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PosixFAdvise", SetLastError = false /* this is explicitly called out in the man page */)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_PosixFAdvise", SetLastError = false /* this is explicitly called out in the man page */)]
         internal static extern int PosixFAdvise(SafeFileHandle fd, long offset, long length, FileAdvice advice);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Read.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Read.cs
@@ -19,7 +19,7 @@ internal static partial class Interop
         /// Returns the number of bytes read on success; otherwise, -1 is returned
         /// Note - on fail. the position of the stream may change depending on the platform; consult man 2 read for more info
         /// </returns>
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Read", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_Read", SetLastError = true)]
         internal static unsafe extern int Read(SafeFileHandle fd, byte* buffer, int count);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Stat.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Stat.cs
@@ -47,13 +47,13 @@ internal static partial class Interop
             HasBirthTime = 1,
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_FStat", SetLastError = true)]
         internal static extern int FStat(SafeFileHandle fd, out FileStatus output);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_Stat", SetLastError = true)]
         internal static extern int Stat(string path, out FileStatus output);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_LStat", SetLastError = true)]
         internal static extern int LStat(string path, out FileStatus output);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Unlink.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Unlink.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Unlink", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_Unlink", SetLastError = true)]
         internal static extern int Unlink(string pathname);
     }
 }

--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Write.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Write.cs
@@ -18,10 +18,10 @@ internal static partial class Interop
         /// <returns>
         /// Returns the number of bytes written on success; otherwise, returns -1 and sets errno
         /// </returns>
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_Write", SetLastError = true)]
         internal static unsafe extern int Write(SafeFileHandle fd, byte* buffer, int bufferSize);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, CallingConvention=CallingConvention.Cdecl, EntryPoint = "SystemNative_Write", SetLastError = true)]
         internal static unsafe extern int Write(int fd, byte* buffer, int bufferSize);
     }
 }

--- a/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
+++ b/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
@@ -15,19 +15,19 @@ internal static partial class Interop
            [MarshalAs(UnmanagedType.LPWStr)] string calendarString,
            IntPtr context);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendars")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendars")]
         internal static extern int GetCalendars(string localeName, CalendarId[] calendars, int calendarsCapacity);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendarInfo")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendarInfo")]
         internal static extern ResultCode GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType calendarDataType, [Out] StringBuilder result, int resultCapacity);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EnumCalendarInfo")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EnumCalendarInfo")]
         internal static extern bool EnumCalendarInfo(EnumCalendarInfoCallback callback, string localeName, CalendarId calendarId, CalendarDataType calendarDataType, IntPtr context);
 
-        [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_GetLatestJapaneseEra")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, EntryPoint = "GlobalizationNative_GetLatestJapaneseEra")]
         internal static extern int GetLatestJapaneseEra();
 
-        [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_GetJapaneseEraStartDate")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, EntryPoint = "GlobalizationNative_GetJapaneseEraStartDate")]
         internal static extern bool GetJapaneseEraStartDate(int era, out int startYear, out int startMonth, out int startDay);
     }
 }

--- a/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
+++ b/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
@@ -11,13 +11,13 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCase")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCase")]
         internal unsafe static extern void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseInvariant")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseInvariant")]
         internal unsafe static extern void ChangeCaseInvariant(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseTurkish")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseTurkish")]
         internal unsafe static extern void ChangeCaseTurkish(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
     }
 }

--- a/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
+++ b/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
@@ -11,39 +11,39 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortHandle")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortHandle")]
         internal unsafe static extern ResultCode GetSortHandle(byte[] localeName, out SafeSortHandle sortHandle);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CloseSortHandle")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CloseSortHandle")]
         internal unsafe static extern void CloseSortHandle(IntPtr handle);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareString")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareString")]
         internal unsafe static extern int CompareString(SafeSortHandle sortHandle, char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOf")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOf")]
         internal unsafe static extern int IndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options, int* matchLengthPtr);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_LastIndexOf")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_LastIndexOf")]
         internal unsafe static extern int LastIndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOfOrdinalIgnoreCase")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOfOrdinalIgnoreCase")]
         internal unsafe static extern int IndexOfOrdinalIgnoreCase(string target, int cwTargetLength, char* pSource, int cwSourceLength, bool findLast);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_StartsWith")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_StartsWith")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool StartsWith(SafeSortHandle sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EndsWith")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EndsWith")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool EndsWith(SafeSortHandle sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortKey")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortKey")]
         internal unsafe static extern int GetSortKey(SafeSortHandle sortHandle, string str, int strLength, byte* sortKey, int sortKeyLength, CompareOptions options);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareStringOrdinalIgnoreCase")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareStringOrdinalIgnoreCase")]
         internal unsafe static extern int CompareStringOrdinalIgnoreCase(char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len);
 
-        [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_GetSortVersion")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, EntryPoint = "GlobalizationNative_GetSortVersion")]
         internal static extern int GetSortVersion();
 
         internal class SafeSortHandle : SafeHandle

--- a/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
+++ b/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
@@ -12,10 +12,10 @@ internal static partial class Interop
         internal const int AllowUnassigned = 0x1;
         internal const int UseStd3AsciiRules = 0x2;
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToAscii")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToAscii")]
         internal static unsafe extern int ToAscii(uint flags, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToUnicode")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToUnicode")]
         internal static unsafe extern int ToUnicode(uint flags, char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Locale.cs
+++ b/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Locale.cs
@@ -10,31 +10,31 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleName")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleName")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleName(string localeName, [Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoString")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoString")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleInfoString(string localeName, uint localeStringData, [Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetDefaultLocaleName")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetDefaultLocaleName")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetDefaultLocaleName([Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleTimeFormat")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleTimeFormat")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleTimeFormat(string localeName, bool shortFormat, [Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoInt")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoInt")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleInfoInt(string localeName, uint localeNumberData, ref int value);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoGroupingSizes")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoGroupingSizes")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleInfoGroupingSizes(string localeName, uint localeGroupingData, ref int primaryGroupSize, ref int secondaryGroupSize);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocales")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocales")]
         internal unsafe static extern int GetLocales([Out] Char[] value, int valueLength);
     }
 }

--- a/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
+++ b/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
@@ -10,10 +10,10 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsNormalized")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsNormalized")]
         internal static extern int IsNormalized(NormalizationForm normalizationForm, string src, int srcLen);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
         internal static extern int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, [Out] char[] dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
+++ b/src/mscorlib/src/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Ansi, EntryPoint = "GlobalizationNative_ReadLink")] // readlink requires char*
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "GlobalizationNative_ReadLink")] // readlink requires char*
         internal static extern bool ReadLink(string filePath, [Out] StringBuilder result, uint resultCapacity);
 
         // needs to be kept in sync with TimeZoneDisplayNameType in System.Globalization.Native
@@ -20,7 +20,7 @@ internal static partial class Interop
             DaylightSavings = 2,
         }
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetTimeZoneDisplayName")]
+        [DllImport(Libraries.GlobalizationInterop, CallingConvention=CallingConvention.Cdecl, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetTimeZoneDisplayName")]
         internal static extern ResultCode GetTimeZoneDisplayName(
             string localeName, 
             string timeZoneId, 


### PR DESCRIPTION
All the native Linux interop functions that System.Native and Symtem.Globalzation uses CDECL (not STDCALL). 

This commit revises each P/Invoke declaration to explicitly annotate its calling convention.