### PR TITLE
Remove dead code

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7108,12 +7108,6 @@ fgArgTabEntryPtr Compiler::gtArgEntryByNode(GenTreePtr call, GenTreePtr node)
         {
             return curArgTabEntry;
         }
-#ifdef PROTO_JIT
-        else if (node->OperGet() == GT_RELOAD && node->gtOp.gtOp1 == curArgTabEntry->node)
-        {
-            return curArgTabEntry;
-        }
-#endif // PROTO_JIT
         else if (curArgTabEntry->parent != nullptr)
         {
             assert(curArgTabEntry->parent->OperIsList());


### PR DESCRIPTION
Remove code under `#ifdef PROTO_JIT`, which hasn't been defined
in a long time. I'm presuming that since this hasn't been defined
in a long time that the code isn't needed.
