### PR TITLE
[Linux][GDB-JIT] Add lexical scopes info for local variables

### DIFF
--- a/src/ToolBox/SOS/NETCore/SymbolReader.cs
+++ b/src/ToolBox/SOS/NETCore/SymbolReader.cs
@@ -23,6 +23,14 @@ namespace SOS
             public string fileName;
         }
 
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct LocalVarInfo
+        {
+            public int startOffset;
+            public int endOffset;
+            public string name;
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         internal struct MethodDebugInfo
         {
@@ -394,7 +402,7 @@ namespace SOS
             }
             return false;
         }
-        internal static bool GetLocalsInfoForMethod(string assemblyPath, int methodToken, out List<string> locals)
+        internal static bool GetLocalsInfoForMethod(string assemblyPath, int methodToken, out List<LocalVarInfo> locals)
         {
             locals = null;
 
@@ -410,7 +418,7 @@ namespace SOS
                     if (handle.Kind != HandleKind.MethodDefinition)
                         return false;
 
-                    locals = new List<string>();
+                    locals = new List<LocalVarInfo>();
 
                     MethodDebugInformationHandle methodDebugHandle =
                         ((MethodDefinitionHandle)handle).ToDebugInformationHandle();
@@ -424,7 +432,11 @@ namespace SOS
                             LocalVariable localVar = openedReader.Reader.GetLocalVariable(varHandle);
                             if (localVar.Attributes == LocalVariableAttributes.DebuggerHidden)
                                 continue;
-                            locals.Add(openedReader.Reader.GetString(localVar.Name));
+                            LocalVarInfo info = new LocalVarInfo();
+                            info.startOffset = scope.StartOffset;
+                            info.endOffset = scope.EndOffset;
+                            info.name = openedReader.Reader.GetString(localVar.Name);
+                            locals.Add(info);
                         }
                     }
                 }
@@ -449,7 +461,7 @@ namespace SOS
             try
             {
                 List<DebugInfo> points = null;
-                List<string> locals = null;
+                List<LocalVarInfo> locals = null;
 
                 if (!GetDebugInfoForMethod(assemblyPath, methodToken, out points))
                 {
@@ -470,14 +482,18 @@ namespace SOS
                     Marshal.StructureToPtr(info, ptr, false);
                     ptr = (IntPtr)(ptr.ToInt64() + structSize);
                 }
+
+                structSize = Marshal.SizeOf<LocalVarInfo>();
+
                 debugInfo.localsSize = locals.Count;
-                debugInfo.locals = Marshal.AllocHGlobal(debugInfo.localsSize * Marshal.SizeOf<IntPtr>());
-                IntPtr ptrLocals = debugInfo.locals;
-                foreach (string s in locals)
+                ptr = debugInfo.locals;
+
+                foreach (var info in locals)
                 {
-                    Marshal.WriteIntPtr(ptrLocals, Marshal.StringToHGlobalUni(s));
-                    ptrLocals += Marshal.SizeOf<IntPtr>();
+                    Marshal.StructureToPtr(info, ptr, false);
+                    ptr = (IntPtr)(ptr.ToInt64() + structSize);
                 }
+
                 return true;
             }
             catch

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -530,7 +530,7 @@ GetDebugInfoFromPDB(MethodDesc* MethodDescPtr, SymbolsInfo** symInfo, unsigned i
     if (*symInfo == nullptr)
         return E_FAIL;
     locals.size = methodDebugInfo.localsSize;
-    locals.localsName = new (nothrow) char *[locals.size];
+    locals.localsName = new (nothrow) NewArrayHolder<char>[locals.size];
     if (locals.localsName == nullptr)
         return E_FAIL;
     locals.localsScope = new (nothrow) LocalsInfo::Scope [locals.size];
@@ -1999,13 +1999,6 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
         method[i]->lines = nullptr;
         method[i]->nlines = 0;
     }
-
-    for (int i = 0; i < locals.size; i++)
-    {
-        delete[] locals.localsName[i];
-    }
-    delete[] locals.localsName;
-    delete[] locals.localsScope;
 
     /* Build .debug_pubname section */
     if (!BuildDebugPub(dbgPubname, methodName, dbgInfo.MemSize, 0x28))

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1989,7 +1989,7 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
     }
     
     /* Build .debug_info section */
-    if (!BuildDebugInfo(dbgInfo, pTypeMap, symInfo, symInfoLen))
+    if (!BuildDebugInfo(dbgInfo, pTypeMap))
     {
         return;
     }
