### PR TITLE
JIT: improve types for single def locals and temps

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -252,8 +252,9 @@ public:
     unsigned char lvStackByref : 1;  // This is a compiler temporary of TYP_BYREF that is known to point into our local
                                      // stack frame.
 
-    unsigned char lvArgWrite : 1; // variable is a parameter and STARG was used on it
-    unsigned char lvIsTemp : 1;   // Short-lifetime compiler temp
+    unsigned char lvArgWrite : 1;         // there is at least one STLOC or STARG on this local
+    unsigned char lvMultipleArgWrite : 1; // there is more than one STLOC on this local
+    unsigned char lvIsTemp : 1;           // Short-lifetime compiler temp
 #if OPT_BOOL_OPS
     unsigned char lvIsBoolean : 1; // set if variable is boolean
 #endif
@@ -2672,10 +2673,13 @@ public:
     // Returns true if this local var is a multireg struct
     bool lvaIsMultiregStruct(LclVarDsc* varDsc);
 
-    // If the class is a TYP_STRUCT, get/set a class handle describing it
-
+    // If the local is a TYP_STRUCT, get/set a class handle describing it
     CORINFO_CLASS_HANDLE lvaGetStruct(unsigned varNum);
     void lvaSetStruct(unsigned varNum, CORINFO_CLASS_HANDLE typeHnd, bool unsafeValueClsCheck, bool setTypeInfo = true);
+
+    // If the local is TYP_REF, set or improve the associated class information.
+    void lvaSetClass(unsigned varNum, CORINFO_CLASS_HANDLE clsHnd, bool isExact = false);
+    void lvaSetClass(unsigned varNum, GenTreePtr tree, CORINFO_CLASS_HANDLE stackHandle = nullptr);
 
 #define MAX_NumOfFieldsInPromotableStruct 4 // Maximum number of fields in promotable struct
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -252,9 +252,10 @@ public:
     unsigned char lvStackByref : 1;  // This is a compiler temporary of TYP_BYREF that is known to point into our local
                                      // stack frame.
 
-    unsigned char lvArgWrite : 1;         // there is at least one STLOC or STARG on this local
-    unsigned char lvMultipleArgWrite : 1; // there is more than one STLOC on this local
-    unsigned char lvIsTemp : 1;           // Short-lifetime compiler temp
+    unsigned char lvHasILStoreOp : 1;         // there is at least one STLOC or STARG on this local
+    unsigned char lvHasMultipleILStoreOp : 1; // there is more than one STLOC on this local
+
+    unsigned char lvIsTemp : 1; // Short-lifetime compiler temp
 #if OPT_BOOL_OPS
     unsigned char lvIsBoolean : 1; // set if variable is boolean
 #endif
@@ -324,6 +325,10 @@ public:
     unsigned char lvRegStruct : 1;           // This is a reg-sized non-field-addressed struct.
 
     unsigned char lvClassIsExact : 1; // lvClassHandle is the exact type
