### PR TITLE
Remove return statement and throwing directly for obsolete Span methods.

### DIFF
--- a/src/mscorlib/src/System/ReadOnlySpan.cs
+++ b/src/mscorlib/src/System/ReadOnlySpan.cs
@@ -244,9 +244,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj)
         {
-            ThrowHelper.ThrowNotSupportedException_CannotCallEqualsOnSpan();
-            // Prevent compiler error CS0161: 'Span<T>.Equals(object)': not all code paths return a value
-            return default(bool);
+            throw new NotSupportedException(SR.NotSupported_CannotCallEqualsOnSpan);
         }
 
         /// <summary>
@@ -259,9 +257,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            ThrowHelper.ThrowNotSupportedException_CannotCallGetHashCodeOnSpan();
-            // Prevent compiler error CS0161: 'Span<T>.GetHashCode()': not all code paths return a value
-            return default(int);
+            throw new NotSupportedException(SR.NotSupported_CannotCallGetHashCodeOnSpan);
         }
 
         /// <summary>

--- a/src/mscorlib/src/System/Span.cs
+++ b/src/mscorlib/src/System/Span.cs
@@ -329,9 +329,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj)
         {
-            ThrowHelper.ThrowNotSupportedException_CannotCallEqualsOnSpan();
-            // Prevent compiler error CS0161: 'Span<T>.Equals(object)': not all code paths return a value
-            return default(bool);
+            throw new NotSupportedException(SR.NotSupported_CannotCallEqualsOnSpan);
         }
 
         /// <summary>
@@ -344,9 +342,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            ThrowHelper.ThrowNotSupportedException_CannotCallGetHashCodeOnSpan();
-            // Prevent compiler error CS0161: 'Span<T>.GetHashCode()': not all code paths return a value
-            return default(int);
+            throw new NotSupportedException(SR.NotSupported_CannotCallGetHashCodeOnSpan);
         }
 
         /// <summary>

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -70,16 +70,6 @@ namespace System
             throw new ArgumentException(SR.Argument_DestinationTooShort);
         }
 
-        internal static void ThrowNotSupportedException_CannotCallEqualsOnSpan()
-        {
-            throw new NotSupportedException(SR.NotSupported_CannotCallEqualsOnSpan);
-        }
-
-        internal static void ThrowNotSupportedException_CannotCallGetHashCodeOnSpan()
-        {
-            throw new NotSupportedException(SR.NotSupported_CannotCallGetHashCodeOnSpan);
-        }
-
         internal static void ThrowArgumentOutOfRange_IndexException()
         {
             throw GetArgumentOutOfRangeException(ExceptionArgument.index,


### PR DESCRIPTION
Part of https://github.com/dotnet/corefxlab/issues/1314 / https://github.com/dotnet/corefx/issues/17078