### PR TITLE
[RyuJIT/ARM32] Fix lvOnFrame for struct args

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -676,11 +676,6 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
                 codeGen->regSet.rsMaskPreSpillRegArg |= regMask;
             }
         }
-        else
-        {
-            varDsc->lvOnFrame = true; // The final home for this incoming register might be our local stack frame
-        }
-
 #else // !_TARGET_ARM_
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
         SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structDesc;
@@ -722,12 +717,11 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
             }
         }
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
+#endif // !_TARGET_ARM_
 
         // The final home for this incoming register might be our local stack frame.
         // For System V platforms the final home will always be on the local stack frame.
         varDsc->lvOnFrame = true;
-
-#endif // !_TARGET_ARM_
 
         bool canPassArgInRegisters = false;
 

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -897,7 +897,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
     JITDUMP("TreeNodeInfoInit for: ");
     DISPNODE(tree);
 
-    NYI_IF(tree->TypeGet() == TYP_STRUCT, "lowering struct");
     NYI_IF(tree->TypeGet() == TYP_DOUBLE, "lowering double");
 
     switch (tree->OperGet())
@@ -1340,11 +1339,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_LCL_FLD_ADDR:
         case GT_LCL_VAR:
         case GT_LCL_VAR_ADDR:
-        {
-            unsigned   varNum = tree->gtLclVarCommon.gtLclNum;
-            LclVarDsc* varDsc = comp->lvaTable + varNum;
-            NYI_IF(varTypeIsStruct(varDsc), "lowering struct var");
-        }
         case GT_PHYSREG:
         case GT_CLS_VAR_ADDR:
         case GT_IL_OFFSET:


### PR DESCRIPTION
This change removes struct-related NYIs introduced earlier to hide assertion failure in `raMarkStkVars` at `regalloc.cpp:6747`:
```c++
        /* Some basic checks */

        // It must be in a register, on frame, or have zero references.

        noway_assert(varDsc->lvIsInReg() || varDsc->lvOnFrame || varDsc->lvRefCnt == 0);
```
NYI stats for `CodeGenBringUpTests` with this change applied (chk build):
```
    745 codegenarm.cpp:1882 - NYI: genRegCopy
    391 lsraarm.cpp:1334 - NYI: Unimplemented node type lclHeap
    256 morph.cpp:4659 - NYI_ARM: fgMorphMultiregStructArgs
    190 lsraarm.cpp:900 - NYI: lowering double
    151 lowerarm.cpp:149 - NYI_ARM: Lowering for GT_STORE_OBJ isn't implemented
      6 lsraarm.cpp:1334 - NYI: Unimplemented node type memoryBarrier
      1 lsraarm.cpp:1334 - NYI: Unimplemented node type obj
```
(Previous stats are available in the umbrella issue #8496.)