### PR TITLE
[WIP]Ensure corerun using the given executable path.

### DIFF
--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -945,6 +945,7 @@ namespace BINDER_SPACE
        IF_FAIL_GO(BindLocked(pApplicationContext,
                               pAssemblyName,
                               dwBindFlags,
+							  false, /* Do not use explicit path */
                               excludeAppPaths,
                               pBindResult));
 
@@ -1023,10 +1024,11 @@ namespace BINDER_SPACE
         AssemblyName *pAssemblyName;
         pAssemblyName = pAssembly->GetAssemblyName();
 
-        if (!fNgenExplicitBind && !fUseExplicitFilePath)
+        if (!fNgenExplicitBind)
         {
             IF_FAIL_GO(BindLockedOrService(pApplicationContext,
                                            pAssemblyName,
+										   fUseExplicitFilePath,
                                            excludeAppPaths,
                                            &lockedBindResult));
             if (lockedBindResult.HaveResult())
@@ -1058,6 +1060,7 @@ namespace BINDER_SPACE
     HRESULT AssemblyBinder::BindLocked(ApplicationContext *pApplicationContext,
                                        AssemblyName       *pAssemblyName,
                                        DWORD               dwBindFlags,
+									   BOOL                fUseExplicitFilePath,
                                        bool                excludeAppPaths,
                                        BindResult         *pBindResult)
     {
@@ -1092,7 +1095,7 @@ namespace BINDER_SPACE
         }
         else
 #endif // !CROSSGEN_COMPILE
-        if (pApplicationContext->IsTpaListProvided())
+        if (!fUseExplicitFilePath && pApplicationContext->IsTpaListProvided())
         {
             IF_FAIL_GO(BindByTpaList(pApplicationContext,
                                      pAssemblyName,
@@ -1116,6 +1119,7 @@ namespace BINDER_SPACE
     /* static */
     HRESULT AssemblyBinder::BindLockedOrService(ApplicationContext *pApplicationContext,
                                                 AssemblyName       *pAssemblyName,
+												BOOL                fUseExplicitFilePath,
                                                 bool                excludeAppPaths,
                                                 BindResult         *pBindResult)
     {
@@ -1127,6 +1131,7 @@ namespace BINDER_SPACE
         IF_FAIL_GO(BindLocked(pApplicationContext,
                               pAssemblyName,
                               0 /*  Do not IgnoreDynamicBinds */,
+							  fUseExplicitFilePath,
                               excludeAppPaths,
                               &lockedBindResult));
 

--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -553,7 +553,8 @@ namespace BINDER_SPACE
                                          /* in */  PEAssembly          *pParentAssembly,
                                          /* in */  BOOL                 fNgenExplicitBind,
                                          /* in */  BOOL                 fExplicitBindToNativeImage,
-                                         /* in */  bool                 excludeAppPaths,
+                                         /* in */  BOOL                 fUseExplicitFilePath,
+										 /* in */  bool                 excludeAppPaths,
                                          /* out */ Assembly           **ppAssembly)
     {
         HRESULT hr = S_OK;
@@ -611,6 +612,7 @@ namespace BINDER_SPACE
                                         assemblyPath,
                                         fDoNgenExplicitBind,
                                         fExplicitBindToNativeImage,
+										fUseExplicitFilePath,
                                         excludeAppPaths,
                                         &bindResult));
             }
@@ -984,7 +986,8 @@ namespace BINDER_SPACE
                                          PathString         &assemblyPath,
                                          BOOL                fNgenExplicitBind,
                                          BOOL                fExplicitBindToNativeImage,
-                                         bool                excludeAppPaths,
+										 BOOL                fUseExplicitFilePath,
+										 bool                excludeAppPaths,
                                          BindResult         *pBindResult)
     {
         HRESULT hr = S_OK;
@@ -1020,7 +1023,7 @@ namespace BINDER_SPACE
         AssemblyName *pAssemblyName;
         pAssemblyName = pAssembly->GetAssemblyName();
 
-        if (!fNgenExplicitBind)
+        if (!fNgenExplicitBind && !fUseExplicitFilePath)
         {
             IF_FAIL_GO(BindLockedOrService(pApplicationContext,
                                            pAssemblyName,

--- a/src/binder/binderinterface.cpp
+++ b/src/binder/binderinterface.cpp
@@ -109,7 +109,7 @@ namespace BinderInterface
                                                         pParentAssembly,
                                                         fNgenExplicitBind,
                                                         fExplicitBindToNativeImage,
-														FALSE, // fUseExplicitFilePath
+                                                        FALSE, // fUseExplicitFilePath
                                                         false, // excludeAppPaths
                                                         ppAssembly));
             }

--- a/src/binder/binderinterface.cpp
+++ b/src/binder/binderinterface.cpp
@@ -109,6 +109,7 @@ namespace BinderInterface
                                                         pParentAssembly,
                                                         fNgenExplicitBind,
                                                         fExplicitBindToNativeImage,
+														FALSE, // fUseExplicitFilePath
                                                         false, // excludeAppPaths
                                                         ppAssembly));
             }

