### PR TITLE
[Linux][GDB-JIT] Remove (nothrow) when using new

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -47,7 +47,7 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle,
         case ELEMENT_TYPE_R8:
         case ELEMENT_TYPE_U:
         case ELEMENT_TYPE_I:
-            typeInfo = new (nothrow) ByteTypeInfo(typeHandle, CorElementTypeToDWEncoding[corType]);
+            typeInfo = new (nothrow) PrimitiveTypeInfo(typeHandle, CorElementTypeToDWEncoding[corType]);
             if (typeInfo == nullptr)
                 return nullptr;
 
@@ -1111,9 +1111,9 @@ static const char *GetCSharpTypeName(TypeInfoBase *typeInfo)
     }
 }
 
-void ByteTypeInfo::DumpStrings(char* ptr, int& offset)
+void PrimitiveTypeInfo::DumpStrings(char* ptr, int& offset)
 {
-    PrimitiveTypeInfo::DumpStrings(ptr, offset);
+    TypeInfoBase::DumpStrings(ptr, offset);
     if (!m_typedef_info->m_typedef_name)
     {
         const char *typeName = GetCSharpTypeName(this);
@@ -1123,21 +1123,13 @@ void ByteTypeInfo::DumpStrings(char* ptr, int& offset)
     m_typedef_info->DumpStrings(ptr, offset);
 }
 
-void ByteTypeInfo::DumpDebugInfo(char *ptr, int &offset)
-{
-    m_typedef_info->DumpDebugInfo(ptr, offset);
-    PrimitiveTypeInfo::DumpDebugInfo(ptr, offset);
-    // Replace offset from real type to typedef
-    if (ptr != nullptr)
-        m_type_offset = m_typedef_info->m_typedef_type_offset;
-}
-
-void PrimitiveTypeInfo::DumpDebugInfo(char* ptr, int& offset)
+void PrimitiveTypeInfo::DumpDebugInfo(char *ptr, int &offset)
 {
     if (m_type_offset != 0)
     {
         return;
     }
+    m_typedef_info->DumpDebugInfo(ptr, offset);
 
     if (ptr != nullptr)
     {
@@ -1154,6 +1146,9 @@ void PrimitiveTypeInfo::DumpDebugInfo(char* ptr, int& offset)
     }
 
     offset += sizeof(DebugInfoType);
+    // Replace offset from real type to typedef
+    if (ptr != nullptr)
+        m_type_offset = m_typedef_info->m_typedef_type_offset;
 }
 
 ClassTypeInfo::ClassTypeInfo(TypeHandle typeHandle, int num_members, FunctionMemberPtrArrayHolder &method)

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1749,13 +1749,8 @@ struct Elf_Symbol {
     int m_off;
     TADDR m_value;
     int m_section, m_size;
-    bool m_releaseName;
-    Elf_Symbol() : m_name(nullptr), m_off(0), m_value(0), m_section(0), m_size(0), m_releaseName(false) {}
-    ~Elf_Symbol()
-    {
-        if (m_releaseName)
-            delete [] m_name;
-    }
+    NewArrayHolder<char> m_symbol_name;
+    Elf_Symbol() : m_name(nullptr), m_off(0), m_value(0), m_section(0), m_size(0) {}
 };
 
 static int countFuncs(const SymbolsInfo *lines, int nlines)
@@ -2624,8 +2619,8 @@ bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods,
             MethodDesc* pMD = pList->GetMethodDesc();
             LPCUTF8 methodName = pMD->GetName();
             int symbolNameLength = strlen(methodName) + sizeof("__thunk_");
-            symbolNames[i].m_name = new char[symbolNameLength];
-            symbolNames[i].m_releaseName = true;
+            symbolNames[i].m_symbol_name = new char[symbolNameLength];
+            symbolNames[i].m_name = symbolNames[i].m_symbol_name;
             sprintf_s((char*)symbolNames[i].m_name, symbolNameLength, "__thunk_%s", methodName);
             symbolNames[i].m_value = callAddr;
             ++i;

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -134,9 +134,10 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle,
                 if (pMT->IsString() && i == 1)
                 {
                     TypeInfoBase* elemTypeInfo = info->members[1].m_member_type;
-                    TypeInfoBase* arrayTypeInfo = new (nothrow) ArrayTypeInfo(typeHandle.MakeSZArray(), 1, elemTypeInfo);
+                    ArrayTypeInfo* arrayTypeInfo = new (nothrow) ArrayTypeInfo(typeHandle.MakeSZArray(), 1, elemTypeInfo);
                     if (arrayTypeInfo == nullptr)
                         return nullptr;
+                    info->m_array_type = arrayTypeInfo;
                     info->members[1].m_member_type = arrayTypeInfo;
                 }
             }
