### PR TITLE
[Local GC] Move some EE-specific finalize-on-unload logic out of the GC

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -70,6 +70,7 @@ public:
     static void EnableFinalization(bool foundFinalizers);
 
     static void HandleFatalError(unsigned int exitCode);
+    static bool ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -70,7 +70,7 @@ public:
     static void EnableFinalization(bool foundFinalizers);
 
     static void HandleFatalError(unsigned int exitCode);
-    static bool ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj);
+    static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -36101,43 +36101,21 @@ CFinalize::FinalizeSegForAppDomain (AppDomain *pDomain,
         // if it has the index we are looking for. If the methodtable is null, it can't be from the
         // unloading domain, so skip it.
         if (method_table(obj) == NULL)
-            continue;
-
-        // eagerly finalize all objects except those that may be agile.
-        if (obj->GetAppDomainIndex() != pDomain->GetIndex())
-            continue;
-
-#ifndef FEATURE_REDHAWK
-        if (method_table(obj)->IsAgileAndFinalizable())
         {
-            // If an object is both agile & finalizable, we leave it in the
-            // finalization queue during unload.  This is OK, since it's agile.
-            // Right now only threads can be this way, so if that ever changes, change
-            // the assert to just continue if not a thread.
-            _ASSERTE(method_table(obj) == g_pThreadClass);
-
-            if (method_table(obj) == g_pThreadClass)
-            {
-                // However, an unstarted thread should be finalized. It could be holding a delegate
-                // in the domain we want to unload. Once the thread has been started, its
-                // delegate is cleared so only unstarted threads are a problem.
-                Thread *pThread = ((THREADBASEREF)ObjectToOBJECTREF(obj))->GetInternal();
-                if (! pThread || ! pThread->IsUnstarted())
-                {
-                    // This appdomain is going to be gone soon so let us assign
-                    // it the appdomain that's guaranteed to exist
-                    // The object is agile and the delegate should be null so we can do it
-                    obj->GetHeader()->ResetAppDomainIndexNoFailure(SystemDomain::System()->DefaultDomain()->GetIndex());
-                    continue;
-                }
-            }
-            else
-            {
-                obj->GetHeader()->ResetAppDomainIndexNoFailure(SystemDomain::System()->DefaultDomain()->GetIndex());
-                continue;
-            }
+            continue;
         }
-#endif //!FEATURE_REDHAWK
+
+        // skip objects not in the unloading appdomain
+        if (obj->GetAppDomainIndex() != pDomain->GetIndex())
+        {
+            continue;
+        }
+
+        // does the EE actually want us to finalize this object? (is it agile?)
+        if (!GCToEEInterface::ShouldFinalizeObjectForUnload(pDomain, obj))
+        {
+            continue;
+        }
 
         if (!fRunFinalizers || (obj->GetHeader()->GetBits()) & BIT_SBLK_FINALIZER_RUN)
         {

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -36105,7 +36105,7 @@ CFinalize::FinalizeSegForAppDomain (AppDomain *pDomain,
             continue;
         }
 
-        // does the EE actually want us to finalize this object? (is it agile?)
+        // does the EE actually want us to finalize this object?
         if (!GCToEEInterface::ShouldFinalizeObjectForUnload(pDomain, obj))
         {
             continue;

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -36105,12 +36105,6 @@ CFinalize::FinalizeSegForAppDomain (AppDomain *pDomain,
             continue;
         }
 
-        // skip objects not in the unloading appdomain
-        if (obj->GetAppDomainIndex() != pDomain->GetIndex())
-        {
-            continue;
-        }
-
         // does the EE actually want us to finalize this object? (is it agile?)
         if (!GCToEEInterface::ShouldFinalizeObjectForUnload(pDomain, obj))
         {

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -213,7 +213,7 @@ ALWAYS_INLINE void GCToEEInterface::HandleFatalError(unsigned int exitCode)
     g_theGCToCLR->HandleFatalError(exitCode);
 }
 
-ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj)
+ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj)
 {
     assert(g_theGCToCLR != nullptr);
     return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -213,6 +213,12 @@ ALWAYS_INLINE void GCToEEInterface::HandleFatalError(unsigned int exitCode)
     g_theGCToCLR->HandleFatalError(exitCode);
 }
 
+ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);
+}
+
 #undef ALWAYS_INLINE
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -141,7 +141,7 @@ public:
     // Asks the EE if it wants a particular object to be finalized when unloading
     // an app domain.
     virtual
