### PR TITLE
Do not spill eeStack after ldtoken opcode.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3104,7 +3104,7 @@ private:
 
     // The maximum number of bytes of IL processed without clean stack state.
     // It allows to limit the maximum tree size and depth.
-    const unsigned MAX_TREE_SIZE = 200;
+    static const unsigned MAX_TREE_SIZE = 200;
     bool impCanSpillNow(OPCODE prevOpcode);
 
     struct PendingDsc

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3102,6 +3102,10 @@ private:
 
     //---------------- Spilling the importer stack ----------------------------
 
+    // The maximum tree size in the importer before it spills all trees from the stack into local variables.
+    const unsigned MAX_TREE_SIZE = 200;
+    bool impCanSpillNow(OPCODE prevOpcode);
+
     struct PendingDsc
     {
         PendingDsc*   pdNext;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3102,7 +3102,8 @@ private:
 
     //---------------- Spilling the importer stack ----------------------------
 
-    // The maximum tree size in the importer before it spills all trees from the stack into local variables.
+    // The maximum number of bytes of IL processed without clean stack state.
+    // It allows to limit the maximum tree size and depth.
     const unsigned MAX_TREE_SIZE = 200;
     bool impCanSpillNow(OPCODE prevOpcode);
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2594,13 +2594,9 @@ inline IL_OFFSETX Compiler::impCurILOffset(IL_OFFSET offs, bool callInstruction)
 //    true if it is legal, false if it could be a sequence that we do not want to divide.
 bool Compiler::impCanSpillNow(OPCODE prevOpcode)
 {
-    StackEntry& lastSE = impStackTop(0);
-    GenTreePtr  tree   = lastSE.val;
-    if (prevOpcode == CEE_LDTOKEN)
-    {
-        return false;
-    }
-    return true;
+    // Don't spill after ldtoken, because it could be a part of the InitializeArray sequence.
+    // Avoid breaking up to guarantee that impInitializeArrayIntrinsic can succeed.
+    return prevOpcode != CEE_LDTOKEN;
 }
 
 /*****************************************************************************

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2584,6 +2584,25 @@ inline IL_OFFSETX Compiler::impCurILOffset(IL_OFFSET offs, bool callInstruction)
     }
 }
 
+//------------------------------------------------------------------------
+// impCanSpillNow: check is it possible to spill all values from eeStack to local variables.
+//
+// Arguments:
+//    prevOpcode - last importer opcode
+//
+// Return Value:
+//    true if it is legal, false if it could be a sequence that we do not want to divide.
+bool Compiler::impCanSpillNow(OPCODE prevOpcode)
+{
+    StackEntry& lastSE = impStackTop(0);
+    GenTreePtr  tree   = lastSE.val;
+    if (prevOpcode == CEE_LDTOKEN)
+    {
+        return false;
+    }
+    return true;
+}
+
 /*****************************************************************************
  *
  *  Remember the instr offset for the statements
@@ -9545,7 +9564,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             /* Has it been a while since we last saw a non-empty stack (which
                guarantees that the tree depth isnt accumulating. */
 
-            if ((opcodeOffs - lastSpillOffs) > 200)
+            if ((opcodeOffs - lastSpillOffs) > MAX_TREE_SIZE && impCanSpillNow(prevOpcode))
             {
                 impSpillStackEnsure();
                 lastSpillOffs = opcodeOffs;


### PR DESCRIPTION
There is old code that spills trees on stack every 200 IL opcodes.
I suppose that it was done because there were non-linear recursive algorithms. It happened many years ago before tf source control and I was not able to find who did it.
Now we should not have them and there is no difference between 
10 trees * 100 nodes each or one tree with 1000 nodes in it.
This spilling might create perfomance regressions because some
optimizations work only with tree values.