### PR TITLE
Change the Jit Disasm message when we have profile data

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2981,7 +2981,8 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 
         if (compiler->fgHaveProfileData())
         {
-            printf("; with IBC profile data\n");
+            printf("; with IBC profile data, edge weights are %s, and fgCalledCount is %u\n",
+                   compiler->fgHaveValidEdgeWeights ? "valid" : "invalid", compiler->fgCalledCount);
         }
 
         if (compiler->fgProfileData_ILSizeMismatch)


### PR DESCRIPTION
It will now include information about the edge weights and the value of fgCalledCount.
Example:

```
; Assembly listing for method System.Number:TrailingZeros(ref,int):bool
; Emitting BLENDED_CODE for X64 CPU with SSE2
; optimized code
; rsp based frame
; fully interruptible
; with IBC profile data, edge weights are valid, and fgCalledCount is 145
; Final local variable assignments

```