### PR TITLE
Do not throw an assertion on no mscorlib when determining to use legacy debug options

### DIFF
--- a/src/ilasm/asmman.cpp
+++ b/src/ilasm/asmman.cpp
@@ -297,9 +297,10 @@ void AsmMan::EmitDebuggableAttribute(mdToken tkOwner)
     else
     {
         AsmManAssembly *pAssembly = GetAsmRefByName("mscorlib");
-        _ASSERTE(pAssembly != NULL);
-        PREFIX_ASSUME(pAssembly != NULL);
-        fOldStyle = (pAssembly->usVerMajor == 1);
+        if(pAssembly != NULL)
+        {
+            fOldStyle = (pAssembly->usVerMajor == 1);
+        }   
     }
 
     bsBytes->appendInt8(1);


### PR DESCRIPTION
It's okay to use debuggable attributes from other BaseAsmRef's

Fixes #10608