### PR TITLE
Fix ToTitleCase Functionality for Dutch Cultures

### DIFF
--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -474,7 +474,7 @@ namespace System.Globalization
             StringBuilder result = new StringBuilder();
             string lowercaseData = null;
             // Store if the current culture is Dutch (special case)
-            bool isDutchCulture = CultureName.StartsWith("nl-",StringComparison.OrdinalIgnoreCase);
+            bool isDutchCulture = CultureName.StartsWith("nl-", StringComparison.OrdinalIgnoreCase);
 
             for (int i = 0; i < str.Length; i++)
             {

--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -482,6 +482,15 @@ namespace System.Globalization
                 charType = CharUnicodeInfo.InternalGetUnicodeCategory(str, i, out charLen);
                 if (Char.CheckLetter(charType))
                 {
+                    // Special case to check for Dutch specific titlecasing with
+                    // "IJ" characters at the beginning of word
+                    if (IsDutchCulture(str) && IsIjAtCurrentPosition(str, i))
+                    {
+                        // Increment the charLen to treat the "IJ" as a surrogate
+                        // pair and capitalize both letters
+                        charLen++;
+                    }
+
                     // Do the titlecasing for the first character of the word.
                     i = AddTitlecaseLetter(ref result, ref str, i, charLen) + 1;
 
@@ -682,6 +691,40 @@ namespace System.Globalization
                  || uc == UnicodeCategory.TitlecaseLetter
                  || uc == UnicodeCategory.ModifierLetter
                  || uc == UnicodeCategory.OtherLetter);
+        }
+
+
+        /// 
+        ///  Checks if the current culture is Dutch (i.e. "nl-BE" or "nl-NL") to
+        ///  determine if special casing rules should be applied. (Dutch Titlecasing)
+        ///
+        private bool IsDutchCulture(String str)
+        {
+            // Validate inputs
+            if (str == null)
+            {
+                throw new ArgumentNullException("string");
+            }
+
+            // Ignore if not Dutch
+            return IndexOfStringOrdinalIgnoreCase("nl-BE,nl-NL", _cultureName, 0, 11) != -1;
+        }
+
+
+        /// 
+        ///  Performs a case-insensitive check for the characters "ij" at the current
+        ///  position within a string. (Dutch Titlecasing)
+        ///
+        private bool IsIjAtCurrentPosition(String str, int position)
+        {
+            // Validate inputs
+            if (str == null)
+            {
+                throw new ArgumentNullException("string");
+            }
+
+            // Determine if "ij" is at the current position in the string
+            return IndexOfStringOrdinalIgnoreCase(str, "ij", position, 2) != -1;
         }
 
         //

--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -473,6 +473,8 @@ namespace System.Globalization
 
             StringBuilder result = new StringBuilder();
             string lowercaseData = null;
