### PR TITLE
Fix Linux/x86 call alignment calculation and insertion

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -107,7 +107,7 @@ CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
     m_stkArgVarNum = BAD_VAR_NUM;
 #endif
 
-#if defined(DEBUG) && defined(UNIX_X86_ABI)
+#if defined(UNIX_X86_ABI)
     curNestedAlignment = 0;
     maxNestedAlignment = 0;
 #endif

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -107,6 +107,11 @@ CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
     m_stkArgVarNum = BAD_VAR_NUM;
 #endif
 
+#if defined(DEBUG) && defined(UNIX_X86_ABI)
+    curNestedAlignment = 0;
+    maxNestedAlignment = 0;
+#endif
+
     regTracker.rsTrackInit(compiler, &regSet);
     gcInfo.regSet        = &regSet;
     m_cgEmitter          = new (compiler->getAllocator()) emitter();
@@ -3201,7 +3206,7 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
                                         genTypeStSz(TYP_LONG) +       // longs/doubles may be transferred via stack, etc
                                         (compiler->compTailCallUsed ? 4 : 0); // CORINFO_HELP_TAILCALL args
 #if defined(UNIX_X86_ABI)
-        maxAllowedStackDepth += genTypeStSz(TYP_INT) * 3; // stack align for x86 - allow up to 3 INT's for padding
+        maxAllowedStackDepth += maxNestedAlignment;
 #endif
         noway_assert(getEmitter()->emitMaxStackDepth <= maxAllowedStackDepth);
     }

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -178,6 +178,40 @@ void genAlignStackBeforeCall(GenTreePutArgStk* putArgStk);
 void genAlignStackBeforeCall(GenTreeCall* call);
 void genRemoveAlignmentAfterCall(GenTreeCall* call);
 
+#if defined(DEBUG) && defined(UNIX_X86_ABI)
+
+    unsigned curNestedAlignment;    // Keep track of alignment adjustment required during codegen.
+    unsigned maxNestedAlignment;    // The maximum amount of alignment adjustment required.
+
+    void SubtractNestedAlignment(unsigned adjustment)
+    {
+        assert(curNestedAlignment >= adjustment);
+        unsigned newNestedAlignment = curNestedAlignment - adjustment;
+        if (curNestedAlignment != newNestedAlignment)
+        {
+            JITDUMP("Adjusting stack nested alignment from %d to %d\n", curNestedAlignment, newNestedAlignment);
+        }
+        curNestedAlignment = newNestedAlignment;
+    }
+
+    void AddNestedAlignment(unsigned adjustment)
+    {
+        unsigned newNestedAlignment = curNestedAlignment + adjustment;
+        if (curNestedAlignment != newNestedAlignment)
+        {
+            JITDUMP("Adjusting stack nested alignment from %d to %d\n", curNestedAlignment, newNestedAlignment);
+        }
+        curNestedAlignment = newNestedAlignment;
+
+        if (curNestedAlignment > maxNestedAlignment)
+        {
+            JITDUMP("Max stack nested alignment changed from %d to %d\n", maxNestedAlignment, curNestedAlignment);
+            maxNestedAlignment = curNestedAlignment;
+        }
+    }
+
+#endif
+
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
 #ifdef _TARGET_X86_
 bool genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -180,35 +180,35 @@ void genRemoveAlignmentAfterCall(GenTreeCall* call);
 
 #if defined(UNIX_X86_ABI)
 
-    unsigned curNestedAlignment;    // Keep track of alignment adjustment required during codegen.
-    unsigned maxNestedAlignment;    // The maximum amount of alignment adjustment required.
+unsigned curNestedAlignment; // Keep track of alignment adjustment required during codegen.
+unsigned maxNestedAlignment; // The maximum amount of alignment adjustment required.
 
