### PR TITLE
[x86/Linux] CDECL as default P/Invoke Calling Convetion

### DIFF
--- a/src/inc/clrinternal.idl
+++ b/src/inc/clrinternal.idl
@@ -117,7 +117,7 @@ typedef enum {
 } CrstFlags;
 
 // Callback function for cleaning up TLS
-typedef VOID (WINAPI *PTLS_CALLBACK_FUNCTION)(PVOID);
+typedef VOID (__stdcall *PTLS_CALLBACK_FUNCTION)(PVOID);
 
 
 [

--- a/src/inc/clrinternal.idl
+++ b/src/inc/clrinternal.idl
@@ -117,7 +117,7 @@ typedef enum {
 } CrstFlags;
 
 // Callback function for cleaning up TLS
-typedef VOID (__stdcall *PTLS_CALLBACK_FUNCTION)(PVOID);
+typedef VOID (WINAPI *PTLS_CALLBACK_FUNCTION)(PVOID);
 
 
 [

--- a/src/pal/inc/pal_mstypes.h
+++ b/src/pal/inc/pal_mstypes.h
@@ -75,7 +75,7 @@ extern "C" {
 
 #endif  // !defined(__i386__)
 
-#define CALLBACK __stdcall
+#define CALLBACK __cdecl
 
 #if !defined(_declspec)
 #define _declspec(e)  __declspec(e)
@@ -105,7 +105,7 @@ extern "C" {
 
 #endif
 
-#define PALAPI      __stdcall
+#define PALAPI      __cdecl
 #define PALAPIV     __cdecl
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -205,9 +205,9 @@ inline void *__cdecl operator new(size_t, void *_P)
 
 #endif // DEBUG
 
-#define NTAPI       __stdcall
-#define WINAPI      __stdcall
-#define CALLBACK    __stdcall
+#define NTAPI       __cdecl
+#define WINAPI      __cdecl
+#define CALLBACK    __cdecl
 #define NTSYSAPI
 
 #define _WINNT_
@@ -1110,7 +1110,7 @@ typedef struct _LIST_ENTRY {
    struct _LIST_ENTRY *Blink;
 } LIST_ENTRY, *PLIST_ENTRY;
 
-typedef VOID (__stdcall *WAITORTIMERCALLBACK)(PVOID, BOOLEAN);
+typedef VOID (NTAPI *WAITORTIMERCALLBACK)(PVOID, BOOLEAN);
 
 // PORTABILITY_ASSERT and PORTABILITY_WARNING macros are meant to be used to
 // mark places in the code that needs attention for portability. The usual

--- a/src/pal/prebuilt/inc/clrinternal.h
+++ b/src/pal/prebuilt/inc/clrinternal.h
@@ -142,7 +142,7 @@ enum __MIDL___MIDL_itf_clrinternal_0000_0000_0001
         CRST_DEBUG_ONLY_CHECK_FORBID_SUSPEND_THREAD	= 0x200
     } 	CrstFlags;
 
-typedef VOID ( __stdcall *PTLS_CALLBACK_FUNCTION )( 
+typedef VOID ( WINAPI *PTLS_CALLBACK_FUNCTION )(
     PVOID __MIDL____MIDL_itf_clrinternal_0000_00000000);
 
 

--- a/src/pal/src/arch/i386/context2.S
+++ b/src/pal/src/arch/i386/context2.S
@@ -83,7 +83,7 @@ LOCAL_LABEL(Done_CONTEXT_EXTENDED_REGISTERS):
     // Restore
     pop   ebx
     pop   eax
-    ret   4
+    ret
 LEAF_END CONTEXT_CaptureContext, _TEXT
 
 LEAF_ENTRY RtlCaptureContext, _TEXT

--- a/src/pal/src/include/pal/module.h
+++ b/src/pal/src/include/pal/module.h
@@ -25,7 +25,7 @@ extern "C"
 {
 #endif // __cplusplus
 
-typedef BOOL (__stdcall *PDLLMAIN)(HINSTANCE, DWORD, LPVOID);   /* entry point of module */
+typedef BOOL (PALAPI *PDLLMAIN)(HINSTANCE, DWORD, LPVOID);   /* entry point of module */
 typedef HINSTANCE (PALAPI *PREGISTER_MODULE)(LPCSTR);           /* used to create the HINSTANCE for above DLLMain entry point */
 typedef VOID (PALAPI *PUNREGISTER_MODULE)(HINSTANCE);           /* used to cleanup the HINSTANCE for above DLLMain entry point */
 

--- a/src/pal/tests/palsuite/filemapping_memmgt/FreeLibrary/test1/dlltest.cpp
+++ b/src/pal/tests/palsuite/filemapping_memmgt/FreeLibrary/test1/dlltest.cpp
@@ -19,13 +19,13 @@
 __declspec(dllexport)
 #endif
 
-int __stdcall DllTest()
+int PALAPI DllTest()
 {
     return 1;
 }
 
 #ifdef WIN32
-int __stdcall _DllMainCRTStartup(void *hinstDLL, int reason, void * lpvReserved)
+int PALAPI _DllMainCRTStartup(void *hinstDLL, int reason, void * lpvReserved)
 {
     return 1;
 }

--- a/src/pal/tests/palsuite/filemapping_memmgt/FreeLibraryAndExitThread/test1/dlltest.cpp
+++ b/src/pal/tests/palsuite/filemapping_memmgt/FreeLibraryAndExitThread/test1/dlltest.cpp
@@ -19,13 +19,13 @@
 __declspec(dllexport)
 #endif
 
-int _stdcall DllTest()
+int PALAPI DllTest()
 {
     return 1;
 }
 
 #if WIN32
-int __stdcall _DllMainCRTStartup(void *hinstDLL, int reason, void * lpvReserved)
+int PALAPI _DllMainCRTStartup(void *hinstDLL, int reason, void * lpvReserved)
 {
     return 1;
 }

--- a/src/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test1/test1.cpp
+++ b/src/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test1/test1.cpp
@@ -15,7 +15,7 @@
 **===========================================================================*/
 #include <palsuite.h>
 
-typedef int (__stdcall *SIMPLEFUNCTION)(int);
+typedef int (PALAPI *SIMPLEFUNCTION)(int);
 
 /* SHLEXT is defined only for Unix variants */
 #if defined(SHLEXT)

--- a/src/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test1/testlib.cpp
+++ b/src/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test1/testlib.cpp
@@ -20,13 +20,13 @@ __declspec(dllexport)
 /**
  * Simple function that returns i+1
  */
-int __stdcall SimpleFunction(int i)
+int PALAPI SimpleFunction(int i)
 {
     return i+1;
 }
 
 #if WIN32
-int __stdcall _DllMainCRTStartup(void *hinstDLL, int reason, void *lpvReserved)
+int PALAPI _DllMainCRTStartup(void *hinstDLL, int reason, void *lpvReserved)
 {
     return 1;
 }

--- a/src/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test2/testlib.cpp
+++ b/src/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test2/testlib.cpp
@@ -20,13 +20,13 @@ __declspec(dllexport)
 /**
  * Simple function that returns i+1
  */
-int __stdcall SimpleFunction(int i)
+int PALAPI SimpleFunction(int i)
 {
     return i+1;
 }
 
 #if WIN32
-int __stdcall _DllMainCRTStartup(void *hinstDLL, int reason, void *lpvReserved)
+int PALAPI _DllMainCRTStartup(void *hinstDLL, int reason, void *lpvReserved)
 {
     return 1;
 }

--- a/src/pal/tests/palsuite/loader/LoadLibraryA/test6/dlltest.cpp
+++ b/src/pal/tests/palsuite/loader/LoadLibraryA/test6/dlltest.cpp
@@ -23,7 +23,7 @@
 static int g_attachCount = 0;
 
 /* standard DllMain() */
-BOOL __stdcall DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
+BOOL PALAPI DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
 {
     switch( reason )
     {
@@ -53,7 +53,7 @@ BOOL __stdcall DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
 }
 
 #if _WIN32
-BOOL __stdcall _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
+BOOL PALAPI _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
 {
     return DllMain(hinstDLL, reason, lpvReserved);
 }

--- a/src/pal/tests/palsuite/loader/LoadLibraryA/test8/dlltest.cpp
+++ b/src/pal/tests/palsuite/loader/LoadLibraryA/test8/dlltest.cpp
@@ -23,7 +23,7 @@
 static int g_attachCount = 0;
 
 /* standard DllMain() */
-BOOL __stdcall DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
+BOOL PALAPI DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
 {
     switch( reason )
     {
@@ -53,7 +53,7 @@ BOOL __stdcall DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
 }
 
 #if _WIN32
-BOOL __stdcall _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
+BOOL PALAPI _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
 {
     return DllMain(hinstDLL, reason, lpvReserved);
 }

--- a/src/pal/tests/palsuite/pal_specific/pal_entrypoint/test1/palstartup.h
+++ b/src/pal/tests/palsuite/pal_specific/pal_entrypoint/test1/palstartup.h
@@ -27,6 +27,11 @@ static DWORD PALAPI run_main(struct _mainargs *args)
     return (DWORD) PAL_startup_main(args->argc, args->argv);
 }
 
+static void terminate(void)
+{
+    PAL_Terminate();
+}
+
 int __cdecl main(int argc, char **argv) {
     struct _mainargs mainargs;
 
@@ -34,9 +39,7 @@ int __cdecl main(int argc, char **argv) {
         return FAIL;;
     }
 
-    // PAL_Terminate is a stdcall function, but it takes no parameters
-    // so the difference doesn't matter.
-    atexit((void (__cdecl *)(void)) PAL_Terminate);
+    atexit(terminate);
 
     mainargs.argc = argc;
     mainargs.argv = argv;

--- a/src/pal/tests/palsuite/threading/DisableThreadLibraryCalls/test1/test1.cpp
+++ b/src/pal/tests/palsuite/threading/DisableThreadLibraryCalls/test1/test1.cpp
@@ -26,7 +26,7 @@
 #define GETCALLCOUNT "_GetCallCount@0"
 #endif
 
-DWORD __stdcall ThreadFunc(LPVOID lpParam);
+DWORD PALAPI ThreadFunc(LPVOID lpParam);
 int RunTest(int DisableThreadCalls);
 
 int __cdecl main(int argc, char **argv)
@@ -78,7 +78,7 @@ int __cdecl main(int argc, char **argv)
 /*
  * Thread entry point.  Doesn't do anything.
  */
-DWORD __stdcall ThreadFunc(LPVOID lpParam)
+DWORD PALAPI ThreadFunc(LPVOID lpParam)
 {
     return 0;
 }

--- a/src/pal/tests/palsuite/threading/DisableThreadLibraryCalls/test1/testlib.cpp
+++ b/src/pal/tests/palsuite/threading/DisableThreadLibraryCalls/test1/testlib.cpp
@@ -15,7 +15,7 @@
 
 static int Count;
 
-BOOL __stdcall DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+BOOL PALAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
 
     if (fdwReason == DLL_PROCESS_ATTACH)
@@ -32,7 +32,7 @@ BOOL __stdcall DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 }
 
 #ifdef WIN32
-BOOL __stdcall _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+BOOL PALAPI _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     return DllMain(hinstDLL, fdwReason, lpvReserved);
 }
@@ -41,7 +41,7 @@ BOOL __stdcall _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lp
 #ifdef WIN32
 __declspec(dllexport)
 #endif
-int __stdcall GetCallCount()
+int PALAPI GetCallCount()
 {
     return Count;
 }

--- a/src/pal/tests/palsuite/threading/DisableThreadLibraryCalls/test2/dllmain1.cpp
+++ b/src/pal/tests/palsuite/threading/DisableThreadLibraryCalls/test2/dllmain1.cpp
@@ -50,7 +50,7 @@ BOOL PALAPI DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
 
 
 #ifdef WIN32
-BOOL __stdcall _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+BOOL PALAPI _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     return DllMain(hinstDLL, fdwReason, lpvReserved);
 }

--- a/src/pal/tests/palsuite/threading/DisableThreadLibraryCalls/test2/dllmain2.cpp
+++ b/src/pal/tests/palsuite/threading/DisableThreadLibraryCalls/test2/dllmain2.cpp
@@ -50,7 +50,7 @@ BOOL PALAPI DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
 
 
 #ifdef WIN32
-BOOL __stdcall _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+BOOL PALAPI _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     return DllMain(hinstDLL, fdwReason, lpvReserved);
 }

--- a/src/pal/tests/palsuite/threading/ExitThread/test3/dllmain.cpp
+++ b/src/pal/tests/palsuite/threading/ExitThread/test3/dllmain.cpp
@@ -48,7 +48,7 @@ BOOL PALAPI DllMain(HINSTANCE hinstDLL, DWORD reason, LPVOID lpvReserved)
 }
 
 #ifdef WIN32
-BOOL __stdcall _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+BOOL PALAPI _DllMainCRTStartup(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     return DllMain(hinstDLL, fdwReason, lpvReserved);
 }

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -289,7 +289,7 @@ static void PulseAllHelper(Thread* pThread)
 }
 
 // When an exposed thread is started by Win32, this is where it starts.
-ULONG __stdcall ThreadNative::KickOffThread(void* pass)
+ULONG WINAPI ThreadNative::KickOffThread(void* pass)
 {
 
     CONTRACTL

--- a/src/vm/comsynchronizable.h
+++ b/src/vm/comsynchronizable.h
@@ -121,7 +121,7 @@ private:
     };
 
     static void KickOffThread_Worker(LPVOID /* KickOffThread_Args* */);
-    static ULONG __stdcall KickOffThread(void *pass);
+    static ULONG WINAPI KickOffThread(void *pass);
     static BOOL DoJoin(THREADBASEREF DyingThread, INT32 timeout);
 };
 

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -705,7 +705,7 @@ void FinalizerThread::FinalizeObjectsOnShutdown(LPVOID args)
 }
 
 
