### PR TITLE
Create Xunit wrappers for 2nd-level test directories instead of top-level

### DIFF
--- a/tests/helixprep.proj
+++ b/tests/helixprep.proj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <TestCmds Include="$(DiscoveryDirectory)\**\*.cmd" ></TestCmds>
-    <XunitDlls Include="$(DiscoveryDirectory)\*\*.XUnitWrapper.dll" ></XunitDlls>
+    <XunitDlls Include="$(DiscoveryDirectory)\**\*.XUnitWrapper.dll" ></XunitDlls>
     <RequiresSigningFilesToDelete Include="$(DiscoveryDirectory)\**\*.requires_signing" />
   </ItemGroup>
 

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -29,10 +29,13 @@
       <AllTestDirsPaths Include="@(AllTestDirsNonCanonicalPaths)" >
         <Path>$([System.IO.Path]::GetFullPath(%(Identity)))</Path>
       </AllTestDirsPaths>
-      <NonExcludedTestDirectories Include="@(AllTestDirsPaths -> '%(Path)')" Exclude="@(_SkipTestDir -> '$(XunitTestBinBase)%(Identity)')">
+      <NonExcludedTestDirectories Include="@(AllTestDirsPaths -> '%(Path)')" Exclude="@(_SkipTestDir -> '$(XunitTestBinBase)%(Identity)')" />
+      <TopLevelDirectories Include="@(NonExcludedTestDirectories)" />
+      <SecondLevel Include="$([System.IO.Directory]::GetDirectories(%(TopLevelDirectories.Identity)))" />
+      <SecondLevelDirectories Include="@(SecondLevel)">
         <Path>$([System.IO.Path]::GetFullPath(%(AllRunnableTestPaths.Identity)))</Path>
-      </NonExcludedTestDirectories>
-      <TestDirectoriesWithDup Include="@(NonExcludedTestDirectories -> '%(Identity)')" Condition="$([System.String]::new('%(Path)').StartsWith('%(Identity)'))" />
+      </SecondLevelDirectories>
+      <TestDirectoriesWithDup Include="@(SecondLevelDirectories -> '%(Identity)')" Condition="$([System.String]::new('%(Path)').StartsWith('%(Identity)'))" />
 
     </ItemGroup>
 
@@ -118,7 +121,7 @@ $(_XunitEpilog)
   </ItemGroup>
   <Import Project="$(SourceDir)dir.targets" />
   <PropertyGroup>
-     <OutDir>$(XunitTestBinBase)\$(Category)\</OutDir>
+     <OutDir>$(XunitTestBinBase)\$(CategoryWithSlash)\</OutDir>
   </PropertyGroup>
 </Project>
         ]]>
@@ -151,7 +154,9 @@ $(_XunitEpilog)
 
     <PropertyGroup>
       <_CMDDIR_Parent>$([System.IO.Path]::GetDirectoryName($(_CMDDIR)))</_CMDDIR_Parent>
-      <Category>$([System.String]::Copy('$(_CMDDIR)').Replace($(_CMDDIR_Parent)\,''))</Category>
+      <_CMDDIR_Grandparent>$([System.IO.Path]::GetDirectoryName($(_CMDDIR_Parent)))</_CMDDIR_Grandparent>
+      <CategoryWithSlash>$([System.String]::Copy('$(_CMDDIR)').Replace($(_CMDDIR_Grandparent)\,''))</CategoryWithSlash>
+      <Category>$([System.String]::Copy('$(CategoryWithSlash)').Replace('\','.'))</Category>
       <XunitWrapper>$(Category).XUnitWrapper</XunitWrapper>
       <XunitWrapperSrcDir>$(XunitWrapperGeneratedCSDirBase)$(Category)</XunitWrapperSrcDir>
       <XunitWrapperOutputDir>$(XunitWrapperOutputIntermediatedDirBase)$(Category)</XunitWrapperOutputDir>

--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <Target Name="FindTestDirectories">
     <ItemGroup>
-      <AllTestAssemblies Include="$(BaseOutputPathWithConfig)\*\*.XUnitWrapper.dll" />
+      <AllTestAssemblies Include="$(BaseOutputPathWithConfig)\**\*.XUnitWrapper.dll" />
       <TestAssemblies Include="@(AllTestAssemblies)" Exclude="@(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity)\%(Identity).XUnitWrapper.dll')" />
     </ItemGroup>
     


### PR DESCRIPTION
As of today, we generate 13 Xunit Wrappers in CoreCLR, one for each of the top-level test directories in our test tree. This means that when executing in Helix, we're only running at most 13 things in parallel, which isn't taking full advantage of all of the available build machines. This change will make our Xunit wrappers more granular by generating a wrapper per-second level directory, instead of per-top level directory - so we should now have ~ 50 wrappers instead of 13, each with a smaller set of tests to run. Hopefully this should cut down our test execution time quite a bit (Currently takes up to 40 minutes in Helix)

CC @MattGal @gkhanna79 @ramarag @Petermarcu 