### PR TITLE
Publish VC Redist DLLs as part of CoreCLR Package

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -20,6 +20,7 @@
     <NativeBinary Include="$(BinDir)mscorrc.dll" />
     <NativeBinary Include="$(BinDir)sos.dll" />
     <NativeBinary Include="$(BinDir)System.Private.CoreLib.ni.dll" />
+    <NativeBinary Include="$(UniversalCRTSDKDir)Redist\ucrt\DLLs\$(BuildArch)\*.dll" Condition="'$(BuildType)'=='Release' AND '$(BuildArch)' != 'arm64'" />
     <ArchitectureSpecificLibFile Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen.exe" />

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+
+  <Target Name="VerifyVCRedist" BeforeTargets="GetSymbolPackageFiles" Condition="'$(_runtimeOSFamily)' == 'win'">
+    <Error Condition="'$(UniversalCRTSDKDir)' == ''" Text="Unable to find VC Redist binaries - check that UniversalCRTSDKDir environment variable is set" />
+  </Target>
   <!--
     Finds symbol files and injects them into the package build.
   -->


### PR DESCRIPTION
CC @gkhanna79 @Petermarcu 

First part of addressing https://github.com/dotnet/coreclr/issues/7994

I tested locally, and this does indeed include VC Redist binaries in the runtime package, in `runtimes\win7-{arch}\native`, next to coreclr.dll & other native binaries.

@chcosta these VC Redist .dll's don't have symbol packages - will that be a problem for publishing? How can I get around that?