-    void SubtractNestedAlignment(unsigned adjustment)
+void SubtractNestedAlignment(unsigned adjustment)
+{
+    assert(curNestedAlignment >= adjustment);
+    unsigned newNestedAlignment = curNestedAlignment - adjustment;
+    if (curNestedAlignment != newNestedAlignment)
     {
-        assert(curNestedAlignment >= adjustment);
-        unsigned newNestedAlignment = curNestedAlignment - adjustment;
-        if (curNestedAlignment != newNestedAlignment)
-        {
-            JITDUMP("Adjusting stack nested alignment from %d to %d\n", curNestedAlignment, newNestedAlignment);
-        }
-        curNestedAlignment = newNestedAlignment;
+        JITDUMP("Adjusting stack nested alignment from %d to %d\n", curNestedAlignment, newNestedAlignment);
     }
+    curNestedAlignment = newNestedAlignment;
+}
 
-    void AddNestedAlignment(unsigned adjustment)
+void AddNestedAlignment(unsigned adjustment)
+{
+    unsigned newNestedAlignment = curNestedAlignment + adjustment;
+    if (curNestedAlignment != newNestedAlignment)
     {
-        unsigned newNestedAlignment = curNestedAlignment + adjustment;
-        if (curNestedAlignment != newNestedAlignment)
-        {
-            JITDUMP("Adjusting stack nested alignment from %d to %d\n", curNestedAlignment, newNestedAlignment);
-        }
-        curNestedAlignment = newNestedAlignment;
-
-        if (curNestedAlignment > maxNestedAlignment)
-        {
-            JITDUMP("Max stack nested alignment changed from %d to %d\n", maxNestedAlignment, curNestedAlignment);
-            maxNestedAlignment = curNestedAlignment;
-        }
+        JITDUMP("Adjusting stack nested alignment from %d to %d\n", curNestedAlignment, newNestedAlignment);
     }
+    curNestedAlignment = newNestedAlignment;
+
+    if (curNestedAlignment > maxNestedAlignment)
+    {
+        JITDUMP("Max stack nested alignment changed from %d to %d\n", maxNestedAlignment, curNestedAlignment);
+        maxNestedAlignment = curNestedAlignment;
+    }
+}
 
 #endif
 

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -174,6 +174,10 @@ void genCodeForCpBlkRepMovs(GenTreeBlk* cpBlkNode);
 
 void genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode);
 
+void genAlignStackBeforeCall(GenTreePutArgStk* putArgStk);
+void genAlignStackBeforeCall(GenTreeCall* call);
+void genRemoveAlignmentAfterCall(GenTreeCall* call);
+
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
 #ifdef _TARGET_X86_
 bool genAdjustStackForPutArgStk(GenTreePutArgStk* putArgStk);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -178,7 +178,7 @@ void genAlignStackBeforeCall(GenTreePutArgStk* putArgStk);
 void genAlignStackBeforeCall(GenTreeCall* call);
 void genRemoveAlignmentAfterCall(GenTreeCall* call);
 
-#if defined(DEBUG) && defined(UNIX_X86_ABI)
+#if defined(UNIX_X86_ABI)
 
     unsigned curNestedAlignment;    // Keep track of alignment adjustment required during codegen.
     unsigned maxNestedAlignment;    // The maximum amount of alignment adjustment required.

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4752,6 +4752,8 @@ bool CodeGen::genEmitOptimizedGCWriteBarrier(GCInfo::WriteBarrierForm writeBarri
 // Produce code for a GT_CALL node
 void CodeGen::genCallInstruction(GenTreeCall* call)
 {
+    genAlignStackBeforeCall(call);
+
     gtCallTypes callType = (gtCallTypes)call->gtCallType;
 
     IL_OFFSETX ilOffset = BAD_IL_OFFSET;
@@ -5173,14 +5175,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
         // clang-format on
     }
 
-#if defined(UNIX_X86_ABI)
-    // Put back the stack pointer if there was any padding for stack alignment
-    unsigned padStackAlign = call->fgArgInfo->GetPadStackAlign();
-    if (padStackAlign != 0)
-    {
-        inst_RV_IV(INS_add, REG_SPBASE, padStackAlign * TARGET_POINTER_SIZE, EA_PTRSIZE);
-    }
-#endif // UNIX_X86_ABI
+    genRemoveAlignmentAfterCall(call);
 
     // if it was a pinvoke we may have needed to get the address of a label
     if (genPendingCallLabel)
@@ -7502,7 +7497,78 @@ unsigned CodeGen::getBaseVarForPutArgStk(GenTreePtr treeNode)
     return baseVarNum;
 }
 
