### PR TITLE
Make Encoding.Default return UTF8 without BOM emission

### DIFF
--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -1230,7 +1230,7 @@ namespace System.Text
 
             Encoding enc;
 
-            // For silverlight and netcore we use UTF8 since ANSI isn't available
+            // For netcore we use UTF8 since ANSI isn't available
             enc = UTF8Encoding.s_defaultNoBOM;
 
             // This method should only ever return one Encoding instance

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -1231,7 +1231,7 @@ namespace System.Text
             Encoding enc;
 
             // For netcore we use UTF8 since ANSI isn't available
-            enc = UTF8Encoding.s_defaultNoBOM;
+            enc = new UTF8Encoding.UTF8EncodingSealed(encoderShouldEmitUTF8Identifier: false);
 
             // This method should only ever return one Encoding instance
             return Interlocked.CompareExchange(ref defaultEncoding, enc, null) ?? enc;

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -1230,10 +1230,8 @@ namespace System.Text
 
             Encoding enc;
 
-
-            // For silverlight we use UTF8 since ANSI isn't available
-            enc = UTF8;
-
+            // For silverlight and netcore we use UTF8 since ANSI isn't available
+            enc = UTF8Encoding.s_defaultNoBOM;
 
             // This method should only ever return one Encoding instance
             return Interlocked.CompareExchange(ref defaultEncoding, enc, null) ?? enc;

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -58,11 +58,13 @@ namespace System.Text
         internal sealed class UTF8EncodingSealed : UTF8Encoding
         {
             public UTF8EncodingSealed() : base(encoderShouldEmitUTF8Identifier: true) { }
+            public UTF8EncodingSealed(bool encoderShouldEmitUTF8Identifier) : base(encoderShouldEmitUTF8Identifier) { }
         }
 
         // Used by Encoding.UTF8 for lazy initialization
         // The initialization code will not be run until a static member of the class is referenced
         internal static readonly UTF8EncodingSealed s_default = new UTF8EncodingSealed();
+        internal static readonly UTF8EncodingSealed s_defaultNoBOM = new UTF8EncodingSealed(encoderShouldEmitUTF8Identifier: false);
 
         // Yes, the idea of emitting U+FEFF as a UTF-8 identifier has made it into
         // the standard.

--- a/src/mscorlib/src/System/Text/UTF8Encoding.cs
+++ b/src/mscorlib/src/System/Text/UTF8Encoding.cs
@@ -64,7 +64,6 @@ namespace System.Text
         // Used by Encoding.UTF8 for lazy initialization
         // The initialization code will not be run until a static member of the class is referenced
         internal static readonly UTF8EncodingSealed s_default = new UTF8EncodingSealed();
-        internal static readonly UTF8EncodingSealed s_defaultNoBOM = new UTF8EncodingSealed(encoderShouldEmitUTF8Identifier: false);
 
         // Yes, the idea of emitting U+FEFF as a UTF-8 identifier has made it into
         // the standard.


### PR DESCRIPTION
Fixes #10643

Encoding.Default today is returning UTF8 but with BOM emission enabled. This is causing many problem when this encoding used. for example in Console we ensure turning of BOM emission. In System IO we always use the default with no BOM. we got the feedback from Powershell team too.
Also most of the tools (especially on Linux) doesn't handle BOM and treat it as part of the text. 

https://github.com/dotnet/standard/issues/260

This is kind of breaking change for netcore but I am expecting this will be very limiting breaking as I am seeing most of the time people trying to do turn off the BOM.