### PR TITLE
System.Diagnostics.Debugger.Break() should NOT be inlined.

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Debugger.cs
+++ b/src/mscorlib/src/System/Diagnostics/Debugger.cs
@@ -30,6 +30,7 @@ namespace System.Diagnostics
         // Break causes a breakpoint to be signalled to an attached debugger.  If no debugger
         // is attached, the user is asked if he wants to attach a debugger. If yes, then the 
         // debugger is launched.
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static void Break()
         {
             // Causing a break is now allowed.


### PR DESCRIPTION
Some CAS support was removed from this function about a month ago simplifying it enough to be inlined. This breaks the debugger tests. Add noinline attribute to fix this.
