### PR TITLE
Allow target of calli to be lowered to ldc.i4

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -5658,7 +5658,11 @@ GenTreeCall* Compiler::impImportIndirectCall(CORINFO_SIG_INFO* sig, IL_OFFSETX i
     /* Get the function pointer */
 
     GenTreePtr fptr = impPopStack().val;
-    assert(genActualType(fptr->gtType) == TYP_I_IMPL);
+
+    // The function pointer is typically a sized to match the target pointer size
+    // However, stubgen IL optimization can change LDC.I8 to LDC.I4
+    // See ILCodeStream::LowerOpcode
+    assert(genActualType(fptr->gtType) == TYP_I_IMPL || genActualType(fptr->gtType) == TYP_INT);
 
 #ifdef DEBUG
     // This temporary must never be converted to a double in stress mode,


### PR DESCRIPTION
Fixes #9481 

@dotnet/jit-contrib Please see comments in #9481