### PR TITLE
[x86/Linux] fix a typo in FillRegDisplay method.

### DIFF
--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -396,7 +396,7 @@ inline void FillRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, PT_CONTEXT pC
 #elif defined(_TARGET_X86_) // _TARGET_ARM_
     for (int i = 0; i < 7; i++)
     {
-        *(&pRD->ctxPtrsOne.Esi + i) = (&pctx->Esi + i);
+        *(&pRD->ctxPtrsOne.Edi + i) = (&pctx->Edi + i);
     }
 #else // _TARGET_X86_
     PORTABILITY_ASSERT("FillRegDisplay");


### PR DESCRIPTION
```
#elif defined(_TARGET_X86_) // _TARGET_ARM_
    for (int i = 0; i < 7; i++)
    {
        *(&pRD->ctxPtrsOne.Esi + i) = (&pctx->Esi + i);
    }
```

An overflow occurs in struct ``_KNONVOLATILE_CONTEXT_POINTERS`` because the loop statement starts from ``Esi`` variable.


This is struct ``_KNONVOLATILE_CONTEXT_POINTERS``.
```
1805 typedef struct _KNONVOLATILE_CONTEXT_POINTERS {
1806 
1807     // The ordering of these fields should be aligned with that
1808     // of corresponding fields in CONTEXT
1809     //
1810     // (See FillRegDisplay in inc/regdisp.h for details)
1811     PDWORD Edi;
1812     PDWORD Esi;
1813     PDWORD Ebx;
1814     PDWORD Edx;
1815     PDWORD Ecx;
1816     PDWORD Eax;
1817    
1818     PDWORD Ebp;
1819 
1820 } KNONVOLATILE_CONTEXT_POINTERS, *PKNONVOLATILE_CONTEXT_POINTERS;
```

This is stuct ``_CONTEXT``.
```
1751 typedef struct _CONTEXT {
...
1768     ULONG   Edi;
1769     ULONG   Esi;
1770     ULONG   Ebx;
1771     ULONG   Edx;
1772     ULONG   Ecx;
1773     ULONG   Eax;
1774 
1775     ULONG   Ebp;
1776     ULONG   Eip;
...
1785 } CONTEXT, *PCONTEXT, *LPCONTEXT;
```