### PR TITLE
Remove `GTF_REVERSE_OPS` from LIR.

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1401,24 +1401,15 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     }
     else // A normal store, not a WriteBarrier store
     {
-        bool reverseOps  = ((tree->gtFlags & GTF_REVERSE_OPS) != 0);
         bool dataIsUnary = false;
 
         // We must consume the operands in the proper execution order,
         // so that liveness is updated appropriately.
-        if (!reverseOps)
-        {
-            genConsumeAddress(addr);
-        }
+        genConsumeAddress(addr);
 
         if (!data->isContained())
         {
             genConsumeRegs(data);
-        }
-
-        if (reverseOps)
-        {
-            genConsumeAddress(addr);
         }
 
         emit->emitInsLoadStoreOp(ins_Store(targetType), emitTypeSize(tree), data->gtRegNum, tree);

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -3599,24 +3599,15 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     }
     else // A normal store, not a WriteBarrier store
     {
-        bool     reverseOps  = ((tree->gtFlags & GTF_REVERSE_OPS) != 0);
         bool     dataIsUnary = false;
         GenTree* nonRMWsrc   = nullptr;
         // We must consume the operands in the proper execution order,
         // so that liveness is updated appropriately.
-        if (!reverseOps)
-        {
-            genConsumeAddress(addr);
-        }
+        genConsumeAddress(addr);
 
         if (!data->isContained())
         {
             genConsumeRegs(data);
-        }
-
-        if (reverseOps)
-        {
-            genConsumeAddress(addr);
         }
 
         regNumber dataReg = REG_NA;

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -2707,6 +2707,11 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode)
 
     emitter* emit = getEmitter();
 
+    if (dstAddr->isUsedFromReg())
+    {
+        genConsumeReg(dstAddr);
+    }
+
     if (cpBlkNode->gtFlags & GTF_BLK_VOLATILE)
     {
         // issue a full memory barrier before & after a volatile CpBlkUnroll operation
@@ -2736,11 +2741,6 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode)
             source->SetOper(GT_LCL_FLD_ADDR);
         }
         srcAddr = source;
