### PR TITLE
Incorrect loop variable

### DIFF
--- a/src/tools/metainfo/mdinfo.cpp
+++ b/src/tools/metainfo/mdinfo.cpp
@@ -1418,7 +1418,7 @@ void MDInfo::DisplayFields(mdTypeDef inTypeDef, COR_FIELD_OFFSET *rFieldOffset, 
             if (cFieldOffset)
             {
                 bool found = false;
-                for (ULONG iLayout = 0; i < cFieldOffset; ++iLayout)
+                for (ULONG iLayout = 0; iLayout < cFieldOffset; ++iLayout)
                 {
                     if (RidFromToken(rFieldOffset[iLayout].ridOfField) == RidFromToken(fields[i]))
                     {


### PR DESCRIPTION
I used PVS-Studio static analyzer to check this project. I would like to suggest a variant of the way to fix the error, detected with the help of V534 diagnostic. Description of the diagnostic: https://www.viva64.com/en/examples/v534/

Incorrect variable 'i' from the outer loop is used in condition of the inner loop.