### PR TITLE
Improve Guid.ToString

### DIFF
--- a/src/mscorlib/src/System/Guid.cs
+++ b/src/mscorlib/src/System/Guid.cs
@@ -1288,9 +1288,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static char HexToChar(int a)
         {
-            // casts for short asm https://github.com/dotnet/coreclr/issues/10666#issuecomment-291246896
-            var b = (char)(a & 0xf);
-            return (char)(b + ((b > 9) ? (char)0x30 : (char)(0x61 - 10)));
+            a = a & 0xf;
+            return (char)((a > 9) ? a - 10 + 0x61 : a + 0x30);
         }
 
         unsafe private static int HexsToChars(char* guidChars, int a, int b)

--- a/src/mscorlib/src/System/Guid.cs
+++ b/src/mscorlib/src/System/Guid.cs
@@ -1285,35 +1285,41 @@ namespace System
             return ToString(format, null);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static char HexToChar(int a)
         {
-            a = a & 0xf;
-            return (char)((a > 9) ? a - 10 + 0x61 : a + 0x30);
+            // casts for short asm https://github.com/dotnet/coreclr/issues/10666#issuecomment-291246896
+            var b = (char)(a & 0xf);
+            return (char)(b + ((b > 9) ? (char)0x30 : (char)(0x61 - 10)));
         }
 
-        unsafe private static int HexsToChars(char* guidChars, int offset, int a, int b)
+        unsafe private static int HexsToChars(char* guidChars, int a, int b)
         {
-            return HexsToChars(guidChars, offset, a, b, false);
+            guidChars[0] = HexToChar(a >> 4);
+            guidChars[1] = HexToChar(a);
+
+            guidChars[2] = HexToChar(b >> 4);
+            guidChars[3] = HexToChar(b);
+
+            return 4;
         }
 
-        unsafe private static int HexsToChars(char* guidChars, int offset, int a, int b, bool hex)
+        unsafe private static int HexsToCharsHexOutput(char* guidChars, int a, int b)
         {
-            if (hex)
-            {
-                guidChars[offset++] = '0';
-                guidChars[offset++] = 'x';
-            }
-            guidChars[offset++] = HexToChar(a >> 4);
-            guidChars[offset++] = HexToChar(a);
-            if (hex)
-            {
-                guidChars[offset++] = ',';
-                guidChars[offset++] = '0';
-                guidChars[offset++] = 'x';
-            }
-            guidChars[offset++] = HexToChar(b >> 4);
-            guidChars[offset++] = HexToChar(b);
-            return offset;
+            guidChars[0] = '0';
+            guidChars[1] = 'x';
+
+            guidChars[2] = HexToChar(a >> 4);
+            guidChars[3] = HexToChar(a);
+
+            guidChars[4] = ',';
+            guidChars[5] = '0';
+            guidChars[6] = 'x';
+
+            guidChars[7] = HexToChar(b >> 4);
+            guidChars[8] = HexToChar(b);
+
+            return 9;
         }
 
         // IFormattable interface
@@ -1396,42 +1402,42 @@ namespace System
                         // {0xdddddddd,0xdddd,0xdddd,{0xdd,0xdd,0xdd,0xdd,0xdd,0xdd,0xdd,0xdd}}
                         guidChars[offset++] = '0';
                         guidChars[offset++] = 'x';
-                        offset = HexsToChars(guidChars, offset, _a >> 24, _a >> 16);
-                        offset = HexsToChars(guidChars, offset, _a >> 8, _a);
+                        offset += HexsToChars(guidChars + offset, _a >> 24, _a >> 16);
+                        offset += HexsToChars(guidChars + offset, _a >> 8, _a);
                         guidChars[offset++] = ',';
                         guidChars[offset++] = '0';
                         guidChars[offset++] = 'x';
-                        offset = HexsToChars(guidChars, offset, _b >> 8, _b);
+                        offset += HexsToChars(guidChars + offset, _b >> 8, _b);
                         guidChars[offset++] = ',';
                         guidChars[offset++] = '0';
                         guidChars[offset++] = 'x';
-                        offset = HexsToChars(guidChars, offset, _c >> 8, _c);
+                        offset += HexsToChars(guidChars + offset, _c >> 8, _c);
                         guidChars[offset++] = ',';
                         guidChars[offset++] = '{';
-                        offset = HexsToChars(guidChars, offset, _d, _e, true);
+                        offset += HexsToCharsHexOutput(guidChars + offset, _d, _e);
                         guidChars[offset++] = ',';
