### PR TITLE
Fix Issue #10022.

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -420,6 +420,9 @@ BasicBlock* Compiler::fgNewBasicBlock(BBjumpKinds jumpKind)
 
 void Compiler::fgEnsureFirstBBisScratch()
 {
+    // This method does not update predecessor lists and so must only be called before they are computed.
+    assert(!fgComputePredsDone);
+
     // Have we already allocated a scratch block?
 
     if (fgFirstBBisScratch())
@@ -439,11 +442,6 @@ void Compiler::fgEnsureFirstBBisScratch()
             block->inheritWeight(fgFirstBB);
         }
 
-        // The first basic block will have a ref count of at least one. This corresponds to the virtual edge
-        // from the prolog to the entry block. We need to remove this virtual edge before adding the scratch
-        // block as a predecessor.
-        fgFirstBB->bbRefs--;
-        fgAddRefPred(fgFirstBB, block);
         fgInsertBBbefore(fgFirstBB, block);
     }
     else
@@ -8069,6 +8067,16 @@ bool Compiler::fgMoreThanOneReturnBlock()
 void Compiler::fgAddInternal()
 {
     noway_assert(!compIsForInlining());
+
+#ifndef LEGACY_BACKEND
+    // The RyuJIT backend requires a scratch BB into which it can safely insert a P/Invoke method prolog if one is
+    // required. Create it here.
+    if (info.compCallUnmanaged != 0)
+    {
+        fgEnsureFirstBBisScratch();
+        fgFirstBB->bbFlags |= BBF_DONT_REMOVE;
+    }
+#endif // !LEGACY_BACKEND
 
     /*
         <BUGNUM> VSW441487 </BUGNUM>

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -438,6 +438,12 @@ void Compiler::fgEnsureFirstBBisScratch()
         {
             block->inheritWeight(fgFirstBB);
         }
+
+        // The first basic block will have a ref count of at least one. This corresponds to the virtual edge
+        // from the prolog to the entry block. We need to remove this virtual edge before adding the scratch
+        // block as a predecessor.
+        fgFirstBB->bbRefs--;
+        fgAddRefPred(fgFirstBB, block);
         fgInsertBBbefore(fgFirstBB, block);
     }
     else

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2838,13 +2838,6 @@ void Lowering::InsertPInvokeMethodProlog()
     // The first BB must be a scratch BB in order for us to be able to safely insert the P/Invoke prolog.
     assert(comp->fgFirstBBisScratch());
 
-    // If the entry block has more than one incoming edge, insert a preceding scratch BB into which we can safely
-    // insert the P/Invoke method prolog.
-    if (comp->fgFirstBB->countOfInEdges() > 1)
-    {
-        comp->fgEnsureFirstBBisScratch();
-    }
-
     LIR::Range& firstBlockRange = LIR::AsRange(comp->fgFirstBB);
 
     const CORINFO_EE_INFO*                       pInfo         = comp->eeGetEEInfo();

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2835,6 +2835,9 @@ void Lowering::InsertPInvokeMethodProlog()
 
     JITDUMP("======= Inserting PInvoke method prolog\n");
 
+    // The first BB must be a scratch BB in order for us to be able to safely insert the P/Invoke prolog.
+    assert(comp->fgFirstBBisScratch());
+
     // If the entry block has more than one incoming edge, insert a preceding scratch BB into which we can safely
     // insert the P/Invoke method prolog.
     if (comp->fgFirstBB->countOfInEdges() > 1)
@@ -2876,10 +2879,8 @@ void Lowering::InsertPInvokeMethodProlog()
     store->gtOp.gtOp1 = call;
     store->gtFlags |= GTF_VAR_DEF;
 
-    GenTree* insertionPoint = firstBlockRange.FirstNonPhiOrCatchArgNode();
-
     comp->fgMorphTree(store);
-    firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, store));
+    firstBlockRange.InsertAtEnd(LIR::SeqTree(comp, store));
     DISPTREERANGE(firstBlockRange, store);
 
 #if !defined(_TARGET_X86_) && !defined(_TARGET_ARM_)
@@ -2893,7 +2894,7 @@ void Lowering::InsertPInvokeMethodProlog()
         GenTreeLclFld(GT_STORE_LCL_FLD, TYP_I_IMPL, comp->lvaInlinedPInvokeFrameVar, callFrameInfo.offsetOfCallSiteSP);
     storeSP->gtOp1 = PhysReg(REG_SPBASE);
 
-    firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, storeSP));
+    firstBlockRange.InsertAtEnd(LIR::SeqTree(comp, storeSP));
     DISPTREERANGE(firstBlockRange, storeSP);
 
 #endif // !defined(_TARGET_X86_) && !defined(_TARGET_ARM_)
@@ -2909,7 +2910,7 @@ void Lowering::InsertPInvokeMethodProlog()
                                                    callFrameInfo.offsetOfCalleeSavedFP);
     storeFP->gtOp1 = PhysReg(REG_FPBASE);
 
-    firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, storeFP));
+    firstBlockRange.InsertAtEnd(LIR::SeqTree(comp, storeFP));
     DISPTREERANGE(firstBlockRange, storeFP);
 #endif // !defined(_TARGET_ARM_)
 
@@ -2924,7 +2925,7 @@ void Lowering::InsertPInvokeMethodProlog()
         // Push a frame - if we are NOT in an IL stub, this is done right before the call
         // The init routine sets InlinedCallFrame's m_pNext, so we just set the thead's top-of-stack
         GenTree* frameUpd = CreateFrameLinkUpdate(PushFrame);
-        firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, frameUpd));
+        firstBlockRange.InsertAtEnd(LIR::SeqTree(comp, frameUpd));
         DISPTREERANGE(firstBlockRange, frameUpd);
     }
 #endif // _TARGET_64BIT_

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2835,6 +2835,13 @@ void Lowering::InsertPInvokeMethodProlog()
 
     JITDUMP("======= Inserting PInvoke method prolog\n");
 
+    // If the entry block has more than one incoming edge, insert a preceding scratch BB into which we can safely
+    // insert the P/Invoke method prolog.
+    if (comp->fgFirstBB->countOfInEdges() > 1)
+    {
+        comp->fgEnsureFirstBBisScratch();
+    }
+
     LIR::Range& firstBlockRange = LIR::AsRange(comp->fgFirstBB);
 
     const CORINFO_EE_INFO*                       pInfo         = comp->eeGetEEInfo();


### PR DESCRIPTION
This issue occurred because the JIT currently inserts the P/Invoke
method prolog into the first block of a function without ensuring that
this block will only execute once. This is not safe, as executing the
P/Invoke prolog multiple times can create cycles in the frame list and
casue the stack unwinder to hang.

This change ensures that lowering inserts a new, single-entry basic
block at the beginning of the function if the existing entry block has
more than one predecessor.