### PR TITLE
[Arm64] Always add UWC_END - WIP

### DIFF
--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -79297,7 +79297,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest963\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest963\Generated963
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_PASS;NEW
 HostStyle=0
 
 [Generated407.cmd_10034]
@@ -85609,7 +85609,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest928\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest928\Generated928
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_PASS;NEW
 HostStyle=0
 
 [DevDiv_367099.cmd_10823]
@@ -86337,7 +86337,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest763\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest763\Generated763
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_PASS;NEW
 HostStyle=0
 
 [Generated1349.cmd_10914]
@@ -87313,7 +87313,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest693\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest693\Generated693
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_PASS;NEW
 HostStyle=0
 
 [Generated500.cmd_11036]
@@ -88401,7 +88401,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest688\Generate
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest688\Generated688
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_PASS;NEW
 HostStyle=0
 
 [Generated169.cmd_11172]
@@ -89577,7 +89577,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1411\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1411\Generated1411
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_PASS;NEW
 HostStyle=0
 
 [Generated303.cmd_11319]
@@ -90065,7 +90065,7 @@ RelativePath=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1412\Generat
 WorkingDir=Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1412\Generated1412
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=EXPECTED_FAIL;9457;NEW
+Categories=EXPECTED_PASS;NEW
 HostStyle=0
 
 [Generated1272.cmd_11380]


### PR DESCRIPTION
To optimize code size we only added a UWC_END code if the last code in
uecMem does not equal UWC_END. However, the uec codes are variable sized
and allow any value to follow the code. Therefore, the value has the
small possibility to equal the value of UWC_END (0x4e on arm64
and 0xFF on arm32). Which incorrectly leaves the unwind array
unterminated.

@BruceForstall @briansull ptal
/cc @dotnet/arm64-contrib @dotnet/jit-contrib @sdmaclea 