### PR TITLE
Fix some bugs in Linux ILLINK testing.

### DIFF
--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -235,20 +235,23 @@ then
   if [  $ERRORLEVEL -ne 0 ]
   then
     echo ILLINK FAILED $ERRORLEVEL
-    if [ ! -z "$KeepLinkedBinaries" ]; 
+    if [ -z "$KeepLinkedBinaries" ]; 
     then
       rm -rf $LinkBin
     fi
     exit 1
   fi
   
-  # Copy CORECLR native binaries to $LinkBin, so that we can run the test based on that directory
-  cp $CORE_ROOT/clrjit.dll $LinkBin
-  cp $CORE_ROOT/coreclr.dll $LinkBin 
-  cp $CORE_ROOT/mscorrc.dll $LinkBin
-  cp $CORE_ROOT/CoreRun.exe $LinkBin
+  # Copy CORECLR native binaries to $LinkBin, 
+  # so that we can run the test based on that directory
+  cp $CORE_ROOT/*.so $LinkBin/
+  cp $CORE_ROOT/corerun $LinkBin/
+
   # Copy some files that may be arguments
-  cp *.txt $LinkBin
+  for f in *.txt;
+  do
+    [ -e "$f" ] && cp $f $LinkBin
+  done
 
   ExePath=$LinkBin/$(InputAssemblyName)
   export CORE_ROOT=$PWD/$LinkBin
@@ -262,7 +265,7 @@ fi
 
 if [ ! -z "$DoLink" ]; 
 then
-  if [ ! -z "$KeepLinkedBinaries" ]; 
+  if [ -z "$KeepLinkedBinaries" ]; 
   then
     rm -rf $LinkBin
   fi


### PR DESCRIPTION
Fix a few problems in the <test>.sh generation for
running CoreCLR tests on Linux via ILLINK