### PR TITLE
Fix wrong comment about pinning bit and change GetGCSafeMethodTable

### DIFF
--- a/src/debug/daccess/dacimpl.h
+++ b/src/debug/daccess/dacimpl.h
@@ -1682,9 +1682,6 @@ public:
         // clear the GC flag bits off the MethodTable
         // equivalent to Object::GetGCSafeMethodTable()
         *mt &= ~1;
-        // Ensure nobody use the last but one bit
-        // Should be removed after CI
-        _ASSERTE((*mt & 3) == 0);
         return true;
     }
 

--- a/src/debug/daccess/dacimpl.h
+++ b/src/debug/daccess/dacimpl.h
@@ -1681,7 +1681,10 @@ public:
 
         // clear the GC flag bits off the MethodTable
         // equivalent to Object::GetGCSafeMethodTable()
-        *mt &= ~3;
+        *mt &= ~1;
+        // Ensure nobody use the last but one bit
+        // Should be removed after CI
+        _ASSERTE((*mt & 3) == 0);
         return true;
     }
 

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -3881,7 +3881,7 @@ public:
         RawSetMethodTable( GetMethodTable() );
         // Ensure nobody use the last but one bit
         // Should be removed after CI
-        _ASSERTE_ALL_BUILDS("clr/src/gc/gc.cpp", (((size_t)RawGetMethodTable()) & 3) == 0);
+        _ASSERTE((((size_t)RawGetMethodTable()) & 3) == 0);
     }
 
     CGCDesc *GetSlotMap ()

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -3879,9 +3879,6 @@ public:
     void ClearMarked()
     {
         RawSetMethodTable( GetMethodTable() );
-        // Ensure nobody use the last but one bit
-        // Should be removed after CI
-        _ASSERTE((((size_t)RawGetMethodTable()) & 3) == 0);
     }
 
     CGCDesc *GetSlotMap ()

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -3879,6 +3879,9 @@ public:
     void ClearMarked()
     {
         RawSetMethodTable( GetMethodTable() );
+        // Ensure nobody use the last but one bit
+        // Should be removed after CI
+        _ASSERTE_ALL_BUILDS("clr/src/gc/gc.cpp", (((size_t)RawGetMethodTable()) & 3) == 0);
     }
 
     CGCDesc *GetSlotMap ()

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -638,7 +638,6 @@ class Object
         // A method table pointer should always be aligned.
         // During GC we set the least significant bit for marked objects.
         // So if we want the actual MT pointer during a GC we must zero out the lowest bit.
-        // In the past we had put pinning bit here but now it's in sync block.
         return dac_cast<PTR_MethodTable>((dac_cast<TADDR>(m_pMethTab)) & (~MARKED_BIT));
     }
 

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -634,12 +634,12 @@ class Object
         LIMITED_METHOD_CONTRACT;
         SUPPORTS_DAC;
 
-        // lose GC marking bit and the pinning bit
-        // A method table pointer should always be aligned.  During GC we set the least 
-        // significant bit for marked objects and we set the second to least significant
-        // bit for pinned objects.  So if we want the actual MT pointer during a GC
-        // we must zero out the lowest 2 bits.
-        return dac_cast<PTR_MethodTable>((dac_cast<TADDR>(m_pMethTab)) & ~((UINT_PTR)3));
+        // lose GC marking bit
+        // A method table pointer should always be aligned.
+        // During GC we set the least significant bit for marked objects.
+        // So if we want the actual MT pointer during a GC we must zero out the lowest bit.
+        // In the past we had put pinning bit here but now it's in sync block.
+        return dac_cast<PTR_MethodTable>((dac_cast<TADDR>(m_pMethTab)) & (~MARKED_BIT));
     }
 
     // There are some cases where it is unsafe to get the type handle during a GC.


### PR DESCRIPTION
Refer to issue #10141
Since pinning bit is moved to sync block,
I change the comment in GetGCSafeMethodTable, and replace the old hard code 3 with MARKED_BIT.

It's a dangerous change, I didn't see any code in gc use the last but one bit, if any of you known please say it.
I also run tests on windows after this change, only one test failed:

```
BEGIN EXECUTION
 "C:\coreclr-fork\coreclr\bin\tests\Windows_NT.x64.Debug\Tests\C
ore_Root\corerun.exe" SizeConstTest.exe

Unhandled Exception: System.Runtime.InteropServices.COMException: The data area passed to a system call is too small (Exception from HRESULT: 0x8007007A)
   at System.StubHelpers.ValueClassMarshaler.ConvertToNative(IntPtr dst, IntPtr
src, IntPtr pMT, CleanupWorkList& pCleanupWorkList)
   at Test.TakeByValTStr(S_CHARArray_ByValTStr s, Int32 size)
   at Test.SizeConstByValTStr()
   at Test.Main(String[] args)
Expected: 100
Actual: -532462766
END EXECUTION - FAILED
FAILED
```

This test also failed before I perform this modification, so I think it's irrelevant.