### PR TITLE
Fix invocation of ILLink in linux testing

### DIFF
--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -222,7 +222,7 @@ then
   # Include all .exe files in this directory as entry points (some tests had multiple .exe file modules)
   for bin in *.exe *.dll; 
   do 
-    Assemblies="$Assemblies -a $bin"
+    Assemblies="$Assemblies -a ${bin%.*}"
   done
 
   # Run dotnet-linker


### PR DESCRIPTION
Fix the input to illink -a argument to not include the extension.
The current command line caused silent wrong code gneration
because of https://github.com/mono/linker/issues/56