### PR TITLE
Change setBBProfileWeight so that we no longer multiply a profile counts by 100

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -545,8 +545,7 @@ struct BasicBlock : private LIR::Range
     void setBBProfileWeight(unsigned weight)
     {
         this->bbFlags |= BBF_PROF_WEIGHT;
-        // Check if the multiplication by BB_UNITY_WEIGHT will overflow.
-        this->bbWeight = (weight <= BB_MAX_WEIGHT / BB_UNITY_WEIGHT) ? weight * BB_UNITY_WEIGHT : BB_MAX_WEIGHT;
+        this->bbWeight = weight;
     }
 
     // modifyBBWeight -- same as setBBWeight, but also make sure that if the block is rarely run, it stays that


### PR DESCRIPTION

Fix fgAddSyncMethodEnterExit to properly set the IBC profile weight when we have profile data
In fgComputeEdgeWeights properly set fgCalledCount when we inserted a new first block using fgFirstBBisScratch
Fix fgOptimizeUncondBranchToSimpleCond to properly set the new BasicBlock's weight and flags