+            // Store if the current culture is Dutch (special case)
+            bool isDutchCulture = IsDutchCulture(str);
 
             for (int i = 0; i < str.Length; i++)
             {
@@ -484,7 +486,7 @@ namespace System.Globalization
                 {
                     // Special case to check for Dutch specific titlecasing with
                     // "IJ" characters at the beginning of word
-                    if (IsDutchCulture(str) && IsIjAtCurrentPosition(str, i))
+                    if (isDutchCulture && IsIjAtCurrentPosition(str, i))
                     {
                         // Increment the charLen to treat the "IJ" as a surrogate
                         // pair and capitalize both letters

--- a/src/mscorlib/src/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/src/System/Globalization/TextInfo.cs
@@ -474,7 +474,7 @@ namespace System.Globalization
             StringBuilder result = new StringBuilder();
             string lowercaseData = null;
             // Store if the current culture is Dutch (special case)
-            bool isDutchCulture = IsDutchCulture(str);
+            bool isDutchCulture = CultureName.StartsWith("nl-",StringComparison.OrdinalIgnoreCase);
 
             for (int i = 0; i < str.Length; i++)
             {
@@ -484,17 +484,18 @@ namespace System.Globalization
                 charType = CharUnicodeInfo.InternalGetUnicodeCategory(str, i, out charLen);
                 if (Char.CheckLetter(charType))
                 {
-                    // Special case to check for Dutch specific titlecasing with
-                    // "IJ" characters at the beginning of word
-                    if (isDutchCulture && IsIjAtCurrentPosition(str, i))
+                    // Special case to check for Dutch specific titlecasing with "IJ" characters 
+                    // at the beginning of a word
+                    if (isDutchCulture && i < str.Length - 1 && (str[i] == 'i' || str[i] == 'I') && (str[i+1] == 'j' || str[i+1] == 'J'))
                     {
-                        // Increment the charLen to treat the "IJ" as a surrogate
-                        // pair and capitalize both letters
-                        charLen++;
+                        result.Append("IJ");
+                        i += 2;
                     }
-
-                    // Do the titlecasing for the first character of the word.
-                    i = AddTitlecaseLetter(ref result, ref str, i, charLen) + 1;
+                    else
+                    {
+                        // Do the titlecasing for the first character of the word.
+                        i = AddTitlecaseLetter(ref result, ref str, i, charLen) + 1;
+                    }
 
                     //
                     // Convert the characters until the end of the this word
@@ -693,40 +694,6 @@ namespace System.Globalization
                  || uc == UnicodeCategory.TitlecaseLetter
                  || uc == UnicodeCategory.ModifierLetter
                  || uc == UnicodeCategory.OtherLetter);
-        }
-
-
-        /// 
-        ///  Checks if the current culture is Dutch (i.e. "nl-BE" or "nl-NL") to
-        ///  determine if special casing rules should be applied. (Dutch Titlecasing)
-        ///
-        private bool IsDutchCulture(String str)
-        {
-            // Validate inputs
-            if (str == null)
-            {
-                throw new ArgumentNullException("string");
-            }
-
-            // Ignore if not Dutch
-            return IndexOfStringOrdinalIgnoreCase("nl-BE,nl-NL", _cultureName, 0, 11) != -1;
-        }
-
-
-        /// 
-        ///  Performs a case-insensitive check for the characters "ij" at the current
-        ///  position within a string. (Dutch Titlecasing)
-        ///
-        private bool IsIjAtCurrentPosition(String str, int position)
-        {
-            // Validate inputs
-            if (str == null)
-            {
-                throw new ArgumentNullException("string");
-            }
-
-            // Determine if "ij" is at the current position in the string
-            return IndexOfStringOrdinalIgnoreCase(str, "ij", position, 2) != -1;
         }
 
         //


### PR DESCRIPTION
fixes https://github.com/dotnet/corefx/issues/16770

Added support for properly handling scenarios where the "IJ" characters at the beginning of a string were not being properly capitalized in Dutch cultures (i.e. "nl-BE" and "nl-NL") as [per Section 3.13 of the Unicode Standard](http://www.unicode.org/versions/Unicode9.0.0/ch03.pdf#page=81)

The fix basically consists of three parts:

- Determine if the current culture is Dutch (via an `IsDutchCulture()` method)
- If so, check if the current position within the string has an "IJ" at the current position (via an `IsIjAtCurrentPosition()` method).
- If both of these conditions are met, increment the `charLen` value, which will be passed to the `AddTitlecaseLetter()` method and will treat the "IJ" as a surrogate pair and capitalize both of them

I wasn't sure how granular to separate the methods or if it would be better to simply consolidate them into a single `ApplySpecialCaseForDutchCultures()` type method or similar. Another option would be to possibly store a flag for the current culture (and if it was Dutch) to avoid checking it repeated as it won't change within the context of a `TextInfo` class.

The following test cases were used to test this : 

```
[Fact]
public void ToTitleCaseDutchTest()
{
        string[] dutchCultureInfos = new string[] { "nl-BE", "nl-NL" };
        foreach (string cultureInfo in dutchCultureInfos)
        {
                TextInfo ti = CultureInfo.GetCultureInfo(cultureInfo).TextInfo;
                Assert.Equal("IJ IJ IJ IJ", ti.ToTitleCase("ij iJ Ij IJ"));
                Assert.Equal("IJzeren Eigenschappen", ti.ToTitleCase("ijzeren eigenschappen"));
                Assert.Equal("Lake IJssel", ti.ToTitleCase("lake iJssel"));
                Assert.Equal("Boba N' IJango Fett PEW PEW", ti.ToTitleCase("Boba n' Ijango fett PEW PEW"));
         }
}
```

It's worth noting that I am not a native Dutch speaker, so if any special-case scenarios need to be added, let me know.

@tarekgh 