### PR TITLE
[Local GC] Move Weak Reference finalization out of the GC

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -71,6 +71,7 @@ public:
 
     static void HandleFatalError(unsigned int exitCode);
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
+    static bool FinalizeIfWeakReference(Object* obj);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -71,7 +71,7 @@ public:
 
     static void HandleFatalError(unsigned int exitCode);
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
-    static bool FinalizeIfWeakReference(Object* obj);
+    static bool EagerFinalized(Object* obj);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -36269,7 +36269,7 @@ CFinalize::ScanForFinalization (promote_func* pfn, int gen, BOOL mark_only_p,
 
                     assert (method_table(obj)->HasFinalizer());
 
-                    if (GCToEEInterface::FinalizeIfWeakReference(obj))
+                    if (GCToEEInterface::EagerFinalized(obj))
                     {
                         MoveItem (i, Seg, FreeList);
                     }

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -36269,16 +36269,11 @@ CFinalize::ScanForFinalization (promote_func* pfn, int gen, BOOL mark_only_p,
 
                     assert (method_table(obj)->HasFinalizer());
 
-#ifndef FEATURE_REDHAWK
-                    if (method_table(obj) == pWeakReferenceMT || method_table(obj)->GetCanonicalMethodTable() == pWeakReferenceOfTCanonMT)
+                    if (GCToEEInterface::FinalizeIfWeakReference(obj))
                     {
-                        //destruct the handle right there.
-                        FinalizeWeakReference (obj);
                         MoveItem (i, Seg, FreeList);
                     }
-                    else
-#endif //!FEATURE_REDHAWK
-                    if ((obj->GetHeader()->GetBits()) & BIT_SBLK_FINALIZER_RUN)
+                    else if ((obj->GetHeader()->GetBits()) & BIT_SBLK_FINALIZER_RUN)
                     {
                         //remove the object because we don't want to
                         //run the finalizer

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -256,12 +256,6 @@ void TouchPages(void * pStart, size_t cb);
 void updateGCShadow(Object** ptr, Object* val);
 #endif
 
-// the method table for the WeakReference class
-extern MethodTable  *pWeakReferenceMT;
-// The canonical method table for WeakReference<T>
-extern MethodTable  *pWeakReferenceOfTCanonMT;
-extern void FinalizeWeakReference(Object * obj);
-
 // The single GC heap instance, shared with the VM.
 extern IGCHeapInternal* g_theGCHeap;
 

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -219,10 +219,10 @@ ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDo
     return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);
 }
 
-ALWAYS_INLINE bool GCToEEInterface::FinalizeIfWeakReference(Object* obj)
+ALWAYS_INLINE bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->FinalizeIfWeakReference(obj);
+    return g_theGCToCLR->EagerFinalized(obj);
 }
 
 #undef ALWAYS_INLINE

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -219,6 +219,12 @@ ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDo
     return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);
 }
 
+ALWAYS_INLINE bool GCToEEInterface::FinalizeIfWeakReference(Object* obj)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->FinalizeIfWeakReference(obj);
+}
+
 #undef ALWAYS_INLINE
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -142,6 +142,13 @@ public:
     // an app domain.
     virtual
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj) = 0;
+
+    // Finalizes the given object, if it is a weak reference. Returns true if the
+    // given object was a weak reference and was finalized by the EE, false if
+    // the object was not a weak reference.
+    virtual
+    bool FinalizeIfWeakReference(Object* obj) = 0;
+
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -143,11 +143,13 @@ public:
     virtual
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj) = 0;
 
-    // Finalizes the given object, if it is a weak reference. Returns true if the
-    // given object was a weak reference and was finalized by the EE, false if
-    // the object was not a weak reference.
+    // Offers the EE the option to finalize the given object eagerly, i.e.
+    // not on the finalizer thread but on the current thread. The
+    // EE returns true if it finalized the object eagerly and the GC does not
+    // need to do so, and false if it chose not to eagerly finalize the object
+    // and it's up to the GC to finalize it later.
     virtual