--- a/src/binder/clrprivbinderassemblyloadcontext.cpp
+++ b/src/binder/clrprivbinderassemblyloadcontext.cpp
@@ -33,7 +33,7 @@ HRESULT CLRPrivBinderAssemblyLoadContext::BindAssemblyByNameWorker(BINDER_SPACE:
                                       NULL,
                                       FALSE, //fNgenExplicitBind,
                                       FALSE, //fExplicitBindToNativeImage,
-									  FALSE, //fUseExplicitFilePath,
+                                      FALSE, //fUseExplicitFilePath,
                                       false, //excludeAppPaths,
                                       ppCoreCLRFoundAssembly);
     if (!FAILED(hr))

--- a/src/binder/clrprivbinderassemblyloadcontext.cpp
+++ b/src/binder/clrprivbinderassemblyloadcontext.cpp
@@ -33,6 +33,7 @@ HRESULT CLRPrivBinderAssemblyLoadContext::BindAssemblyByNameWorker(BINDER_SPACE:
                                       NULL,
                                       FALSE, //fNgenExplicitBind,
                                       FALSE, //fExplicitBindToNativeImage,
+									  FALSE, //fUseExplicitFilePath,
                                       false, //excludeAppPaths,
                                       ppCoreCLRFoundAssembly);
     if (!FAILED(hr))

