### PR TITLE
Jit: decrement finally nesting level when removing empty trys

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_10621/GitHub_10621.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_10621/GitHub_10621.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class GitHub_10621
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int F(int x) 
+    { 
+        return x * x;
+    }
+
+    // An empty try with nested try finallys where
+    // the inner finally cannot be cloned.
+    public static int Main()
+    {
+        int x = 0;
+        try {
+            // empty
+        }
+        finally {
+            try {
+                for (int i = 0; i < 11; i++) {
+                    x += F(i);
+                }
+            }
+            finally {
+
+                x -= 81;
+
+                try {
+                    // empty
+                }
+                finally
+                {
+                    x -= 64; 
+                    try {
+                        x -= 49;
+                    }
+                    finally {
+                        try {
+                            // empty
+                        }
+                        finally {
+                            x -= 36;
+                            try {
+                                x -= 25;
+                            }
+                            finally {
+                                try {
+                                    // empty
+                                }
+                                finally
+                                {
+                                    x -= 16; 
+                                    try {
+                                        x -= 9;
+                                    }
+                                    finally {
+                                        try {
+                                            // empty
+                                        }
+                                        finally {
+                                            x -= 4;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return x - 1;
+    }
+}
+

--- a/tests/src/JIT/Regression/JitBlue/GitHub_10621/GitHub_10621.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_10621/GitHub_10621.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DADEC17C-DA8A-4F7D-9927-47A9033A2E80}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
For non-funclet EH models, the GT_END_LFIN statement tracks the
nesting level of the associated finally. When removing a try-finally
with an empty try we need to decrement this level for any try-finallys
nested within the associated finally.

Added a test case with several levels of empty try and nesting.

Closes #10621.