-    bool FinalizeIfWeakReference(Object* obj) = 0;
+    bool EagerFinalized(Object* obj) = 0;
 
 };
 

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -275,10 +275,9 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
-bool GCToEEInterface::FinalizeIfWeakReference(Object* obj)
+bool GCToEEInterface::EagerFinalized(Object* obj)
 {
-    // The sample does not implement weak references, so there is nothing
-    // to do with them.
+    // The sample does not finalize anything eagerly.
     return false;
 }
 

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -275,6 +275,13 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
+bool GCToEEInterface::FinalizeIfWeakReference(Object* obj)
+{
+    // The sample does not implement weak references, so there is nothing
+    // to do with them.
+    return false;
+}
+
 bool IsGCSpecialThread()
 {
     // TODO: Implement for background GC

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1369,10 +1369,11 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
-bool GCToEEInterface::FinalizeIfWeakReference(Object* obj)
+bool GCToEEInterface::EagerFinalized(Object* obj)
 {
-    MethodTable* pMT = obj->GetMethodTable();
-    if (pMT == pWeakReferenceMT || pMT == pWeakReferenceOfTCanonMT)
+    MethodTable* pMT = obj->GetGCSafeMethodTable();
+    if (pMT == pWeakReferenceMT ||
+        pMT->GetCanonicalMethodTable() == pWeakReferenceOfTCanonMT)
     {
         FinalizeWeakReference(obj);
         return true;

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -29,6 +29,15 @@
 #include "comcallablewrapper.h"
 #endif // FEATURE_COMINTEROP
 
+// the method table for the WeakReference class
+extern MethodTable* pWeakReferenceMT;
+
+// The canonical method table for WeakReference<T>
+extern MethodTable* pWeakReferenceOfTCanonMT;
+
+// Finalizes a weak reference directly.
+extern void FinalizeWeakReference(Object* obj);
+
 void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)
 {
     WRAPPER_NO_CONTRACT;
@@ -1358,4 +1367,16 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     // [DESKTOP TODO] Desktop looks for "agile and finalizable" objects and may choose
     // to move them to a new app domain instead of finalizing them here.
     return true;
+}
+
+bool GCToEEInterface::FinalizeIfWeakReference(Object* obj)
+{
+    MethodTable* pMT = obj->GetMethodTable();
+    if (pMT == pWeakReferenceMT || pMT == pWeakReferenceOfTCanonMT)
+    {
+        FinalizeWeakReference(obj);
+        return true;
+    }
+
+    return false;
 }

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -46,7 +46,7 @@ public:
     void EnableFinalization(bool foundFinalizers);
     void HandleFatalError(unsigned int exitCode);
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
-    bool FinalizeIfWeakReference(Object* obj);
+    bool EagerFinalized(Object* obj);
 };
 
 #endif // FEATURE_STANDALONE_GC

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -46,6 +46,7 @@ public:
     void EnableFinalization(bool foundFinalizers);
     void HandleFatalError(unsigned int exitCode);
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
+    bool FinalizeIfWeakReference(Object* obj);
 };
 
 #endif // FEATURE_STANDALONE_GC


### PR DESCRIPTION
When finalizing objects on a segment, the GC checks whether or not an object's method table is that of `System.WeakReference` or `System.WeakReference<T>`, in which case it calls `FinalizeWeakReference` on the EE side to perform the actual work of finalizing a weak reference.

This PR moves all of this logic to `GCToEEInterface`, so that the GC does not know or care whether or not an object is a weak reference: it will call `GCToEEInterface::FinalizeIfWeakReference`, which returns `true` if the object was a weak reference (and was finalized) and `false` if the object wasn't a weak reference. The implementation of `GCToEEInterface::FinalizeIfWeakReference` does the method table check and, if the object is a weak reference, calls `FinalizeWeakReference` on it.