### PR TITLE
Don't ignore exceptions thrown from handlers of some events

### DIFF
--- a/src/vm/comdelegate.h
+++ b/src/vm/comdelegate.h
@@ -180,8 +180,8 @@ enum DelegateBindingFlags
     DBF_RelaxedSignature    =   0x00000080, // Allow relaxed signature matching (co/contra variance)
 };
 
-void DistributeEventReliably(OBJECTREF *pDelegate,
-                             OBJECTREF *pDomain);
+void DistributeEvent(OBJECTREF *pDelegate,
+                     OBJECTREF *pDomain);
 
 void DistributeUnhandledExceptionReliably(OBJECTREF *pDelegate,
                                           OBJECTREF *pDomain,


### PR DESCRIPTION
Fixes dotnet/corefx#14747:
- Events include: AssemblyLoadContext.Unloading, AppDomain.ProcessExit
- Made the same change for AppDomain.DomainUnload for consistency, but it's not raised