### PR TITLE
[x86/Linux] Correctly adjust stack for double aligned frames

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -5967,8 +5967,12 @@ void Compiler::lvaAlignFrame()
         // Align the stack with STACK_ALIGN value.
         int adjustFrameSize = compLclFrameSize;
 #if defined(UNIX_X86_ABI)
+        bool isEbpPushed = codeGen->isFramePointerUsed();
+#if DOUBLE_ALIGN
+        isEbpPushed |= genDoubleAlign();
+#endif
         // we need to consider spilled register(s) plus return address and/or EBP
-        int adjustCount = compCalleeRegsPushed + 1 + (codeGen->isFramePointerUsed() ? 1 : 0);
+        int adjustCount = compCalleeRegsPushed + 1 + (isEbpPushed ? 1 : 0);
         adjustFrameSize += (adjustCount * REGSIZE_BYTES) % STACK_ALIGN;
 #endif
         if ((adjustFrameSize % STACK_ALIGN) != 0)

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -5965,9 +5965,9 @@ void Compiler::lvaAlignFrame()
         }
 
         // Align the stack with STACK_ALIGN value.
-        int adjustFrameSize = compLclFrameSize;
+        int  adjustFrameSize = compLclFrameSize;
 #if defined(UNIX_X86_ABI)
-        bool isEbpPushed = codeGen->isFramePointerUsed();
+        bool isEbpPushed     = codeGen->isFramePointerUsed();
 #if DOUBLE_ALIGN
         isEbpPushed |= genDoubleAlign();
 #endif


### PR DESCRIPTION
The current implementation of lvaAlignFrame assume that ebp is pushed only for ebp frames, but ebp is also pushed for double aligned frames.

This commit revises lvaAlignFrame to count ebp when double aligned frame is used.