### PR TITLE
delete GetMethod2

### DIFF
--- a/src/jit/_typeinfo.h
+++ b/src/jit/_typeinfo.h
@@ -559,13 +559,6 @@ public:
         return m_method;
     }
 
-    // If FEATURE_CORECLR is enabled, GetMethod can be called
-    // before the pointer type is known to be a method pointer type.
-    CORINFO_METHOD_HANDLE GetMethod2() const
-    {
-        return m_method;
-    }
-
     // Get this item's type
     // If primitive, returns the primitive type (TI_*)
     // If not primitive, returns:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2892,10 +2892,6 @@ protected:
     void impHandleAccessAllowed(CorInfoIsAccessAllowedResult result, CORINFO_HELPER_DESC* helperCall);
     void impHandleAccessAllowedInternal(CorInfoIsAccessAllowedResult result, CORINFO_HELPER_DESC* helperCall);
 
-    void impInsertCalloutForDelegate(CORINFO_METHOD_HANDLE callerMethodHnd,
-                                     CORINFO_METHOD_HANDLE calleeMethodHnd,
-                                     CORINFO_CLASS_HANDLE  delegateTypeHnd);
-
     var_types impImportCall(OPCODE                  opcode,
                             CORINFO_RESOLVED_TOKEN* pResolvedToken,
                             CORINFO_RESOLVED_TOKEN* pConstrainedResolvedToken, // Is this a "constrained." call on a

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -12814,10 +12814,17 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
 #ifdef FEATURE_CORECLR
                     // In coreclr the delegate transparency rule needs to be enforced even if verification is disabled
-                    typeInfo              tiActualFtn          = impStackTop(0).seTypeInfo;
-                    CORINFO_METHOD_HANDLE delegateMethodHandle = tiActualFtn.GetMethod2();
+                    typeInfo tiActualFtn = impStackTop(0).seTypeInfo;
+                    if (tiActualFtn.GetType() != TI_ERROR)
+                    {
+                        CORINFO_METHOD_HANDLE delegateMethodHandle = tiActualFtn.GetMethod();
+                        impInsertCalloutForDelegate(info.compMethodHnd, delegateMethodHandle, resolvedToken.hClass);
+                    }
+                    else
+                    {
+                        // the issue 10620.
+                    }
 
-                    impInsertCalloutForDelegate(info.compMethodHnd, delegateMethodHandle, resolvedToken.hClass);
 #endif // FEATURE_CORECLR
                 }
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6116,25 +6116,6 @@ void Compiler::impInsertHelperCall(CORINFO_HELPER_DESC* helperInfo)
     impAppendTree(callout, (unsigned)CHECK_SPILL_NONE, impCurStmtOffs);
 }
 
-void Compiler::impInsertCalloutForDelegate(CORINFO_METHOD_HANDLE callerMethodHnd,
-                                           CORINFO_METHOD_HANDLE calleeMethodHnd,
-                                           CORINFO_CLASS_HANDLE  delegateTypeHnd)
-{
-#ifdef FEATURE_CORECLR
-    if (!info.compCompHnd->isDelegateCreationAllowed(delegateTypeHnd, calleeMethodHnd))
-    {
-        // Call the JIT_DelegateSecurityCheck helper before calling the actual function.
-        // This helper throws an exception if the CLR host disallows the call.
-
-        GenTreePtr helper = gtNewHelperCallNode(CORINFO_HELP_DELEGATE_SECURITY_CHECK, TYP_VOID, GTF_EXCEPT,
-                                                gtNewArgList(gtNewIconEmbClsHndNode(delegateTypeHnd),
-                                                             gtNewIconEmbMethHndNode(calleeMethodHnd)));
-        // Append the callout statement
-        impAppendTree(helper, (unsigned)CHECK_SPILL_NONE, impCurStmtOffs);
-    }
-#endif // FEATURE_CORECLR
-}
-
 // Checks whether the return types of caller and callee are compatible
 // so that callee can be tail called. Note that here we don't check
 // compatibility in IL Verifier sense, but on the lines of return type
@@ -12811,21 +12792,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         assert(verCheckDelegateCreation(delegateCreateStart, codeAddr - 1, delegateMethodRef));
                     }
 #endif
-
-#ifdef FEATURE_CORECLR
-                    // In coreclr the delegate transparency rule needs to be enforced even if verification is disabled
-                    typeInfo tiActualFtn = impStackTop(0).seTypeInfo;
-                    if (tiActualFtn.GetType() != TI_ERROR)
-                    {
-                        CORINFO_METHOD_HANDLE delegateMethodHandle = tiActualFtn.GetMethod();
-                        impInsertCalloutForDelegate(info.compMethodHnd, delegateMethodHandle, resolvedToken.hClass);
-                    }
-                    else
-                    {
-                        // the issue 10620.
-                    }
-
-#endif // FEATURE_CORECLR
                 }
 
                 callTyp = impImportCall(opcode, &resolvedToken, constraintCall ? &constrainedResolvedToken : nullptr,


### PR DESCRIPTION
The description is in #10620 .
I need to delete this methods because I want to add another class inside the union in typeInfo for resolver token. It is necessary for dotnet/corert#2102. All methods that work with typeInfo should check type.