### PR TITLE
[x86/Linux] add three functions for _X86_TARGET_

### DIFF
--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -2393,6 +2393,10 @@ typedef DPTR(IMAGE_TLS_DIRECTORY)   PTR_IMAGE_TLS_DIRECTORY;
 #include <xclrdata.h>
 #endif
 
+#if defined(_TARGET_X86_) && defined(FEATURE_PAL)
+typedef DPTR(struct _UNWIND_INFO)      PTR_UNWIND_INFO;
+#endif
+
 #ifdef _WIN64
 typedef DPTR(T_RUNTIME_FUNCTION) PTR_RUNTIME_FUNCTION;
 typedef DPTR(struct _UNWIND_INFO)      PTR_UNWIND_INFO;

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -988,7 +988,7 @@ PTR_VOID GetUnwindDataBlob(TADDR moduleBase, PTR_RUNTIME_FUNCTION pRuntimeFuncti
 #elif defined(_TARGET_X86_) && defined(FEATURE_PAL)
     PTR_UNWIND_INFO pUnwindInfo(dac_cast<PTR_UNWIND_INFO>(moduleBase + RUNTIME_FUNCTION__GetUnwindInfoAddress(pRuntimeFunction)));
 
-    *pSize = ALIGN_UP(sizeof(UNWIND_INFO), sizeof(BYTE));
+    *pSize = ALIGN_UP(sizeof(UNWIND_INFO), sizeof(DWORD));
 
     return pUnwindInfo;
 

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -988,7 +988,7 @@ PTR_VOID GetUnwindDataBlob(TADDR moduleBase, PTR_RUNTIME_FUNCTION pRuntimeFuncti
 #elif defined(_TARGET_X86_) && defined(FEATURE_PAL)
     PTR_UNWIND_INFO pUnwindInfo(dac_cast<PTR_UNWIND_INFO>(moduleBase + RUNTIME_FUNCTION__GetUnwindInfoAddress(pRuntimeFunction)));
 
-    *pSize = ALIGN_UP(sizeof(ULONG), sizeof(DWORD));
+    *pSize = ALIGN_UP(sizeof(UNWIND_INFO), sizeof(BYTE));
 
     return pUnwindInfo;
 

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -985,6 +985,13 @@ PTR_VOID GetUnwindDataBlob(TADDR moduleBase, PTR_RUNTIME_FUNCTION pRuntimeFuncti
 
     return pUnwindInfo;
 
+#elif defined(_TARGET_X86_) && defined(FEATURE_PAL)
+    PTR_UNWIND_INFO pUnwindInfo(dac_cast<PTR_UNWIND_INFO>(moduleBase + RUNTIME_FUNCTION__GetUnwindInfoAddress(pRuntimeFunction)));
+
+    *pSize = ALIGN_UP(sizeof(ULONG), sizeof(DWORD));
+
+    return pUnwindInfo;
+
 #elif defined(_TARGET_ARM_)
 
     // if this function uses packed unwind data then at least one of the two least significant bits

--- a/src/zap/zapcode.cpp
+++ b/src/zap/zapcode.cpp
@@ -1206,7 +1206,7 @@ void ZapUnwindData::Save(ZapWriter * pZapWriter)
 
 UINT ZapUnwindData::GetAlignment()
 {
-    return sizeof(ULONG);
+    return sizeof(BYTE);
 }
 
 DWORD ZapUnwindData::GetSize()
@@ -1222,8 +1222,6 @@ void ZapUnwindData::Save(ZapWriter * pZapWriter)
 
     PVOID pData = GetData();
     DWORD dwSize = GetBlobSize();
-
-    UNWIND_INFO * pUnwindInfo = (UNWIND_INFO *)pData;
 
     pZapWriter->Write(pData, dwSize);
 }

--- a/src/zap/zapcode.cpp
+++ b/src/zap/zapcode.cpp
@@ -1202,7 +1202,7 @@ void ZapUnwindData::Save(ZapWriter * pZapWriter)
 #endif //REDHAWK
 }
 
-#elif defined(_TARGET_X86_)
+#elif defined(_TARGET_X86_) && defined(FEATURE_PAL)
 
 UINT ZapUnwindData::GetAlignment()
 {
@@ -1212,14 +1212,6 @@ UINT ZapUnwindData::GetAlignment()
 DWORD ZapUnwindData::GetSize()
 {
     DWORD dwSize = ZapBlob::GetSize();
-
-#ifndef REDHAWK
-    // Add space for personality routine, it must be 4-byte aligned.
-    // Everything in the UNWIND_INFO has already had its size included in size
-    dwSize = AlignUp(dwSize, sizeof(ULONG));
-
-    dwSize += sizeof(ULONG);
-#endif //REDHAWK
 
     return dwSize;
 }
@@ -1234,15 +1226,6 @@ void ZapUnwindData::Save(ZapWriter * pZapWriter)
     UNWIND_INFO * pUnwindInfo = (UNWIND_INFO *)pData;
 
     pZapWriter->Write(pData, dwSize);
-
-#ifndef REDHAWK
-    DWORD dwPad = AlignmentPad(dwSize, sizeof(DWORD));
-    if (dwPad != 0)
-        pZapWriter->WritePad(dwPad);
-
-    ULONG personalityRoutine = GetPersonalityRoutine(pImage)->GetRVA();
-    pZapWriter->Write(&personalityRoutine, sizeof(personalityRoutine));
-#endif //REDHAWK
 }
 
 #elif defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)


### PR DESCRIPTION
There is no functions for _X86_TARGET_.
  - ZapUnwindData::GetAlignment()
  - DWORD ZapUnwindData::GetSize()
  - void ZapUnwindData::Save(ZapWriter * pZapWriter)