### PR TITLE
memory limit in containers on linux

### DIFF
--- a/src/gc/unix/CMakeLists.txt
+++ b/src/gc/unix/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories("../env")
 include(configure.cmake)
 
 set(GC_PAL_SOURCES
-    gcenv.unix.cpp)
+    gcenv.unix.cpp
+    cgroup.cpp)
 
 add_library(gc_unix STATIC ${GC_PAL_SOURCES} ${VERSION_FILE_PATH})

--- a/src/gc/unix/cgroup.cpp
+++ b/src/gc/unix/cgroup.cpp
@@ -1,0 +1,342 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*++
+
+Module Name:
+
+    cgroup.cpp
+
+Abstract:
+    Read memory limits for the current process
+--*/
+#include <cstdint>
+#include <cstddef>
+#include <cassert>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <errno.h>
+
+#define SIZE_T_MAX (~(size_t)0)
+#define PROC_MOUNTINFO_FILENAME "/proc/self/mountinfo"
+#define PROC_CGROUP_FILENAME "/proc/self/cgroup"
+#define PROC_STATM_FILENAME "/proc/self/statm"
+#define MEM_LIMIT_FILENAME "/memory.limit_in_bytes"
+
+class CGroup
+{
+    char* m_memory_cgroup_path;
+public:
+    CGroup()
+    {
+        m_memory_cgroup_path = nullptr;
+        char* memoryHierarchyMount = nullptr;
+        char *cgroup_path_relative_to_mount = nullptr;
+        size_t len;
+        memoryHierarchyMount = FindMemoryHierarchyMount();
+        if (memoryHierarchyMount == nullptr)
+            goto done;
+
+        cgroup_path_relative_to_mount = FindCGroupPathForMemorySubsystem();
+        if (cgroup_path_relative_to_mount == nullptr)
+            goto done;
+
+        len = strlen(memoryHierarchyMount);
+        len += strlen(cgroup_path_relative_to_mount);
+        m_memory_cgroup_path = (char*)malloc(len+1);
+        if (m_memory_cgroup_path == nullptr)
+           goto done;
+        
+        strcpy(m_memory_cgroup_path, memoryHierarchyMount);
+        strcat(m_memory_cgroup_path, cgroup_path_relative_to_mount);
+
+    done:
+        free(memoryHierarchyMount);
+        free(cgroup_path_relative_to_mount);
+    }
+
+    ~CGroup()
+    {
+        free(m_memory_cgroup_path);
+    }
+
+    bool GetPhysicalMemoryLimit(size_t *val)
+    {
+        char *mem_limit_filename = nullptr;
+        bool result = false;
+
+        if (m_memory_cgroup_path == nullptr)
+            return result;
+
+        size_t len = strlen(m_memory_cgroup_path);
+        len += strlen(MEM_LIMIT_FILENAME);
+        mem_limit_filename = (char*)malloc(len+1);
+        if (mem_limit_filename == nullptr)
+            return result;
+
+        strcpy(mem_limit_filename, m_memory_cgroup_path);
+        strcat(mem_limit_filename, MEM_LIMIT_FILENAME);
+        result = ReadMemoryValueFromFile(mem_limit_filename, val);
+        free(mem_limit_filename);
+        return result;
+    }
+    
+private:
+    char* FindMemoryHierarchyMount()
+    {
+        char *line = nullptr;
+        size_t lineLen = 0, maxLineLen = 0;
+        char *filesystemType = nullptr;
+        char *options = nullptr;
+        char* mountpath = nullptr;
+
+        FILE *mountinfofile = fopen(PROC_MOUNTINFO_FILENAME, "r");
+        if (mountinfofile == nullptr)
+            goto done;
+    
+        while (getline(&line, &lineLen, mountinfofile) != -1)
+        {
+            if (filesystemType == nullptr || lineLen > maxLineLen)
+            {
+                free(filesystemType);
+                free(options);
+                filesystemType = (char*)malloc(lineLen+1);
+                if (filesystemType == nullptr)
+                    goto done;
+                options = (char*)malloc(lineLen+1);
+                if (options == nullptr)
+                    goto done;
+                maxLineLen = lineLen;
+            }
+
+            char* separatorChar = strchr(line, '-');
+
+            // See man page of proc to get format for /proc/self/mountinfo file
+            int sscanfRet = sscanf(separatorChar, 
+                                   "- %s %*s %s",
+                                   filesystemType,
+                                   options);
+            if (sscanfRet != 2)
+            {
+                assert(!"Failed to parse mount info file contents with sscanf.");
+                goto done;
+            }
+    
+            if (strncmp(filesystemType, "cgroup", 6) == 0)
+            {
+                char* context = nullptr;
+                char* strTok = strtok_r(options, ",", &context); 
+                while (strTok != nullptr)
+                {
+                    if (strncmp("memory", strTok, 6) == 0)
+                    {
+                        mountpath = (char*)malloc(lineLen+1);
+                        if (mountpath == nullptr)
+                            goto done;
+    
+                        sscanfRet = sscanf(line,
+                                           "%*s %*s %*s %*s %s ",
+                                           mountpath);
+                        if (sscanfRet != 1)
+                        {
+                            free(mountpath);
+                            mountpath = nullptr;
+                            assert(!"Failed to parse mount info file contents with sscanf.");
+                        }
+                        goto done;
+                    }
+                    strTok = strtok_r(nullptr, ",", &context);
+                }
+            }
+        }
+    done:
+        free(filesystemType);
+        free(options);
+        free(line);
+        if (mountinfofile)
+            fclose(mountinfofile);
+        return mountpath;
+    }
+    
+    char* FindCGroupPathForMemorySubsystem()
+    {
+        char *line = nullptr;
+        size_t lineLen = 0;
+        size_t maxLineLen = 0;
+        char *subsystem_list = nullptr;
+        char *cgroup_path = nullptr;
+        bool result = false;
+
+        FILE *cgroupfile = fopen(PROC_CGROUP_FILENAME, "r");
+        if (cgroupfile == nullptr)
+            goto done;
+    
+        while (!result && getline(&line, &lineLen, cgroupfile) != -1)
+        {
+            if (subsystem_list == nullptr || lineLen > maxLineLen)
+            {
+                free(subsystem_list);
+                free(cgroup_path);
+                subsystem_list = (char*)malloc(lineLen+1);
+                if (subsystem_list == nullptr)
+                    goto done;
+                cgroup_path = (char*)malloc(lineLen+1);
+                if (cgroup_path == nullptr)
+                    goto done;
+                maxLineLen = lineLen;
+            }
+                   
+            // See man page of proc to get format for /proc/self/cgroup file
+            int sscanfRet = sscanf(line, 
+                                   "%*[^:]:%[^:]:%s",
+                                   subsystem_list,
+                                   cgroup_path);
+            if (sscanfRet != 2)
+            {
+                assert(!"Failed to parse cgroup info file contents with sscanf.");
+                goto done;
+            }
+    
+            char* context = nullptr;
+            char* strTok = strtok_r(subsystem_list, ",", &context); 
+            while (strTok != nullptr)
+            {
+                if (strncmp("memory", strTok, 6) == 0)
+                {
+                    result = true;
+                    break;  
+                }
+                strTok = strtok_r(nullptr, ",", &context);
+            }
+        }
+    done:
+        free(subsystem_list);
+        if (!result)
+        {
+            free(cgroup_path);
+            cgroup_path = nullptr;
+        }
+        free(line);
+        if (cgroupfile)
+            fclose(cgroupfile);
+        return cgroup_path;
+    }
+    
+    bool ReadMemoryValueFromFile(const char* filename, size_t* val)
+    {
+        bool result = false;
+        char *line = nullptr;
+        size_t lineLen = 0;
+        char* endptr = nullptr;
+        size_t num = 0, l, multiplier;
+        FILE* file = nullptr;
+    
+        if (val == nullptr)
+            goto done;
+    
+        file = fopen(filename, "r");
+        if (file == nullptr)
+            goto done;
+        
+        if (getline(&line, &lineLen, file) == -1)
+            goto done;
+    
+        errno = 0;
+        num = strtoull(line, &endptr, 0); 
+        if (errno != 0)
+            goto done;
+    
+        multiplier = 1;
+        switch(*endptr)
+        {
+            case 'g':
+            case 'G': multiplier = 1024;
+            case 'm': 
+            case 'M': multiplier = multiplier*1024;
+            case 'k':
+            case 'K': multiplier = multiplier*1024;
+        }
+    
+        *val = num * multiplier;
+        result = true;
+        if (*val/multiplier != num)
+            result = false;
+    done:
+        if (file)
+            fclose(file);
+        free(line);    
+        return result;
+    }
+};
+   
+size_t GetRestrictedPhysicalMemoryLimit()
+{
+    CGroup cgroup;
+    size_t physical_memory_limit;
+ 
+    if (!cgroup.GetPhysicalMemoryLimit(&physical_memory_limit))
+         physical_memory_limit = SIZE_T_MAX;
+
+    struct rlimit curr_rlimit;
+    size_t rlimit_soft_limit = RLIM_INFINITY;
+    if (getrlimit(RLIMIT_AS, &curr_rlimit) == 0)
+    {
+        rlimit_soft_limit = curr_rlimit.rlim_cur;
+    }
+    physical_memory_limit = (physical_memory_limit < rlimit_soft_limit) ? 
+                            physical_memory_limit : rlimit_soft_limit;
+
+    // Ensure that limit is not greater than real memory size
+    long pages = sysconf(_SC_PHYS_PAGES);
+    if (pages != -1) 
+    {
+        long pageSize = sysconf(_SC_PAGE_SIZE);
+        if (pageSize != -1)
+        {
+            physical_memory_limit = (physical_memory_limit < (size_t)pages * pageSize)?
+                                    physical_memory_limit : (size_t)pages * pageSize;
+        }
+    }
+
+    return physical_memory_limit;
+}
+
+bool GetWorkingSetSize(size_t* val)
+{
+    bool result = false;
+    size_t linelen;
+    char* line = nullptr;
+
+    if (val == nullptr)
+        return false;
+
+    FILE* file = fopen(PROC_STATM_FILENAME, "r");
+    if (file != nullptr && getline(&line, &linelen, file) != -1)
+    {
+
+        char* context = nullptr;
+        char* strTok = strtok_r(line, " ", &context); 
+        strTok = strtok_r(nullptr, " ", &context); 
+
+        errno = 0;
+        *val = strtoull(strTok, nullptr, 0); 
+        if (errno == 0)
+        {
+            long pageSize = sysconf(_SC_PAGE_SIZE);
+            if (pageSize != -1)
+            {
+                *val = *val * pageSize;
+                result = true;
+            }
+        }
+    }
+
+    if (file)
+        fclose(file);
+    free(line);
+    return result;
+}

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -538,7 +538,6 @@ PAL_ProbeMemory(
     BOOL fWriteAccess);
 
 /******************* winuser.h Entrypoints *******************************/