--- a/src/binder/clrprivbindercoreclr.cpp
+++ b/src/binder/clrprivbindercoreclr.cpp
@@ -32,7 +32,7 @@ HRESULT CLRPrivBinderCoreCLR::BindAssemblyByNameWorker(BINDER_SPACE::AssemblyNam
                                       FALSE, //fNgenExplicitBind,
                                       FALSE, //fExplicitBindToNativeImage,
                                       FALSE, //fUseExplicitFilePath
-									  excludeAppPaths,
+                                      excludeAppPaths,
                                       ppCoreCLRFoundAssembly);
     if (!FAILED(hr))
     {
@@ -253,8 +253,8 @@ HRESULT CLRPrivBinderCoreCLR::Bind(SString           &assemblyDisplayName,
                                    PEAssembly        *pParentAssembly,
                                    BOOL               fNgenExplicitBind,
                                    BOOL               fExplicitBindToNativeImage,
-								   BOOL               fUseExplicitFilePath,
-								   ICLRPrivAssembly **ppAssembly)
+                                   BOOL               fUseExplicitFilePath,
+                                   ICLRPrivAssembly **ppAssembly)
 {
     HRESULT hr = S_OK;
     VALIDATE_ARG_RET(ppAssembly != NULL);
@@ -279,7 +279,7 @@ HRESULT CLRPrivBinderCoreCLR::Bind(SString           &assemblyDisplayName,
                                           pParentAssembly,
                                           fNgenExplicitBind,
                                           fExplicitBindToNativeImage,
-										  fUseExplicitFilePath,
+                                          fUseExplicitFilePath,
                                           false, // excludeAppPaths
                                           &pAsm);
         if(SUCCEEDED(hr))

--- a/src/binder/clrprivbindercoreclr.cpp
+++ b/src/binder/clrprivbindercoreclr.cpp
@@ -31,7 +31,8 @@ HRESULT CLRPrivBinderCoreCLR::BindAssemblyByNameWorker(BINDER_SPACE::AssemblyNam
                                       NULL,
                                       FALSE, //fNgenExplicitBind,
                                       FALSE, //fExplicitBindToNativeImage,
-                                      excludeAppPaths,
+                                      FALSE, //fUseExplicitFilePath
+									  excludeAppPaths,
                                       ppCoreCLRFoundAssembly);
     if (!FAILED(hr))
     {
@@ -252,7 +253,8 @@ HRESULT CLRPrivBinderCoreCLR::Bind(SString           &assemblyDisplayName,
                                    PEAssembly        *pParentAssembly,
                                    BOOL               fNgenExplicitBind,
                                    BOOL               fExplicitBindToNativeImage,
-                                   ICLRPrivAssembly **ppAssembly)
+								   BOOL               fUseExplicitFilePath,
+								   ICLRPrivAssembly **ppAssembly)
 {
     HRESULT hr = S_OK;
     VALIDATE_ARG_RET(ppAssembly != NULL);
@@ -277,6 +279,7 @@ HRESULT CLRPrivBinderCoreCLR::Bind(SString           &assemblyDisplayName,
                                           pParentAssembly,
                                           fNgenExplicitBind,
                                           fExplicitBindToNativeImage,
+										  fUseExplicitFilePath,
                                           false, // excludeAppPaths
                                           &pAsm);
         if(SUCCEEDED(hr))

--- a/src/binder/inc/assemblybinder.hpp
+++ b/src/binder/inc/assemblybinder.hpp
@@ -147,10 +147,12 @@ namespace BINDER_SPACE
         static HRESULT BindLocked(/* in */  ApplicationContext *pApplicationContext,
                                   /* in */  AssemblyName       *pAssemblyName,
                                   /* in */  DWORD               dwBindFlags,
+								  /* in */  BOOL                fUseExplicitFilePath,
                                   /* in */  bool                excludeAppPaths,
                                   /* out */ BindResult         *pBindResult);
         static HRESULT BindLockedOrService(/* in */  ApplicationContext *pApplicationContext,
                                            /* in */  AssemblyName       *pAssemblyName,
+										   /* in */  BOOL                fUseExplicitFilePath,
                                            /* in */  bool                excludeAppPaths,
                                            /* out */ BindResult         *pBindResult);
 

--- a/src/binder/inc/assemblybinder.hpp
+++ b/src/binder/inc/assemblybinder.hpp
@@ -46,7 +46,8 @@ namespace BINDER_SPACE
                                     /* in */  PEAssembly          *pParentAssembly,
                                     /* in */  BOOL                 fNgenExplicitBind,
                                     /* in */  BOOL                 fExplicitBindToNativeImage,
-                                    /* in */  bool                 excludeAppPaths,
+                                    /* in */  BOOL                 fUseExplicitFilePath,
+									/* in */  bool                 excludeAppPaths,
                                     /* out */ Assembly           **ppAssembly);
 
         static HRESULT BindToSystem(/* in */ SString    &systemDirectory,
@@ -139,6 +140,7 @@ namespace BINDER_SPACE
                                     /* in */  PathString         &assemblyPath,
                                     /* in */  BOOL                fNgenExplicitBind,
                                     /* in */  BOOL                fExplicitBindToNativeImage,
+									/* in */  BOOL                fUseExplicitFilePath,
                                     /* in */  bool                excludeAppPaths,
                                     /* out */ BindResult         *pBindResult);
 

--- a/src/binder/inc/assemblybinder.hpp
+++ b/src/binder/inc/assemblybinder.hpp
@@ -47,7 +47,7 @@ namespace BINDER_SPACE
                                     /* in */  BOOL                 fNgenExplicitBind,
                                     /* in */  BOOL                 fExplicitBindToNativeImage,
                                     /* in */  BOOL                 fUseExplicitFilePath,
-									/* in */  bool                 excludeAppPaths,
+                                    /* in */  bool                 excludeAppPaths,
                                     /* out */ Assembly           **ppAssembly);
 
         static HRESULT BindToSystem(/* in */ SString    &systemDirectory,
@@ -140,19 +140,19 @@ namespace BINDER_SPACE
                                     /* in */  PathString         &assemblyPath,
                                     /* in */  BOOL                fNgenExplicitBind,
                                     /* in */  BOOL                fExplicitBindToNativeImage,
-									/* in */  BOOL                fUseExplicitFilePath,
+                                    /* in */  BOOL                fUseExplicitFilePath,
                                     /* in */  bool                excludeAppPaths,
                                     /* out */ BindResult         *pBindResult);
 
         static HRESULT BindLocked(/* in */  ApplicationContext *pApplicationContext,
                                   /* in */  AssemblyName       *pAssemblyName,
                                   /* in */  DWORD               dwBindFlags,
-								  /* in */  BOOL                fUseExplicitFilePath,
+                                  /* in */  BOOL                fUseExplicitFilePath,
                                   /* in */  bool                excludeAppPaths,
                                   /* out */ BindResult         *pBindResult);
         static HRESULT BindLockedOrService(/* in */  ApplicationContext *pApplicationContext,
                                            /* in */  AssemblyName       *pAssemblyName,
-										   /* in */  BOOL                fUseExplicitFilePath,
+                                           /* in */  BOOL                fUseExplicitFilePath,
                                            /* in */  bool                excludeAppPaths,
                                            /* out */ BindResult         *pBindResult);
 

