### PR TITLE
[x86/Linux] WIP, Enable FEATURE_FIXED_OUT_ARGS

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -3957,12 +3957,29 @@ void CodeGen::genGCWriteBarrier(GenTreePtr tgt, GCInfo::WriteBarrierForm wbf)
         }
 #endif // DEBUG
 #endif // 0
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+        unsigned baseVarNum = getBaseVarForPutArgStk(tgt);
+
+        getEmitter()->emitIns_S_I(ins_Store(TYP_INT), EA_PTRSIZE, baseVarNum, 0, wbKind);
+        // TODO-FOA: remove this after we meet this block and it's tested
+        instGen(INS_nop);
+        instGen(INS_nop);
+        instGen(INS_nop);
+        assert(false);
+
+        genEmitHelperCall(helper,
+                          4,           // argSize
+                          EA_PTRSIZE); // retSize
+        // Restore ESP for stdcall callee pop
+        inst_RV_IV(INS_sub, REG_SPBASE, 4, EA_PTRSIZE);
+#else  // !(UNIX_X86_ABI && FEATURE_FIXED_OUT_ARGS)
         AddStackLevel(4);
         inst_IV(INS_push, wbKind);
         genEmitHelperCall(helper,
                           4,           // argSize
                           EA_PTRSIZE); // retSize
         SubtractStackLevel(4);
