### PR TITLE
replace the linear time algorithm from lclvars with the constant one.

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -438,6 +438,8 @@ struct BasicBlock : private LIR::Range
 #define BBF_CLONED_FINALLY_BEGIN 0x100000000 // First block of a cloned finally region
 #define BBF_CLONED_FINALLY_END 0x200000000   // Last block of a cloned finally region
 
+#define BBF_DOMINATED_BY_NOT_NORMAL_ENTRY 0x400000000 // Full set of dominators contains not normal entry.
+
 // Flags that relate blocks to loop structure.
 
 #define BBF_LOOP_FLAGS (BBF_LOOP_PREHEADER | BBF_LOOP_HEAD | BBF_LOOP_CALL0 | BBF_LOOP_CALL1)
@@ -1171,6 +1173,16 @@ public:
 
     void MakeLIR(GenTree* firstNode, GenTree* lastNode);
     bool IsLIR();
+
+    void SetDominatedByNotNormalEntryFlag()
+    {
+        bbFlags |= BBF_DOMINATED_BY_NOT_NORMAL_ENTRY;
+    }
+
+    bool IsDominatedByNotNormalEntryFlag()
+    {
+        return (bbFlags & BBF_DOMINATED_BY_NOT_NORMAL_ENTRY) != 0;
+    }
 };
 
 template <>

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -438,7 +438,7 @@ struct BasicBlock : private LIR::Range
 #define BBF_CLONED_FINALLY_BEGIN 0x100000000 // First block of a cloned finally region
 #define BBF_CLONED_FINALLY_END 0x200000000   // Last block of a cloned finally region
 
-#define BBF_DOMINATED_BY_NOT_NORMAL_ENTRY 0x400000000 // Full set of dominators contains not normal entry.
+#define BBF_DOMINATED_BY_EXCEPTIONAL_ENTRY 0x400000000 // Block is dominated by exceptional entry.
 
 // Flags that relate blocks to loop structure.
 
@@ -880,11 +880,6 @@ struct BasicBlock : private LIR::Range
     unsigned bbDfsNum;   // The index of this block in DFS reverse post order
                          // relative to the flow graph.
 
-#if ASSERTION_PROP
-    // A set of blocks which dominate this one *except* the normal entry block. This is lazily initialized
-    // and used only by Assertion Prop, intersected with fgEnterBlks!
-#endif
-
     IL_OFFSET bbCodeOffs;    // IL offset of the beginning of the block
     IL_OFFSET bbCodeOffsEnd; // IL offset past the end of the block. Thus, the [bbCodeOffs..bbCodeOffsEnd)
                              // range is not inclusive of the end offset. The count of IL bytes in the block
@@ -1079,9 +1074,7 @@ struct BasicBlock : private LIR::Range
     GenTree*     FirstNonPhiDefOrCatchArgAsg();
 
     BasicBlock()
-        :
-        VARSET_INIT_NOCOPY(bbLiveIn, VarSetOps::UninitVal())
-        , VARSET_INIT_NOCOPY(bbLiveOut, VarSetOps::UninitVal())
+        : VARSET_INIT_NOCOPY(bbLiveIn, VarSetOps::UninitVal()), VARSET_INIT_NOCOPY(bbLiveOut, VarSetOps::UninitVal())
     {
     }
 
@@ -1169,14 +1162,14 @@ public:
     void MakeLIR(GenTree* firstNode, GenTree* lastNode);
     bool IsLIR();
 
-    void SetDominatedByNotNormalEntryFlag()
+    void SetDominatedByExceptionalEntryFlag()
     {
-        bbFlags |= BBF_DOMINATED_BY_NOT_NORMAL_ENTRY;
+        bbFlags |= BBF_DOMINATED_BY_EXCEPTIONAL_ENTRY;
     }
 
-    bool IsDominatedByNotNormalEntryFlag()
+    bool IsDominatedByExceptionalEntryFlag()
     {
-        return (bbFlags & BBF_DOMINATED_BY_NOT_NORMAL_ENTRY) != 0;
+        return (bbFlags & BBF_DOMINATED_BY_EXCEPTIONAL_ENTRY) != 0;
     }
 };
 

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -883,7 +883,6 @@ struct BasicBlock : private LIR::Range
 #if ASSERTION_PROP
     // A set of blocks which dominate this one *except* the normal entry block. This is lazily initialized
     // and used only by Assertion Prop, intersected with fgEnterBlks!
