### PR TITLE
Create an IGCHandleTable interface

### DIFF
--- a/src/gc/CMakeLists.txt
+++ b/src/gc/CMakeLists.txt
@@ -31,6 +31,7 @@ set( GC_SOURCES_DAC_AND_WKS_COMMON
 
 set( GC_SOURCES_WKS
   ${GC_SOURCES_DAC_AND_WKS_COMMON}
+  gchandletable.cpp
   gceesvr.cpp
   gceewks.cpp
   handletablecache.cpp)

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -111,6 +111,8 @@ extern "C" uint32_t* g_gc_card_table;
 extern "C" uint8_t* g_gc_lowest_address;
 extern "C" uint8_t* g_gc_highest_address;
 
+::IGCHandleTable*  CreateGCHandleTable();
+
 namespace WKS {
     ::IGCHeapInternal* CreateGCHeap();
     class GCHeap;
@@ -261,6 +263,9 @@ extern void FinalizeWeakReference(Object * obj);
 
 // The single GC heap instance, shared with the VM.
 extern IGCHeapInternal* g_theGCHeap;
+
+// The single GC handle table instance, shared with the VM.
+extern IGCHandleTable* g_theGCHandleTable;
 
 #ifndef DACCESS_COMPILE
 inline bool IsGCInProgress(bool bConsiderGCStart = false)

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -21,6 +21,7 @@ SVAL_IMPL_INIT(uint32_t,IGCHeap,gcHeapType,IGCHeap::GC_HEAP_INVALID);
 SVAL_IMPL_INIT(uint32_t,IGCHeap,maxGeneration,2);
 
 IGCHeapInternal* g_theGCHeap;
+IGCHandleTable* g_theGCHandleTable;
 
 #ifdef FEATURE_STANDALONE_GC
 IGCToCLR* g_theGCToCLR;
@@ -145,7 +146,7 @@ namespace SVR
     extern void PopulateDacVars(GcDacVars* dacVars);
 }
 
-bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, GcDacVars* gcDacVars)
+bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleTable** gcHandleTable, GcDacVars* gcDacVars)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -153,6 +154,14 @@ bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, GcDacVars* 
 
     assert(gcDacVars != nullptr);
     assert(gcHeap != nullptr);
+    assert(gcHandleTable != nullptr);
+
+    IGCHandleTable* handleTable = CreateGCHandleTable();
+    if (handleTable == nullptr)
+    {
+        return false;
+    }
+
 #ifdef FEATURE_SVR_GC
     assert(IGCHeap::gcHeapType != IGCHeap::GC_HEAP_INVALID);
 
@@ -169,7 +178,6 @@ bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, GcDacVars* 
 #else
     heap = WKS::CreateGCHeap();
     WKS::PopulateDacVars(gcDacVars);
-
 #endif
 
     if (heap == nullptr)
@@ -187,6 +195,7 @@ bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, GcDacVars* 
     assert(clrToGC == nullptr);
 #endif
 
+    *gcHandleTable = handleTable;
     *gcHeap = heap;
     return true;
 }

--- a/src/gc/gceesvr.cpp
+++ b/src/gc/gceesvr.cpp
@@ -12,8 +12,10 @@
 
 #include "gc.h"
 #include "gcscan.h"
+#include "gchandletableimpl.h"
 
 #define SERVER_GC 1
+
 
 namespace SVR { 
 #include "gcimpl.h"

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -1,23 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-
+// 
 
 #include "common.h"
-
 #include "gcenv.h"
-
-#include "gc.h"
-#include "gcscan.h"
 #include "gchandletableimpl.h"
+#include "objecthandle.h"
 
-#ifdef SERVER_GC
-#undef SERVER_GC
-#endif
-
-namespace WKS { 
-#include "gcimpl.h"
-#include "gcee.cpp"
+IGCHandleTable* CreateGCHandleTable()
+{
+    return new(nothrow) GCHandleTable();
 }
 
+bool GCHandleTable::Initialize()
+{
+    return Ref_Initialize();
+}
+
+void GCHandleTable::Shutdown()
+{
+    Ref_Shutdown();
+}

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef GCHANDLETABLE_H_
+#define GCHANDLETABLE_H_
+
+#include "gcinterface.h"
+
+class GCHandleTable : public IGCHandleTable
+{
+public:
+    virtual bool Initialize();
+
+    virtual void Shutdown();
+};
+
+#endif  // GCHANDLETABLE_H_

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -171,11 +171,12 @@ struct segment_info
 
 class Object;
 class IGCHeap;
+class IGCHandleTable;
 
 // Initializes the garbage collector. Should only be called
 // once, during EE startup. Returns true if the initialization
 // was successful, false otherwise.
-bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap **gcHeap, GcDacVars* gcDacVars);
+bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleTable** gcHandleTable, GcDacVars* gcDacVars);
 
 // The runtime needs to know whether we're using workstation or server GC 
 // long before the GCHeap is created. This function sets the type of
