### PR TITLE
[Arm64] Fix GCStress hole in genReturn

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1883,8 +1883,8 @@ void CodeGen::genReturn(GenTreePtr treeNode)
 
         if (movRequired)
         {
-            emitAttr movSize = EA_ATTR(genTypeSize(targetType));
-            getEmitter()->emitIns_R_R(INS_mov, movSize, retReg, op1->gtRegNum);
+            emitAttr attr = emitTypeSize(targetType);
+            getEmitter()->emitIns_R_R(INS_mov, attr, retReg, op1->gtRegNum);
         }
     }
 


### PR DESCRIPTION
@briansull @dotnet/arm64-contrib PTAL

This fixed many GCStress0x4 ZapDisable failures.

Also looks like it may have fixed #10115.  In any case it is working on my tip with this patch