### PR TITLE
remove fedora 23

### DIFF
--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -47,7 +47,7 @@ ellismg@linux:~$ sudo apt-get install cmake llvm-3.5 clang-3.5 lldb-3.6 lldb-3.6
 
 You now have all the required components.
 
-If you are using Fedora 23 or 24, then you will need to install the following packages:
+If you are using Fedora, then you will need to install the following packages:
 
 `$ sudo dnf install llvm cmake clang lldb-devel libunwind-devel lttng-ust-devel libuuid-devel libicu-devel`
 
@@ -61,7 +61,7 @@ Set the maximum number of file-handles
 
 To ensure that your system can allocate enough file-handles for the corefx build run `sysctl fs.file-max`. If it is less than 100000, add `fs.file-max = 100000` to `/etc/sysctl.conf`, and then run `sudo sysctl -p`.
 
-On Fedora 23 or 24:
+On Fedora:
 
 `$ sudo dnf install mono-devel`
 

--- a/build-test.cmd
+++ b/build-test.cmd
@@ -392,8 +392,8 @@ echo buildagainstpackages: builds tests against restored packages, instead of ag
 echo runtimeid ^<ID^>: Builds a test overlay for the specified OS (Only supported when building against packages). Supported IDs are:
 echo     alpine.3.4.3-x64: Builds overlay for Alpine 3.4.3
 echo     debian.8-x64: Builds overlay for Debian 8
-echo     fedora.23-x64: Builds overlay for Fedora 23
-echo     fedora.24-x64: Builds overlay for Fedora 23
+echo     fedora.24-x64: Builds overlay for Fedora 24
+echo     fedora.25-x64: Builds overlay for Fedora 25
 echo     opensuse.42.1-x64: Builds overlay for OpenSUSE 42.1
 echo     osx.10.12-x64: Builds overlay for OSX 10.12
 echo     rhel.7-x64: Builds overlay for RHEL 7 or CentOS

--- a/build.sh
+++ b/build.sh
@@ -334,10 +334,10 @@ isMSBuildOnNETCoreSupported()
                 "debian.8-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
-                "fedora.23-x64")
+                "fedora.24-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
-                "fedora.24-x64")
+                "fedora.25-x64")
                     __isMSBuildOnNETCoreSupported=1
                     ;;
                 "opensuse.42.1-x64")

--- a/config.json
+++ b/config.json
@@ -327,7 +327,7 @@
     "RuntimeId": {
       "description": "Specifies the OS to build Core_Root for",
       "valueType": "property",
-      "values": [ "debian.8-x64", "fedora.23-x64", "opensuse.42.1-x64", "osx.10.12-x64", "rhel.7-x64", "ubuntu.14.04-x64", "ubuntu.16.04-x64", "ubuntu.16.10-x64" ],
+      "values": [ "debian.8-x64", "fedora.24-x64", "fedora.25-x64", "opensuse.42.1-x64", "osx.10.12-x64", "rhel.7-x64", "ubuntu.14.04-x64", "ubuntu.16.04-x64", "ubuntu.16.10-x64" ],
       "defaultValue": "${__RuntimeId}"
     },
     "UpdateDependencies": {

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -44,11 +44,11 @@ get_current_linux_name() {
         return 0
     elif [ "$(cat /etc/os-release | grep -cim1 fedora)" -eq 1 ]; then
         if [ "$(cat /etc/os-release | grep -cim1 23)" -eq 1 ]; then
-            echo "fedora.23"
+            echo "fedora.24"
             return 0
         fi
         if [ "$(cat /etc/os-release | grep -cim1 24)" -eq 1 ]; then
-            echo "fedora.24"
+            echo "fedora.25"
             return 0
         fi
     elif [ "$(cat /etc/os-release | grep -cim1 opensuse)" -eq 1 ]; then

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -43,11 +43,11 @@ get_current_linux_name() {
         echo "alpine"
         return 0
     elif [ "$(cat /etc/os-release | grep -cim1 fedora)" -eq 1 ]; then
-        if [ "$(cat /etc/os-release | grep -cim1 23)" -eq 1 ]; then
+        if [ "$(cat /etc/os-release | grep -cim1 24)" -eq 1 ]; then
             echo "fedora.24"
             return 0
         fi
-        if [ "$(cat /etc/os-release | grep -cim1 24)" -eq 1 ]; then
+        if [ "$(cat /etc/os-release | grep -cim1 25)" -eq 1 ]; then
             echo "fedora.25"
             return 0
         fi

--- a/tests/src/Common/build_against_pkg_dependencies/project.json
+++ b/tests/src/Common/build_against_pkg_dependencies/project.json
@@ -25,7 +25,7 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
+    "fedora.24-x64": {},   
     "opensuse.42.1-x64": {},
     "linux-x64": {}
   }

--- a/tests/src/Common/empty/project.json
+++ b/tests/src/Common/empty/project.json
@@ -14,6 +14,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {}
+    "fedora.24-x64": {}
   }
 }

--- a/tests/src/Common/targeting_pack_ref/project.json
+++ b/tests/src/Common/targeting_pack_ref/project.json
@@ -20,6 +20,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {}
+    "fedora.24-x64": {}
   }
 }

--- a/tests/src/Common/test_dependencies/project.json
+++ b/tests/src/Common/test_dependencies/project.json
@@ -24,7 +24,7 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "linux-x64": {}
   }
 }

--- a/tests/src/Common/test_runtime/project.json
+++ b/tests/src/Common/test_runtime/project.json
@@ -24,6 +24,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {}
+    "fedora.24-x64": {}
   }
 }

--- a/tests/src/TestWrappersConfig/project.json
+++ b/tests/src/TestWrappersConfig/project.json
@@ -27,6 +27,6 @@
     "centos.7-x64": {},
     "rhel.7-x64": {},
     "debian.8-x64": {},
-    "fedora.23-x64": {}
+    "fedora.24-x64": {}
   }
 }


### PR DESCRIPTION
Remove more Fedora 23.
@wtgodbe @gkhanna79 

I added 25 to places where it had no runtime significance, but not elsewhere since I'm  not sure of the status of builds of it.

contributes to https://github.com/dotnet/coreclr/pull/10719