### PR TITLE
fix syntax error in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -401,7 +401,7 @@ build_CoreLib()
 
     # Invoke MSBuild
     __ExtraBuildArgs=""
-    if [ "$__IbcTuning" -eq "" ]; then
+    if [[ "$__IbcTuning" -eq "" ]]; then
         __ExtraBuildArgs="$__ExtraBuildArgs -OptimizationDataDir=\"$__PackagesDir/optimization.$__BuildOS-$__BuildArch.IBC.CoreCLR/$__IbcOptDataVersion/data/\""
         __ExtraBuildArgs="$__ExtraBuildArgs -EnableProfileGuidedOptimization=true"
     fi


### PR DESCRIPTION
fixed:
`./build.sh: line 404: [: : integer expression expected`
