### PR TITLE
[x86/Linux] Fix IL_STUB_PInvoke with RetBuf

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -1007,6 +1007,7 @@ var_types Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
         // and also examine the clsHnd to see if it is an HFA of count one
         useType = getPrimitiveTypeForStruct(structSize, clsHnd);
     }
+
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
 #ifdef _TARGET_64BIT_

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -997,6 +997,7 @@ var_types Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
 
 #else // not UNIX_AMD64
 
+#ifndef UNIX_X86_ABI
     // The largest primitive type is 8 bytes (TYP_DOUBLE)
     // so we can skip calling getPrimitiveTypeForStruct when we
     // have a struct that is larger than that.
@@ -1007,6 +1008,7 @@ var_types Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
         // and also examine the clsHnd to see if it is an HFA of count one
         useType = getPrimitiveTypeForStruct(structSize, clsHnd);
     }
+#endif
 
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -997,7 +997,6 @@ var_types Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
 
 #else // not UNIX_AMD64
 
-#ifndef UNIX_X86_ABI
     // The largest primitive type is 8 bytes (TYP_DOUBLE)
     // so we can skip calling getPrimitiveTypeForStruct when we
     // have a struct that is larger than that.
@@ -1008,8 +1007,6 @@ var_types Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd,
         // and also examine the clsHnd to see if it is an HFA of count one
         useType = getPrimitiveTypeForStruct(structSize, clsHnd);
     }
-#endif
-
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
 #ifdef _TARGET_64BIT_

--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -1702,12 +1702,12 @@ inline BOOL HasRetBuffArg(MetaSig * pSig)
 }
 
 #ifdef UNIX_X86_ABI
+// For UNIX_X86_ABI and unmanaged function, we always need RetBuf if the return type is VALUETYPE
 inline BOOL HasRetBuffArgUnmanagedFixup(MetaSig * pSig)
 {
     WRAPPER_NO_CONTRACT;
-    CorElementType type = pSig->GetReturnTypeNormalized();
-
-    // For UNIX_X86_ABI and unmanaged function, we always need RetBuf if the return type is VALUETYPE
+    // We cannot just pSig->GetReturnType() here since it will return ELEMENT_TYPE_VALUETYPE for enums
+    CorElementType type = pSig->GetRetTypeHandleThrowing().GetVerifierCorElementType();
     return type == ELEMENT_TYPE_VALUETYPE;
 }
 #endif

--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -1415,8 +1415,11 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ComputeReturnFlags()
             }
 #endif
 
+#ifndef UNIX_X86_ABI
             if  (size <= ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE)
                 break;
+#endif
+
 #endif // UNIX_AMD64_ABI && FEATURE_UNIX_AMD64_STRUCT_PASSING
         }
 #endif // ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE

--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -1415,11 +1415,8 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ComputeReturnFlags()
             }
 #endif
 
-#ifndef UNIX_X86_ABI
             if  (size <= ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE)
                 break;
-#endif
-
 #endif // UNIX_AMD64_ABI && FEATURE_UNIX_AMD64_STRUCT_PASSING
         }
 #endif // ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE
@@ -1703,6 +1700,17 @@ inline BOOL HasRetBuffArg(MetaSig * pSig)
     ArgIterator argit(pSig);
     return argit.HasRetBuffArg();
 }
+
+#ifdef UNIX_X86_ABI
+inline BOOL HasRetBuffArgUnmanagedFixup(MetaSig * pSig)
+{
+    WRAPPER_NO_CONTRACT;
+    CorElementType type = pSig->GetReturnTypeNormalized();
+
+    // For UNIX_X86_ABI and unmanaged function, we always need RetBuf if the return type is VALUETYPE
+    return type == ELEMENT_TYPE_VALUETYPE;
+}
+#endif
 
 inline BOOL IsRetBuffPassedAsFirstArg()
 {

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -3684,10 +3684,12 @@ static void CreateNDirectStubWorker(StubState*         pss,
         // return buffer in correct register.
         // The return structure secret arg comes first, however byvalue return is processed at
         // the end because it could be the HRESULT-swapped argument which always comes last.
-        fMarshalReturnValueFirst = HasRetBuffArg(&msig);
 
 #ifdef UNIX_X86_ABI
-        fMarshalReturnValueFirst |= HasRetBuffArgUnmanagedFixup(&msig);
+        // For functions with value type class, managed and unmanaged calling convention differ
+        fMarshalReturnValueFirst = HasRetBuffArgUnmanagedFixup(&msig);
+#else // UNIX_X86_ABI
+        fMarshalReturnValueFirst = HasRetBuffArg(&msig);
 #endif // UNIX_X86_ABI
 
 #endif // defined(_TARGET_X86_) || defined(_TARGET_ARM_)

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -3685,7 +3685,12 @@ static void CreateNDirectStubWorker(StubState*         pss,
         // The return structure secret arg comes first, however byvalue return is processed at
         // the end because it could be the HRESULT-swapped argument which always comes last.
         fMarshalReturnValueFirst = HasRetBuffArg(&msig);
-#endif
+
+#ifdef UNIX_X86_ABI
+        fMarshalReturnValueFirst |= HasRetBuffArgUnmanagedFixup(&msig);
+#endif // UNIX_X86_ABI
+
+#endif // defined(_TARGET_X86_) || defined(_TARGET_ARM_)
 
     }
     

--- a/src/vm/i386/cgencpu.h
+++ b/src/vm/i386/cgencpu.h
@@ -483,10 +483,15 @@ inline BOOL IsUnmanagedValueTypeReturnedByRef(UINT sizeofvaluetype)
 {
     LIMITED_METHOD_CONTRACT;
 
+#ifndef UNIX_X86_ABI
     // odd-sized small structures are not 
     //  enregistered e.g. struct { char a,b,c; }
     return (sizeofvaluetype > 8) ||
         (sizeofvaluetype & (sizeofvaluetype - 1)); // check that the size is power of two
+#else
+    // For UNIX_X86_ABI, we always return the value type by reference regardless of its size
+    return true;
+#endif
 }
 
 #include <pshpack1.h>

--- a/src/vm/ilmarshalers.h
+++ b/src/vm/ilmarshalers.h
@@ -607,12 +607,15 @@ public:
 
             // for X86 and AMD64-Windows we bash the return type from struct to U1, U2, U4 or U8
             // and use byrefNativeReturn for all other structs.
+            // for UNIX_X86_ABI, we always need a return buffer argument for any size of structs.
             switch (nativeSize)
             {
+#ifndef UNIX_X86_ABI
                 case 1: typ = ELEMENT_TYPE_U1; break;
                 case 2: typ = ELEMENT_TYPE_U2; break;
                 case 4: typ = ELEMENT_TYPE_U4; break;
                 case 8: typ = ELEMENT_TYPE_U8; break;
+#endif
                 default: byrefNativeReturn = true; break;
             }
 #endif


### PR DESCRIPTION
Fix calling convention and IL_STUB_PInvoke for native functions
which was problematic for native functions that has
a RetBuf argument(struct size <= 8) on x86/Linux.

Fix #10027