### PR TITLE
Added DisableInlining flag to the ProfileData.

### DIFF
--- a/src/inc/corbbtprof.h
+++ b/src/inc/corbbtprof.h
@@ -178,6 +178,7 @@ enum MethodProfilingDataFlags
     WriteMethodPrecode            = 12, // 0x01000
     ExcludeHotMethodCode          = 13, // 0x02000  // Hot method should be excluded from the ReadyToRun image
     ExcludeColdMethodCode         = 14, // 0x04000  // Cold method should be excluded from the ReadyToRun image
+    DisableInlining               = 15, // 0x08000  // Disable inlining of this method in optimized AOT native code
 };
 
 enum GeneralProfilingDataFlags

--- a/src/zap/zapimage.h
+++ b/src/zap/zapimage.h
@@ -338,10 +338,20 @@ private:
 
 public:
     enum CompileStatus {
-        LOOKUP_FAILED   = -2,  COMPILE_FAILED   = -1,      // Failure
-        NOT_COMPILED    =  0,  COMPILE_EXCLUDED =  1,      // Info
-        COMPILE_SUCCEED = 10,  ALREADY_COMPILED = 11
-    };      // Success
+        // Failure status values are negative
+        LOOKUP_FAILED    = -2,
+        COMPILE_FAILED   = -1,
+
+        // Info status values are [0..9]
+        NOT_COMPILED          =  0,
+        COMPILE_EXCLUDED      =  1,
+        COMPILE_HOT_EXCLUDED  =  2,
+        COMPILE_COLD_EXCLUDED =  3,
+
+        // Successful status values are 10 or greater
+        COMPILE_SUCCEED  = 10,
+        ALREADY_COMPILED = 11
+    };
 
 private:
     // A hash table entry that contains the profile infomation and the CompileStatus for a given method
@@ -376,8 +386,24 @@ private:
             return (count_t)k;
         }
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; ProfileDataHashEntry e; e.pos = 0; e.size = 0; e.md = 0; return e; } // Assuming method profile data cannot start from position 0.
-        static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e.pos == 0; }
+        static const element_t Null()
+        {
+            LIMITED_METHOD_CONTRACT; 
+            ProfileDataHashEntry e; 
+            e.md = 0; 
+            e.size = 0; 
+            e.pos = 0;
+            e.flags = 0;
+            e.status = NOT_COMPILED;
+            return e;
+        }
+
+        static bool IsNull(const element_t &e)
+        {
+            LIMITED_METHOD_CONTRACT;
+            // returns true if both md and pos are zero
+            return (e.md == 0) && (e.pos == 0);
+        }
     };
     typedef SHash<ProfileDataHashTraits> ProfileDataHashTable;
 

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1009,12 +1009,19 @@ HRESULT ZapInfo::getBBProfileData (
     }
 
     // The md must match.
-    _ASSERTE(foundEntry->md == md); 
+    _ASSERTE(foundEntry->md == md);
 
+    if (foundEntry->pos == 0)
+    {
+        // We might not have profile data and instead only have CompileStatus and flags
+        assert(foundEntry->size == 0);
+        return E_FAIL;
+    }
+
+    //
     //
     // We found the md. Let's retrieve the profile data.
     //
-    _ASSERTE(foundEntry->pos > 0);                                   // The target position cannot be 0.
     _ASSERTE(foundEntry->size >= sizeof(CORBBTPROF_METHOD_HEADER));   // The size must at least this
 
     ProfileReader profileReader(DataSection_MethodBlockCounts->pData, DataSection_MethodBlockCounts->dataSize);


### PR DESCRIPTION
Extended CompileStatus to have both COMPILE_HOT_EXCLUDED and COMPILE_COLD_EXCLUDED.
Fixes the IsNull implementation for SHash 
Fixes getBBProfileData to handle the case where pos can now be zero