### PR TITLE
Fix InternalsVisibleTo when it references an assembly with some Debug…

### DIFF
--- a/src/inc/corhdr.h
+++ b/src/inc/corhdr.h
@@ -751,6 +751,7 @@ typedef enum CorAssemblyFlags
 
     afEnableJITcompileTracking   =  0x8000, // From "DebuggableAttribute".
     afDisableJITcompileOptimizer =  0x4000, // From "DebuggableAttribute".
+    afDebuggableAttributeMask    =  0xc000,
 
     afRetargetable          =   0x0100,     // The assembly can be retargeted (at runtime) to an
                                             //  assembly from a different publisher.

--- a/src/md/compiler/mdvalidator.cpp
+++ b/src/md/compiler/mdvalidator.cpp
@@ -5207,7 +5207,7 @@ HRESULT RegMeta::ValidateAssembly(RID rid)
     dwFlags = (CorAssemblyFlags) pMiniMd->getFlagsOfAssembly(pRecord);
 
     // Validate the flags 
-    invalidAssemblyFlags = dwFlags & (~(afPublicKey | afRetargetable | afPA_FullMask | afEnableJITcompileTracking | afDisableJITcompileOptimizer | afContentType_Mask));
+    invalidAssemblyFlags = dwFlags & (~(afPublicKey | afRetargetable | afPA_FullMask | afDebuggableAttributeMask | afContentType_Mask));
 
     // Validate we only set a legal processor architecture flags
     // The processor architecture flags were introduced in CLR v2.0.

--- a/src/vm/baseassemblyspec.cpp
+++ b/src/vm/baseassemblyspec.cpp
@@ -266,9 +266,9 @@ BOOL BaseAssemblySpec::CompareRefToDef(const BaseAssemblySpec *pRef, const BaseA
     }
 
     //
-    // flags are non-optional, except processor architecture and content type
+    // flags are non-optional, except processor architecture, content type, and debuggable attribute bits
     //
-    DWORD dwFlagsMask = ~(afPA_FullMask | afContentType_Mask);
+    DWORD dwFlagsMask = ~(afPA_FullMask | afContentType_Mask | afDebuggableAttributeMask);
     if ((pRef->m_dwFlags & dwFlagsMask) != (pDef->m_dwFlags & dwFlagsMask))
         return FALSE;
 


### PR DESCRIPTION
…gableAttribute flags

Fixes #3541
- Mask out the DebuggableAttribute bits from when comparing assembly spec flags for matching an InternalsVisibleTo reference to an assembly