### PR TITLE
Updating tests/runtest.cmd to use delayed expansion for instances of `_msbuildexe`

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -120,7 +120,7 @@ if /i "%__VSVersion%" == "vs2017" (
   set "__VCToolsRoot=%VS140COMNTOOLS%\..\..\VC"
 
   set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
-  if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
+  if not exist !_msbuildexe! set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
 )
 
 :: Does VS really exist?


### PR DESCRIPTION
Resolves https://github.com/dotnet/coreclr/issues/10091