### PR TITLE
[RyuJIT/ARM32] Implement for GT_STORE_OBJ

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -880,7 +880,7 @@ void CodeGen::genCodeForCpObj(GenTreeObj* cpObjNode)
     gcInfo.gcMarkRegPtrVal(REG_WRITE_BARRIER_DST_BYREF, dstAddr->TypeGet());
 
     // Temp register used to perform the sequence of loads and stores.
-    regNumber tmpReg = cpObjNode->GetSingleTempReg();
+    regNumber tmpReg = cpObjNode->ExtractTempReg();
     assert(genIsValidIntReg(tmpReg));
 
     unsigned slots = cpObjNode->gtSlots;

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -820,6 +820,124 @@ void CodeGen::genCodeForNegNot(GenTree* tree)
     genProduceReg(tree);
 }
 
+// Generate code for CpObj nodes wich copy structs that have interleaved
+// GC pointers.
+// For this case we'll generate a sequence of loads/stores in the case of struct
+// slots that don't contain GC pointers.  The generated code will look like:
+// ldr tempReg, [R13, #8]
+// str tempReg, [R14, #8]
+//
+// In the case of a GC-Pointer we'll call the ByRef write barrier helper
+// who happens to use the same registers as the previous call to maintain
+// the same register requirements and register killsets:
+// bl CORINFO_HELP_ASSIGN_BYREF
+//
+// So finally an example would look like this:
+// ldr tempReg, [R13, #8]
+// str tempReg, [R14, #8]
+// bl CORINFO_HELP_ASSIGN_BYREF
+// ldr tempReg, [R13, #8]
+// str tempReg, [R14, #8]
+// bl CORINFO_HELP_ASSIGN_BYREF
+// ldr tempReg, [R13, #8]
+// str tempReg, [R14, #8]
+void CodeGen::genCodeForCpObj(GenTreeObj* cpObjNode)
+{
+    GenTreePtr dstAddr       = cpObjNode->Addr();
+    GenTreePtr source        = cpObjNode->Data();
+    var_types  srcAddrType   = TYP_BYREF;
+    bool       sourceIsLocal = false;
+    regNumber  dstReg        = REG_NA;
+    regNumber  srcReg        = REG_NA;
+
+    assert(source->isContained());
+    if (source->gtOper == GT_IND)
+    {
+        GenTree* srcAddr = source->gtGetOp1();
+        assert(!srcAddr->isContained());
+        srcAddrType = srcAddr->TypeGet();
+    }
+    else
+    {
+        noway_assert(source->IsLocal());
+        sourceIsLocal = true;
+    }
+
+    bool dstOnStack = dstAddr->OperIsLocalAddr();
+
+#ifdef DEBUG
+    assert(!dstAddr->isContained());
+
+    // This GenTree node has data about GC pointers, this means we're dealing
+    // with CpObj.
+    assert(cpObjNode->gtGcPtrCount > 0);
+#endif // DEBUG
+
+    // Consume the operands and get them into the right registers.
+    // They may now contain gc pointers (depending on their type; gcMarkRegPtrVal will "do the right thing").
+    genConsumeBlockOp(cpObjNode, REG_WRITE_BARRIER_DST_BYREF, REG_WRITE_BARRIER_SRC_BYREF, REG_NA);
+    gcInfo.gcMarkRegPtrVal(REG_WRITE_BARRIER_SRC_BYREF, srcAddrType);
+    gcInfo.gcMarkRegPtrVal(REG_WRITE_BARRIER_DST_BYREF, dstAddr->TypeGet());
+
+    // Temp register used to perform the sequence of loads and stores.
+    regNumber tmpReg = cpObjNode->GetSingleTempReg();
+    assert(genIsValidIntReg(tmpReg));
+
+    unsigned slots = cpObjNode->gtSlots;
+    emitter* emit  = getEmitter();
+
+    BYTE* gcPtrs = cpObjNode->gtGcPtrs;
+
+    // If we can prove it's on the stack we don't need to use the write barrier.
+    emitAttr attr = EA_PTRSIZE;
+    if (dstOnStack)
+    {
+        for (unsigned i = 0; i < slots; ++i)
+        {
+            if (gcPtrs[i] == GCT_GCREF)
+                attr = EA_GCREF;
+            else if (gcPtrs[i] == GCT_BYREF)
+                attr = EA_BYREF;
+            emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE,
+                                INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
+            emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE,
+                                INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
+        }
+    }
+    else
+    {
+        unsigned gcPtrCount = cpObjNode->gtGcPtrCount;
+
+        unsigned i = 0;
+        while (i < slots)
+        {
+            switch (gcPtrs[i])
+            {
+                case TYPE_GC_NONE:
+                    emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE,
+                                        INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
+                    emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE,
+                                        INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
+                    break;
+
+                default:
+                    // In the case of a GC-Pointer we'll call the ByRef write barrier helper
+                    genEmitHelperCall(CORINFO_HELP_ASSIGN_BYREF, 0, EA_PTRSIZE);
+
+                    gcPtrCount--;
+                    break;
+            }
+            ++i;
+        }
+        assert(gcPtrCount == 0);
+    }
+
+    // Clear the gcInfo for registers of source and dest.
+    // While we normally update GC info prior to the last instruction that uses them,
+    // these actually live into the helper call.
+    gcInfo.gcMarkRegSetNpt(RBM_WRITE_BARRIER_SRC_BYREF | RBM_WRITE_BARRIER_DST_BYREF);
+}
+
 //------------------------------------------------------------------------
 // genCodeForShiftLong: Generates the code sequence for a GenTree node that
 // represents a three operand bit shift or rotate operation (<<Hi, >>Lo).

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2328,18 +2328,12 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
 {
     assert(blkOp->OperIs(GT_STORE_OBJ, GT_STORE_DYN_BLK, GT_STORE_BLK));
 
-#ifdef _TARGET_ARM_
-    NYI_IF(blkOp->OperIs(GT_STORE_OBJ), "GT_STORE_OBJ");
-#endif // _TARGET_ARM_
-
-#ifndef _TARGET_ARM_ // NYI for ARM
     if (blkOp->OperIs(GT_STORE_OBJ) && blkOp->OperIsCopyBlkOp())
     {
         assert(blkOp->AsObj()->gtGcPtrCount != 0);
         genCodeForCpObj(blkOp->AsObj());
         return;
     }
-#endif // !_TARGET_ARM_
 
     if (blkOp->gtBlkOpGcUnsafe)
     {

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1349,8 +1349,10 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
             {
                 case TYPE_GC_NONE:
 #if defined(_TARGET_ARM_)
-                    emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE);
-                    emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE);
+                    emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE,
+                                        INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
+                    emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE,
+                                        INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
 #elif defined(_TARGET_ARM64_)
                     // TODO-ARM64-CQ: Consider using LDP/STP to save codesize in case of contigous NON-GC slots.
                     emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE,

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1339,52 +1339,6 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
     genConsumeAddress(tree->Addr());
     emit->emitInsLoadStoreOp(ins_Load(targetType), emitTypeSize(tree), targetReg, tree);
     genProduceReg(tree);
-        unsigned gcPtrCount = cpObjNode->gtGcPtrCount;
-
-        unsigned i = 0;
-        while (i < slots)
-        {
-            switch (gcPtrs[i])
-            {
-                case TYPE_GC_NONE:
-#if defined(_TARGET_ARM_)
-                    emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE,
-                                        INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
-                    emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE,
-                                        INS_FLAGS_DONT_CARE, INS_OPTS_LDST_POST_INC);
-#elif defined(_TARGET_ARM64_)
-                    // TODO-ARM64-CQ: Consider using LDP/STP to save codesize in case of contigous NON-GC slots.
-                    emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE,
-                                        INS_OPTS_POST_INDEX);
-                    emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE,
-                                        INS_OPTS_POST_INDEX);
-#endif
-                    break;
-
-                default:
-                    // In the case of a GC-Pointer we'll call the ByRef write barrier helper
-                    genEmitHelperCall(CORINFO_HELP_ASSIGN_BYREF, 0, EA_PTRSIZE);
-
-                    gcPtrCount--;
-                    break;
-            }
-            ++i;
-        }
-        assert(gcPtrCount == 0);
-    }
-
-    // Clear the gcInfo for registers of source and dest.
-    // While we normally update GC info prior to the last instruction that uses them,
-    // these actually live into the helper call.
-    regMaskTP sourceRegMask, destRegMask;
-#if defined(_TARGET_ARM_)
-    destRegMask   = RBM_ARG_0;
-    sourceRegMask = RBM_ARG_1;
-#elif defined(_TARGET_ARM64_)
-    destRegMask   = RBM_WRITE_BARRIER_DST_BYREF;
-    sourceRegMask = RBM_WRITE_BARRIER_SRC_BYREF;
-#endif
-    gcInfo.gcMarkRegSetNpt(sourceRegMask | destRegMask);
 }
 
 // Generate code for a CpBlk node by the means of the VM memcpy helper call

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1216,7 +1216,6 @@ void CodeGen::genCodeForShift(GenTreePtr tree)
     genProduceReg(tree);
 }
 