-    bool ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj) = 0;
+    bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -137,6 +137,11 @@ public:
     // Signals to the EE that the GC encountered a fatal error and can't recover.
     virtual
     void HandleFatalError(unsigned int exitCode) = 0;
+
+    // Asks the EE if it wants a particular object to be finalized when unloading
+    // an app domain.
+    virtual
+    bool ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -270,6 +270,11 @@ void GCToEEInterface::HandleFatalError(unsigned int exitCode)
     abort();
 }
 
+bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj)
+{
+    return true;
+}
+
 bool IsGCSpecialThread()
 {
     // TODO: Implement for background GC

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -270,7 +270,7 @@ void GCToEEInterface::HandleFatalError(unsigned int exitCode)
     abort();
 }
 
-bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj)
+bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj)
 {
     return true;
 }

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1350,7 +1350,7 @@ void GCToEEInterface::HandleFatalError(unsigned int exitCode)
     EEPOLICY_HANDLE_FATAL_ERROR(exitCode);
 }
 
-bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj)
+bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj)
 {
     MethodTable *pMT = obj->GetMethodTable();
     if (pMT->IsAgileAndFinalizable())

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1352,36 +1352,7 @@ void GCToEEInterface::HandleFatalError(unsigned int exitCode)
 
 bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj)
 {
-    MethodTable *pMT = obj->GetMethodTable();
-    if (pMT->IsAgileAndFinalizable())
-    {
-        // If an object is both agile & finalizable, we leave it in the
-        // finalization queue during unload.  This is OK, since it's agile.
-        // Right now only threads can be this way, so if that ever changes, change
-        // the assert to just continue if not a thread.
-        _ASSERTE(pMT == g_pThreadClass);
-
-        if (pMT == g_pThreadClass)
-        {
-            // However, an unstarted thread should be finalized. It could be holding a delegate
-            // in the domain we want to unload. Once the thread has been started, its
-            // delegate is cleared so only unstarted threads are a problem.
-            Thread *pThread = ((THREADBASEREF)ObjectToOBJECTREF(obj))->GetInternal();
-            if (!pThread || !pThread->IsUnstarted())
-            {
-                // This appdomain is going to be gone soon so let us assign
-                // it the appdomain that's guaranteed to exist
-                // The object is agile and the delegate should be null so we can do it
-                obj->GetHeader()->ResetAppDomainIndexNoFailure(SystemDomain::System()->DefaultDomain()->GetIndex());
-                return false;
-            }
-        }
-        else
-        {
-            obj->GetHeader()->ResetAppDomainIndexNoFailure(SystemDomain::System()->DefaultDomain()->GetIndex());
-            return false;
-        }
-    }
-
+    // CoreCLR does not have appdomains, so this code path is dead. Other runtimes may
+    // choose to inspect the object being finalized here.
     return true;
 }

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1354,5 +1354,7 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
 {
     // CoreCLR does not have appdomains, so this code path is dead. Other runtimes may
     // choose to inspect the object being finalized here.
+    // [DESKTOP TODO] Desktop looks for "agile and finalizable" objects and may choose
+    // to move them to a new app domain instead of finalizing them here.
     return true;
 }

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -45,7 +45,7 @@ public:
 
     void EnableFinalization(bool foundFinalizers);
     void HandleFatalError(unsigned int exitCode);
-    bool ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj);
+    bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
 };
 
 #endif // FEATURE_STANDALONE_GC

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -45,6 +45,7 @@ public:
 
     void EnableFinalization(bool foundFinalizers);
     void HandleFatalError(unsigned int exitCode);
+    bool ShouldFinalizeObjectForUnload(AppDomain *pDomain, Object* obj);
 };
 
 #endif // FEATURE_STANDALONE_GC


### PR DESCRIPTION
`IGCHeap::FinalizeAppDomain` ultimately ends up calling `CFinalize::FinalizeSegForAppDomain`, which finalizes every eligible object on the segment. Today, a little bit of EE introspection is done: if the object we are looking at is "agile and finalizable", it might not get finalized. In particular, if the object being finalized is a thread that is started or some other "agile" non-thread object, it'll get migrated to another app domain.

The GC does not care about these details so this PR moves this logic to the EE as a part of `GCToEEInterface`, since it's an EE-specific detail (`FEATURE_REDHAWK` does not do this check). With this change the GC no longer depends on the Thread class's method table.