### PR TITLE
[x86/Linux] Fix incorrect update inside ResumableFrame::UpdateRegDisplay

### DIFF
--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -742,7 +742,7 @@ void ResumableFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 
 #ifdef WIN64EXCEPTIONS
 
-    memcpy(pRD->pCurrentContext, &m_Regs, sizeof(CONTEXT));
+    CopyMemory(pRD->pCurrentContext, m_Regs, sizeof(T_CONTEXT));
 
     pRD->SP = m_Regs->Esp;
     pRD->ControlPC = m_Regs->Eip;


### PR DESCRIPTION
m_Regs is not a context (CONTEXT), but a pointer to a context (PCONTEXT), but ResumableFrame::UpdateRegDisplay uses it as a context.

This results in random failures discussed in #10338 (especially when a thread is resumed from interruption).

This commit revises ResumableFrame::UpdateRegDisplay to update pRD->pCurrentContext correctly in order to fix #10338.