### PR TITLE
Use the correct type for interlocked instructions

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -3826,6 +3826,7 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
     regNumber   targetReg = treeNode->gtRegNum;
     regNumber   dataReg   = data->gtRegNum;
     regNumber   addrReg   = addr->gtRegNum;
+    var_types   type      = genActualType(data->TypeGet());
     instruction ins;
 
     // The register allocator should have extended the lifetime of the address
@@ -3840,7 +3841,7 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
     genConsumeOperands(treeNode);
     if (targetReg != REG_NA && dataReg != REG_NA && dataReg != targetReg)
     {
-        inst_RV_RV(ins_Copy(data->TypeGet()), targetReg, dataReg);
+        inst_RV_RV(ins_Copy(type), targetReg, dataReg);
         data->gtRegNum = targetReg;
 
         // TODO-XArch-Cleanup: Consider whether it is worth it, for debugging purposes, to restore the
@@ -3866,8 +3867,8 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
 
     // all of these nodes implicitly do an indirection on op1
     // so create a temporary node to feed into the pattern matching
-    GenTreeIndir i = indirForm(data->TypeGet(), addr);
-    getEmitter()->emitInsBinary(ins, emitTypeSize(data), &i, data);
+    GenTreeIndir i = indirForm(type, addr);
+    getEmitter()->emitInsBinary(ins, emitTypeSize(type), &i, data);
 
     if (treeNode->gtRegNum != REG_NA)
     {

--- a/tests/src/JIT/Regression/JitBlue/GitHub_10714/GitHub_10714.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_10714/GitHub_10714.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+class GitHub_10714
+{
+    const int Passed = 100;
+    const int Failed = 0;
+    
+    static int intToExchange = -1;
+    static short innerShort = 2;
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test() => Interlocked.Exchange(ref intToExchange, innerShort);
+
+    static int Main()
+    {
+        int oldValue = Test();
+        return (oldValue == -1 && intToExchange == 2) ? Passed : Failed;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_10714/GitHub_10714.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_10714/GitHub_10714.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DADEC17C-DA8A-4F7D-9927-47A9033A2E80}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
The interlocked operation type can, at least in theory, be `TYP_VOID` in the case of `GT_LOCKADD`. The first operand type is not relevant because it's the address of the memory location and not an indir.

The only option is to use the type of the second operand but that may be a small int type so `genActualType` needs to be used to get the correct type.

Fixes #10714