### PR TITLE
Support cross compiling for Zesty

### DIFF
--- a/cross/arm/sources.list.zesty
+++ b/cross/arm/sources.list.zesty
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ zesty main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ zesty-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ zesty-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ zesty-security main restricted universe multiverse

--- a/cross/arm64/sources.list.zesty
+++ b/cross/arm64/sources.list.zesty
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ zesty main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ zesty-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ zesty-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ zesty-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ zesty-security main restricted universe multiverse

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -5,7 +5,7 @@ usage()
     echo "Usage: $0 [BuildArch] [LinuxCodeName] [lldbx.y] [--skipunmount]"
     echo "BuildArch can be: arm(default), armel, arm64, x86"
     echo "LinuxCodeName - optional, Code name for Linux, can be: trusty(default), vivid, wily, xenial, zesty. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
-    echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8, no-lldb"
+    echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8, lldb3.9, lldb4.0, no-lldb"
     echo "--skipunmount - optional, will skip the unmount of rootfs folder."
     exit 1
 }

--- a/cross/build-rootfs.sh
+++ b/cross/build-rootfs.sh
@@ -4,7 +4,7 @@ usage()
 {
     echo "Usage: $0 [BuildArch] [LinuxCodeName] [lldbx.y] [--skipunmount]"
     echo "BuildArch can be: arm(default), armel, arm64, x86"
-    echo "LinuxCodeName - optional, Code name for Linux, can be: trusty(default), vivid, wily, xenial. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
+    echo "LinuxCodeName - optional, Code name for Linux, can be: trusty(default), vivid, wily, xenial, zesty. If BuildArch is armel, LinuxCodeName is jessie(default) or tizen."
     echo "lldbx.y - optional, LLDB version, can be: lldb3.6(default), lldb3.8, no-lldb"
     echo "--skipunmount - optional, will skip the unmount of rootfs folder."
     exit 1
@@ -70,6 +70,12 @@ for i in "$@" ; do
         lldb3.8)
             __LLDB_Package="lldb-3.8-dev"
             ;;
+        lldb3.9)
+            __LLDB_Package="lldb-3.9-dev"
+            ;;
+        lldb4.0)
+            __LLDB_Package="lldb-4.0-dev"
+            ;;
         no-lldb)
             unset __LLDB_Package
             ;;
@@ -86,6 +92,11 @@ for i in "$@" ; do
         xenial)
             if [ "$__LinuxCodeName" != "jessie" ]; then
                 __LinuxCodeName=xenial
+            fi
+            ;;
+        zesty)
+            if [ "$__LinuxCodeName" != "jessie" ]; then
+                __LinuxCodeName=zesty
             fi
             ;;
         jessie)


### PR DESCRIPTION
Adds support for cross compiling for Ubuntu Zesty, 17.04

It's of interest because Zesty is the first Ubuntu release which includes liblldb-*-dev for arm64, so if you want to cross compile with support for the lldb plugin, you have to target this release.

If approved I'll also port to corefx and core-setup.