### PR TITLE
[x86/Linux] Invoke gcResetForBB() in genFuncletProlog

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10367,6 +10367,8 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
 
     ScopedSetVariable<bool> _setGeneratingProlog(&compiler->compGeneratingProlog, true);
 
+    gcInfo.gcResetForBB();
+
     compiler->unwindBegProlog();
 
     // This is the end of the OS-reported prolog for purposes of unwinding


### PR DESCRIPTION
A trivial fix.

Looks like this code is missing. It is present in all architectures other than x86.

cc: @jkotas @janvorli @parjong 