### PR TITLE
[Linux] 'root' as a special case in UTIL_IsExecuteBitsSet

### DIFF
--- a/src/pal/src/misc/utils.cpp
+++ b/src/pal/src/misc/utils.cpp
@@ -124,7 +124,12 @@ BOOL UTIL_IsExecuteBitsSet( struct stat * stat_data )
     }
     
     /* Check for read permissions. */
-    if ( stat_data->st_uid == geteuid() )
+    if ( 0 == geteuid() )
+    {
+        /* The process owner is root */
+        bRetVal = TRUE;
+    }
+    else if ( stat_data->st_uid == geteuid() )
     {
         /* The process owner is the file owner as well. */
         if ( ( stat_data->st_mode & S_IXUSR ) )


### PR DESCRIPTION
The current PAL implementation checks whether execution bit is set for the current executable, or not.

Unfortunately, it does not consider when the current user is root, which results in coreclr_initialize failure with status 0x8007001f.

This commit revises UTIL_IsExecuteBitsSet to consider root (euid == 0) as a special case.