-    BlockSet bbDoms;
 #endif
 
     IL_OFFSET bbCodeOffs;    // IL offset of the beginning of the block
@@ -1081,10 +1080,6 @@ struct BasicBlock : private LIR::Range
 
     BasicBlock()
         :
-#if ASSERTION_PROP
-        BLOCKSET_INIT_NOCOPY(bbDoms, BlockSetOps::UninitVal())
-        ,
-#endif // ASSERTION_PROP
         VARSET_INIT_NOCOPY(bbLiveIn, VarSetOps::UninitVal())
         , VARSET_INIT_NOCOPY(bbLiveOut, VarSetOps::UninitVal())
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2798,6 +2798,9 @@ protected:
     static fgWalkPreFn lvaMarkLclRefsCallback;
     void lvaMarkLclRefs(GenTreePtr tree);
 
+    bool IsDominatedByNotNormalEntry(BasicBlock* block);
+    void SetVolatileHint(LclVarDsc* varDsc);
+
     // Keeps the mapping from SSA #'s to VN's for the implicit memory variables.
     PerSsaArray lvMemoryPerSsaData;
     unsigned    lvMemoryNumSsaNames;
@@ -4074,6 +4077,8 @@ protected:
                           // by fgBuildDomTree to build the dominance tree structure.
                           // Based on: A Simple, Fast Dominance Algorithm
                           // by Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy
+
+    void fgCompDominatedByNotNormalEntryBlocks();
 
     BlockSet_ValRet_T fgGetDominatorSet(BasicBlock* block); // Returns a set of blocks that dominate the given block.
     // Note: this is relatively slow compared to calling fgDominate(),

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2798,7 +2798,7 @@ protected:
     static fgWalkPreFn lvaMarkLclRefsCallback;
     void lvaMarkLclRefs(GenTreePtr tree);
 
-    bool IsDominatedByNotNormalEntry(BasicBlock* block);
+    bool IsDominatedByExceptionalEntry(BasicBlock* block);
     void SetVolatileHint(LclVarDsc* varDsc);
 
     // Keeps the mapping from SSA #'s to VN's for the implicit memory variables.
@@ -4078,7 +4078,7 @@ protected:
                           // Based on: A Simple, Fast Dominance Algorithm
                           // by Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy
 
-    void fgCompDominatedByNotNormalEntryBlocks();
+    void fgCompDominatedByExceptionalEntryBlocks();
 
     BlockSet_ValRet_T fgGetDominatorSet(BasicBlock* block); // Returns a set of blocks that dominate the given block.
     // Note: this is relatively slow compared to calling fgDominate(),

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -2532,7 +2532,7 @@ void Compiler::fgComputeDoms()
         }
     }
 
-    fgCompDominatedByNotNormalEntryBlocks();
+    fgCompDominatedByExceptionalEntryBlocks();
 
 #ifdef DEBUG
     if (verbose)
@@ -24936,10 +24936,10 @@ unsigned Compiler::fgMeasureIR()
 }
 
 //------------------------------------------------------------------------
-// fgCompDominatedByNotNormalEntryBlocks: compute blocks that are
+// fgCompDominatedByExceptionalEntryBlocks: compute blocks that are
 // dominated by not normal entry.
 //
-void Compiler::fgCompDominatedByNotNormalEntryBlocks()
+void Compiler::fgCompDominatedByExceptionalEntryBlocks()
 {
     for (unsigned i = 1; i <= fgBBNumMax; ++i)
     {
@@ -24948,12 +24948,12 @@ void Compiler::fgCompDominatedByNotNormalEntryBlocks()
         {
             if (fgFirstBB != block) // skip the normal entry.
             {
-                block->SetDominatedByNotNormalEntryFlag();
+                block->SetDominatedByExceptionalEntryFlag();
             }
         }
-        else if (block->bbIDom->IsDominatedByNotNormalEntryFlag())
+        else if (block->bbIDom->IsDominatedByExceptionalEntryFlag())
         {
-            block->SetDominatedByNotNormalEntryFlag();
+            block->SetDominatedByExceptionalEntryFlag();
         }
     }
 }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -2409,7 +2409,7 @@ void Compiler::fgComputeDoms()
     bbRoot.bbNum    = 0;
     bbRoot.bbIDom   = &bbRoot;
     bbRoot.bbDfsNum = 0;