-<<<<<<< e4d54d57f74f79a668794f444476c7f7180d443a
 //------------------------------------------------------------------------
 // genCodeForCast: Generates the code for GT_CAST.
 //

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1348,13 +1348,15 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
             switch (gcPtrs[i])
             {
                 case TYPE_GC_NONE:
-// TODO-ARM64-CQ: Consider using LDP/STP to save codesize in case of contigous NON-GC slots.
 #if defined(_TARGET_ARM_)
-                    emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, srcReg, TARGET_POINTER_SIZE);
-                    emit->emitIns_R_R_I(INS_str, attr, tmpReg, dstReg, TARGET_POINTER_SIZE);
+                    emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE);
+                    emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE);
 #elif defined(_TARGET_ARM64_)
-                    emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, srcReg, TARGET_POINTER_SIZE, INS_OPTS_POST_INDEX);
-                    emit->emitIns_R_R_I(INS_str, attr, tmpReg, dstReg, TARGET_POINTER_SIZE, INS_OPTS_POST_INDEX);
+                    // TODO-ARM64-CQ: Consider using LDP/STP to save codesize in case of contigous NON-GC slots.
+                    emit->emitIns_R_R_I(INS_ldr, attr, tmpReg, REG_WRITE_BARRIER_SRC_BYREF, TARGET_POINTER_SIZE,
+                                        INS_OPTS_POST_INDEX);
+                    emit->emitIns_R_R_I(INS_str, attr, tmpReg, REG_WRITE_BARRIER_DST_BYREF, TARGET_POINTER_SIZE,
+                                        INS_OPTS_POST_INDEX);
 #endif
                     break;
 
