### PR TITLE
Copy Targeting Pack files into Core_Root for Non-Windows

### DIFF
--- a/tests/publishdependency.targets
+++ b/tests/publishdependency.targets
@@ -123,6 +123,7 @@
       </AllResolvedRuntimeDependencies>
       <RunTimeDependecyCopyLocalFile Include="@(AllResolvedRuntimeDependencies)"  Exclude="@(RunTimeDependecyExcludeFiles)"/>
       <RunTimeDependecyCopyLocal Include="@(RunTimeDependecyCopyLocalFile -> '%(File)')"  />
+      <RunTimeDependecyCopyLocal Include="$(TargetingPackPath)/*" />
     </ItemGroup>
     
     <Copy


### PR DESCRIPTION
Post merging of https://github.com/dotnet/coreclr/pull/10074, external dependencies from the Targeting Pack weren't getting copied into Core_Root on non-Windows (meaning no xunit, among other dependencies). This caused non-windows tests to fail in Helix - this PR should fix that (my fault for only running a Windows test in Helix before merging).

CC @gkhanna79 