### PR TITLE
Remove potential overflow in SafeBSTRHandle

### DIFF
--- a/src/mscorlib/src/System/Security/SafeBSTRHandle.cs
+++ b/src/mscorlib/src/System/Security/SafeBSTRHandle.cs
@@ -13,7 +13,7 @@ namespace System.Security
 
         internal static SafeBSTRHandle Allocate(uint lenInChars)
         {
-            ulong lenInBytes = lenInChars * sizeof(char);
+            ulong lenInBytes = (ulong)lenInChars * sizeof(char);
             SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(IntPtr.Zero, lenInChars);
             if (bstr.IsInvalid) // SysAllocStringLen returns a NULL ptr when there's insufficient memory
             {

--- a/src/mscorlib/src/System/Security/SafeBSTRHandle.cs
+++ b/src/mscorlib/src/System/Security/SafeBSTRHandle.cs
@@ -13,7 +13,7 @@ namespace System.Security
 
         internal static SafeBSTRHandle Allocate(uint lenInChars)
         {
-            uint lenInBytes = lenInChars * sizeof(char);
+            ulong lenInBytes = lenInChars * sizeof(char);
             SafeBSTRHandle bstr = Interop.OleAut32.SysAllocStringLen(IntPtr.Zero, lenInChars);
             if (bstr.IsInvalid) // SysAllocStringLen returns a NULL ptr when there's insufficient memory
             {


### PR DESCRIPTION
I was working on porting SafeBSTRHandle to CoreRT and while in code review, it was noted that SafeBSTRHandle.Allocate has an opportunity for integer overflow which would be left unhandled. I fixed it in CoreRT, and figured I'd offer up the fix here as well.

This PR changes the type of the local variable lenInBytes from uint to ulong. This avoids the integer overflow and works out well because bstr.Initialize, to which lenInBytes is given as an argument, takes an argument of type ulong.