### PR TITLE
Fix typo in Compiler::gtHasRef()

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -2531,7 +2531,7 @@ AGAIN:
                 }
             }
 
-            if (tree->gtCall.gtCallLateArgs)
+            if (tree->gtCall.gtControlExpr)
             {
                 if (gtHasRef(tree->gtCall.gtControlExpr, lclNum, defOnly))
                 {


### PR DESCRIPTION
Maybe from copy-paste typo?