### PR TITLE
Re-disable b08046 and add correct metadata.

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -61,6 +61,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\nonrefsdarr_il_r\nonrefsdarr_il_r.cmd">
             <Issue>4851</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b08046\b08046\b08046.cmd">
+            <Issue>4849</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic1\rva_rvastatic1.cmd">
             <Issue>2451</Issue>
         </ExcludeList>


### PR DESCRIPTION
\JIT\Regression\CLR-x86-JIT\V1.2-M01\b08046\b08046\b08046.cmd was disabled because the issue #2414
was closed but the tests tagged with that issue were not removed. b08046's correct issue is #4849.

Fixes #10549 but not #4849.