### PR TITLE
[Ryujit/ARM32][ReadyToRun] Fix invocation to Thunk

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2554,13 +2554,18 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
             GenTree* indir    = Ind(cellAddr);
 
 #ifdef FEATURE_READYTORUN_COMPILER
-#ifdef _TARGET_ARM64_
+#if defined(_TARGET_ARM64_)
             // For arm64, we dispatch code same as VSD using X11 for indirection cell address,
             // which ZapIndirectHelperThunk expects.
             if (call->IsR2RRelativeIndir())
             {
                 cellAddr->gtRegNum = REG_R2R_INDIRECT_PARAM;
                 indir->gtRegNum    = REG_JUMP_THUNK_PARAM;
+            }
+#elif defined(_TARGET_ARM_)
+            if (call->IsR2RRelativeIndir())
+            {
+                cellAddr->gtRegNum = REG_JUMP_THUNK_PARAM;
             }
 #endif
 #endif


### PR DESCRIPTION
Fix invocation to ZapIndirectHelperThunk from code generated by ReadyToRun.
ZapIndirectHelperThunk code for ARM32 accept `r12` as a parameter.

Fixes #10347


## Example
```
JIT/CodeGenBringUpTests/Add1/Add1.exe
using System;
using System.Runtime.CompilerServices;
public class BringUpTest
{
    const int Pass = 100;
    const int Fail = -1;

    [MethodImplAttribute(MethodImplOptions.NoInlining)]
    public static int Add1(int x) { return x+1; }

    public static int Main()
    {   
        int y = Add1(1);
        if (y == 2) return Pass;
        else return Fail;
    }
}
```

# Before
- Code generated from crossgen with /ReadyToRun option
```
G_M27682_IG01:
000000  B508           push    {r3,lr}

G_M27682_IG02:
000002  2001           movs    r0, 1
000004  F240 0300      movw    r3, LOW RELOC 0x74409a2c
000008  F2C0 0300      movt    r3, HIGH RELOC 0x74409a2c
00000C  681B           ldr     r3, [r3]
00000E  4798           blx     r3               // BringUpTest:Add1(int):int
000010  2802           cmp     r0, 2
000012  D101           bne     SHORT G_M27682_IG04
000014  2064           movs    r0, 100

G_M27682_IG03:
000016  BD08           pop     {r3,pc}

G_M27682_IG04:
000018  F04F 30FF      mov     r0, -1

G_M27682_IG05:
00001C  BD08           pop     {r3,pc}
```


- Code generated by runtime Ryujit
```
G_M27682_IG01:
000000  B508           push    {r3,lr}

G_M27682_IG02:
000002  2001           movs    r0, 1
000004  F244 0339      movw    r3, 0x4039
000008  F2C7 13B2      movt    r3, 0x71b2
00000C  4798           blx     r3               // BringUpTest:Add1(int):int
00000E  2802           cmp     r0, 2
000010  D101           bne     SHORT G_M27682_IG04
000012  2064           movs    r0, 100

G_M27682_IG03:
000014  BD08           pop     {r3,pc}

G_M27682_IG04:
000016  F04F 30FF      mov     r0, -1

G_M27682_IG05:
00001A  BD08           pop     {r3,pc}
```


# After
- Code generated from crossgen with /ReadyToRun option

```
G_M27682_IG01:
000000  B508           push    {r3,lr}

G_M27682_IG02:
000002  2001           movs    r0, 1
000004  F240 0C00      movw    r12, LOW RELOC 0x74408a2c
000008  F2C0 0C00      movt    r12, HIGH RELOC 0x74408a2c
00000C  F8DC 3000      ldr     r3, [r12]
000010  4798           blx     r3               // BringUpTest:Add1(int):int
000012  2802           cmp     r0, 2
000014  D101           bne     SHORT G_M27682_IG04
000016  2064           movs    r0, 100

G_M27682_IG03:
000018  BD08           pop     {r3,pc}

G_M27682_IG04:
00001A  F04F 30FF      mov     r0, -1

G_M27682_IG05:
00001E  BD08           pop     {r3,pc}
```

- No change in code generated by runtime Ryujit
(This is a part of #8496)