### PR TITLE
gtLdftnResolvedToken is no longer necessary

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -7222,7 +7222,6 @@ GenTreePtr Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
 
             call = gtNewHelperCallNode(CORINFO_HELP_READYTORUN_DELEGATE_CTOR, TYP_VOID, GTF_EXCEPT, helperArgs);
 
-            assert(ldftnToken == targetMethod->gtFptrVal.gtLdftnResolvedToken);
             CORINFO_LOOKUP entryPoint;
             info.compCompHnd->getReadyToRunDelegateCtorHelper(ldftnToken, clsHnd, &entryPoint);
             assert(!entryPoint.lookupKind.needsRuntimeLookup);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7900,8 +7900,7 @@ GenTreePtr Compiler::gtCloneExpr(
                 copy = new (this, oper) GenTreeFptrVal(tree->gtType, tree->gtFptrVal.gtFptrMethod);
 
 #ifdef FEATURE_READYTORUN_COMPILER
-                copy->gtFptrVal.gtEntryPoint         = tree->gtFptrVal.gtEntryPoint;
-                copy->gtFptrVal.gtLdftnResolvedToken = tree->gtFptrVal.gtLdftnResolvedToken;
+                copy->gtFptrVal.gtEntryPoint = tree->gtFptrVal.gtEntryPoint;
 #endif
                 goto DONE;
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3715,8 +3715,7 @@ struct GenTreeFptrVal : public GenTree
     CORINFO_METHOD_HANDLE gtFptrMethod;
 
 #ifdef FEATURE_READYTORUN_COMPILER
-    CORINFO_CONST_LOOKUP    gtEntryPoint;
-    CORINFO_RESOLVED_TOKEN* gtLdftnResolvedToken;
+    CORINFO_CONST_LOOKUP gtEntryPoint;
 #endif
 
     GenTreeFptrVal(var_types type, CORINFO_METHOD_HANDLE meth) : GenTree(GT_FTN_ADDR, type), gtFptrMethod(meth)

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1881,9 +1881,7 @@ GenTreePtr Compiler::impMethodPointer(CORINFO_RESOLVED_TOKEN* pResolvedToken, CO
 #ifdef FEATURE_READYTORUN_COMPILER
             if (opts.IsReadyToRun())
             {
-                op1->gtFptrVal.gtEntryPoint          = pCallInfo->codePointerLookup.constLookup;
-                op1->gtFptrVal.gtLdftnResolvedToken  = new (this, CMK_Unknown) CORINFO_RESOLVED_TOKEN;
-                *op1->gtFptrVal.gtLdftnResolvedToken = *pResolvedToken;
+                op1->gtFptrVal.gtEntryPoint = pCallInfo->codePointerLookup.constLookup;
             }
             else
             {


### PR DESCRIPTION
Because token is saved on the stack.

The was an error in the assert because I checked pointers that were obviously different.
The actual values could not be different because they are created from
the same token in the same place 
```
importer.cpp DO_LDFTN:
impMethodPointer 
```
saved resolvedToken as gtLdftnResolvedToken ,
```
CORINFO_RESOLVED_TOKEN* heapToken = impAllocateToken(resolvedToken);
impPushOnStack(op1, typeInfo(heapToken)); 
```
the next line saved the token on the stack.