### PR TITLE
[ARM/CI] Update image for armel Tizen CI

### DIFF
--- a/cross/armel/tizen/tizen-dotnet.ks
+++ b/cross/armel/tizen/tizen-dotnet.ks
@@ -4,8 +4,8 @@ timezone --utc Asia/Seoul
 
 part / --fstype="ext4" --size=3500 --ondisk=mmcblk0 --label rootfs --fsoptions=defaults,noatime
 
-repo --name=mobile  --baseurl=http://download.tizen.org/snapshots/tizen/mobile/latest/repos/arm-wayland/packages/ --ssl_verify=no
-repo --name=base    --baseurl=http://download.tizen.org/snapshots/tizen/base/latest/repos/arm/packages/           --ssl_verify=no
+repo --name=mobile  --baseurl=http://download.tizen.org/releases/weekly/tizen/mobile/latest/repos/arm-wayland/packages/ --ssl_verify=no
+repo --name=base    --baseurl=http://download.tizen.org/releases/weekly/tizen/base/latest/repos/arm/packages/           --ssl_verify=no
 
 %packages
 tar


### PR DESCRIPTION
Make use of same rootfs for building CoreCLR and running unit test for Tizen armel cross.

FYI. rootfs for building is from https://github.com/dotnet/coreclr/blob/master/cross/armel/tizen-fetch.sh#L54