+//---------------------------------------------------------------------
+// genAlignStackBeforeCall: Align the stack if necessary before a call.
+//
+// Arguments:
+//    putArgStk - the putArgStk node.
+//
+void CodeGen::genAlignStackBeforeCall(GenTreePutArgStk* putArgStk)
+{
+#if defined(UNIX_X86_ABI)
+
+    genAlignStackBeforeCall(putArgStk->gtCall);
+
+#endif // UNIX_X86_ABI
+}
+
+//---------------------------------------------------------------------
+// genAlignStackBeforeCall: Align the stack if necessary before a call.
+//
+// Arguments:
+//    call - the call node.
+//
+void CodeGen::genAlignStackBeforeCall(GenTreeCall* call)
+{
+#if defined(UNIX_X86_ABI)
+
+    // Have we aligned the stack yet?
+    if (!call->fgArgInfo->IsStkAlignmentDone())
+    {
+        // We haven't done any stack alignment yet for this call.  We might need to create
+        // an alignment adjustment, even if this function itself doesn't have any stack args.
+        // This can happen if this function call is part of a nested call sequence, and the outer
+        // call has already pushed some arguments.
+
+        unsigned stkLevel = genStackLevel + call->fgArgInfo->GetStkSizeBytes();
+        call->fgArgInfo->ComputeStackAlignment(stkLevel);
+
+        unsigned padStkAlign = call->fgArgInfo->GetStkAlign();
+        if (padStkAlign != 0)
+        {
+            // Now generate the alignment
+            inst_RV_IV(INS_sub, REG_SPBASE, padStkAlign, EA_PTRSIZE);
+            AddStackLevel(padStkAlign);
+        }
+
+        call->fgArgInfo->SetStkAlignmentDone();
+    }
+
+#endif // UNIX_X86_ABI
+}
+
+//---------------------------------------------------------------------
+// genRemoveAlignmentAfterCall: After a call, remove the alignment
+// added before the call, if any.
+//
+// Arguments:
+//    call - the call node.
+//
+void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call)
+{
+#if defined(UNIX_X86_ABI)
+    // Put back the stack pointer if there was any padding for stack alignment
+    unsigned padStkAlign = call->fgArgInfo->GetStkAlign();
+    if (padStkAlign != 0)
+    {
+        inst_RV_IV(INS_add, REG_SPBASE, padStkAlign, EA_PTRSIZE);
+        SubtractStackLevel(padStkAlign);
+    }
+#endif // UNIX_X86_ABI
+}
+
 #ifdef _TARGET_X86_
+
 //---------------------------------------------------------------------
 // genAdjustStackForPutArgStk:
 //    adjust the stack pointer for a putArgStk node if necessary.
@@ -7754,14 +7820,14 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk)
         }
         else
         {
-#if defined(_TARGET_X86_) && defined(FEATURE_SIMD)
+#if defined(FEATURE_SIMD)
             if (fieldType == TYP_SIMD12)
             {
                 assert(genIsValidFloatReg(simdTmpReg));
                 genStoreSIMD12ToStack(argReg, simdTmpReg);
             }
             else
-#endif // defined(_TARGET_X86_) && defined(FEATURE_SIMD)
+#endif // defined(FEATURE_SIMD)
             {
                 genStoreRegToStackArg(fieldType, argReg, fieldOffset - currentOffset);
             }
@@ -7799,15 +7865,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* putArgStk)
 
 #ifdef _TARGET_X86_
 
