### PR TITLE
Change AMD64 direct call behavior

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1002,7 +1002,7 @@ bool Lowering::IsCallTargetInRange(void* addr)
 {
 #ifdef _TARGET_AMD64_
     return (comp->eeGetRelocTypeHint(addr) == IMAGE_REL_BASED_REL32);
-#else // _TARGET_X86_
+#else  // _TARGET_X86_
     return true;
 #endif // _TARGET_X86_
 }

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -992,10 +992,19 @@ bool Lowering::isRMWRegOper(GenTreePtr tree)
     }
 }
 
-// anything is in range for AMD64
+// Everything is in range for x86.
+// For AMD64, if we have overflowed the rel32 space at least once, and are forcing indirect data
+// accesses to 64-bit, then also force code addresses to 64-bit. This means we will not create jump
+// stubs. Not using jump stubs means the code is quite a bit bigger (12 byte calls versus 5 byte calls),
+// but we avoid the fatal problem of being unable to allocate jump stubs in very large, constrained
+// memory situations.
 bool Lowering::IsCallTargetInRange(void* addr)
 {
+#ifdef _TARGET_AMD64_
+    return (comp->eeGetRelocTypeHint(addr) == IMAGE_REL_BASED_REL32);
+#else // _TARGET_X86_
     return true;
+#endif // _TARGET_X86_
 }
 
 // return true if the immediate can be folded into an instruction, for example small enough and non-relocatable


### PR DESCRIPTION
Currently, when AMD64 generates direct calls, it always assumes the
calls are in rel32 range. The VM creates "jump stubs" if that ends
up not being true. Change this behavior such that the JIT generates
large call sequences "mov rax, <8-byte-address>; call rax" whenever
the VM says that rel32 calls are out-of-range. This will only occur
if we've ever failed to fix up a rel32 relocation, but, once that
happens, we will never generate rel32 addresses for the duration
of the process.

This resolves problems of failure to allocate the jump stubs themselves,
which is currently a fatal error in the process.