### PR TITLE
[x86/Linux] Use CDECL instead of STDCALL

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -747,6 +747,17 @@ enum CorInfoCallConv
     CORINFO_CALLCONV_PARAMTYPE  = 0x80,     // Passed last. Same as CORINFO_GENERICS_CTXT_FROM_PARAMTYPEARG
 };
 
+#ifdef UNIX_X86_ABI
+inline bool IsCallerPop(CorInfoCallConv callConv)
+{
+    unsigned int umask = CORINFO_CALLCONV_STDCALL
+                       | CORINFO_CALLCONV_THISCALL
+                       | CORINFO_CALLCONV_FASTCALL;
+
+    return !(callConv & umask);
+}
+#endif // UNIX_X86_ABI
+
 enum CorInfoUnmanagedCallConv
 {
     // These correspond to CorUnmanagedCallingConvention

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1637,7 +1637,7 @@ void CodeGen::genDefineTempLabel(BasicBlock* label)
 
 void CodeGen::genAdjustSP(ssize_t delta)
 {
-#ifdef _TARGET_X86_
+#if defined(_TARGET_X86_) && !defined(UNIX_X86_ABI)
     if (delta == sizeof(int))
         inst_RV(INS_pop, REG_ECX, TYP_INT);
     else

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -9717,7 +9717,7 @@ void CodeGen::genFnEpilog(BasicBlock* block)
         unsigned stkArgSize = 0; // Zero on all platforms except x86
 
 #if defined(_TARGET_X86_)
-        bool fCalleePop = true;
+        bool     fCalleePop = true;
 
         // varargs has caller pop
         if (compiler->info.compIsVarArgs)

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -9716,7 +9716,7 @@ void CodeGen::genFnEpilog(BasicBlock* block)
     {
         unsigned stkArgSize = 0; // Zero on all platforms except x86
 
-#if defined(_TARGET_X86_)
+#if defined(_TARGET_X86_) && !defined(UNIX_X86_ABI)
 
         noway_assert(compiler->compArgSize >= intRegState.rsCalleeRegArgCount * sizeof(void*));
         stkArgSize = compiler->compArgSize - intRegState.rsCalleeRegArgCount * sizeof(void*);
@@ -9727,7 +9727,7 @@ void CodeGen::genFnEpilog(BasicBlock* block)
         if (compiler->info.compIsVarArgs)
             stkArgSize = 0;
 
-#endif // defined(_TARGET_X86_)
+#endif // _TARGET_X86_ && !UNIX_X86_ABI
 
         /* Return, popping our arguments (if any) */
         instGen_Return(stkArgSize);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -176,7 +176,7 @@ void genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode);
 
 void genAlignStackBeforeCall(GenTreePutArgStk* putArgStk);
 void genAlignStackBeforeCall(GenTreeCall* call);
-void genRemoveAlignmentAfterCall(GenTreeCall* call);
+void genRemoveAlignmentAfterCall(GenTreeCall* call, unsigned bias = 0);
 
 #if defined(UNIX_X86_ABI)
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7575,6 +7575,7 @@ void CodeGen::genAlignStackBeforeCall(GenTreeCall* call)
 //
 void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call, unsigned bias)
 {
+#if definex(_TARGET_X86_)
 #if defined(UNIX_X86_ABI)
     // Put back the stack pointer if there was any padding for stack alignment
     unsigned padStkAlign  = call->fgArgInfo->GetStkAlign();
@@ -7587,8 +7588,14 @@ void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call, unsigned bias)
         SubtractNestedAlignment(padStkAlign);
     }
 #else  // UNIX_X86_ABI
-    assert(bias == 0);
+    if (bias != 0)
+    {
+        inst_RV_IV(INS_add, REG_SPBASE, bias, EA_PTRSIZE);
+    }
 #endif // !UNIX_X86_ABI_
+#else  // _TARGET_X86_
+    assert(bias == 0);
+#endif // !_TARGET_X86
 }
 
 #ifdef _TARGET_X86_

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7590,7 +7590,7 @@ void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call, unsigned bias)
 #else  // UNIX_X86_ABI
     if (bias != 0)
     {
-        inst_RV_IV(INS_add, REG_SPBASE, bias, EA_PTRSIZE);
+        genAdjustSP(bias);
     }
 #endif // !UNIX_X86_ABI_
 #else  // _TARGET_X86_

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7570,8 +7570,8 @@ void CodeGen::genAlignStackBeforeCall(GenTreeCall* call)
 //    bias - additional stack adjustment
 //
 // Note:
-//    When bias > 0, caller should adjust stack level appropriately as 
-//    bias is not considered when adjusting stack level. 
+//    When bias > 0, caller should adjust stack level appropriately as
+//    bias is not considered when adjusting stack level.
 //
 void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call, unsigned bias)
 {
@@ -7586,9 +7586,9 @@ void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call, unsigned bias)
         SubtractStackLevel(padStkAlign);
         SubtractNestedAlignment(padStkAlign);
     }
-#else // _TARGET_X86_
+#else  // UNIX_X86_ABI
     assert(bias == 0);
-#endif // !_TARGET_X86_
+#endif // !UNIX_X86_ABI_
 }
 
 #ifdef _TARGET_X86_

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7575,7 +7575,7 @@ void CodeGen::genAlignStackBeforeCall(GenTreeCall* call)
 //
 void CodeGen::genRemoveAlignmentAfterCall(GenTreeCall* call, unsigned bias)
 {
-#if definex(_TARGET_X86_)
+#if defined(_TARGET_X86_)
 #if defined(UNIX_X86_ABI)
     // Put back the stack pointer if there was any padding for stack alignment
     unsigned padStkAlign  = call->fgArgInfo->GetStkAlign();

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6957,6 +6957,14 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     }
 #endif // !FEATURE_VARARG
 
