### PR TITLE
Mark b425314 Incompatible

### DIFF
--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314.csproj
@@ -11,9 +11,9 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
 
-    <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
-    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86'">true</HeapVerifyIncompatible>
+    <!-- NOTE: This test takes too long and internally times out under GCStress/heap verify. It is not fundamentally incompatible if stress testing is fast enough.  -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
b425314 has internal logic to determine if it making forward progress

If test takes too long, test self check fails and test aborts with a
failure.  This makes this test difficult in GCStress/HeapVerify situations
where run time is substantially longer.

This test was already marked gcStress/HeapVerify incompatible for x86.  Remove x86 condition
to mark incompatible on all platforms.

Fixes #10420 

@jkotas @pgavlin @dotnet/jit-contrib 