### PR TITLE
Update SpanBench test

### DIFF
--- a/tests/src/Common/test_dependencies/project.json
+++ b/tests/src/Common/test_dependencies/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "2.0.0-beta-25118-01",
     "Microsoft.Private.CoreFx.NETCoreApp": "4.4.0-beta-25118-01",
+    "System.Memory": "4.4.0-beta-25118-01",
     "System.Runtime.CompilerServices.Unsafe": "4.4.0-beta-25118-01"
   },
   "frameworks": {


### PR DESCRIPTION
 - Re-enable the tests that were disabled in e859c309.
 - Re-work how tests are invoked from the command line to require less
   boilerplate
     - Now each test has a single [Benchmark] entrypoint
     - That entrypoint invokes its test's single inner-loop by wrapping it
       in a lambda that it passes to a new helper Invoke method (shared
       across all tests) which handles the xunit vs. command-line
       differences..
     - Main finds the entrypoints by using reflection to search for the
       [Benchmark] attributes, so the explicit list of stringified test
       names is no longer needed and the command line will run the same
       set of tests that xunit-perf does.
 - The new SpanAPI tests now get invoked when this tests is run from the
   command line as well.
 - Add [NoInlining] to the SpanAPI tests' kernels.
 - Add some heap writes and conditional writes to prevent deadcode
   optimization from eliminating tests' kernels (assuming we don't do
   interprocedural constant propagation or deadcode, or store sinking and
   final value calculation, or PRE...).
 - Split the Index SpanAPI tests into one version that uses a
   loop-invariant index and thus should get hoisted out of the loop, and
   another version that uses variant indices.