### PR TITLE
Refactor dotnet download code in init-tools.cmd

### DIFF
--- a/dotnet-download.ps1
+++ b/dotnet-download.ps1
@@ -1,40 +1,37 @@
 param(
-[parameter(Mandatory = $true)]
-$DOTNET_REMOTE_PATH,
-[parameter(Mandatory = $true)]
-$DOTNET_LOCAL_PATH,
-[parameter(Mandatory = $true)]
-$DOTNET_PATH)
+    [parameter(Mandatory=$true)]$DotnetRemotePath,
+    [parameter(Mandatory=$true)]$DotnetLocalPath,
+    [parameter(Mandatory = $true)]$DotnetPath
+)
 
-$retryCount = 0;
-$success = $false;
+$retryCount = 0
+$success = $false
 
 do {
-     try {
-          Write-Output "Downloading from $DOTNET_REMOTE_PATH"
-          (New-Object Net.WebClient).DownloadFile($DOTNET_REMOTE_PATH, $DOTNET_LOCAL_PATH);
-          $success = $true;
-        } catch { 
-            if ($retryCount -ge 6) {
-                Write-Output "Maximum of 5 retries exceeded. Aborting"
-                throw;
-            } 
-            else { 
-                $retryCount++;
-                $retryTime = 5 * $retryCount;
-                Write-Output "Download failed. Retrying in $retryTime seconds"
-                Start-Sleep -Seconds (5 * $retryCount);
-            }
+    try {
+        Write-Output "Downloading from $DotnetRemotePath"
+        (New-Object Net.WebClient).DownloadFile($DotnetRemotePath, $DotnetLocalPath)
+        $success = $true
+    } catch { 
+        if ($retryCount -ge 6) {
+            Write-Output "Maximum of 5 retries exceeded. Aborting"
+            throw
+        } 
+        else { 
+            $retryCount++
+            $retryTime = 5 * $retryCount
+            Write-Output "Download failed. Retrying in $retryTime seconds"
+            Start-Sleep -Seconds (5 * $retryCount)
         }
     }
-while ($success -eq $false);
+} while ($success -eq $false)
 
 Write-Output "Download finished"
-Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; 
+Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors
 
 if ($AddTypeErrors.Count -eq 0) { 
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($DOTNET_LOCAL_PATH, $DOTNET_PATH) 
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($DotnetLocalPath, $DotnetPath) 
 }
 else { 
-    (New-Object -com shell.application).namespace($DOTNET_PATH).CopyHere((new-object -com shell.application).namespace($DOTNET_LOCAL_PATH).Items(), 16) 
+    (New-Object -com shell.application).namespace($DotnetPath).CopyHere((new-object -com shell.application).namespace($DotnetLocalPath).Items(), 16)
 }

--- a/dotnet-download.ps1
+++ b/dotnet-download.ps1
@@ -1,0 +1,40 @@
+param(
+[parameter(Mandatory = $true)]
+$DOTNET_REMOTE_PATH,
+[parameter(Mandatory = $true)]
+$DOTNET_LOCAL_PATH,
+[parameter(Mandatory = $true)]
+$DOTNET_PATH)
+
+$retryCount = 0;
+$success = $false;
+
+do {
+     try {
+          Write-Output "Downloading from $DOTNET_REMOTE_PATH"
+          (New-Object Net.WebClient).DownloadFile($DOTNET_REMOTE_PATH, $DOTNET_LOCAL_PATH);
+          $success = $true;
+        } catch { 
+            if ($retryCount -ge 6) {
+                Write-Output "Maximum of 5 retries exceeded. Aborting"
+                throw;
+            } 
+            else { 
+                $retryCount++;
+                $retryTime = 5 * $retryCount;
+                Write-Output "Download failed. Retrying in $retryTime seconds"
+                Start-Sleep -Seconds (5 * $retryCount);
+            }
+        }
+    }
+while ($success -eq $false);
+
+Write-Output "Download finished"
+Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; 
+
+if ($AddTypeErrors.Count -eq 0) { 
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($DOTNET_LOCAL_PATH, $DOTNET_PATH) 
+}
+else { 
+    (New-Object -com shell.application).namespace($DOTNET_PATH).CopyHere((new-object -com shell.application).namespace($DOTNET_LOCAL_PATH).Items(), 16) 
+}

--- a/dotnet-download.ps1
+++ b/dotnet-download.ps1
@@ -1,7 +1,7 @@
 param(
     [parameter(Mandatory=$true)]$DotnetRemotePath,
     [parameter(Mandatory=$true)]$DotnetLocalPath,
-    [parameter(Mandatory = $true)]$DotnetPath
+    [parameter(Mandatory=$true)]$DotnetPath
 )
 
 $retryCount = 0

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -4,6 +4,8 @@ setlocal
 set INIT_TOOLS_LOG=%~dp0init-tools.log
 set PACKAGES_DIR=%~dp0packages\
 set TOOLRUNTIME_DIR=%~dp0Tools
+:: This is an isolated script that handles the download of dotnet binaries and shall be removed after bootstrap.ps1/sh refactor (dotnet/corefx#15427)
+set DOTNET_DOWNLOAD_PATH=%~dp0dotnet-download.ps1
 set DOTNET_PATH=%TOOLRUNTIME_DIR%\dotnetcli\
 set DOTNET_CMD=%DOTNET_PATH%dotnet.exe
 if [%BUILDTOOLS_SOURCE%]==[] set BUILDTOOLS_SOURCE=https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json
@@ -48,7 +50,7 @@ if [%PROCESSOR_ARCHITECTURE%]==[x86] (set DOTNET_ZIP_NAME=dotnet-dev-win-x86.%DO
 set DOTNET_REMOTE_PATH=https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/%DOTNET_VERSION%/%DOTNET_ZIP_NAME%
 set DOTNET_LOCAL_PATH=%DOTNET_PATH%%DOTNET_ZIP_NAME%
 echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> "%INIT_TOOLS_LOG%"
-powershell -NoProfile -ExecutionPolicy unrestricted -Command %~dp0dotnet-download.ps1 -DOTNET_REMOTE_PATH %DOTNET_REMOTE_PATH% -DOTNET_LOCAL_PATH %DOTNET_LOCAL_PATH% -DOTNET_PATH %DOTNET_PATH% >> "%INIT_TOOLS_LOG%"
+powershell -NoProfile -ExecutionPolicy unrestricted -File %DOTNET_DOWNLOAD_PATH% -DotnetRemotePath %DOTNET_REMOTE_PATH% -DotnetLocalPath %DOTNET_LOCAL_PATH% -DotnetPath %DOTNET_PATH% >> "%INIT_TOOLS_LOG%"
 if NOT exist "%DOTNET_LOCAL_PATH%" (
   echo ERROR: Could not install dotnet cli correctly. See '%INIT_TOOLS_LOG%' for more details.
   set TOOLS_INIT_RETURN_CODE=1

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -48,7 +48,7 @@ if [%PROCESSOR_ARCHITECTURE%]==[x86] (set DOTNET_ZIP_NAME=dotnet-dev-win-x86.%DO
 set DOTNET_REMOTE_PATH=https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/%DOTNET_VERSION%/%DOTNET_ZIP_NAME%
 set DOTNET_LOCAL_PATH=%DOTNET_PATH%%DOTNET_ZIP_NAME%
 echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> "%INIT_TOOLS_LOG%"
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "$retryCount = 0; $success = $false; do { try { (New-Object Net.WebClient).DownloadFile('%DOTNET_REMOTE_PATH%', '%DOTNET_LOCAL_PATH%'); $success = $true; } catch { if ($retryCount -ge 6) { throw; } else { $retryCount++; Start-Sleep -Seconds (5 * $retryCount); } } } while ($success -eq $false); Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; if ($AddTypeErrors.Count -eq 0) { [System.IO.Compression.ZipFile]::ExtractToDirectory('%DOTNET_LOCAL_PATH%', '%DOTNET_PATH%') } else { (New-Object -com shell.application).namespace('%DOTNET_PATH%').CopyHere((new-object -com shell.application).namespace('%DOTNET_LOCAL_PATH%').Items(),16) }" >> "%INIT_TOOLS_LOG%"
+powershell -NoProfile -ExecutionPolicy unrestricted -Command %~dp0dotnet-download.ps1 -DOTNET_REMOTE_PATH %DOTNET_REMOTE_PATH% -DOTNET_LOCAL_PATH %DOTNET_LOCAL_PATH% -DOTNET_PATH %DOTNET_PATH% >> "%INIT_TOOLS_LOG%"
 if NOT exist "%DOTNET_LOCAL_PATH%" (
   echo ERROR: Could not install dotnet cli correctly. See '%INIT_TOOLS_LOG%' for more details.
   set TOOLS_INIT_RETURN_CODE=1


### PR DESCRIPTION
This addresses the improvements proposed in issue #10526.
Includes the init-tools.cmd script refactor and a new script called
dotnet-download.ps1 which includes the extracted code and logic