### PR TITLE
Change PackagePlatform to Platform for x86 jit pkg

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.Windows_NT.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.Windows_NT.Microsoft.NETCore.Jit.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <NativeBinary Include="$(BinDir)clrjit.dll" />
-    <NativeBinary Condition="'$(PackagePlatform)' == 'x86'" Include="$(BinDir)compatjit.dll" />
+    <NativeBinary Condition="'$(Platform)' == 'x86'" Include="$(BinDir)compatjit.dll" />
     <CrossArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)$(CrossTargetComponentFolder)\clrjit.dll" />
 
     <!-- prevent accidental inclusion in AOT projects. -->


### PR DESCRIPTION
PackagePlatform was removed in 8dcf9665feabee339029c79b9d86dd24c71905d1,
but the x86 jit package props file was never updated to not use that
property. This change updates the props file to use Platform instead of
PackagePlatform to make sure we package compatjit.dll for x86.