### PR TITLE
[Ryujit/ARM32] Support binary operator for decomposed long

### DIFF
--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -845,6 +845,10 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             info->dstCount = 0;
             break;
 
+        case GT_ADD_LO:
+        case GT_ADD_HI:
+        case GT_SUB_LO:
+        case GT_SUB_HI:
         case GT_ADD:
         case GT_SUB:
             if (varTypeIsFloating(tree->TypeGet()))


### PR DESCRIPTION
Implement binary operator for decomposed long type, e.g. GT_ADD_HI,
in Lowering::TreeNodeInfoInit and CodeGen::genGetInsForOper.

For `Lowering::TreeNodeInfoInit`, x86 implementation from lsraxarch.cpp is referenced and written.
For `CodeGen::genGetInsForOper`, arm implementation from codegenlegacy.cpp is referenced.

(This is a part of  #8496)