-
 PALIMPORT
 LPSTR
 PALAPI
@@ -2532,6 +2531,16 @@ PALIMPORT
 DWORD
 PALAPI
 PAL_GetLogicalCpuCountFromOS(VOID);
+
+PALIMPORT
+size_t
+PALAPI
+PAL_GetRestrictedPhysicalMemoryLimit(VOID);
+
+PALIMPORT
+BOOL
+PALAPI
+PAL_GetWorkingSetSize(size_t* val);
 
 PALIMPORT
 size_t

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -168,6 +168,7 @@ set(SOURCES
   map/virtual.cpp
   memory/heap.cpp
   memory/local.cpp
+  misc/cgroup.cpp
   misc/dbgmsg.cpp
   misc/environ.cpp
   misc/error.cpp

--- a/src/pal/src/misc/cgroup.cpp
+++ b/src/pal/src/misc/cgroup.cpp
@@ -1,0 +1,335 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*++
+
+Module Name:
+
+    cgroup.cpp
+
+Abstract:
+    Read memory limits for the current process
+--*/
+
+#include "pal/dbgmsg.h"
+SET_DEFAULT_DEBUG_CHANNEL(MISC);
+#include "pal/palinternal.h"
+#include <sys/resource.h>
+#include "pal/virtual.h"
+
+#define PROC_MOUNTINFO_FILENAME "/proc/self/mountinfo"
+#define PROC_CGROUP_FILENAME "/proc/self/cgroup"
+#define PROC_STATM_FILENAME "/proc/self/statm"
+#define MEM_LIMIT_FILENAME "/memory.limit_in_bytes"
+
+class CGroup
+{
+    char *m_memory_cgroup_path;
+public:
+    CGroup()
+    {
+        m_memory_cgroup_path = nullptr;
+        char* memoryHierarchyMount = nullptr;
+        char *cgroup_path_relative_to_mount = nullptr;
+        size_t len;
+        memoryHierarchyMount = FindMemoryHierarchyMount();
+        if (memoryHierarchyMount == nullptr)
+            goto done;
+
+        cgroup_path_relative_to_mount = FindCGroupPathForMemorySubsystem();
+        if (cgroup_path_relative_to_mount == nullptr)
+            goto done;
+
+        len = strlen(memoryHierarchyMount);
+        len += strlen(cgroup_path_relative_to_mount);
+        m_memory_cgroup_path = (char*)PAL_malloc(len+1);
+        if (m_memory_cgroup_path == nullptr)
+           goto done;
+        
+        strcpy_s(m_memory_cgroup_path, len+1, memoryHierarchyMount);
+        strcat_s(m_memory_cgroup_path, len+1, cgroup_path_relative_to_mount);
+
+    done:
+        PAL_free(memoryHierarchyMount);
+        PAL_free(cgroup_path_relative_to_mount);
+    }
+    ~CGroup()
+    {
+        PAL_free(m_memory_cgroup_path);
+    }
+    
+    bool GetPhysicalMemoryLimit(size_t *val)
+    {
+        char *mem_limit_filename = nullptr;
+        bool result = false;
+
+        if (m_memory_cgroup_path == nullptr)
+            return result;
+
+        size_t len = strlen(m_memory_cgroup_path);
+        len += strlen(MEM_LIMIT_FILENAME);
+        mem_limit_filename = (char*)PAL_malloc(len+1);
+        if (mem_limit_filename == nullptr)
+            return result;
+
+        strcpy_s(mem_limit_filename, len+1, m_memory_cgroup_path);
+        strcat_s(mem_limit_filename, len+1, MEM_LIMIT_FILENAME);
+        result = ReadMemoryValueFromFile(mem_limit_filename, val);
+        PAL_free(mem_limit_filename);
+        return result;
+    }
+private:
+    char* FindMemoryHierarchyMount()
+    {
+        char *line = nullptr;
+        size_t lineLen = 0, maxLineLen = 0;
+        char *filesystemType = nullptr;
+        char *options = nullptr;
+        char* mountpath = nullptr;
+
+        FILE *mountinfofile = fopen(PROC_MOUNTINFO_FILENAME, "r");
+        if (mountinfofile == nullptr)
+            goto done;
+
+        while (getline(&line, &lineLen, mountinfofile) != -1)
+        {
+            if (filesystemType == nullptr || lineLen > maxLineLen)
+            {
+                PAL_free(filesystemType);
+                PAL_free(options);
+                filesystemType = (char*)PAL_malloc(lineLen+1);
+                if (filesystemType == nullptr)
+                    goto done;
+                options = (char*)PAL_malloc(lineLen+1);
+                if (options == nullptr)
+                    goto done;
+                maxLineLen = lineLen;
+            }
+            char* separatorChar = strchr(line, '-');
+
+            // See man page of proc to get format for /proc/self/mountinfo file
+            int sscanfRet = sscanf_s(separatorChar, 
+                                     "- %s %*s %s",
+                                     filesystemType, lineLen+1,
+                                     options, lineLen+1);
+            if (sscanfRet != 2)
+            {
+                _ASSERTE(!"Failed to parse mount info file contents with sscanf_s.");
+                goto done;
+            }
+
+            if (strncmp(filesystemType, "cgroup", 6) == 0)
+            {
+                char* context = nullptr;
+                char* strTok = strtok_s(options, ",", &context); 
+                while (strTok != nullptr)
+                {
+                    if (strncmp("memory", strTok, 6) == 0)
+                    {
+                        mountpath = (char*)PAL_malloc(lineLen+1);
+                        if (mountpath == nullptr)
+                            goto done;
+
+                        sscanfRet = sscanf_s(line,
+                                             "%*s %*s %*s %*s %s ",
+                                             mountpath, lineLen+1);
+                        if (sscanfRet != 1)
+                        {
+                            PAL_free(mountpath);
+                            mountpath = nullptr;
+                            _ASSERTE(!"Failed to parse mount info file contents with sscanf_s.");
+                        }
+                        goto done;
+                    }
+                    strTok = strtok_s(nullptr, ",", &context);
+                }
+            }
+        }
+    done:
+        PAL_free(filesystemType);
+        PAL_free(options);
+        free(line);
+        if (mountinfofile)
+            fclose(mountinfofile);
+        return mountpath;
+    }
+
+    char* FindCGroupPathForMemorySubsystem()
+    {
+        char *line = nullptr;
+        size_t lineLen = 0;
+        size_t maxLineLen = 0;
+        char *subsystem_list = nullptr;
+        char *cgroup_path = nullptr;
+        bool result = false;
+
+        FILE *cgroupfile = fopen(PROC_CGROUP_FILENAME, "r");
+        if (cgroupfile == nullptr)
+            goto done;
+
+        while (!result && getline(&line, &lineLen, cgroupfile) != -1)
+        {
+            if (subsystem_list == nullptr || lineLen > maxLineLen)
+            {
+                PAL_free(subsystem_list);
+                PAL_free(cgroup_path);
+                subsystem_list = (char*)PAL_malloc(lineLen+1);
+                if (subsystem_list == nullptr)
+                    goto done;
+                cgroup_path = (char*)PAL_malloc(lineLen+1);
+                if (cgroup_path == nullptr)
+                    goto done;
+                maxLineLen = lineLen;
+            }
+
+            // See man page of proc to get format for /proc/self/cgroup file
+            int sscanfRet = sscanf_s(line, 
+                                     "%*[^:]:%[^:]:%s",
+                                     subsystem_list, lineLen+1,
+                                     cgroup_path, lineLen+1);
+            if (sscanfRet != 2)
+            {
+                _ASSERTE(!"Failed to parse cgroup info file contents with sscanf_s.");
+                goto done;
+            }
+
+            char* context = nullptr;
+            char* strTok = strtok_s(subsystem_list, ",", &context); 
+            while (strTok != nullptr)
+            {
+                if (strncmp("memory", strTok, 6) == 0)
+                {
+                    result = true;
+                    break;  
+                }
+                strTok = strtok_s(nullptr, ",", &context);
+            }
+        }
+    done:
+        PAL_free(subsystem_list);
+        if (!result)
+        {
+            PAL_free(cgroup_path);
+            cgroup_path = nullptr;
+        }
+        free(line);
+        if (cgroupfile)
+            fclose(cgroupfile);
+        return cgroup_path;
+    }
+
+    bool ReadMemoryValueFromFile(const char* filename, size_t* val)
+    {
+        bool result = false;
+        char *line = nullptr;
+        size_t lineLen = 0;
+        char* endptr = nullptr;
+        size_t num = 0, l, multiplier;
+
+        if (val == nullptr)
+            return false;
+
+        FILE* file = fopen(filename, "r");
+        if (file == nullptr)
+            goto done;
+        
+        if (getline(&line, &lineLen, file) == -1)
+            goto done;
+
+        errno = 0;
+        num = strtoull(line, &endptr, 0); 
+        if (errno != 0)
+            goto done;
+
+        multiplier = 1;
+        switch(*endptr)
+        {
+            case 'g':
+            case 'G': multiplier = 1024;
+            case 'm': 
+            case 'M': multiplier = multiplier*1024;
+            case 'k':
+            case 'K': multiplier = multiplier*1024;
+        }
+
+        *val = num * multiplier;
+        result = true;
+        if (*val/multiplier != num)
+            result = false;
+    done:
+        if (file)
+            fclose(file);
+        free(line);    
+        return result;
+    }
+};
+
+
+size_t
+PALAPI
+PAL_GetRestrictedPhysicalMemoryLimit()
+{
+    CGroup cgroup;
+    size_t physical_memory_limit;
+
+    if (!cgroup.GetPhysicalMemoryLimit(&physical_memory_limit))
+         physical_memory_limit = SIZE_T_MAX;
+
+    struct rlimit curr_rlimit;
+    size_t rlimit_soft_limit = (size_t)RLIM_INFINITY;
+    if (getrlimit(RLIMIT_AS, &curr_rlimit) == 0)
+    {
+        rlimit_soft_limit = curr_rlimit.rlim_cur;
+    }
+    physical_memory_limit = min(physical_memory_limit, rlimit_soft_limit);
+
+    // Ensure that limit is not greater than real memory size
+    long pages = sysconf(_SC_PHYS_PAGES);
+    if (pages != -1) 
+    {
+        long pageSize = sysconf(_SC_PAGE_SIZE);
+        if (pageSize != -1)
+        {
+            physical_memory_limit = min(physical_memory_limit, 
+                                        (size_t)pages * pageSize);
+        }
+    }
+
+    if(physical_memory_limit == SIZE_T_MAX)
+        physical_memory_limit = 0;
+    return physical_memory_limit;
+}
+
+BOOL
+PALAPI
+PAL_GetWorkingSetSize(size_t* val)
+{
+    BOOL result = false;
+    size_t linelen;
+    char* line = nullptr;
+
+    if (val == nullptr)
+        return FALSE;
+
+    FILE* file = fopen(PROC_STATM_FILENAME, "r");
+    if (file != nullptr && getline(&line, &linelen, file) != -1)
+    {
+        char* context = nullptr;
+        char* strTok = strtok_s(line, " ", &context); 
+        strTok = strtok_s(nullptr, " ", &context); 
+
+        errno = 0;
+        *val = strtoull(strTok, nullptr, 0); 
+        if(errno == 0)
+        {
+            *val = *val * VIRTUAL_PAGE_SIZE;
+            result = true;
+        }
+    }
+
+    if (file)
+        fclose(file);
+    free(line);
+    return result;
+}

--- a/src/pal/tests/palsuite/miscellaneous/CGroup/CMakeLists.txt
+++ b/src/pal/tests/palsuite/miscellaneous/CGroup/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.12.2)
+
+add_subdirectory(test1)
+

