### PR TITLE
[Local GC] Opt-out of GC Stress for FEATURE_STANDALONE_GC

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -208,8 +208,10 @@ void GCStatistics::AddGCStats(const gc_mechanisms& settings, size_t timeInMSec)
 
     if (is_induced (settings.reason))
         cntReasons[(int)reason_induced]++;
+#ifdef STRESS_HEAP
     else if (settings.stress_induced)
         cntReasons[(int)reason_gcstress]++;
+#endif // STRESS_HEAP
     else
         cntReasons[(int)settings.reason]++;
 

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -31,6 +31,11 @@ Module Name:
 
 #ifdef FEATURE_STANDALONE_GC
 #include "gcenv.ee.standalone.inl"
+
+// GCStress does not currently work with Standalone GC
+#ifdef STRESS_HEAP
+ #undef STRESS_HEAP
+#endif // STRESS_HEAP
 #endif // FEATURE_STANDALONE_GC
 
 /*


### PR DESCRIPTION
GCStress requires a level of coordination between the EE and the VM that isn't appropriate (yet) for a standalone GC, so this PR opts-out of it. Any developer validating their changes to a standalone GC and wishing to run GCStress can do a non-standalone build and validate their changes that way until we re-enable it for standalone GC.