### PR TITLE
Fix registry name enumeration

### DIFF
--- a/src/mscorlib/shared/Interop/Windows/Interop.Errors.cs
+++ b/src/mscorlib/shared/Interop/Windows/Interop.Errors.cs
@@ -4,6 +4,7 @@
 
 internal partial class Interop
 {
+    // As defined in winerror.h and https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382.aspx
     internal partial class Errors
     {
         internal const int ERROR_SUCCESS = 0x0;

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -834,13 +834,13 @@ namespace Microsoft.Win32
 
         [DllImport(ADVAPI32, CharSet = CharSet.Auto, BestFitMapping = false)]
         internal unsafe static extern int RegEnumKeyEx(SafeRegistryHandle hKey, int dwIndex,
-                    char* lpName, ref int lpcbName, int[] lpReserved,
+                    char[] lpName, ref int lpcbName, int[] lpReserved,
                     [Out]StringBuilder lpClass, int[] lpcbClass,
                     long[] lpftLastWriteTime);
 
         [DllImport(ADVAPI32, CharSet = CharSet.Auto, BestFitMapping = false)]
         internal unsafe static extern int RegEnumValue(SafeRegistryHandle hKey, int dwIndex,
-                    char* lpValueName, ref int lpcbValueName,
+                    char[] lpValueName, ref int lpcbValueName,
                     IntPtr lpReserved_MustBeZero, int[] lpType, byte[] lpData,
                     int[] lpcbData);
 


### PR DESCRIPTION
Same change as https://github.com/dotnet/corefx/pull/17826, also pulls dead permission checks. I'll be cutting out the rest of the unused SPCL reg code after this goes in. From the original change:

Key data (values and subkeys) can change while we're in the midst of enumerating. This is causing intermittent failures in tests as ERROR_NO_MORE_ITEMS surfaces as an exception as we try and iterate past removed data.

In addition, allocating 32K to get value names causes 32K * number of items to get natively allocated on the heap. While these allocs are returned on each iteration it could potentially cause significant grief for large keys and concurrent heap allocations. Above and beyond this, allocating 64K for what are typically < 20 character names is a bit crazy, and as such we'll optimize for the common case.