### PR TITLE
Revise Interop TC calling convention

### DIFF
--- a/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayNative.cpp
+++ b/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayNative.cpp
@@ -19,7 +19,7 @@ const int ArraySIZE = 5;
 
 //Reverse PInvoke
 //Pass by value
-typedef BOOL (__stdcall *CallBackIn)(int size,bool arr[]);
+typedef BOOL (CALLBACK *CallBackIn)(int size,bool arr[]);
 extern "C" DLL_EXPORT BOOL DoCallBackIn(CallBackIn callback)
 {
 	//Init
@@ -62,7 +62,7 @@ extern "C" DLL_EXPORT BOOL DoCallBackIn(CallBackIn callback)
 	return true;
 }
 
-typedef BOOL (__stdcall *CallBackOut)(int size,bool arr[]);
+typedef BOOL (CALLBACK *CallBackOut)(int size,bool arr[]);
 extern "C" DLL_EXPORT BOOL DoCallBackOut(CallBackOut callback)
 {
 	bool * arr =(bool *)CoTaskMemAlloc(ArraySIZE);
@@ -87,7 +87,7 @@ extern "C" DLL_EXPORT BOOL DoCallBackOut(CallBackOut callback)
 	return true;
 }
 
-typedef BOOL (__stdcall *CallBackInOut)(int size,bool arr[]);
+typedef BOOL (CALLBACK *CallBackInOut)(int size,bool arr[]);
 extern "C" DLL_EXPORT BOOL DoCallBackInOut(CallBackInOut callback)
 {
 	//Init
@@ -128,7 +128,7 @@ extern "C" DLL_EXPORT BOOL DoCallBackInOut(CallBackInOut callback)
 
 //Reverse PInvoke
 //Pass by reference
-typedef BOOL (__stdcall *CallBackRefIn)(int size,bool ** arr);
+typedef BOOL (CALLBACK *CallBackRefIn)(int size,bool ** arr);
 extern "C" DLL_EXPORT BOOL DoCallBackRefIn(CallBackRefIn callback)
 {
 	//Init:true,false,true,false,true
@@ -172,7 +172,7 @@ extern "C" DLL_EXPORT BOOL DoCallBackRefIn(CallBackRefIn callback)
 	return true;
 }
 
-typedef BOOL (__stdcall *CallBackRefOut)(int size,bool ** arr);
+typedef BOOL (CALLBACK *CallBackRefOut)(int size,bool ** arr);
 extern "C" DLL_EXPORT BOOL DoCallBackRefOut(CallBackRefOut callback)
 {
 
@@ -198,7 +198,7 @@ extern "C" DLL_EXPORT BOOL DoCallBackRefOut(CallBackRefOut callback)
 	return true;
 }
 
-typedef BOOL (__stdcall *CallBackRefInOut)(int size,bool ** arr);
+typedef BOOL (CALLBACK *CallBackRefInOut)(int size,bool ** arr);
 extern "C" DLL_EXPORT BOOL DoCallBackRefInOut(CallBackRefInOut callback)
 {
 	//Init,true,false,true,false

--- a/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValNative.cpp
+++ b/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValNative.cpp
@@ -185,84 +185,84 @@ Function
 /*----------------------------------------------------------------------------
 marshal sequential strut
 ----------------------------------------------------------------------------*/
-extern "C" DLL_EXPORT BOOL WINAPI TakeIntArraySeqStructByVal( S_INTArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeIntArraySeqStructByVal( S_INTArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( INT, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeUIntArraySeqStructByVal( S_UINTArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeUIntArraySeqStructByVal( S_UINTArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( UINT, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeShortArraySeqStructByVal( S_SHORTArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeShortArraySeqStructByVal( S_SHORTArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( SHORT, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeWordArraySeqStructByVal( S_WORDArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeWordArraySeqStructByVal( S_WORDArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( WORD, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLong64ArraySeqStructByVal( S_LONG64Array s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLong64ArraySeqStructByVal( S_LONG64Array s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( LONG64, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeULong64ArraySeqStructByVal( S_ULONG64Array s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeULong64ArraySeqStructByVal( S_ULONG64Array s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( ULONG64, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeDoubleArraySeqStructByVal( S_DOUBLEArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeDoubleArraySeqStructByVal( S_DOUBLEArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( DOUBLE, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeFloatArraySeqStructByVal( S_FLOATArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeFloatArraySeqStructByVal( S_FLOATArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( FLOAT, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeByteArraySeqStructByVal( S_BYTEArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeByteArraySeqStructByVal( S_BYTEArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( BYTE, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeCharArraySeqStructByVal( S_CHARArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeCharArraySeqStructByVal( S_CHARArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
     INIT_EXPECTED( CHAR, ARRAY_SIZE );
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeIntPtrArraySeqStructByVal(S_DWORD_PTRArray s, int size)
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeIntPtrArraySeqStructByVal(S_DWORD_PTRArray s, int size)
 {
 	CHECK_PARAM_NOT_EMPTY(s.arr);
 	INIT_EXPECTED( DWORD_PTR, ARRAY_SIZE);
 	return Equals(s.arr, size, expected, ARRAY_SIZE);
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLPSTRArraySeqStructByVal( S_LPSTRArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLPSTRArraySeqStructByVal( S_LPSTRArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
 
@@ -273,7 +273,7 @@ extern "C" DLL_EXPORT BOOL WINAPI TakeLPSTRArraySeqStructByVal( S_LPSTRArray s, 
     return Equals( s.arr, size, expected, ARRAY_SIZE );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLPCSTRArraySeqStructByVal( S_LPCSTRArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLPCSTRArraySeqStructByVal( S_LPCSTRArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
 
@@ -286,7 +286,7 @@ extern "C" DLL_EXPORT BOOL WINAPI TakeLPCSTRArraySeqStructByVal( S_LPCSTRArray s
 
 
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeStructArraySeqStructByVal( S_StructArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeStructArraySeqStructByVal( S_StructArray s, int size )
 {
     CHECK_PARAM_NOT_EMPTY( s.arr );
 
@@ -297,69 +297,69 @@ extern "C" DLL_EXPORT BOOL WINAPI TakeStructArraySeqStructByVal( S_StructArray s
 /*----------------------------------------------------------------------------
 marshal sequential class
 ----------------------------------------------------------------------------*/
-extern "C" DLL_EXPORT BOOL WINAPI TakeIntArraySeqClassByVal( S_INTArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeIntArraySeqClassByVal( S_INTArray *s, int size )
 {
     return TakeIntArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeUIntArraySeqClassByVal( S_UINTArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeUIntArraySeqClassByVal( S_UINTArray *s, int size )
 {
     return TakeUIntArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeShortArraySeqClassByVal( S_SHORTArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeShortArraySeqClassByVal( S_SHORTArray *s, int size )
 {
     return TakeShortArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeWordArraySeqClassByVal( S_WORDArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeWordArraySeqClassByVal( S_WORDArray *s, int size )
 {
     return TakeWordArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLong64ArraySeqClassByVal( S_LONG64Array *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLong64ArraySeqClassByVal( S_LONG64Array *s, int size )
 {
     return TakeLong64ArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeULong64ArraySeqClassByVal( S_ULONG64Array *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeULong64ArraySeqClassByVal( S_ULONG64Array *s, int size )
 {
     return TakeULong64ArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeDoubleArraySeqClassByVal( S_DOUBLEArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeDoubleArraySeqClassByVal( S_DOUBLEArray *s, int size )
 {
     return TakeDoubleArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeFloatArraySeqClassByVal( S_FLOATArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeFloatArraySeqClassByVal( S_FLOATArray *s, int size )
 {
     return TakeFloatArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeByteArraySeqClassByVal( S_BYTEArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeByteArraySeqClassByVal( S_BYTEArray *s, int size )
 {
     return TakeByteArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeCharArraySeqClassByVal( S_CHARArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeCharArraySeqClassByVal( S_CHARArray *s, int size )
 {
     return TakeCharArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLPSTRArraySeqClassByVal( S_LPSTRArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLPSTRArraySeqClassByVal( S_LPSTRArray *s, int size )
 {
     return TakeLPSTRArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLPCSTRArraySeqClassByVal( S_LPCSTRArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLPCSTRArraySeqClassByVal( S_LPCSTRArray *s, int size )
 {
     return TakeLPCSTRArraySeqStructByVal( *s, size );
 }
 
 
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeStructArraySeqClassByVal( S_StructArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeStructArraySeqClassByVal( S_StructArray *s, int size )
 {
     return TakeStructArraySeqStructByVal( *s, size );
 }
@@ -367,69 +367,69 @@ extern "C" DLL_EXPORT BOOL WINAPI TakeStructArraySeqClassByVal( S_StructArray *s
 /*----------------------------------------------------------------------------
 marshal explicit struct
 ----------------------------------------------------------------------------*/
-extern "C" DLL_EXPORT BOOL WINAPI TakeIntArrayExpStructByVal( S_INTArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeIntArrayExpStructByVal( S_INTArray s, int size )
 {
     return TakeIntArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeUIntArrayExpStructByVal( S_UINTArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeUIntArrayExpStructByVal( S_UINTArray s, int size )
 {
     return TakeUIntArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeShortArrayExpStructByVal( S_SHORTArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeShortArrayExpStructByVal( S_SHORTArray s, int size )
 {
     return TakeShortArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeWordArrayExpStructByVal( S_WORDArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeWordArrayExpStructByVal( S_WORDArray s, int size )
 {
     return TakeWordArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLong64ArrayExpStructByVal( S_LONG64Array s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLong64ArrayExpStructByVal( S_LONG64Array s, int size )
 {
     return TakeLong64ArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeULong64ArrayExpStructByVal( S_ULONG64Array s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeULong64ArrayExpStructByVal( S_ULONG64Array s, int size )
 {
     return TakeULong64ArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeDoubleArrayExpStructByVal( S_DOUBLEArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeDoubleArrayExpStructByVal( S_DOUBLEArray s, int size )
 {
     return TakeDoubleArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeFloatArrayExpStructByVal( S_FLOATArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeFloatArrayExpStructByVal( S_FLOATArray s, int size )
 {
     return TakeFloatArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeByteArrayExpStructByVal( S_BYTEArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeByteArrayExpStructByVal( S_BYTEArray s, int size )
 {
     return TakeByteArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeCharArrayExpStructByVal( S_CHARArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeCharArrayExpStructByVal( S_CHARArray s, int size )
 {
     return TakeCharArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLPSTRArrayExpStructByVal( S_LPSTRArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLPSTRArrayExpStructByVal( S_LPSTRArray s, int size )
 {
     return TakeLPSTRArraySeqStructByVal( s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLPCSTRArrayExpStructByVal( S_LPCSTRArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLPCSTRArrayExpStructByVal( S_LPCSTRArray s, int size )
 {
     return TakeLPCSTRArraySeqStructByVal( s, size );
 }
 
 
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeStructArrayExpStructByVal( S_StructArray s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeStructArrayExpStructByVal( S_StructArray s, int size )
 {
     return TakeStructArraySeqStructByVal( s, size );
 }
@@ -437,69 +437,69 @@ extern "C" DLL_EXPORT BOOL WINAPI TakeStructArrayExpStructByVal( S_StructArray s
 /*----------------------------------------------------------------------------
 marshal explicit class
 ----------------------------------------------------------------------------*/
-extern "C" DLL_EXPORT BOOL WINAPI TakeIntArrayExpClassByVal( S_INTArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeIntArrayExpClassByVal( S_INTArray *s, int size )
 {
     return TakeIntArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeUIntArrayExpClassByVal( S_UINTArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeUIntArrayExpClassByVal( S_UINTArray *s, int size )
 {
     return TakeUIntArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeShortArrayExpClassByVal( S_SHORTArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeShortArrayExpClassByVal( S_SHORTArray *s, int size )
 {
     return TakeShortArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeWordArrayExpClassByVal( S_WORDArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeWordArrayExpClassByVal( S_WORDArray *s, int size )
 {
     return TakeWordArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLong64ArrayExpClassByVal( S_LONG64Array *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLong64ArrayExpClassByVal( S_LONG64Array *s, int size )
 {
     return TakeLong64ArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeULong64ArrayExpClassByVal( S_ULONG64Array *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeULong64ArrayExpClassByVal( S_ULONG64Array *s, int size )
 {
     return TakeULong64ArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeDoubleArrayExpClassByVal( S_DOUBLEArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeDoubleArrayExpClassByVal( S_DOUBLEArray *s, int size )
 {
     return TakeDoubleArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeFloatArrayExpClassByVal( S_FLOATArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeFloatArrayExpClassByVal( S_FLOATArray *s, int size )
 {
     return TakeFloatArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeByteArrayExpClassByVal( S_BYTEArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeByteArrayExpClassByVal( S_BYTEArray *s, int size )
 {
     return TakeByteArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeCharArrayExpClassByVal( S_CHARArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeCharArrayExpClassByVal( S_CHARArray *s, int size )
 {
     return TakeCharArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLPSTRArrayExpClassByVal( S_LPSTRArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLPSTRArrayExpClassByVal( S_LPSTRArray *s, int size )
 {
     return TakeLPSTRArraySeqStructByVal( *s, size );
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeLPCSTRArrayExpClassByVal( S_LPCSTRArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeLPCSTRArrayExpClassByVal( S_LPCSTRArray *s, int size )
 {
     return TakeLPCSTRArraySeqStructByVal( *s, size );
 }
 
 
 
-extern "C" DLL_EXPORT BOOL WINAPI TakeStructArrayExpClassByVal( S_StructArray *s, int size )
+extern "C" DLL_EXPORT BOOL NATIVEAPI TakeStructArrayExpClassByVal( S_StructArray *s, int size )
 {
     return TakeStructArraySeqStructByVal( *s, size );
 }
@@ -507,77 +507,77 @@ extern "C" DLL_EXPORT BOOL WINAPI TakeStructArrayExpClassByVal( S_StructArray *s
 /*----------------------------------------------------------------------------
 return a struct including a C array
 ----------------------------------------------------------------------------*/
-extern "C" DLL_EXPORT S_INTArray* WINAPI S_INTArray_Ret()
+extern "C" DLL_EXPORT S_INTArray* NATIVEAPI S_INTArray_Ret()
 {
     INIT_EXPECTED_STRUCT( S_INTArray, ARRAY_SIZE, INT );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_UINTArray* WINAPI S_UINTArray_Ret()
+extern "C" DLL_EXPORT S_UINTArray* NATIVEAPI S_UINTArray_Ret()
 {
     INIT_EXPECTED_STRUCT( S_UINTArray, ARRAY_SIZE, UINT );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_SHORTArray* WINAPI S_SHORTArray_Ret()
+extern "C" DLL_EXPORT S_SHORTArray* NATIVEAPI S_SHORTArray_Ret()
 {
     INIT_EXPECTED_STRUCT( S_SHORTArray, ARRAY_SIZE, SHORT );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_WORDArray* WINAPI S_WORDArray_Ret()
+extern "C" DLL_EXPORT S_WORDArray* NATIVEAPI S_WORDArray_Ret()
 {
     INIT_EXPECTED_STRUCT( S_WORDArray, ARRAY_SIZE, WORD );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_LONG64Array* WINAPI S_LONG64Array_Ret()
+extern "C" DLL_EXPORT S_LONG64Array* NATIVEAPI S_LONG64Array_Ret()
 {
     INIT_EXPECTED_STRUCT( S_LONG64Array, ARRAY_SIZE, LONG64 );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_ULONG64Array* WINAPI S_ULONG64Array_Ret()
+extern "C" DLL_EXPORT S_ULONG64Array* NATIVEAPI S_ULONG64Array_Ret()
 {
     INIT_EXPECTED_STRUCT( S_ULONG64Array, ARRAY_SIZE, ULONG64 );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_DOUBLEArray* WINAPI S_DOUBLEArray_Ret()
+extern "C" DLL_EXPORT S_DOUBLEArray* NATIVEAPI S_DOUBLEArray_Ret()
 {
     INIT_EXPECTED_STRUCT( S_DOUBLEArray, ARRAY_SIZE, DOUBLE );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_FLOATArray* WINAPI S_FLOATArray_Ret()
+extern "C" DLL_EXPORT S_FLOATArray* NATIVEAPI S_FLOATArray_Ret()
 {
     INIT_EXPECTED_STRUCT( S_FLOATArray, ARRAY_SIZE, FLOAT );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_BYTEArray* WINAPI S_BYTEArray_Ret()
+extern "C" DLL_EXPORT S_BYTEArray* NATIVEAPI S_BYTEArray_Ret()
 {
     INIT_EXPECTED_STRUCT( S_BYTEArray, ARRAY_SIZE, BYTE );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_CHARArray* WINAPI S_CHARArray_Ret()
+extern "C" DLL_EXPORT S_CHARArray* NATIVEAPI S_CHARArray_Ret()
 {
     INIT_EXPECTED_STRUCT( S_CHARArray, ARRAY_SIZE, CHAR );
 
     return expected;
 }
 
-extern "C" DLL_EXPORT S_LPSTRArray* WINAPI S_LPSTRArray_Ret()
+extern "C" DLL_EXPORT S_LPSTRArray* NATIVEAPI S_LPSTRArray_Ret()
 {        
     S_LPSTRArray *expected = (S_LPSTRArray *)::CoTaskMemAlloc( sizeof(S_LPSTRArray) );
     for ( int i = 0; i < ARRAY_SIZE; ++i )
@@ -587,7 +587,7 @@ extern "C" DLL_EXPORT S_LPSTRArray* WINAPI S_LPSTRArray_Ret()
 }
 
 
-extern "C" DLL_EXPORT S_StructArray* WINAPI S_StructArray_Ret()
+extern "C" DLL_EXPORT S_StructArray* NATIVEAPI S_StructArray_Ret()
 {
     S_StructArray *expected = (S_StructArray *)::CoTaskMemAlloc( sizeof(S_StructArray) );
     for ( int i = 0; i < ARRAY_SIZE; ++i )

--- a/tests/src/Interop/MarshalAPI/FunctionPointer/FunctionPointerNative.cpp
+++ b/tests/src/Interop/MarshalAPI/FunctionPointer/FunctionPointerNative.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <xplatform.h>
 
-extern "C" DLL_EXPORT bool __cdecl CheckFcnPtr(bool(__stdcall *fcnptr)(__int64))
+extern "C" DLL_EXPORT bool __cdecl CheckFcnPtr(bool(CALLBACK *fcnptr)(__int64))
 {
     if (fcnptr == 0)
     {

--- a/tests/src/Interop/NativeCallable/NativeCallableDll.cpp
+++ b/tests/src/Interop/NativeCallable/NativeCallableDll.cpp
@@ -4,9 +4,9 @@
 
 #include <xplatform.h> 
 
-typedef int (WINAPI *CALLBACKADDPROC)(int n);
+typedef int (NATIVEAPI *CALLBACKADDPROC)(int n);
 
-extern "C" DLL_EXPORT int WINAPI CallManagedAdd(CALLBACKADDPROC pCallbackAddProc, int n)
+extern "C" DLL_EXPORT int NATIVEAPI CallManagedAdd(CALLBACKADDPROC pCallbackAddProc, int n)
 {
     return pCallbackAddProc(n);
 }

--- a/tests/src/Interop/PrimitiveMarshalling/UIntPtr/UIntPtrNative.cpp
+++ b/tests/src/Interop/PrimitiveMarshalling/UIntPtr/UIntPtrNative.cpp
@@ -10,7 +10,10 @@ UINT_PTR uintPtrNative = 2000;
 UINT_PTR uintPtrReturn = 3000;
 UINT_PTR uintPtrErrReturn = 4000;
 
-extern "C" DLL_EXPORT UINT_PTR WINAPI Marshal_In(/*[in]*/UINT_PTR uintPtr)
+//
+// PInvokeUIntPtrTest.cs declares that all of these APIs use STDCALL.
+//
+extern "C" DLL_EXPORT UINT_PTR __stdcall Marshal_In(/*[in]*/UINT_PTR uintPtr)
 {
     //Check the input
     if(uintPtr != uintPtrManaged)
@@ -24,7 +27,7 @@ extern "C" DLL_EXPORT UINT_PTR WINAPI Marshal_In(/*[in]*/UINT_PTR uintPtr)
     return uintPtrReturn;
 }
 
-extern "C" DLL_EXPORT UINT_PTR WINAPI Marshal_InOut(/*[In,Out]*/UINT_PTR uintPtr)
+extern "C" DLL_EXPORT UINT_PTR __stdcall Marshal_InOut(/*[In,Out]*/UINT_PTR uintPtr)
 {
     //Check the input
     if(uintPtr != uintPtrManaged)
@@ -42,7 +45,7 @@ extern "C" DLL_EXPORT UINT_PTR WINAPI Marshal_InOut(/*[In,Out]*/UINT_PTR uintPtr
     return uintPtrReturn;
 }
 
-extern "C" DLL_EXPORT UINT_PTR WINAPI Marshal_Out(/*[Out]*/UINT_PTR uintPtr)
+extern "C" DLL_EXPORT UINT_PTR __stdcall Marshal_Out(/*[Out]*/UINT_PTR uintPtr)
 {
     uintPtr = uintPtrNative;
 
@@ -50,7 +53,7 @@ extern "C" DLL_EXPORT UINT_PTR WINAPI Marshal_Out(/*[Out]*/UINT_PTR uintPtr)
     return uintPtrReturn;
 }
 
-extern "C" DLL_EXPORT UINT_PTR WINAPI MarshalPointer_In(/*[in]*/UINT_PTR *puintPtr)
+extern "C" DLL_EXPORT UINT_PTR __stdcall MarshalPointer_In(/*[in]*/UINT_PTR *puintPtr)
 {
     //Check the input
     if(*puintPtr != uintPtrManaged)
@@ -63,7 +66,7 @@ extern "C" DLL_EXPORT UINT_PTR WINAPI MarshalPointer_In(/*[in]*/UINT_PTR *puintP
     return uintPtrReturn;
 }
 
-extern "C" DLL_EXPORT UINT_PTR WINAPI MarshalPointer_InOut(/*[in,out]*/UINT_PTR *puintPtr)
+extern "C" DLL_EXPORT UINT_PTR __stdcall MarshalPointer_InOut(/*[in,out]*/UINT_PTR *puintPtr)
 {
     //Check the input
     if(*puintPtr != uintPtrManaged)
@@ -80,7 +83,7 @@ extern "C" DLL_EXPORT UINT_PTR WINAPI MarshalPointer_InOut(/*[in,out]*/UINT_PTR 
     return uintPtrReturn;
 }
 
-extern "C" DLL_EXPORT UINT_PTR WINAPI MarshalPointer_Out(/*[out]*/ UINT_PTR *puintPtr)
+extern "C" DLL_EXPORT UINT_PTR __stdcall MarshalPointer_Out(/*[out]*/ UINT_PTR *puintPtr)
 {
     *puintPtr = uintPtrNative;
 

--- a/tests/src/Interop/SimpleStruct/SimpleStructNative.cpp
+++ b/tests/src/Interop/SimpleStruct/SimpleStructNative.cpp
@@ -81,7 +81,7 @@ DLL_EXPORT ExplStruct* _cdecl CdeclSimpleExplStruct(ExplStruct p,BOOL *result)
 }
 
 extern "C"
-DLL_EXPORT voidPtr __stdcall GetFptr(int i)
+DLL_EXPORT voidPtr NATIVEAPI GetFptr(int i)
 {
 	switch(i)
 	{

--- a/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTestNative.cpp
+++ b/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTestNative.cpp
@@ -143,8 +143,11 @@ extern "C" DLL_EXPORT BOOL __cdecl RPinvoke_DelMarshal_InOut(Test_DelMarshal_InO
     return TRUE;
 }
 
+//
+// PInvokeDef.cs explicitly declares that RPinvoke_DelMarshalPointer_Out uses STDCALL
+//
 typedef LPCSTR (__cdecl * Test_DelMarshalPointer_Out)(/*[out]*/ LPSTR * s);
-extern "C" DLL_EXPORT BOOL WINAPI RPinvoke_DelMarshalPointer_Out(Test_DelMarshalPointer_Out d)
+extern "C" DLL_EXPORT BOOL __stdcall RPinvoke_DelMarshalPointer_Out(Test_DelMarshalPointer_Out d)
 {
     LPSTR str;
     LPCSTR ret = d(&str);
@@ -173,8 +176,11 @@ extern "C" DLL_EXPORT BOOL WINAPI RPinvoke_DelMarshalPointer_Out(Test_DelMarshal
     return TRUE;
 }
 
+//
+// PInvokeDef.cs explicitly declares that ReverseP_MarshalStrB_InOut uses STDCALL
+//
 typedef LPSTR (__stdcall * Test_Del_MarshalStrB_InOut)(/*[in,out]*/ LPSTR s);
-extern "C" DLL_EXPORT  BOOL WINAPI ReverseP_MarshalStrB_InOut(Test_Del_MarshalStrB_InOut d, /*[in]*/ LPCSTR s)
+extern "C" DLL_EXPORT  BOOL __stdcall ReverseP_MarshalStrB_InOut(Test_Del_MarshalStrB_InOut d, /*[in]*/ LPCSTR s)
 {
     LPSTR ret = d((LPSTR)s);
     LPCSTR expected = "Return";

--- a/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTestNative.cpp
+++ b/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTestNative.cpp
@@ -101,7 +101,7 @@ extern "C" DLL_EXPORT LPWSTR MarshalPointer_Out(/*[out]*/ LPWSTR *s)
 }
 
 typedef LPTSTR (__stdcall * Test_Del_MarshalStrB_InOut)(/*[in,out]*/ LPTSTR s);
-extern "C" DLL_EXPORT BOOL __stdcall ReverseP_MarshalStrB_InOut(Test_Del_MarshalStrB_InOut d, /*[in]*/ LPCTSTR  s)
+extern "C" DLL_EXPORT BOOL NATIVEAPI ReverseP_MarshalStrB_InOut(Test_Del_MarshalStrB_InOut d, /*[in]*/ LPCTSTR  s)
 {
     LPTSTR ret = d((LPTSTR)s);
     LPTSTR expectedret =(LPTSTR)W("Native");
@@ -127,7 +127,7 @@ extern "C" DLL_EXPORT BOOL __stdcall ReverseP_MarshalStrB_InOut(Test_Del_Marshal
 }
 
 typedef LPTSTR (__cdecl * Test_Del_MarshalStrB_Out)(/*[out]*/ LPTSTR * s);
-extern "C" DLL_EXPORT BOOL __stdcall ReverseP_MarshalStrB_Out(Test_Del_MarshalStrB_Out d)
+extern "C" DLL_EXPORT BOOL NATIVEAPI ReverseP_MarshalStrB_Out(Test_Del_MarshalStrB_Out d)
 {
     LPTSTR s;
     LPTSTR ret = d((LPTSTR*)&s);

--- a/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
+++ b/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
@@ -3,7 +3,7 @@
 ///////////////////////////////////////////////////////////////////////////////////
 //							EXPORTED METHODS
 ///////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal(InnerSequential inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal(InnerSequential inner)
 {
 	if(!IsCorrectInnerSequential(&inner))
 	{
@@ -15,7 +15,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal(InnerSequentia
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef(InnerSequential* inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef(InnerSequential* inner)
 {
 	if(!IsCorrectInnerSequential(inner))
 	{
@@ -26,7 +26,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef(InnerSequentia
 	ChangeInnerSequential(inner);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn(InnerSequential* inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn(InnerSequential* inner)
 {
 	if(!IsCorrectInnerSequential(inner))
 	{
@@ -38,7 +38,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn(InnerSequent
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut(InnerSequential inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut(InnerSequential inner)
 {
 	if(!IsCorrectInnerSequential(&inner))
 	{
@@ -50,14 +50,14 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut(InnerSequen
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut(InnerSequential* inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut(InnerSequential* inner)
 {
 	ChangeInnerSequential(inner);
 	return TRUE;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal2(InnerArraySequential outer)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal2(InnerArraySequential outer)
 {
 	if(!IsCorrectInnerArraySequential(&outer))
 	{
@@ -69,7 +69,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal2(InnerArraySeq
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef2(InnerArraySequential* outer)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef2(InnerArraySequential* outer)
 {
 	if(!IsCorrectInnerArraySequential(outer))
 	{
@@ -80,7 +80,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef2(InnerArraySeq
 	ChangeInnerArraySequential(outer);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn2(InnerArraySequential* outer)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn2(InnerArraySequential* outer)
 {
 	if(!IsCorrectInnerArraySequential(outer))
 	{
@@ -91,7 +91,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn2(InnerArrayS
 	ChangeInnerArraySequential(outer);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut2(InnerArraySequential outer)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut2(InnerArraySequential outer)
 {
 	if(!IsCorrectInnerArraySequential(&outer))
 	{
@@ -106,7 +106,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut2(InnerArray
 	}
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut2(InnerArraySequential* outer)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut2(InnerArraySequential* outer)
 {
 	for(int i = 0;i<NumArrElements;i++)
 	{
@@ -121,7 +121,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut2(InnerArray
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal3(CharSetAnsiSequential str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal3(CharSetAnsiSequential str1)
 {
 	if(!IsCorrectCharSetAnsiSequential(&str1))
 	{
@@ -132,7 +132,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal3(CharSetAnsiSe
 	ChangeCharSetAnsiSequential(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef3(CharSetAnsiSequential* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef3(CharSetAnsiSequential* str1)
 {
 	if(!IsCorrectCharSetAnsiSequential(str1))
 	{
@@ -143,7 +143,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef3(CharSetAnsiSe
 	ChangeCharSetAnsiSequential(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn3(CharSetAnsiSequential* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn3(CharSetAnsiSequential* str1)
 {
 	if(!IsCorrectCharSetAnsiSequential(str1))
 	{
@@ -154,7 +154,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn3(CharSetAnsi
 	ChangeCharSetAnsiSequential(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut3(CharSetAnsiSequential str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut3(CharSetAnsiSequential str1)
 {
 	if(!IsCorrectCharSetAnsiSequential(&str1))
 	{
@@ -165,7 +165,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut3(CharSetAns
 	str1.f2 = 'n';
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut3(CharSetAnsiSequential* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut3(CharSetAnsiSequential* str1)
 {
 	TP_CoTaskMemFree((void*)(str1->f1));
 	str1->f1 = CoStrDup("change string");
@@ -174,7 +174,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut3(CharSetAns
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal4(CharSetUnicodeSequential str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal4(CharSetUnicodeSequential str1)
 {
 	if(!IsCorrectCharSetUnicodeSequential(&str1))
 	{
@@ -185,7 +185,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal4(CharSetUnicod
 	ChangeCharSetUnicodeSequential(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef4(CharSetUnicodeSequential* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef4(CharSetUnicodeSequential* str1)
 {
 	if(!IsCorrectCharSetUnicodeSequential(str1))
 	{
@@ -196,7 +196,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef4(CharSetUnicod
 	ChangeCharSetUnicodeSequential(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn4(CharSetUnicodeSequential* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn4(CharSetUnicodeSequential* str1)
 {
 	if(!IsCorrectCharSetUnicodeSequential(str1))
 	{
@@ -207,7 +207,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn4(CharSetUnic
 	ChangeCharSetUnicodeSequential(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut4(CharSetUnicodeSequential str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut4(CharSetUnicodeSequential str1)
 {
 	if(!IsCorrectCharSetUnicodeSequential(&str1))
 	{
@@ -218,7 +218,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut4(CharSetUni
 	str1.f2 = L'n';
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut4(CharSetUnicodeSequential* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut4(CharSetUnicodeSequential* str1)
 {
 	if(str1->f1 != 0 || str1->f2 != 0)
 		return false;
@@ -227,7 +227,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut4(CharSetUni
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal6(NumberSequential str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal6(NumberSequential str1)
 {
 	if(!IsCorrectNumberSequential(&str1))
 	{
@@ -238,7 +238,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal6(NumberSequent
 	ChangeNumberSequential(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef6(NumberSequential* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef6(NumberSequential* str1)
 {
 	if(!IsCorrectNumberSequential(str1))
 	{
@@ -249,7 +249,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef6(NumberSequent
 	ChangeNumberSequential(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn6(NumberSequential* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn6(NumberSequential* str1)
 {
 	if(!IsCorrectNumberSequential(str1))
 	{
@@ -261,7 +261,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn6(NumberSeque
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut6(NumberSequential str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut6(NumberSequential str1)
 {
 	if(!IsCorrectNumberSequential(&str1))
 	{
@@ -271,14 +271,14 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut6(NumberSequ
 	}
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut6(NumberSequential* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut6(NumberSequential* str1)
 {
 	ChangeNumberSequential(str1);
 	return TRUE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal7(S3 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal7(S3 str1)
 {
 	if(!IsCorrectS3(&str1))
 	{
@@ -290,7 +290,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal7(S3 str1)
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef7(S3* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef7(S3* str1)
 {
 	if(!IsCorrectS3(str1))
 	{
@@ -300,7 +300,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef7(S3* str1)
 	ChangeS3(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn7(S3* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn7(S3* str1)
 {
 	if(!IsCorrectS3(str1))
 	{
@@ -312,7 +312,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn7(S3* str1)
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut7(S3 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut7(S3 str1)
 {
 	if(!IsCorrectS3(&str1))
 	{
@@ -324,13 +324,13 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut7(S3 str1)
 	return TRUE;
 
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut7(S3* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut7(S3* str1)
 {
 	ChangeS3(str1);
 	return TRUE;
 }
 ////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal8(S5 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal8(S5 str1)
 {
 	if(!IsCorrectS5(&str1))
 	{
@@ -341,7 +341,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal8(S5 str1)
 	ChangeS5(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef8(S5* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef8(S5* str1)
 {
 	if(!IsCorrectS5(str1))
 	{
@@ -353,7 +353,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef8(S5* str1)
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn8(S5* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn8(S5* str1)
 {
 	if(!IsCorrectS5(str1))
 	{
@@ -364,7 +364,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn8(S5* str1)
 	ChangeS5(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut8(S5* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut8(S5* str1)
 {
 	ChangeS5(str1);
 	return TRUE;
@@ -372,7 +372,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut8(S5* str1)
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal9(StringStructSequentialAnsi str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal9(StringStructSequentialAnsi str1)
 {
 	if(!IsCorrectStringStructSequentialAnsi(&str1))
 	{
@@ -383,7 +383,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal9(StringStructS
 	ChangeStringStructSequentialAnsi(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef9(StringStructSequentialAnsi* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef9(StringStructSequentialAnsi* str1)
 {
 	if(!IsCorrectStringStructSequentialAnsi(str1))
 	{
@@ -395,7 +395,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef9(StringStructS
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn9(StringStructSequentialAnsi* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn9(StringStructSequentialAnsi* str1)
 {
 	if(!IsCorrectStringStructSequentialAnsi(str1))
 	{
@@ -406,7 +406,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn9(StringStruc
 	ChangeStringStructSequentialAnsi(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut9(StringStructSequentialAnsi str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut9(StringStructSequentialAnsi str1)
 {
 	if(!IsCorrectStringStructSequentialAnsi(&str1))
 	{
@@ -416,7 +416,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut9(StringStru
 	}
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut9(StringStructSequentialAnsi* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut9(StringStructSequentialAnsi* str1)
 {
 	ChangeStringStructSequentialAnsi(str1);
 
@@ -425,7 +425,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut9(StringStru
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal10(StringStructSequentialUnicode str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal10(StringStructSequentialUnicode str1)
 {
 	if(!IsCorrectStringStructSequentialUnicode(&str1))
 	{
@@ -436,7 +436,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal10(StringStruct
 	ChangeStringStructSequentialUnicode(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef10(StringStructSequentialUnicode* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef10(StringStructSequentialUnicode* str1)
 {
 	if(!IsCorrectStringStructSequentialUnicode(str1))
 	{
@@ -448,7 +448,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef10(StringStruct
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn10(StringStructSequentialUnicode* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn10(StringStructSequentialUnicode* str1)
 {
 	if(!IsCorrectStringStructSequentialUnicode(str1))
 	{
@@ -459,7 +459,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn10(StringStru
 	ChangeStringStructSequentialUnicode(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut10(StringStructSequentialUnicode str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut10(StringStructSequentialUnicode str1)
 {
 	if(!IsCorrectStringStructSequentialUnicode(&str1))
 	{
@@ -469,7 +469,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut10(StringStr
 	}
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut10(StringStructSequentialUnicode* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut10(StringStructSequentialUnicode* str1)
 {
 	ChangeStringStructSequentialUnicode(str1);
 
@@ -477,7 +477,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut10(StringStr
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal11(S8 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal11(S8 str1)
 {
 	if(!IsCorrectS8(&str1))
 	{
@@ -488,7 +488,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal11(S8 str1)
 	ChangeS8(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef11(S8* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef11(S8* str1)
 {
 	if(!IsCorrectS8(str1))
 	{
@@ -500,7 +500,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef11(S8* str1)
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn11(S8* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn11(S8* str1)
 {
 	if(!IsCorrectS8(str1))
 	{
@@ -511,7 +511,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn11(S8* str1)
 	ChangeS8(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut11(S8 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut11(S8 str1)
 {
 	if(!IsCorrectS8(&str1))
 	{
@@ -523,7 +523,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut11(S8 str1)
 	str1.ui32 = 256;
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut11(S8* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut11(S8* str1)
 {
 	ChangeS8(str1);
 
@@ -535,7 +535,7 @@ extern "C" void NtestMethod(S9 str1)
 {
 	printf("\tAction of the delegate");
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal12(S9 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal12(S9 str1)
 {
 	if(str1.i32 != 128 ||
 		str1.myDelegate1 == NULL)
@@ -546,7 +546,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal12(S9 str1)
 	str1.myDelegate1 = NULL;
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef12(S9* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef12(S9* str1)
 {
 	if(str1->i32 != 128 ||
 		str1->myDelegate1 == NULL)
@@ -560,7 +560,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef12(S9* str1)
 	}
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn12(S9* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn12(S9* str1)
 {
 	if(str1->i32 != 128 ||
 		str1->myDelegate1 == NULL)
@@ -574,7 +574,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn12(S9* str1)
 	}
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut12(S9 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut12(S9 str1)
 {
 	if(str1.i32 != 128 ||
 		str1.myDelegate1 == NULL)
@@ -585,7 +585,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut12(S9 str1)
 	str1.myDelegate1 = NULL;
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut12(S9* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut12(S9* str1)
 {
 	str1->i32 = 256;
 	str1->myDelegate1 = NtestMethod;
@@ -594,7 +594,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut12(S9* str1)
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal13(S10 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal13(S10 str1)
 {
 	if(!IsCorrectS10(&str1))
 	{
@@ -605,7 +605,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal13(S10 str1)
 	ChangeS10(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef13(S10* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef13(S10* str1)
 {
 	if(!IsCorrectS10(str1))
 	{
@@ -617,7 +617,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef13(S10* str1)
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn13(S10* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn13(S10* str1)
 {
 	if(!IsCorrectS10(str1))
 	{
@@ -628,7 +628,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn13(S10* str1)
 	ChangeS10(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut13(S10 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut13(S10 str1)
 {
 	if(!IsCorrectS10(&str1))
 	{
@@ -639,7 +639,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut13(S10 str1)
 	str1.s.i = 64;
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut13(S10* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut13(S10* str1)
 {
 	ChangeS10(str1);
 
@@ -647,7 +647,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut13(S10* str1
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal14(S11 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByVal14(S11 str1)
 {
 	if( str1.i32 != 0 || str1.i != 32 )
 		return FALSE;
@@ -655,7 +655,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByVal14(S11 str1)
 	str1.i = 64;
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef14(S11* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRef14(S11* str1)
 {
 	if(str1->i32 != 0 || str1->i != 32)
 		return FALSE;
@@ -666,7 +666,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRef14(S11* str1)
 		return TRUE;
 	}
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn14(S11* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefIn14(S11* str1)
 {
 	if(str1->i32 != 0 || str1->i != 32)
 		return FALSE;
@@ -677,21 +677,21 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefIn14(S11* str1)
 		return TRUE;
 	}
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByValOut14(S11 str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByValOut14(S11 str1)
 {
 	if( str1.i32 != (LPINT)32 || str1.i != 32 )
 		return FALSE;
 	str1.i = 64;
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsSeqByRefOut14(S11* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsSeqByRefOut14(S11* str1)
 {
 	str1->i32 = reinterpret_cast<LPINT>(static_cast<INT_PTR>(str1->i));
 	str1->i = 64;
 	return TRUE;
 }
 //////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValINNER2(INNER2 inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValINNER2(INNER2 inner)
 {
 	if(!IsCorrectINNER2(&inner))
 	{
@@ -703,7 +703,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValINNER2(INNER2 i
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefINNER2(INNER2* inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefINNER2(INNER2* inner)
 {
 	if(!IsCorrectINNER2(inner))
 	{
@@ -714,7 +714,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefINNER2(INNER2* 
 	ChangeINNER2(inner);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInINNER2(INNER2* inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInINNER2(INNER2* inner)
 {
 	if(!IsCorrectINNER2(inner))
 	{
@@ -726,7 +726,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInINNER2(INNER2
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValOutINNER2(INNER2 inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValOutINNER2(INNER2 inner)
 {
 	if(!IsCorrectINNER2(&inner))
 	{
@@ -738,14 +738,14 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValOutINNER2(INNER
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutINNER2(INNER2* inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOutINNER2(INNER2* inner)
 {
 	//change struct
 	ChangeINNER2(inner);
 	return TRUE;
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValInnerExplicit(InnerExplicit inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValInnerExplicit(InnerExplicit inner)
 {
 	if((&inner)->f1 != 1 || memcmp((&inner)->f3, "some string",11*sizeof(char)) != 0)
 	{
@@ -757,7 +757,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValInnerExplicit(I
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInnerExplicit(InnerExplicit* inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInnerExplicit(InnerExplicit* inner)
 {
 	if(inner->f1 != 1 || memcmp(inner->f3, "some string",11*sizeof(char)) != 0)
 	{
@@ -769,7 +769,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInnerExplicit(I
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInInnerExplicit(InnerExplicit* inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInInnerExplicit(InnerExplicit* inner)
 {
 	if(inner->f1 != 1 || memcmp(inner->f3, "some string",11*sizeof(char)) != 0)
 	{
@@ -781,7 +781,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInInnerExplicit
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutInnerExplicit(InnerExplicit* inner)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOutInnerExplicit(InnerExplicit* inner)
 {
 	if(inner->f1 != 0 || inner->f2 != 0.0)
 	{
@@ -795,7 +795,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutInnerExplici
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValInnerArrayExplicit(InnerArrayExplicit outer2)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValInnerArrayExplicit(InnerArrayExplicit outer2)
 {
 	for(int i = 0;i<NumArrElements;i++)
 	{
@@ -813,7 +813,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValInnerArrayExpli
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInnerArrayExplicit(InnerArrayExplicit* outer2)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInnerArrayExplicit(InnerArrayExplicit* outer2)
 {
 	for(int i = 0;i<NumArrElements;i++)
 	{
@@ -837,7 +837,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInnerArrayExpli
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInInnerArrayExplicit(InnerArrayExplicit* outer2)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInInnerArrayExplicit(InnerArrayExplicit* outer2)
 {
 	for(int i = 0;i<NumArrElements;i++)
 	{
@@ -859,7 +859,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInInnerArrayExp
 	outer2->s.f4 = CoStrDup("change string2");
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutInnerArrayExplicit(InnerArrayExplicit* outer2)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOutInnerArrayExplicit(InnerArrayExplicit* outer2)
 {
 	for(int i =0;i<NumArrElements;i++)
 	{
@@ -871,7 +871,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutInnerArrayEx
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValOUTER3(OUTER3 outer3)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValOUTER3(OUTER3 outer3)
 {
 	if(!IsCorrectOUTER3(&outer3))
 	{
@@ -882,7 +882,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValOUTER3(OUTER3 o
 	ChangeOUTER3(&outer3);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOUTER3(OUTER3* outer3)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOUTER3(OUTER3* outer3)
 {
 	if(!IsCorrectOUTER3(outer3))
 	{
@@ -893,7 +893,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOUTER3(OUTER3* 
 	ChangeOUTER3(outer3);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInOUTER3(OUTER3* outer3)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInOUTER3(OUTER3* outer3)
 {
 	if(!IsCorrectOUTER3(outer3))
 	{
@@ -904,14 +904,14 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInOUTER3(OUTER3
 	ChangeOUTER3(outer3);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutOUTER3(OUTER3* outer3)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOutOUTER3(OUTER3* outer3)
 {
 	ChangeOUTER3(outer3);
 	return TRUE;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValU(U str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValU(U str1)
 {
 	if(!IsCorrectU(&str1))
 	{
@@ -922,7 +922,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValU(U str1)
 	ChangeU(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefU(U* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefU(U* str1)
 {
 	if(!IsCorrectU(str1))
 	{
@@ -934,7 +934,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefU(U* str1)
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInU(U* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInU(U* str1)
 {
 	if(!IsCorrectU(str1))
 	{
@@ -945,7 +945,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInU(U* str1)
 	ChangeU(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutU(U* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOutU(U* str1)
 {
 	ChangeU(str1);
 
@@ -953,7 +953,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutU(U* str1)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValByteStructPack2Explicit(ByteStructPack2Explicit str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValByteStructPack2Explicit(ByteStructPack2Explicit str1)
 {
 	if(!IsCorrectByteStructPack2Explicit(&str1))
 	{
@@ -964,7 +964,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValByteStructPack2
 	ChangeByteStructPack2Explicit(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefByteStructPack2Explicit(ByteStructPack2Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefByteStructPack2Explicit(ByteStructPack2Explicit* str1)
 {
 	if(!IsCorrectByteStructPack2Explicit(str1))
 	{
@@ -976,7 +976,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefByteStructPack2
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInByteStructPack2Explicit(ByteStructPack2Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInByteStructPack2Explicit(ByteStructPack2Explicit* str1)
 {
 	if(!IsCorrectByteStructPack2Explicit(str1))
 	{
@@ -987,7 +987,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInByteStructPac
 	ChangeByteStructPack2Explicit(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutByteStructPack2Explicit(ByteStructPack2Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOutByteStructPack2Explicit(ByteStructPack2Explicit* str1)
 {
 	ChangeByteStructPack2Explicit(str1);
 
@@ -995,7 +995,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutByteStructPa
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValShortStructPack4Explicit(ShortStructPack4Explicit str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValShortStructPack4Explicit(ShortStructPack4Explicit str1)
 {
 	if(!IsCorrectShortStructPack4Explicit(&str1))
 	{
@@ -1006,7 +1006,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValShortStructPack
 	ChangeShortStructPack4Explicit(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefShortStructPack4Explicit(ShortStructPack4Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefShortStructPack4Explicit(ShortStructPack4Explicit* str1)
 {
 	if(!IsCorrectShortStructPack4Explicit(str1))
 	{
@@ -1018,7 +1018,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefShortStructPack
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInShortStructPack4Explicit(ShortStructPack4Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInShortStructPack4Explicit(ShortStructPack4Explicit* str1)
 {
 	if(!IsCorrectShortStructPack4Explicit(str1))
 	{
@@ -1029,7 +1029,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInShortStructPa
 	ChangeShortStructPack4Explicit(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutShortStructPack4Explicit(ShortStructPack4Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOutShortStructPack4Explicit(ShortStructPack4Explicit* str1)
 {
 	ChangeShortStructPack4Explicit(str1);
 
@@ -1037,7 +1037,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutShortStructP
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValIntStructPack8Explicit(IntStructPack8Explicit str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValIntStructPack8Explicit(IntStructPack8Explicit str1)
 {
 	if(!IsCorrectIntStructPack8Explicit(&str1))
 	{
@@ -1048,7 +1048,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValIntStructPack8E
 	ChangeIntStructPack8Explicit(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefIntStructPack8Explicit(IntStructPack8Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefIntStructPack8Explicit(IntStructPack8Explicit* str1)
 {
 	if(!IsCorrectIntStructPack8Explicit(str1))
 	{
@@ -1060,7 +1060,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefIntStructPack8E
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInIntStructPack8Explicit(IntStructPack8Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInIntStructPack8Explicit(IntStructPack8Explicit* str1)
 {
 	if(!IsCorrectIntStructPack8Explicit(str1))
 	{
@@ -1071,7 +1071,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInIntStructPack
 	ChangeIntStructPack8Explicit(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutIntStructPack8Explicit(IntStructPack8Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOutIntStructPack8Explicit(IntStructPack8Explicit* str1)
 {
 	ChangeIntStructPack8Explicit(str1);
 
@@ -1079,7 +1079,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutIntStructPac
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValLongStructPack16Explicit(LongStructPack16Explicit str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByValLongStructPack16Explicit(LongStructPack16Explicit str1)
 {
 	if(!IsCorrectLongStructPack16Explicit(&str1))
 	{
@@ -1090,7 +1090,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByValLongStructPack1
 	ChangeLongStructPack16Explicit(&str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefLongStructPack16Explicit(LongStructPack16Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefLongStructPack16Explicit(LongStructPack16Explicit* str1)
 {
 	if(!IsCorrectLongStructPack16Explicit(str1))
 	{
@@ -1102,7 +1102,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefLongStructPack1
 	return TRUE;
 }
 
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInLongStructPack16Explicit(LongStructPack16Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefInLongStructPack16Explicit(LongStructPack16Explicit* str1)
 {
 	if(!IsCorrectLongStructPack16Explicit(str1))
 	{
@@ -1113,7 +1113,7 @@ extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefInLongStructPac
 	ChangeLongStructPack16Explicit(str1);
 	return TRUE;
 }
-extern "C" DLL_EXPORT BOOL WINAPI MarshalStructAsParam_AsExpByRefOutLongStructPack16Explicit(LongStructPack16Explicit* str1)
+extern "C" DLL_EXPORT BOOL NATIVEAPI MarshalStructAsParam_AsExpByRefOutLongStructPack16Explicit(LongStructPack16Explicit* str1)
 {
 	ChangeLongStructPack16Explicit(str1);
 

--- a/tests/src/Interop/common/xplatform.h
+++ b/tests/src/Interop/common/xplatform.h
@@ -53,9 +53,14 @@
 
 #endif //_WIN32
 
-#ifndef WINAPI
-#define WINAPI __stdcall
-#endif
+// The default P/Invoke calling convetion is STDCALL on Window, but CDECL on Unix.
+#ifdef _WIN32
+#define CALLBACK    __stdcall
+#define NATIVEAPI   __stdcall
+#else // _WIN32
+#define CALLBACK
+#define NATIVEAPI
+#endif // !_WIN32
 
 #ifndef _MSC_VER
 #if __i386__


### PR DESCRIPTION
Recently merged #9977 changes the default P/Invoke calling convention from STDCALL and CDECL, but several Interop testcases assume that the default is STDCALL.

This commit revises Interop TC's calling convention.