### PR TITLE
Optimize Span.Clear() on AMD64

### DIFF
--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -614,7 +614,7 @@ namespace System
                 return;
             
 #if AMD64
-            if (byteLength > uint.MaxValue) goto PInvoke;
+            if (byteLength > 4096) goto PInvoke;
             Unsafe.InitBlockUnaligned(ref b, 0, (uint)byteLength);
             return;
 #endif // AMD64

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -612,7 +612,13 @@ namespace System
         {
             if (byteLength == 0)
                 return;
-
+            
+#if AMD64
+            if (byteLength > uint.MaxValue) goto PInvoke;
+            Unsafe.InitBlockUnaligned(ref b, 0, (uint)byteLength);
+            return;
+#endif // AMD64
+            // TODO: Optimize this method on X86 machine
             // Note: It's important that this switch handles lengths at least up to 22.
             // See notes below near the main loop for why.
 


### PR DESCRIPTION
This PR optimizes `Span.Clear()` on AMD64 by using `initblk `IL to call `JIT_MemSet`. Before 512 bytes, the baseline uses C# manged implementation. And after 512 Byte, it eventually calls CRT `memset`, which uses `rep stosb` for this copy bucket. The prototype calls `JIT_MemSet`, which has better implementation for short length up to 512 bytes and same `rep stosb` after 512 bytes. Performance measurements were made on a Skylake Desktop - Intel(R) Core(TM)i7-6700K CPU @ 4.00 GHz 32 GB RAM with Windows 10 Enterprise. 

One micro benchmark as shown below is used to test performance gain. The performance gain (from 22% to 58%) is shown in below table.

            begin = DateTime.Now.Ticks;
            for (uint i = 0; i < ITERATION; i++)
            {
                byteSpan.Clear();
            }
            time = DateTime.Now.Ticks - begin;

![image](https://cloud.githubusercontent.com/assets/18431130/23818241/3d5798cc-05ae-11e7-9e4c-79e6ddd208dc.png)



Fix https://github.com/dotnet/coreclr/issues/9698