### PR TITLE
Add PNSE messages

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -4335,6 +4335,9 @@
   <data name="PlatformNotSupported_SecureBinarySerialization" xml:space="preserve">
     <value>Secure binary serialization is not supported on this platform.</value>
   </data>
+  <data name="PlatformNotSupported_StrongNameSigning" xml:space="preserve">
+    <value>Strong name signing is not supported on this platform.</value>
+  </data>
   <data name="PlatformNotSupported_WinRT" xml:space="preserve">
     <value>Windows Runtime is not supported on this operating system.</value>
   </data>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -1,64 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -4361,6 +4302,12 @@
   <data name="PartitionerStatic_CurrentCalledBeforeMoveNext" xml:space="preserve">
     <value>MoveNext must be called at least once before calling Current.</value>
   </data>
+  <data name="PlatformNotSupported_ArgIterator" xml:space="preserve">
+    <value>ArgIterator is not supported on this platform.</value>
+  </data>
+     <data name="PlatformNotSupported_ComInterop" xml:space="preserve">
+    <value>COM Interop is not supported on this platform.</value>
+  </data>
   <data name="PlatformNotSupported_NamedSynchronizationPrimitives" xml:space="preserve">
     <value>The named version of this synchronization primitive is not supported on this platform.</value>
   </data>
@@ -4373,6 +4320,9 @@
   <data name="PlatformNotSupported_ReflectionOnly" xml:space="preserve">
     <value>ReflectionOnly loading is not supported on this platform.</value>
   </data>
+  <data name="PlatformNotSupported_Remoting" xml:space="preserve">
+    <value>Remoting is not supported on this platform.</value>
+  </data>   
   <data name="PlatformNotSupported_RequiresLonghorn" xml:space="preserve">
     <value>This operation is only supported on Windows Vista and above.</value>
   </data>

--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -4305,7 +4305,7 @@
   <data name="PlatformNotSupported_ArgIterator" xml:space="preserve">
     <value>ArgIterator is not supported on this platform.</value>
   </data>
-     <data name="PlatformNotSupported_ComInterop" xml:space="preserve">
+  <data name="PlatformNotSupported_ComInterop" xml:space="preserve">
     <value>COM Interop is not supported on this platform.</value>
   </data>
   <data name="PlatformNotSupported_NamedSynchronizationPrimitives" xml:space="preserve">
@@ -4331,6 +4331,9 @@
   </data>
   <data name="PlatformNotSupported_RequiresW2kSP3" xml:space="preserve">
     <value>This operation is only supported on Windows 2000 SP3 or later operating systems.</value>
+  </data>
+  <data name="PlatformNotSupported_SecureBinarySerialization" xml:space="preserve">
+    <value>Secure binary serialization is not supported on this platform.</value>
   </data>
   <data name="PlatformNotSupported_WinRT" xml:space="preserve">
     <value>Windows Runtime is not supported on this operating system.</value>

--- a/src/mscorlib/shared/System/MarshalByRefObject.cs
+++ b/src/mscorlib/shared/System/MarshalByRefObject.cs
@@ -13,12 +13,12 @@ namespace System
 
         public object GetLifetimeService()
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_Remoting);
         }
 
         public virtual object InitializeLifetimeService()
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_Remoting);
         }
 
         protected MarshalByRefObject MemberwiseClone(bool cloneIdentity)

--- a/src/mscorlib/shared/System/Reflection/StrongNameKeyPair.cs
+++ b/src/mscorlib/shared/System/Reflection/StrongNameKeyPair.cs
@@ -50,14 +50,14 @@ namespace System.Reflection
 
         public StrongNameKeyPair(string keyPairContainer)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_StrongNameSigning);
         }
 
         public byte[] PublicKey
         {
             get
             {
-                throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_StrongNameSigning);
             }
         }
 

