### PR TITLE
Fix incremental build of mscordaccore

### DIFF
--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -102,7 +102,7 @@ if(WIN32)
 
     # Generate export file
     add_custom_command(
-        DEPENDS ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def ${MSCORDAC_OBJ_PATH} "$<TARGET_FILE:daccess>"
+        DEPENDS mscordaccore_def mscordacobj daccess
         OUTPUT ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.exp
         COMMAND lib.exe /OUT:"${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.lib" /DEF:"${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def" "$<TARGET_FILE:daccess>" $<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/LTCG> ${STATIC_LIBRARY_FLAGS} ${MSCORDAC_OBJ_PATH}
         COMMENT "Generating mscordaccore.exp export file"

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -7,7 +7,6 @@ if(CLR_CMAKE_PLATFORM_UNIX)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 set(CLR_DAC_SOURCES
-    mscordac.cpp
 )
 
 add_definitions(-DFX_VER_INTERNALNAME_STR=mscordaccore.dll)
@@ -20,11 +19,13 @@ if(WIN32)
         mscordac.src
     )
 
+    set(CURRENT_BINARY_DIR_FOR_CONFIG ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR})
+
     #Preprocess exports definition file
-    preprocess_def_file(${CMAKE_CURRENT_SOURCE_DIR}/${DEF_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/mscordac.def)
+    preprocess_def_file(${CMAKE_CURRENT_SOURCE_DIR}/${DEF_SOURCES} ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def)
 
     #create target to add file dependency on mscordac.def
-    add_custom_target(mscordaccore_def DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/mscordac.def)
+    add_custom_target(mscordaccore_def DEPENDS ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def)
 
     # No library groups for Win32
     set(START_LIBRARY_GROUP)
@@ -58,7 +59,11 @@ if(CLR_CMAKE_PLATFORM_DARWIN)
     set(EXPORTS_LINKER_OPTION -Wl,-exported_symbols_list,${EXPORTS_FILE})
 endif(CLR_CMAKE_PLATFORM_DARWIN)
 
-add_library_clr(mscordaccore SHARED ${CLR_DAC_SOURCES})
+# Create object library to enable creation of proper dependency of mscordaccore.exp on mscordac.obj and
+# mscordaccore on both the mscordaccore.exp and mscordac.obj.
+add_library(mscordacobj OBJECT mscordac.cpp)
+
+add_library_clr(mscordaccore SHARED ${CLR_DAC_SOURCES} $<TARGET_OBJECTS:mscordacobj>)
 
 if(CLR_CMAKE_PLATFORM_UNIX)
     add_custom_target(mscordaccore_exports DEPENDS ${EXPORTS_FILE})
@@ -93,15 +98,21 @@ if(WIN32)
     # mscordac.def should be generated before mscordaccore.dll is built
     add_dependencies(mscordaccore mscordaccore_def)
 
+    set(MSCORDAC_OBJ_PATH "${CMAKE_CURRENT_BINARY_DIR}/mscordacobj.dir/${CMAKE_CFG_INTDIR}/mscordac.obj")
+
     # Generate export file
-    add_custom_command(TARGET mscordaccore
-        PRE_LINK
-        COMMAND lib.exe /OUT:"${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordaccore.lib" /DEF:"${CMAKE_CURRENT_BINARY_DIR}/mscordac.def" "$<TARGET_FILE:daccess>" $<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/LTCG> ${STATIC_LIBRARY_FLAGS} "${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.dir/$<CONFIG>/mscordac.obj"
+    add_custom_command(
+        DEPENDS ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def ${MSCORDAC_OBJ_PATH} "$<TARGET_FILE:daccess>"
+        OUTPUT ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.exp
+        COMMAND lib.exe /OUT:"${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.lib" /DEF:"${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def" "$<TARGET_FILE:daccess>" $<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/LTCG> ${STATIC_LIBRARY_FLAGS} ${MSCORDAC_OBJ_PATH}
         COMMENT "Generating mscordaccore.exp export file"
     )
 
+    add_custom_target(mscordaccore_exp DEPENDS ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.exp)
+    add_dependencies(mscordaccore mscordaccore_exp)
+
     set(COREDAC_LIBRARIES
-        ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordaccore.exp # export file
+        ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.exp # export file
         ${COREDAC_LIBRARIES}
         mdwinmd_dac
         kernel32.lib

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -1,5 +1,4 @@
 include(${CLR_DIR}/dac.cmake)
-
 add_definitions(-DFEATURE_NO_HOST)
 
 if(CLR_CMAKE_PLATFORM_UNIX)
@@ -102,17 +101,22 @@ if(WIN32)
 
     # Generate export file
     add_custom_command(
-        DEPENDS mscordaccore_def mscordacobj daccess
-        OUTPUT ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.exp
-        COMMAND lib.exe /OUT:"${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.lib" /DEF:"${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def" "$<TARGET_FILE:daccess>" $<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/LTCG> ${STATIC_LIBRARY_FLAGS} ${MSCORDAC_OBJ_PATH}
+        DEPENDS mscordaccore_def "${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def" mscordacobj daccess
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.exp
+        COMMAND lib.exe /OUT:"${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.lib" /DEF:"${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def" "$<TARGET_FILE:daccess>" $<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/LTCG> ${STATIC_LIBRARY_FLAGS} ${MSCORDAC_OBJ_PATH}
         COMMENT "Generating mscordaccore.exp export file"
     )
 
-    add_custom_target(mscordaccore_exp DEPENDS ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.exp)
+    set_source_files_properties(
+        ${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.exp
+        PROPERTIES GENERATED TRUE
+    )
+
+    add_custom_target(mscordaccore_exp DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.exp)
     add_dependencies(mscordaccore mscordaccore_exp)
 
     set(COREDAC_LIBRARIES
-        ${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordaccore.exp # export file
+        ${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.exp # export file
         ${COREDAC_LIBRARIES}
         mdwinmd_dac
         kernel32.lib


### PR DESCRIPTION
This change sets up proper dependency for the mscordaccore build and stops
using PRE_LINK command which is executed always.
The way it solves the problem is that it creates an object library from the
mscordac.cpp and then lets the mscordaccore.exp be generated from that object
and finally use both that object library and the mscordaccore.exp while building
mscordaccore.