### PR TITLE
Fix handling of empty environment variables in PAL

### DIFF
--- a/src/pal/src/misc/environ.cpp
+++ b/src/pal/src/misc/environ.cpp
@@ -218,7 +218,13 @@ GetEnvironmentVariableW(
     }
     else if (size == 0)
     {
-        // handle error in GetEnvironmentVariableA
+        // If size is 0, it either means GetEnvironmentVariableA failed, or that
+        // it succeeded and the value of the variable is empty. Check GetLastError
+        // to determine which. If the call failed, we won't touch the buffer.
+        if (GetLastError() == ERROR_SUCCESS)
+        {
+            *lpBuffer = '\0';
+        }
     }
     else
     {


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/17614

@stephentoub 

BTW, there are still codepaths (such as malloc failure) where 0 can be returned from this function and the error code isn't ENV_VAR_NOT_FOUND. We may want to make GetEnvironmentVariableCore treat anything other than ERROR_SUCCESS as a failure if the return value is 0.