--- a/src/mscorlib/shared/System/Reflection/StrongNameKeyPair.cs
+++ b/src/mscorlib/shared/System/Reflection/StrongNameKeyPair.cs
@@ -50,14 +50,14 @@ namespace System.Reflection
 
         public StrongNameKeyPair(string keyPairContainer)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
         public byte[] PublicKey
         {
             get
             {
-                throw new PlatformNotSupportedException();
+                throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
             }
         }
 

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -815,9 +815,6 @@ namespace Microsoft.Win32
         [DllImport(KERNEL32, CharSet = CharSet.Auto, SetLastError = true)]
         internal static extern uint GetCurrentProcessId();
 
-        [DllImport(KERNEL32, CharSet = CharSet.Auto, BestFitMapping = false)]
-        internal extern static int GetComputerName([Out]StringBuilder nameBuffer, ref int bufferSize);
-
         [DllImport(OLE32)]
         internal extern static int CoCreateGuid(out Guid guid);
 

--- a/src/mscorlib/src/System/ArgIterator.cs
+++ b/src/mscorlib/src/System/ArgIterator.cs
@@ -136,50 +136,50 @@ namespace System
 #else
         public ArgIterator(RuntimeArgumentHandle arglist)
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
 
         [CLSCompliant(false)]
         public unsafe ArgIterator(RuntimeArgumentHandle arglist, void* ptr)
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
 
         public void End()
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
 
         public override bool Equals(Object o)
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
 
         public override int GetHashCode()
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
 
         [System.CLSCompliantAttribute(false)]
         public System.TypedReference GetNextArg()
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
 
         [System.CLSCompliantAttribute(false)]
         public System.TypedReference GetNextArg(System.RuntimeTypeHandle rth)
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
 
         public unsafe System.RuntimeTypeHandle GetNextArgType()
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
 
         public int GetRemainingCount()
         {
-            throw new PlatformNotSupportedException(); //The JIT requires work to enable ArgIterator see: https://github.com/dotnet/coreclr/issues/9204.
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/coreclr/issues/9204
         }
 #endif //VARARGS_ENABLED
     }

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -233,27 +233,6 @@ namespace System
             return blob.ToString();
         }
 
-        public static String MachineName
-        {
-            get
-            {
-                // UWP Debug scenarios
-                if (AppDomain.IsAppXModel() && !AppDomain.IsAppXDesignMode())
-                {
-                    // Getting Computer Name is not a supported scenario on Store apps.
-                    throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
-                }
-
-                // In future release of operating systems, you might be able to rename a machine without
-                // rebooting.  Therefore, don't cache this machine name.
-                StringBuilder buf = new StringBuilder(MaxMachineNameLength);
-                int len = MaxMachineNameLength;
-                if (Win32Native.GetComputerName(buf, ref len) == 0)
-                    throw new InvalidOperationException(SR.InvalidOperation_ComputerName);
-                return buf.ToString();
-            }
-        }
-
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         [SuppressUnmanagedCodeSecurity]
         private static extern Int32 GetProcessorCount();

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -180,13 +180,6 @@ namespace System
                 return name;
             }
 
-            if (AppDomain.IsAppXModel() && !AppDomain.IsAppXDesignMode())
-            {
-                // Environment variable accessors are not approved modern API.
-                // Behave as if no variables are defined in this case.
-                return name;
-            }
-
             int currentSize = 100;
             StringBuilder blob = new StringBuilder(currentSize); // A somewhat reasonable default size
 