@@ -188,11 +189,13 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle,
                 TypeHandle(MscorlibBinder::GetElementType(ELEMENT_TYPE_I4)), pTypeMap, method);
 
             TypeInfoBase* valTypeInfo = GetTypeInfoFromTypeHandle(typeHandle.GetTypeParam(), pTypeMap, method);
-            TypeInfoBase* arrayTypeInfo = new (nothrow) ArrayTypeInfo(typeHandle, 1, valTypeInfo);
+            ArrayTypeInfo* arrayTypeInfo = new (nothrow) ArrayTypeInfo(typeHandle, 1, valTypeInfo);
             if (arrayTypeInfo == nullptr)
                 return nullptr;
 
             ClassTypeInfo *info = static_cast<ClassTypeInfo*>(typeInfo);
+
+            info->m_array_type = arrayTypeInfo;
 
             info->members[0].m_member_name = new (nothrow) char[16];
             strcpy(info->members[0].m_member_name, "m_NumComponents");
@@ -208,10 +211,10 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle,
             if (pMT->GetRank() != 1)
             {
                 TypeHandle dwordArray(MscorlibBinder::GetElementType(ELEMENT_TYPE_I4));
-                TypeInfoBase* arrayTypeInfo = new (nothrow) ArrayTypeInfo(dwordArray.MakeSZArray(), pMT->GetRank(), lengthTypeInfo);
+                ArrayTypeInfo* arrayTypeInfo = new (nothrow) ArrayTypeInfo(dwordArray.MakeSZArray(), pMT->GetRank(), lengthTypeInfo);
                 if (arrayTypeInfo == nullptr)
                     return nullptr;
-
+                info->m_array_bounds_type = arrayTypeInfo;
                 info->members[2].m_member_name = new (nothrow) char[9];
                 strcpy(info->members[2].m_member_name, "m_Bounds");
                 info->members[2].m_member_offset = ArrayBase::GetBoundsOffset(pMT);
@@ -1158,7 +1161,8 @@ ClassTypeInfo::ClassTypeInfo(TypeHandle typeHandle, int num_members, FunctionMem
           m_num_members(num_members),
           members(new TypeMember[num_members]),
           m_parent(nullptr),
-          m_method(method)
+          m_method(method),
+          m_array_type(nullptr)
 {
 }
 

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -73,9 +73,6 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle,
                 {
                     return nullptr;
                 }
-                refTypeInfo->m_type_size = sizeof(TADDR);
-                refTypeInfo->m_value_type = typeInfo;
-                refTypeInfo->CalculateName();
 
                 pTypeMap->Add(refTypeInfo->GetTypeKey(), refTypeInfo);
             }
@@ -152,10 +149,8 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle,
             typeInfo = new (nothrow) RefTypeInfo(typeHandle, valTypeInfo);
             if (typeInfo == nullptr)
                 return nullptr;
-            typeInfo->m_type_size = sizeof(TADDR);
-            typeInfo->m_type_offset = valTypeInfo->m_type_offset;
 
-            typeInfo->CalculateName();
+            typeInfo->m_type_offset = valTypeInfo->m_type_offset;
 
             pTypeMap->Add(typeInfo->GetTypeKey(), typeInfo);
             return typeInfo;
@@ -172,9 +167,6 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle,
             {
                 return nullptr;
             }
-            refTypeInfo->m_type_size = sizeof(TADDR);
-            refTypeInfo->m_value_type = typeInfo;
-            refTypeInfo->CalculateName();
 
             pTypeMap->Add(refTypeInfo->GetTypeKey(), refTypeInfo);
 

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -2021,10 +2021,7 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
     }
 
     /* Build section headers table and section names table */
-    if (!BuildSectionTables(sectHeaders, sectStr, method, symbolCount))
-    {
-        return;
-    }
+    BuildSectionTables(sectHeaders, sectStr, method, symbolCount);
 
     /* Patch section offsets & sizes */
     long offset = sizeof(Elf_Ehdr);
@@ -2726,7 +2723,7 @@ int NotifyGdb::GetSectionIndex(const char *sectName)
 }
 
 /* Build the ELF section headers table and section names table */