@@ -2561,7 +2561,7 @@ bool NotifyGdb::BuildDebugAbbrev(MemBuf& buf)
 }
 
 /* Build tge DWARF .debug_info section */
-bool NotifyGdb::BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap, SymbolsInfo* lines, unsigned nlines)
+bool NotifyGdb::BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap)
 {
     int totalTypeVarSubSize = 0;
     {
@@ -2576,22 +2576,8 @@ bool NotifyGdb::BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap, SymbolsInf
 
     for (int i = 0; i < method.GetCount(); ++i)
     {
-        method[i]->lines = lines;
-        method[i]->nlines = nlines;
         method[i]->DumpDebugInfo(nullptr, totalTypeVarSubSize);
     }
-    // Drop pointers to lines when exiting current scope
-    struct DropMethodLines
-    {
-        ~DropMethodLines()
-        {
-            for (int i = 0; i < method.GetCount(); ++i)
-            {
-                method[i]->lines = nullptr;
-                method[i]->nlines = 0;
-            }
-        }
-    } dropMethodLines;
 
     //int locSize = GetArgsAndLocalsLen(argsDebug, argsDebugSize, localsDebug, localsDebugSize);
     buf.MemSize = sizeof(DwarfCompUnit) + sizeof(DebugInfoCU) + totalTypeVarSubSize + 2;

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -554,6 +554,8 @@ GetDebugInfoFromPDB(MethodDesc* MethodDescPtr, SymbolsInfo** symInfo, unsigned i
         }
     }
 
+    for (ULONG32 i = 0; i < methodDebugInfo.size; i++)
+        CoTaskMemFree(methodDebugInfo.points[i].fileName);
     CoTaskMemFree(methodDebugInfo.points);
     return S_OK;
 }
@@ -1890,6 +1892,8 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
     {
         delete[] locals.localsName[i];
     }
+    delete[] locals.localsName;
+
     /* Build .debug_pubname section */
     if (!BuildDebugPub(dbgPubname, methodName, dbgInfo.MemSize, 0x28))
     {

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -368,6 +368,8 @@ public:
     uintptr_t m_high_pc;
 };
 
+struct Elf_Symbol;
+
 class NotifyGdb
 {
 public:
@@ -450,9 +452,11 @@ private:
 
     static int GetSectionIndex(const char *sectName);
     static bool BuildELFHeader(MemBuf& buf);
-    static bool BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method);
-    static bool BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize, FunctionMemberPtrArrayHolder &method);
-    static bool BuildStringTableSection(MemBuf& strTab);
+    static bool BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method,
+                                   int SymbolCount);
+    static bool BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize, FunctionMemberPtrArrayHolder &method,
+                                        NewArrayHolder<Elf_Symbol> &SymbolNames, int SymbolCount);
+    static bool BuildStringTableSection(MemBuf& strTab, NewArrayHolder<Elf_Symbol> &SymbolNames, int SymbolCount);
     static bool BuildDebugStrings(MemBuf& buf, PTK_TypeInfoMap pTypeMap, FunctionMemberPtrArrayHolder &method);
     static bool BuildDebugAbbrev(MemBuf& buf);
     static bool BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap, FunctionMemberPtrArrayHolder &method);
@@ -465,7 +469,8 @@ private:
     static void IssueSimpleCommand(char*& ptr, uint8_t command);
     static void IssueParamCommand(char*& ptr, uint8_t command, char* param, int param_len);
     static void SplitPathname(const char* path, const char*& pathName, const char*& fileName);
-    static bool CollectCalledMethods(CalledMethod* pCM, TADDR nativeCode, FunctionMemberPtrArrayHolder &method);
+    static bool CollectCalledMethods(CalledMethod* pCM, TADDR nativeCode, FunctionMemberPtrArrayHolder &method,
+                                     NewArrayHolder<Elf_Symbol> &SymbolNames, int &SymbolCount);
 #ifdef _DEBUG
     static void DumpElf(const char* methodName, const MemBuf& buf);
 #endif

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -538,6 +538,7 @@ private:
     void DumpLinkageName(char* ptr, int& offset);
     bool GetBlockInNativeCode(int blockILOffset, int blockILLen, TADDR *startOffset, TADDR *endOffset);
     void DumpTryCatchBlock(char* ptr, int& offset, int ilOffset, int ilLen, int abbrev);
