### PR TITLE
[Linux] Clean up Windows-specific EH code

### DIFF
--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1893,6 +1893,7 @@ part2:
 
                 TerminateStackProbes();
 
+#ifndef FEATURE_PAL
                 // Unregister our vectored exception and continue handlers from the OS.
                 // This will ensure that if any other DLL unload (after ours) has an exception,
                 // we wont attempt to process that exception (which could lead to various
@@ -1905,6 +1906,7 @@ part2:
                 //
                 // 2) Only when the runtime is processing DLL_PROCESS_DETACH. 
                 CLRRemoveVectoredHandlers();
+#endif // !FEATURE_PAL
 
 #if USE_DISASSEMBLER
                 Disassembler::StaticClose();
@@ -2580,10 +2582,12 @@ BOOL STDMETHODCALLTYPE EEDllMain( // TRUE on success, FALSE on error.
                     LOG((LF_STARTUP, INFO3, "EEShutDown invoked from EEDllMain"));
                     EEShutDown(TRUE); // shut down EE if it was started up
                 }
+#ifndef FEATURE_PAL
                 else
                 {
                     CLRRemoveVectoredHandlers();
                 }
+#endif // !FEATURE_PAL
                 break;
             }
 

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -7192,7 +7192,8 @@ AdjustContextForWriteBarrier(
 #endif // ELSE
 }
 
-#if defined(USE_FEF) && !defined(FEATURE_PAL)
+#ifndef FEATURE_PAL
+#ifdef USE_FEF
 
 struct SavedExceptionInfo
 {
@@ -7325,13 +7326,14 @@ void HandleManagedFault(EXCEPTION_RECORD*               pExceptionRecord,
     SetIP(pContext, GetEEFuncEntryPoint(NakedThrowHelper));
 }
 
-#else // USE_FEF && !FEATURE_PAL
+#else // USE_FEF
 
 void InitSavedExceptionInfo()
 {
 }
 
-#endif // USE_FEF && !FEATURE_PAL
+#endif // !USE_FEF
+#endif // !FEATURE_PAL
 
 //
 // Init a new frame
@@ -8397,12 +8399,12 @@ LONG WINAPI CLRVectoredExceptionHandlerShim(PEXCEPTION_POINTERS pExceptionInfo)
 
 #endif // !FEATURE_PAL
 
+#ifndef FEATURE_PAL
 // Contains the handle to the registered VEH
 static PVOID g_hVectoredExceptionHandler = NULL;
 
 void CLRAddVectoredHandlers(void)
 {
-#ifndef FEATURE_PAL
 
     // We now install a vectored exception handler on all supporting Windows architectures.
     g_hVectoredExceptionHandler = AddVectoredExceptionHandler(TRUE, (PVECTORED_EXCEPTION_HANDLER)CLRVectoredExceptionHandlerShim);
@@ -8413,7 +8415,6 @@ void CLRAddVectoredHandlers(void)
     }
 
     LOG((LF_EH, LL_INFO100, "CLRAddVectoredHandlers: AddVectoredExceptionHandler() succeeded\n"));
-#endif // !FEATURE_PAL
 }
 
 // This function removes the vectored exception and continue handler registration
@@ -8427,7 +8428,6 @@ void CLRRemoveVectoredHandlers(void)
         MODE_ANY;
     }
     CONTRACTL_END;
-#ifndef FEATURE_PAL
 
     // Unregister the vectored exception handler if one is registered (and we can).
     if (g_hVectoredExceptionHandler != NULL)
@@ -8442,8 +8442,8 @@ void CLRRemoveVectoredHandlers(void)
             LOG((LF_EH, LL_INFO100, "CLRRemoveVectoredHandlers: RemoveVectoredExceptionHandler() succeeded.\n"));
         }
     }
-#endif // !FEATURE_PAL
 }
+#endif // !FEATURE_PAL
 
 //
 // This does the work of the Unwind and Continue Hanlder inside the catch clause of that handler. The stack has not

--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -125,8 +125,10 @@ struct ThrowCallbackType
 struct EE_ILEXCEPTION_CLAUSE;
 
 void InitializeExceptionHandling();
+#ifndef FEATURE_PAL
 void CLRAddVectoredHandlers(void);
 void CLRRemoveVectoredHandlers(void);
+#endif // !FEATURE_PAL
 void TerminateExceptionHandling();
 
 // Prototypes
@@ -768,7 +770,9 @@ void CPFH_AdjustContextForThreadSuspensionRace(T_CONTEXT *pContext, Thread *pThr
 DWORD GetGcMarkerExceptionCode(LPVOID ip);
 bool IsGcMarker(DWORD exceptionCode, T_CONTEXT *pContext);
 
+#ifndef FEATURE_PAL
 void InitSavedExceptionInfo();
+#endif // !FEATURE_PAL
 
 bool ShouldHandleManagedFault(
                         EXCEPTION_RECORD*               pExceptionRecord,

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -182,9 +182,11 @@ void InitializeExceptionHandling()
 {
     EH_LOG((LL_INFO100, "InitializeExceptionHandling(): ExceptionTracker size: 0x%x bytes\n", sizeof(ExceptionTracker)));
 
+#ifndef FEATURE_PAL
     InitSavedExceptionInfo();
 
     CLRAddVectoredHandlers();
+#endif // !FEATURE_PAL
 
     g_theTrackerAllocator.Init();
 


### PR DESCRIPTION
This commit cleans up EH code not to invoke the following Windows-specific methods in Linux:
 - InitSavedExceptionInfo
 - CLRAddVectoredHandlers
 - CLRRemoveVectoredHandlers
 