--- a/src/binder/inc/clrprivbindercoreclr.h
+++ b/src/binder/inc/clrprivbindercoreclr.h
@@ -61,7 +61,7 @@ public:
                  PEAssembly  *pParentAssembly,
                  BOOL         fNgenExplicitBind,
                  BOOL         fExplicitBindToNativeImage,
-				 BOOL         fUseExplicitFilePath,
+                 BOOL         fUseExplicitFilePath,
                  ICLRPrivAssembly **ppAssembly);
 
 #ifndef CROSSGEN_COMPILE

--- a/src/binder/inc/clrprivbindercoreclr.h
+++ b/src/binder/inc/clrprivbindercoreclr.h
@@ -61,6 +61,7 @@ public:
                  PEAssembly  *pParentAssembly,
                  BOOL         fNgenExplicitBind,
                  BOOL         fExplicitBindToNativeImage,
+				 BOOL         fUseExplicitFilePath,
                  ICLRPrivAssembly **ppAssembly);
 
 #ifndef CROSSGEN_COMPILE

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -7096,7 +7096,7 @@ PEAssembly * AppDomain::BindAssemblySpec(
     StackCrawlMark *       pCallerStackMark, 
     AssemblyLoadSecurity * pLoadSecurity,
     BOOL                   fUseHostBinderIfAvailable,
-	BOOL                   fUseExplicitFilePath)
+    BOOL                   fUseExplicitFilePath)
 {
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -7095,7 +7095,8 @@ PEAssembly * AppDomain::BindAssemblySpec(
     BOOL                   fRaisePrebindEvents, 
     StackCrawlMark *       pCallerStackMark, 
     AssemblyLoadSecurity * pLoadSecurity,
-    BOOL                   fUseHostBinderIfAvailable)
+    BOOL                   fUseHostBinderIfAvailable,
+	BOOL                   fUseExplicitFilePath)
 {
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
@@ -7197,7 +7198,7 @@ EndTry2:;
                     // Use CoreClr's fusion alternative
                     CoreBindResult bindResult;
 
-                    pSpec->Bind(this, fThrowOnFileNotFound, &bindResult, FALSE /* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */, pCallerStackMark);
+                    pSpec->Bind(this, fThrowOnFileNotFound, &bindResult, FALSE /* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */, pCallerStackMark, fUseExplicitFilePath);
                     hrBindResult = bindResult.GetHRBindResult();
 
                     if (bindResult.Found()) 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -2470,7 +2470,8 @@ public:
         BOOL fRaisePrebindEvents,
         StackCrawlMark *pCallerStackMark = NULL,
         AssemblyLoadSecurity *pLoadSecurity = NULL,
-        BOOL fUseHostBinderIfAvailable = TRUE) DAC_EMPTY_RET(NULL);
+        BOOL fUseHostBinderIfAvailable = TRUE,
+		BOOL fUseExplicitFilePath = FALSE) DAC_EMPTY_RET(NULL);
 
     HRESULT BindAssemblySpecForHostedBinder(
         AssemblySpec *   pSpec, 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -2471,7 +2471,7 @@ public:
         StackCrawlMark *pCallerStackMark = NULL,
         AssemblyLoadSecurity *pLoadSecurity = NULL,
         BOOL fUseHostBinderIfAvailable = TRUE,
-		BOOL fUseExplicitFilePath = FALSE) DAC_EMPTY_RET(NULL);
+        BOOL fUseExplicitFilePath = FALSE) DAC_EMPTY_RET(NULL);
 
     HRESULT BindAssemblySpecForHostedBinder(
         AssemblySpec *   pSpec, 

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -719,7 +719,7 @@ PEAssembly *AssemblySpec::ResolveAssemblyFile(AppDomain *pDomain, BOOL fPreBind)
 }
 
 
-Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel, AssemblyLoadSecurity *pLoadSecurity, BOOL fThrowOnFileNotFound, BOOL fRaisePrebindEvents, StackCrawlMark *pCallerStackMark)
+Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel, AssemblyLoadSecurity *pLoadSecurity, BOOL fThrowOnFileNotFound, BOOL fRaisePrebindEvents, StackCrawlMark *pCallerStackMark, BOOL fUseExplicitFilePath)
 {
     CONTRACTL
     {
@@ -729,7 +729,7 @@ Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel, AssemblyLoadSecu
     }
     CONTRACTL_END;
  
-    DomainAssembly * pDomainAssembly = LoadDomainAssembly(targetLevel, pLoadSecurity, fThrowOnFileNotFound, fRaisePrebindEvents, pCallerStackMark);
+    DomainAssembly * pDomainAssembly = LoadDomainAssembly(targetLevel, pLoadSecurity, fThrowOnFileNotFound, fRaisePrebindEvents, pCallerStackMark, fUseExplicitFilePath);
     if (pDomainAssembly == NULL) {
         _ASSERTE(!fThrowOnFileNotFound);
         return NULL;
@@ -870,7 +870,8 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
                                                  AssemblyLoadSecurity *pLoadSecurity,
                                                  BOOL fThrowOnFileNotFound,
                                                  BOOL fRaisePrebindEvents,
-                                                 StackCrawlMark *pCallerStackMark)
+                                                 StackCrawlMark *pCallerStackMark,
+												 BOOL fUseExplicitFilePath)
 {
     CONTRACT(DomainAssembly *)
     {
@@ -922,7 +923,7 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
     }
 
 
-    PEAssemblyHolder pFile(pDomain->BindAssemblySpec(this, fThrowOnFileNotFound, fRaisePrebindEvents, pCallerStackMark, pLoadSecurity));
+    PEAssemblyHolder pFile(pDomain->BindAssemblySpec(this, fThrowOnFileNotFound, fRaisePrebindEvents, pCallerStackMark, pLoadSecurity, TRUE, fUseExplicitFilePath));
     if (pFile == NULL)
         RETURN NULL;
 
@@ -972,7 +973,8 @@ Assembly *AssemblySpec::LoadAssembly(LPCWSTR pFilePath)
 
     AssemblySpec spec;
     spec.SetCodeBase(pFilePath);
-    RETURN spec.LoadAssembly(FILE_LOADED);
+
+    RETURN spec.LoadAssembly(FILE_LOADED, NULL, TRUE, TRUE, NULL, TRUE);
 }
 
 HRESULT AssemblySpec::CheckFriendAssemblyName()

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -871,7 +871,7 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
                                                  BOOL fThrowOnFileNotFound,
                                                  BOOL fRaisePrebindEvents,
                                                  StackCrawlMark *pCallerStackMark,
