### PR TITLE
Fix comment on mark::recover_plug_info

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -5589,7 +5589,7 @@ public:
 
     // We should think about whether it's really necessary to have to copy back the pre plug
     // info since it was already copied during compacting plugs. But if a plug doesn't move
-    // by < 3 ptr size, it means we'd have to recover pre plug info.
+    // by >= 3 ptr size (the size of gap_reloc_pair), it means we'd have to recover pre plug info.
     void recover_plug_info() 
     {
         if (saved_pre_p)


### PR DESCRIPTION
I think the comment on recover_plug_info has a small mistake.
The original text is
```
We should think about whether it's really necessary to have to copy back the pre plug
info since it was already copied during compacting plugs. But if a plug doesn't move
by < 3 ptr size, it means we'd have to recover pre plug info.
```

It should be "doesn't move by >= 3 ptr" or "only move by < 3 ptr",
I replaced them with

```
We should think about whether it's really necessary to have to copy back the pre plug
info since it was already copied during compacting plugs. But if a plug doesn't move
by >= 3 ptr size (the size of gap_reloc_pair), it means we'd have to recover pre plug info.
```