### PR TITLE
Implement TLS field handles for RyuJIT/x86

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1640,7 +1640,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             {
                 noway_assert(EA_ATTR(genTypeSize(treeNode->gtType)) == EA_PTRSIZE);
                 emit->emitIns_R_C(ins_Load(TYP_I_IMPL), EA_PTRSIZE, treeNode->gtRegNum, FLD_GLOBAL_FS,
-                    (int)addr->gtIntCon.gtIconVal);
+                                  (int)addr->gtIntCon.gtIconVal);
             }
             else
             {
@@ -1649,7 +1649,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             }
             genProduceReg(treeNode);
         }
-            break;
+        break;
 
         case GT_MULHI:
 #ifdef _TARGET_X86_

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1314,7 +1314,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 
         case GT_CNS_INT:
 #ifdef _TARGET_X86_
-            NYI_IF(treeNode->IsIconHandle(GTF_ICON_TLS_HDL), "TLS constants");
+            assert(!treeNode->IsIconHandle(GTF_ICON_TLS_HDL));
 #endif // _TARGET_X86_
             __fallthrough;
 
@@ -1625,6 +1625,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         break;
 
         case GT_IND:
+        {
 #ifdef FEATURE_SIMD
             // Handling of Vector3 type values loaded through indirection.
             if (treeNode->TypeGet() == TYP_SIMD12)
@@ -1634,9 +1635,20 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             }
 #endif // FEATURE_SIMD
 
-            genConsumeAddress(treeNode->AsIndir()->Addr());
-            emit->emitInsMov(ins_Load(treeNode->TypeGet()), emitTypeSize(treeNode), treeNode);
+            GenTree* addr = treeNode->AsIndir()->Addr();
+            if (addr->IsCnsIntOrI() && addr->IsIconHandle(GTF_ICON_TLS_HDL))
+            {
+                noway_assert(EA_ATTR(genTypeSize(treeNode->gtType)) == EA_PTRSIZE);
+                emit->emitIns_R_C(ins_Load(TYP_I_IMPL), EA_PTRSIZE, treeNode->gtRegNum, FLD_GLOBAL_FS,
+                    (int)addr->gtIntCon.gtIconVal);
+            }
+            else
+            {
+                genConsumeAddress(addr);
+                emit->emitInsMov(ins_Load(treeNode->TypeGet()), emitTypeSize(treeNode), treeNode);
+            }
             genProduceReg(treeNode);
+        }
             break;
 
         case GT_MULHI:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16076,9 +16076,7 @@ bool GenTreeIntConCommon::FitsInAddrBase(Compiler* comp)
 #endif
 #endif //! LEGACY_BACKEND
 
-    // TODO-x86 - TLS field handles are excluded for now as they are accessed relative to FS segment.
-    // Handling of TLS field handles is a NYI and this needs to be relooked after implementing it.
-    return IsCnsIntOrI() && !IsIconHandle(GTF_ICON_TLS_HDL);
+    return IsCnsIntOrI();
 }
 
 // Returns true if this icon value is encoded as addr needs recording a relocation with VM


### PR DESCRIPTION
This isn't used by .NET Core, but helps us run desktop testing.