### PR TITLE
[x86/Linux] 16-byte aligned HelperMethodFrameRestoreState

### DIFF
--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -366,8 +366,9 @@ LEAF_ENTRY HelperMethodFrameRestoreState, _TEXT
     PROLOG_BEG
     PROLOG_END
 
-    // Call HelperMethodFrameConfirmState
-    sub         esp, 4
+    // Call HelperMethodFrameConfirmState (with stack alignment padding)
+    #define STACK_ALIGN_PADDING 4
+    sub         esp, STACK_ALIGN_PADDING
     push        eax     // eax = ebp
     push        ebx
     push        edi
@@ -375,7 +376,8 @@ LEAF_ENTRY HelperMethodFrameRestoreState, _TEXT
     push        ecx     // HelperFrame*
     CHECK_STACK_ALIGNMENT
     call        C_FUNC(HelperMethodFrameConfirmState)
-    add         esp, 4
+    add         esp, STACK_ALIGN_PADDING
+    #undef STACK_ALIGN_PADDING
 
     // Restore EBP
     EPILOG_BEG

--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -359,12 +359,28 @@ LEAF_ENTRY HelperMethodFrameRestoreState, _TEXT
 
 #ifdef _DEBUG
     jnz         LOCAL_LABEL(noConfirm)
-    push        ebp
+
+    mov         eax, ebp
+
+    // Create a minimal EBP-frame (for clean stack trace under debugger)
+    PROLOG_BEG
+    PROLOG_END
+
+    // Call HelperMethodFrameConfirmState
+    sub         esp, 4
+    push        eax     // eax = ebp
     push        ebx
     push        edi
     push        esi
     push        ecx     // HelperFrame*
+    CHECK_STACK_ALIGNMENT
     call        C_FUNC(HelperMethodFrameConfirmState)
+    add         esp, 4
+
+    // Restore EBP
+    EPILOG_BEG
+    EPILOG_END
+
     // on return, eax = MachState*
     cmp         DWORD PTR [eax + MachState__pRetAddr], 0
 LOCAL_LABEL(noConfirm):


### PR DESCRIPTION
This commit revises HelperMethodFrameRestoreState to emit 16-byte aligned frame before invoking HelperMethodFrameConfirmState.