+#endif // UNIX_X86_ABI && FEATURE_FIXED_OUT_ARGS
     }
     else
     {
@@ -7530,6 +7547,10 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
     unsigned saveStackLvl2 = genStackLevel;
 
 #if defined(_TARGET_X86_)
+#if FEATURE_FIXED_OUT_ARGS
+    // TODO-FOA: Fix here
+    assert(false);
+#else
     // Important note: when you change enter probe layout, you must also update SKIP_ENTER_PROF_CALLBACK()
     // for x86 stack unwinding
 
@@ -7542,6 +7563,7 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
     {
         inst_IV(INS_push, (size_t)compiler->compProfilerMethHnd);
     }
+#endif // !FEATURE_FIXED_OUT_ARGS
 #elif defined(_TARGET_ARM_)
     // On Arm arguments are prespilled on stack, which frees r0-r3.
     // For generating Enter callout we would need two registers and one of them has to be r0 to pass profiler handle.
@@ -7718,6 +7740,10 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper /*= CORINFO_HELP_PROF_FC
 
 #elif defined(_TARGET_X86_)
 
+#if FEATURE_FIXED_OUT_ARGS
+    // TODO-FOA: Fix here
+    assert(false);
+#else
     //
     // Push the profilerHandle
     //
@@ -7744,6 +7770,7 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper /*= CORINFO_HELP_PROF_FC
         JITDUMP("Upping fgPtrArgCntMax from %d to 1\n", compiler->fgPtrArgCntMax);
         compiler->fgPtrArgCntMax = 1;
     }
+#endif // FEATURE_FIXED_OUT_ARGS
 
 #elif defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
 
@@ -11198,7 +11225,12 @@ unsigned CodeGen::getFirstArgWithStackSlot()
 //
 void CodeGen::genSinglePush()
 {
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+    // genSinglePush shouldn't be called
+    assert(false);
+#else
     AddStackLevel(REGSIZE_BYTES);
+#endif
 }
 
 //------------------------------------------------------------------------
@@ -11206,7 +11238,12 @@ void CodeGen::genSinglePush()
 //
 void CodeGen::genSinglePop()
 {
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+    // genSinglePop shouldn't be called
+    assert(false);
+#else
     SubtractStackLevel(REGSIZE_BYTES);
+#endif
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -491,6 +491,9 @@ void CodeGen::genCodeForBBlist()
         }
 
         SubtractStackLevel(savedStkLvl);
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+        assert(genStackLevel == 0);
+#endif
 
 #ifdef DEBUG
         // compCurLife should be equal to the liveOut set, except that we don't keep

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -215,7 +215,9 @@ void AddNestedAlignment(unsigned adjustment)
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
 #ifdef _TARGET_X86_
 bool genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk);
+#if !FEATURE_FIXED_OUT_ARGS
 void genPushReg(var_types type, regNumber srcReg);
+#endif // !FEATURE_FIXED_OUT_ARGS
 void genPutArgStkFieldList(GenTreePutArgStk* putArgStk);
 #endif // _TARGET_X86_
 
@@ -300,8 +302,8 @@ bool genIsRegCandidateLocal(GenTreePtr tree)
 bool m_pushStkArg;
 #else  // !_TARGET_X86_
 unsigned m_stkArgVarNum;
-unsigned m_stkArgOffset;
 #endif // !_TARGET_X86_
+unsigned m_stkArgOffset;
 #endif // !FEATURE_PUT_STRUCT_ARG_STK
 
 #ifdef DEBUG

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -3393,6 +3393,10 @@ void CodeGen::genStructPutArgUnroll(GenTreePutArgStk* putArgNode)
     }
 #endif // !_TARGET_X86_
 
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+    m_stkArgOffset = putArgOffset;
+#endif
+
     // If the size of this struct is larger than 16 bytes
     // let's use SSE2 to be able to do 16 byte at a time
     // loads and stores.
@@ -3425,6 +3429,7 @@ void CodeGen::genStructPutArgUnroll(GenTreePutArgStk* putArgNode)
     if ((size & 0xf) != 0)
     {
 #ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
         if (m_pushStkArg)
         {
             // This case is currently supported only for the case where the total size is
@@ -3440,6 +3445,7 @@ void CodeGen::genStructPutArgUnroll(GenTreePutArgStk* putArgNode)
             pushedBytes += genMove8IfNeeded(size, longTmpReg, src->gtOp.gtOp1, 0);
         }
         else
+#endif // !FEATURE_FIXED_OUT_ARGS
 #endif // _TARGET_X86_
         {
             offset += genMove8IfNeeded(size, longTmpReg, src->gtOp.gtOp1, offset);
@@ -5317,6 +5323,13 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     unsigned stackAdjustBias = 0;
 
 #if defined(_TARGET_X86_)
+#if FEATURE_FIXED_OUT_ARGS
+    // Is the callee pop?
+    if (!fCallerPop && (stackArgBytes != 0))
+    {
+        stackAdjustBias = stackArgBytes;
+    }
+#else
     // Is the caller supposed to pop the arguments?
     if (fCallerPop && (stackArgBytes != 0))
     {
@@ -5324,6 +5337,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     }
 
     SubtractStackLevel(stackArgBytes);
+#endif // FEATURE_FIXED_OUT_ARGS
 #endif // _TARGET_X86_
 
     genRemoveAlignmentAfterCall(call, stackAdjustBias);
@@ -7466,9 +7480,11 @@ unsigned CodeGen::getBaseVarForPutArgStk(GenTreePtr treeNode)
 void CodeGen::genAlignStackBeforeCall(GenTreePutArgStk* putArgStk)
 {
 #if defined(UNIX_X86_ABI)
+#if !FEATURE_FIXED_OUT_ARGS
 
     genAlignStackBeforeCall(putArgStk->gtCall);
 
+#endif // !FEATURE_FIXED_OUT_ARGS
 #endif // UNIX_X86_ABI
 }
 
@@ -7481,6 +7497,7 @@ void CodeGen::genAlignStackBeforeCall(GenTreePutArgStk* putArgStk)
 void CodeGen::genAlignStackBeforeCall(GenTreeCall* call)
 {
 #if defined(UNIX_X86_ABI)
+#if !FEATURE_FIXED_OUT_ARGS
 
     // Have we aligned the stack yet?
     if (!call->fgArgInfo->IsStkAlignmentDone())
@@ -7505,6 +7522,7 @@ void CodeGen::genAlignStackBeforeCall(GenTreeCall* call)
         call->fgArgInfo->SetStkAlignmentDone();
     }
 
+#endif // !FEATURE_FIXED_OUT_ARGS
 #endif // UNIX_X86_ABI
 }
 
@@ -7524,6 +7542,15 @@ void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call, unsigned bias)
 {
 #if defined(_TARGET_X86_)
 #if defined(UNIX_X86_ABI)
+#if FEATURE_FIXED_OUT_ARGS
+    // Put back the stack pointer for callee pop
+    unsigned padStkAdjust = bias;
+
+    if (padStkAdjust != 0)
+    {
+        inst_RV_IV(INS_sub, REG_SPBASE, padStkAdjust, EA_PTRSIZE);
+    }
+#else  // FEATURE_FIXED_OUT_ARGS
     // Put back the stack pointer if there was any padding for stack alignment
     unsigned padStkAlign  = call->fgArgInfo->GetStkAlign();
     unsigned padStkAdjust = padStkAlign + bias;
@@ -7534,6 +7561,7 @@ void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call, unsigned bias)
         SubtractStackLevel(padStkAlign);
         SubtractNestedAlignment(padStkAlign);
     }
+#endif // !FEATURE_FIXED_OUT_ARGS
 #else  // UNIX_X86_ABI
     if (bias != 0)
     {
@@ -7612,8 +7640,10 @@ bool CodeGen::genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk)
     else
     {
         m_pushStkArg = false;
+#if !FEATURE_FIXED_OUT_ARGS
         inst_RV_IV(INS_sub, REG_SPBASE, argSize, EA_PTRSIZE);
         AddStackLevel(argSize);
+#endif // !FEATURE_FIXED_OUT_ARGS
         return true;
     }
 }
@@ -7648,6 +7678,24 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
     unsigned  prevFieldOffset = currentOffset;
     regNumber intTmpReg       = REG_NA;
     regNumber simdTmpReg      = REG_NA;
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+    unsigned  argOffsetOut = putArgStk->gtSlotNum * TARGET_POINTER_SIZE;
+    unsigned  baseVarNum   = getBaseVarForPutArgStk(putArgStk);
+    regNumber foaTmpReg    = REG_NA;
+
+    currentOffset   = 0;
+    prevFieldOffset = currentOffset;
+
+    if (putArgStk->AvailableTempRegCount() != 0)
+    {
+        regMaskTP rsvdRegs = putArgStk->gtRsvdRegs;
+        if ((rsvdRegs & RBM_ALLINT) != 0)
+        {
+            foaTmpReg = putArgStk->ExtractTempReg(RBM_ALLINT);
+        }
+    }
+#endif
+
     if (putArgStk->AvailableTempRegCount() != 0)
     {
         regMaskTP rsvdRegs = putArgStk->gtRsvdRegs;
@@ -7673,7 +7721,9 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
         // Long-typed nodes should have been handled by the decomposition pass, and lowering should have sorted the
         // field list in descending order by offset.
         assert(!varTypeIsLong(fieldType));
+#if !FEATURE_FIXED_OUT_ARGS
         assert(fieldOffset <= prevFieldOffset);
+#endif
 
         // Consume the register, if any, for this field. Note that genConsumeRegs() will appropriately
         // update the liveness info for a lclVar that has been marked RegOptional, which hasn't been
@@ -7693,7 +7743,8 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
         int        adjustment  = roundUp(currentOffset - fieldOffset, 4);
         if (fieldIsSlot && !varTypeIsSIMD(fieldType))
         {
-            fieldType         = genActualType(fieldType);
+            fieldType = genActualType(fieldType);
+#if !FEATURE_FIXED_OUT_ARGS
             unsigned pushSize = genTypeSize(fieldType);
             assert((pushSize % 4) == 0);
             adjustment -= pushSize;
@@ -7704,6 +7755,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
                 AddStackLevel(pushSize);
                 adjustment -= pushSize;
             }
+#endif // !FEATURE_FIXED_OUT_ARGS
             m_pushStkArg = true;
         }
         else
@@ -7714,6 +7766,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
             // require special handling).
             assert(varTypeIsIntegralOrI(fieldNode) || varTypeIsSIMD(fieldNode));
 
+#if !FEATURE_FIXED_OUT_ARGS
             // If we can't push this field, it needs to be in a register so that we can store
             // it to the stack location.
             if (adjustment != 0)
@@ -7725,6 +7778,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
                 currentOffset -= adjustment;
                 AddStackLevel(adjustment);
             }
+#endif // !FEATURE_FIXED_OUT_ARGS
 
             // Does it need to be in a byte register?
             // If so, we'll use intTmpReg, which must have been allocated as a byte register.
@@ -7749,19 +7803,59 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
                 {
                     assert(!varTypeIsSIMD(fieldType)); // Q: can we get here with SIMD?
                     assert(fieldNode->IsRegOptional());
-                    TempDsc* tmp = getSpillTempDsc(fieldNode);
-                    getEmitter()->emitIns_S(INS_push, emitActualTypeSize(fieldNode->TypeGet()), tmp->tdTempNum(), 0);
+                    TempDsc* tmp      = getSpillTempDsc(fieldNode);
+                    emitAttr typeSize = emitActualTypeSize(fieldNode->TypeGet());
+
+#if FEATURE_FIXED_OUT_ARGS
+                    assert(genIsValidIntReg(foaTmpReg));
+                    // mov      eax, gword ptr [ebp-n] ; where n is from tmp->tdTempNum()
+                    // mov      gword ptr [esp+m], eax ; where m is argOffsetOut
+                    getEmitter()->emitIns_R_S(ins_Store(fieldType), typeSize, foaTmpReg, tmp->tdTempNum(), 0);
+                    getEmitter()->emitIns_AR_R(ins_Store(fieldType), EA_4BYTE, foaTmpReg, REG_SPBASE,
+                                               fieldOffset + argOffsetOut);
+#else
+                    getEmitter()->emitIns_S(INS_push, typeSize, tmp->tdTempNum(), 0);
+#endif
                     compiler->tmpRlsTemp(tmp);
                 }
                 else
                 {
                     assert(varTypeIsIntegralOrI(fieldNode));
+                    emitAttr typeSize = emitActualTypeSize(fieldNode->TypeGet());
                     switch (fieldNode->OperGet())
                     {
                         case GT_LCL_VAR:
-                            inst_TT(INS_push, fieldNode, 0, 0, emitActualTypeSize(fieldNode->TypeGet()));
-                            break;
+#if FEATURE_FIXED_OUT_ARGS
+                        {
+                            unsigned fieldLclNum = fieldNode->AsLclVarCommon()->gtLclNum;
+
+                            assert(genIsValidIntReg(foaTmpReg));
+                            // mov      eax, gword ptr [ebp-n]
+                            // mov      gword ptr [esp+argOffset], eax
+                            getEmitter()->emitIns_R_S(ins_Store(fieldType), typeSize, foaTmpReg, fieldLclNum, 0);
+                            getEmitter()->emitIns_AR_R(ins_Store(fieldType), EA_4BYTE, foaTmpReg, REG_SPBASE,
+                                                       fieldOffset + argOffsetOut);
+                        }
+#else
+                            // push     dword ptr [ebp-N]
+                            inst_TT(INS_push, fieldNode, 0, 0, typeSize);
+#endif // FEATURE_FIXED_OUT_ARGS
+                        break;
                         case GT_CNS_INT:
+#if FEATURE_FIXED_OUT_ARGS
+                            if (fieldNode->IsIconHandle())
+                            {
+                                // mov dword ptr [esp+n], fieldNode->gtIntCon.gtIconVal
+                                getEmitter()->emitIns_S_I(ins_Store(fieldType), EA_HANDLE_CNS_RELOC, baseVarNum,
+                                                          fieldOffset + argOffsetOut, fieldNode->gtIntCon.gtIconVal);
+                            }
+                            else
+                            {
+                                // mov gword ptr [esp+n], fieldNode->gtIntCon.gtIconVal
+                                getEmitter()->emitIns_S_I(ins_Store(fieldType), typeSize, baseVarNum,
+                                                          fieldOffset + argOffsetOut, fieldNode->gtIntCon.gtIconVal);
+                            }
+#else
                             if (fieldNode->IsIconHandle())
                             {
                                 inst_IV_handle(INS_push, fieldNode->gtIntCon.gtIconVal);
@@ -7770,13 +7864,16 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
                             {
                                 inst_IV(INS_push, fieldNode->gtIntCon.gtIconVal);
                             }
+#endif // FEATURE_FIXED_OUT_ARGS
                             break;
                         default:
                             unreached();
                     }
                 }
+#if !FEATURE_FIXED_OUT_ARGS
                 currentOffset -= TARGET_POINTER_SIZE;
                 AddStackLevel(TARGET_POINTER_SIZE);
+#endif // !FEATURE_FIXED_OUT_ARGS
             }
             else
             {
@@ -7793,7 +7890,12 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
                     default:
                         unreached();
                 }
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+                m_stkArgOffset = 0;
+                genStoreRegToStackArg(fieldType, intTmpReg, fieldOffset + argOffsetOut);
+#else
                 genStoreRegToStackArg(fieldType, intTmpReg, fieldOffset - currentOffset);
+#endif
             }
         }
         else
@@ -7806,6 +7908,12 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
             }
             else
 #endif // defined(FEATURE_SIMD)
+#if FEATURE_FIXED_OUT_ARGS
+            {
+                m_stkArgOffset = 0;
+                genStoreRegToStackArg(fieldType, argReg, fieldOffset + argOffsetOut);
+            }
+#else
             {
                 genStoreRegToStackArg(fieldType, argReg, fieldOffset - currentOffset);
             }
@@ -7814,16 +7922,19 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
                 // We always push a slot-rounded size
                 currentOffset -= genTypeSize(fieldType);
             }
+#endif // FEATURE_FIXED_OUT_ARGS
         }
 
         prevFieldOffset = fieldOffset;
     }
+#if !FEATURE_FIXED_OUT_ARGS
     if (currentOffset != 0)
     {
         // We don't expect padding at the beginning of a struct, but it could happen with explicit layout.
         inst_RV_IV(INS_sub, REG_SPBASE, currentOffset, EA_PTRSIZE);
         AddStackLevel(currentOffset);
     }
+#endif // FEATURE_FIXED_OUT_ARGS
 }
 #endif // _TARGET_X86_
 
@@ -7864,8 +7975,27 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
     const unsigned argSize = putArgStk->getArgSize();
     assert((argSize % TARGET_POINTER_SIZE) == 0);
 
+#if FEATURE_FIXED_OUT_ARGS
+    unsigned baseVarNum = getBaseVarForPutArgStk(putArgStk);
+    unsigned argOffset  = putArgStk->getArgOffset();
+#endif // FEATURE_FIXED_OUT_ARGS
+
     if (data->isContainedIntOrIImmed())
     {
+#if FEATURE_FIXED_OUT_ARGS
+        if (data->IsIconHandle())
+        {
+            // mov dword ptr [esp+n], data->gtIntCon.gtIconVal
+            getEmitter()->emitIns_S_I(ins_Store(targetType), EA_HANDLE_CNS_RELOC, baseVarNum, argOffset,
+                                      data->gtIntCon.gtIconVal);
+        }
+        else
+        {
+            // mov gword ptr [esp+n], data->gtIntCon.gtIconVal
+            getEmitter()->emitIns_S_I(ins_Store(targetType), emitTypeSize(targetType), baseVarNum, argOffset,
+                                      data->gtIntCon.gtIconVal);
+        }
+#else
         if (data->IsIconHandle())
         {
             inst_IV_handle(INS_push, data->gtIntCon.gtIconVal);
@@ -7875,6 +8005,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
             inst_IV(INS_push, data->gtIntCon.gtIconVal);
         }
         AddStackLevel(argSize);
+#endif // FEATURE_FIXED_OUT_ARGS
     }
     else if (data->OperGet() == GT_FIELD_LIST)
     {
@@ -7885,7 +8016,12 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
         // We should not see any contained nodes that are not immediates.
         assert(data->isUsedFromReg());
         genConsumeReg(data);
+#if FEATURE_FIXED_OUT_ARGS
+        getEmitter()->emitIns_S_R(ins_Store(targetType), emitTypeSize(targetType), data->gtRegNum, baseVarNum,
+                                  argOffset);
+#else
         genPushReg(targetType, data->gtRegNum);
+#endif // FEATURE_FIXED_OUT_ARGS
     }
 #else // !_TARGET_X86_
     {
@@ -7936,6 +8072,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
 }
 
 #ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
 // genPushReg: Push a register value onto the stack and adjust the stack level
 //
 // Arguments:
@@ -7975,6 +8112,7 @@ void CodeGen::genPushReg(var_types type, regNumber srcReg)
     }
     AddStackLevel(size);
 }
+#endif // !FEATURE_FIXED_OUT_ARGS
 #endif // _TARGET_X86_
 
 #if defined(FEATURE_PUT_STRUCT_ARG_STK)
@@ -8041,6 +8179,9 @@ void CodeGen::genStoreRegToStackArg(var_types type, regNumber srcReg, int offset
     }
 
 #ifdef _TARGET_X86_
+#if FEATURE_FIXED_OUT_ARGS
+    getEmitter()->emitIns_AR_R(ins, attr, srcReg, REG_SPBASE, m_stkArgOffset + offset);
+#else
     if (m_pushStkArg)
     {
         genPushReg(type, srcReg);
@@ -8049,6 +8190,7 @@ void CodeGen::genStoreRegToStackArg(var_types type, regNumber srcReg, int offset
     {
         getEmitter()->emitIns_AR_R(ins, attr, srcReg, REG_SPBASE, offset);
     }
+#endif // !FEATURE_FIXED_OUT_ARGS
 #else  // !_TARGET_X86_
     assert(m_stkArgVarNum != BAD_VAR_NUM);
     getEmitter()->emitIns_S_R(ins, attr, srcReg, m_stkArgVarNum, m_stkArgOffset + offset);
@@ -8084,6 +8226,9 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
     {
         regNumber srcReg = genConsumeReg(putArgStk->gtGetOp1());
         assert((srcReg != REG_NA) && (genIsValidFloatReg(srcReg)));
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+        m_stkArgOffset = 0;
+#endif
         genStoreRegToStackArg(targetType, srcReg, 0);
         return;
     }
@@ -8145,6 +8290,10 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
             }
         }
 
+#if FEATURE_FIXED_OUT_ARGS
+        regNumber foaTmpReg = putArgStk->ExtractTempReg(RBM_ALLINT);
+#endif
+
         for (int i = numSlots - 1; i >= 0; --i)
         {
             emitAttr slotAttr;
@@ -8163,6 +8312,28 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
             }
 
             const unsigned offset = i * TARGET_POINTER_SIZE;
+#if FEATURE_FIXED_OUT_ARGS
+            const unsigned argOffset = putArgStk->getArgOffset();
+            if (srcAddrInReg)
+            {
+                // This block doesn't seem to be called with any of unit test cases.
+                getEmitter()->emitIns_AR_R(ins_Store(TYP_INT), slotAttr, foaTmpReg, srcRegNum, offset);
+                getEmitter()->emitIns_AR_R(ins_Store(TYP_INT), EA_4BYTE, foaTmpReg, REG_SPBASE, argOffset + offset);
+
+                // TODO-FOA: remove this after we meet this block and it's tested
+                instGen(INS_nop);
+                instGen(INS_nop);
+                instGen(INS_nop);
+                assert(false);
+            }
+            else
+            {
+                // mov      eax, gword ptr [ebp-n] ; where n is from srcLclNum+srcLclOffset+offset
+                // mov      gword ptr [esp+m], eax ; where m is argOffset+offset
+                getEmitter()->emitIns_R_S(ins_Store(TYP_INT), slotAttr, foaTmpReg, srcLclNum, srcLclOffset + offset);
+                getEmitter()->emitIns_AR_R(ins_Store(TYP_INT), EA_4BYTE, foaTmpReg, REG_SPBASE, argOffset + offset);
+            }
+#else  // FEATURE_FIXED_OUT_ARGS
             if (srcAddrInReg)
             {
                 getEmitter()->emitIns_AR_R(INS_push, slotAttr, REG_NA, srcRegNum, offset);
@@ -8172,6 +8343,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
                 getEmitter()->emitIns_S(INS_push, slotAttr, srcLclNum, srcLclOffset + offset);
             }
             AddStackLevel(TARGET_POINTER_SIZE);
+#endif // FEATURE_FIXED_OUT_ARGS
         }
 #else // !defined(_TARGET_X86_)
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1412,6 +1412,10 @@ public:
     {
         alignmentDone = true;
     }
+#if FEATURE_FIXED_OUT_ARGS
+    void     ReverseArgumentSlot();
+    unsigned GetCalleePop();
+#endif // FEATURE_FIXED_OUT_ARGS
 #endif // defined(UNIX_X86_ABI)
 
     // Get the late arg for arg at position argIndex.  Caller must ensure this position has a late arg.

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1868,7 +1868,9 @@ private:
 #endif
 
 #ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
     void emitMarkStackLvl(unsigned stackLevel);
+#endif // !FEATURE_FIXED_OUT_ARGS
 #endif
 
     int emitNextRandomNop();

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -718,6 +718,7 @@ unsigned emitter::emitGetPrefixSize(code_t code)
 }
 
 #ifdef _TARGET_X86_
+#if !FEATURE_FIXED_OUT_ARGS
 /*****************************************************************************
  *
  *  Record a non-empty stack
@@ -740,6 +741,7 @@ void emitter::emitMarkStackLvl(unsigned stackLevel)
         emitMaxStackDepth = emitCurStackLvl;
     }
 }
+#endif // !FEATURE_FIXED_OUT_ARGS
 #endif
 
 /*****************************************************************************
@@ -5221,9 +5223,11 @@ void emitter::emitIns_Call(EmitCallType          callType,
            (ireg == REG_NA && xreg == REG_NA && xmul == 0 && disp < (int)emitComp->lvaCount));
     assert(callType != EC_INDIR_C || (ireg == REG_NA && xreg == REG_NA && xmul == 0 && disp != 0));
 
+#if !FEATURE_FIXED_OUT_ARGS
     // Our stack level should be always greater than the bytes of arguments we push. Just
     // a sanity test.
     assert((unsigned)abs((signed)argSize) <= codeGen->genStackLevel);
+#endif // !FEATURE_FIXED_OUT_ARGS
 
 #if STACK_PROBES
     if (emitComp->opts.compNeedStackProbes)
@@ -10563,6 +10567,9 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
                 assert(callInstrSize != 0);
 
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+// TODO-FOA: Fix here
+#else
                 if (args >= 0)
                 {
                     emitStackPop(dst, /*isCall*/ true, callInstrSize, args);
