### PR TITLE
Support devirtulization of Encoders

### DIFF
--- a/src/mscorlib/src/System/Text/EncoderBestFitFallback.cs
+++ b/src/mscorlib/src/System/Text/EncoderBestFitFallback.cs
@@ -16,7 +16,7 @@ using System.Diagnostics.Contracts;
 namespace System.Text
 {
     [Serializable]
-    internal class InternalEncoderBestFitFallback : EncoderFallback
+    internal sealed class InternalEncoderBestFitFallback : EncoderFallback
     {
         // Our variables
         internal Encoding encoding = null;

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -1430,7 +1430,7 @@ namespace System.Text
         }
 
         [Serializable]
-        internal class DefaultEncoder : Encoder, IObjectReference, ISerializable
+        internal sealed class DefaultEncoder : Encoder, IObjectReference, ISerializable
         {
             private Encoding m_encoding;
             [NonSerialized] private bool m_hasInitializedEncoding;
@@ -1552,7 +1552,7 @@ namespace System.Text
         }
 
         [Serializable]
-        internal class DefaultDecoder : Decoder, IObjectReference, ISerializable
+        internal sealed class DefaultDecoder : Decoder, IObjectReference, ISerializable
         {
             private Encoding m_encoding;
             [NonSerialized]

--- a/src/mscorlib/src/System/Text/UTF32Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF32Encoding.cs
@@ -998,7 +998,7 @@ namespace System.Text
         }
 
         [Serializable]
-        internal class UTF32Decoder : DecoderNLS
+        private sealed class UTF32Decoder : DecoderNLS
         {
             // Need a place to store any extra bytes we may have picked up
             internal int iChar = 0;

--- a/src/mscorlib/src/System/Text/UTF7Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF7Encoding.cs
@@ -628,7 +628,7 @@ namespace System.Text
         [Serializable]
         // Of all the amazing things... This MUST be Decoder so that our com name
         // for System.Text.Decoder doesn't change
-        private class Decoder : DecoderNLS, ISerializable
+        private sealed class Decoder : DecoderNLS, ISerializable
         {
             /*private*/
             internal int bits;
@@ -694,7 +694,7 @@ namespace System.Text
         [Serializable]
         // Of all the amazing things... This MUST be Encoder so that our com name
         // for System.Text.Encoder doesn't change
-        private class Encoder : EncoderNLS, ISerializable
+        private sealed class Encoder : EncoderNLS, ISerializable
         {
             /*private*/
             internal int bits;
@@ -753,7 +753,7 @@ namespace System.Text
         // Preexisting UTF7 behavior for bad bytes was just to spit out the byte as the next char
         // and turn off base64 mode if it was in that mode.  We still exit the mode, but now we fallback.
         [Serializable]
-        internal sealed class DecoderUTF7Fallback : DecoderFallback
+        private sealed class DecoderUTF7Fallback : DecoderFallback
         {
             // Construction.  Default replacement fallback uses no best fit and ? replacement string
             public DecoderUTF7Fallback()
@@ -791,7 +791,7 @@ namespace System.Text
             }
         }
 
-        internal sealed class DecoderUTF7FallbackBuffer : DecoderFallbackBuffer
+        private sealed class DecoderUTF7FallbackBuffer : DecoderFallbackBuffer
         {
             // Store our default string
             private char cFallback = (char)0;

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -2314,7 +2314,7 @@ namespace System.Text
         }
 
         [Serializable]
-        internal class UTF8Encoder : EncoderNLS, ISerializable
+        private sealed class UTF8Encoder : EncoderNLS, ISerializable
         {
             // We must save a high surrogate value until the next call, looking
             // for a low surrogate value.
@@ -2386,7 +2386,7 @@ namespace System.Text
         }
 
         [Serializable]
-        internal class UTF8Decoder : DecoderNLS, ISerializable
+        private sealed class UTF8Decoder : DecoderNLS, ISerializable
         {
             // We'll need to remember the previous information. See the comments around definition
             // of FinalByte for details.

--- a/src/mscorlib/src/System/Text/UnicodeEncoding.cs
+++ b/src/mscorlib/src/System/Text/UnicodeEncoding.cs
@@ -1781,7 +1781,7 @@ namespace System.Text
         }
 
         [Serializable]
-        private class Decoder : System.Text.DecoderNLS, ISerializable
+        private sealed class Decoder : System.Text.DecoderNLS, ISerializable
         {
             internal int lastByte = -1;
             internal char lastChar = '\0';


### PR DESCRIPTION
Seal and make private the internal classes `UTF8Encoder` and `UTF8Decoder` 

@AndyAyersMS @jkotas @stephentoub PTAL