-    }
-
-    if (dstAddr->isUsedFromReg())
-    {
-        genConsumeReg(dstAddr);
     }
 
     unsigned offset = 0;

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1282,12 +1282,7 @@ void CodeGen::genConsumeOperands(GenTreeOp* tree)
 {
     GenTree* firstOp  = tree->gtOp1;
     GenTree* secondOp = tree->gtOp2;
-    if ((tree->gtFlags & GTF_REVERSE_OPS) != 0)
-    {
-        assert(secondOp != nullptr);
-        firstOp  = secondOp;
-        secondOp = tree->gtOp1;
-    }
+
     if (firstOp != nullptr)
     {
         genConsumeRegs(firstOp);
@@ -1511,71 +1506,28 @@ void CodeGen::genSetBlockSrc(GenTreeBlk* blkNode, regNumber srcReg)
 
 void CodeGen::genConsumeBlockOp(GenTreeBlk* blkNode, regNumber dstReg, regNumber srcReg, regNumber sizeReg)
 {
-    // We have to consume the registers, and perform any copies, in the actual execution order.
-    // The nominal order is: dst, src, size.  However this may have been changed
-    // with reverse flags on the blkNode and the setting of gtEvalSizeFirst in the case of a dynamic
-    // block size.
+    // We have to consume the registers, and perform any copies, in the actual execution order: dst, src, size.
+    //
     // Note that the register allocator ensures that the registers ON THE NODES will not interfere
     // with one another if consumed (i.e. reloaded or moved to their ASSIGNED reg) in execution order.
     // Further, it ensures that they will not interfere with one another if they are then copied
     // to the REQUIRED register (if a fixed register requirement) in execution order.  This requires,
     // then, that we first consume all the operands, then do any necessary moves.
 
-    GenTree* dstAddr       = blkNode->Addr();
-    GenTree* src           = nullptr;
-    unsigned blockSize     = blkNode->Size();
-    GenTree* size          = nullptr;
-    bool     evalSizeFirst = true;
+    GenTree* const dstAddr  = blkNode->Addr();
 
-    // First, consume all the sources in order
+    // First, consume all the sources in order.
+    genConsumeReg(dstAddr);
+    genConsumeBlockSrc(blkNode);
     if (blkNode->OperGet() == GT_STORE_DYN_BLK)
     {
-        size = blkNode->AsDynBlk()->gtDynamicSize;
-        if (blkNode->AsDynBlk()->gtEvalSizeFirst)
-        {
-            genConsumeReg(size);
-        }
-        else
-        {
-            evalSizeFirst = false;
-        }
-    }
-    if (blkNode->IsReverseOp())
-    {
-
-        genConsumeBlockSrc(blkNode);
-        genConsumeReg(dstAddr);
-    }
-    else
-    {
-        genConsumeReg(dstAddr);
-        genConsumeBlockSrc(blkNode);
-    }
-    if (!evalSizeFirst)
-    {
-        noway_assert(size != nullptr);
-        genConsumeReg(size);
+        genConsumeReg(blkNode->AsDynBlk()->gtDynamicSize);
     }
 
     // Next, perform any necessary moves.
-    if (evalSizeFirst)
-    {
-        genSetBlockSize(blkNode, sizeReg);
-    }
-    if (blkNode->IsReverseOp())
-    {
-        genSetBlockSrc(blkNode, srcReg);
-        genCopyRegIfNeeded(dstAddr, dstReg);
-    }
-    else
-    {
-        genCopyRegIfNeeded(dstAddr, dstReg);
-        genSetBlockSrc(blkNode, srcReg);
-    }
-    if (!evalSizeFirst)
-    {
-        genSetBlockSize(blkNode, sizeReg);
-    }
+    genCopyRegIfNeeded(dstAddr, dstReg);
+    genSetBlockSrc(blkNode, srcReg);
+    genSetBlockSize(blkNode, sizeReg);
 }
 
 //-------------------------------------------------------------------------

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1514,7 +1514,7 @@ void CodeGen::genConsumeBlockOp(GenTreeBlk* blkNode, regNumber dstReg, regNumber
     // to the REQUIRED register (if a fixed register requirement) in execution order.  This requires,
     // then, that we first consume all the operands, then do any necessary moves.
 
-    GenTree* const dstAddr  = blkNode->Addr();
+    GenTree* const dstAddr = blkNode->Addr();
 
     // First, consume all the sources in order.
     genConsumeReg(dstAddr);

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -800,7 +800,6 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
         new (m_compiler, GT_LEA) GenTreeAddrMode(TYP_REF, addrBaseHigh, nullptr, 0, genTypeSize(TYP_INT));
     GenTree* storeIndHigh = new (m_compiler, GT_STOREIND) GenTreeStoreInd(TYP_INT, addrHigh, dataHigh);
     storeIndHigh->gtFlags = (storeIndLow->gtFlags & (GTF_ALL_EFFECT | GTF_LIVENESS_MASK));
-    storeIndHigh->gtFlags |= GTF_REVERSE_OPS;
 
     m_compiler->lvaIncRefCnts(addrBaseHigh);
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -18340,10 +18340,13 @@ void Compiler::fgSetTreeSeqHelper(GenTreePtr tree, bool isLIR)
 
 void Compiler::fgSetTreeSeqFinish(GenTreePtr tree, bool isLIR)
 {
-    // If we are sequencing a node that does not appear in LIR,
-    // do not add it to the list.
+    // If we are sequencing for LIR:
+    // - Clear the reverse ops flag
+    // - If we are processing a node that does not appear in LIR, do not add it to the list.
     if (isLIR)
     {
+        tree->gtFlags &= ~GTF_REVERSE_OPS;
+
         if ((tree->OperGet() == GT_LIST) || (tree->OperGet() == GT_ARGPLACE) ||
             (tree->OperGet() == GT_FIELD_LIST && !tree->AsFieldList()->IsFieldListHead()))
         {

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1468,6 +1468,11 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
         // Verify that the node is allowed in LIR.
         assert(node->IsLIR());
 
+        // Verify that the REVERSE_OPS flag is not set. NOTE: if we ever decide to reuse the bit assigned to
+        // GTF_REVERSE_OPS for an LIR-only flag we will need to move this check to the points at which we
+        // insert nodes into an LIR range.
+        assert((node->gtFlags & GTF_REVERSE_OPS) == 0);
+
         // TODO: validate catch arg stores
 
         // Check that all phi nodes (if any) occur at the start of the range.

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3762,28 +3762,6 @@ GenTree* Lowering::TryCreateAddrMode(LIR::Use&& use, bool isIndir)
     DISPNODE(addrMode);
     JITDUMP("\n");
 
-    // Required to prevent assert failure:
-    //    Assertion failed 'op1 && op2' in flowgraph.cpp, Line: 34431
-    // when iterating the operands of a GT_LEA
-    // Test Case: self_host_tests_amd64\jit\jit64\opt\cse\VolatileTest_op_mul.exe
-    //    Method: TestCSE:.cctor
-    // The method genCreateAddrMode() above probably should be fixed
-    //    to not return rev=true, when index is returned as NULL
-    //
-    if (rev && index == nullptr)
-    {
-        rev = false;
-    }
-
-    if (rev)
-    {
-        addrMode->gtFlags |= GTF_REVERSE_OPS;
-    }
-    else
-    {
-        addrMode->gtFlags &= ~(GTF_REVERSE_OPS);
-    }
-
     BlockRange().InsertAfter(addr, addrMode);
 
     // Now we need to remove all the nodes subsumed by the addrMode
@@ -4380,7 +4358,6 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     BlockRange().InsertBefore(insertionPoint, leaBase);
 
     GenTreePtr leaNode = new (comp, GT_LEA) GenTreeAddrMode(arrElem->TypeGet(), leaBase, leaIndexNode, scale, offset);
-    leaNode->gtFlags |= GTF_REVERSE_OPS;
 
     BlockRange().InsertBefore(insertionPoint, leaNode);
 

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -1130,11 +1130,7 @@ GenTree* Lowering::PreferredRegOptionalOperand(GenTree* tree)
     }
     else
     {
-        // Neither of the operands is a local, prefer marking
-        // operand that is evaluated first as reg optional
-        // since its use position is less likely to get a register.
-        bool reverseOps = ((tree->gtFlags & GTF_REVERSE_OPS) != 0);
-        preferredOp     = reverseOps ? op2 : op1;
+        preferredOp = op1;
     }
 
     return preferredOp;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -10673,20 +10673,11 @@ void LinearScan::lsraDispNode(GenTreePtr tree, LsraTupleDumpMode mode, bool hasD
     else if (tree->OperIsAssignment())
     {
         assert(!tree->gtHasReg());
-        const char* isRev = "";
-        if ((tree->gtFlags & GTF_REVERSE_OPS) != 0)
-        {
-            isRev = "(Rev)";
-        }
-        printf("  asg%s%s  ", GenTree::NodeName(tree->OperGet()), isRev);
+        printf("  asg%s  ", GenTree::NodeName(tree->OperGet()));
     }
     else
     {
         compiler->gtDispNodeName(tree);
-        if ((tree->gtFlags & GTF_REVERSE_OPS) != 0)
-        {
-            printf("(Rev)");
-        }
         if (tree->OperKind() & GTK_LEAF)
         {
             compiler->gtDispLeaf(tree, nullptr);

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -93,45 +93,10 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             TreeNodeInfoInitStoreLoc(tree->AsLclVarCommon());
             break;
 
-        case GT_BOX:
-            noway_assert(!"box should not exist here");
-            // The result of 'op1' is also the final result
-            info->srcCount = 0;
-            info->dstCount = 0;
-            break;
-
         case GT_PHYSREGDST:
             info->srcCount = 1;
             info->dstCount = 0;
             break;
-
-        case GT_COMMA:
-        {
-            GenTreePtr firstOperand;
-            GenTreePtr secondOperand;
-            if (tree->gtFlags & GTF_REVERSE_OPS)
-            {
-                firstOperand  = tree->gtOp.gtOp2;
-                secondOperand = tree->gtOp.gtOp1;
-            }
-            else
-            {
-                firstOperand  = tree->gtOp.gtOp1;
-                secondOperand = tree->gtOp.gtOp2;
-            }
-            if (firstOperand->TypeGet() != TYP_VOID)
-            {
-                firstOperand->gtLsraInfo.isLocalDefUse = true;
-                firstOperand->gtLsraInfo.dstCount      = 0;
-            }
-            if (tree->TypeGet() == TYP_VOID && secondOperand->TypeGet() != TYP_VOID)
-            {
-                secondOperand->gtLsraInfo.isLocalDefUse = true;
-                secondOperand->gtLsraInfo.dstCount      = 0;
-            }
-        }
-
-            __fallthrough;
 
         case GT_LIST:
         case GT_FIELD_LIST:
@@ -162,6 +127,8 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             }
             break;
 
+        case GT_BOX:
+        case GT_COMMA:
         case GT_QMARK:
         case GT_COLON:
             info->srcCount = 0;

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -171,44 +171,8 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             TreeNodeInfoInitStoreLoc(tree->AsLclVarCommon());
             break;
 
-        case GT_BOX:
-            noway_assert(!"box should not exist here");
-            // The result of 'op1' is also the final result
-            info->srcCount = 0;
-            info->dstCount = 0;
-            break;
-
         case GT_PHYSREGDST:
             info->srcCount = 1;
-            info->dstCount = 0;
-            break;
-
-        case GT_COMMA:
-        {
-            GenTreePtr firstOperand;
-            GenTreePtr secondOperand;
-            if (tree->gtFlags & GTF_REVERSE_OPS)
-            {
-                firstOperand  = tree->gtOp.gtOp2;
-                secondOperand = tree->gtOp.gtOp1;
-            }
-            else
-            {
-                firstOperand  = tree->gtOp.gtOp1;
-                secondOperand = tree->gtOp.gtOp2;
-            }
-            if (firstOperand->TypeGet() != TYP_VOID)
-            {
-                firstOperand->gtLsraInfo.isLocalDefUse = true;
-                firstOperand->gtLsraInfo.dstCount      = 0;
-            }
-            if (tree->TypeGet() == TYP_VOID && secondOperand->TypeGet() != TYP_VOID)
-            {
-                secondOperand->gtLsraInfo.isLocalDefUse = true;
-                secondOperand->gtLsraInfo.dstCount      = 0;
-            }
-        }
-            info->srcCount = 0;
             info->dstCount = 0;
             break;
 
@@ -246,6 +210,8 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 
 #endif // !defined(_TARGET_64BIT_)
 
+        case GT_BOX:
+        case GT_COMMA:
         case GT_QMARK:
         case GT_COLON:
             info->srcCount = 0;

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -577,7 +577,7 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
                     storeOper = GT_STORE_OBJ;
                     break;
                 case GT_DYN_BLK:
-                    storeOper = GT_STORE_DYN_BLK;
+                    storeOper                             = GT_STORE_DYN_BLK;
                     storeBlk->AsDynBlk()->gtEvalSizeFirst = false;
                     break;
                 default:
@@ -587,8 +587,8 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
                     GenTree::NodeName(storeOper));
             storeBlk->SetOperRaw(storeOper);
             storeBlk->gtFlags &= ~GTF_DONT_CSE;
-            storeBlk->gtFlags |= (assignment->gtFlags & (GTF_ALL_EFFECT | GTF_BLK_VOLATILE |
-                                                         GTF_BLK_UNALIGNED | GTF_DONT_CSE));
+            storeBlk->gtFlags |=
+                (assignment->gtFlags & (GTF_ALL_EFFECT | GTF_BLK_VOLATILE | GTF_BLK_UNALIGNED | GTF_DONT_CSE));
             storeBlk->gtBlk.Data() = value;
 
             // Replace the assignment node with the store

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -503,7 +503,7 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
                 {
                     storeBlk = new (comp, GT_STORE_BLK) GenTreeBlk(GT_STORE_BLK, TYP_STRUCT, location, value, size);
                 }
-                storeBlk->gtFlags |= (GTF_REVERSE_OPS | GTF_ASG);
+                storeBlk->gtFlags |= GTF_ASG;
                 storeBlk->gtFlags |= ((location->gtFlags | value->gtFlags) & GTF_ALL_EFFECT);
 
                 GenTree* insertionPoint = location->gtNext;
@@ -539,11 +539,6 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
 
             copyFlags(store, assignment, GTF_ALL_EFFECT);
             copyFlags(store, location, GTF_IND_FLAGS);
-
-            if (assignment->IsReverseOp())
-            {
-                store->gtFlags |= GTF_REVERSE_OPS;
-            }
 
             // TODO: JIT dump
 
@@ -583,6 +578,7 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
                     break;
                 case GT_DYN_BLK:
                     storeOper = GT_STORE_DYN_BLK;
+                    storeBlk->AsDynBlk()->gtEvalSizeFirst = false;
                     break;
                 default:
                     unreached();
@@ -591,7 +587,7 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
                     GenTree::NodeName(storeOper));
             storeBlk->SetOperRaw(storeOper);
             storeBlk->gtFlags &= ~GTF_DONT_CSE;
-            storeBlk->gtFlags |= (assignment->gtFlags & (GTF_ALL_EFFECT | GTF_REVERSE_OPS | GTF_BLK_VOLATILE |
+            storeBlk->gtFlags |= (assignment->gtFlags & (GTF_ALL_EFFECT | GTF_BLK_VOLATILE |
                                                          GTF_BLK_UNALIGNED | GTF_DONT_CSE));
             storeBlk->gtBlk.Data() = value;
 
@@ -683,8 +679,12 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
     for (GenTree* prev = node->gtPrev; prev != nullptr && prev->OperIsAnyList() && !(prev->OperIsFieldListHead());
          prev          = node->gtPrev)
     {
+        prev->gtFlags &= ~GTF_REVERSE_OPS;
         BlockRange().Remove(prev);
     }
+
+    // Now clear the REVERSE_OPS flag on the current node.
+    node->gtFlags &= ~GTF_REVERSE_OPS;
 
     // In addition, remove the current node if it is a GT_LIST node that is not an aggregate.
     if (node->OperIsAnyList())


### PR DESCRIPTION
In HIR, this flag indicates that the second operand to a binary node will execute before
the node's first operand. LIR, however, no longer determines ordering via use edges, so
this flag only affects the order in which operands to a node are considered. The sole
constraint on this use ordering is that for a given node, the same ordering must be used
in liveness, LSRA, and the code generator; this is due to the correspondence between
use ordering and spill/reload/last-use ordering. As a result, the reverse ops flag is
unnecessary and rather unhelpful in LIR, causing little more than a bit of extra complexity
throughout the backend.

This change removes `GTF_REVERSE_OPS` from LIR by clearing this flag during rationalize
and verifying that it remains clear in `LIR::CheckLIR`. We could reuse this bit for an
additional backend-specific purpose in the future with a bit more work in the checker.