### PR TITLE
simplify PreAllocatedOverlapped lifetime management

### DIFF
--- a/src/mscorlib/src/System/Threading/ClrThreadPoolBoundHandle.cs
+++ b/src/mscorlib/src/System/Threading/ClrThreadPoolBoundHandle.cs
@@ -197,23 +197,14 @@ namespace System.Threading
 
             EnsureNotDisposed();
 
-            preAllocated.AddRef();
-            try
-            {
-                ThreadPoolBoundHandleOverlapped overlapped = preAllocated._overlapped;
+            ThreadPoolBoundHandleOverlapped overlapped = preAllocated._overlapped;
 
-                if (overlapped._boundHandle != null)
-                    throw new ArgumentException(SR.Argument_PreAllocatedAlreadyAllocated, nameof(preAllocated));
+            if (overlapped._boundHandle != null)
+                throw new ArgumentException(SR.Argument_PreAllocatedAlreadyAllocated, nameof(preAllocated));
 
-                overlapped._boundHandle = this;
+            overlapped._boundHandle = this;
 
-                return overlapped._nativeOverlapped;
-            }
-            catch
-            {
-                preAllocated.Release();
-                throw;
-            }
+            return overlapped._nativeOverlapped;
         }
 
         /// <summary>


### PR DESCRIPTION
PreAllocatedOverlapped has some lifetime management state/logic that is not used in practice.  Remove this.

On my socket microbenchmark, this seems to give a small win (1-1.5%), though it may be noise.

@jkotas @stephentoub 