### PR TITLE
Move adjustments to genStackLevel into functions

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -162,6 +162,36 @@ private:
     //
     unsigned genStackLevel;
 
+    void SubtractStackLevel(unsigned adjustment)
+    {
+        assert(genStackLevel >= adjustment);
+        unsigned newStackLevel = genStackLevel - adjustment;
+        if (genStackLevel != newStackLevel)
+        {
+            JITDUMP("Adjusting stack level from %d to %d\n", genStackLevel, newStackLevel);
+        }
+        genStackLevel = newStackLevel;
+    }
+
+    void AddStackLevel(unsigned adjustment)
+    {
+        unsigned newStackLevel = genStackLevel + adjustment;
+        if (genStackLevel != newStackLevel)
+        {
+            JITDUMP("Adjusting stack level from %d to %d\n", genStackLevel, newStackLevel);
+        }
+        genStackLevel = newStackLevel;
+    }
+
+    void SetStackLevel(unsigned newStackLevel)
+    {
+        if (genStackLevel != newStackLevel)
+        {
+            JITDUMP("Setting stack level from %d to %d\n", genStackLevel, newStackLevel);
+        }
+        genStackLevel = newStackLevel;
+    }
+
 #if STACK_PROBES
     // Stack Probes
     bool genNeedPrologStackProbe;

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1663,14 +1663,14 @@ void CodeGen::genAdjustStackLevel(BasicBlock* block)
     {
         noway_assert(block->bbFlags & BBF_JMP_TARGET);
 
-        genStackLevel = compiler->fgThrowHlpBlkStkLevel(block) * sizeof(int);
+        SetStackLevel(compiler->fgThrowHlpBlkStkLevel(block) * sizeof(int));
 
         if (genStackLevel != 0)
         {
 #ifdef _TARGET_X86_
             getEmitter()->emitMarkStackLvl(genStackLevel);
             inst_RV_IV(INS_add, REG_SPBASE, genStackLevel, EA_PTRSIZE);
-            genStackLevel = 0;
+            SetStackLevel(0);
 #else  // _TARGET_X86_
             NYI("Need emitMarkStackLvl()");
 #endif // _TARGET_X86_
@@ -3927,12 +3927,12 @@ void CodeGen::genGCWriteBarrier(GenTreePtr tgt, GCInfo::WriteBarrierForm wbf)
         }
 #endif // DEBUG
 #endif // 0
-        genStackLevel += 4;
+        AddStackLevel(4);
         inst_IV(INS_push, wbKind);
         genEmitHelperCall(helper,
                           4,           // argSize
                           EA_PTRSIZE); // retSize
-        genStackLevel -= 4;
+        SubtractStackLevel(4);
     }
     else
     {
@@ -7567,7 +7567,7 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed)
 
     /* Restore the stack level */
 
-    genStackLevel = saveStackLvl2;
+    SetStackLevel(saveStackLvl2);
 
 #else  // target
     NYI("Emit Profiler Enter callback");
@@ -7796,7 +7796,7 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper /*= CORINFO_HELP_PROF_FC
 #endif // target
 
     /* Restore the stack level */
-    genStackLevel = saveStackLvl2;
+    SetStackLevel(saveStackLvl2);
 }
 
 #endif // PROFILING_SUPPORTED
@@ -11148,7 +11148,7 @@ unsigned CodeGen::getFirstArgWithStackSlot()
 //
 void CodeGen::genSinglePush()
 {
-    genStackLevel += sizeof(void*);
+    AddStackLevel(REGSIZE_BYTES);
 }
 
 //------------------------------------------------------------------------
@@ -11156,7 +11156,7 @@ void CodeGen::genSinglePush()
 //
 void CodeGen::genSinglePop()
 {
-    genStackLevel -= sizeof(void*);
+    SubtractStackLevel(REGSIZE_BYTES);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -5226,7 +5226,7 @@ void CodeGen::genCodeForTreeLeaf_GT_JMP(GenTreePtr tree)
 #endif //_TARGET_X86_
 
         /* Restore the stack level */
-        genStackLevel = saveStackLvl2;
+        SetStackLevel(saveStackLvl2);
     }
 #endif // PROFILING_SUPPORTED
 
@@ -12744,7 +12744,7 @@ void CodeGen::genCodeForBBlist()
 
         /* Both stacks are always empty on entry to a basic block */
 
-        genStackLevel = 0;
+        SetStackLevel(0);
 #if FEATURE_STACK_FP_X87
         genResetFPstkLevel();
 #endif // FEATURE_STACK_FP_X87
@@ -12950,7 +12950,7 @@ void CodeGen::genCodeForBBlist()
             }
         }
 
-        genStackLevel -= savedStkLvl;
+        SubtractStackLevel(savedStkLvl);
 
         gcInfo.gcMarkRegSetNpt(gcrefRegs | byrefRegs);
 
@@ -16347,7 +16347,7 @@ size_t CodeGen::genPushArgList(GenTreePtr call)
                         }
 
                         inst_RV_IV(INS_sub, REG_SPBASE, stkDisp, EA_PTRSIZE);
