### PR TITLE
Add TaskExtensions to CoreLib

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -708,6 +708,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Threading\Tasks\Task.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\Tasks\TaskContinuation.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\Tasks\TaskCanceledException.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Threading\Tasks\TaskExtensions.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\Tasks\TaskSchedulerException.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\Tasks\TaskExceptionHolder.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\Tasks\TaskFactory.cs" />

--- a/src/mscorlib/src/System/Threading/Tasks/TaskExtensions.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskExtensions.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Threading.Tasks
+{
+    /// <summary>Provides a set of static methods for working with specific kinds of <see cref="Task"/> instances.</summary>
+    public static class TaskExtensions
+    {
+        /// <summary>Creates a proxy <see cref="Task"/> that represents the asynchronous operation of a <see cref="Task{Task}"/>.</summary>
+        /// <param name="task">The <see cref="Task{Task}"/> to unwrap.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation of the provided <see cref="Task{Task}"/>.</returns>
+        public static Task Unwrap(this Task<Task> task)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            // If the task hasn't completed or was faulted/canceled, wrap it in an unwrap promise. Otherwise,
+            // it completed successfully.  Return its inner task to avoid unnecessary wrapping, or if the inner
+            // task is null, return a canceled task to match the same semantics as CreateUnwrapPromise.
+            return
+                !task.IsRanToCompletion ? Task.CreateUnwrapPromise<VoidTaskResult>(task, lookForOce: false) :
+                task.Result ??
+                Task.FromCanceled(new CancellationToken(true));
+        }
+
+        /// <summary>Creates a proxy <see cref="Task{TResult}"/> that represents the asynchronous operation of a <see cref="Task{Task{TResult}}"/>.</summary>
+        /// <param name="task">The <see cref="Task{Task{TResult}}"/> to unwrap.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation of the provided <see cref="Task{Task{TResult}}"/>.</returns>
+        public static Task<TResult> Unwrap<TResult>(this Task<Task<TResult>> task)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            // If the task hasn't completed or was faulted/canceled, wrap it in an unwrap promise. Otherwise,
+            // it completed successfully.  Return its inner task to avoid unnecessary wrapping, or if the inner
+            // task is null, return a canceled task to match the same semantics as CreateUnwrapPromise.
+            return
+                !task.IsRanToCompletion ? Task.CreateUnwrapPromise<TResult>(task, lookForOce: false) :
+                task.Result ??
+                Task.FromCanceled<TResult>(new CancellationToken(true));
+        }
+    }
+}


### PR DESCRIPTION
Our TaskExtensions.Unwrap implementation in corefx is more allocation-heavy than the implementation we had in desktop and we could have in CoreLib, where CreateUnwrapPromise is available.  By moving this API down to CoreLib, the code:
```C#
Task<Task> toUnwrap = ...;
Task t = toUnwrap.Unwrap();
```
incurs 1 allocation instead of 4.

Contributes to https://github.com/dotnet/corefx/issues/15152
cc: @alexperovich, @jkotas 