### PR TITLE
Add support for CoreCLR testing via ILLINK on Linux

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1429,7 +1429,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
 
                     def illinkArch = (architecture == 'x86compatjit') ? 'x86' : architecture
                     if (scenario == 'illink') {
-                        buildCommands += "tests\\build_illink.cmd clone ${illinkArch}"
+                        buildCommands += "tests\\scripts\\build_illink.cmd clone ${illinkArch}"
                     }
 
                     if (Constants.jitStressModeScenarios.containsKey(scenario) ||

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -55,6 +55,7 @@ function print_usage {
     echo '    8: GC on every allowable NGEN instr   16: GC only on a unique stack trace'
     echo '  --long-gc                        : Runs the long GC tests'
     echo '  --gcsimulator                    : Runs the GCSimulator tests'
+    echo '  --link <ILlink>                  : Runs the tests after linking via ILlink'
     echo '  --show-time                      : Print execution sequence and running time for each test'
     echo '  --no-lf-conversion               : Do not execute LF conversion before running test script'
     echo '  --build-overlay-only             : Exit after overlay directory is populated'
@@ -945,7 +946,7 @@ buildOverlayOnly=
 gcsimulator=
 longgc=
 limitedCoreDumps=
-
+illinker=
 ((disableEventLogging = 0))
 ((serverGC = 0))
 
@@ -978,6 +979,10 @@ do
             ;;
         --jitforcerelocs)
             export COMPlus_ForceRelocs=1
+            ;;
+        --link=*)
+            export ILLINK=${i#*=}
+            export DoLink=true
             ;;
         --jitdisasm)
             jitdisasm=1

--- a/tests/scripts/build_illink.cmd
+++ b/tests/scripts/build_illink.cmd
@@ -8,7 +8,6 @@ if /i "%1" == "-?"     goto Usage
 if /i "%1" == "-h"     goto Usage
 if /i "%1" == "-help"  goto Usage
 if /i "%1" == "clone"  (set doClone=1&shift&goto Arg_Loop)
-if /i "%1" == "setenv" (set setEnv=1&shift&goto Arg_Loop)
 if /i "%1" == "x64"    (set rid=win10-x64&shift&goto Arg_Loop)
 if /i "%1" == "x86"    (set rid=win10-x86&shift&goto Arg_Loop)
 
@@ -27,22 +26,19 @@ cd ..\linker
 ..\corebuild\Tools\dotnetcli\dotnet.exe publish -r %rid% -c netcore_Relase
 popd
 
-if not defined setEnv goto Done
-echo set ILLINK=%cd%\linker\linker\bin\netcore_Relase\netcoreapp2.0\%rid%\publish\illink.exe
-endlocal && set ILLINK=%cd%\linker\linker\bin\netcore_Relase\netcoreapp2.0\%rid%\publish\illink.exe
-
+echo Built %cd%\linker\linker\bin\netcore_Release\netcoreapp2.0\%rid%\publish\illink.exe
 :Done
 exit /b 0
 
 :Usage
 echo.
-echo.Build the ILLINK for CoreCLR testing
+echo.Build ILLINKer for CoreCLR testing
 echo.
 echo.Usage:
-echo     build_illink.cmd [clone] [setenv] runtime-ID
+echo     build_illink.cmd [clone] [setenv] [arch]
 echo.Where:
 echo.-? -h -help: view this message.
-echo.clone: Clone the repository https://github.com/mono/linker
-echo.set: set ILLINK to the path to illink.exe
-echo.runtime-ID: The os-architecture configuration to build: x64 (default) or x86
+echo.clone      : Clone the repository https://github.com/mono/linker
+echo.arch       : The architecture to build: x64 (default) or x86
+echo.
 goto Done