-                        genStackLevel += stkDisp;
+                        AddStackLevel(stkDisp);
 
                         while (curDisp < stkDisp)
                         {
@@ -18571,7 +18571,7 @@ regMaskTP CodeGen::genCodeForCall(GenTreePtr call, bool valUsed)
 #endif //_TARGET_X86_
 
         /* Restore the stack level */
-        genStackLevel = saveStackLvl2;
+        SetStackLevel(saveStackLvl2);
     }
 
 #endif // PROFILING_SUPPORTED
@@ -19669,7 +19669,7 @@ regMaskTP CodeGen::genCodeForCall(GenTreePtr call, bool valUsed)
 
     /* The function will pop all arguments before returning */
 
-    genStackLevel = saveStackLvl;
+    SetStackLevel(saveStackLvl);
 
     /* No trashed registers may possibly hold a pointer at this point */
     CLANG_FORMAT_COMMENT_ANCHOR;

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -296,7 +296,7 @@ void CodeGen::genCodeForBBlist()
 
         /* Both stacks are always empty on entry to a basic block */
 
-        genStackLevel = 0;
+        SetStackLevel(0);
         genAdjustStackLevel(block);
         savedStkLvl = genStackLevel;
 
@@ -490,7 +490,7 @@ void CodeGen::genCodeForBBlist()
             }
         }
 
-        genStackLevel -= savedStkLvl;
+        SubtractStackLevel(savedStkLvl);
 
 #ifdef DEBUG
         // compCurLife should be equal to the liveOut set, except that we don't keep

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5196,7 +5196,7 @@ void CodeGen::genCallInstruction(GenTreePtr node)
 
 #if defined(_TARGET_X86_)
     // The call will pop its arguments.
-    genStackLevel -= stackArgBytes;
+    SubtractStackLevel(stackArgBytes);
 #endif // defined(_TARGET_X86_)
 
     // Update GC info:
@@ -7535,7 +7535,7 @@ bool CodeGen::genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk)
     {
         const unsigned argSize = genTypeSize(putArgStk);
         inst_RV_IV(INS_sub, REG_SPBASE, argSize, EA_PTRSIZE);
-        genStackLevel += argSize;
+        AddStackLevel(argSize);
         m_pushStkArg = false;
         return true;
     }
@@ -7579,7 +7579,7 @@ bool CodeGen::genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk)
     {
         m_pushStkArg = false;
         inst_RV_IV(INS_sub, REG_SPBASE, argSize, EA_PTRSIZE);
-        genStackLevel += argSize;
+        AddStackLevel(argSize);
         return true;
     }
 }
@@ -7667,7 +7667,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
             {
                 inst_IV(INS_push, 0);
                 currentOffset -= pushSize;
-                genStackLevel += pushSize;
+                AddStackLevel(pushSize);
                 adjustment -= pushSize;
             }
             m_pushStkArg = true;
@@ -7689,7 +7689,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
                 // Adjust the stack pointer to the next slot boundary.
                 inst_RV_IV(INS_sub, REG_SPBASE, adjustment, EA_PTRSIZE);
                 currentOffset -= adjustment;
-                genStackLevel += adjustment;
+                AddStackLevel(adjustment);
             }
 
             // Does it need to be in a byte register?
@@ -7742,7 +7742,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
                     }
                 }
                 currentOffset -= TARGET_POINTER_SIZE;
-                genStackLevel += TARGET_POINTER_SIZE;
+                AddStackLevel(TARGET_POINTER_SIZE);
             }
             else
             {
@@ -7788,7 +7788,7 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
     {
         // We don't expect padding at the beginning of a struct, but it could happen with explicit layout.
         inst_RV_IV(INS_sub, REG_SPBASE, currentOffset, EA_PTRSIZE);
-        genStackLevel += currentOffset;
+        AddStackLevel(currentOffset);
     }
 }
 #endif // _TARGET_X86_
@@ -7848,7 +7848,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
         {
             inst_IV(INS_push, data->gtIntCon.gtIconVal);
         }
-        genStackLevel += argSize;
+        AddStackLevel(argSize);
     }
     else if (data->OperGet() == GT_FIELD_LIST)
     {
@@ -7947,7 +7947,7 @@ void CodeGen::genPushReg(var_types type, regNumber srcReg)
         inst_RV_IV(INS_sub, REG_SPBASE, size, EA_PTRSIZE);
         getEmitter()->emitIns_AR_R(ins, attr, srcReg, REG_SPBASE, 0);
     }
-    genStackLevel += size;
+    AddStackLevel(size);
 }
 #endif // _TARGET_X86_
 
@@ -8145,7 +8145,7 @@ void CodeGen::genPutStructArgStk(GenTreePutArgStk* putArgStk)
             {
                 getEmitter()->emitIns_S(INS_push, slotAttr, srcLclNum, srcLclOffset + offset);
             }
-            genStackLevel += TARGET_POINTER_SIZE;
+            AddStackLevel(TARGET_POINTER_SIZE);
         }
 #else // !defined(_TARGET_X86_)
 


### PR DESCRIPTION
Add functions AddStackLevel(), SubtractStackLevel(), and SetStackLevel()
for making any changes to genStackLevel. this allows for centralized asserts,
JitDump output, and breakpoint setting.