### PR TITLE
Use roslyn common props

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
@@ -197,4 +198,7 @@
     <PackageIndex Include="$(PackageIndexFile)" />
   </ItemGroup>
 
+  <!-- Use Roslyn Compilers to build -->
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'!='true' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
+  <Import Project="$(RoslynPropsFile)" Condition="'$(RunningOnUnix)'=='true' and Exists('$(RoslynPropsFile)')" />
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/10056

Import Roslyn common props so that we don't get mismatched imports on VS2017

/cc @weshaggard @gkhanna79 