### PR TITLE
Make portable PDBs on Unix instead of no symbols at all.

### DIFF
--- a/src/ToolBox/SOS/NETCore/SOS.NETCore.csproj
+++ b/src/ToolBox/SOS/NETCore/SOS.NETCore.csproj
@@ -32,8 +32,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OsEnvironment)' == 'Unix'">
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -54,7 +53,6 @@
     </Copy>
 
     <Copy 
-      Condition="'$(OsEnvironment)' != 'Unix'"
       SourceFiles="$(OutputPath)$(AssemblyName).pdb"
       DestinationFolder="$(BinDir)\PDB"
       SkipUnchangedFiles="false"

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -81,10 +81,9 @@
     <DebugType>pdbOnly</DebugType>
     <DefineConstants>TRACE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-  <!-- Roslyn does not support writing PDBs on Unix -->
+  <!-- Make portable PDBs on Unix -->
   <PropertyGroup Condition="'$(OsEnvironment)' == 'Unix'">
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsOSX)' == 'true'">

--- a/src/mscorlib/facade/mscorlib.csproj
+++ b/src/mscorlib/facade/mscorlib.csproj
@@ -48,10 +48,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Release|AnyCPU'" />
 
-  <!-- Roslyn does not support writing PDBs on Unix -->
+  <!-- Make portable PDBs on Unix -->
   <PropertyGroup Condition="'$(OsEnvironment)' == 'Unix'">
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <!-- Output paths -->

--- a/src/mscorlib/ref/mscorlib.csproj
+++ b/src/mscorlib/ref/mscorlib.csproj
@@ -39,10 +39,9 @@
     <DefineConstants>$(DefineConstants);FEATURE_COREFX_GLOBALIZATION;FEATURE_COMINTEROP</DefineConstants>
   </PropertyGroup>
 
-  <!-- Roslyn does not support writing PDBs on Unix -->
+  <!-- Make portable PDBs on Unix -->
   <PropertyGroup Condition="'$(OsEnvironment)' == 'Unix'">
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <!-- Assembly attributes -->


### PR DESCRIPTION
When building managed code on non-Windows we can produce portable PDBs, so debugging is possible.  With this change, I can debug System.Private.CoreLib.dll on my OSX using VS Code.

/cc @ramarag @tarekgh @gkhanna79 