### PR TITLE
Missing comma

### DIFF
--- a/src/debug/di/rsmain.cpp
+++ b/src/debug/di/rsmain.cpp
@@ -60,7 +60,7 @@ const char * GetDebugCodeName(DWORD dwCode)
         "(5) EXIT_PROCESS_DEBUG_EVENT",
         "(6) LOAD_DLL_DEBUG_EVENT",
         "(7) UNLOAD_DLL_DEBUG_EVENT",
-        "(8) OUTPUT_DEBUG_STRING_EVENT"
+        "(8) OUTPUT_DEBUG_STRING_EVENT",
         "(9) RIP_EVENT",// <-- only on Win9X
     };
 


### PR DESCRIPTION
We have found and fixed a security weakness (CWE-188) using PVS-Studio tool: Analyzer warning: V557 Array overrun is possible. The value of 'dwCode - 1' index could reach 8.

PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/