### PR TITLE
Fix CSE bug with GT_MUL and GTF_MUL_64RSLT

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -10869,7 +10869,6 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                             op1->gtOp.gtOp1 = gtNewOperNode(GT_NOP, TYP_INT, op1->gtCast.CastOp());
                             op1->gtFlags &= ~GTF_ALL_EFFECT;
                             op1->gtFlags |= (op1->gtCast.CastOp()->gtFlags & GTF_ALL_EFFECT);
-                            op1->gtFlags |= GTF_DONT_CSE;
                         }
 
                         if (op2->gtCast.CastOp()->OperGet() != GT_NOP)
@@ -10877,8 +10876,10 @@ GenTreePtr Compiler::fgMorphSmpOp(GenTreePtr tree, MorphAddrContext* mac)
                             op2->gtOp.gtOp1 = gtNewOperNode(GT_NOP, TYP_INT, op2->gtCast.CastOp());
                             op2->gtFlags &= ~GTF_ALL_EFFECT;
                             op2->gtFlags |= (op2->gtCast.CastOp()->gtFlags & GTF_ALL_EFFECT);
-                            op2->gtFlags |= GTF_DONT_CSE;
                         }
+
+                        op1->gtFlags |= GTF_DONT_CSE;
+                        op2->gtFlags |= GTF_DONT_CSE;
 
                         tree->gtFlags &= ~GTF_ALL_EFFECT;
                         tree->gtFlags |= ((op1->gtFlags | op2->gtFlags) & GTF_ALL_EFFECT);


### PR DESCRIPTION
Unconditionally set op1 and op2 as GTF_DONT_CSE.
Previously, this was only done if the cast was not
a GT_NOP. It is possible for it already to come in
as GT_NOP, thus leading to the possibility to CSE
the operand, and leading to this assert firing:
```
assert(tree->gtIsValid64RsltMul());
```