-    bbRoot.bbFlags = 0;
+    bbRoot.bbFlags  = 0;
     flRoot.flNext   = nullptr;
     flRoot.flBlock  = &bbRoot;
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -2409,6 +2409,7 @@ void Compiler::fgComputeDoms()
     bbRoot.bbNum    = 0;
     bbRoot.bbIDom   = &bbRoot;
     bbRoot.bbDfsNum = 0;
+    bbRoot.bbFlags = 0;
     flRoot.flNext   = nullptr;
     flRoot.flBlock  = &bbRoot;
 
@@ -2530,6 +2531,8 @@ void Compiler::fgComputeDoms()
             block->bbPreds = nullptr;
         }
     }
+
+    fgCompDominatedByNotNormalEntryBlocks();
 
 #ifdef DEBUG
     if (verbose)
@@ -24930,4 +24933,27 @@ unsigned Compiler::fgMeasureIR()
     }
 
     return nodeCount;
+}
+
+//------------------------------------------------------------------------
+// fgCompDominatedByNotNormalEntryBlocks: compute blocks that are
+// dominated by not normal entry.
+//
+void Compiler::fgCompDominatedByNotNormalEntryBlocks()
+{
+    for (unsigned i = 1; i <= fgBBNumMax; ++i)
+    {
+        BasicBlock* block = fgBBInvPostOrder[i];
+        if (BlockSetOps::IsMember(this, fgEnterBlks, block->bbNum))
+        {
+            if (fgFirstBB != block) // skip the normal entry.
+            {
+                block->SetDominatedByNotNormalEntryFlag();
+            }
+        }
+        else if (block->bbIDom->IsDominatedByNotNormalEntryFlag())
+        {
+            block->SetDominatedByNotNormalEntryFlag();
+        }
+    }
 }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -24941,19 +24941,23 @@ unsigned Compiler::fgMeasureIR()
 //
 void Compiler::fgCompDominatedByExceptionalEntryBlocks()
 {
-    for (unsigned i = 1; i <= fgBBNumMax; ++i)
+    assert(fgEnterBlksSetValid);
+    if (BlockSetOps::Count(this, fgEnterBlks) != 1) // There are exception entries.
     {
-        BasicBlock* block = fgBBInvPostOrder[i];
-        if (BlockSetOps::IsMember(this, fgEnterBlks, block->bbNum))
+        for (unsigned i = 1; i <= fgBBNumMax; ++i)
         {
-            if (fgFirstBB != block) // skip the normal entry.
+            BasicBlock* block = fgBBInvPostOrder[i];
+            if (BlockSetOps::IsMember(this, fgEnterBlks, block->bbNum))
+            {
+                if (fgFirstBB != block) // skip the normal entry.
+                {
+                    block->SetDominatedByExceptionalEntryFlag();
+                }
+            }
+            else if (block->bbIDom->IsDominatedByExceptionalEntryFlag())
             {
                 block->SetDominatedByExceptionalEntryFlag();
             }
-        }
-        else if (block->bbIDom->IsDominatedByExceptionalEntryFlag())
-        {
-            block->SetDominatedByExceptionalEntryFlag();
         }
     }
 }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3434,23 +3434,9 @@ void Compiler::lvaMarkLclRefs(GenTreePtr tree)
     }
 
 #if ASSERTION_PROP
-    /* Exclude the normal entry block */
-    if (fgDomsComputed && (lvaMarkRefsCurBlock->bbNum != 1) && lvaMarkRefsCurBlock->bbIDom != nullptr)
+    if (fgDomsComputed && IsDominatedByNotNormalEntry(lvaMarkRefsCurBlock))
     {
-        // If any entry block except the normal entry block dominates the block, then mark the local with the
-        // lvVolatileHint flag.
-
-        if (BlockSetOps::MayBeUninit(lvaMarkRefsCurBlock->bbDoms))
-        {
-            // Lazy init (If a block is not dominated by any other block, we'll redo this every time, but it'll be fast)
-            BlockSetOps::AssignNoCopy(this, lvaMarkRefsCurBlock->bbDoms, fgGetDominatorSet(lvaMarkRefsCurBlock));
-            BlockSetOps::RemoveElemD(this, lvaMarkRefsCurBlock->bbDoms, fgFirstBB->bbNum);
-        }
-        assert(fgEnterBlksSetValid);
-        if (!BlockSetOps::IsEmptyIntersection(this, lvaMarkRefsCurBlock->bbDoms, fgEnterBlks))
-        {
-            varDsc->lvVolatileHint = 1;
-        }
+        SetVolatileHint(varDsc);
     }
 
     /* Record if the variable has a single def or not */
