### PR TITLE
[Ryujit/ARM32] Implement GT_COPY and genRegCopy()

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1082,24 +1082,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
         break;
 
         case GT_COPY:
-        {
-            assert(treeNode->gtOp.gtOp1->IsLocal());
-            GenTreeLclVarCommon* lcl    = treeNode->gtOp.gtOp1->AsLclVarCommon();
-            LclVarDsc*           varDsc = &compiler->lvaTable[lcl->gtLclNum];
-            inst_RV_RV(ins_Move_Extend(targetType, true), targetReg, genConsumeReg(treeNode->gtOp.gtOp1), targetType,
-                       emitTypeSize(targetType));
-
-            // The old location is dying
-            genUpdateRegLife(varDsc, /*isBorn*/ false, /*isDying*/ true DEBUGARG(treeNode->gtOp.gtOp1));
-
-            gcInfo.gcMarkRegSetNpt(genRegMask(treeNode->gtOp.gtOp1->gtRegNum));
-
-            genUpdateVarReg(varDsc, treeNode);
-
-            // The new location is going live
-            genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));
-        }
-            genProduceReg(treeNode);
+            // This is handled at the time we call genConsumeReg() on the GT_COPY
             break;
 
         case GT_LIST:

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -14184,13 +14184,13 @@ GenTreePtr Compiler::fgRecognizeAndMorphBitwiseRotation(GenTreePtr tree)
     //
     //                         OR                      ROL
     //                      /      \                   / \
-        //                    LSH      RSZ      ->        x   y
+    //                    LSH      RSZ      ->        x   y
     //                    / \      / \
-        //                   x  AND   x  AND
+    //                   x  AND   x  AND
     //                      / \      / \
-        //                     y  31   ADD  31
+    //                     y  31   ADD  31
     //                             / \
-        //                            NEG 32
+    //                            NEG 32
     //                             |
     //                             y
     // The patterns recognized:


### PR DESCRIPTION
Remove out-dated implementation of GT_COPY in CodeGen::genCodeForTreeNode
Implement genRegCopy() for ARM
Fix indentation of comment in Compiler::fgRecognizeAndMorphBitwiseRotation

## Example
`rol64const` in tests/src/JIT/CodeGenBringUpTests/Rotate.cs
```C#
  [MethodImpl(MethodImplOptions.NoInlining)]
  static ulong rol64const()
  {   
      ulong value = flag() ? (ulong)0x123456789abcdef : (ulong)0xabcdef123456789;
      int amount = 16;
      return (value >> (64 - amount)) | (value << amount);
  }
```

### Before
Assertion occurred.
```
$ COMPlus_AltJit=rol64const ./corerun Rotate.exe

Assert failure(PID 9587 [0x00002573], Thread: 9587 [0x2573]): Assertion failed 'treeNode->gtOp.gtOp1->IsLocal()' in 'Test:rol64const():long' (IL size 48)

    File: /opt/code/github/hqueue/coreclr/src/jit/codegenarm.cpp Line: 1086
    Image: /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170328debug/corerun

Aborted (core dumped)
```

### After
Rotate.exe passed.
```
$ COMPlus_JitDisasm=rol64const COMPlus_AltJit=rol64const ./corerun Rotate.exe
; Assembly listing for method Test:rol64const():long
; Emitting BLENDED_CODE for generic ARM CPU
; optimized code
; r11 based frame
; partially interruptible
; Final local variable assignments
;
;* V00 loc0         [V00    ] (  0,  0   )    long  ->  zero-ref   
;* V01 loc1         [V01    ] (  0,  0   )     int  ->  zero-ref   
;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref   
;# V03 OutArgs      [V03    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]  
;  V04 rat0         [V04,T00] (  4,  3   )     int  ->   r1         V02.lo(offs=0x00)
;  V05 rat1         [V05,T01] (  4,  3   )     int  ->   r0         V02.hi(offs=0x04)
;
; Lcl frame size = 0

G_M24995_IG01:
000000  E92D 4800      push    {r11,lr}
000004  46EB           mov     r11, sp

G_M24995_IG02:
000006  F645 3329      movw    r3, 0x5b29
00000A  F2C7 13AE      movt    r3, 0x71ae
00000E  4798           blx     r3               // Test:flag():bool
000010  2800           cmp     r0, 0
000012  D108           bne     SHORT G_M24995_IG03
000014  F246 7189      movw    r1, 0x6789
000018  F2C2 3145      movt    r1, 0x2345
00001C  F64D 60F1      movw    r0, 0xdef1
000020  F6C0 20BC      movt    r0, 0xabc
000024  E007           b       SHORT G_M24995_IG04

G_M24995_IG03:
000026  F64C 51EF      movw    r1, 0xcdef
00002A  F6C8 11AB      movt    r1, 0x89ab
00002E  F244 5067      movw    r0, 0x4567
000032  F2C0 1023      movt    r0, 0x123

G_M24995_IG04:
000036  460B           mov     r3, r1
000038  041B           lsls    r3, r3, 16
00003A  EA43 4310      orr     r3, r3, r0 LSR 16
00003E  4602           mov     r2, r0
000040  0412           lsls    r2, r2, 16
000042  EA42 4211      orr     r2, r2, r1 LSR 16
000046  4618           mov     r0, r3
000048  4611           mov     r1, r2

G_M24995_IG05:
00004A  E8BD 8800      pop     {r11,pc}

; Total bytes of code 78, prolog size 6 for method Test:rol64const():long
; ============================================================
$ echo $?
100
```

(This is a part of #8496)