### PR TITLE
Add support for Multiqueing jobs in Helix

### DIFF
--- a/tests/helixpublish.proj
+++ b/tests/helixpublish.proj
@@ -1,73 +1,97 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
-  <PropertyGroup>
-    <__BuildType>$(ConfigurationGroup)</__BuildType>
-  </PropertyGroup>
-
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
-  <Import Project="$(ToolsDir)CloudTest.targets" Condition="Exists('$(ToolsDir)CloudTest.targets')" />
+  <!-- CoreClr-Specific Helix test submission project. -->
 
-  <!-- Define test payload & Correlation (Core_Root) payload -->
-  <ItemGroup>
-    <TestList Include="$(TestWorkingDir)\archive\tests\*" ></TestList>
-    <CoreRootUri Include="$(TestWorkingDir)\archive\Core_Root*\*.zip" ></CoreRootUri>
-    <DummyPackages Include="$(TestWorkingDir)\archive\packages\*" ></DummyPackages>
-    <ForUpload Include="@(TestList)" ></ForUpload>
-    <ForUpload Include="@(CoreRootUri)" ></ForUpload>
-  </ItemGroup>
-
-  <!-- Define name & location of test JSON blob -->
   <PropertyGroup>
-    <SkipArchive>true</SkipArchive>
-    <PayloadTestListFilename>Tests.$(ConfigurationGroup).json</PayloadTestListFilename>
-    <PayloadTestListFile>$(TestWorkingDir)$(PayloadTestListFilename)</PayloadTestListFile>
+    <!-- Workaround for dealing with building on Linux/OSX.  
+         It doesn't seem possible to pass a connection string on the command line, as it contains ';' characters. 
+         Checking for the existence of a connection string will happen inside CloudTest.Helix.targets -->
+    <CloudDropConnectionString    Condition="'$(CloudDropConnectionString)'==''"   >DefaultEndpointsProtocol=https;AccountName=$(CloudDropAccountName);AccountKey=$(CloudDropAccessToken);EndpointSuffix=core.windows.net</CloudDropConnectionString>
+    <CloudResultsConnectionString Condition="'$(CloudResultsConnectionString)'==''">DefaultEndpointsProtocol=https;AccountName=$(CloudResultsAccountName);AccountKey=$(CloudResultsAccessToken);EndpointSuffix=core.windows.net</CloudResultsConnectionString>    
+
+    <!-- Finally, these archives represent the zips of tests that are OSPlatform specific 
+         This is used by CloudTest.Helix.Targets to generate relative blob paths for archives. -->
+    <ArchivesRoot>$(TestWorkingDir)/archive</ArchivesRoot>
+    <TestArchivesRoot>$(ArchivesRoot)/tests</TestArchivesRoot>
+
+    <RunnerScript Condition="'$(RunnerScript)' == ''">$(TestRunnerScript)</RunnerScript>
+    <SupplementalPayloadDir Condition="'$(SupplementalPayloadDir)' == ''">$(TestWorkingDir)SupplementalPayload/</SupplementalPayloadDir>
+
+    <!-- The old CloudTest.targets forced a single timeout value onto every test -->
+    <!-- Possible TODO: With the CloudTest.Helix.targets refactor, we have the ability to specify variable timeout-->
+    <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">1000</TimeoutInSeconds>
+
+    <!-- Set required properties for Helix Submission -->
+    <IsOfficial Condition="'$(OfficialBuildId)'!=''">true</IsOfficial>
+    <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd.mmss))</CurrentDate>
+
+    <HelixJobType Condition="'$(HelixJobType)'==''">test/functional/cli/</HelixJobType>
+
+    <HelixSource Condition="'$(HelixSource)'=='' And '$(IsOfficial)'!='' And '$(TestProduct)'!='' And '$(Branch)'!=''">official/$(TestProduct)/$(Branch)/</HelixSource>
+    <HelixSource Condition="'$(HelixSource)'=='' And '$(IsOfficial)'=='' And '$(TestProduct)'!='' And '$(Branch)'!=''">pr/$(TestProduct)/$(Branch)/</HelixSource>
+    <HelixSource Condition="'$(HelixSource)'==''">pr/unknown/</HelixSource>
+
+    <!-- Local path for storing submission-related files -->
+    <HelixLogFolder>$(ArchivesRoot)/</HelixLogFolder>
+
+    <!-- Properties used for submission by CloudTest.Helix.Targets-->
+    <BuildMoniker>$(CurrentDate)</BuildMoniker>
+    <BuildMoniker Condition="'$(IsOfficial)'=='true'">$(OfficialBuildId)</BuildMoniker>
+    <HelixArchLabel>$(Platform)</HelixArchLabel>
+    <HelixConfigLabel>$(ConfigurationGroup)</HelixConfigLabel>
   </PropertyGroup>
 
-  <Target Name="CreateTestListJson"
-          DependsOnTargets="CreateAzureStorage">
+  <!-- Set Helix environment vars based on target platform -->
+  <!-- This is only used in the case where property 'UseScriptRunner' is true.-->
+  <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
+    <HelixPythonPath>%HELIX_PYTHONPATH%</HelixPythonPath>
+    <RunnerScript>%HELIX_CORRELATION_PAYLOAD%\RunnerScripts\scriptrunner\scriptrunner.py</RunnerScript>
+  </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
+    <HelixPythonPath>$HELIX_PYTHONPATH</HelixPythonPath>
+    <RunnerScript>$HELIX_CORRELATION_PAYLOAD/RunnerScripts/scriptrunner/scriptrunner.py</RunnerScript>
+  </PropertyGroup>
+
+  <Target Name="CoreClrPreCloudBuild" >
+    <!-- Put anything you want to do before submitting the general purpose helix job here.
+         Helix requires properly formatted work items and accessible zip files / others to upload, which we'll construct here. -->
+    
+    <!-- Gather the test archives for this build 
+         If you change binplacing behavior and official runs break, 
+         this is a good place to check.-->
     <ItemGroup>
