### PR TITLE
Harden resolveVirtualMethod against invalid types

### DIFF
--- a/tests/src/JIT/opt/Devirtualization/GitHub_9945_2.il
+++ b/tests/src/JIT/opt/Devirtualization/GitHub_9945_2.il
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib
+{
+}
+
+.assembly GitHub_9945_2
+{
+}
+
+.class public auto ansi beforefieldinit Base extends [mscorlib]System.Object
+{
+   // Need enough virtuals here to get F's slot past max virtual slot on object
+  .method public hidebysig newslot virtual instance void M0() cil managed { ret }
+  .method public hidebysig newslot virtual instance void M1() cil managed { ret }
+  .method public hidebysig newslot virtual instance void M2() cil managed { ret }
+  .method public hidebysig newslot virtual instance void M3() cil managed { ret }
+
+  .method public hidebysig newslot virtual instance void  F() cil managed
+  {
+    ldstr      "Base:F"
+    call       void [mscorlib]System.Console::WriteLine(string)
+    ret
+  }
+
+  .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed
+  {
+    ldarg.0
+    call       instance void [mscorlib]System.Object::.ctor()
+    ret
+  }
+}
+
+.class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
+{
+  .method public hidebysig static  int32  Main() cil managed
+  {
+    .locals (object)
+    .entrypoint
+    // Store ref in supertyped local to "forget" type
+    newobj     instance void Base::.ctor()
+    stloc.0
+    ldloc.0
+    // Now callvirt via the supertype
+    callvirt   instance void Base::F()
+    ldc.i4.s   100
+    ret
+  }
+}
+
+

--- a/tests/src/JIT/opt/Devirtualization/GitHub_9945_2.ilproj
+++ b/tests/src/JIT/opt/Devirtualization/GitHub_9945_2.ilproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+ </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+     <DebugType>None</DebugType>
+     <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_9945_2.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Split resolveVirtualMethod into a wrapper/helper to allow early
returns as failure reasons are discovered.

Before devirtualizing, ensure that the derived class claimed by the jit
is really a subclass of the class that introduces the virtual method.
Fail early if this is not the case.

Also add early out for interface call devirtualization. The jit currently
does not ask for this but asking for it should not trigger an assert.

Closes #9945 (along with #9959).