### PR TITLE
Fix MAC build

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -574,7 +574,8 @@
     <Compile Include="$(BclSourcesRoot)\System\Globalization\DateTimeStyles.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Globalization\DigitShapes.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Globalization\EastAsianLunisolarCalendar.cs" />
-    <Compile Include="$(BclSourcesRoot)\System\Globalization\GlobalizationMode.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Globalization\GlobalizationMode.cs"  Condition="'$(BuildOS)' != 'OSX'"/>
+    <Compile Include="$(BclSourcesRoot)\System\Globalization\GlobalizationMode.OSX.cs"  Condition="'$(BuildOS)' == 'OSX'"/>
     <Compile Include="$(BclSourcesRoot)\System\Globalization\GregorianCalendar.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Globalization\GregorianCalendarHelper.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Globalization\GregorianCalendarTypes.cs" />
@@ -616,7 +617,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Globalization\CompareInfo.Unix.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Globalization\CultureData.Unix.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Globalization\CultureInfo.Unix.cs" />
-    <Compile Include="$(BclSourcesRoot)\System\Globalization\GlobalizationMode.Unix.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Globalization\GlobalizationMode.Unix.cs" Condition="'$(BuildOS)' != 'OSX'"/>
     <Compile Include="$(BclSourcesRoot)\System\Globalization\TextInfo.Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' != 'true'">

--- a/src/mscorlib/src/System/Globalization/GlobalizationMode.OSX.cs
+++ b/src/mscorlib/src/System/Globalization/GlobalizationMode.OSX.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Globalization
+{
+    internal sealed partial class GlobalizationMode
+    {
+        // private const string c_InvariantModeConfigSwitch = "System.Globalization.Invariant";
+        internal static bool Invariant { get; } = false;
+    }
+}


### PR DESCRIPTION
This is temporary fix  to unblock the CI and coreclr building for MAC. this change should be reverted after having the proper fix for how we load ICU on MAC