-      <SupplementalPayload Include="@(DummyPackages)" >
-        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/Packages.zip</RelativeBlobPath>
-      </SupplementalPayload>
-      <CorrelationPayloadUri Include="@(SupplementalPayload->'$(DropUri)%(RelativeBlobPath)$(DropUriReadOnlyToken)')" />
+      <HelixWorkItem Include="$(TestArchivesRoot)/*.zip" />
     </ItemGroup>
+    <Message Text="Full test archive collection : @(HelixWorkItem)" Importance="Low" />
 
-    <PropertyGroup>
-      <!-- flatten it into a property as msbuild chokes on @(CorrelationPayloadUri) -->
-      <CorrelationPayloadUris>@(CorrelationPayloadUri)</CorrelationPayloadUris>
-      <!-- Define Correlation Payload as a property -->
-      <CoreRootUris>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(CoreRootUri.Filename)%(CoreRootUri.Extension)$(DropUriReadOnlyToken)</CoreRootUris>
-      <CorrelationPayloadProperty>$(CorrelationPayloadUris);$(CoreRootUris)</CorrelationPayloadProperty>
-    </PropertyGroup>
+    <!-- Verify the test archives exist.  
+         NOTE: It may be better to make this an error, but in the past we chose not to as this causes a build break when triggered, versus just no tests run. -->
+    <Warning Condition="'@(HelixWorkItem->Count())' == '0'" Text="Didn't find any test archives in supplied folders!!! Review logs to see where test archive(s) were placed and fix." />
 
-    <ItemGroup>
-      <TestList>
+    <ItemGroup>      
+      <HelixCorrelationPayloadFile Include="$(ArchivesRoot)\Core_Root*\*.zip">
+        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/%(Identity)</RelativeBlobPath>
+      </HelixCorrelationPayloadFile>
+      <HelixWorkItem>
         <Command Condition="'$(TargetsWindows)' == 'true'">$(HelixPythonPath) $(RunnerScript) --script %HELIX_WORKITEM_PAYLOAD%\runtests.cmd</Command>
         <Command Condition="'$(TargetsWindows)' != 'true'">chmod +x $HELIX_WORKITEM_PAYLOAD/runtests.sh &amp;&amp; $(HelixPythonPath) $(RunnerScript) --script $HELIX_WORKITEM_PAYLOAD/runtests.sh</Command>
-        <CorrelationPayloadUris>[$(CorrelationPayloadProperty)]</CorrelationPayloadUris>
-        <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
+        <PayloadFile>%(Identity)</PayloadFile>
         <WorkItemId>%(Filename)</WorkItemId>
         <TimeoutInSeconds>$(TimeoutInSeconds)</TimeoutInSeconds>
-      </TestList>
-    </ItemGroup>
-    <WriteItemsToJson JsonFileName="$(PayloadTestListFile)" Items="@(TestList)" />
-    <!-- add test lists to the list of items for upload -->
-    <ItemGroup>
-      <ForUpload Include="$(PayloadTestListFile)">
-        <RelativeBlobPath>$(PayloadTestListFilename)</RelativeBlobPath>
-      </ForUpload>
-    </ItemGroup>
-    <!-- for completion event -->
-    <ItemGroup>
-      <TestListFile Include="$(PayloadTestListFile)">
-        <BuildCompleteJson>$(TestWorkingDir)$(OSPlatformConfig)/FuncBuildComplete.json</BuildCompleteJson>
-        <OfficialBuildJson>$(TestWorkingDir)$(OSPlatformConfig)/FuncOfficialBuild.json</OfficialBuildJson>
-        <HelixJobUploadCompletePath>$(TestWorkingDir)$(OSPlatformConfig)/helixjobuploadcomplete.sem</HelixJobUploadCompletePath>
-      </TestListFile>
+        <RelativeBlobPath>$(Platform)-$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)</RelativeBlobPath>
+      </HelixWorkItem>      
     </ItemGroup>
   </Target>
 
-  <Target Name="Build" />
+  <!-- Import this at the end so that it can compose properties as needed -->
+  <Import Project="$(ToolsDir)CloudTest.Helix.targets" />
 
+  <!-- main Entrypoint -->
+  <Target Name="Build">
+    <Message Text="CoreClr-specific Helix test upload project, beginning submission to Helix" />
+    <Message Condition="'$(EnableCloudTest)' == 'false'" Text="... skipping upload / submission due to property 'EnableCloudTest' being set to 'false'" />
+    <CallTarget Condition="'$(EnableCloudTest)' != 'false'" Targets="CoreClrPreCloudBuild;HelixCloudBuild" />
+  </Target>
+  
 </Project>

--- a/tests/src/Common/build_against_pkg_dependencies/project.json
+++ b/tests/src/Common/build_against_pkg_dependencies/project.json
@@ -26,6 +26,7 @@
     "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.42.1-x64": {}
+    "opensuse.42.1-x64": {},
+    "linux-x64": {}
   }
 }

--- a/tests/src/Common/test_dependencies/project.json
+++ b/tests/src/Common/test_dependencies/project.json
@@ -23,6 +23,7 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {}
+    "fedora.23-x64": {},
+    "linux-x64": {}
   }
 }


### PR DESCRIPTION
Switches to new CloudTest model, which allows us to enable multiqueuing jobs in Helix. I'll put together a corresponding change to the build definitions & VSO JSON blobs to enable same. For diff of helixpublish.proj, just look at the raw file - I deleted the entire old file & replaced it.