### PR TITLE
Reduce case iteration counts in SeekUnroll.

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
@@ -151,7 +151,17 @@ public static class SeekUnroll
             InnerIterations = 100000;
         }
 
-        int manualLoopCount = (args != null && args.Length >= 1) ? int.Parse(args[0]) : 1;
+        int manualLoopCount = 1;
+        if (args == null || args.Length == 0)
+        {
+            Console.WriteLine("Warning: no iteration count specified; defaulting to 1 iteration per case");
+            Console.WriteLine("To use multiple iterations per case, pass the desired number of iterations as the first command-line argument to this test");
+        }
+        else
+        {
+            manualLoopCount = int.Parse(args[0]);
+        }
+
         foreach(int index in IndicesToTest)
         {
             ManualLoopTimes = new long[manualLoopCount];

--- a/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SIMD/SeekUnroll/SeekUnroll.cs
@@ -140,7 +140,7 @@ public static class SeekUnroll
 
 
     // Main method entrypoint runs the manual timer loop
-    public static int Main()
+    public static int Main(string[] args)
     {
         int failures = 0;
 
@@ -151,9 +151,10 @@ public static class SeekUnroll
             InnerIterations = 100000;
         }
 
+        int manualLoopCount = (args != null && args.Length >= 1) ? int.Parse(args[0]) : 1;
         foreach(int index in IndicesToTest)
         {
-            ManualLoopTimes = new long[10];
+            ManualLoopTimes = new long[manualLoopCount];
             bool passed = Test(index, false);
             if (!passed)
             {


### PR DESCRIPTION
This test was taking too long to run on x86. After investigation, it
does not appear that there is a fundamental problem with the code
generated for the test; rather, it seems that we are running an
excessive number of iterations when using this test as a correctness
test. This change reduces the number of times we run each case from 10
to 1 unless otherwise specified on the command line.

[Here is an example of a job where this test has hit the timeout.](https://ci.dot.net/job/dotnet_coreclr/job/master/job/x86_release_windows_nt/967/)