@@ -10571,6 +10578,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
                 {
                     emitStackKillArgs(dst, -args, callInstrSize);
                 }
+#endif // UNIX_X86_ABI && FEATURE_FIXED_OUT_ARGS
             }
 
             // Do we need to record a call location for GC purposes?

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9169,6 +9169,10 @@ void Compiler::fgSimpleLowering()
                     case GT_CALL:
                     {
                         GenTreeCall* call = tree->AsCall();
+#if defined(UNIX_X86_ABI)
+                        // Reverse arguments order after morph and optimization and before lowering.
+                        call->fgArgInfo->ReverseArgumentSlot();
+#endif
                         // Fast tail calls use the caller-supplied scratch
                         // space so have no impact on this method's outgoing arg size.
                         if (!call->IsFastTailCall())

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4701,7 +4701,9 @@ void LinearScan::buildIntervals()
         for (BasicBlock* succ : block->GetAllSuccs(compiler))
         {
             if (VarSetOps::IsEmpty(compiler, expUseSet))
+            {
                 break;
+            }
 
             if (isBlockVisited(succ))
             {

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -1410,6 +1410,13 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
 
         if (curArgTabEntry->regNum == REG_STK)
         {
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+            // srcCount and dstCount are set to correct value in
+            // TreeNodeInfoInitPutArgStk(). Below code will set to '1'
+            // for case of LONG type where srcCount should be '2'
+            continue;
+#endif // UNIX_X86_ABI && FEATURE_FIXED_OUT_ARGS
+
             // late arg that is not passed in a register
             DISPNODE(argNode);
             assert(argNode->gtOper == GT_PUTARG_STK);
@@ -1885,6 +1892,11 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* putArgStk)
             info->addInternalCandidates(l, l->allSIMDRegs());
         }
 #endif // defined(FEATURE_SIMD)
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+        // to allocate scratch register to copy from lclvars to stack args
+        info->internalIntCount += 1;
+        info->addInternalCandidates(l, l->allRegs(TYP_INT));
+#endif // UNIX_X86_ABI && FEATURE_FIXED_OUT_ARGS
 
         return;
     }
@@ -1968,6 +1980,14 @@ void Lowering::TreeNodeInfoInitPutArgStk(GenTreePutArgStk* putArgStk)
                 info->addInternalCandidates(l, l->internalFloatRegCandidates());
                 SetContainsAVXFlags();
             }
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+            // to allocate scratch register to copy from lclvars to stack args
+            if (info->internalIntCount == 0)
+            {
+                info->internalIntCount = 1;
+                info->addInternalCandidates(l, l->allRegs(TYP_INT));
+            }
+#endif // UNIX_X86_ABI && FEATURE_FIXED_OUT_ARGS
             break;
 
         case GenTreePutArgStk::Kind::RepInstr:

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2443,6 +2443,68 @@ void fgArgInfo::EvalArgsToTemps()
 #endif
 }
 