+    void DumpVarsWithScopes(char* ptr, int& offset);
     BOOL dumped;
 };
 #endif // #ifndef __GDBJIT_H__

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -251,10 +251,12 @@ public:
     void DumpDebugInfo(char* ptr, int& offset) override;
 };
 
+class FunctionMemberPtrArrayHolder;
+
 class ClassTypeInfo: public TypeInfoBase
 {
 public:
-    ClassTypeInfo(TypeHandle typeHandle, int num_members);
+    ClassTypeInfo(TypeHandle typeHandle, int num_members, FunctionMemberPtrArrayHolder &method);
     ~ClassTypeInfo();
 
     void DumpStrings(char* ptr, int& offset) override;
@@ -263,6 +265,7 @@ public:
     int m_num_members;
     TypeMember* members;
     TypeInfoBase* m_parent;
+    FunctionMemberPtrArrayHolder &m_method;
 };
 
 class TypeMember: public DwarfDumpable
@@ -447,12 +450,12 @@ private:
 
     static int GetSectionIndex(const char *sectName);
     static bool BuildELFHeader(MemBuf& buf);
-    static bool BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf);
-    static bool BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize);
+    static bool BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method);
+    static bool BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize, FunctionMemberPtrArrayHolder &method);
     static bool BuildStringTableSection(MemBuf& strTab);
-    static bool BuildDebugStrings(MemBuf& buf, PTK_TypeInfoMap pTypeMap);
+    static bool BuildDebugStrings(MemBuf& buf, PTK_TypeInfoMap pTypeMap, FunctionMemberPtrArrayHolder &method);
     static bool BuildDebugAbbrev(MemBuf& buf);
-    static bool BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap);
+    static bool BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap, FunctionMemberPtrArrayHolder &method);
     static bool BuildDebugPub(MemBuf& buf, const char* name, uint32_t size, uint32_t dieOffset);
     static bool BuildLineTable(MemBuf& buf, PCODE startAddr, TADDR codeSize, SymbolsInfo* lines, unsigned nlines);
     static bool BuildFileTable(MemBuf& buf, SymbolsInfo* lines, unsigned nlines);
@@ -462,7 +465,7 @@ private:
     static void IssueSimpleCommand(char*& ptr, uint8_t command);
     static void IssueParamCommand(char*& ptr, uint8_t command, char* param, int param_len);
     static void SplitPathname(const char* path, const char*& pathName, const char*& fileName);
-    static bool CollectCalledMethods(CalledMethod* pCM, TADDR nativeCode);
+    static bool CollectCalledMethods(CalledMethod* pCM, TADDR nativeCode, FunctionMemberPtrArrayHolder &method);
 #ifdef _DEBUG
     static void DumpElf(const char* methodName, const MemBuf& buf);
 #endif
@@ -513,7 +516,8 @@ public:
     void DumpTryCatchDebugInfo(char* ptr, int& offset);
     HRESULT GetLocalsDebugInfo(NotifyGdb::PTK_TypeInfoMap pTypeMap,
                            LocalsInfo& locals,
-                           int startNativeOffset);
+                           int startNativeOffset,
+                           FunctionMemberPtrArrayHolder &method);
     BOOL IsDumped()
     {
         return dumped;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -133,8 +133,8 @@ public:
         int ilEndOffset;
     };
     int size;
-    char** localsName;
-    Scope *localsScope;
+    NewArrayHolder< NewArrayHolder<char> > localsName;
+    NewArrayHolder<Scope> localsScope;
     ULONG32 countVars;
     ICorDebugInfo::NativeVarInfo *pVars;
 };

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -453,10 +453,10 @@ private:
     static int GetSectionIndex(const char *sectName);
     static bool BuildELFHeader(MemBuf& buf);
     static bool BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method,
-                                   int SymbolCount);
+                                   int symbolCount);
     static bool BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize, FunctionMemberPtrArrayHolder &method,
-                                        NewArrayHolder<Elf_Symbol> &SymbolNames, int SymbolCount);
-    static bool BuildStringTableSection(MemBuf& strTab, NewArrayHolder<Elf_Symbol> &SymbolNames, int SymbolCount);
+                                        NewArrayHolder<Elf_Symbol> &symbolNames, int symbolCount);
+    static bool BuildStringTableSection(MemBuf& strTab, NewArrayHolder<Elf_Symbol> &symbolNames, int symbolCount);
     static bool BuildDebugStrings(MemBuf& buf, PTK_TypeInfoMap pTypeMap, FunctionMemberPtrArrayHolder &method);
     static bool BuildDebugAbbrev(MemBuf& buf);
     static bool BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap, FunctionMemberPtrArrayHolder &method);
