### PR TITLE
Zip all test wrappers in parallel

### DIFF
--- a/tests/helixprep.proj
+++ b/tests/helixprep.proj
@@ -47,6 +47,7 @@
     <Delete Files="@(RequiresSigningFilesToDelete)" />
     <MSBuild Projects="helixprep.proj"
              Properties="BuildPath=%(XunitDlls.RootDir)%(XunitDlls.Directory);ProjectName=%(XunitDlls.Filename);BuildArchiveDir=$(TestWorkingDir)archive\tests\"
+             BuildInParallel="true"
              Targets="ArchiveBuild" />
   </Target>
 


### PR DESCRIPTION
https://github.com/dotnet/coreclr/pull/9986 did succeed in improving test execution times in Helix (I'm seeing a 20-25 minute improvement), but it also lengthened the test build step by almost the same amount, so the improvement in the overall pipeline build time, end-to-end, was marginal. This is a low-hanging-fruit attempt to speed up the test build by zipping the test Xunit wrappers in parallel, which wasn't happening before. Will look into other possible improvements as well.