### PR TITLE
[x86/Linux] 16-byte aligned TheUMEntryPrestub

### DIFF
--- a/src/vm/i386/umthunkstub.S
+++ b/src/vm/i386/umthunkstub.S
@@ -10,12 +10,16 @@
 // eax = UMEntryThunk*
 //
 NESTED_ENTRY TheUMEntryPrestub, _TEXT, UnhandledExceptionHandlerUnix
+#define STK_ALIGN_PADDING 8
+    sub     esp, STK_ALIGN_PADDING
     push    eax  // UMEntryThunk*
+    CHECK_STACK_ALIGNMENT
     call    C_FUNC(TheUMEntryPrestubWorker)
-    add     esp, 4
-    // eax = PCODE
+    add     esp, (4 + STK_ALIGN_PADDING)
 
+    // eax = PCODE
     jmp     eax     // Tail Jmp
+#undef STK_ALIGN_PADDING
 NESTED_END TheUMEntryPrestub, _TEXT
 
 //


### PR DESCRIPTION
This commit revises TheUMEntryPrestub to align its stack frame and check alignment before invoking TheUMEntryPrestubWorker.