-												 BOOL fUseExplicitFilePath)
+                                                 BOOL fUseExplicitFilePath)
 {
     CONTRACT(DomainAssembly *)
     {

--- a/src/vm/assemblyspec.hpp
+++ b/src/vm/assemblyspec.hpp
@@ -222,20 +222,20 @@ class AssemblySpec  : public BaseAssemblySpec
         BOOL fNgenExplicitBind = FALSE, 
         BOOL fExplicitBindToNativeImage = FALSE,
         StackCrawlMark *pCallerStackMark  = NULL,
-		BOOL fUseExplicitFilePath = FALSE);
+        BOOL fUseExplicitFilePath = FALSE);
 
     Assembly *LoadAssembly(FileLoadLevel targetLevel, 
                            AssemblyLoadSecurity *pLoadSecurity = NULL,
                            BOOL fThrowOnFileNotFound = TRUE,
                            BOOL fRaisePrebindEvents = TRUE,
                            StackCrawlMark *pCallerStackMark = NULL,
-						   BOOL fUseExplicitFilePath = FALSE);
+                           BOOL fUseExplicitFilePath = FALSE);
     DomainAssembly *LoadDomainAssembly(FileLoadLevel targetLevel,
                                        AssemblyLoadSecurity *pLoadSecurity = NULL,
                                        BOOL fThrowOnFileNotFound = TRUE,
                                        BOOL fRaisePrebindEvents = TRUE,
                                        StackCrawlMark *pCallerStackMark = NULL,
-									   BOOL fUseExplicitFilePath = FALSE);
+                                       BOOL fUseExplicitFilePath = FALSE);
 
     //****************************************************************************************
     //

--- a/src/vm/assemblyspec.hpp
+++ b/src/vm/assemblyspec.hpp
@@ -72,7 +72,7 @@ class AssemblySpec  : public BaseAssemblySpec
         m_pParentAssembly = NULL;
 
         m_pFallbackLoadContextBinder = NULL;     
-        m_fPreferFallbackLoadContextBinder = false;   
+        m_fPreferFallbackLoadContextBinder = false;
 
     }
 #endif //!DACCESS_COMPILE
@@ -221,18 +221,21 @@ class AssemblySpec  : public BaseAssemblySpec
         CoreBindResult* pBindResult,
         BOOL fNgenExplicitBind = FALSE, 
         BOOL fExplicitBindToNativeImage = FALSE,
