### PR TITLE
[Linux] Define critical section for cross components

### DIFF
--- a/src/inc/crosscomp.h
+++ b/src/inc/crosscomp.h
@@ -174,6 +174,29 @@ typedef struct _T_DISPATCHER_CONTEXT {
 #define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
 #define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
 
+#ifdef FEATURE_PAL
+typedef struct _T_CRITICAL_SECTION {
+    PVOID DebugInfo;
+    LONG LockCount;
+    LONG RecursionCount;
+    HANDLE OwningThread;
+    HANDLE LockSemaphore;
+    ULONG_PTR SpinCount;
+
+    BOOL bInternal;
+    volatile DWORD dwInitState;
+    union CSNativeDataStorage
+    {
+        // PAL_CS_NATIVE_DATA_SIZE for linux ARM: 80
+        BYTE rgNativeDataStorage[80];
+        void * pvAlign; // make sure the storage is machine-pointer-size aligned
+    } csnds;    
+} T_CRITICAL_SECTION, *PT_CRITICAL_SECTION, *LPT_CRITICAL_SECTION;
+#else
+#define T_CRITICAL_SECTION CRITICAL_SECTION
+#define PT_CRITICAL_SECTION PCRITICAL_SECTION
+#endif
+
 #elif defined(_AMD64_) && defined(_TARGET_ARM64_)  // Host amd64 managing ARM64 related code
 
 #ifndef CROSS_COMPILE
@@ -343,6 +366,29 @@ typedef struct _T_KNONVOLATILE_CONTEXT_POINTERS {
 
 } T_KNONVOLATILE_CONTEXT_POINTERS, *PT_KNONVOLATILE_CONTEXT_POINTERS;
 
+#ifdef FEATURE_PAL
+typedef struct _T_CRITICAL_SECTION {
+    PVOID DebugInfo;
+    LONG LockCount;
+    LONG RecursionCount;
+    HANDLE OwningThread;
+    HANDLE LockSemaphore;
+    ULONG_PTR SpinCount;
+
+    BOOL bInternal;
+    volatile DWORD dwInitState;
+    union CSNativeDataStorage
+    {
+        // PAL_CS_NATIVE_DATA_SIZE for linux ARM64: 116
+        BYTE rgNativeDataStorage[116];
+        void * pvAlign; // make sure the storage is machine-pointer-size aligned
+    } csnds;    
+} T_CRITICAL_SECTION, *PT_CRITICAL_SECTION, *LPT_CRITICAL_SECTION;
+#else
+#define T_CRITICAL_SECTION CRITICAL_SECTION
+#define PT_CRITICAL_SECTION PCRITICAL_SECTION
+#endif
+
 #else  // !(defined(_X86_) && defined(_TARGET_ARM_)) && !(defined(_AMD64_) && defined(_TARGET_ARM64_))
 
 #define T_CONTEXT CONTEXT
@@ -356,6 +402,9 @@ typedef struct _T_KNONVOLATILE_CONTEXT_POINTERS {
 
 #define T_RUNTIME_FUNCTION RUNTIME_FUNCTION
 #define PT_RUNTIME_FUNCTION PRUNTIME_FUNCTION
+
+#define T_CRITICAL_SECTION CRITICAL_SECTION
+#define PT_CRITICAL_SECTION PCRITICAL_SECTION
 
 #endif 
 

--- a/src/inc/crosscomp.h
+++ b/src/inc/crosscomp.h
@@ -189,7 +189,7 @@ typedef struct _T_CRITICAL_SECTION {
     {
         // PAL_CS_NATIVE_DATA_SIZE for linux ARM: 80
         BYTE rgNativeDataStorage[80];
-        void * pvAlign; // make sure the storage is machine-pointer-size aligned
+        VOID * pvAlign; // make sure the storage is machine-pointer-size aligned
     } csnds;    
 } T_CRITICAL_SECTION, *PT_CRITICAL_SECTION, *LPT_CRITICAL_SECTION;
 #else
@@ -381,7 +381,7 @@ typedef struct _T_CRITICAL_SECTION {
     {
         // PAL_CS_NATIVE_DATA_SIZE for linux ARM64: 116
         BYTE rgNativeDataStorage[116];
-        void * pvAlign; // make sure the storage is machine-pointer-size aligned
+        VOID * pvAlign; // make sure the storage is machine-pointer-size aligned
     } csnds;    
 } T_CRITICAL_SECTION, *PT_CRITICAL_SECTION, *LPT_CRITICAL_SECTION;
 #else

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2577,11 +2577,7 @@ PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 #warning 
 #error  PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
 #endif
-#define CS_NATIVE_DATA_STRUCT_SIZE 128
     
-// CRITICAL_SECTION should pair with PAL_CRITICAL_SECTION because it is casted explicitly.
-// CRITICAL_SECTION uses same size of CNativeDataStorage (CS_NATIVE_DATA_STRUCT_SIZE) in all architecture
-//  using extra space for compativility of critical section in cross-architecture component.
 typedef struct _CRITICAL_SECTION {
     PVOID DebugInfo;
     LONG LockCount;
@@ -2592,10 +2588,10 @@ typedef struct _CRITICAL_SECTION {
 
     BOOL bInternal;
     volatile DWORD dwInitState;
-    struct CSNativeDataStorage
+    union CSNativeDataStorage
     {
         BYTE rgNativeDataStorage[PAL_CS_NATIVE_DATA_SIZE]; 
-        BYTE rgExtraStorage[CS_NATIVE_DATA_STRUCT_SIZE - PAL_CS_NATIVE_DATA_SIZE]; // make sure the storage is machine-pointer-size aligned
+        void * pvAlign; // make sure the storage is machine-pointer-size aligned
     } csnds;    
 } CRITICAL_SECTION, *PCRITICAL_SECTION, *LPCRITICAL_SECTION;
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2577,8 +2577,11 @@ PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 #warning 
 #error  PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
 #endif
+#define CS_NATIVE_DATA_STRUCT_SIZE 128
     
-// 
+// CRITICAL_SECTION should pair with PAL_CRITICAL_SECTION because it is casted explicitly.
+// CRITICAL_SECTION uses same size of CNativeDataStorage (CS_NATIVE_DATA_STRUCT_SIZE) in all architecture
+//  using extra space for compativility of critical section in cross-architecture component.
 typedef struct _CRITICAL_SECTION {
     PVOID DebugInfo;
     LONG LockCount;
@@ -2589,10 +2592,10 @@ typedef struct _CRITICAL_SECTION {
 
     BOOL bInternal;
     volatile DWORD dwInitState;
-    union CSNativeDataStorage
+    struct CSNativeDataStorage
     {
         BYTE rgNativeDataStorage[PAL_CS_NATIVE_DATA_SIZE]; 
-        VOID * pvAlign; // make sure the storage is machine-pointer-size aligned
+        BYTE rgExtraStorage[CS_NATIVE_DATA_STRUCT_SIZE - PAL_CS_NATIVE_DATA_SIZE]; // make sure the storage is machine-pointer-size aligned
     } csnds;    
 } CRITICAL_SECTION, *PCRITICAL_SECTION, *LPCRITICAL_SECTION;
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2577,7 +2577,7 @@ PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 #warning 
 #error  PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
 #endif
-    
+
 typedef struct _CRITICAL_SECTION {
     PVOID DebugInfo;
     LONG LockCount;
@@ -2591,7 +2591,7 @@ typedef struct _CRITICAL_SECTION {
     union CSNativeDataStorage
     {
         BYTE rgNativeDataStorage[PAL_CS_NATIVE_DATA_SIZE]; 
-        void * pvAlign; // make sure the storage is machine-pointer-size aligned
+        VOID * pvAlign; // make sure the storage is machine-pointer-size aligned
     } csnds;    
 } CRITICAL_SECTION, *PCRITICAL_SECTION, *LPCRITICAL_SECTION;
 

--- a/src/vm/crst.h
+++ b/src/vm/crst.h
@@ -296,7 +296,11 @@ protected:
 #endif
 
     union {
+#ifdef CROSSGEN_COMPILE
+        T_CRITICAL_SECTION  m_criticalsection;
+#else
         CRITICAL_SECTION    m_criticalsection;
+#endif
     };
 
     typedef enum


### PR DESCRIPTION
It modifies size of critical section same in all architecture.
Finally it makes same size of Module in all architecture.
It enables cross-crossgen (x86-host/arm-target) in Linux.

related issue: #9488 