--- a/src/pal/tests/palsuite/miscellaneous/CGroup/test1/CMakeLists.txt
+++ b/src/pal/tests/palsuite/miscellaneous/CGroup/test1/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.12.2)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(SOURCES
+  test.cpp
+)
+
+add_executable(paltest_cgroup_test1
+  ${SOURCES}
+)
+
+add_dependencies(paltest_cgroup_test1 coreclrpal)
+
+target_link_libraries(paltest_cgroup_test1
+  ${COMMON_TEST_LIBRARIES}
+)

--- a/src/pal/tests/palsuite/miscellaneous/CGroup/test1/test.cpp
+++ b/src/pal/tests/palsuite/miscellaneous/CGroup/test1/test.cpp
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*============================================================
+**
+** Source: test.c
+**
+** Purpose: Test for CGroup
+**
+**
+**  Steps to run this test on ubuntu:
+**  1. sudo apt-get install cgroup-bin
+**  2. sudo vi /etc/default/grub
+**     Add cgroup_enable=memory swapaccount=1 to GRUB_CMDLINE_LINUX_DEFAULT
+**  3. sudo update-grub
+**  4. reboot
+**  5. sudo cgcreate -g cpu,memory:/myGroup -a <username>:<username> -t <username>:<username>
+**  6. echo 4M > /sys/fs/cgroup/memory/mygroup/memory.limit_in_bytes
+**  7. echo 4M > /sys/fs/cgroup/memory/mygroup/memory.memsw.limit_in_bytes
+**  8. cgexe -g memory:/mygroup --sticky <application>
+**=========================================================*/
+
+#include <palsuite.h>
+
+int __cdecl main(int argc,char *argv[]) 
+{
+
+    /*
+     * Initialize the PAL and return FAILURE if this fails
+     */
+
+    if(0 != (PAL_Initialize(argc, argv)))
+    {
+      return FAIL;
+    }
+
+    size_t mem_limit = PAL_GetRestrictedPhysicalMemoryLimit();
+
+    FILE* file = fopen("/sys/fs/cgroup/memory/mygroup/memory.limit_in_bytes", "r");
+    if(file != NULL)
+    {
+        if(mem_limit != 4194304)
+            Fail("Memory limit obtained from PAL_GetRestrictedPhysicalMemory is not 4MB\n");
+        fclose(file); 
+    }
+
+    PAL_Terminate();
+    return PASS;
+}
+
+
+

