### PR TITLE
Lookup System.Runtime and mscorlib references by Assembly name

### DIFF
--- a/src/ilasm/asmman.cpp
+++ b/src/ilasm/asmman.cpp
@@ -131,6 +131,17 @@ mdToken             AsmMan::GetAsmRefTokByName(__in __nullterminated const char*
     AsmManAssembly* tmp = GetAsmRefByName(szAsmRefName);
     return(tmp ? tmp->tkTok : mdAssemblyRefNil);
 }
+AsmManAssembly*     AsmMan::GetAsmRefByAsmName(__in __nullterminated const char* szAsmName)
+{
+    AsmManAssembly* ret = NULL;
+    if(szAsmName)
+    {
+        for(int i=0; (ret = m_AsmRefLst.PEEK(i))&&
+            (strcmp(ret->szName,szAsmName)); i++);
+    }
+    return ret;
+}
+
 //==============================================================================================================
 void    AsmMan::SetModuleName(__inout_opt __nullterminated char* szName)
 {

--- a/src/ilasm/asmman.hpp
+++ b/src/ilasm/asmman.hpp
@@ -272,6 +272,8 @@ public:
     void    SetManifestResFile(__in __nullterminated char* szFileName, ULONG ulOffset);
     void    SetManifestResAsmRef(__in __nullterminated char* szAsmRefName);
 
+    AsmManAssembly*     GetAsmRefByAsmName(__in __nullterminated const char* szAsmName);
+    
     mdToken             GetFileTokByName(__in __nullterminated char* szFileName);
     mdToken             GetAsmRefTokByName(__in __nullterminated const char* szAsmRefName);
     mdToken             GetAsmTokByName(__in __nullterminated const char* szAsmName)

--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -276,14 +276,22 @@ mdToken Assembler::GetAsmRef(__in __nullterminated const char* szName)
 
 mdToken Assembler::GetBaseAsmRef()
 {
-    if (RidFromToken(m_pManifest->GetAsmRefTokByName("System.Runtime")) != 0)
+    AsmManAssembly* sysRuntime = m_pManifest->GetAsmRefByAsmName("System.Runtime");
+    if(sysRuntime != NULL)
     {
-        return GetAsmRef("System.Runtime");
+        return GetAsmRef(sysRuntime->szAlias ? sysRuntime->szAlias : sysRuntime->szName);
     }
 
-    if (RidFromToken(m_pManifest->GetAsmRefTokByName("netstandard")) != 0)
+    AsmManAssembly* mscorlibAsm = m_pManifest->GetAsmRefByAsmName("mscorlib");
+    if(mscorlibAsm != NULL)
     {
-        return GetAsmRef("netstandard");
+        return GetAsmRef(mscorlibAsm->szAlias ? mscorlibAsm->szAlias : mscorlibAsm->szName);
+    }
+
+    AsmManAssembly* netstandardAsm = m_pManifest->GetAsmRefByAsmName("netstandard");
+    if (netstandardAsm != NULL)
+    {
+        return GetAsmRef(netstandardAsm->szAlias ? netstandardAsm->szAlias : netstandardAsm->szName);
     }
 
     return GetAsmRef("mscorlib");


### PR DESCRIPTION
Rather than by alias.

Fixes #10595