@@ -1382,7 +1384,6 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
     sourceRegMask = RBM_WRITE_BARRIER_SRC_BYREF;
 #endif
     gcInfo.gcMarkRegSetNpt(sourceRegMask | destRegMask);
->>>>>>> Implement CodeGen::genCodeForCpObj
 }
 
 // Generate code for a CpBlk node by the means of the VM memcpy helper call

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -175,11 +175,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         if (blkNode->OperGet() == GT_STORE_OBJ)
         {
             // CopyObj
-
-            NYI_ARM("Lowering for GT_STORE_OBJ isn't implemented");
-
-#ifdef _TARGET_ARM64_
-
             GenTreeObj* objNode = blkNode->AsObj();
 
             unsigned slots = objNode->gtSlots;
@@ -205,8 +200,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
 #endif
 
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
-
-#endif // _TARGET_ARM64_
         }
         else
         {

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -788,7 +788,20 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
             // a temporary register to perform the sequence of loads and stores.
             blkNode->gtLsraInfo.internalIntCount = 1;
 
+            if (size >= 2 * REGSIZE_BYTES)
+            {
+                // We will use ldp/stp to reduce code size and improve performance
+                // so we need to reserve an extra internal register
+                blkNode->gtLsraInfo.internalIntCount++;
+            }
+
+            // We can't use the special Write Barrier registers, so exclude them from the mask
+            regMaskTP internalIntCandidates = RBM_ALLINT & ~(RBM_WRITE_BARRIER_DST_BYREF | RBM_WRITE_BARRIER_SRC_BYREF);
+            blkNode->gtLsraInfo.setInternalCandidates(l, internalIntCandidates);
+
+            // If we have a dest address we want it in RBM_WRITE_BARRIER_DST_BYREF.
             dstAddr->gtLsraInfo.setSrcCandidates(l, RBM_WRITE_BARRIER_DST_BYREF);
+
             // If we have a source address we want it in REG_WRITE_BARRIER_SRC_BYREF.
             // Otherwise, if it is a local, codegen will put its address in REG_WRITE_BARRIER_SRC_BYREF,
             // which is killed by a StoreObj (and thus needn't be reserved).

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -788,22 +788,13 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
             // a temporary register to perform the sequence of loads and stores.
             blkNode->gtLsraInfo.internalIntCount = 1;
 
-            regMaskTP dstAddrRegMask, sourceRegMask;
-#if defined(_TARGET_ARM_)
-            dstAddrRegMask = RBM_ARG_0;
-            sourceRegMask  = RBM_ARG_1;
-#elif defined(_TARGET_ARM64_)
-            dstAddrRegMask = RBM_WRITE_BARRIER_DST_BYREF;
+            dstAddr->gtLsraInfo.setSrcCandidates(l, RBM_WRITE_BARRIER_DST_BYREF);
             // If we have a source address we want it in REG_WRITE_BARRIER_SRC_BYREF.
             // Otherwise, if it is a local, codegen will put its address in REG_WRITE_BARRIER_SRC_BYREF,
             // which is killed by a StoreObj (and thus needn't be reserved).
-            sourceRegMask = RBM_WRITE_BARRIER_SRC_BYREF;
-#endif // _TARGET_ARM64_*
-            dstAddr->gtLsraInfo.setSrcCandidates(l, dstAddrRegMask);
-
             if (srcAddrOrFill != nullptr)
             {
-                srcAddrOrFill->gtLsraInfo.setSrcCandidates(l, sourceRegMask);
+                srcAddrOrFill->gtLsraInfo.setSrcCandidates(l, RBM_WRITE_BARRIER_SRC_BYREF);
             }
         }
         else

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -784,37 +784,27 @@ void Lowering::TreeNodeInfoInitBlockStore(GenTreeBlk* blkNode)
         if (blkNode->OperGet() == GT_STORE_OBJ)
         {
             // CopyObj
-            NYI_ARM("GT_STORE_OBJ is needed of write barriers implementation");
-
-#ifdef _TARGET_ARM64_
-
             // We don't need to materialize the struct size but we still need
             // a temporary register to perform the sequence of loads and stores.
             blkNode->gtLsraInfo.internalIntCount = 1;
 
-            if (size >= 2 * REGSIZE_BYTES)
-            {
-                // We will use ldp/stp to reduce code size and improve performance
-                // so we need to reserve an extra internal register
-                blkNode->gtLsraInfo.internalIntCount++;
-            }
-
-            // We can't use the special Write Barrier registers, so exclude them from the mask
-            regMaskTP internalIntCandidates = RBM_ALLINT & ~(RBM_WRITE_BARRIER_DST_BYREF | RBM_WRITE_BARRIER_SRC_BYREF);
-            blkNode->gtLsraInfo.setInternalCandidates(l, internalIntCandidates);
-
-            // If we have a dest address we want it in RBM_WRITE_BARRIER_DST_BYREF.
-            dstAddr->gtLsraInfo.setSrcCandidates(l, RBM_WRITE_BARRIER_DST_BYREF);
-
+            regMaskTP dstAddrRegMask, sourceRegMask;
+#if defined(_TARGET_ARM_)
+            dstAddrRegMask = RBM_ARG_0;
+            sourceRegMask  = RBM_ARG_1;
+#elif defined(_TARGET_ARM64_)
+            dstAddrRegMask = RBM_WRITE_BARRIER_DST_BYREF;
             // If we have a source address we want it in REG_WRITE_BARRIER_SRC_BYREF.
             // Otherwise, if it is a local, codegen will put its address in REG_WRITE_BARRIER_SRC_BYREF,
             // which is killed by a StoreObj (and thus needn't be reserved).
+            sourceRegMask = RBM_WRITE_BARRIER_SRC_BYREF;
+#endif // _TARGET_ARM64_*
+            dstAddr->gtLsraInfo.setSrcCandidates(l, dstAddrRegMask);
+
             if (srcAddrOrFill != nullptr)
             {
-                srcAddrOrFill->gtLsraInfo.setSrcCandidates(l, RBM_WRITE_BARRIER_SRC_BYREF);
+                srcAddrOrFill->gtLsraInfo.setSrcCandidates(l, sourceRegMask);
             }
-
-#endif // _TARGET_ARM64_
         }
         else
         {

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1357,6 +1357,13 @@ typedef unsigned short regPairNoSmall; // arm: need 12 bits
   #define RBM_WRITE_BARRIER        RBM_R1
 #endif
 
+  //In the ARM case, registers of write barrier use the normal argument registers.
+  #define REG_WRITE_BARRIER_SRC_BYREF    REG_ARG_1
+  #define RBM_WRITE_BARRIER_SRC_BYREF    RBM_ARG_1
+
+  #define REG_WRITE_BARRIER_DST_BYREF    REG_ARG_0
+  #define RBM_WRITE_BARRIER_DST_BYREF    RBM_ARG_0
+
   // GenericPInvokeCalliHelper VASigCookie Parameter 
   #define REG_PINVOKE_COOKIE_PARAM          REG_R4
   #define RBM_PINVOKE_COOKIE_PARAM          RBM_R4


### PR DESCRIPTION
In #10657, I commented that the messages for NYI were printed about GT_STORE_OBJ on running the CodeGenBringUpTests.

'Lowering::LowerBlockStore(GenTreeBlk* blkNode)' method implementation is just copied.
but after lowering phase, in code generation, codegenarm.cpp, below would be run.

- genCodeForCpBlk
- genCodeForInitBlk
- genCodeForCpBlkUnroll
- genCodeForInitBlkUnroll

'genCodeForCpBlk' and 'genCodeForInitBlk' are implemented in ARM/ARM64 by MEMCPY/MEMSET
but 'genCodeForCpBlkUnroll' and 'genCodeForInitBlkUnroll' are not implemented both ARM and ARM64.

Therefore those need to implement.

Related main issue : #8496