### PR TITLE
[Ryujit/ARM32] Support shift and rotate for decomposed long

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -597,7 +597,11 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         case GT_RSZ:
         case GT_ROR:
             genCodeForShift(treeNode);
-            // genCodeForShift() calls genProduceReg()
+            break;
+
+        case GT_LSH_HI:
+        case GT_RSH_LO:
+            genCodeForShiftLong(treeNode);
             break;
 
         case GT_CAST:
@@ -1652,6 +1656,12 @@ instruction CodeGen::genGetInsForOper(genTreeOps oper, var_types type)
         case GT_SUB_HI:
             ins = INS_sbc;
             break;
+        case GT_LSH_HI:
+            ins = INS_SHIFT_LEFT_LOGICAL;
+            break;
+        case GT_RSH_LO:
+            ins = INS_SHIFT_RIGHT_LOGICAL;
+            break;
         default:
             unreached();
             break;
@@ -1797,6 +1807,69 @@ void CodeGen::genCodeForInitBlk(GenTreeBlk* initBlkNode)
 
     genConsumeBlockOp(initBlkNode, REG_ARG_0, REG_ARG_1, REG_ARG_2);
     genEmitHelperCall(CORINFO_HELP_MEMSET, 0, EA_UNKNOWN);
+}
+
+//------------------------------------------------------------------------
+// genCodeForShiftLong: Generates the code sequence for a GenTree node that
+// represents a three operand bit shift or rotate operation (<<Hi, >>Lo).
+//
+// Arguments:
+//    tree - the bit shift node (that specifies the type of bit shift to perform).
+//
+// Assumptions:
+//    a) All GenTrees are register allocated.
+//    b) The shift-by-amount in tree->gtOp.gtOp2 is a contained constant
+//
+void CodeGen::genCodeForShiftLong(GenTreePtr tree)
+{
+    // Only the non-RMW case here.
+    genTreeOps oper = tree->OperGet();
+    assert(oper == GT_LSH_HI || oper == GT_RSH_LO);
+
+    GenTree* operand = tree->gtOp.gtOp1;
+    assert(operand->OperGet() == GT_LONG);
+    assert(operand->gtOp.gtOp1->isUsedFromReg());
+    assert(operand->gtOp.gtOp2->isUsedFromReg());
+
+    GenTree* operandLo = operand->gtGetOp1();
+    GenTree* operandHi = operand->gtGetOp2();
+
+    regNumber regLo = operandLo->gtRegNum;
+    regNumber regHi = operandHi->gtRegNum;
+
+    genConsumeOperands(tree->AsOp());
+
+    var_types   targetType = tree->TypeGet();
+    instruction ins        = genGetInsForOper(oper, targetType);
+
+    GenTreePtr shiftBy = tree->gtGetOp2();
+
+    assert(shiftBy->isContainedIntOrIImmed());
+
+    unsigned int count = shiftBy->AsIntConCommon()->IconValue();
+
+    regNumber regResult = (oper == GT_LSH_HI) ? regHi : regLo;
+
+    if (regResult != tree->gtRegNum)
+    {
+        inst_RV_RV(INS_mov, tree->gtRegNum, regResult, targetType);
+    }
+
+    if (oper == GT_LSH_HI)
+    {
+        inst_RV_SH(ins, EA_4BYTE, tree->gtRegNum, count);
+        getEmitter()->emitIns_R_R_R_I(INS_OR, EA_4BYTE, tree->gtRegNum, tree->gtRegNum, regLo, 32 - count,
+                                      INS_FLAGS_DONT_CARE, INS_OPTS_LSR);
+    }
+    else
+    {
+        assert(oper == GT_RSH_LO);
+        inst_RV_SH(INS_SHIFT_RIGHT_LOGICAL, EA_4BYTE, tree->gtRegNum, count);
+        getEmitter()->emitIns_R_R_R_I(INS_OR, EA_4BYTE, tree->gtRegNum, tree->gtRegNum, regHi, 32 - count,
+                                      INS_FLAGS_DONT_CARE, INS_OPTS_LSL);
+    }
+
+    genProduceReg(tree);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -158,7 +158,7 @@ void genSetRegToIcon(regNumber reg, ssize_t val, var_types type = TYP_INT, insFl
 
 void genCodeForShift(GenTreePtr tree);
 
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) || defined(_TARGET_ARM_)
 void genCodeForShiftLong(GenTreePtr tree);
 #endif
 


### PR DESCRIPTION
 Support shift and rotate for decomposed long

1. `Lowering::TreeNodeInfoInitShiftRotate()` is implemented with code from `lsraxarch.cpp`.
2. `CodeGen::genCodeForShiftLong()` in `codegenarm.cpp` is implemented with code from `CodeGen::genCodeForTreeLng()` in `codegenlegacy.cpp` for arm.

## Code comparison between legacy and ryujit

### Example
```
    [MethodImpl(MethodImplOptions.NoInlining)]
    static ulong shl64_17_inplace(ulong shift)
    {   
        ulong x = shift;
        x = x << 17;
        return x;
    }
```

### Legacy
```
IN000d: 000038      str     r2, [sp+0x08]       // [V01 loc0]
IN000e: 00003A      str     r3, [sp+0x0c]       // [V01 loc0+0x04]
IN0010: 00003E      ldr     r2, [r3]
IN0011: 000040      ldr     r3, [r3+4]
IN0012: 000042      lsls    r3, r3, 17
IN0013: 000044      orr     r3, r3, r2 LSR 15
IN0014: 000048      lsls    r2, r2, 17
IN0015: 00004A      str     r2, [sp+0x08]       // [V01 loc0]
IN0016: 00004C      str     r3, [sp+0x0c]       // [V01 loc0+0x04]
```

### Ryujit (before)
NYI assertion observed.
```
Assert failure(PID 12809 [0x00003209], Thread: 12809 [0x3209]): Assertion failed 'NYI: Unimplemented node type <<Hi' in 'Test:shl64_17_inplace(long):long' (IL size 14)

    File: /opt/code/github/hqueue/coreclr/src/jit/lsraarm.cpp Line: 1105
    Image: /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170310debug/corerun

Aborted (core dumped)
```

### Ryujit (after)
```
IN000e: 00003E      ldr     r1, [sp+0x10]
IN000f: 000040      str     r1, [sp+0x04]       // [V04 tmp1]
IN0010: 000042      ldr     r1, [sp+0x04]       // [V04 tmp1]
IN0011: 000044      ldr     r0, [sp+0x14]       // [V01 loc0+0x04]
IN0012: 000046      lsls    r0, r0, 17
IN0013: 000048      orr     r0, r0, r1 LSR 15
IN0014: 00004C      ldr     r1, [sp+0x04]       // [V04 tmp1]
IN0015: 00004E      lsls    r1, r1, 17
IN0016: 000050      str     r1, [sp+0x10]       // [V01 loc0]
IN0017: 000052      str     r0, [sp+0x14]       // [V01 loc0+0x04]
```

(This is part of #8496.)