### PR TITLE
Fix handling of environment variables with empty string values.

### DIFF
--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -676,10 +676,10 @@ namespace System
             StringBuilder sb = StringBuilderCache.Acquire(128); // A somewhat reasonable default size
             int requiredSize = Win32Native.GetEnvironmentVariable(variable, sb, sb.Capacity);
 
-            if (requiredSize == 0 && Marshal.GetLastWin32Error() == Win32Native.ERROR_ENVVAR_NOT_FOUND)
+            if (requiredSize == 0)
             {
                 StringBuilderCache.Release(sb);
-                return null;
+                return Marshal.GetLastWin32Error() == Win32Native.ERROR_ENVVAR_NOT_FOUND ? null : string.Empty;
             }
 
             while (requiredSize > sb.Capacity)


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/17614

[`GetEnvironmentVariableCore`](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Environment.cs#L679) doesn't handle the case where an environment variable is found but has length 0. If this happens, it effectively just does `StringBuilderCache.Acquire` followed by `StringBuilderCache.GetStringAndRelease`.

@JeremyKuhne @jkotas 