### PR TITLE
Remove the SO_TOLERANT contact from CEEInfo::resolveVirtualMethodHelper

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -8719,7 +8719,6 @@ CORINFO_METHOD_HANDLE CEEInfo::resolveVirtualMethodHelper(CORINFO_METHOD_HANDLE 
                                                           CORINFO_CONTEXT_HANDLE ownerType)
 {
     CONTRACTL {
-        SO_TOLERANT;
         THROWS;
         GC_TRIGGERS;
         MODE_PREEMPTIVE;


### PR DESCRIPTION
that contract should only apply to CEEInfo::resolveVirtualMethod which uses the JIT_TO_EE_TRANSITION() transition macros.