### PR TITLE
Fix Convert.FromBase64CharArray with empty array

### DIFF
--- a/src/mscorlib/shared/System/Convert.cs
+++ b/src/mscorlib/shared/System/Convert.cs
@@ -2713,6 +2713,11 @@ namespace System
 
             Contract.EndContractBlock();
 
+            if (inArray.Length == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
             unsafe
             {
                 fixed (Char* inArrayPtr = &inArray[0])


### PR DESCRIPTION
A recent changed caused a CoreFx test failure, verifying that FromBase64CharArray could be used successfully with an empty array.  It started failing with an out of range exception.

cc: @alexperovich, @jkotas 