### PR TITLE
Add handling of multiple CMake installations in probe-win

### DIFF
--- a/src/pal/tools/probe-win.ps1
+++ b/src/pal/tools/probe-win.ps1
@@ -29,11 +29,12 @@ function LocateCMake
 {
   $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from http://www.cmake.org/download/ and ensure it is on your path."
   $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue)
-  # Resolve the first version of CMake if multiple commands are found
-  if ($inPathPath.Length -gt 1) {
-    $inPathPath = $inPathPath[0].Path
-  } else {
-    $inPathPath = $inPathPath.Path
+  if ($inPathPath -ne $null) {
+    # Resolve the first version of CMake if multiple commands are found
+    if ($inPathPath.Length -gt 1) {
+      return $inPathPath = $inPathPath[0].Path
+    }
+    return $inPathPath = $inPathPath.Path
   }
   # Let us hope that CMake keep using their current version scheme
   $validVersions = @()

--- a/src/pal/tools/probe-win.ps1
+++ b/src/pal/tools/probe-win.ps1
@@ -28,9 +28,12 @@ function GetCMakeInfo($regKey)
 function LocateCMake
 {
   $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from http://www.cmake.org/download/ and ensure it is on your path."
-  $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue).Path
-  if ($inPathPath -ne $null) {
-    return $inPathPath
+  $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue)
+  # Resolve the first version of CMake if multiple commands are found
+  if ($inPathPath.Length -gt 1) {
+    $inPathPath = $inPathPath[0].Path
+  } else {
+    $inPathPath = $inPathPathPath
   }
   # Let us hope that CMake keep using their current version scheme
   $validVersions = @()

--- a/src/pal/tools/probe-win.ps1
+++ b/src/pal/tools/probe-win.ps1
@@ -33,7 +33,7 @@ function LocateCMake
   if ($inPathPath.Length -gt 1) {
     $inPathPath = $inPathPath[0].Path
   } else {
-    $inPathPath = $inPathPathPath
+    $inPathPath = $inPathPath.Path
   }
   # Let us hope that CMake keep using their current version scheme
   $validVersions = @()

--- a/src/pal/tools/probe-win.ps1
+++ b/src/pal/tools/probe-win.ps1
@@ -32,9 +32,9 @@ function LocateCMake
   if ($inPathPath -ne $null) {
     # Resolve the first version of CMake if multiple commands are found
     if ($inPathPath.Length -gt 1) {
-      return $inPathPath = $inPathPath[0].Path
+      return $inPathPath[0].Path
     }
-    return $inPathPath = $inPathPath.Path
+    return $inPathPath.Path
   }
   # Let us hope that CMake keep using their current version scheme
   $validVersions = @()


### PR DESCRIPTION
Check if multiple CMake versions are installed, and use by default the first path available

Fixes #8221