-DWORD __stdcall FinalizerThread::FinalizerThreadStart(void *args)
+DWORD WINAPI FinalizerThread::FinalizerThreadStart(void *args)
 {
     ClrFlsSetThreadType (ThreadType_Finalizer);
 

--- a/src/vm/finalizerthread.h
+++ b/src/vm/finalizerthread.h
@@ -89,7 +89,7 @@ public:
 
     static VOID FinalizerThreadWorker(void *args);
     static void FinalizeObjectsOnShutdown(LPVOID args);
-    static DWORD __stdcall FinalizerThreadStart(void *args);
+    static DWORD WINAPI FinalizerThreadStart(void *args);
 
     static void FinalizerThreadCreate();
     static BOOL FinalizerThreadWatchDog();

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -576,7 +576,7 @@ struct GCThreadStubParam
 };
 
 // GC thread stub to convert GC thread function to an OS specific thread function
-static DWORD __stdcall GCThreadStub(void* param)
+static DWORD WINAPI GCThreadStub(void* param)
 {
     WRAPPER_NO_CONTRACT;
 

--- a/src/vm/qcall.h
+++ b/src/vm/qcall.h
@@ -118,7 +118,11 @@
 // }
 
 
+#ifdef PLATFORM_UNIX
+#define QCALLTYPE __cdecl
+#else // PLATFORM_UNIX
 #define QCALLTYPE __stdcall
+#endif // !PLATFORM_UNIX
 
 #define BEGIN_QCALL                      \
     INSTALL_MANAGED_EXCEPTION_DISPATCHER \

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -1140,7 +1140,7 @@ DWORD GetRuntimeId()
 //---------------------------------------------------------------------------
 // Creates new Thread for reverse p-invoke calls.  
 //---------------------------------------------------------------------------
-Thread* __stdcall CreateThreadBlockThrow()
+Thread* WINAPI CreateThreadBlockThrow()
 {
 
     WRAPPER_NO_CONTRACT;
@@ -2585,7 +2585,7 @@ BOOL Thread::CreateNewThread(SIZE_T stackSize, LPTHREAD_START_ROUTINE start, voi
 
 // This is to avoid the 64KB/1MB aliasing problem present on Pentium 4 processors,
 // which can significantly impact performance with HyperThreading enabled
-DWORD __stdcall Thread::intermediateThreadProc(PVOID arg)
+DWORD WINAPI Thread::intermediateThreadProc(PVOID arg)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -4638,7 +4638,7 @@ void PendingSync::Restore(BOOL bRemoveFromSB)
 
 // This is the callback from the OS, when we queue an APC to interrupt a waiting thread.
 // The callback occurs on the thread we wish to interrupt.  It is a STATIC method.
-void __stdcall Thread::UserInterruptAPC(ULONG_PTR data)
+void WINAPI Thread::UserInterruptAPC(ULONG_PTR data)
 {
     CONTRACTL {
         NOTHROW;

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -638,7 +638,7 @@ DWORD GetAppDomainTLSIndex();
 
 DWORD GetRuntimeId();
 
-EXTERN_C Thread* __stdcall CreateThreadBlockThrow();
+EXTERN_C Thread* WINAPI CreateThreadBlockThrow();
 
 //---------------------------------------------------------------------------
 // One-time initialization. Called during Dll initialization.
@@ -651,9 +651,9 @@ void InitThreadManager();
 
 #ifdef FEATURE_HIJACK
 
-EXTERN_C void __stdcall OnHijackTripThread();
+EXTERN_C void WINAPI OnHijackTripThread();
 #ifdef _TARGET_X86_
-EXTERN_C void __stdcall OnHijackFPTripThread();  // hijacked JIT code is returning an FP value
+EXTERN_C void WINAPI OnHijackFPTripThread();  // hijacked JIT code is returning an FP value
 #endif // _TARGET_X86_
 
 #endif // FEATURE_HIJACK
@@ -3852,7 +3852,7 @@ private:
     void        HandleThreadInterrupt(BOOL fWaitForADUnload);
 
 public:
-    static void __stdcall UserInterruptAPC(ULONG_PTR ignore);
+    static void WINAPI UserInterruptAPC(ULONG_PTR ignore);
 
 #if defined(_DEBUG) && defined(TRACK_SYNC)
 
@@ -4760,7 +4760,7 @@ public:
 private:
     // used to pad stack on thread creation to avoid aliasing penalty in P4 HyperThread scenarios
 
-    static DWORD __stdcall intermediateThreadProc(PVOID arg);
+    static DWORD WINAPI intermediateThreadProc(PVOID arg);
     static int m_offset_counter;
     static const int offset_multiplier = 128;
 

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -1834,7 +1834,7 @@ void ThreadpoolMgr::RecycleMemory(LPVOID mem, enum MemType memType)
 
 // This is to avoid the 64KB/1MB aliasing problem present on Pentium 4 processors,
 // which can significantly impact performance with HyperThreading enabled
-DWORD __stdcall ThreadpoolMgr::intermediateThreadProc(PVOID arg)
+DWORD WINAPI ThreadpoolMgr::intermediateThreadProc(PVOID arg)
 {
     WRAPPER_NO_CONTRACT;
     STATIC_CONTRACT_SO_INTOLERANT;
@@ -1973,7 +1973,7 @@ BOOL ThreadpoolMgr::CreateWorkerThread()
 }
 
 
-DWORD __stdcall ThreadpoolMgr::WorkerThreadStart(LPVOID lpArgs)
+DWORD WINAPI ThreadpoolMgr::WorkerThreadStart(LPVOID lpArgs)
 {
     ClrFlsSetThreadType (ThreadType_Threadpool_Worker);
 
@@ -2670,7 +2670,7 @@ DWORD ThreadpoolMgr::MinimumRemainingWait(LIST_ENTRY* waitInfo, unsigned int num
 #pragma warning(disable:22008) // "Prefast integer overflow check on (0 + lval) is bogus.  Tried local disable without luck, doing whole method."
 #endif
 
-DWORD __stdcall ThreadpoolMgr::WaitThreadStart(LPVOID lpArgs)
+DWORD WINAPI ThreadpoolMgr::WaitThreadStart(LPVOID lpArgs)
 {
     CONTRACTL
     {
@@ -2937,7 +2937,7 @@ void ThreadpoolMgr::ProcessWaitCompletion(WaitInfo* waitInfo,
 }
 
 
-DWORD __stdcall ThreadpoolMgr::AsyncCallbackCompletion(PVOID pArgs)
+DWORD WINAPI ThreadpoolMgr::AsyncCallbackCompletion(PVOID pArgs)
 {
     CONTRACTL
     {
@@ -3350,7 +3350,7 @@ BOOL ThreadpoolMgr::CreateCompletionPortThread(LPVOID lpArgs)
     return FALSE;
 }
 
-DWORD __stdcall ThreadpoolMgr::CompletionPortThreadStart(LPVOID lpArgs)
+DWORD WINAPI ThreadpoolMgr::CompletionPortThreadStart(LPVOID lpArgs)
 {
     ClrFlsSetThreadType (ThreadType_Threadpool_IOCompletion);
 
@@ -4194,7 +4194,7 @@ public:
 };
 
 
-DWORD __stdcall ThreadpoolMgr::GateThreadStart(LPVOID lpArgs)
+DWORD WINAPI ThreadpoolMgr::GateThreadStart(LPVOID lpArgs)
 {
     ClrFlsSetThreadType (ThreadType_Gate);
 
@@ -4645,7 +4645,7 @@ BOOL ThreadpoolMgr::CreateTimerQueueTimer(PHANDLE phNewTimer,
 #pragma warning (disable : 4715)
 #endif
 #endif
-DWORD __stdcall ThreadpoolMgr::TimerThreadStart(LPVOID p)
+DWORD WINAPI ThreadpoolMgr::TimerThreadStart(LPVOID p)
 {
     ClrFlsSetThreadType (ThreadType_Timer);
 
@@ -4872,7 +4872,7 @@ DWORD ThreadpoolMgr::FireTimers()
     return nextFiringInterval;
 }
 
-DWORD __stdcall ThreadpoolMgr::AsyncTimerCallbackCompletion(PVOID pArgs)
+DWORD WINAPI ThreadpoolMgr::AsyncTimerCallbackCompletion(PVOID pArgs)
 {
     CONTRACTL
     {
@@ -4928,7 +4928,7 @@ void ThreadpoolMgr::DeactivateTimer(TimerInfo* timerInfo)
     timerInfo->state = timerInfo->state & ~TIMER_ACTIVE;
 }
 
-DWORD __stdcall ThreadpoolMgr::AsyncDeleteTimer(PVOID pArgs)
+DWORD WINAPI ThreadpoolMgr::AsyncDeleteTimer(PVOID pArgs)
 {
     CONTRACTL
     {

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -997,7 +997,7 @@ public:
 
     // Private methods
 
-    static DWORD __stdcall intermediateThreadProc(PVOID arg);
+    static DWORD WINAPI intermediateThreadProc(PVOID arg);
 
     typedef struct {
         LPTHREAD_START_ROUTINE  lpThreadFunction;
@@ -1107,7 +1107,7 @@ public:
 
     static DWORD SafeWait(CLREvent * ev, DWORD sleepTime, BOOL alertable);
 
-    static DWORD __stdcall WorkerThreadStart(LPVOID lpArgs);
+    static DWORD WINAPI WorkerThreadStart(LPVOID lpArgs);
 
     static BOOL AddWaitRequest(HANDLE waitHandle, WaitInfo* waitInfo);
 
@@ -1116,7 +1116,7 @@ public:
 
     static BOOL CreateWaitThread();
 
-    static void __stdcall InsertNewWaitForSelf(WaitInfo* pArg);
+    static void WINAPI InsertNewWaitForSelf(WaitInfo* pArg);
 
     static int FindWaitIndex(const ThreadCB* threadCB, const HANDLE waitHandle);
 
@@ -1126,9 +1126,9 @@ public:
                                 unsigned index,      // array index 
                                 BOOL waitTimedOut);
 
-    static DWORD __stdcall WaitThreadStart(LPVOID lpArgs);
+    static DWORD WINAPI WaitThreadStart(LPVOID lpArgs);
 
-    static DWORD __stdcall AsyncCallbackCompletion(PVOID pArgs);
+    static DWORD WINAPI AsyncCallbackCompletion(PVOID pArgs);
 
     static void QueueTimerInfoForRelease(TimerInfo *pTimerInfo);
 
@@ -1152,7 +1152,7 @@ public:
                count * sizeof(LIST_ENTRY));
     }
 
-    static void __stdcall DeregisterWait(WaitInfo* pArgs);
+    static void WINAPI DeregisterWait(WaitInfo* pArgs);
 
 #ifndef FEATURE_PAL
     // holds the aggregate of system cpu usage of all processors
@@ -1169,7 +1169,7 @@ public:
 
     static int GetCPUBusyTime_NT(PROCESS_CPU_INFORMATION* pOldInfo);
     static BOOL CreateCompletionPortThread(LPVOID lpArgs);
-    static DWORD __stdcall CompletionPortThreadStart(LPVOID lpArgs);
+    static DWORD WINAPI CompletionPortThreadStart(LPVOID lpArgs);
 public:
     inline static bool HaveNativeWork()
     {
@@ -1190,7 +1190,7 @@ private:
     static BOOL CreateGateThread();
     static void EnsureGateThreadRunning();
     static bool ShouldGateThreadKeepRunning();
-    static DWORD __stdcall GateThreadStart(LPVOID lpArgs);
+    static DWORD WINAPI GateThreadStart(LPVOID lpArgs);
     static BOOL SufficientDelaySinceLastSample(unsigned int LastThreadCreationTime, 
                                                unsigned NumThreads, // total number of threads of that type (worker or CP)
                                                double   throttleRate=0.0 // the delay is increased by this percentage for each extra thread
@@ -1199,17 +1199,17 @@ private:
 
     static LPVOID   GetRecycledMemory(enum MemType memType);
 
-    static DWORD __stdcall TimerThreadStart(LPVOID args);
+    static DWORD WINAPI TimerThreadStart(LPVOID args);
     static void TimerThreadFire(); // helper method used by TimerThreadStart
-    static void __stdcall InsertNewTimer(TimerInfo* pArg);
+    static void WINAPI InsertNewTimer(TimerInfo* pArg);
     static DWORD FireTimers();
-    static DWORD __stdcall AsyncTimerCallbackCompletion(PVOID pArgs);
+    static DWORD WINAPI AsyncTimerCallbackCompletion(PVOID pArgs);
     static void DeactivateTimer(TimerInfo* timerInfo);
-    static DWORD __stdcall AsyncDeleteTimer(PVOID pArgs);
+    static DWORD WINAPI AsyncDeleteTimer(PVOID pArgs);
     static void DeleteTimer(TimerInfo* timerInfo);
-    static void __stdcall UpdateTimer(TimerUpdateInfo* pArgs);
+    static void WINAPI UpdateTimer(TimerUpdateInfo* pArgs);
 
-    static void __stdcall DeregisterTimer(TimerInfo* pArgs);
+    static void WINAPI DeregisterTimer(TimerInfo* pArgs);
 
     inline static DWORD QueueDeregisterWait(HANDLE waitThread, WaitInfo* waitInfo)
     {


### PR DESCRIPTION
This commit revises P/Invoke without explicit annotation to use CDECL instead of STDCALL.
