### PR TITLE
Add reflection roots for tests calling CreateInstance()

### DIFF
--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444a.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444a.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444a.reflect.xml
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444a.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="b399444a">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444b.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444b.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444b.reflect.xml
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444b.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="b399444b">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/CastClass001.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/CastClass001.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>CastClass001</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/CastClass001.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/CastClass001.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="CastClass001">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/CastClass004.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/CastClass004.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>CastClass004</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/CastClass004.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/CastClass004.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="CastClass004">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst001.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst001.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst001</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst001.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst001.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="IsInst001">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst002.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst002.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst002</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst002.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst002.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="IsInst002">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst003.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst003.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst003</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst003.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst003.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="IsInst003">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst004.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst004.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst004</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst004.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst004.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="IsInst004">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst005.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst005.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst005</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst005.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst005.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="IsInst005">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst006.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst006.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst006</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst006.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst006.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="IsInst006">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox001.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox001.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox001</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox001.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox001.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="Unbox001">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox002.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox002.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox002</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox002.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox002.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="Unbox002">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox003.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox003.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox003</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox003.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox003.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="Unbox003">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox004.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox004.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox004</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox004.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox004.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="Unbox004">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox005.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox005.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox005</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox005.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox005.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="Unbox005">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox006.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox006.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox006</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox006.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox006.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="Unbox006">
+        <type fullname="*" required="true" />
+    </assembly>
+</linker>


### PR DESCRIPTION
Add the XML files identifying the reflection roots to keep the
type (and constructors threof) which are used by tests as
Activator.CreateInstance(typeof(T))

This will help these tests pass while running under ILLINIK