### PR TITLE
Remove CORECLR_GDBJIT length check in gdbjit

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1739,7 +1739,7 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
     {
         cCharsNeeded = GetEnvironmentVariableW(W("CORECLR_GDBJIT"), NULL, 0);
 
-        if((cCharsNeeded == 0) || (cCharsNeeded >= MAX_LONGPATH))
+        if(cCharsNeeded == 0)
             return;
         wszModuleNames = new WCHAR[cCharsNeeded+1];
         cCharsNeeded = GetEnvironmentVariableW(W("CORECLR_GDBJIT"), wszModuleNames, cCharsNeeded);


### PR DESCRIPTION
issue: https://github.com/dotnet/coreclr/issues/10003

This length check is obsolete since it is based on wrong assumption that this variable holds the path of assembly to debug 