### PR TITLE
Add assert to GCHeap::ValidateObjectMember

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -33501,6 +33501,7 @@ void GCHeap::ValidateObjectMember (Object* obj)
                                     {
                                         dprintf (3, ("VOM: m: %Ix obj %Ix", (size_t)child_o, o));
                                         MethodTable *pMT = method_table (child_o);
+                                        assert(pMT);
                                         if (!pMT->SanityCheck()) {
                                             dprintf (3, ("Bad member of %Ix %Ix",
                                                         (size_t)oo, (size_t)child_o));


### PR DESCRIPTION
In presence of a corrupt heap, objects can contain
null method table.  Add assertion to prevent segfault
in checked/debug builds.