-        StackCrawlMark *pCallerStackMark  = NULL );
+        StackCrawlMark *pCallerStackMark  = NULL,
+		BOOL fUseExplicitFilePath = FALSE);
 
     Assembly *LoadAssembly(FileLoadLevel targetLevel, 
                            AssemblyLoadSecurity *pLoadSecurity = NULL,
                            BOOL fThrowOnFileNotFound = TRUE,
                            BOOL fRaisePrebindEvents = TRUE,
-                           StackCrawlMark *pCallerStackMark = NULL);
+                           StackCrawlMark *pCallerStackMark = NULL,
+						   BOOL fUseExplicitFilePath = FALSE);
     DomainAssembly *LoadDomainAssembly(FileLoadLevel targetLevel,
                                        AssemblyLoadSecurity *pLoadSecurity = NULL,
                                        BOOL fThrowOnFileNotFound = TRUE,
                                        BOOL fRaisePrebindEvents = TRUE,
-                                       StackCrawlMark *pCallerStackMark = NULL);
+                                       StackCrawlMark *pCallerStackMark = NULL,
+									   BOOL fUseExplicitFilePath = FALSE);
 
     //****************************************************************************************
     //

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -7298,7 +7298,7 @@ PEAssembly *CompilationDomain::BindAssemblySpec(
     StackCrawlMark *pCallerStackMark,
     AssemblyLoadSecurity *pLoadSecurity,
     BOOL fUseHostBinderIfAvailable,
-	BOOL fUseExplicitFilePath)
+    BOOL fUseExplicitFilePath)
 {
     PEAssembly *pFile = NULL;
     //

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -7297,7 +7297,8 @@ PEAssembly *CompilationDomain::BindAssemblySpec(
     BOOL fRaisePrebindEvents,
     StackCrawlMark *pCallerStackMark,
     AssemblyLoadSecurity *pLoadSecurity,
-    BOOL fUseHostBinderIfAvailable)
+    BOOL fUseHostBinderIfAvailable,
+	BOOL fUseExplicitFilePath)
 {
     PEAssembly *pFile = NULL;
     //

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -790,7 +790,7 @@ class CompilationDomain : public AppDomain,
         BOOL fRaisePrebindEvents,
         StackCrawlMark *pCallerStackMark = NULL,
         AssemblyLoadSecurity *pLoadSecurity = NULL,
-		BOOL fUseHostBinderIfAvailable = TRUE,
+        BOOL fUseHostBinderIfAvailable = TRUE,
         BOOL fUseExplicitFilePath = FALSE) DAC_EMPTY_RET(NULL);
 
     BOOL CanEagerBindToZapFile(Module *targetModule, BOOL limitToHardBindList = TRUE);

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -790,7 +790,8 @@ class CompilationDomain : public AppDomain,
         BOOL fRaisePrebindEvents,
         StackCrawlMark *pCallerStackMark = NULL,
         AssemblyLoadSecurity *pLoadSecurity = NULL,
-        BOOL fUseHostBinderIfAvailable = TRUE) DAC_EMPTY_RET(NULL);
+		BOOL fUseHostBinderIfAvailable = TRUE,
+        BOOL fUseExplicitFilePath = FALSE) DAC_EMPTY_RET(NULL);
 
     BOOL CanEagerBindToZapFile(Module *targetModule, BOOL limitToHardBindList = TRUE);
 

--- a/src/vm/coreassemblyspec.cpp
+++ b/src/vm/coreassemblyspec.cpp
@@ -108,7 +108,8 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
                          CoreBindResult *pResult,
                          BOOL fNgenExplicitBind /* = FALSE */,
                          BOOL fExplicitBindToNativeImage /* = FALSE */,
-                         StackCrawlMark *pCallerStackMark /* = NULL */)
+                         StackCrawlMark *pCallerStackMark /* = NULL */,
+						 BOOL fUseExplicitFilePath /* = FALSE */)
 {
     CONTRACTL
     {
@@ -178,6 +179,7 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
                            GetParentAssembly()? GetParentAssembly()->GetFile():NULL,
                            fNgenExplicitBind,
                            fExplicitBindToNativeImage,
+						   fUseExplicitFilePath,
                           &pPrivAsm);
     }
 

--- a/src/vm/coreassemblyspec.cpp
+++ b/src/vm/coreassemblyspec.cpp
@@ -109,7 +109,7 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
                          BOOL fNgenExplicitBind /* = FALSE */,
                          BOOL fExplicitBindToNativeImage /* = FALSE */,
                          StackCrawlMark *pCallerStackMark /* = NULL */,
-						 BOOL fUseExplicitFilePath /* = FALSE */)
+                         BOOL fUseExplicitFilePath /* = FALSE */)
 {
     CONTRACTL
     {
@@ -179,7 +179,7 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
                            GetParentAssembly()? GetParentAssembly()->GetFile():NULL,
                            fNgenExplicitBind,
                            fExplicitBindToNativeImage,
-						   fUseExplicitFilePath,
+                           fUseExplicitFilePath,
                           &pPrivAsm);
     }
 


### PR DESCRIPTION
Fix the bug that corerun trying to load the executable from current directory even if the user has specified a full path of the executable.

Fix #5631