+
+#ifdef DEBUG
+    unsigned char lvClassInfoUpdated : 1; // true if this var has updated class handle or exactness
+#endif
 
     union {
         unsigned lvFieldLclStart; // The index of the local var representing the first field in the promoted struct
@@ -2677,9 +2682,11 @@ public:
     CORINFO_CLASS_HANDLE lvaGetStruct(unsigned varNum);
     void lvaSetStruct(unsigned varNum, CORINFO_CLASS_HANDLE typeHnd, bool unsafeValueClsCheck, bool setTypeInfo = true);
 
-    // If the local is TYP_REF, set or improve the associated class information.
+    // If the local is TYP_REF, set or update the associated class information.
     void lvaSetClass(unsigned varNum, CORINFO_CLASS_HANDLE clsHnd, bool isExact = false);
     void lvaSetClass(unsigned varNum, GenTreePtr tree, CORINFO_CLASS_HANDLE stackHandle = nullptr);
+    void lvaUpdateClass(unsigned varNum, CORINFO_CLASS_HANDLE clsHnd, bool isExact = false);
+    void lvaUpdateClass(unsigned varNum, GenTreePtr tree, CORINFO_CLASS_HANDLE stackHandle = nullptr);
 
 #define MAX_NumOfFieldsInPromotableStruct 4 // Maximum number of fields in promotable struct
 

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2530,10 +2530,10 @@ inline BOOL Compiler::lvaIsOriginalThisArg(unsigned varNum)
         // copy to a new local, and mark the original as DoNotEnregister, to
         // ensure that it is stack-allocated.  It should not be the case that the original one can be modified -- it
         // should not be written to, or address-exposed.
-        assert(!varDsc->lvArgWrite &&
+        assert(!varDsc->lvHasILStoreOp &&
                (!varDsc->lvAddrExposed || ((info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0)));
 #else
-        assert(!varDsc->lvArgWrite && !varDsc->lvAddrExposed);
+        assert(!varDsc->lvHasILStoreOp && !varDsc->lvAddrExposed);
 #endif
     }
 #endif

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2175,9 +2175,12 @@ bool Compiler::impSpillStackEntry(unsigned level,
         }
     }
 
+    bool isNewTemp = false;
+
     if (tnum == BAD_VAR_NUM)
     {
-        tnum = lvaGrabTemp(true DEBUGARG(reason));
+        tnum      = lvaGrabTemp(true DEBUGARG(reason));
+        isNewTemp = true;
     }
     else if (tiVerificationNeeded && lvaTable[tnum].TypeGet() != TYP_UNDEF)
     {
@@ -2207,8 +2210,8 @@ bool Compiler::impSpillStackEntry(unsigned level,
     /* Assign the spilled entry to the temp */
     impAssignTempGen(tnum, tree, verCurrentState.esStack[level].seTypeInfo.GetClassHandle(), level);
 
-    // If temp is single def and a ref type, grab what type info we can.
-    if (lvaTable[tnum].lvIsTemp && (lvaTable[tnum].lvType == TYP_REF))
+    // If temp is newly introduced and a ref type, grab what type info we can.
+    if (isNewTemp && (lvaTable[tnum].lvType == TYP_REF))
     {
         CORINFO_CLASS_HANDLE stkHnd = verCurrentState.esStack[level].seTypeInfo.GetClassHandle();
         lvaSetClass(tnum, tree, stkHnd);

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2207,6 +2207,13 @@ bool Compiler::impSpillStackEntry(unsigned level,
     /* Assign the spilled entry to the temp */
     impAssignTempGen(tnum, tree, verCurrentState.esStack[level].seTypeInfo.GetClassHandle(), level);
 
+    // If temp is single def and a ref type, grab what type info we can.
+    if (lvaTable[tnum].lvIsTemp && (lvaTable[tnum].lvType == TYP_REF))
+    {
+        CORINFO_CLASS_HANDLE stkHnd = verCurrentState.esStack[level].seTypeInfo.GetClassHandle();
+        lvaSetClass(tnum, tree, stkHnd);
+    }
+
     // The tree type may be modified by impAssignTempGen, so use the type of the lclVar.
     var_types  type                    = genActualType(lvaTable[tnum].TypeGet());
     GenTreePtr temp                    = gtNewLclvNode(tnum, type);
@@ -9410,9 +9417,10 @@ GenTreePtr Compiler::impCastClassOrIsInstToTree(GenTreePtr              op1,
 
     // Make QMark node a top level node by spilling it.
     unsigned tmp = lvaGrabTemp(true DEBUGARG("spilling QMark2"));
-    // TODO: Is it possible op1 has a better type?
-    lvaTable[tmp].lvClassHnd = pResolvedToken->hClass;
     impAssignTempGen(tmp, qmarkNull, (unsigned)CHECK_SPILL_NONE);
+
+    // TODO: Is it possible op1 has a better type?
+    lvaSetClass(tmp, pResolvedToken->hClass);
     return gtNewLclvNode(tmp, TYP_REF);
 #endif
 }
@@ -9670,6 +9678,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
         GenTreeArgList* args          = nullptr; // What good do these "DUMMY_INIT"s do?
         GenTreePtr      newObjThisPtr = DUMMY_INIT(NULL);
         bool            uns           = DUMMY_INIT(false);
+        bool            isLocal       = false;
 
         /* Get the next opcode and the size of its parameters */
 
@@ -9925,7 +9934,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 {
                     lclNum = lvaArg0Var;
                 }
-                lvaTable[lclNum].lvArgWrite = 1;
+
+                // We should have seen this arg write in the prescan
+                assert(lvaTable[lclNum].lvArgWrite == 1);
 
                 if (tiVerificationNeeded)
                 {
@@ -9942,12 +9953,14 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 goto VAR_ST;
 
             case CEE_STLOC:
-                lclNum = getU2LittleEndian(codeAddr);
+                lclNum  = getU2LittleEndian(codeAddr);
+                isLocal = true;
                 JITDUMP(" %u", lclNum);
                 goto LOC_ST;
 
             case CEE_STLOC_S:
-                lclNum = getU1LittleEndian(codeAddr);
+                lclNum  = getU1LittleEndian(codeAddr);
+                isLocal = true;
                 JITDUMP(" %u", lclNum);
                 goto LOC_ST;
 
@@ -9955,7 +9968,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             case CEE_STLOC_1:
             case CEE_STLOC_2:
             case CEE_STLOC_3:
-                lclNum = (opcode - CEE_STLOC_0);
+                isLocal = true;
+                lclNum  = (opcode - CEE_STLOC_0);
                 assert(lclNum >= 0 && lclNum < 4);
 
             LOC_ST:
@@ -10053,6 +10067,23 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     if (genActualType(lclTyp) == TYP_I_IMPL)
                     {
                         op1->gtType = TYP_I_IMPL;
+                    }
+                }
+
+                // If this is a local and the local is a ref type, see
+                // if we can improve type information based on the
+                // value being assigned.
+                if (isLocal && (lclTyp == TYP_REF))
+                {
+                    // We should have seen a stloc in our IL prescan.
+                    assert(lvaTable[lclNum].lvArgWrite);
+
+                    const bool isSingleDefLocal =
+                        !lvaTable[lclNum].lvMultipleArgWrite && !lvaTable[lclNum].lvHasLdAddrOp;
+
+                    if (isSingleDefLocal)
+                    {
+                        lvaSetClass(lclNum, op1, clsHnd);
                     }
                 }
 
@@ -11929,6 +11960,12 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     impAssignTempGen(tmpNum, op1, tiRetVal.GetClassHandle(), (unsigned)CHECK_SPILL_ALL);
                     var_types type = genActualType(lvaTable[tmpNum].TypeGet());
                     op1            = gtNewLclvNode(tmpNum, type);
+
+                    // Propagate type info to the temp
+                    if (type == TYP_REF)
+                    {
+                        lvaSetClass(tmpNum, op1, tiRetVal.GetClassHandle());
+                    }
                 }
 
                 op1 = impCloneExpr(op1, &op2, tiRetVal.GetClassHandle(), (unsigned)CHECK_SPILL_ALL,
@@ -12517,10 +12554,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     /* get a temporary for the new object */
                     lclNum = lvaGrabTemp(true DEBUGARG("NewObj constructor temp"));
 
-                    // Note the class handle...
-                    lvaTable[lclNum].lvClassHnd     = resolvedToken.hClass;
-                    lvaTable[lclNum].lvClassIsExact = 1;
-
                     // In the value class case we only need clsHnd for size calcs.
                     //
                     // The lookup of the code pointer will be handled by CALL in this case
@@ -12626,6 +12659,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         // without exhaustive walk over all expressions.
 
                         impAssignTempGen(lclNum, op1, (unsigned)CHECK_SPILL_NONE);
+                        lvaSetClass(lclNum, resolvedToken.hClass, true);
 
                         newObjThisPtr = gtNewLclvNode(lclNum, TYP_REF);
                     }
@@ -13587,8 +13621,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     Verify(elemTypeHnd == nullptr ||
                                !(info.compCompHnd->getClassAttribs(elemTypeHnd) & CORINFO_FLG_CONTAINS_STACK_PTR),
                            "array of byref-like type");
-                    tiRetVal = verMakeTypeInfo(resolvedToken.hClass);
                 }
+
+                tiRetVal = verMakeTypeInfo(resolvedToken.hClass);
 
                 accessAllowedResult =
                     info.compCompHnd->canAccessClass(&resolvedToken, info.compMethodHnd, &calloutHelper);
@@ -17706,15 +17741,17 @@ unsigned Compiler::impInlineFetchLocal(unsigned lclNum DEBUGARG(const char* reas
         impInlineInfo->lclTmpNum[lclNum] = tmpNum = lvaGrabTemp(false DEBUGARG(reason));
 
         // Copy over key info
-        lvaTable[tmpNum].lvType        = lclTyp;
-        lvaTable[tmpNum].lvHasLdAddrOp = inlineeLocal.lclHasLdlocaOp;
-        lvaTable[tmpNum].lvPinned      = inlineeLocal.lclIsPinned;
+        lvaTable[tmpNum].lvType             = lclTyp;
+        lvaTable[tmpNum].lvHasLdAddrOp      = inlineeLocal.lclHasLdlocaOp;
+        lvaTable[tmpNum].lvPinned           = inlineeLocal.lclIsPinned;
+        lvaTable[tmpNum].lvArgWrite         = inlineeLocal.lclHasStlocOp;
+        lvaTable[tmpNum].lvMultipleArgWrite = inlineeLocal.lclHasMultipleStlocOp;
 
         // Copy over class handle for ref types. Note this may be
         // further improved if it is a shared type.
         if (lclTyp == TYP_REF)
         {
-            lvaTable[tmpNum].lvClassHnd = inlineeLocal.lclVerTypeInfo.GetClassHandleForObjRef();
+            lvaSetClass(tmpNum, inlineeLocal.lclVerTypeInfo.GetClassHandleForObjRef());
         }
 
         if (inlineeLocal.lclVerTypeInfo.IsStruct())
@@ -17886,7 +17923,7 @@ GenTreePtr Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, 
             // further improved if it is a shared type and we know the exact context.
             if (lclTyp == TYP_REF)
             {
-                lvaTable[tmpNum].lvClassHnd = lclInfo.lclVerTypeInfo.GetClassHandleForObjRef();
+                lvaSetClass(tmpNum, lclInfo.lclVerTypeInfo.GetClassHandleForObjRef());
             }
 
             assert(lvaTable[tmpNum].lvAddrExposed == 0);

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -514,31 +514,32 @@ struct InlineCandidateInfo
 
 struct InlArgInfo
 {
-    unsigned argIsUsed : 1;               // is this arg used at all?
-    unsigned argIsInvariant : 1;          // the argument is a constant or a local variable address
-    unsigned argIsLclVar : 1;             // the argument is a local variable
-    unsigned argIsThis : 1;               // the argument is the 'this' pointer
-    unsigned argHasSideEff : 1;           // the argument has side effects
-    unsigned argHasGlobRef : 1;           // the argument has a global ref
-    unsigned argHasTmp : 1;               // the argument will be evaluated to a temp
-    unsigned argIsByRefToStructLocal : 1; // Is this arg an address of a struct local or a normed struct local or a
-                                          // field in them?
-    unsigned argHasLdargaOp : 1;          // Is there LDARGA(s) operation on this argument?
-    unsigned argHasStargOp : 1;           // Is there STARG(s) operation on this argument?
-
-    unsigned   argTmpNum; // the argument tmp number
-    GenTreePtr argNode;
-    GenTreePtr argBashTmpNode; // tmp node created, if it may be replaced with actual arg
+    GenTreePtr argNode;                     // caller node for this argument
+    GenTreePtr argBashTmpNode;              // tmp node created, if it may be replaced with actual arg
+    unsigned   argTmpNum;                   // the argument tmp number
+    unsigned   argIsUsed : 1;               // is this arg used at all?
+    unsigned   argIsInvariant : 1;          // the argument is a constant or a local variable address
+    unsigned   argIsLclVar : 1;             // the argument is a local variable
+    unsigned   argIsThis : 1;               // the argument is the 'this' pointer
+    unsigned   argHasSideEff : 1;           // the argument has side effects
+    unsigned   argHasGlobRef : 1;           // the argument has a global ref
+    unsigned   argHasTmp : 1;               // the argument will be evaluated to a temp
+    unsigned   argHasLdargaOp : 1;          // Is there LDARGA(s) operation on this argument?
+    unsigned   argHasStargOp : 1;           // Is there STARG(s) operation on this argument?
+    unsigned   argIsByRefToStructLocal : 1; // Is this arg an address of a struct local or a normed struct local or a
+                                            // field in them?
 };
 
-// InlArgInfo describes inline candidate local variable properties.
+// InlLclVarInfo describes inline candidate argument and local variable properties.
 
 struct InlLclVarInfo
 {
-    var_types lclTypeInfo;
     typeInfo  lclVerTypeInfo;
-    bool      lclHasLdlocaOp; // Is there LDLOCA(s) operation on this argument?
-    bool      lclIsPinned;
+    var_types lclTypeInfo;
+    unsigned  lclHasLdlocaOp : 1;        // Is there LDLOCA(s) operation on this local?
+    unsigned  lclHasStlocOp : 1;         // Is there a STLOC on this local?
+    unsigned  lclHasMultipleStlocOp : 1; // Is there more than one STLOC on this local
+    unsigned  lclIsPinned : 1;
 };
 
 // InlineInfo provides detailed information about a particular inline candidate.

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -257,7 +257,8 @@ void Compiler::lvaInitTypeRef()
 
         if (strip(corInfoType) == CORINFO_TYPE_CLASS)
         {
-            varDsc->lvClassHnd = info.compCompHnd->getArgClass(&info.compMethodInfo->locals, localsSig);
+            CORINFO_CLASS_HANDLE clsHnd = info.compCompHnd->getArgClass(&info.compMethodInfo->locals, localsSig);
+            lvaSetClass(varNum, clsHnd);
         }
     }
 
@@ -404,6 +405,7 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
         else
         {
             varDsc->lvType = TYP_REF;
+            lvaSetClass(varDscInfo->varNum, info.compClassHnd);
         }
 
         if (tiVerificationNeeded)
@@ -419,8 +421,6 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
         {
             varDsc->lvVerTypeInfo = typeInfo();
         }
-
-        varDsc->lvClassHnd = info.compClassHnd;
 
         // Mark the 'this' pointer for the method
         varDsc->lvVerTypeInfo.SetIsThisPtr();
@@ -562,7 +562,8 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
 
         if (strip(corInfoType) == CORINFO_TYPE_CLASS)
         {
-            varDsc->lvClassHnd = info.compCompHnd->getArgClass(&info.compMethodInfo->args, argLst);
+            CORINFO_CLASS_HANDLE clsHnd = info.compCompHnd->getArgClass(&info.compMethodInfo->args, argLst);
+            lvaSetClass(varDscInfo->varNum, clsHnd);
         }
 
         // For ARM, ARM64, and AMD64 varargs, all arguments go in integer registers
@@ -2294,6 +2295,115 @@ void Compiler::lvaSetStruct(unsigned varNum, CORINFO_CLASS_HANDLE typeHnd, bool 
         setNeedsGSSecurityCookie();
         compGSReorderStackLayout = true;
         varDsc->lvIsUnsafeBuffer = true;
+    }
+}
+
+//------------------------------------------------------------------------
+// lvaSetClass: set or update class information for a local var.
+//
+// Arguments:
+//    varNum -- number of the variable
+//    clsHnd -- class handle to use in set or update
+//    isExact -- true if class is known exactly
+//
+// Notes:
+//
+//    This method can be viewed as a rudimentary lattice meet in a
+//    type lattice.
+//
+//    Updates currently should only happen for single-def user args or
+//    locals, when we are processing the expression actually being
+//    used to initialize the local (or inlined arg). The update will
+//    change the local from the declared type to the type of the
+//    initial value.
+//
+//    These updates should always *improve* what we know about the
+//    type, that is making an inexact type exact, or changing a type
+//    to some subtype. However the jit lacks precise type information
+//    for shared code, so ensuring this is so is currently not
+//    possible.
+
+void Compiler::lvaSetClass(unsigned varNum, CORINFO_CLASS_HANDLE clsHnd, bool isExact)
+{
+    noway_assert(varNum < lvaCount);
+    assert(clsHnd != nullptr);
+
+    LclVarDsc* varDsc = &lvaTable[varNum];
+    assert(varDsc->lvType == TYP_REF);
+
+    // If previous type was exact, nothing to update.  Would like
+    // to verify new type is compatible but can't do this yet.
+    if (varDsc->lvClassIsExact)
+    {
+        assert(varDsc->lvClassHnd != nullptr);
+        return;
+    }
+
+    // If we didn't have a type yet, use the one we have now.
+    if (varDsc->lvClassHnd == nullptr)
+    {
+        assert(!varDsc->lvClassIsExact);
+        JITDUMP("\nlvaSetClass: setting class for V%02i to (%p) %s %s\n", varNum, clsHnd,
+                info.compCompHnd->getClassName(clsHnd), isExact ? " [exact]" : "");
+
+        varDsc->lvClassHnd     = clsHnd;
+        varDsc->lvClassIsExact = isExact;
+        return;
+    }
+
+    // Are we updating the type?
+    if (varDsc->lvClassHnd != clsHnd)
+    {
+        JITDUMP("\nlvaSetClass: Updating class for V%02i from (%p) %s to (%p) %s %s\n", varNum, varDsc->lvClassHnd,
+                info.compCompHnd->getClassName(varDsc->lvClassHnd), clsHnd, info.compCompHnd->getClassName(clsHnd),
+                isExact ? " [exact]" : "");
+
+        varDsc->lvClassHnd     = clsHnd;
+        varDsc->lvClassIsExact = isExact;
+        return;
+    }
+
+    // Class info matched. Are we updating exactness?
+    if (isExact)
+    {
+        JITDUMP("\nlvaSetClass: Updating class for V%02i (%p) %s to be exact\n", varNum, varDsc->lvClassHnd,
+                info.compCompHnd->getClassName(varDsc->lvClassHnd));
+
+        varDsc->lvClassIsExact = isExact;
+        return;
+    }
+
+    // Else we have the same handle and (in)exactness as before. Do nothing.
+    return;
+}
+
+//------------------------------------------------------------------------
+// lvaSetClass: set or update class information for a local var from a tree
+//  or stack type
+//
+// Arguments:
+//    varNum -- number of the variable. Must be a single def local
+//    tree  -- tree establishing the variable's value
+//    stackHnd -- handle for the type from the evaluation stack
+//
+// Notes:
+//    Preferentially uses the tree's type, when available. Since not all
+//    tree kinds can track ref types, the stack type is used as a
+//    fallback.
+
+void Compiler::lvaSetClass(unsigned varNum, GenTreePtr tree, CORINFO_CLASS_HANDLE stackHnd)
+{
+    bool                 isExact   = false;
+    bool                 isNonNull = false;
+    CORINFO_CLASS_HANDLE clsHnd    = gtGetClassHandle(tree, &isExact, &isNonNull);
+
+    if (clsHnd != nullptr)
+    {
+        lvaSetClass(varNum, clsHnd, isExact);
+    }
+    else if (stackHnd != nullptr)
+    {
+        lvaSetClass(varNum, stackHnd);
     }
 }
 
@@ -6490,6 +6600,14 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     if (varDsc->lvStackByref)
     {
         printf(" stack-byref");
+    }
+    if (varDsc->lvClassHnd != nullptr)
+    {
+        printf(" class-hnd");
+    }
+    if (varDsc->lvClassIsExact)
+    {
+        printf(" exact");
     }
 #ifndef _TARGET_64BIT_
     if (varDsc->lvStructDoubleAlign)


### PR DESCRIPTION
Track whether a local has a single definition, and if so, if it has
a reference type, try and update its type from the declared type to
a better type taken from the value being assigned to the local.

Obtain types for some of the 'short-lived' ref type temps that should
have a single definition. Use both the tree and the eval stack as sources
of type information (the latter can be phased out if/when all tree nodes
can return rich type information).

Refactor the code that sets or updates lvClassHnd into utilities
to provide better auditing of type flow and make the set/update process
a bit more rigorous.

Cleanup the code that passes argument values a bit by commoning redundant
argument lookup expressions.