+#ifdef UNIX_X86_ABI
+    if (call->gtCall.callSig == nullptr)
+    {
+      call->gtCall.callSig  = new (this, CMK_CorSig) CORINFO_SIG_INFO;
+      *call->gtCall.callSig = *sig;
+    }
+#endif // UNIX_X86_ABI
+
     if ((sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_VARARG ||
         (sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_NATIVEVARARG)
     {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6960,8 +6960,8 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 #ifdef UNIX_X86_ABI
     if (call->gtCall.callSig == nullptr)
     {
-      call->gtCall.callSig  = new (this, CMK_CorSig) CORINFO_SIG_INFO;
-      *call->gtCall.callSig = *sig;
+        call->gtCall.callSig  = new (this, CMK_CorSig) CORINFO_SIG_INFO;
+        *call->gtCall.callSig = *sig;
     }
 #endif // UNIX_X86_ABI
 

--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -277,10 +277,13 @@ VOID GenerateShuffleArray(MethodDesc* pInvoke, MethodDesc *pTargetMeth, SArray<S
         COMPlusThrow(kVerificationException);
     }
 
-    UINT stackSizeDelta = stackSizeSrc - stackSizeDst;
+    UINT stackSizeDelta;
 
 #ifdef UNIX_X86_ABI
+    // Stack does not shrink as UNIX_X86_ABI uses CDECL (instead of STDCALL).
     stackSizeDelta = 0;
+#else
+    stackSizeDelta = stackSizeSrc - stackSizeDst;
 #endif
 
     INT ofsSrc, ofsDst;

--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -279,6 +279,10 @@ VOID GenerateShuffleArray(MethodDesc* pInvoke, MethodDesc *pTargetMeth, SArray<S
 
     UINT stackSizeDelta = stackSizeSrc - stackSizeDst;
 
+#ifdef UNIX_X86_ABI
+    stackSizeDelta = 0;
+#endif
+
     INT ofsSrc, ofsDst;
 
     // if the function is non static we need to place the 'this' first

--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -377,7 +377,7 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
 
 // Choose the appropriate calling convention for FCALL helpers on the basis of the JIT calling convention
 #ifdef __GNUC__
-#define F_CALL_CONV __attribute__((stdcall, regparm(3)))
+#define F_CALL_CONV __attribute__((cdecl, regparm(3)))
 
 // GCC fastcall convention (simulated via stdcall) is different from MSVC fastcall convention. GCC can use up
 // to 3 registers to store parameters. The registers used are EAX, EDX, ECX. Dummy parameters and reordering

--- a/src/vm/i386/jithelp.S
+++ b/src/vm/i386/jithelp.S
@@ -562,7 +562,7 @@ LEAF_ENTRY JIT_Dbl2LngP4x87, _TEXT
     // restore stack
     add     esp, 8
 
-    ret     8
+    ret
 LEAF_END JIT_Dbl2LngP4x87, _TEXT
 
 // *********************************************************************/
@@ -588,7 +588,7 @@ LEAF_ENTRY JIT_Dbl2LngSSE3, _TEXT
     // restore stack
     add     esp, 8
 
-    ret     8
+    ret
 LEAF_END JIT_Dbl2LngSSE3, _TEXT
 
 // *********************************************************************/
@@ -605,7 +605,7 @@ LEAF_END JIT_Dbl2LngSSE3, _TEXT
 LEAF_ENTRY JIT_Dbl2IntSSE2, _TEXT
     movsd     xmm0, [esp + 4]
     cvttsd2si eax, xmm0
-    ret       8
+    ret
 LEAF_END JIT_Dbl2IntSSE2, _TEXT
 
 // *********************************************************************/

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -1251,7 +1251,7 @@ VOID StubLinkerCPU::X86EmitReturn(WORD wArgBytes)
     CONTRACTL
     {
         STANDARD_VM_CHECK;
-#ifdef _TARGET_AMD64_
+#if defined(_TARGET_AMD64_) || defined(UNIX_X86_ABI)
         PRECONDITION(wArgBytes == 0);
 #endif
 
@@ -3268,7 +3268,7 @@ VOID StubLinkerCPU::EmitMethodStubEpilog(WORD numArgBytes, int transitionBlockOf
     X86EmitPopReg(kR15);
 #endif
 
-#ifdef _TARGET_AMD64_
+#if defined(_TARGET_AMD64_) || defined(UNIX_X86_ABI)
     // Caller deallocates argument space.  (Bypasses ASSERT in
     // X86EmitReturn.)
     numArgBytes = 0;
@@ -4222,6 +4222,10 @@ VOID StubLinkerCPU::EmitShuffleThunk(ShuffleEntry *pShuffleEntryArray)
 
     if (haveMemMemMove)
         X86EmitPopReg(SCRATCH_REGISTER_X86REG);
+
+#ifdef UNIX_X86_ABI
+    _ASSERTE(pWalk->stacksizedelta == 0);
+#endif
 
     if (pWalk->stacksizedelta)
         X86EmitAddEsp(pWalk->stacksizedelta);
@@ -5717,8 +5721,12 @@ COPY_VALUE_CLASS:
     X86EmitPopReg(kFactorReg);
     X86EmitPopReg(kTotalReg);
 
+#ifndef UNIX_X86_ABI
     // ret N
     X86EmitReturn(pArrayOpScript->m_cbretpop);
+#else
+    X86EmitReturn(0);
+#endif
 #endif // !_TARGET_AMD64_
 
     // Exception points must clean up the stack for all those extra args.


### PR DESCRIPTION
This commit changes global calling convention from STDCALL into CDECL to fix #10377.
