### PR TITLE
[x86/Linux] Relax maxAllowedStackDepth constraint

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -3203,6 +3203,7 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
                                         (compiler->compTailCallUsed ? 4 : 0); // CORINFO_HELP_TAILCALL args
 #if defined(UNIX_X86_ABI)
         maxAllowedStackDepth += genTypeStSz(TYP_INT) * 3; // stack align for x86 - allow up to 3 INT's for padding
+        maxAllowedStackDepth += compiler->fgPtrArgCntMax; // stack align for x86 - allow up to 1 INT for each argument
 #endif
         noway_assert(getEmitter()->emitMaxStackDepth <= maxAllowedStackDepth);
     }


### PR DESCRIPTION
 float64 arguments may have 4-byte additional padding, which results in #10059.

This commit relaxes maxAllowedStackDepth to fix #10059. 
