### PR TITLE
Fix triggers for ILLINK job

### DIFF
--- a/tests/build_illink.cmd
+++ b/tests/build_illink.cmd
@@ -1,4 +1,4 @@
-if not defined _echo @echo off
+@if not defined _echo @echo off
 setlocal
 set rid=win10-x64
 


### PR DESCRIPTION
This PR has two checkins: 
1) Fix the trigger phrase for ILLink jobs so that PRs can request ILLink runs per architecture.
2) Fix the way ILLink.exe is passed to runtest.cmd by the lab script.
