### PR TITLE
Add PGO support for Clang/LLVM on Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ project(CoreCLR)
 # Include cmake functions
 include(functions.cmake)
 
+# Include global configure settings
+include(configure.cmake)
+
 if (WIN32)
   message(STATUS "VS_PLATFORM_TOOLSET is ${CMAKE_VS_PLATFORM_TOOLSET}")
   message(STATUS "VS_PLATFORM_NAME is ${CMAKE_VS_PLATFORM_NAME}")

--- a/configure.cmake
+++ b/configure.cmake
@@ -1,0 +1,12 @@
+include(CheckCXXSourceCompiles)
+
+# VC++ guarantees support for LTCG (LTO's equivalent)
+if(NOT WIN32)
+  # Function required to give CMAKE_REQUIRED_* local scope
+  function(check_have_lto)
+    set(CMAKE_REQUIRED_FLAGS -flto)
+    set(CMAKE_REQUIRED_LIBRARIES -flto -fuse-ld=gold)
+    check_cxx_source_compiles("int main() { return 0; }" HAVE_LTO)
+  endfunction(check_have_lto)
+  check_have_lto()
+endif(NOT WIN32)

--- a/pgosupport.cmake
+++ b/pgosupport.cmake
@@ -6,10 +6,19 @@ function(clr_pgo_unknown_arch)
     endif()
 endfunction(clr_pgo_unknown_arch)
 
+function(append_prop_strings TargetName PropertyName)
+    foreach(Flag IN LISTS ARGN)
+        set_property(TARGET ${TargetName} APPEND_STRING PROPERTY ${PropertyName} " ${Flag}")
+    endforeach(Flag)
+endfunction(append_prop_strings)
+
 # Adds Profile Guided Optimization (PGO) flags to the current target
 function(add_pgo TargetName)
     if(WIN32)
         set(ProfileFileName "${TargetName}.pgd")
+    elseif(UNIX)
+        # Clang/LLVM uses one profdata file for the entire repo
+        set(ProfileFileName "coreclr.profdata")
     endif(WIN32)
 
     set(CLR_CMAKE_OPTDATA_PACKAGEWITHRID "optimization.${CLR_CMAKE_TARGET_OS}-${CLR_CMAKE_TARGET_ARCH}.PGO.CoreCLR")
@@ -19,23 +28,39 @@ function(add_pgo TargetName)
     )
 
     # Enable PGO only for optimized configs
-    set(ConfigTypeList RELEASE RELWITHDEBINFO)
+    set(ConfigList RELEASE RELWITHDEBINFO)
+    set(IsReleaseConfig "$<OR:$<CONFIG:RELEASE>,$<CONFIG:RELWITHDEBINFO>>")
 
-    foreach(ConfigType IN LISTS ConfigTypeList)
-        set(LinkFlagsProperty "LINK_FLAGS_${ConfigType}")
-        if(CLR_CMAKE_PGO_INSTRUMENT)
+    if(CLR_CMAKE_PGO_INSTRUMENT)
+        # Unfortunately LINK_FLAGS_* don't support generator expressions, so we need to use a loop
+        foreach(Config IN LISTS ConfigList)
             if(WIN32)
-                set_property(TARGET ${TargetName} APPEND_STRING PROPERTY ${LinkFlagsProperty} "/LTCG /GENPROFILE")
+                append_prop_strings(${TargetName} LINK_FLAGS_${Config} /LTCG /GENPROFILE)
+            elseif(UNIX)
+                append_prop_strings(${TargetName} LINK_FLAGS_${Config} -flto -fuse-ld=gold -fprofile-instr-generate)
             endif(WIN32)
-        else(CLR_CMAKE_PGO_INSTRUMENT)
-            # If we don't have profile data availble, gracefully fall back to a non-PGO opt build
-            if(EXISTS ${ProfilePath})
+        endforeach(Config)
+        if(UNIX)
+            # On Unix we need to pass PGO flags to the compiler as well as the linker
+            target_compile_options(${TargetName} PRIVATE $<${IsReleaseConfig}:-flto -fprofile-instr-generate>)
+        endif(UNIX)
+    else(CLR_CMAKE_PGO_INSTRUMENT)
+        # If we don't have profile data availble, gracefully fall back to a non-PGO opt build
+        if(EXISTS ${ProfilePath})
+            # Unfortunately LINK_FLAGS_* don't support generator expressions, so we need to use a loop
+            foreach(Config IN LISTS ConfigList)
                 if(WIN32)
-                    set_property(TARGET ${TargetName} APPEND_STRING PROPERTY ${LinkFlagsProperty} "/LTCG /USEPROFILE:PGD=${ProfilePath}")
+                    append_prop_strings(${TargetName} LINK_FLAGS_${Config} /LTCG /USEPROFILE:PGD=${ProfilePath})
+                elseif(UNIX)
+                    append_prop_strings(${TargetName} LINK_FLAGS_${Config} -flto -fuse-ld=gold -fprofile-instr-use=${ProfilePath})
                 endif(WIN32)
-            endif(EXISTS ${ProfilePath})
-        endif(CLR_CMAKE_PGO_INSTRUMENT)
-    endforeach(ConfigType)
+            endforeach(Config)
+            if(UNIX)
+                ## On Unix we need to pass PGO flags to the compiler as well as the linker
+                target_compile_options(${TargetName} PRIVATE $<${IsReleaseConfig}:-flto -fprofile-instr-use=${ProfilePath}>)
+            endif(UNIX)
+        endif(EXISTS ${ProfilePath})
+    endif(CLR_CMAKE_PGO_INSTRUMENT)
 endfunction(add_pgo)
 
 if(WIN32)

--- a/tests/cmake_tests/try_compile.cpp
+++ b/tests/cmake_tests/try_compile.cpp
@@ -1,0 +1,4 @@
+// The purpose of this file is to serve as a trivial test case for cmake's try_compile.
+int main(int argc, char **argv) {
+    return 0;
+}

--- a/tests/cmake_tests/try_compile.cpp
+++ b/tests/cmake_tests/try_compile.cpp
@@ -1,4 +1,0 @@
-// The purpose of this file is to serve as a trivial test case for cmake's try_compile.
-int main(int argc, char **argv) {
-    return 0;
-}


### PR DESCRIPTION
Extend PGO support from VC++ on WIN32 to Clang/LLVM on UNIX as well.
* Just like on Windows: if profile data is missing, skip enabling PGO (allows non-PGO builds in branches where we don't publish PGO data).
* PGO with LTO requires additional dependencies (namely a discoverable `ld.gold` and `LLVMgold.so`). To protect against broken support and keep the build flexible across a wider array of distros, attempt to detect whether PGO compilation would work (using cmake's `try_compile()`), and fall back to a non-PGO/non-LTO build if the test fails.