### PR TITLE
[x86/Linux] Correctly unwind esp frames

### DIFF
--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -76,7 +76,7 @@ OOPStackUnwinderX86::VirtualUnwind(
 
     FillRegDisplay(&rd, ContextRecord);
 
-    rd.SP = ContextRecord->ResumeEsp;
+    rd.SP = ContextRecord->Esp;
     rd.PCTAddr = (UINT_PTR)&(ContextRecord->Eip);
 
     if (ContextPointers)

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -3815,7 +3815,10 @@ bool UnwindEbpDoubleAlignFrame(
         // TODO Currently we assume that ESP of funclet frames is always fixed but actually it could change.
         if (pCodeInfo->IsFunclet())
         {
-            baseSP = curESP + 12; // padding for 16byte stack alignment allocated in genFuncletProlog()
+            // Set baseSP as initial SP
+            baseSP = pContext->pCurrentContext->ResumeEsp;
+            // 16-byte stack alignment padding (allocated in genFuncletProlog)
+            baseSP += 12;
 
             pContext->PCTAddr = baseSP;
             pContext->ControlPC = *PTR_PCODE(pContext->PCTAddr);


### PR DESCRIPTION
UnwindEspFrame already considers pushed argument size when unwinding esp frame, and thus SP should be current SP (not SP before argument pushes) when invoking UnwindEspFrame.

Unfortunately, OOPStackUnwinderX86::VirtualUnwind provides SP before argument pushes, which results in  incorrect unwinding inside baseservices.threading.monitor.enter.monitorenter.

This commit revises x86/Linux unwider to correctly unwind esp frames.