@@ -680,13 +673,6 @@ namespace System
 
         private static string GetEnvironmentVariableCore(string variable)
         {
-            if (AppDomain.IsAppXModel() && !AppDomain.IsAppXDesignMode())
-            {
-                // Environment variable accessors are not approved modern API.
-                // Behave as if the variable was not found in this case.
-                return null;
-            }
-
             StringBuilder sb = StringBuilderCache.Acquire(128); // A somewhat reasonable default size
             int requiredSize = Win32Native.GetEnvironmentVariable(variable, sb, sb.Capacity);
 
@@ -742,13 +728,6 @@ namespace System
 
         private static IDictionary GetEnvironmentVariablesCore()
         {
-            if (AppDomain.IsAppXModel() && !AppDomain.IsAppXDesignMode())
-            {
-                // Environment variable accessors are not approved modern API.
-                // Behave as if no environment variables are defined in this case.
-                return new Dictionary<string, string>(0);
-            }
-
             return GetRawEnvironmentVariables();
         }
 

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -241,7 +241,7 @@ namespace System
                 if (AppDomain.IsAppXModel() && !AppDomain.IsAppXDesignMode())
                 {
                     // Getting Computer Name is not a supported scenario on Store apps.
-                    throw new PlatformNotSupportedException();
+                    throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
                 }
 
                 // In future release of operating systems, you might be able to rename a machine without
@@ -820,13 +820,6 @@ namespace System
             // explicitly null out value if is the empty string.
             if (string.IsNullOrEmpty(value) || value[0] == '\0')
                 value = null;
-
-            if (AppDomain.IsAppXModel() && !AppDomain.IsAppXDesignMode())
-            {
-                // Environment variable accessors are not approved modern API.
-                // so we throw PlatformNotSupportedException.
-                throw new PlatformNotSupportedException();
-            }
 
             if (!Win32Native.SetEnvironmentVariable(variable, value))
             {

--- a/src/mscorlib/src/System/Exception.cs
+++ b/src/mscorlib/src/System/Exception.cs
@@ -520,8 +520,8 @@ namespace System
 
         protected event EventHandler<SafeSerializationEventArgs> SerializeObjectState
         {
-            add { throw new PlatformNotSupportedException(); }
-            remove { throw new PlatformNotSupportedException(); }
+            add { throw new PlatformNotSupportedException(WHAT_TEXT_HERE); }
+            remove { throw new PlatformNotSupportedException(WHAT_TEXT_HERE); }
         }
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/src/mscorlib/src/System/Exception.cs
+++ b/src/mscorlib/src/System/Exception.cs
@@ -520,8 +520,8 @@ namespace System
 
         protected event EventHandler<SafeSerializationEventArgs> SerializeObjectState
         {
-            add { throw new PlatformNotSupportedException(WHAT_TEXT_HERE); }
-            remove { throw new PlatformNotSupportedException(WHAT_TEXT_HERE); }
+            add { throw new PlatformNotSupportedException(SR.PlatformNotSupported_SecureBinarySerialization); }
+            remove { throw new PlatformNotSupportedException(SR.PlatformNotSupported_SecureBinarySerialization); }
         }
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -408,7 +408,7 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static byte ReadByte([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
         public static unsafe byte ReadByte(IntPtr ptr, int ofs)
@@ -432,7 +432,7 @@ namespace System.Runtime.InteropServices
 
         public static short ReadInt16([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
         public static unsafe short ReadInt16(IntPtr ptr, int ofs)
@@ -469,7 +469,7 @@ namespace System.Runtime.InteropServices
 
         public static int ReadInt32([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
         public static unsafe int ReadInt32(IntPtr ptr, int ofs)
@@ -535,7 +535,7 @@ namespace System.Runtime.InteropServices
 
         public static long ReadInt64([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
         public static unsafe long ReadInt64(IntPtr ptr, int ofs)
@@ -596,7 +596,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteByte([MarshalAs(UnmanagedType.AsAny), In, Out] Object ptr, int ofs, byte val)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
         public static void WriteByte(IntPtr ptr, byte val)
@@ -631,7 +631,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteInt16([MarshalAs(UnmanagedType.AsAny), In, Out] Object ptr, int ofs, short val)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
         public static void WriteInt16(IntPtr ptr, short val)
@@ -683,7 +683,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteInt32([MarshalAs(UnmanagedType.AsAny), In, Out] Object ptr, int ofs, int val)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
         public static void WriteInt32(IntPtr ptr, int val)
@@ -751,7 +751,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteInt64([MarshalAs(UnmanagedType.AsAny), In, Out] Object ptr, int ofs, long val)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
         public static void WriteInt64(IntPtr ptr, long val)
@@ -1172,7 +1172,7 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static IntPtr /* IDispatch */ GetIDispatchForObject(Object o)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
         }
 
 #if FEATURE_COMINTEROP
@@ -1470,7 +1470,7 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static Object GetComObjectData(Object obj, Object key)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         //====================================================================
@@ -1481,7 +1481,7 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static bool SetComObjectData(Object obj, Object key, Object data)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
 #if FEATURE_COMINTEROP
@@ -1772,7 +1772,7 @@ namespace System.Runtime.InteropServices
 #if FEATURE_COMINTEROP
             return s.MarshalToBSTR();
 #else
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
 #endif
         }
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -408,7 +408,7 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static byte ReadByte([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/coreclr/issues/10442
         }
 
         public static unsafe byte ReadByte(IntPtr ptr, int ofs)
@@ -432,7 +432,7 @@ namespace System.Runtime.InteropServices
 
         public static short ReadInt16([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/coreclr/issues/10442
         }
 
         public static unsafe short ReadInt16(IntPtr ptr, int ofs)
@@ -469,7 +469,7 @@ namespace System.Runtime.InteropServices
 
         public static int ReadInt32([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/coreclr/issues/10442
         }
 
         public static unsafe int ReadInt32(IntPtr ptr, int ofs)
@@ -535,7 +535,7 @@ namespace System.Runtime.InteropServices
 
         public static long ReadInt64([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/coreclr/issues/10442
         }
 
         public static unsafe long ReadInt64(IntPtr ptr, int ofs)
@@ -596,7 +596,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteByte([MarshalAs(UnmanagedType.AsAny), In, Out] Object ptr, int ofs, byte val)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/coreclr/issues/10442
         }
 
         public static void WriteByte(IntPtr ptr, byte val)
@@ -631,7 +631,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteInt16([MarshalAs(UnmanagedType.AsAny), In, Out] Object ptr, int ofs, short val)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/coreclr/issues/10442
         }
 
         public static void WriteInt16(IntPtr ptr, short val)
@@ -683,7 +683,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteInt32([MarshalAs(UnmanagedType.AsAny), In, Out] Object ptr, int ofs, int val)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/coreclr/issues/10442
         }
 
         public static void WriteInt32(IntPtr ptr, int val)
@@ -751,7 +751,7 @@ namespace System.Runtime.InteropServices
 
         public static void WriteInt64([MarshalAs(UnmanagedType.AsAny), In, Out] Object ptr, int ofs, long val)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/coreclr/issues/10442
         }
 
         public static void WriteInt64(IntPtr ptr, long val)

--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1772,7 +1772,7 @@ namespace System.Runtime.InteropServices
 #if FEATURE_COMINTEROP
             return s.MarshalToBSTR();
 #else
-            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/coreclr/issues/10443
 #endif
         }
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1172,7 +1172,7 @@ namespace System.Runtime.InteropServices
         //====================================================================
         public static IntPtr /* IDispatch */ GetIDispatchForObject(Object o)
         {
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException();
         }
 
 #if FEATURE_COMINTEROP

--- a/src/mscorlib/src/System/Runtime/InteropServices/NonPortable.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/NonPortable.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices
 
         public static int AddRef(System.IntPtr pUnk)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static bool AreComObjectsAvailableForCleanup()
@@ -25,12 +25,12 @@ namespace System.Runtime.InteropServices
 
         public static System.IntPtr CreateAggregatedObject(System.IntPtr pOuter, object o)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static Object BindToMoniker(String monikerName)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
         
         public static void CleanupUnusedObjectsInCurrentContext()
@@ -40,42 +40,42 @@ namespace System.Runtime.InteropServices
 
         public static System.IntPtr CreateAggregatedObject<T>(System.IntPtr pOuter, T o)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static object CreateWrapperOfType(object o, System.Type t)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static TWrapper CreateWrapperOfType<T, TWrapper>(T o)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static void ChangeWrapperHandleStrength(Object otp, bool fIsWeak)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }           
 
         public static int FinalReleaseComObject(object o)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static System.IntPtr GetComInterfaceForObject(object o, System.Type T)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static System.IntPtr GetComInterfaceForObject(object o, System.Type T, System.Runtime.InteropServices.CustomQueryInterfaceMode mode)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static System.IntPtr GetComInterfaceForObject<T, TInterface>(T o)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static System.IntPtr GetHINSTANCE(System.Reflection.Module m)
@@ -89,67 +89,67 @@ namespace System.Runtime.InteropServices
 
         public static System.IntPtr GetIUnknownForObject(object o)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static void GetNativeVariantForObject(object obj, System.IntPtr pDstNativeVariant)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static void GetNativeVariantForObject<T>(T obj, System.IntPtr pDstNativeVariant)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static Object GetTypedObjectForIUnknown(System.IntPtr pUnk, System.Type t)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static object GetObjectForIUnknown(System.IntPtr pUnk)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static object GetObjectForNativeVariant(System.IntPtr pSrcNativeVariant)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static T GetObjectForNativeVariant<T>(System.IntPtr pSrcNativeVariant)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static object[] GetObjectsForNativeVariants(System.IntPtr aSrcNativeVariant, int cVars)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static T[] GetObjectsForNativeVariants<T>(System.IntPtr aSrcNativeVariant, int cVars)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static int GetStartComSlot(System.Type t)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static System.Type GetTypeFromCLSID(System.Guid clsid) 
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static string GetTypeInfoName(System.Runtime.InteropServices.ComTypes.ITypeInfo typeInfo)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static object GetUniqueObjectForIUnknown(System.IntPtr unknown)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static bool IsComObject(object o)
@@ -159,22 +159,22 @@ namespace System.Runtime.InteropServices
 
         public static int QueryInterface(System.IntPtr pUnk, ref System.Guid iid, out System.IntPtr ppv)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static int Release(System.IntPtr pUnk)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static int ReleaseComObject(object o)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static void ZeroFreeBSTR(System.IntPtr s)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
     }
 
@@ -182,14 +182,14 @@ namespace System.Runtime.InteropServices
     {
         public DispatchWrapper(object obj)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public object WrappedObject
         {
             get
             {
-                throw new PlatformNotSupportedException();
+                throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
             }
         }
     }
@@ -198,12 +198,12 @@ namespace System.Runtime.InteropServices
     {
         public static void Combine(object rcw, System.Guid iid, int dispid, System.Delegate d)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
 
         public static System.Delegate Remove(object rcw, System.Guid iid, int dispid, System.Delegate d)
         {
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
         }
     }
 }

--- a/src/mscorlib/src/System/Runtime/InteropServices/NonPortable.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/NonPortable.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices
 
         public static int AddRef(System.IntPtr pUnk)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static bool AreComObjectsAvailableForCleanup()
@@ -25,12 +25,12 @@ namespace System.Runtime.InteropServices
 
         public static System.IntPtr CreateAggregatedObject(System.IntPtr pOuter, object o)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static Object BindToMoniker(String monikerName)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
         
         public static void CleanupUnusedObjectsInCurrentContext()
@@ -40,42 +40,42 @@ namespace System.Runtime.InteropServices
 
         public static System.IntPtr CreateAggregatedObject<T>(System.IntPtr pOuter, T o)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static object CreateWrapperOfType(object o, System.Type t)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static TWrapper CreateWrapperOfType<T, TWrapper>(T o)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static void ChangeWrapperHandleStrength(Object otp, bool fIsWeak)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }           
 
         public static int FinalReleaseComObject(object o)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static System.IntPtr GetComInterfaceForObject(object o, System.Type T)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static System.IntPtr GetComInterfaceForObject(object o, System.Type T, System.Runtime.InteropServices.CustomQueryInterfaceMode mode)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static System.IntPtr GetComInterfaceForObject<T, TInterface>(T o)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static System.IntPtr GetHINSTANCE(System.Reflection.Module m)
@@ -89,67 +89,67 @@ namespace System.Runtime.InteropServices
 
         public static System.IntPtr GetIUnknownForObject(object o)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static void GetNativeVariantForObject(object obj, System.IntPtr pDstNativeVariant)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static void GetNativeVariantForObject<T>(T obj, System.IntPtr pDstNativeVariant)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static Object GetTypedObjectForIUnknown(System.IntPtr pUnk, System.Type t)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static object GetObjectForIUnknown(System.IntPtr pUnk)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static object GetObjectForNativeVariant(System.IntPtr pSrcNativeVariant)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static T GetObjectForNativeVariant<T>(System.IntPtr pSrcNativeVariant)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static object[] GetObjectsForNativeVariants(System.IntPtr aSrcNativeVariant, int cVars)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static T[] GetObjectsForNativeVariants<T>(System.IntPtr aSrcNativeVariant, int cVars)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static int GetStartComSlot(System.Type t)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static System.Type GetTypeFromCLSID(System.Guid clsid) 
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static string GetTypeInfoName(System.Runtime.InteropServices.ComTypes.ITypeInfo typeInfo)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static object GetUniqueObjectForIUnknown(System.IntPtr unknown)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static bool IsComObject(object o)
@@ -159,22 +159,22 @@ namespace System.Runtime.InteropServices
 
         public static int QueryInterface(System.IntPtr pUnk, ref System.Guid iid, out System.IntPtr ppv)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static int Release(System.IntPtr pUnk)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static int ReleaseComObject(object o)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static void ZeroFreeBSTR(System.IntPtr s)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
     }
 
@@ -182,14 +182,14 @@ namespace System.Runtime.InteropServices
     {
         public DispatchWrapper(object obj)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public object WrappedObject
         {
             get
             {
-                throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+                throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
             }
         }
     }
@@ -198,12 +198,12 @@ namespace System.Runtime.InteropServices
     {
         public static void Combine(object rcw, System.Guid iid, int dispid, System.Delegate d)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static System.Delegate Remove(object rcw, System.Guid iid, int dispid, System.Delegate d)
         {
-            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
     }
 }

--- a/src/mscorlib/src/System/Threading/WaitHandle.cs
+++ b/src/mscorlib/src/System/Threading/WaitHandle.cs
@@ -448,7 +448,7 @@ namespace System.Threading
                                         WaitHandle toWaitOn)
         {
 #if PLATFORM_UNIX
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported); // https://github.com/dotnet/coreclr/issues/10441
 #else
             return SignalAndWait(toSignal, toWaitOn, -1, false);
 #endif
@@ -461,7 +461,7 @@ namespace System.Threading
                                         bool exitContext)
         {
 #if PLATFORM_UNIX
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported); // https://github.com/dotnet/coreclr/issues/10441
 #else
             long tm = (long)timeout.TotalMilliseconds;
             if (-1 > tm || (long)Int32.MaxValue < tm)
