### PR TITLE
[Ryujit/ARM32] Implement NYI related with overflow for ARM

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -610,10 +610,6 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             // Cast is never contained (?)
             noway_assert(targetReg != REG_NA);
 
-            // Overflow conversions from float/double --> int types go through helper calls.
-            if (treeNode->gtOverflow() && !varTypeIsFloating(treeNode->gtOp.gtOp1))
-                NYI("Unimplmented GT_CAST:int <--> int with overflow");
-
             if (varTypeIsFloating(targetType) && varTypeIsFloating(treeNode->gtOp.gtOp1))
             {
                 // Casts float/double <--> double/float
@@ -2483,7 +2479,76 @@ void CodeGen::genIntToIntCast(GenTreePtr treeNode)
 
     if (castInfo.requiresOverflowCheck)
     {
-        NYI_ARM("CodeGen::genIntToIntCast for OverflowCheck");
+        emitAttr cmpSize = EA_ATTR(genTypeSize(srcType));
+
+        if (castInfo.signCheckOnly)
+        {
+            // We only need to check for a negative value in sourceReg
+            emit->emitIns_R_I(INS_cmp, cmpSize, sourceReg, 0);
+            emitJumpKind jmpLT = genJumpKindForOper(GT_LT, CK_SIGNED);
+            genJumpToThrowHlpBlk(jmpLT, SCK_OVERFLOW);
+            noway_assert(genTypeSize(srcType) == 4 || genTypeSize(srcType) == 8);
+            // This is only interesting case to ensure zero-upper bits.
+            if ((srcType == TYP_INT) && (dstType == TYP_ULONG))
+            {
+                // cast to TYP_ULONG:
+                // We use a mov with size=EA_4BYTE
+                // which will zero out the upper bits
+                movSize     = EA_4BYTE;
+                movRequired = true;
+            }
+        }
+        else if (castInfo.unsignedSource || castInfo.unsignedDest)
+        {
+            // When we are converting from/to unsigned,
+            // we only have to check for any bits set in 'typeMask'
+
+            noway_assert(castInfo.typeMask != 0);
+            emit->emitIns_R_I(INS_tst, cmpSize, sourceReg, castInfo.typeMask);
+            emitJumpKind jmpNotEqual = genJumpKindForOper(GT_NE, CK_SIGNED);
+            genJumpToThrowHlpBlk(jmpNotEqual, SCK_OVERFLOW);
+        }
+        else
+        {
+            // For a narrowing signed cast
+            //
+            // We must check the value is in a signed range.
+
+            // Compare with the MAX
+
+            noway_assert((castInfo.typeMin != 0) && (castInfo.typeMax != 0));
+
+            if (emitter::emitIns_valid_imm_for_cmp(castInfo.typeMax, INS_FLAGS_DONT_CARE))
+            {
+                emit->emitIns_R_I(INS_cmp, cmpSize, sourceReg, castInfo.typeMax);
+            }
+            else
+            {
+                noway_assert(tmpReg != REG_NA);
+                instGen_Set_Reg_To_Imm(cmpSize, tmpReg, castInfo.typeMax);
+                emit->emitIns_R_R(INS_cmp, cmpSize, sourceReg, tmpReg);
+            }
+
+            emitJumpKind jmpGT = genJumpKindForOper(GT_GT, CK_SIGNED);
+            genJumpToThrowHlpBlk(jmpGT, SCK_OVERFLOW);
+
+            // Compare with the MIN
+
+            if (emitter::emitIns_valid_imm_for_cmp(castInfo.typeMin, INS_FLAGS_DONT_CARE))
+            {
+                emit->emitIns_R_I(INS_cmp, cmpSize, sourceReg, castInfo.typeMin);
+            }
+            else
+            {
+                noway_assert(tmpReg != REG_NA);
+                instGen_Set_Reg_To_Imm(cmpSize, tmpReg, castInfo.typeMin);
+                emit->emitIns_R_R(INS_cmp, cmpSize, sourceReg, tmpReg);
+            }
+
+            emitJumpKind jmpLT = genJumpKindForOper(GT_LT, CK_SIGNED);
+            genJumpToThrowHlpBlk(jmpLT, SCK_OVERFLOW);
+        }
+        ins = INS_mov;
     }
     else // Non-overflow checking cast.
     {

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -1380,7 +1380,7 @@ DONE:
 
 /*****************************************************************************
  *
- *  emitIns_valid_imm_for_add() returns true when the immediate 'imm'
+ *  emitins_valid_imm_for_add() returns true when the immediate 'imm'
  *   can be encoded using a single add or sub instruction.
  */
 /*static*/ bool emitter::emitIns_valid_imm_for_add(int imm, insFlags flags)
@@ -1392,6 +1392,16 @@ DONE:
     if (isModImmConst(-imm)) // funky arm immediate via sub
         return true;
     return false;
+}
+
+/*****************************************************************************
+ *
+ *  emitins_valid_imm_for_cmp() returns true if this 'imm' 
+ *   can be encoded as a input operand to an non-add/sub alu instruction
+ */
+/*static*/ bool emitter::emitIns_valid_imm_for_cmp(int imm, insFlags flags) 
+{
+	    return emitIns_valid_imm_for_add(imm, flags);
 }
 
 /*****************************************************************************

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -1397,11 +1397,15 @@ DONE:
 /*****************************************************************************
  *
  *  emitins_valid_imm_for_cmp() returns true if this 'imm'
- *   can be encoded as a input operand to an non-add/sub alu instruction
+ *   can be encoded as a input operand to an cmp instruction.
  */
 /*static*/ bool emitter::emitIns_valid_imm_for_cmp(int imm, insFlags flags)
 {
-    return emitIns_valid_imm_for_add(imm, flags);
+    if (isModImmConst(imm)) // funky arm immediate
+        return true;
+    if (isModImmConst(-imm)) // funky arm immediate via sub
+        return true;
+    return false;
 }
 
 /*****************************************************************************

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -1396,12 +1396,12 @@ DONE:
 
 /*****************************************************************************
  *
- *  emitins_valid_imm_for_cmp() returns true if this 'imm' 
+ *  emitins_valid_imm_for_cmp() returns true if this 'imm'
  *   can be encoded as a input operand to an non-add/sub alu instruction
  */
-/*static*/ bool emitter::emitIns_valid_imm_for_cmp(int imm, insFlags flags) 
+/*static*/ bool emitter::emitIns_valid_imm_for_cmp(int imm, insFlags flags)
 {
-	    return emitIns_valid_imm_for_add(imm, flags);
+    return emitIns_valid_imm_for_add(imm, flags);
 }
 
 /*****************************************************************************

--- a/src/jit/emitarm.h
+++ b/src/jit/emitarm.h
@@ -243,6 +243,7 @@ static bool emitIns_valid_imm_for_alu(int imm);
 static bool emitIns_valid_imm_for_mov(int imm);
 static bool emitIns_valid_imm_for_small_mov(regNumber reg, int imm, insFlags flags);
 static bool emitIns_valid_imm_for_add(int imm, insFlags flags);
+static bool emitIns_valid_imm_for_cmp(int imm, insFlags flags);
 static bool emitIns_valid_imm_for_add_sp(int imm);
 
 void emitIns(instruction ins);


### PR DESCRIPTION
On last comment of #8496, the NYI message of overflow checks is printed after running the CodeGenBringUpTests.

I tried to create the sample code for making same assertion.
```
using System;
namespace Checked
{
    class Program
    {   
        unsafe private void* m_value;
        public unsafe void Foo(long value)
        {
            m_value= (void*)checked((int)value);
        }
        static void Main(string[] args)
        {
            Program p = new Program();
            p.Foo(0x4234abcdL);
        }
    }   
}
```
It made same results.
```
Assert failure(PID 21515 [0x0000540b], Thread: 21515 [0x540b]): Assertion failed 'NYI_ARM: overflow checks' in 'System.IntPtr:.ctor(long):this' (IL size 11)
    File: /home/sjsujinkim/works/dotnet/coreclr/src/jit/lsraarm.cpp Line: 996
    Image: /home/sjsujinkim/works/dotnet/Windows_NT.x64.Release/Tests/coreoverlay/corerun
Aborted
```

That was the message about a temp register setup for overflow checks.

It was referenced
https://github.com/dotnet/coreclr/blob/master/src/jit/lsraarm64.cpp#L399

I think it doesn't make any problem even though writing it the same as arm64.