### PR TITLE
[x86/Linux][GDB-JIT] Fix crash after changing default calling convention

### DIFF
--- a/src/vm/gdbjithelpers.h
+++ b/src/vm/gdbjithelpers.h
@@ -27,7 +27,7 @@ struct MethodDebugInfo
     int localsSize;
 };
 
-typedef BOOL (STDCALL *GetInfoForMethodDelegate)(const char*, unsigned int, MethodDebugInfo& methodDebugInfo);
+typedef BOOL (CALLBACK *GetInfoForMethodDelegate)(const char*, unsigned int, MethodDebugInfo& methodDebugInfo);
 extern GetInfoForMethodDelegate getInfoForMethodDelegate;
 
 #endif // !__GDBJITHELPERS_H__


### PR DESCRIPTION
This PR fixes crash of GDB JIT interface after changing default calling convention to cdecl in PR #9977
@janvorli @jkotas PTAL
\CC: @parjong 
