### PR TITLE
[Linux/GDB-JIT] Fix 'this' pointer in struct methods

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -398,7 +398,10 @@ HRESULT FunctionMember::GetLocalsDebugInfo(NotifyGdb::PTK_TypeInfoMap pTypeMap,
     {
         if (FindNativeInfoInILVariable(0, startNativeOffset, &locals.pVars, locals.countVars, &nativeVar) == S_OK)
         {
-            vars[0].m_var_type = GetTypeInfoFromTypeHandle(TypeHandle(md->GetMethodTable()), pTypeMap, method);
+            TypeHandle th = TypeHandle(md->GetMethodTable());
+            if (th.IsValueType())
+                th = th.MakePointer();
+            vars[0].m_var_type = GetTypeInfoFromTypeHandle(th, pTypeMap, method);
             vars[0].m_var_name = new char[strlen("this") + 1];
             strcpy(vars[0].m_var_name, "this");
             vars[0].m_il_index = 0;


### PR DESCRIPTION
This PR fixes `this` method argument for value types - `this` should always be a pointer to underlying structure.

@mikem8361, @janvorli PTAL

cc @Dmitri-Botcharnikov @chunseoklee @seanshpark @lucenticus @kvochko