### PR TITLE
[x86/Linux] Fix incorrect FP values

### DIFF
--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -396,7 +396,7 @@ inline void FillRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, PT_CONTEXT pC
 #elif defined(_TARGET_X86_) // _TARGET_ARM_
     for (int i = 0; i < 7; i++)
     {
-        *(&pRD->ctxPtrsOne.Esi + i) = (&pRD->pCurrentContext->Esi + i);
+        *(&pRD->ctxPtrsOne.Esi + i) = (&pctx->Esi + i);
     }
 #else // _TARGET_X86_
     PORTABILITY_ASSERT("FillRegDisplay");

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -396,7 +396,7 @@ inline void FillRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, PT_CONTEXT pC
 #elif defined(_TARGET_X86_) // _TARGET_ARM_
     for (int i = 0; i < 7; i++)
     {
-        *(&pRD->ctxPtrsOne.Esi + i) = (&pctx->Esi + i);
+        *(&pRD->ctxPtrsOne.Esi + i) = (&pRD->pCurrentContext->Esi + i);
     }
 #else // _TARGET_X86_
     PORTABILITY_ASSERT("FillRegDisplay");

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -5190,11 +5190,7 @@ OBJECTREF EECodeManager::GetInstance( PREGDISPLAY    pContext,
     if (info.ebpFrame)
     {
         _ASSERTE(stackDepth == 0);
-#if defined(WIN64EXCEPTIONS)
-        taArgBase = GetCallerSp(pContext) - 2 * sizeof(TADDR);
-#else
-        taArgBase = *pContext->pEbp;
-#endif
+        taArgBase = GetRegdisplayFP(pContext);
     }
     else
     {
@@ -5365,11 +5361,7 @@ PTR_VOID EECodeManager::GetParamTypeArg(PREGDISPLAY     pContext,
         return NULL;
     }
 
-#if defined(WIN64EXCEPTIONS)
-    TADDR fp = GetCallerSp(pContext) - 2 * sizeof(TADDR);
-#else
     TADDR fp = GetRegdisplayFP(pContext);
-#endif
     TADDR taParamTypeArg = *PTR_TADDR(fp - GetParamTypeArgOffset(&info));
     return PTR_VOID(taParamTypeArg);
 
@@ -5497,13 +5489,7 @@ void * EECodeManager::GetGSCookieAddr(PREGDISPLAY     pContext,
     
     if  (info->ebpFrame)
     {
-        DWORD curEBP;
-
-#ifdef WIN64EXCEPTIONS
-        curEBP = GetCallerSp(pContext) - 2 * 4;
-#else
-        curEBP = *pContext->pEbp;
-#endif
+        DWORD curEBP = GetRegdisplayFP(pContext);
 
         return PVOID(SIZE_T(curEBP - info->gsCookieOffset));
     }

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -47,6 +47,13 @@ inline void RestoreNonvolatileRegisters(PCONTEXT pContext, PKNONVOLATILE_CONTEXT
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 }
+
+inline void RestoreNonvolatileRegisterPointers(PT_KNONVOLATILE_CONTEXT_POINTERS pContextPointers, PKNONVOLATILE_CONTEXT pNonvolatileContext)
+{
+#define CALLEE_SAVED_REGISTER(reg) pContextPointers->reg = &pNonvolatileContext->reg;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+}
 #endif
 #ifndef DACCESS_COMPILE
 
@@ -1312,6 +1319,7 @@ void ExceptionTracker::InitializeCurrentContextForCrawlFrame(CrawlFrame* pcfThis
         SetIP(pRD->pCurrentContext, 0);
 #else // !USE_CURRENT_CONTEXT_IN_FILTER
         RestoreNonvolatileRegisters(pRD->pCurrentContext, pDispatcherContext->CurrentNonVolatileContextRecord);
+        RestoreNonvolatileRegisterPointers(pRD->pCurrentContextPointers, pDispatcherContext->CurrentNonVolatileContextRecord);
 #endif // USE_CURRENT_CONTEXT_IN_FILTER
 
         *(pRD->pCallerContext)      = *(pDispatcherContext->ContextRecord);


### PR DESCRIPTION
Restoring FP by CallerSP could be incorrect for nested EH.
Now that we have #9820, we can use current context for 1st pass of EH.

Fix #9848