@@ -384,6 +385,13 @@ typedef void (* record_surv_fn)(uint8_t* begin, uint8_t* end, ptrdiff_t reloc, v
 typedef void (* fq_walk_fn)(bool, void*);
 typedef void (* fq_scan_fn)(Object** ppObject, ScanContext *pSC, uint32_t dwFlags);
 typedef void (* handle_scan_fn)(Object** pRef, Object* pSec, uint32_t flags, ScanContext* context, bool isDependent);
+class IGCHandleTable {
+public:
+
+    virtual bool Initialize() = 0;
+
+    virtual void Shutdown() = 0;
+};
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.
 class IGCHeap {

--- a/src/gc/sample/CMakeLists.txt
+++ b/src/gc/sample/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     gcenv.ee.cpp
     ../gccommon.cpp
     ../gceewks.cpp
+    ../gchandletable.cpp
     ../gcscan.cpp
     ../gcwks.cpp
     ../handletable.cpp

--- a/src/gc/sample/GCSample.cpp
+++ b/src/gc/sample/GCSample.cpp
@@ -126,22 +126,23 @@ int __cdecl main(int argc, char* argv[])
     g_pFreeObjectMethodTable = &freeObjectMT;
 
     //
-    // Initialize handle table
-    //
-    if (!Ref_Initialize())
-        return -1;
-
-    //
     // Initialize GC heap
     //
     GcDacVars dacVars;
     IGCHeap *pGCHeap;
-    if (!InitializeGarbageCollector(nullptr, &pGCHeap, &dacVars))
+    IGCHandleTable *pGCHandleTable;
+    if (!InitializeGarbageCollector(nullptr, &pGCHeap, &pGCHandleTable, &dacVars))
     {
         return -1;
     }
 
     if (FAILED(pGCHeap->Initialize()))
+        return -1;
+
+    //
+    // Initialize handle table
+    //
+    if (!pGCHandleTable->Initialize())
         return -1;
 
     //

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -22,6 +22,8 @@ uint32_t* g_card_bundle_table = nullptr;
 // This is the global GC heap, maintained by the VM.
 GPTR_IMPL(IGCHeap, g_pGCHeap);
 
+IGCHandleTable* g_pGCHandleTable = nullptr;
+
 GcDacVars g_gc_dac_vars;
 GPTR_IMPL(GcDacVars, g_gcDacGlobals);
 

--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -26,6 +26,7 @@ GPTR_DECL(uint32_t,g_card_table);
 // GC will update it when it needs to.
 extern "C" gc_alloc_context g_global_alloc_context;
 
+extern "C" IGCHandleTable* g_pGCHandleTable;
 extern "C" uint32_t* g_card_bundle_table;
 extern "C" uint8_t* g_ephemeral_low;
 extern "C" uint8_t* g_ephemeral_high;
@@ -69,6 +70,15 @@ public:
 
         assert(g_pGCHeap != nullptr);
         return g_pGCHeap;
+    }
+
+    // Retrieves the GC handle table.
+    static IGCHandleTable* GetGCHandleTable() 
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        assert(g_pGCHandleTable != nullptr);
+        return g_pGCHandleTable;
     }
 
     // Returns true if the heap has been initialized, false otherwise.


### PR DESCRIPTION
This PR introduces the concept of IGCHandleTable, which the VM will use when dealing with handles and handle table-related things. Today, the VM code is directly including heads like objecthandle.h, handletable.h, and handletablepriv.h, which should only be used on the GC side of things. 

In order to keep this change simple, I've only included `Initialize` and `Shutdown` functions on the interface. This way, we can focus on the mechanics of where things are and how the VM gets an instance of GCHandleTable. Once this is in, I will follow up with changes that add all the other functionality (like handle creation, destruction, storing objects in handles, etc.) that the VM uses. In the end, the VM code will no longer be using the handle-related headers and only go through this interface for all its needs.

@Maoni0 @swgillespie @sergiy-k 