-bool NotifyGdb::BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method,
+void NotifyGdb::BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method,
                                    int symbolCount)
 {
     static const int symtabSectionIndex = GetSectionIndex(".symtab");
@@ -2738,10 +2735,7 @@ bool NotifyGdb::BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemb
     // Used only to reduce memory reallocations.
     static const int SECT_NAME_LENGTH = 11;
 
-    if (!strBuf.Resize(SECT_NAME_LENGTH * (SectionNamesCount + thunks_count)))
-    {
-        return false;
-    }
+    strBuf.Resize(SECT_NAME_LENGTH * (SectionNamesCount + thunks_count));
 
     Elf_Shdr* sectionHeaders = new Elf_Shdr[SectionNamesCount + thunks_count];
     sectBuf.MemPtr = reinterpret_cast<char*>(sectionHeaders);
@@ -2778,8 +2772,7 @@ bool NotifyGdb::BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemb
         if (sectNameOffset > strBuf.MemSize)
         {
             // Allocate more memory for remaining section names
-            if (!strBuf.Resize(sectNameOffset + addSize))
-                return false;
+            strBuf.Resize(sectNameOffset + addSize);
             addSize *= 2;
         }
 
@@ -2801,7 +2794,6 @@ bool NotifyGdb::BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemb
 
     // Set actual used size to avoid garbage in ELF section
     strBuf.MemSize = sectNameOffset;
-    return true;
 }
 
 /* Build the ELF header */

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1750,6 +1750,18 @@ static NotifyGdb::AddrSet codeAddrs;
 /* Create ELF/DWARF debug info for jitted method */
 void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
 {
+    EX_TRY
+    {
+        NotifyGdb::OnMethodCompiled(MethodDescPtr);
+    }
+    EX_CATCH
+    {
+    }
+    EX_END_CATCH(SwallowAllExceptions);
+}
+
+void NotifyGdb::OnMethodCompiled(MethodDesc* MethodDescPtr)
+{
     int symbolCount = 0;
     NewArrayHolder<Elf_Symbol> symbolNames;
 

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1136,14 +1136,6 @@ ClassTypeInfo::ClassTypeInfo(TypeHandle typeHandle, int num_members, FunctionMem
     CalculateName();
 }
 
-ClassTypeInfo::~ClassTypeInfo()
-{
-    if (members != nullptr && m_num_members > 0)
-    {
-        delete[] members;
-    }
-}
-
 void TypeMember::DumpStrings(char* ptr, int& offset)
 {
     if (ptr != nullptr)

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -184,8 +184,7 @@ GetTypeInfoFromTypeHandle(TypeHandle typeHandle,
             return refTypeInfo;
         }
         default:
-            ASSERT(0 && "not implemented");
-            return nullptr;
+            COMPlusThrowHR(COR_E_NOTSUPPORTED);
     }
 }
 

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -2626,9 +2626,7 @@ bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods,
             ++i;
             codeAddrs.Add(callAddr);
         }
-        CalledMethod* ptr = pList;
         pList = pList->GetNext();
-        delete ptr;
     }
     symbolCount = i;
     return true;

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -243,7 +243,7 @@ TypeInfoBase* GetLocalTypeInfo(MethodDesc *MethodDescPtr,
     return nullptr;
 }
 
