### PR TITLE
LoadFromStream should throw badimageformat early on

### DIFF
--- a/src/mscorlib/src/System.Private.CoreLib.txt
+++ b/src/mscorlib/src/System.Private.CoreLib.txt
@@ -854,6 +854,7 @@ BadImageFormat_StreamPositionInvalid = Corrupt .resources file.  The specified p
 BadImageFormat_ResourcesDataInvalidOffset = Corrupt .resources file. Invalid offset '{0}' into data section.
 BadImageFormat_NegativeStringLength = Corrupt .resources file. String length must be non-negative.
 BadImageFormat_ParameterSignatureMismatch = The parameters and the signature of the method don't match.
+BadImageFormat_BadILFormat = Bad IL format.
 
 ; Cryptography
 ; These strings still appear in bcl.small but should go away eventually

--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -137,6 +137,11 @@ namespace System.Runtime.Loader
                 throw new ArgumentNullException(nameof(assembly));
             }
 
+            if (assembly.Length <= 0)
+            {
+                throw new BadImageFormatException(Environment.GetResourceString("BadImageFormat_BadILFormat"));
+            }
+
             int iAssemblyStreamLength = (int)assembly.Length;
             int iSymbolLength = 0;
 


### PR DESCRIPTION
Otherwise it violates the invariant at https://github.com/dotnet/coreclr/blob/master/src/vm/assemblynative.cpp#L660

Fixes issue #10048 and issue #8160