### PR TITLE
Revert "TimeSpan.FromMilliseconds(TimeSpan.MaxValue.TotalMilliseconds…

### DIFF
--- a/src/mscorlib/src/System/TimeSpan.cs
+++ b/src/mscorlib/src/System/TimeSpan.cs
@@ -252,10 +252,10 @@ namespace System
                 throw new ArgumentException(SR.Arg_CannotBeNaN);
             Contract.EndContractBlock();
             double tmp = value * scale;
-            double ticks = Math.Round(tmp * TicksPerMillisecond, 0);
-            if ((ticks > Int64.MaxValue) || (ticks < Int64.MinValue))
+            double millis = tmp + (value >= 0 ? 0.5 : -0.5);
+            if ((millis > Int64.MaxValue / TicksPerMillisecond) || (millis < Int64.MinValue / TicksPerMillisecond))
                 throw new OverflowException(SR.Overflow_TimeSpanTooLong);
-            return new TimeSpan((long)ticks);
+            return new TimeSpan((long)millis * TicksPerMillisecond);
         }
 
         public static TimeSpan FromMilliseconds(double value)


### PR DESCRIPTION
…) exception fix (#10352)"

This reverts commit 7951bc9accbbf9552d9b5c8105df8f5a32d6c3ab.

https://github.com/dotnet/corefx/pull/17648#issuecomment-290052104

cc: @jkotas, @tarekgh, @ezverev