### PR TITLE
Move '#pragma warning(disable:21000)' to correct place

### DIFF
--- a/src/debug/di/process.cpp
+++ b/src/debug/di/process.cpp
@@ -4525,10 +4525,6 @@ void CordbProcess::QueueFakeConnectionEvents()
 // from the runtime controller. This represents the last amount of processing
 // the DI gets to do on an event before giving it to the user.
 //
-#ifdef _PREFAST_
-#pragma warning(push)
-#pragma warning(disable:21000) // Suppress PREFast warning about overly large function
-#endif
 void CordbProcess::DispatchRCEvent()
 {
     INTERNAL_API_ENTRY(this);
@@ -4729,6 +4725,10 @@ void CordbProcess::DbgAssertAppDomainDeleted(VMPTR_AppDomain vmAppDomainDeleted)
 //    A V2 shim can provide a proxy calllack that takes these events and queues them and 
 //    does the real dispatch to the user to emulate V2 semantics.
 //
+#ifdef _PREFAST_
+#pragma warning(push)
+#pragma warning(disable:21000) // Suppress PREFast warning about overly large function
+#endif
 void CordbProcess::RawDispatchEvent(
     DebuggerIPCEvent *          pEvent, 
     RSLockHolder *              pLockHolder,


### PR DESCRIPTION
Whilst I was writing a blog post ['A Hitchhikers Guide to the CoreCLR Source Code'](http://mattwarren.org/2017/03/23/Hitchhikers-Guide-to-the-CoreCLR-Source-Code/#top-10-lists) I noticed that a `#pragma warning(disable:21000)` was mis-aligned.

I'm pretty sure that having it in the wrong place doesn't cause a problem, because the other methods are smaller (i.e. this doesn't actually *fix* anything). So I understand if you don't want to take the PR.