### PR TITLE
Fix a reference to System.Exception in a JIT test.

### DIFF
--- a/tests/src/JIT/opt/Tailcall/TailcallVerifyWithPrefix.il
+++ b/tests/src/JIT/opt/Tailcall/TailcallVerifyWithPrefix.il
@@ -173,7 +173,7 @@
   {
     // Code size       154 (0x9a)
     .maxstack  3
-    .locals init ([0] class [System.Console]System.Exception e)
+    .locals init ([0] class [mscorlib]System.Exception e)
     IL_0000:  ldstr      "Executing Condition18.Test2 - Caller(imperative se"
     + "curity): Arguments: None - ReturnType: 3 byte struct; Callee: Arguments"
     + ": None - ReturnType: 3 byte struct"


### PR DESCRIPTION
This bad reference was casuing a failure in the x64 pri1 R2R jobs.