-HRESULT GetArgNameByILIndex(MethodDesc* MethodDescPtr, unsigned index, LPSTR &paramName)
+HRESULT GetArgNameByILIndex(MethodDesc* MethodDescPtr, unsigned index, NewArrayHolder<char> &paramName)
 {
     IMDInternalImport* mdImport = MethodDescPtr->GetMDImport();
     mdParamDef paramToken;

--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -349,11 +349,7 @@ GetMethodNativeMap(MethodDesc* methodDesc,
     // Need to convert map formats.
     *numMap = countMapCopy;
 
-    *map = new (nothrow) DebuggerILToNativeMap[countMapCopy];
-    if (!*map)
-    {
-        return E_OUTOFMEMORY;
-    }
+    *map = new DebuggerILToNativeMap[countMapCopy];
 
     ULONG32 i;
     for (i = 0; i < *numMap; i++)
@@ -853,9 +849,7 @@ public:
 
     bool Alloc(int cElements)
     {
-        FunctionMember** value = new (nothrow) FunctionMember*[cElements];
-        if (value == nullptr)
-            return false;
+        FunctionMember** value = new FunctionMember*[cElements];
 
         for (int i = 0; i < cElements; i++)
         {
@@ -1060,7 +1054,7 @@ static const char *GetCSharpTypeName(TypeInfoBase *typeInfo)
 
 PrimitiveTypeInfo::PrimitiveTypeInfo(TypeHandle typeHandle)
     : TypeInfoBase(typeHandle),
-      m_typedef_info(new (nothrow) TypeDefInfo(nullptr, 0))
+      m_typedef_info(new TypeDefInfo(nullptr, 0))
 {
     CorElementType corType = typeHandle.GetSignatureCorElementType();
     m_type_encoding = CorElementTypeToDWEncoding[corType];
@@ -1083,7 +1077,7 @@ void PrimitiveTypeInfo::DumpStrings(char* ptr, int& offset)
     if (!m_typedef_info->m_typedef_name)
     {
         const char *typeName = GetCSharpTypeName(this);
-        m_typedef_info->m_typedef_name = new (nothrow) char[strlen(typeName) + 1];
+        m_typedef_info->m_typedef_name = new char[strlen(typeName) + 1];
         strcpy(m_typedef_info->m_typedef_name, typeName);
     }
     m_typedef_info->DumpStrings(ptr, offset);
@@ -1405,9 +1399,7 @@ void FunctionMember::DumpTryCatchDebugInfo(char* ptr, int& offset)
 
 void FunctionMember::DumpVarsWithScopes(char *ptr, int &offset)
 {
-    NewArrayHolder<DebugInfoLexicalBlock> scopeStack = new (nothrow) DebugInfoLexicalBlock[m_num_vars];
-    if (scopeStack == nullptr)
-        return;
+    NewArrayHolder<DebugInfoLexicalBlock> scopeStack = new DebugInfoLexicalBlock[m_num_vars];
 
     int scopeStackSize = 0;
     for (int i = 0; i < m_num_vars; ++i)
@@ -1836,7 +1828,7 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
     int length = MultiByteToWideChar(CP_UTF8, 0, szModuleFile, -1, NULL, 0);
     if (length == 0)
         return;
-    NewArrayHolder<WCHAR> wszModuleFile = new (nothrow) WCHAR[length+1];
+    NewArrayHolder<WCHAR> wszModuleFile = new WCHAR[length+1];
     length = MultiByteToWideChar(CP_UTF8, 0, szModuleFile, -1, wszModuleFile, length);
 
     if (length == 0)
@@ -2118,12 +2110,8 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
     elfFile.MemSize = elfHeader.MemSize + sectStr.MemSize + dbgStr.MemSize + dbgAbbrev.MemSize + dbgInfo.MemSize +
                       dbgPubname.MemSize + dbgPubType.MemSize + dbgLine.MemSize + sectSymTab.MemSize +
                       sectStrTab.MemSize + sectHeaders.MemSize;
-    elfFile.MemPtr =  new (nothrow) char[elfFile.MemSize];
-    if (elfFile.MemPtr == nullptr)
-    {
-        return;
-    }
-    
+    elfFile.MemPtr =  new char[elfFile.MemSize];
+
     /* Copy section data */
     offset = 0;
     memcpy(elfFile.MemPtr, elfHeader.MemPtr, elfHeader.MemSize);
@@ -2156,13 +2144,8 @@ void NotifyGdb::MethodCompiled(MethodDesc* MethodDescPtr)
 #endif
 
     /* Create GDB JIT structures */
-    NewHolder<jit_code_entry> jit_symbols = new (nothrow) jit_code_entry;
-    
-    if (jit_symbols == nullptr)
-    {
-        return;
-    }
-    
+    NewHolder<jit_code_entry> jit_symbols = new jit_code_entry;
+
     /* Fill the new entry */
     jit_symbols->next_entry = jit_symbols->prev_entry = 0;
     jit_symbols->symfile_addr = elfFile.MemPtr;
@@ -2242,13 +2225,8 @@ bool NotifyGdb::BuildLineTable(MemBuf& buf, PCODE startAddr, TADDR codeSize, Sym
     }
     
     buf.MemSize = sizeof(DwarfLineNumHeader) + 1 + fileTable.MemSize + lineProg.MemSize;
-    buf.MemPtr = new (nothrow) char[buf.MemSize];
-    
-    if (buf.MemPtr == nullptr)
-    {
-        return false;
-    }
-    
+    buf.MemPtr = new char[buf.MemSize];
+
     /* Fill the line info header */
     DwarfLineNumHeader* header = reinterpret_cast<DwarfLineNumHeader*>(buf.MemPtr.GetValue());
     memcpy(buf.MemPtr, &LineNumHeader, sizeof(DwarfLineNumHeader));
@@ -2270,7 +2248,7 @@ bool NotifyGdb::BuildFileTable(MemBuf& buf, SymbolsInfo* lines, unsigned nlines)
     unsigned nfiles = 0;
     
     /* GetValue file names and replace them with indices in file table */
-    files = new (nothrow) const char*[nlines];
+    files = new const char*[nlines];
     if (files == nullptr)
         return false;
     for (unsigned i = 0; i < nlines; ++i)
@@ -2310,13 +2288,8 @@ bool NotifyGdb::BuildFileTable(MemBuf& buf, SymbolsInfo* lines, unsigned nlines)
     totalSize += 1;
     
     buf.MemSize = totalSize;
-    buf.MemPtr = new (nothrow) char[buf.MemSize];
-    
-    if (buf.MemPtr == nullptr)
-    {
-        return false;
-    }
-    
+    buf.MemPtr = new char[buf.MemSize];
+
     /* copy collected file names */
     char *ptr = buf.MemPtr;
     for (unsigned i = 0; i < nfiles; ++i)
@@ -2429,7 +2402,7 @@ bool NotifyGdb::BuildLineProg(MemBuf& buf, PCODE startAddr, TADDR codeSize, Symb
                 + nlines * 1                     /* copy commands */
                 + 6                              /* advance PC command */
                 + 3;                             /* end of sequence command */
-    buf.MemPtr = new (nothrow) char[buf.MemSize];
+    buf.MemPtr = new char[buf.MemSize];
     char* ptr = buf.MemPtr;
   
     if (buf.MemPtr == nullptr)
@@ -2513,10 +2486,7 @@ bool NotifyGdb::BuildDebugStrings(MemBuf& buf, PTK_TypeInfoMap pTypeMap, Functio
     }
 
     buf.MemSize = totalLength;
-    buf.MemPtr = new (nothrow) char[totalLength];
-    
-    if (buf.MemPtr == nullptr)
-        return false;
+    buf.MemPtr = new char[totalLength];
 
     /* copy strings */
     char* bufPtr = buf.MemPtr;
@@ -2548,12 +2518,9 @@ bool NotifyGdb::BuildDebugStrings(MemBuf& buf, PTK_TypeInfoMap pTypeMap, Functio
 /* Build the DWARF .debug_abbrev section */
 bool NotifyGdb::BuildDebugAbbrev(MemBuf& buf)
 {
-    buf.MemPtr = new (nothrow) char[AbbrevTableSize];
+    buf.MemPtr = new char[AbbrevTableSize];
     buf.MemSize = AbbrevTableSize;
 
-    if (buf.MemPtr == nullptr)
-        return false;
-    
     memcpy(buf.MemPtr, AbbrevTable, AbbrevTableSize);
     return true;
 }
@@ -2579,10 +2546,8 @@ bool NotifyGdb::BuildDebugInfo(MemBuf& buf, PTK_TypeInfoMap pTypeMap, FunctionMe
 
     //int locSize = GetArgsAndLocalsLen(argsDebug, argsDebugSize, localsDebug, localsDebugSize);
     buf.MemSize = sizeof(DwarfCompUnit) + sizeof(DebugInfoCU) + totalTypeVarSubSize + 2;
-    buf.MemPtr = new (nothrow) char[buf.MemSize];
+    buf.MemPtr = new char[buf.MemSize];
 
-    if (buf.MemPtr == nullptr)
-        return false;
     int offset = 0;
     /* Compile uint header */
     DwarfCompUnit* cu = reinterpret_cast<DwarfCompUnit*>(buf.MemPtr.GetValue());
@@ -2627,10 +2592,7 @@ bool NotifyGdb::BuildDebugPub(MemBuf& buf, const char* name, uint32_t size, uint
     uint32_t length = sizeof(DwarfPubHeader) + sizeof(uint32_t) + strlen(name) + 1 + sizeof(uint32_t);
     
     buf.MemSize = length;
-    buf.MemPtr = new (nothrow) char[buf.MemSize];
-    
-    if (buf.MemPtr == nullptr)
-        return false;
+    buf.MemPtr = new char[buf.MemSize];
 
     DwarfPubHeader* header = reinterpret_cast<DwarfPubHeader*>(buf.MemPtr.GetValue());
     header->m_length = length - sizeof(uint32_t);
@@ -2669,7 +2631,7 @@ bool NotifyGdb::CollectCalledMethods(CalledMethod* pCalledMethods,
     }
 
     symbolCount = 1 + method.GetCount() + tmpCodeAddrs.GetCount();
-    symbolNames = new (nothrow) Elf_Symbol[symbolCount];
+    symbolNames = new Elf_Symbol[symbolCount];
 
     pList = pCalledMethods;
     int i = 1 + method.GetCount();
@@ -2705,9 +2667,8 @@ bool NotifyGdb::BuildStringTableSection(MemBuf& buf, NewArrayHolder<Elf_Symbol> 
     len++; // end table with zero-length string
     
     buf.MemSize = len;
-    buf.MemPtr = new (nothrow) char[buf.MemSize];
-    if (buf.MemPtr == nullptr)
-        return false;
+    buf.MemPtr = new char[buf.MemSize];
+
     char* ptr = buf.MemPtr;
     for (int i = 0; i < symbolCount; ++i)
     {
@@ -2727,9 +2688,7 @@ bool NotifyGdb::BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize,
     static const int textSectionIndex = GetSectionIndex(".text");
 
     buf.MemSize = symbolCount * sizeof(Elf_Sym);
-    buf.MemPtr = new (nothrow) char[buf.MemSize];
-    if (buf.MemPtr == nullptr)
-        return false;
+    buf.MemPtr = new char[buf.MemSize];
 
     Elf_Sym *sym = reinterpret_cast<Elf_Sym*>(buf.MemPtr.GetValue());
 
@@ -2792,12 +2751,7 @@ bool NotifyGdb::BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemb
         return false;
     }
 
-    Elf_Shdr* sectionHeaders = new (nothrow) Elf_Shdr[SectionNamesCount + thunks_count];
-    if (sectionHeaders == nullptr)
-    {
-        return false;
-    }
-
+    Elf_Shdr* sectionHeaders = new Elf_Shdr[SectionNamesCount + thunks_count];
     sectBuf.MemPtr = reinterpret_cast<char*>(sectionHeaders);
     sectBuf.MemSize = sizeof(Elf_Shdr) * (SectionNamesCount + thunks_count);
 
@@ -2861,13 +2815,7 @@ bool NotifyGdb::BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemb
 /* Build the ELF header */
 bool NotifyGdb::BuildELFHeader(MemBuf& buf)
 {
-    Elf_Ehdr* header = new (nothrow) Elf_Ehdr;
-
-    if (header == nullptr)
-    {
-        return false;
-    }
-
+    Elf_Ehdr* header = new Elf_Ehdr;
     buf.MemPtr = reinterpret_cast<char*>(header);
     buf.MemSize = sizeof(Elf_Ehdr);
     return true;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -402,6 +402,8 @@ private:
         }
     };
 
+    static void OnMethodCompiled(MethodDesc* MethodDescPtr);
+
     static int GetSectionIndex(const char *sectName);
     static bool BuildELFHeader(MemBuf& buf);
     static void BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method,

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -258,19 +258,11 @@ public:
     {
     }
 
-    virtual ~TypeMember()
-    {
-        if (m_member_name != nullptr)
-        {
-            delete[] m_member_name;
-        }
-    }
-
     void DumpStrings(char* ptr, int& offset) override;
     void DumpDebugInfo(char* ptr, int& offset) override;
     void DumpStaticDebugInfo(char* ptr, int& offset);
 
-    char* m_member_name;
+    NewArrayHolder<char> m_member_name;
     int m_member_name_offset;
     int m_member_offset;
     TADDR m_static_member_address;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -312,15 +312,10 @@ public:
     {
     }
 
-    virtual ~VarDebugInfo()
-    {
-        delete[] m_var_name;
-    }
-
     void DumpStrings(char* ptr, int& offset) override;
     void DumpDebugInfo(char* ptr, int& offset) override;
 
-    char* m_var_name;
+    NewArrayHolder<char> m_var_name;
     int m_var_abbrev;
     int m_var_name_offset;
     int m_il_index;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -309,14 +309,6 @@ public:
     {
     }
 
-    ~ArrayTypeInfo()
-    {
-        if (m_elem_type != nullptr)
-        {
-            delete m_elem_type;
-        }
-    }
-
     void DumpDebugInfo(char* ptr, int& offset) override;
 
     int m_count;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -216,6 +216,8 @@ public:
         : TypeInfoBase(typeHandle),
           m_value_type(value_type)
     {
+        m_type_size = sizeof(TADDR);
+        CalculateName();
     }
     void DumpStrings(char* ptr, int& offset) override;
     void DumpDebugInfo(char* ptr, int& offset) override;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -328,8 +328,8 @@ struct Elf_Symbol;
 class NotifyGdb
 {
 public:
-    static void MethodCompiled(MethodDesc* MethodDescPtr);
-    static void MethodDropped(MethodDesc* MethodDescPtr);
+    static void MethodCompiled(MethodDesc* methodDescPtr);
+    static void MethodDropped(MethodDesc* methodDescPtr);
     template <typename PARENT_TRAITS>
     class DeleteValuesOnDestructSHashTraits : public PARENT_TRAITS
     {
@@ -402,7 +402,7 @@ private:
         }
     };
 
-    static void OnMethodCompiled(MethodDesc* MethodDescPtr);
+    static void OnMethodCompiled(MethodDesc* methodDescPtr);
 
     static int GetSectionIndex(const char *sectName);
     static bool BuildELFHeader(MemBuf& buf);

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -414,27 +414,24 @@ private:
         unsigned MemSize;
         MemBuf() : MemPtr(0), MemSize(0)
         {}
-        bool Resize(unsigned newSize)
+        void Resize(unsigned newSize)
         {
             if (newSize == 0)
             {
                 MemPtr = nullptr;
                 MemSize = 0;
-                return true;
+                return;
             }
-            char *tmp = new (nothrow) char [newSize];
-            if (tmp == nullptr)
-                return false;
+            char *tmp = new char [newSize];
             memmove(tmp, MemPtr.GetValue(), newSize < MemSize ? newSize : MemSize);
             MemPtr = tmp;
             MemSize = newSize;
-            return true;
         }
     };
 
     static int GetSectionIndex(const char *sectName);
     static bool BuildELFHeader(MemBuf& buf);
-    static bool BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method,
+    static void BuildSectionTables(MemBuf& sectBuf, MemBuf& strBuf, FunctionMemberPtrArrayHolder &method,
                                    int symbolCount);
     static bool BuildSymbolTableSection(MemBuf& buf, PCODE addr, TADDR codeSize, FunctionMemberPtrArrayHolder &method,
                                         NewArrayHolder<Elf_Symbol> &symbolNames, int symbolCount);

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -256,6 +256,7 @@ public:
 };
 
 class FunctionMemberPtrArrayHolder;
+class ArrayTypeInfo;
 
 class ClassTypeInfo: public TypeInfoBase
 {
@@ -270,6 +271,8 @@ public:
     TypeMember* members;
     TypeInfoBase* m_parent;
     FunctionMemberPtrArrayHolder &m_method;
+    NewHolder<ArrayTypeInfo> m_array_type;
+    NewHolder<ArrayTypeInfo> m_array_bounds_type;
 };
 
 class TypeMember: public DwarfDumpable

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -123,6 +123,8 @@ public:
     virtual void DumpStrings(char* ptr, int& offset) = 0;
 
     virtual void DumpDebugInfo(char* ptr, int& offset) = 0;
+
+    virtual ~DwarfDumpable() {}
 };
 
 class LocalsInfo
@@ -154,21 +156,13 @@ public:
     {
     }
 
-    virtual ~TypeInfoBase()
-    {
-        if (m_type_name != nullptr)
-        {
-            delete[] m_type_name;
-        }
-    }
-
     virtual void DumpStrings(char* ptr, int& offset) override;
     void CalculateName();
     void SetTypeHandle(TypeHandle handle);
     TypeHandle GetTypeHandle();
     TypeKey* GetTypeKey();
 
-    char* m_type_name;
+    NewArrayHolder<char> m_type_name;
     int m_type_name_offset;
     ULONG m_type_size;
     int m_type_offset;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -178,14 +178,8 @@ public:
     m_typedef_name(typedef_name), m_typedef_type(typedef_type), m_typedef_type_offset(0) {}
     void DumpStrings(char* ptr, int& offset) override;
     void DumpDebugInfo(char* ptr, int& offset) override;
-    virtual ~TypeDefInfo()
-    {
-        if (m_typedef_name != nullptr)
-        {
-            delete [] m_typedef_name;
-        }
-    }
-    char *m_typedef_name;
+
+    NewArrayHolder<char> m_typedef_name;
     int m_typedef_type;
     int m_typedef_type_offset;
     int m_typedef_name_offset;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -270,7 +270,7 @@ public:
     {
     }
 
-    ~TypeMember()
+    virtual ~TypeMember()
     {
         if (m_member_name != nullptr)
         {
@@ -490,11 +490,6 @@ public:
 #endif
     }
 
-    virtual ~FunctionMember()
-    {
-        delete[] vars;
-    }
-
     void DumpStrings(char* ptr, int& offset) override;
     void DumpDebugInfo(char* ptr, int& offset) override;
     void DumpTryCatchDebugInfo(char* ptr, int& offset);
@@ -515,7 +510,7 @@ public:
     uint8_t m_num_locals;
     uint16_t m_num_vars;
     int m_entry_offset;
-    VarDebugInfo* vars;
+    NewArrayHolder<VarDebugInfo> vars;
     SymbolsInfo* lines;
     unsigned nlines;
     int m_linkage_name_offset;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -200,21 +200,13 @@ public:
 class PrimitiveTypeInfo: public TypeInfoBase
 {
 public:
-    PrimitiveTypeInfo(TypeHandle typeHandle, int encoding)
-        : TypeInfoBase(typeHandle),
-          m_type_encoding(encoding),
-          m_typedef_info(new (nothrow) TypeDefInfo(nullptr, 0))
-    {
-    }
-    virtual ~PrimitiveTypeInfo()
-    {
-        delete m_typedef_info;
-    }
+    PrimitiveTypeInfo(TypeHandle typeHandle);
+
     void DumpDebugInfo(char* ptr, int& offset) override;
     void DumpStrings(char* ptr, int& offset) override;
 
     int m_type_encoding;
-    TypeDefInfo* m_typedef_info;
+    NewHolder<TypeDefInfo> m_typedef_info;
 };
 
 class RefTypeInfo: public TypeInfoBase

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -177,20 +177,6 @@ private:
     TypeKey typeKey;
 };
 
-class PrimitiveTypeInfo: public TypeInfoBase
-{
-public:
-    PrimitiveTypeInfo(TypeHandle typeHandle, int encoding)
-        : TypeInfoBase(typeHandle),
-          m_type_encoding(encoding)
-    {
-    }
-
-    void DumpDebugInfo(char* ptr, int& offset) override;
-
-    int m_type_encoding;
-};
-
 class TypeDefInfo : public DwarfDumpable
 {
 public:
@@ -211,20 +197,23 @@ public:
     int m_typedef_name_offset;
 };
 
-class ByteTypeInfo : public PrimitiveTypeInfo
+class PrimitiveTypeInfo: public TypeInfoBase
 {
 public:
-    ByteTypeInfo(TypeHandle typeHandle, int encoding) : PrimitiveTypeInfo(typeHandle, encoding)
+    PrimitiveTypeInfo(TypeHandle typeHandle, int encoding)
+        : TypeInfoBase(typeHandle),
+          m_type_encoding(encoding),
+          m_typedef_info(new (nothrow) TypeDefInfo(nullptr, 0))
     {
-        m_typedef_info = new (nothrow) TypeDefInfo(nullptr, 0);
     }
-    virtual ~ByteTypeInfo()
+    virtual ~PrimitiveTypeInfo()
     {
         delete m_typedef_info;
     }
     void DumpDebugInfo(char* ptr, int& offset) override;
     void DumpStrings(char* ptr, int& offset) override;
 
+    int m_type_encoding;
     TypeDefInfo* m_typedef_info;
 };
 

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -248,6 +248,10 @@ public:
         : RefTypeInfo(typeHandle, value_type)
     {
     }
+    virtual ~NamedRefTypeInfo()
+    {
+        delete m_value_type;
+    }
     void DumpDebugInfo(char* ptr, int& offset) override;
 };
 

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -216,14 +216,13 @@ class NamedRefTypeInfo: public RefTypeInfo
 {
 public:
     NamedRefTypeInfo(TypeHandle typeHandle, TypeInfoBase *value_type)
-        : RefTypeInfo(typeHandle, value_type)
+        : RefTypeInfo(typeHandle, value_type), m_value_type_storage(value_type)
     {
     }
-    virtual ~NamedRefTypeInfo()
-    {
-        delete m_value_type;
-    }
+
     void DumpDebugInfo(char* ptr, int& offset) override;
+
+    NewHolder<TypeInfoBase> m_value_type_storage;
 };
 
 class FunctionMemberPtrArrayHolder;

--- a/src/vm/gdbjit.h
+++ b/src/vm/gdbjit.h
@@ -233,13 +233,12 @@ class ClassTypeInfo: public TypeInfoBase
 {
 public:
     ClassTypeInfo(TypeHandle typeHandle, int num_members, FunctionMemberPtrArrayHolder &method);
-    ~ClassTypeInfo();
 
     void DumpStrings(char* ptr, int& offset) override;
     void DumpDebugInfo(char* ptr, int& offset) override;
 
     int m_num_members;
-    TypeMember* members;
+    NewArrayHolder<TypeMember> members;
     TypeInfoBase* m_parent;
     FunctionMemberPtrArrayHolder &m_method;
     NewHolder<ArrayTypeInfo> m_array_type;


### PR DESCRIPTION
This PR removes usage of (nothrow) in gdbjit by refactoring memory management code in gdbjit.

Summary:

* Code hardening against oom exceptions: always use a holder as receiver of `new` operator and every object that owns a pointer to another objects manages it using a holder. So most `delete` operators are gone. The only remaining are in allocators/traits and in code related to `__jit_debug_register_code` function.

* Fix some memory leak/double free issues.

* Wrap NotifyGdb::MethodCompiled entry point in EX_TRY/EX_CATCH.

* Remove CalledMethod list cleanup - avoid having dangling pointer in CodeHeader class.

* Simplify of `GetTypeInfoFromTypeHandle` function: most type creation code moved into type constructors.

Related issue: #10033 

@mikem8361, @janvorli PTAL

cc @Dmitri-Botcharnikov @chunseoklee @seanshpark @lucenticus @kvochko
