### PR TITLE
[Linux/x86] Change non-PR Linux/x86 build CI job to daily job

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -364,7 +364,10 @@ def static addNonPRTriggers(def job, def branch, def isPR, def architecture, def
                 case 'x64':
                 case 'x86':
                 case 'x86compatjit':
-                    if (isFlowJob || os == 'Windows_NT' || !(os in Constants.crossList)) {
+                    if (architecture == 'x86' && os == 'Ubuntu') {
+                        Utilities.addPeriodicTrigger(job, '@daily')
+                    }
+                    else if (isFlowJob || os == 'Windows_NT' || !(os in Constants.crossList)) {
                         Utilities.addGithubPushTrigger(job)
                     }
                     break


### PR DESCRIPTION
This commit changes non-PR Linux/x86 build CI job as daily job.
This job only perform build process now, but it will be perform Linux/x86 CoreCLR unittest later.
And build result could be used for Linux/x86 CoreFX unittest.

related issue: #9903