### PR TITLE
delete wrong and unused value ti_types::TI_COUNT

### DIFF
--- a/src/jit/_typeinfo.h
+++ b/src/jit/_typeinfo.h
@@ -27,8 +27,7 @@ enum ti_types
 #define DEF_TI(ti, nm) ti,
 #include "titypes.h"
 #undef DEF_TI
-    TI_ONLY_ENUM = TI_METHOD, // Enum values above this are completely described by the enumeration
-    TI_COUNT
+    TI_ONLY_ENUM = TI_METHOD, // Enum values with greater value are completely described by the enumeration.
 };
 
 #if defined(_TARGET_64BIT_)
@@ -190,8 +189,6 @@ inline ti_types JITtype2tiType(CorInfoType type)
  *
  */
 
-// TI_COUNT is less than or equal to TI_FLAG_DATA_MASK
-
 #define TI_FLAG_DATA_BITS 6
 #define TI_FLAG_DATA_MASK ((1 << TI_FLAG_DATA_BITS) - 1)
 
@@ -287,7 +284,7 @@ private:
     union {
         struct
         {
-            ti_types type : 6;
+            ti_types type : TI_FLAG_DATA_BITS;
             unsigned uninitobj : 1;        // used
             unsigned byref : 1;            // used
             unsigned byref_readonly : 1;   // used


### PR DESCRIPTION
In the original tf commit enum ti_types was defined without include:

```
enum ti_types
{
    TI_ERROR,

    TI_REF,
    TI_STRUCT,
    TI_METHOD,

    TI_ONLY_ENUM = TI_METHOD,   //Enum values above this are completely described by the enumeration

    TI_BYTE,
    TI_SHORT,
    TI_INT,
    TI_LONG,
    TI_FLOAT,
    TI_DOUBLE,
    TI_NULL,

    TI_COUNT
};
```

So TI_COUNT was equal to the number of enum members.
Then it was changed to 

```
enum ti_types
{
#define DEF_TI(ti, nm) ti,
#include "titypes.h"
#undef DEF_TI
    TI_ONLY_ENUM = TI_METHOD, // Enum values above this are completely described by the enumeration
    TI_COUNT
};
```
for verification dumps and TI_COUNT became equal to TI_ONLY_ENUM  + 1, that was incorrect.
But all uses of this value were commented out so nobody saw the error.
The original purpose of TI_COUNT was to check that the enum doesn't overflow its bite size inside the typeInfo union. 

`#define TI_FLAG_DATA_BITS              6
#define TI_FLAG_DATA_MASK              ((1 << TI_FLAG_DATA_BITS)-1)
assert(TI_COUNT <= TI_FLAG_DATA_MASK);
`