@@ -470,7 +470,7 @@ private:
     static void IssueParamCommand(char*& ptr, uint8_t command, char* param, int param_len);
     static void SplitPathname(const char* path, const char*& pathName, const char*& fileName);
     static bool CollectCalledMethods(CalledMethod* pCM, TADDR nativeCode, FunctionMemberPtrArrayHolder &method,
-                                     NewArrayHolder<Elf_Symbol> &SymbolNames, int &SymbolCount);
+                                     NewArrayHolder<Elf_Symbol> &symbolNames, int &symbolCount);
 #ifdef _DEBUG
     static void DumpElf(const char* methodName, const MemBuf& buf);
 #endif

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -125,11 +125,16 @@ public:
     virtual void DumpDebugInfo(char* ptr, int& offset) = 0;
 };
 
-class LocalsInfo 
+class LocalsInfo
 {
 public:
+    struct Scope {
+        int ilStartOffset;
+        int ilEndOffset;
+    };
     int size;
     char** localsName;
+    Scope *localsScope;
     ULONG32 countVars;
     ICorDebugInfo::NativeVarInfo *pVars;
 };

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -329,7 +329,9 @@ public:
           m_var_name_offset(0),
           m_il_index(0),
           m_native_offset(0),
-          m_var_type(nullptr)
+          m_var_type(nullptr),
+          m_low_pc(0),
+          m_high_pc(0)
     {
     }
 
@@ -339,7 +341,9 @@ public:
           m_var_name_offset(0),
           m_il_index(0),
           m_native_offset(0),
-          m_var_type(nullptr)
+          m_var_type(nullptr),
+          m_low_pc(0),
+          m_high_pc(0)
     {
     }
 
@@ -357,6 +361,8 @@ public:
     int m_il_index;
     int m_native_offset;
     TypeInfoBase *m_var_type;
+    uintptr_t m_low_pc;
+    uintptr_t m_high_pc;
 };
 
 class NotifyGdb

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -452,7 +452,7 @@ private:
     static bool BuildStringTableSection(MemBuf& strTab);
     static bool BuildDebugStrings(MemBuf& buf, PTK_TypeInfoMap pTypeMap);
     static bool BuildDebugAbbrev(MemBuf& buf);
-    static bool BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap, SymbolsInfo* lines, unsigned nlines);
+    static bool BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap);
     static bool BuildDebugPub(MemBuf& buf, const char* name, uint32_t size, uint32_t dieOffset);
     static bool BuildLineTable(MemBuf& buf, PCODE startAddr, TADDR codeSize, SymbolsInfo* lines, unsigned nlines);
     static bool BuildFileTable(MemBuf& buf, SymbolsInfo* lines, unsigned nlines);

--- a/src/vm/gdbjithelpers.h
+++ b/src/vm/gdbjithelpers.h
@@ -32,6 +32,9 @@ struct MethodDebugInfo
     int size;
     LocalVarInfo* locals;
     int localsSize;
+
+    MethodDebugInfo(int numPoints, int numLocals);
+    ~MethodDebugInfo();
 };
 
 typedef BOOL (STDCALL *GetInfoForMethodDelegate)(const char*, unsigned int, MethodDebugInfo& methodDebugInfo);

--- a/src/vm/gdbjithelpers.h
+++ b/src/vm/gdbjithelpers.h
@@ -19,11 +19,18 @@ struct SequencePointInfo
     char16_t* fileName;
 };
 
+struct LocalVarInfo
+{
+    int startOffset;
+    int endOffset;
+    char16_t *name;
+};
+
 struct MethodDebugInfo
 {
     SequencePointInfo* points;
     int size;
-    char16_t** locals;
+    LocalVarInfo* locals;
     int localsSize;
 };
 


### PR DESCRIPTION
This PR adds lexical scopes info for local variables in GDBJIT. It also includes related code refactoring and memory leak fix.

Summary:
* Pass addresses of lexical scopes for local variables from SymbolReader to GDBJIT
* Fix memory leak when passing structures from SymbolReader to GDBJIT
* Generate lexical scope DWARF entries
* Move global variables to local scope to avoid confusion about lifetimes of methods, lines and symbol names

@mikem8361, @janvorli PTAL

cc @Dmitri-Botcharnikov @chunseoklee @seanshpark @lucenticus @kvochko 
