### PR TITLE
Permit null object in `GenTreeUseEdgeIterator`

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -9322,9 +9322,15 @@ GenTreeUseEdgeIterator::GenTreeUseEdgeIterator(GenTree* node)
             return;
 
         case GT_FIELD:
-            m_edge = &m_node->AsField()->gtFldObj;
-            assert(*m_edge != nullptr);
-            m_advance = &GenTreeUseEdgeIterator::Terminate;
+            if (m_node->AsField()->gtFldObj == nullptr)
+            {
+                m_state = -1;
+            }
+            else
+            {
+                m_edge    = &m_node->AsField()->gtFldObj;
+                m_advance = &GenTreeUseEdgeIterator::Terminate;
+            }
             return;
 
         case GT_STMT:


### PR DESCRIPTION
We use `GT_FIELD` for static field loads, which have no instance pointer.
Update the iterator constructor to recognize this as a valid state rather
than fail an assertion.