-#if defined(UNIX_X86_ABI)
-    // For each call, first stack argument has the padding for alignment
-    // if this value is not zero, use it to adjust the ESP
-    unsigned argPadding = putArgStk->getArgPadding();
-    if (argPadding != 0)
-    {
-        inst_RV_IV(INS_sub, REG_SPBASE, argPadding * TARGET_POINTER_SIZE, EA_PTRSIZE);
-    }
-#endif
+    genAlignStackBeforeCall(putArgStk);
 
     if (varTypeIsStruct(targetType))
     {

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7539,6 +7539,7 @@ void CodeGen::genAlignStackBeforeCall(GenTreeCall* call)
             // Now generate the alignment
             inst_RV_IV(INS_sub, REG_SPBASE, padStkAlign, EA_PTRSIZE);
             AddStackLevel(padStkAlign);
+            AddNestedAlignment(padStkAlign);
         }
 
         call->fgArgInfo->SetStkAlignmentDone();
@@ -7563,6 +7564,7 @@ void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call)
     {
         inst_RV_IV(INS_add, REG_SPBASE, padStkAlign, EA_PTRSIZE);
         SubtractStackLevel(padStkAlign);
+        SubtractNestedAlignment(padStkAlign);
     }
 #endif // UNIX_X86_ABI
 }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4646,7 +4646,7 @@ struct GenTreePutArgStk : public GenTreeUnOp
         , gtNumberReferenceSlots(0)
         , gtGcPtrs(nullptr)
 #endif // FEATURE_PUT_STRUCT_ARG_STK
-#ifdef DEBUG
+#if defined(DEBUG) || defined(UNIX_X86_ABI)
         , gtCall(callNode)
 #endif
     {
@@ -4742,7 +4742,7 @@ struct GenTreePutArgStk : public GenTreeUnOp
 
 #endif // FEATURE_PUT_STRUCT_ARG_STK
 
-#if defined(DEBUG)
+#if defined(DEBUG) || defined(UNIX_X86_ABI)
     GenTreeCall* gtCall; // the call node to which this argument belongs
 #endif
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -946,11 +946,6 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
             GenTreePutArgStk(GT_PUTARG_STK, type, arg, info->slotNum PUT_STRUCT_ARG_STK_ONLY_ARG(info->numSlots),
                              call->IsFastTailCall(), call);
 
-#if defined(UNIX_X86_ABI)
-        assert((info->padStkAlign > 0 && info->numSlots > 0) || (info->padStkAlign == 0));
-        putArg->AsPutArgStk()->setArgPadding(info->padStkAlign);
-#endif
-
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
         // If the ArgTabEntry indicates that this arg is a struct
         // get and store the number of slots that are references.


### PR DESCRIPTION
The existing system of calculating per-call alignment adjustments
did not consider the possibility of nested calls. On x86, some
arguments for a call might be pushed on the stack before a
nested call's arguments start being pushed. Thus, a call can't
consider only its own arguments when determining the stack level.

Instead, use the existing genStackLevel variable, updated
dynamically during code generation, to determine the baseline
stack alignment when a call first needs to push something on
the stack, or if it has no stack arguments, whether it needs to
align the stack before a call.

One wrinkle here is that the fgAddCodeRef() function for adding
throw blocks for array bounds checks, and other similar helpers,
need to know the stack level on entry, and this stack level is
computed during argument morphing. There is a tough phase ordering
problem here. So, we bail out and force an EBP frame if there are
any such throw helpers in the function. When using an EBP frame,
the helper block doesn't need to know the stack level -- it is
only needed for ESP frames, needed for unwinding. Note that this
bail out already existed if the same helper needed multiple different
stack levels on entry. We could do slightly better without too much
work by not bailing out for top-level calls with no stack arguments.

Fixes #10122 