--- a/src/pal/tests/palsuite/miscellaneous/CGroup/test1/testinfo.dat
+++ b/src/pal/tests/palsuite/miscellaneous/CGroup/test1/testinfo.dat
@@ -1,0 +1,12 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+Version = 1.0
+Section = Miscellaneous
+Function = CGroup
+Name = Positive Test for CGroup
+TYPE = DEFAULT
+EXE1 = test
+Description
+= Test to see if Cgroup memory limit works properly 

--- a/src/pal/tests/palsuite/miscellaneous/CMakeLists.txt
+++ b/src/pal/tests/palsuite/miscellaneous/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12.2)
 
+add_subdirectory(CGroup)
 add_subdirectory(CharNextA)
 add_subdirectory(CharNextExA)
 add_subdirectory(CloseHandle)


### PR DESCRIPTION
This adds implementation in pal to get memory limit from cgroups. Memory limit values are written in file <path_to_memory_cgroup>/memory.limit_in_bytes and <path_to_memory_cgroup>/memory.memsw.limit_int_bytes. path_to_memory_cgroup is <path_to_memory_hierarchy>/<cgroup_name>. cgroup_name can be found in file /proc/self/cgroup. <path_to_memory_hierarchy>is normally set to /sys/fs/cgroup/memory. However this is not the standard. It can be changed to any mount point. Standard way of getting that value is from /proc/self/mountinfo. 

Note: CGroup implementation is not available on OSX. Docker does not run natively on OSX. It runs under a light-weigth hypervisor which runs a linux distro and you add container on top of it. So the current implementation so work just fine in this scenario.