### PR TITLE
[x86/Linux] Use Portable ArrayInitializeWorker

### DIFF
--- a/src/classlibnative/bcltype/arraynative.cpp
+++ b/src/classlibnative/bcltype/arraynative.cpp
@@ -175,7 +175,7 @@ void ArrayInitializeWorker(ARRAYBASEREF * arrayRef,
 
     PCODE ctorFtn = pCanonMT->GetSlot(slot);
 
-#ifdef _X86_
+#if defined(_TARGET_X86_) && !defined(FEATURE_PAL)
     BEGIN_CALL_TO_MANAGED();
 
 
@@ -206,7 +206,7 @@ void ArrayInitializeWorker(ARRAYBASEREF * arrayRef,
     }
 
     END_CALL_TO_MANAGED();
-#else // _X86_
+#else // _TARGET_X86_ && !FEATURE_PAL
     //
     // This is quite a bit slower, but it is portable.
     //
@@ -230,7 +230,7 @@ void ArrayInitializeWorker(ARRAYBASEREF * arrayRef,
 
         offset += size;
     }
-#endif // _X86_
+#endif // !_TARGET_X86_ || FEATURE_PAL
 }
 
 


### PR DESCRIPTION
x86 uses optimized ArrayInitializeWorker implementation. Unfortunately, C++ unwinder cannot unwind the stack frame by this optimized ArrayIniitliazeWorker, which leads to baseservices.exceptions.simple.ArrayInit test failure.

This commit revises it to use portable ArrayInitializeWorker instead of optimized one for x86/Linux.