### PR TITLE
Removed check for the maximum quantity of arguments in gen-buildsys-clang.sh

### DIFF
--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -3,7 +3,7 @@
 # This file invokes cmake and generates the build system for Clang.
 #
 
-if [ $# -lt 4 -o $# -gt 8 ]
+if [ $# -lt 4 ]
 then
   echo "Usage..."
   echo "gen-buildsys-clang.sh <path to top level CMakeLists.txt> <ClangMajorVersion> <ClangMinorVersion> <Architecture> [build flavor] [coverage] [ninja] [cmakeargs]"


### PR DESCRIPTION
When I am trying to build coreclr with next command:
`./build.sh clang3.8 arm debug cross ninja -rebuild cmakeargs -DFEATURE_GDBJIT=TRUE`
I am getting the following error:
```
...
Command execution succeeded.
Command successfully completed.
~/GIT/coreclr/bin/obj/Linux.arm.Debug ~/GIT/coreclr
Invoking "/home/ivan/GIT/coreclr/src/pal/tools/gen-buildsys-clang.sh" "/home/ivan/GIT/coreclr" 3 8 arm Debug  Include_Tests ninja -DCLR_CMAKE_TARGET_OS=Linux -DCLR_CMAKE_PACKAGES_DIR=/home/ivan/GIT/coreclr/packages -DCLR_CMAKE_PGO_INSTRUMENT=0 -DCLR_CMAKE_OPTDATA_VERSION= -DFEATURE_GDBJIT=TRUE
Usage...
gen-buildsys-clang.sh <path to top level CMakeLists.txt> <ClangMajorVersion> <ClangMinorVersion> <Architecture> [build flavor] [coverage] [ninja] [cmakeargs]
Specify the path to the top level CMake file - <ProjectK>/src/NDP
Specify the clang version to use, split into major and minor version
Specify the target architecture.
Optionally specify the build configuration (flavor.) Defaults to DEBUG.
Optionally specify 'coverage' to enable code coverage build.
Target ninja instead of make. ninja must be on the PATH.
Pass additional arguments to CMake call.
~/GIT/coreclr
Failed to generate CoreCLR component build project!
```
build.sh passing more then eight arguments to gen-buildsys-clang.sh, so I just removed check for the maximum quantity of arguments in gen-buildsys-clang.sh