### PR TITLE
[x86/Linux] Enforce EBP-frame

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16270,6 +16270,11 @@ void Compiler::fgSetOptions()
         codeGen->setFramePointerRequiredGCInfo(true);
     }
 
+#ifdef UNIX_X86_ABI
+    // TODO Remove this line once SP restored by unwinder becomes reliable.
+    codeGen->setFramePointerRequired(true);
+#endif // UNIX_X86_ABI
+
     // printf("method will %s be fully interruptible\n", genInterruptible ? "   " : "not");
 }
 


### PR DESCRIPTION
The current implementation of x86/Linux unwinder sometimes failed to restore SP correctly, which results in  #10025.

As a workaround, this commit enforces JIT to emit EBP-frame for all methods on x86/Linux to fix #10025.