### PR TITLE
Fix bogus assert in resolveVirtualMethodHelper and update related ilproj

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -8796,7 +8796,6 @@ static CORINFO_METHOD_HANDLE resolveVirtualMethodHelper(MethodDesc* callerMethod
         // The base method should be in the base vtable
         WORD slot = pBaseMD->GetSlot();
         _ASSERTE(slot < pBaseMT->GetNumVirtuals());
-        _ASSERTE(pBaseMD == pBaseMT->GetMethodDescForSlot(slot));
         
         // Fetch the method that would be invoked if the class were
         // exactly derived class. It is up to the jit to determine whether

--- a/tests/src/Loader/classloader/MethodImpl/self_override1.ilproj
+++ b/tests/src/Loader/classloader/MethodImpl/self_override1.ilproj
@@ -14,6 +14,15 @@
     <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
 
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
       <Visible>False</Visible>


### PR DESCRIPTION
This commit removes suspicious assertion from resolveVirtualMethodHelper to fix #10131, and updates related ilproj similarly as #9676.