### PR TITLE
Move ObjectFromHandle to the GCHandleTable interface

### DIFF
--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -5718,9 +5718,9 @@ BOOL DacDbiInterfaceImpl::IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle)
     // SEH exceptions will be caught
     EX_TRY
     {
-        OBJECTREF objRef = ObjectFromHandle((OBJECTHANDLE)vmHandle.GetDacPtr());
+        OBJECTREF objRef = HndFetchHandle((OBJECTHANDLE)vmHandle.GetDacPtr());
 
-        // NULL is certinally valid...
+        // NULL is certainly valid...
         if (objRef != NULL)
         {
             if (objRef->ValidateObjectWithPossibleAV())

--- a/src/debug/daccess/request.cpp
+++ b/src/debug/daccess/request.cpp
@@ -3890,7 +3890,7 @@ HRESULT ClrDataAccess::GetClrWatsonBucketsWorker(Thread * pThread, GenericModeBl
     if (ohThrowable != NULL)
     {
         // Get the object from handle and check if the throwable is preallocated or not
-        OBJECTREF oThrowable = ObjectFromHandle(ohThrowable);
+        OBJECTREF oThrowable = ::HndFetchHandle(ohThrowable);
         if (oThrowable != NULL)
         {
             // Does the throwable have buckets?
@@ -4184,7 +4184,7 @@ HRESULT ClrDataAccess::GetCCWData(CLRDATA_ADDRESS ccw, struct DacpCCWData *ccwDa
     ccwData->isAggregated = pCCW->GetSimpleWrapper()->IsAggregated();
 
     if (pCCW->GetObjectHandle() != NULL)
-        ccwData->managedObject = PTR_CDADDR(ObjectFromHandle(pCCW->GetObjectHandle()));
+        ccwData->managedObject = PTR_CDADDR(::HndFetchHandle(pCCW->GetObjectHandle()));
 
     // count the number of COM vtables
     ccwData->interfaceCount = 0;

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -34206,11 +34206,11 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
         StringObject* str;
 
         // If the current string is used up
-        if (ObjectFromHandle(m_StressObjs[m_CurStressObj]) == 0)
+        if (HndFetchHandle(m_StressObjs[m_CurStressObj]) == 0)
         {
             // Populate handles with strings
             int i = m_CurStressObj;
-            while(ObjectFromHandle(m_StressObjs[i]) == 0)
+            while(HndFetchHandle(m_StressObjs[i]) == 0)
             {
                 _ASSERTE(m_StressObjs[i] != 0);
                 unsigned strLen = (LARGE_OBJECT_SIZE - 32) / sizeof(WCHAR);
@@ -34242,7 +34242,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
         }
 
         // Get the current string
-        str = (StringObject*) OBJECTREFToObject(ObjectFromHandle(m_StressObjs[m_CurStressObj]));
+        str = (StringObject*) OBJECTREFToObject(HndFetchHandle(m_StressObjs[m_CurStressObj]));
         if (str)
         {
             // Chop off the end of the string and form a new object out of it.

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -22,3 +22,13 @@ void GCHandleTable::Shutdown()
 {
     Ref_Shutdown();
 }
+
+void* GCHandleTable::GetHandleTableContext(HHANDLETABLE hTable)
+{
+    return (void*)((uintptr_t)::HndGetHandleTableADIndex(hTable).m_dwIndex);
+}
+
+HHANDLETABLE GCHandleTable::GetHandleTableForHandle(OBJECTHANDLE handle)
+{
+    return ::HndGetHandleTable(handle);
+}

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -23,12 +23,12 @@ void GCHandleTable::Shutdown()
     Ref_Shutdown();
 }
 
-void* GCHandleTable::GetHandleTableContext(HHANDLETABLE hTable)
+void* GCHandleTable::GetHandleTableContext(void* handleTable)
 {
-    return (void*)((uintptr_t)::HndGetHandleTableADIndex(hTable).m_dwIndex);
+    return (void*)((uintptr_t)::HndGetHandleTableADIndex((HHANDLETABLE)handleTable).m_dwIndex);
 }
 
-HHANDLETABLE GCHandleTable::GetHandleTableForHandle(OBJECTHANDLE handle)
+void* GCHandleTable::GetHandleTableForHandle(OBJECTHANDLE handle)
 {
-    return ::HndGetHandleTable(handle);
+    return (void*)::HndGetHandleTable(handle);
 }

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -14,9 +14,9 @@ public:
 
     virtual void Shutdown();
 
-    virtual void* GetHandleTableContext(HHANDLETABLE hTable);
+    virtual void* GetHandleTableContext(void* handleTable);
 
-    virtual HHANDLETABLE GetHandleTableForHandle(OBJECTHANDLE handle);
+    virtual void* GetHandleTableForHandle(OBJECTHANDLE handle);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -13,6 +13,10 @@ public:
     virtual bool Initialize();
 
     virtual void Shutdown();
+
+    virtual void* GetHandleTableContext(HHANDLETABLE hTable);
+
+    virtual HHANDLETABLE GetHandleTableForHandle(OBJECTHANDLE handle);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -149,10 +149,18 @@ struct segment_info
     void * pvMem; // base of the allocation, not the first object (must add ibFirstObject)
     size_t ibFirstObject;   // offset to the base of the first object in the segment
     size_t ibAllocated; // limit of allocated memory in the segment (>= firstobject)
-    size_t ibCommit; // limit of committed memory in the segment (>= alllocated)
+    size_t ibCommit; // limit of committed memory in the segment (>= allocated)
     size_t ibReserved; // limit of reserved memory in the segment (>= commit)
 };
 
+
+/*
+ * handle to handle table
+ */
+typedef DPTR(struct HandleTable) PTR_HandleTable;
+typedef DPTR(PTR_HandleTable) PTR_PTR_HandleTable;
+typedef PTR_HandleTable HHANDLETABLE;
+typedef PTR_PTR_HandleTable PTR_HHANDLETABLE;
 #ifdef PROFILING_SUPPORTED
 #define GC_PROFILING       //Turn on profiling
 #endif // PROFILING_SUPPORTED
@@ -391,6 +399,10 @@ public:
     virtual bool Initialize() = 0;
 
     virtual void Shutdown() = 0;
+
+    virtual void* GetHandleTableContext(HHANDLETABLE hTable) = 0;
+
+    virtual HHANDLETABLE GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -153,14 +153,6 @@ struct segment_info
     size_t ibReserved; // limit of reserved memory in the segment (>= commit)
 };
 
-
-/*
- * handle to handle table
- */
-typedef DPTR(struct HandleTable) PTR_HandleTable;
-typedef DPTR(PTR_HandleTable) PTR_PTR_HandleTable;
-typedef PTR_HandleTable HHANDLETABLE;
-typedef PTR_PTR_HandleTable PTR_HHANDLETABLE;
 #ifdef PROFILING_SUPPORTED
 #define GC_PROFILING       //Turn on profiling
 #endif // PROFILING_SUPPORTED
@@ -400,9 +392,9 @@ public:
 
     virtual void Shutdown() = 0;
 
-    virtual void* GetHandleTableContext(HHANDLETABLE hTable) = 0;
+    virtual void* GetHandleTableContext(void* handleTable) = 0;
 
-    virtual HHANDLETABLE GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
+    virtual void* GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/gc/handletable.h
+++ b/src/gc/handletable.h
@@ -177,8 +177,11 @@ BOOL HndFirstAssignHandle(OBJECTHANDLE handle, OBJECTREF objref);
 
 /*
  * inline handle dereferencing
+ *
+ * NOTE: Changes to this implementation should be kept in sync with ObjectFromHandle
+ *       on the VM side.
+ *
  */
-
 FORCEINLINE OBJECTREF HndFetchHandle(OBJECTHANDLE handle)
 {
     WRAPPER_NO_CONTRACT;

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -27,7 +27,6 @@
  * non-NULL.  In other words, if this handle is being initialized for the first
  * time.
  */
-#define ObjectFromHandle(handle)                   HndFetchHandle(handle)
 #define StoreObjectInHandle(handle, object)        HndAssignHandle(handle, object)
 #define InterlockedCompareExchangeObjectInHandle(handle, object, oldObj)        HndInterlockedCompareExchangeHandle(handle, object, oldObj)
 #define StoreFirstObjectInHandle(handle, object)   HndFirstAssignHandle(handle, object)
@@ -119,7 +118,7 @@ inline OBJECTHANDLE CreateDuplicateHandle(OBJECTHANDLE handle) {
     WRAPPER_NO_CONTRACT;
 
     // Create a new STRONG handle in the same table as an existing handle.  
-    return HndCreateHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, ObjectFromHandle(handle));
+    return HndCreateHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, HndFetchHandle(handle));
 }
 
 

--- a/src/gc/sample/GCSample.cpp
+++ b/src/gc/sample/GCSample.cpp
@@ -207,24 +207,24 @@ int __cdecl main(int argc, char* argv[])
 
     for (int i = 0; i < 1000000; i++)
     {
-        Object * pBefore = ((My *)ObjectFromHandle(oh))->m_pOther1;
+        Object * pBefore = ((My *)HndFetchHandle(oh))->m_pOther1;
 
         // Allocate more instances of the same object
         Object * p = AllocateObject(pMyMethodTable);
         if (p == NULL)
             return -1;
 
-        Object * pAfter = ((My *)ObjectFromHandle(oh))->m_pOther1;
+        Object * pAfter = ((My *)HndFetchHandle(oh))->m_pOther1;
 
         // Uncomment this assert to see how GC triggered inside AllocateObject moved objects around
         // assert(pBefore == pAfter);
 
         // Store the newly allocated object into a field using WriteBarrier
-        WriteBarrier(&(((My *)ObjectFromHandle(oh))->m_pOther1), p);
+        WriteBarrier(&(((My *)HndFetchHandle(oh))->m_pOther1), p);
     }
 
     // Create weak handle that points to our object
-    OBJECTHANDLE ohWeak = CreateGlobalWeakHandle(ObjectFromHandle(oh));
+    OBJECTHANDLE ohWeak = CreateGlobalWeakHandle(HndFetchHandle(oh));
     if (ohWeak == NULL)
         return -1;
 
@@ -235,7 +235,7 @@ int __cdecl main(int argc, char* argv[])
     pGCHeap->GarbageCollect();
 
     // Verify that the weak handle got cleared by the GC
-    assert(ObjectFromHandle(ohWeak) == NULL);
+    assert(HndFetchHandle(ohWeak) == NULL);
 
     printf("Done\n");
 

--- a/src/vm/exinfo.h
+++ b/src/vm/exinfo.h
@@ -134,7 +134,7 @@ public:
         return m_pPrevNestedInfo;
     }
     
-    // Returns the throwble associated with the tracker
+    // Returns the throwable associated with the tracker
     inline OBJECTREF GetThrowable()
     {
         LIMITED_METHOD_CONTRACT;

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -35,4 +35,3 @@ bool g_sw_ww_enabled_for_gc_heap = false;
 #endif // FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 
 gc_alloc_context g_global_alloc_context = {};
-

--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -209,5 +209,22 @@ private:
     GCHeapUtilities() = delete;
 };
 
+// Handle-related utilities.
+
+void ValidateHandleAndAppDomain(OBJECTHANDLE handle);
+
+// Given a handle, returns an OBJECTREF for the object it refers to.
+inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
+{
+    _ASSERTE(handle);
+
+#ifdef _DEBUG_IMPL
+    ValidateHandleAndAppDomain(handle);
+#endif // _DEBUG_IMPL
+
+    // Wrap the raw OBJECTREF and return it
+    return UNCHECKED_OBJECTREF_TO_OBJECTREF(*PTR_UNCHECKED_OBJECTREF(handle));
+}
+
 #endif // _GCHEAPUTILITIES_H_
 


### PR DESCRIPTION
This change touches a lot of files, but it's essentially the same idea everywhere: Rather than using the `ObjectFromHandle` macro that was in objecthandle.h, put `ObjectFromHandle` on the `GCHandleTable` interface and modify the callers to call that. 

The DAC will use HndFetchHandle directly since for now we don't want to deal with getting it to call virtual functions on the GC side.