### PR TITLE
Add /silent option to crossgen

### DIFF
--- a/src/inc/coregen.h
+++ b/src/inc/coregen.h
@@ -18,5 +18,6 @@
 #define NGENWORKER_FLAGS_WINMD_RESILIENT         0x1000
 #define NGENWORKER_FLAGS_READYTORUN              0x2000
 #define NGENWORKER_FLAGS_NO_METADATA             0x4000
+#define NGENWORKER_FLAGS_SILENT                  0x8000
 
 #endif // _NGENCOMMON_H_

--- a/src/tools/crossgen/crossgen.cpp
+++ b/src/tools/crossgen/crossgen.cpp
@@ -108,6 +108,7 @@ void PrintUsageHelper()
        W("\n")
        W("    /? or /help          - Display this screen\n")
        W("    /nologo              - Prevents displaying the logo\n")
+       W("    /silent              - Do not display completion message\n")
        W("    @response.rsp        - Process command line arguments from specified\n")
        W("                           response file\n")
        W("    /partialtrust        - Assembly will be run in a partial trust domain.\n")
@@ -497,6 +498,10 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
         else if (MatchParameter(*argv, W("nologo")))
         {
             fDisplayLogo = false;
+        }
+        else if (MatchParameter(*argv, W("silent")))
+        {
+            dwFlags |= NGENWORKER_FLAGS_SILENT;
         }
         else if (MatchParameter(*argv, W("Tuning")))
         {

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -105,7 +105,7 @@ STDAPI NGenWorker(LPCWSTR pwzFilename, DWORD dwFlags, LPCWSTR pwzPlatformAssembl
         ngo.fDebug = false;
         ngo.fDebugOpt = false;
         ngo.fProf = false;
-        ngo.fSilent = false;
+        ngo.fSilent = (dwFlags & NGENWORKER_FLAGS_SILENT) != 0;
         ngo.lpszExecutableFileName = pwzFilename;
 
         // V2 (Whidbey)


### PR DESCRIPTION
This sets the NGenOptions.fSilent flag, which prevents displaying
the final output message.

This is useful for JIT asm diff generation.