### PR TITLE
Some improvements for testing via ILLINK

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -1734,5 +1734,20 @@
             <Issue>needs triage</Issue>
         </ExcludeList>
     </ItemGroup>
+
+    <!-- Failures while testing via ILLINK -->
+    
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(RunTestsViaIllink)' == 'true'">
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\superpmi\superpmicollect\superpmicollect.cmd">
+            <!-- Linker runs reset CORE_ROOT to the linked directory based on superpmicollect.exe.
+                 The test runs other benchmarks to collect superpmi data.
+                 These tests cannot run from the binaries generated wrt superpmicollect.exe -->
+            <Issue>By Test Infrastructure design</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\nested\nested.cmd">
+            <!-- Data refered from static field is dropped -->
+            <Issue>Bug</Issue>
+        </ExcludeList>
+    </ItemGroup>
     
 </Project>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -160,6 +160,10 @@ if defined __AgainstPackages (
     set __msbuildCommonArgs=%__msbuildCommonArgs% /p:BuildTestsAgainstPackages=true
 )
 
+if defined DoLink (
+    set __msbuildCommonArgs=%__msbuildCommonArgs% /p:RunTestsViaIllink=true
+)
+
 REM Prepare the Test Drop
 REM Cleans any NI from the last run
 powershell "Get-ChildItem -path %__TestWorkingDir% -Include '*.ni.*' -Recurse -Force | Remove-Item -force"

--- a/tests/src/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.csproj
+++ b/tests/src/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/tests/src/GC/Scenarios/ReflectObj/reflectobj.csproj
+++ b/tests/src/GC/Scenarios/ReflectObj/reflectobj.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444a.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444a.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444b.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444b.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/tests/src/JIT/Regression/Dev11/External/dev11_13748/ReflectOnField.ilproj
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_13748/ReflectOnField.ilproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/tests/src/Loader/classloader/MethodImpl/self_override1.ilproj
+++ b/tests/src/Loader/classloader/MethodImpl/self_override1.ilproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>self_override1</AssemblyName>

--- a/tests/src/Loader/classloader/MethodImpl/self_override2.ilproj
+++ b/tests/src/Loader/classloader/MethodImpl/self_override2.ilproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>self_override2</AssemblyName>

--- a/tests/src/Loader/classloader/MethodImpl/self_override3.ilproj
+++ b/tests/src/Loader/classloader/MethodImpl/self_override3.ilproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>self_override3</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract02.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract02.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="abstract02">
+        <type fullname="GenBase" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract03.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract03.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="abstract03">
+        <type fullname="GenBase" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract04.reflect.xml
+++ b/tests/src/Loader/classloader/generics/Instantiation/Negative/abstract04.reflect.xml
@@ -1,0 +1,5 @@
+<linker>
+    <assembly fullname="abstract04">
+        <type fullname="GenBase" required="true" />
+    </assembly>
+</linker>

--- a/tests/src/Loader/classloader/generics/Variance/IL/CastClass001.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/CastClass001.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>CastClass001</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/CastClass004.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/CastClass004.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>CastClass004</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst001.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst001.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst001</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst002.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst002.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst002</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst003.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst003.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst003</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst004.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst004.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst004</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst005.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst005.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst005</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/IsInst006.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/IsInst006.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>IsInst006</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox001.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox001.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox001</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox002.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox002.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox002</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox003.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox003.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox003</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox004.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox004.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox004</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox005.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox005.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox005</AssemblyName>

--- a/tests/src/Loader/classloader/generics/Variance/IL/Unbox006.csproj
+++ b/tests/src/Loader/classloader/generics/Variance/IL/Unbox006.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>Unbox006</AssemblyName>

--- a/tests/src/Loader/classloader/regressions/14610/TestObjectGetTypeVirtual.csproj
+++ b/tests/src/Loader/classloader/regressions/14610/TestObjectGetTypeVirtual.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>TestObjectGetTypeVirtual</AssemblyName>

--- a/tests/src/Loader/classloader/regressions/dev11_95728/dev11_95728.csproj
+++ b/tests/src/Loader/classloader/regressions/dev11_95728/dev11_95728.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build;CopyReflectionRoots" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>dev11_95728</AssemblyName>

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -184,9 +184,9 @@
 
   </Target>
 
-  <Target Name="CopyReflectionRoots">  
-    <Copy SourceFiles="$(AssemblyName).reflect.xml" 
-          DestinationFolder="$(OutputPath)"
-	  Condition="Exists('$(AssemblyName).reflect.xml')"/>  
-  </Target>  
+  <Target Name="AfterBuild">
+     <Copy SourceFiles="$(AssemblyName).reflect.xml"
+           DestinationFolder="$(OutputPath)"
+       Condition="Exists('$(AssemblyName).reflect.xml')"/>
+  </Target>
 </Project>


### PR DESCRIPTION
This PR has the following changes:
1) Fix the way msbuild processes *.reflect.xml files files so that they are copied correctly by runtests.cmd.
2) Exclude the tests with known problems so that the lab is green for ILLINK tests.
3) Add reflect.xml overrides for some testes
