### PR TITLE
Minor fix to address ?: VC conformance improvement.

### DIFF
--- a/src/vm/dwreport.cpp
+++ b/src/vm/dwreport.cpp
@@ -2468,7 +2468,7 @@ FaultReportResult DoFaultReportWorker(      // Was Watson attempted, successful?
             {   // Look for final '\'
                 pName = wcsrchr(buf, W('\\'));
                 // If found, skip it; if not, point to full name.
-                pName = pName ? pName+1 : buf;
+                pName = pName ? pName+1 : (LPCWSTR)buf;
             }
         }
 

--- a/src/vm/eventreporter.cpp
+++ b/src/vm/eventreporter.cpp
@@ -64,7 +64,7 @@ EventReporter::EventReporter(EventReporterType type)
     {
         // If app name has a '\', consider the part after that; otherwise consider whole name.
         LPCWSTR appName =  wcsrchr(appPath, W('\\'));
-        appName = appName ? appName+1 : appPath;
+        appName = appName ? appName+1 : (LPCWSTR)appPath;
         m_Description.Append(appName);
         m_Description.Append(W("\n"));
     }


### PR DESCRIPTION
Visual C++ has made some conformance changes to conditional operator that will be available under /permissive- and which make the inference of result type of the conditional operator in these 2 places ambiguous. This happens because the class type in one of the arguments provides both: the constructor from and the conversion operator to T - LCWSTR here. To resolve the ambiguity, we add an explicit cast to one of the arguments.