### PR TITLE
Fix issue #8648.

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -3118,9 +3118,10 @@ bool ValueNumStore::IsVNNonZeroIntConstant(ValueNum vn)
         case TYP_LONG:
         case TYP_ULONG:
             return ConstantValue<INT64>(vn) != 0;
-    }
 
-    return false;
+        default:
+            return false;
+    }
 }
 
 unsigned ValueNumStore::GetHandleFlags(ValueNum vn)

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -537,6 +537,9 @@ public:
     // Returns true iff the VN represents an integeral constant.
     bool IsVNInt32Constant(ValueNum vn);
 
+    // Returns true iff the VN represents an integral constant that is not 0.
+    bool IsVNNonZeroIntConstant(ValueNum vn);
+
     struct ArrLenUnsignedBoundInfo
     {
         unsigned cmpOper;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8648/GitHub_8648.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8648/GitHub_8648.cs
@@ -25,12 +25,14 @@ class Program
         return (x * 2) + (p.y * z);
     }
 
-    static void Main()
+    static int Main()
     {
+        bool success = true;
         try
         {
             Case1((sbyte)42);
             Console.WriteLine("Case 1 failed: expected a DivideByZeroException, but none was thrown");
+            success = false;
         }
         catch (DivideByZeroException)
         {
@@ -38,19 +40,24 @@ class Program
         catch (Exception e)
         {
             Console.WriteLine("Case 1 failed: expected a DivideByZeroException, but {0} was thrown instead", e);
+            success = false;
         }
 
         try
         {
             Case2(null, 5, 0);
-            Console.WriteLine("Case 1 failed: expected a NullReferenceException, but none was thrown");
+            Console.WriteLine("Case 2 failed: expected a NullReferenceException, but none was thrown");
+            success = false;
         }
         catch (NullReferenceException)
         {
         }
         catch (Exception e)
         {
-            Console.WriteLine("Case 1 failed: expected a NullReferenceException, but {0} was thrown instead", e);
+            Console.WriteLine("Case 2 failed: expected a NullReferenceException, but {0} was thrown instead", e);
+            success = false;
         }
+
+        return success ? 100 : 0;
     }
 }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8648/GitHub_8648.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8648/GitHub_8648.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// This test is intended to ensure that the JIT properly incorporates divide-by-zero and null-reference exceptions into
+// value numbers. Prior to the fix for GitHub #8648, value numbers for indirect loads and divide/modulus operators did
+// not incorporate these exceptions, which could lead to the optimizer improperly elminiating side effects.
+
+class Program
+{
+    int y;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Case1(sbyte x)
+    {
+        return x % 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static int Case2(Program p, int x, int z)
+    {
+        return (x * 2) + (p.y * z);
+    }
+
+    static void Main()
+    {
+        try
+        {
+            Case1((sbyte)42);
+            Console.WriteLine("Case 1 failed: expected a DivideByZeroException, but none was thrown");
+        }
+        catch (DivideByZeroException)
+        {
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Case 1 failed: expected a DivideByZeroException, but {0} was thrown instead", e);
+        }
+
+        try
+        {
+            Case2(null, 5, 0);
+            Console.WriteLine("Case 1 failed: expected a NullReferenceException, but none was thrown");
+        }
+        catch (NullReferenceException)
+        {
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Case 1 failed: expected a NullReferenceException, but {0} was thrown instead", e);
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_8648/GitHub_8648.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_8648/GitHub_8648.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
This change fixes oversights in the value numbering of indirect loads
and divides. Unless value numbering can prove otherwise (e.g. by observing
that the address for an indirect load is never invalid or the divisor for
a divide is never 0), both of these operators may produce an exception that
must be accounted for in the operator's value number. Before this change,
neither operator was consistently including the appropriate exceptions,
which could lead the optimizer to improperly eliminate side effects (e.g.
in the referenced issue).