### PR TITLE
Enable StandAloneGC and Server GC

### DIFF
--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -597,8 +597,8 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
         ::SetThreadAffinityMask(gc_thread, (DWORD_PTR)1 << affinity->Processor);
     }
 
-	ResumeThread(gc_thread);
-	CloseHandle(gc_thread);
+    ResumeThread(gc_thread);
+    CloseHandle(gc_thread);
 
     return true;
 }

--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -597,6 +597,9 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
         ::SetThreadAffinityMask(gc_thread, (DWORD_PTR)1 << affinity->Processor);
     }
 
+	ResumeThread(gc_thread);
+	CloseHandle(gc_thread);
+
     return true;
 }
 


### PR DESCRIPTION
Change necessary to enable standalonegc on server gc.  Now CreateThread in gcenv.windows.cpp matches gcenv.os.cpp.

There was an oversight in GCToOSInterface::CreateThread where the newly created suspended thread was not resumed.  The result is a hang if you build standalone and run with servergc.

Repo:
build.cmd buildstandalonegc skiptests
set CORECLR_SERVER_GC
corerun.exe helloworld.exe