### PR TITLE
[x86/Linux] Use 4-byte align for double in struct

### DIFF
--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -85,7 +85,12 @@ enum NStructFieldType
 //=======================================================================
 // Magic number for default struct packing size.
 //=======================================================================
+#if defined(_TARGET_X86_) && defined(UNIX_X86_ABI)
+// A double is 4-byte aligned on GCC (without -malign-dobule)
+#define DEFAULT_PACKING_SIZE 4
+#else // _TARGET_X86_ && UNIX_X86_ABI
 #define DEFAULT_PACKING_SIZE 8
+#endif // !_TARGET_X86_ || !UNIX_X86_ABI
 
 
 //=======================================================================


### PR DESCRIPTION
This commit revises default struct layout in order to fix  #10133.

This commit introduces 3 failures for x86/Linux, but it turns out that all of these tests depend on the existing struct layout rule, and thus invalid for x86/Linux:
 - Interop.MarshalAPI.OffsetOf.OffsetOf.OffsetOf
 - JIT.Directed.RVAInit.nested.nested
 - JIT.Directed.RVAInit.simple.simple