@@ -3533,6 +3519,46 @@ void Compiler::lvaMarkLclRefs(GenTreePtr tree)
         }
     }
 #endif
+}
+
+//------------------------------------------------------------------------
+// IsDominatedByNotNormalEntry: Check is the block dominated by an exception entry block.
+//
+// Arguments:
+//    block - the checking block.
+//
+bool Compiler::IsDominatedByNotNormalEntry(BasicBlock* block)
+{
+    assert(fgDomsComputed);
+
+    // If any entry block except the normal entry block dominates the block, then mark the local with the
+    // lvVolatileHint flag.
+
+    if (BlockSetOps::MayBeUninit(block->bbDoms))
+    {
+        // Lazy init (If a block is not dominated by any other block, we'll redo this every time, it is not fast).
+        BlockSetOps::AssignNoCopy(this, block->bbDoms, fgGetDominatorSet(block));
+        BlockSetOps::RemoveElemD(this, block->bbDoms, fgFirstBB->bbNum);
+    }
+    assert(fgEnterBlksSetValid);
+    if (!BlockSetOps::IsEmptyIntersection(this, block->bbDoms, fgEnterBlks))
+    {
+        assert(block->IsDominatedByNotNormalEntryFlag() == true);
+        return true;
+    }
+    assert(block->IsDominatedByNotNormalEntryFlag() == false);
+    return false;
+}
+
+//------------------------------------------------------------------------
+// SetVolatileHint: Set a local var's volatile hint.
+//
+// Arguments:
+//    varDsc - the local variable that needs the hint.
+//
+void Compiler::SetVolatileHint(LclVarDsc* varDsc)
+{
+    varDsc->lvVolatileHint = true;
 }
 
 /*****************************************************************************

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3530,24 +3530,7 @@ void Compiler::lvaMarkLclRefs(GenTreePtr tree)
 bool Compiler::IsDominatedByNotNormalEntry(BasicBlock* block)
 {
     assert(fgDomsComputed);
-
-    // If any entry block except the normal entry block dominates the block, then mark the local with the
-    // lvVolatileHint flag.
-
-    if (BlockSetOps::MayBeUninit(block->bbDoms))
-    {
-        // Lazy init (If a block is not dominated by any other block, we'll redo this every time, it is not fast).
-        BlockSetOps::AssignNoCopy(this, block->bbDoms, fgGetDominatorSet(block));
-        BlockSetOps::RemoveElemD(this, block->bbDoms, fgFirstBB->bbNum);
-    }
-    assert(fgEnterBlksSetValid);
-    if (!BlockSetOps::IsEmptyIntersection(this, block->bbDoms, fgEnterBlks))
-    {
-        assert(block->IsDominatedByNotNormalEntryFlag() == true);
-        return true;
-    }
-    assert(block->IsDominatedByNotNormalEntryFlag() == false);
-    return false;
+    return block->IsDominatedByNotNormalEntryFlag();
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3434,7 +3434,7 @@ void Compiler::lvaMarkLclRefs(GenTreePtr tree)
     }
 
 #if ASSERTION_PROP
-    if (fgDomsComputed && IsDominatedByNotNormalEntry(lvaMarkRefsCurBlock))
+    if (fgDomsComputed && IsDominatedByExceptionalEntry(lvaMarkRefsCurBlock))
     {
         SetVolatileHint(varDsc);
     }
@@ -3522,15 +3522,15 @@ void Compiler::lvaMarkLclRefs(GenTreePtr tree)
 }
 
 //------------------------------------------------------------------------
-// IsDominatedByNotNormalEntry: Check is the block dominated by an exception entry block.
+// IsDominatedByExceptionalEntry: Check is the block dominated by an exception entry block.
 //
 // Arguments:
 //    block - the checking block.
 //
-bool Compiler::IsDominatedByNotNormalEntry(BasicBlock* block)
+bool Compiler::IsDominatedByExceptionalEntry(BasicBlock* block)
 {
     assert(fgDomsComputed);
-    return block->IsDominatedByNotNormalEntryFlag();
+    return block->IsDominatedByExceptionalEntryFlag();
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
It allows to answer the question: "Is block dominated by non normal
entry" - in O(1). 
It is asked per block and time complexity was O(N^2), where N is the number of blocks in IR.
The third commit fixes #10314 