### PR TITLE
[Local GC] Pull some logic using SystemDomain::System out of the GC

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -71,6 +71,7 @@ public:
 
     static void HandleFatalError(unsigned int exitCode);
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
+    static bool ForceFullGCToBeBlocking();
     static bool ShouldElevateForAppDomainCleanup();
     static bool EagerFinalized(Object* obj);
 };

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -71,6 +71,7 @@ public:
 
     static void HandleFatalError(unsigned int exitCode);
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
+    static bool ShouldElevateForAppDomainCleanup();
     static bool EagerFinalized(Object* obj);
 };
 

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -15136,26 +15136,21 @@ exit:
         }
     }
 
-#ifndef FEATURE_REDHAWK
-    if (n == max_generation)
+    if (n == max_generation && GCToEEInterface::ShouldElevateForAppDomainCleanup())
     {
-        if (SystemDomain::System()->RequireAppDomainCleanup())
-        {
 #ifdef BACKGROUND_GC
-            // do not turn stress-induced collections into blocking GCs, unless there
-            // have already been more full BGCs than full NGCs
+        // do not turn stress-induced collections into blocking GCs, unless there
+        // have already been more full BGCs than full NGCs
 #if 0
-            // This exposes DevDiv 94129, so we'll leave this out for now
-            if (!settings.stress_induced || 
-                full_gc_counts[gc_type_blocking] <= full_gc_counts[gc_type_background])
+        // This exposes DevDiv 94129, so we'll leave this out for now
+        if (!settings.stress_induced ||
+            full_gc_counts[gc_type_blocking] <= full_gc_counts[gc_type_background])
 #endif // 0
 #endif // BACKGROUND_GC
-            {
-                *blocking_collection_p = TRUE;
-            }
+        {
+            *blocking_collection_p = TRUE;
         }
     }
-#endif //!FEATURE_REDHAWK
 
     return n;
 }

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -15136,7 +15136,7 @@ exit:
         }
     }
 
-    if (n == max_generation && GCToEEInterface::ShouldElevateForAppDomainCleanup())
+    if (n == max_generation && GCToEEInterface::ForceFullGCToBeBlocking())
     {
 #ifdef BACKGROUND_GC
         // do not turn stress-induced collections into blocking GCs, unless there

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -219,6 +219,12 @@ ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDo
     return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);
 }
 
+ALWAYS_INLINE bool GCToEEInterface::ShouldElevateForAppDomainCleanup()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->ShouldElevateForAppDomainCleanup();
+}
+
 ALWAYS_INLINE bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     assert(g_theGCToCLR != nullptr);

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -219,10 +219,10 @@ ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDo
     return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);
 }
 
-ALWAYS_INLINE bool GCToEEInterface::ShouldElevateForAppDomainCleanup()
+ALWAYS_INLINE bool GCToEEInterface::ForceFullGCToBeBlocking()
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->ShouldElevateForAppDomainCleanup();
+    return g_theGCToCLR->ForceFullGCToBeBlocking();
 }
 
 ALWAYS_INLINE bool GCToEEInterface::EagerFinalized(Object* obj)

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -143,6 +143,11 @@ public:
     virtual
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj) = 0;
 
+    // Asks the EE if the GC scheduled for the given condemned generation should be
+    // elevated to a blocking collection, to clean up an app domain.
+    virtual
+    bool ShouldElevateForAppDomainCleanup() = 0;
+
     // Offers the EE the option to finalize the given object eagerly, i.e.
     // not on the finalizer thread but on the current thread. The
     // EE returns true if it finalized the object eagerly and the GC does not
@@ -150,7 +155,6 @@ public:
     // and it's up to the GC to finalize it later.
     virtual
     bool EagerFinalized(Object* obj) = 0;
-
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -155,6 +155,12 @@ public:
     // and it's up to the GC to finalize it later.
     virtual
     bool EagerFinalized(Object* obj) = 0;
+
+    // Asks the EE if it wishes for the current GC to be a blocking GC. The GC will
+    // only invoke this callback when it intends to do a full GC, so at this point
+    // the EE can opt to elevate that collection to be a blocking GC and not a background one.
+    virtual
+    bool ForceFullGCToBeBlocking() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -275,7 +275,7 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
-bool GCToEEInterface::ShouldElevateForAppDomainCleanup()
+bool GCToEEInterface::ForceFullGCToBeBlocking()
 {
     return false;
 }

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -275,6 +275,11 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
+bool GCToEEInterface::ShouldElevateForAppDomainCleanup()
+{
+    return false;
+}
+
 bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     // The sample does not finalize anything eagerly.

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1369,6 +1369,11 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
+bool GCToEEInterface::ShouldElevateForAppDomainCleanup()
+{
+    return !!SystemDomain::System()->RequireAppDomainCleanup();
+}
+
 bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     MethodTable* pMT = obj->GetGCSafeMethodTable();

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1369,8 +1369,16 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
-bool GCToEEInterface::ShouldElevateForAppDomainCleanup()
+bool GCToEEInterface::ForceFullGCToBeBlocking()
 {
+    // In theory, there is nothing fundamental that requires an AppDomain unload to induce
+    // a blocking GC. In the past, this workaround was done to fix an Stress AV, but the root
+    // cause of the AV was never discovered and this workaround remains in place.
+    //
+    // It would be nice if this were not necessary. However, it's not clear if the aformentioned
+    // stress bug is still lurking and will return if this workaround is removed. We should
+    // do some experiments: remove this workaround and see if the stress bug still repros.
+    // If so, we should find the root cause instead of relying on this.
     return !!SystemDomain::System()->RequireAppDomainCleanup();
 }
 

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -47,6 +47,7 @@ public:
     void HandleFatalError(unsigned int exitCode);
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
     bool ShouldElevateForAppDomainCleanup();
+    bool ForceFullGCToBeBlocking();
     bool EagerFinalized(Object* obj);
 };
 

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -46,6 +46,7 @@ public:
     void EnableFinalization(bool foundFinalizers);
     void HandleFatalError(unsigned int exitCode);
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
+    bool ShouldElevateForAppDomainCleanup();
     bool EagerFinalized(Object* obj);
 };
 


### PR DESCRIPTION
In the same vein of my last few PRs, this PR moves some EE introspection out of the GC and onto `GCToEEInterface`:

In `generation_to_condemn`, the GC may choose to elevate a Gen 2 GC to be blocking if the system domain requires app domain cleanup. Instead of calling `RequiresAppDomainCleanup` on the system domain from the GC, this PR moves all of that logic to the EE side and instead has the GC invoke a method on `GCToEEInterface` to determine whether or not this GC should be elevated to a blocking collection on behalf of the system domain.