### PR TITLE
Fix overflow when computing dwWeight in CPUGroupInfo::InitCPUGroupInfoArray

### DIFF
--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -964,8 +964,10 @@ DWORD LCM(DWORD u, DWORD v)
         dwWeight = LCM(dwWeight, (DWORD)m_CPUGroupInfoArray[i].nr_active);
     }
 
-    //NOTE: the weight setting should work fine with 4 CPU groups upto 64 LPs each. the minimum number of threads
-    //     per group before the weight overflow is 2^32/(2^6x2^6x2^6) = 2^14 (i.e. 16K threads)
+    // The number of threads per group that can be supported will depend on the number of CPU groups
+    // and the number of LPs within each processor group. For example, when the number of LPs within
+    // CPU groups are the same and are 64, the number of threads per group before weight overflow
+    // would be 2^32/2^6 = 2^26 (64M threads)
     for (DWORD i = 0; i < m_nGroups; i++)
     {
         m_CPUGroupInfoArray[i].groupWeight = dwWeight / (DWORD)m_CPUGroupInfoArray[i].nr_active;

--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -879,6 +879,27 @@ BYTE * ClrVirtualAllocWithinRange(const BYTE *pMinAddr,
 #endif
 }
 
+#if !defined(FEATURE_REDHAWK) && defined(_TARGET_AMD64_) && !defined(FEATURE_PAL)
+// Calculate greatest common divisor
+DWORD GCD(DWORD u, DWORD v)
+{
+    while (v != 0)
+    {
+        DWORD dwTemp = v;
+        v = u % v;
+        u = dwTemp;
+    }
+
+    return u;
+}
+
+// Calculate least common multiple
+DWORD LCM(DWORD u, DWORD v)
+{
+    return u / GCD(u, v) * v;
+}
+#endif
+
 /*static*/ BOOL CPUGroupInfo::InitCPUGroupInfoArray()
 {
     CONTRACTL
@@ -940,7 +961,7 @@ BYTE * ClrVirtualAllocWithinRange(const BYTE *pMinAddr,
         m_CPUGroupInfoArray[i].nr_active   = (WORD)pRecord->Group.GroupInfo[i].ActiveProcessorCount;
         m_CPUGroupInfoArray[i].active_mask = pRecord->Group.GroupInfo[i].ActiveProcessorMask;
         m_nProcessors += m_CPUGroupInfoArray[i].nr_active;
-        dwWeight *= (DWORD)m_CPUGroupInfoArray[i].nr_active;
+        dwWeight = LCM(dwWeight, (DWORD)m_CPUGroupInfoArray[i].nr_active);
     }
 
     //NOTE: the weight setting should work fine with 4 CPU groups upto 64 LPs each. the minimum number of threads

--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -965,8 +965,8 @@ DWORD LCM(DWORD u, DWORD v)
     }
 
     // The number of threads per group that can be supported will depend on the number of CPU groups
-    // and the number of LPs within each processor group. For example, when the number of LPs within
-    // CPU groups are the same and are 64, the number of threads per group before weight overflow
+    // and the number of LPs within each processor group. For example, when the number of LPs in
+    // CPU groups is the same and is 64, the number of threads per group before weight overflow
     // would be 2^32/2^6 = 2^26 (64M threads)
     for (DWORD i = 0; i < m_nGroups; i++)
     {


### PR DESCRIPTION
`dwWeight` is computed as nr_active<sup>m_nGroups</sup> which can overflow as the number of CPU groups increase.  This fix uses least common multiple of nr_active of different CPU groups to  compute `dwWeight` instead.
@Maoni0 PTAL - this should address `DivideByZeroException` issue on machines with large number of cores, but I don't have access to such machine to test at the moment.