### PR TITLE
Use working_tree_root instead of __scriptpath

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ echo "Running init-tools.sh"
 $working_tree_root/init-tools.sh
 
 # Always copy over the Tools-Override
-cp $__scriptpath/Tools-Override/* $__scriptpath/Tools > /dev/null
+cp $working_tree_root/Tools-Override/* $working_tree_root/Tools > /dev/null
 
 toolRuntime=$working_tree_root/Tools
 dotnet=$toolRuntime/dotnetcli/dotnet


### PR DESCRIPTION
This attempts to fix the following warning while build:
'cp: cannot stat ‘/Tools-Override/*’: No such file or directory'
