### PR TITLE
Fix ValueNumStore::IsVNArrLenUnsignedBound checks

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -3182,10 +3182,10 @@ bool ValueNumStore::IsVNArrLenUnsignedBound(ValueNum vn, ArrLenUnsignedBoundInfo
 
     if (GetVNFunc(vn, &funcApp))
     {
-        if (IsVNArrLen(funcApp.m_args[1]))
+        if ((funcApp.m_func == VNF_LT_UN) || (funcApp.m_func == VNF_GE_UN))
         {
             // We only care about "(uint)i < (uint)a.len" and its negation "(uint)i >= (uint)a.len"
-            if ((funcApp.m_func == VNF_LT_UN) || (funcApp.m_func == VNF_GE_UN))
+            if (IsVNArrLen(funcApp.m_args[1]))
             {
                 info->vnIdx   = funcApp.m_args[0];
                 info->cmpOper = funcApp.m_func;
@@ -3193,10 +3193,10 @@ bool ValueNumStore::IsVNArrLenUnsignedBound(ValueNum vn, ArrLenUnsignedBoundInfo
                 return true;
             }
         }
-        else if (IsVNArrLen(funcApp.m_args[0]))
+        else if ((funcApp.m_func == VNF_GT_UN) || (funcApp.m_func == VNF_LE_UN))
         {
             // We only care about "(uint)a.len > (uint)i" and its negation "(uint)a.len <= (uint)i"
-            if ((funcApp.m_func == VNF_GT_UN) || (funcApp.m_func == VNF_LE_UN))
+            if (IsVNArrLen(funcApp.m_args[0]))
             {
                 info->vnIdx = funcApp.m_args[1];
                 // Let's keep a consistent operand order - it's always i < a.len, never a.len > i


### PR DESCRIPTION
`VNFuncApp::m_func` should be checked first to be sure that `m_args[0]` and `m_args[1]` contain valid VNs. It's not clear if `m_func` can ever be something other than a binary func in the case of a relop VN but the code doesn't look right as it is.