### PR TITLE
Prepare TimeZoneInfo.cs for move to shared partition.

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -310,7 +310,8 @@
     <Compile Include="$(BclSourcesRoot)\System\AppContext\AppContextDefaultValues.CoreClrOverrides.cs" />
     <Compile Include="$(BclSourcesRoot)\System\AppContext\AppContextDefaultValues.Defaults.cs" />
     <Compile Include="$(BclSourcesRoot)\System\AppContext\AppContextDefaultValues.Defaults.Central.cs" />
-    <Compile Include="$(BclSourcesRoot)\System\CurrentTimeZone.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\CurrentSystemTimeZone.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\CurrentSystemTimeZone.Cache.cs" />
     <Compile Include="$(BclSourcesRoot)\System\TimeZone.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Object.cs" />
     <Compile Include="$(BclSourcesRoot)\System\ICloneable.cs" />

--- a/src/mscorlib/src/System/CurrentSystemTimeZone.Cache.cs
+++ b/src/mscorlib/src/System/CurrentSystemTimeZone.Cache.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Globalization;
+
+namespace System
+{
+    internal partial class CurrentSystemTimeZone
+    {
+        private DaylightTime GetCachedDaylightChanges(int year)
+        {
+            Object objYear = (Object)year;
+
+            if (!m_CachedDaylightChanges.Contains(objYear))
+            {
+                DaylightTime currentDaylightChanges = CreateDaylightChanges(year);
+                lock (m_CachedDaylightChanges)
+                {
+                    if (!m_CachedDaylightChanges.Contains(objYear))
+                    {
+                        m_CachedDaylightChanges.Add(objYear, currentDaylightChanges);
+                    }
+                }
+            }
+
+            return (DaylightTime)m_CachedDaylightChanges[objYear];
+        }
+
+        // The per-year information is cached in in this instance value. As a result it can
+        // be cleaned up by CultureInfo.ClearCachedData, which will clear the instance of this object
+        private readonly Hashtable m_CachedDaylightChanges = new Hashtable();
+    }
+}


### PR DESCRIPTION
TimeZoneInfo.cs needs no changes but it brings in
another file CurrentTimeZone.cs.

Which drags in yet another file (Hashtable.cs)
which is widely used inside CoreCLR but aside
from this one file, it seems to be stuff that'll
will never be ported over or already has been
ported over sans Hashtable.

So we'll refactor the memoization logic of
CurrentTimeZone.cs into its own partial file
and share the rest. CoreCLR will use continue to use Hashtable.
CoreRT will use ConcurrentUnifier.

And while we're at it, will rename it to
CurrentSystemTimeZone.cs to match the actual class name.

Once we make a corresponding change on the CoreRT side,
both TimeZone.cs and CurrentSystemTimeZone.cs will
be fully synced and can move to the shared partition.