### PR TITLE
Change typedef for BOOL in gcenv.base.h to int

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -37,7 +37,7 @@
 // Aliases for Win32 types
 //
 
-typedef uint32_t BOOL;
+typedef int BOOL;
 typedef uint32_t DWORD;
 
 // -----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I'm not sure why this was defined this way here before, but some GC changes I'm about to make were breaking the GCSample project because of this.