+#if defined(UNIX_X86_ABI) && FEATURE_FIXED_OUT_ARGS
+// Reverse slot number for each arguments so that arguments will be placed
+// in the same order when changed from 'push' to 'move' instruction.
+// It would be better not to do this if possible.
+void fgArgInfo::ReverseArgumentSlot()
+{
+    unsigned curInx;
+    unsigned numStackArgs = 0;
+
+    for (curInx = 0; curInx < argCount; curInx++)
+    {
+        fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+        if (curArgTabEntry->numSlots > 0)
+        {
+            // The argument may be REG_STK or constant or register that goes to stack
+            assert(nextSlotNum >= curArgTabEntry->slotNum);
+
+            numStackArgs++;
+        }
+    }
+
+    if (numStackArgs > 1)
+    {
+        for (curInx = 0; curInx < argCount; curInx++)
+        {
+            fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+            if (curArgTabEntry->numSlots > 0)
+            {
+                curArgTabEntry->slotNum = (nextSlotNum - 1) - curArgTabEntry->slotNum;
+                // Consider 2 or more slots used for the argument
+                // For example, if there is 4 arguments with numSlots value 1, 2, 1, 1 each
+                // nextSlotNum will be 5 and slot number will be like this
+                //     before: [O] [1][ ] [3] [4]
+                //      after: [4] [3] [2][ ] [0]
+                curArgTabEntry->slotNum -= (curArgTabEntry->numSlots - 1);
+            }
+        }
+    }
+}
+
+// Return number of slots to adjust ESP for callee pop
+unsigned fgArgInfo::GetCalleePop()
+{
+    unsigned curInx;
+    unsigned numSlots = 0;
+
+    for (curInx = 0; curInx < argCount; curInx++)
+    {
+        fgArgTabEntryPtr curArgTabEntry = argTable[curInx];
+        if (curArgTabEntry->numSlots > 0)
+        {
+            // The argument may be REG_STK or constant or register that goes to stack
+            assert(nextSlotNum >= curArgTabEntry->slotNum);
+
+            numSlots += curArgTabEntry->numSlots;
+        }
+    }
+
+    return numSlots;
+}
+#endif // UNIX_X86_ABI && FEATURE_FIXED_OUT_ARGS
+
 // Get the late arg for arg at position argIndex.
 // argIndex - 0-based position to get late arg for.
 //            Caller must ensure this position has a late arg.

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -358,7 +358,12 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
 #endif // FEATURE_SIMD
 
   #define FEATURE_WRITE_BARRIER    1       // Generate the proper WriteBarrier calls for GC
+#if defined(UNIX_X86_ABI)
+//#define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
   #define FEATURE_FIXED_OUT_ARGS   0       // X86 uses push instructions to pass args
+#else
+  #define FEATURE_FIXED_OUT_ARGS   0       // X86 uses push instructions to pass args
+#endif
   #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers
   #define FEATURE_MULTIREG_STRUCT_PROMOTE  0  // True when we want to promote fields of a multireg struct into registers
   #define FEATURE_FASTTAILCALL     0       // Tail calls made as epilog+jmp


### PR DESCRIPTION
This is initial patch to enable FEATURE_FIXED_OUT_ARGS for x86/Linux

Enable `UNIX_X86_ABI_FOA` line in src/inc/corabi.h to test.