### PR TITLE
Updates for the handling of Profile data in the JIT

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -518,8 +518,11 @@ struct BasicBlock : private LIR::Range
 
     weight_t bbWeight; // The dynamic execution weight of this block
 
+    // getCalledCount -- get the value used to normalize weights for this method
+    weight_t getCalledCount(Compiler* comp);
+
     // getBBWeight -- get the normalized weight of this block
-    unsigned getBBWeight(Compiler* comp);
+    weight_t getBBWeight(Compiler* comp);
 
     // hasProfileWeight -- Returns true if this block's weight came from profile data
     bool hasProfileWeight() const
@@ -530,7 +533,7 @@ struct BasicBlock : private LIR::Range
     // setBBWeight -- if the block weight is not derived from a profile,
     // then set the weight to the input weight, making sure to not overflow BB_MAX_WEIGHT
     // Note to set the weight from profile data, instead use setBBProfileWeight
-    void setBBWeight(unsigned weight)
+    void setBBWeight(weight_t weight)
     {
         if (!hasProfileWeight())
         {
@@ -548,7 +551,7 @@ struct BasicBlock : private LIR::Range
 
     // modifyBBWeight -- same as setBBWeight, but also make sure that if the block is rarely run, it stays that
     // way, and if it's not rarely run then its weight never drops below 1.
-    void modifyBBWeight(unsigned weight)
+    void modifyBBWeight(weight_t weight)
     {
         if (this->bbWeight != BB_ZERO_WEIGHT)
         {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3552,7 +3552,7 @@ public:
     bool                 fgSlopUsedInEdgeWeights;  // true if their was some slop used when computing the edge weights
     bool                 fgRangeUsedInEdgeWeights; // true if some of the edgeWeight are expressed in Min..Max form
     bool                 fgNeedsUpdateFlowGraph;   // true if we need to run fgUpdateFlowGraph
-    BasicBlock::weight_t fgCalledWeight;           // count of the number of times this method was called
+    BasicBlock::weight_t fgCalledCount;            // count of the number of times this method was called
                                                    // This is derived from the profile data
                                                    // or is BB_UNITY_WEIGHT when we don't have profile data
 
@@ -4528,12 +4528,22 @@ protected:
 
     bool fgHaveProfileData();
     bool fgGetProfileWeightForBasicBlock(IL_OFFSET offset, unsigned* weight);
+    void fgInstrumentMethod();
 
+public:
+    // fgIsUsingProfileWeights - returns true if we have real profile data for this method
+    //                           or if we have some fake profile data for the stress mode
     bool fgIsUsingProfileWeights()
     {
         return (fgHaveProfileData() || fgStressBBProf());
     }
-    void fgInstrumentMethod();
+
+    // fgProfileRunsCount - returns total number of scenario runs for the profile data
+    //                      or BB_UNITY_WEIGHT when we aren't using profile data.
+    unsigned fgProfileRunsCount()
+    {
+        return fgIsUsingProfileWeights() ? fgNumProfileRuns : BB_UNITY_WEIGHT;
+    }
 
 //-------- Insert a statement at the start or end of a basic block --------
 

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -4502,7 +4502,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     //
     if (emitComp->fgHaveProfileData())
     {
-        if (emitComp->fgCalledWeight > (BB_VERY_HOT_WEIGHT * emitComp->fgNumProfileRuns))
+        if (emitComp->fgCalledCount > (BB_VERY_HOT_WEIGHT * emitComp->fgProfileRunsCount()))
         {
             allocMemFlag = CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN;
         }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -44,7 +44,7 @@ void Compiler::fgInit()
     fgSlopUsedInEdgeWeights  = false;
     fgRangeUsedInEdgeWeights = true;
     fgNeedsUpdateFlowGraph   = false;
-    fgCalledWeight           = BB_ZERO_WEIGHT;
+    fgCalledCount            = BB_ZERO_WEIGHT;
 
     /* We haven't yet computed the dominator sets */
     fgDomsComputed = false;
@@ -12554,7 +12554,7 @@ void Compiler::fgComputeEdgeWeights()
         }
 #endif // DEBUG
         fgHaveValidEdgeWeights = false;
-        fgCalledWeight         = BB_UNITY_WEIGHT;
+        fgCalledCount          = BB_UNITY_WEIGHT;
     }
 
 #if DEBUG
@@ -12692,12 +12692,12 @@ void Compiler::fgComputeEdgeWeights()
     }
 #endif
 
-    // When we are not using profile data we have already setup fgCalledWeight
+    // When we are not using profile data we have already setup fgCalledCount
     // only set it here if we are using profile data
     //
     if (fgIsUsingProfileWeights())
     {
-        // If the first block has one ref then it's weight is the fgCalledWeight
+        // If the first block has one ref then it's weight is the fgCalledCount
         // otherwise we have backedge's into the first block so instead
         // we use the sum of the return block weights.
         // If the profile data has a 0 for the returnWeoght
@@ -12705,11 +12705,11 @@ void Compiler::fgComputeEdgeWeights()
         //
         if ((fgFirstBB->countOfInEdges() == 1) || (returnWeight == 0))
         {
-            fgCalledWeight = fgFirstBB->bbWeight;
+            fgCalledCount = fgFirstBB->bbWeight;
         }
         else
         {
-            fgCalledWeight = returnWeight;
+            fgCalledCount = returnWeight;
         }
     }
 
@@ -12723,7 +12723,7 @@ void Compiler::fgComputeEdgeWeights()
         //
         if (bDst == fgFirstBB)
         {
-            bDstWeight -= fgCalledWeight;
+            bDstWeight -= fgCalledCount;
         }
 
         for (edge = bDst->bbPreds; edge != nullptr; edge = edge->flNext)
@@ -12888,7 +12888,7 @@ void Compiler::fgComputeEdgeWeights()
                 //
                 if (bDst == fgFirstBB)
                 {
-                    bDstWeight -= fgCalledWeight;
+                    bDstWeight -= fgCalledCount;
                 }
 
                 UINT64 minEdgeWeightSum = 0;
@@ -19132,7 +19132,7 @@ bool Compiler::fgDumpFlowGraph(Phases phase)
         return false;
     }
     bool        validWeights  = fgHaveValidEdgeWeights;
-    unsigned    calledCount   = max(fgCalledWeight, BB_UNITY_WEIGHT) / BB_UNITY_WEIGHT;
+    unsigned    calledCount   = max(fgCalledCount, BB_UNITY_WEIGHT) / BB_UNITY_WEIGHT;
     double      weightDivisor = (double)(calledCount * BB_UNITY_WEIGHT);
     const char* escapedString;
     const char* regionString = "NONE";


### PR DESCRIPTION
    Use the type weight_t instead of unsigned when dealing with BasicBlock weights.
    Added new method getCalledCount to return the number of times that the method was called.
    Added new method fgProfileRunsCount to return the number of scenario runs for the profile data.
    Made the method fgIsUsingProfileWeight public instead of protected
    Renamed fgCalledWeight to fgCalledCount
    Updated the logic in getBBWeight and added comments explaining how it works.