### PR TITLE
Bring back kApplicationException

### DIFF
--- a/src/vm/rexcep.h
+++ b/src/vm/rexcep.h
@@ -109,8 +109,7 @@
 //
 
 DEFINE_EXCEPTION(g_ReflectionNS,       AmbiguousMatchException,        false,  COR_E_AMBIGUOUSMATCH)
-// ApplicationException is removed in CoreCLR
-#define kApplicationException kException 
+DEFINE_EXCEPTION(g_SystemNS,           ApplicationException,           false,  COR_E_APPLICATION)
 DEFINE_EXCEPTION(g_SystemNS,           AppDomainUnloadedException,     false,  COR_E_APPDOMAINUNLOADED)
 DEFINE_EXCEPTION(g_SystemNS,           ArithmeticException,            false,  COR_E_ARITHMETIC)
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/17789

It seems ApplicationException is back in coreclr with the .NET Standard 2.0 work. This caused an unecessary divergence from netfx in https://github.com/dotnet/corefx/issues/17789