-                        offset = HexsToChars(guidChars, offset, _f, _g, true);
+                        offset += HexsToCharsHexOutput(guidChars + offset, _f, _g);
                         guidChars[offset++] = ',';
-                        offset = HexsToChars(guidChars, offset, _h, _i, true);
+                        offset += HexsToCharsHexOutput(guidChars + offset, _h, _i);
                         guidChars[offset++] = ',';
-                        offset = HexsToChars(guidChars, offset, _j, _k, true);
+                        offset += HexsToCharsHexOutput(guidChars + offset, _j, _k);
                         guidChars[offset++] = '}';
                     }
                     else
                     {
                         // [{|(]dddddddd[-]dddd[-]dddd[-]dddd[-]dddddddddddd[}|)]
-                        offset = HexsToChars(guidChars, offset, _a >> 24, _a >> 16);
-                        offset = HexsToChars(guidChars, offset, _a >> 8, _a);
+                        offset += HexsToChars(guidChars + offset, _a >> 24, _a >> 16);
+                        offset += HexsToChars(guidChars + offset, _a >> 8, _a);
                         if (dash) guidChars[offset++] = '-';
-                        offset = HexsToChars(guidChars, offset, _b >> 8, _b);
+                        offset += HexsToChars(guidChars + offset, _b >> 8, _b);
                         if (dash) guidChars[offset++] = '-';
-                        offset = HexsToChars(guidChars, offset, _c >> 8, _c);
+                        offset += HexsToChars(guidChars + offset, _c >> 8, _c);
                         if (dash) guidChars[offset++] = '-';
-                        offset = HexsToChars(guidChars, offset, _d, _e);
+                        offset += HexsToChars(guidChars + offset, _d, _e);
                         if (dash) guidChars[offset++] = '-';
-                        offset = HexsToChars(guidChars, offset, _f, _g);
-                        offset = HexsToChars(guidChars, offset, _h, _i);
-                        offset = HexsToChars(guidChars, offset, _j, _k);
+                        offset += HexsToChars(guidChars + offset, _f, _g);
+                        offset += HexsToChars(guidChars + offset, _h, _i);
+                        offset += HexsToChars(guidChars + offset, _j, _k);
                     }
                 }
             }


### PR DESCRIPTION
Prior ToString
```asm
; Assembly listing for method Guid:ToString(ref,ref):ref:this
; Lcl frame size = 88
G_M22417_IG01:
       4157                 push     r15
       4156                 push     r14
       57                   push     rdi
       56                   push     rsi
       55                   push     rbp
       53                   push     rbx
       4883EC58             sub      rsp, 88
       488BF1               mov      rsi, rcx
       488D7C2438           lea      rdi, [rsp+38H]
       B908000000           mov      ecx, 8
       33C0                 xor      rax, rax
       F3AB                 rep stosd 
...
; Total bytes of code 1336, prolog size 32 for method Guid:ToString(ref,ref):ref:this
```
Post ToString
```asm
; Assembly listing for method Guid:ToString(ref,ref):ref:this
; Lcl frame size = 88
G_M22417_IG01:
       4157                 push     r15
       4156                 push     r14
       57                   push     rdi
       56                   push     rsi
       55                   push     rbp
       53                   push     rbx
       4883EC58             sub      rsp, 88
       488BF1               mov      rsi, rcx
       488D7C2438           lea      rdi, [rsp+38H]
       B908000000           mov      ecx, 8
       33C0                 xor      rax, rax
       F3AB                 rep stosd 
...
; Total bytes of code 1205, prolog size 32 for method Guid:ToString(ref,ref):ref:this
```
Same preamble, but 131 bytes shorter; however main change is in called functions

Which drop the 6 pushes and 6 pops per call and shortening the non-inlined call chains from

```
Guid:ToString
->  Guid:HexsToChars (22 bytes)
             ->  Guid:HexsToChars (6+6 stack, 221 bytes) 
                          ->  4 x Guid:HexsToChar (25 bytes)
->  Guid:HexsToChars (6+6 stack, 221 bytes) 
             ->  4 x Guid:HexsToChar (25 bytes)
```
Which is essentially a function call per char to
```
Guid:ToString 
->  Guid:HexsToChars (121 bytes)
->  Guid:HexsToCharsHexOutput (151 bytes)
```

guid.ToString() per second

Current: 11,130,764.33
PR: 18,861,594.86

So x1.69 gain