--- a/tests/scripts/build_illink.sh
+++ b/tests/scripts/build_illink.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+function print_usage {
+    echo ''
+    echo 'Build ILLINKer for CoreCLR testing'
+    echo ''
+    echo 'Optional arguments:'
+    echo '  -?|-h|--help       : Show usage information.'
+    echo '  --clone            : Clone the repository https://github.com/mono/linker'
+    echo '  --arch             : The architecture to build (default X64)'
+    echo '  --os               : The os/runtime to build x64 (ubuntu.16.04)'
+    echo ''
+}
+
+# Argument variables
+clone=
+setenv=
+os='ubuntu.16.04'
+arch='x64'
+
+for i in "$@"
+do
+    case $i in
+        -?|-h|--help)
+            print_usage
+            exit $EXIT_CODE_SUCCESS
+            ;;
+	
+        --clone)
+	    echo "Need to clone"
+            clone=1
+            ;;
+	
+        --arch=*)
+            arch=${i#*=}
+            ;;
+	
+        --os=*)
+            os=${i#*=}
+            ;;
+	
+        *)
+            echo "Unknown switch: $i"
+            print_usage
+            exit $EXIT_CODE_SUCCESS
+            ;;
+    esac
+done
+
+rid="$os-$arch"
+
+if [ ! -z "$clone" ]; then
+    echo "Of Course Not here" 
+    git clone --recursive https://github.com/mono/linker
+fi
+
+pushd linker/corebuild
+./restore.sh -RuntimeIdentifier=$rid
+export DoNotEmbedDescriptors=1
+cd ../linker
+../corebuild/Tools/dotnetcli/dotnet publish -r $rid -c netcore_Release
+popd
+
+dir=$(pwd)
+output="$dir/linker/linker/bin/netcore_Release/netcoreapp2.0/$rid/publish/illink"
+echo Built $output
+
+exit $EXIT_CODE_SUCCESS

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -29,23 +29,29 @@ WARNING:   When setting properties based on their current state (for example:
 
       <IlasmRoundTripBashScript Condition="'$(IlasmRoundTrip)'=='true'">
       <![CDATA[
-echo "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
-"$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
-ERRORLEVEL=$?
-if [  $ERRORLEVEL -ne 0 ]
+# Disable Ilasm round-tripping for Linker tests.
+# Todo: Ilasm round-trip on linked binaries.
+      
+if [ -z "$DoLink" ]; 
 then
-  echo EXECUTION OF ILDASM - FAILED $ERRORLEVEL
-  exit 1
-fi
+  echo "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
+  "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
+  ERRORLEVEL=$?
+  if [  $ERRORLEVEL -ne 0 ]
+  then
+    echo EXECUTION OF ILDASM - FAILED $ERRORLEVEL
+    exit 1
+  fi
 
-echo "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-"$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-ERRORLEVEL=$?
-if [ $ERRORLEVEL -ne 0 ]
-then
-  echo EXECUTION OF ILASM - FAILED $ERRORLEVEL
-  exit 1
-fi
+  echo "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+  "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+  ERRORLEVEL=$?
+  if [ $ERRORLEVEL -ne 0 ]
+  then
+    echo EXECUTION OF ILASM - FAILED $ERRORLEVEL
+    exit 1
+  fi
+fi    
       ]]>
       </IlasmRoundTripBashScript>
     </PropertyGroup>
@@ -181,25 +187,113 @@ fi
       </BashCLRTestExecutionScriptArgument>
     </ItemGroup>
 
+      <PropertyGroup>
+          <ReflectionRootsXml>$(MSBuildProjectName).reflect.xml</ReflectionRootsXml>
+          <BashLinkerTestLaunchCmds>
+              <![CDATA[
+# Linker commands
+
+LinkBin=__Link
+Assemblies="-a System.Private.CoreLib"
+ReflectionRoots=
+
+shopt -s nullglob
+
+if [ ! -z "$DoLink" ]; 
+then
+  if [ ! -x "$ILLINK" ]; 
+  then
+    echo "Illink executable [$ILLINK] Invalid"
+    exit 1
+  fi
+  
+  # Clean up old Linked binaries, if any
+  rm -rf $LinkBin
     
-    <PropertyGroup>
+  # Remove Native images, since the goal is to run from Linked binaries
+  rm -f *.ni.*
+
+  # Use hints for reflection roots, if provided in $(ReflectionRootsXml)
+  if [ -f $(ReflectionRootsXml) ]; 
+  then
+    ReflectionRoots="-x $(ReflectionRootsXml)"
+  fi
+
+  # Include all .exe files in this directory as entry points (some tests had multiple .exe file modules)
+  for bin in *.exe *.dll; 
+  do 
+    Assemblies="$Assemblies -a $bin"
+  done
+
+  # Run dotnet-linker
+  # Run the Linker such that all assemblies except System.Private.Corlib.dll are linked
+  # Debug symbol generation needs some fixes, and is currently omitted.
+  # Once this is fixed, add -b true option.
+  echo "$ILLINK -out $LinkBin -d $CORE_ROOT -c link -l none -t $Assemblies $ReflectionRoots"
+  $ILLINK -out $LinkBin -d $CORE_ROOT -c link -l none -t $Assemblies $ReflectionRoots
+  ERRORLEVEL=$?
+  if [  $ERRORLEVEL -ne 0 ]
+  then
+    echo ILLINK FAILED $ERRORLEVEL
+    if [ ! -z "$KeepLinkedBinaries" ]; 
+    then
+      rm -rf $LinkBin
+    fi
+    exit 1
+  fi
+  
+  # Copy CORECLR native binaries to $LinkBin, so that we can run the test based on that directory
+  cp $CORE_ROOT/clrjit.dll $LinkBin
+  cp $CORE_ROOT/coreclr.dll $LinkBin 
+  cp $CORE_ROOT/mscorrc.dll $LinkBin
+  cp $CORE_ROOT/CoreRun.exe $LinkBin
+  # Copy some files that may be arguments
+  cp *.txt $LinkBin
+
+  ExePath=$LinkBin/$(InputAssemblyName)
+  export CORE_ROOT=$PWD/$LinkBin
+fi
+]]>
+          </BashLinkerTestLaunchCmds>
+          <BashLinkerTestCleanupCmds>
+              <![CDATA[
+# Clean up the LinkBin directories after test execution.
+# Otherwise, RunTests may run out of disk space.
+
+if [ ! -z "$DoLink" ]; 
+then
+  if [ ! -z "$KeepLinkedBinaries" ]; 
+  then
+    rm -rf $LinkBin
+  fi
+fi
+]]>
+          </BashLinkerTestCleanupCmds>
+      </PropertyGroup>
+      <PropertyGroup>
       <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun"</_CLRTestRunFile>
       <BashCLRTestLaunchCmds Condition="'$(IlasmRoundTrip)'=='true'"><![CDATA[
-echo $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
-$(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
-if [  $? -ne $CLRTestExpectedExitCode ]
-then
-  echo END EXECUTION OF IL{D}ASM BINARY - FAILED $? vs $CLRTestExpectedExitCode
-  echo FAILED
-  exit 1
+if [ -z "$DoLink" ]; then
+  echo $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
+  $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
+  if [  $? -ne $CLRTestExpectedExitCode ]
+  then
+    echo END EXECUTION OF IL{D}ASM BINARY - FAILED $? vs $CLRTestExpectedExitCode
+    echo FAILED
+    exit 1
+  fi
 fi
       ]]></BashCLRTestLaunchCmds>
 
-      <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'"><![CDATA[
+      <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'">
+    <![CDATA[
+ExePath=$(InputAssemblyName)
+$(BashLinkerTestLaunchCmds)
 $(BashCLRTestLaunchCmds)
-echo $_DebuggerFullPath $(_CLRTestRunFile) $(InputAssemblyName) $CLRTestExecutionArguments 
-$_DebuggerFullPath $(_CLRTestRunFile) $(InputAssemblyName) $CLRTestExecutionArguments 
+echo $_DebuggerFullPath $(_CLRTestRunFile) $ExePath $CLRTestExecutionArguments 
+$_DebuggerFullPath $(_CLRTestRunFile) $ExePath $CLRTestExecutionArguments 
 CLRTestExitCode=$?
+$(BashLinkerTestCleanupCmds)
       ]]></BashCLRTestLaunchCmds>
       <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'RunOnly'"><![CDATA[
 $(BashCLRTestLaunchCmds)

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -214,7 +214,7 @@ set Assemblies=-a System.Private.CoreLib
 
 IF defined DoLink ( 
     IF NOT EXIST !ILLINK! (
-      ECHO ILLink [%ILLINK%] Not Found
+      ECHO ILLink executable [%ILLINK%] Invalid
       Exit /b 1
     )
     
@@ -237,8 +237,10 @@ IF defined DoLink (
     ECHO %ILLINK% -out %LinkBin% -d %CORE_ROOT% -c link -l none -t !Assemblies! !ReflectionRoots!
     %ILLINK% -out %LinkBin% -d %CORE_ROOT% -c link -l none -t !Assemblies! !ReflectionRoots!
     IF NOT "!ERRORLEVEL!"=="0" (
-      ECHO EXECUTION OF %DOTNETLINK% - FAILED !ERRORLEVEL!
-      IF EXIST %LinkBin% rmdir /s /q %LinkBin%
+      ECHO ILLINK FAILED !ERRORLEVEL!
+      IF NOT defined KeepLinkedBinaries (
+          IF EXIST %LinkBin% rmdir /s /q %LinkBin%
+      )
       Exit /b 1
     )
 


### PR DESCRIPTION
Made changes to the test infrastructure to
1) Generate <test>.sh with commands to invoke ILLINK and run the output
2) Add runtest.sh --link=<path-to-illink> to invoke the ILLINK testing