@@ -480,7 +480,7 @@ namespace System.Threading
                                         bool exitContext)
         {
 #if PLATFORM_UNIX
-            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
+            throw new PlatformNotSupportedException(SR.Arg_PlatformNotSupported); // https://github.com/dotnet/coreclr/issues/10441
 #else
             if (null == toSignal)
             {

--- a/src/mscorlib/src/System/Threading/WaitHandle.cs
+++ b/src/mscorlib/src/System/Threading/WaitHandle.cs
@@ -448,7 +448,7 @@ namespace System.Threading
                                         WaitHandle toWaitOn)
         {
 #if PLATFORM_UNIX
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
 #else
             return SignalAndWait(toSignal, toWaitOn, -1, false);
 #endif
@@ -461,7 +461,7 @@ namespace System.Threading
                                         bool exitContext)
         {
 #if PLATFORM_UNIX
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
 #else
             long tm = (long)timeout.TotalMilliseconds;
             if (-1 > tm || (long)Int32.MaxValue < tm)
@@ -480,7 +480,7 @@ namespace System.Threading
                                         bool exitContext)
         {
 #if PLATFORM_UNIX
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException(WHAT_TEXT_HERE);
 #else
             if (null == toSignal)
             {


### PR DESCRIPTION
Tightening up on PNSE because it looks like should actually have implementations and got overlooked (eg: most in Marshal)

I'm doing this by making sure they all have messages, either a specific one or the `SR.Arg_PlatformNotSupported` that they'd get by default anyway. That will help me grep again in future.

For `throw new PlatformNotSupportedException(WHAT_TEXT_HERE);` in this change please let me know whether we should have an implementation, and if not why it's not possible. Then I'll fix the message / open an issue as needed.

I didn't look at `new NotSupportedException()` as I'm assuming those are all carried over from desktop, ie., we've consistently only used that when no other platform supports the codepath either.

@jkotas 