### PR TITLE
[x86/Linux] Fix ResumeEsp before resume

### DIFF
--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -653,7 +653,7 @@ HRESULT FixContextForEnC(PCONTEXT        pCtx,
     static void EnsureCallerContextIsValid( PREGDISPLAY pRD, StackwalkCacheEntry* pCacheEntry, EECodeInfo * pCodeInfo = NULL );
     static size_t GetCallerSp( PREGDISPLAY  pRD );
 #ifdef _TARGET_X86_
-    static size_t GetResumeSp( PREGDISPLAY  pRD );
+    static size_t GetResumeSp( PCONTEXT  pContext );
 #endif // _TARGET_X86_
 #endif // WIN64EXCEPTIONS
 

--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -652,7 +652,10 @@ HRESULT FixContextForEnC(PCONTEXT        pCtx,
 #ifdef WIN64EXCEPTIONS
     static void EnsureCallerContextIsValid( PREGDISPLAY pRD, StackwalkCacheEntry* pCacheEntry, EECodeInfo * pCodeInfo = NULL );
     static size_t GetCallerSp( PREGDISPLAY  pRD );
-#endif
+#ifdef _TARGET_X86_
+    static size_t GetResumeSp( PREGDISPLAY  pRD );
+#endif // _TARGET_X86_
+#endif // WIN64EXCEPTIONS
 
 #ifdef DACCESS_COMPILE
     virtual void EnumMemoryRegions(CLRDataEnumMemoryFlags flags);

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -4033,6 +4033,50 @@ bool UnwindStackFrame(PREGDISPLAY     pContext,
 
 #endif // _TARGET_X86_
 
+#ifdef WIN64EXCEPTIONS
+#ifdef _TARGET_X86_
+size_t EECodeManager::GetResumeSp( PREGDISPLAY  pRD )
+{
+    EECodeInfo codeInfo(pRD->ControlPC);
+
+    PTR_CBYTE methodStart = PTR_CBYTE(codeInfo.GetSavedMethodCode());
+
+    GCInfoToken gcInfoToken = codeInfo.GetGCInfoToken();
+    PTR_VOID    methodInfoPtr = gcInfoToken.Info;
+    DWORD       curOffs = codeInfo.GetRelOffset();
+
+    CodeManStateBuf stateBuf;
+
+    stateBuf.hdrInfoSize = (DWORD)DecodeGCHdrInfo(gcInfoToken,
+                                                  curOffs,
+                                                  &stateBuf.hdrInfoBody);
+
+    PTR_CBYTE table = dac_cast<PTR_CBYTE>(methodInfoPtr) + stateBuf.hdrInfoSize;
+
+    hdrInfo *info = &stateBuf.hdrInfoBody;
+
+    _ASSERTE(info->epilogOffs == hdrInfo::NOT_IN_EPILOG && info->prologOffs == hdrInfo::NOT_IN_PROLOG);
+
+    bool isESPFrame = !info->ebpFrame && !info->doubleAlign;
+
+    if (codeInfo.IsFunclet())
+    {
+        // Treat funclet's frame as ESP frame
+        isESPFrame = true;
+    }
+
+    if (isESPFrame)
+    {
+        const size_t curESP = pRD->SP;
+        return curESP + GetPushedArgSize(info, table, curOffs);
+    }
+
+    const size_t curEBP = *pRD->GetEbpLocation();
+    return GetOutermostBaseFP(curEBP, info);
+}
+#endif // _TARGET_X86_
+#endif // WIN64EXCEPTIONS
+
 #ifndef CROSSGEN_COMPILE
 #ifndef WIN64EXCEPTIONS
 

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -4035,9 +4035,13 @@ bool UnwindStackFrame(PREGDISPLAY     pContext,
 
 #ifdef WIN64EXCEPTIONS
 #ifdef _TARGET_X86_
-size_t EECodeManager::GetResumeSp( PREGDISPLAY  pRD )
+size_t EECodeManager::GetResumeSp( PCONTEXT  pContext )
 {
-    EECodeInfo codeInfo(pRD->ControlPC);
+    PCODE currentPc = PCODE(pContext->Eip);
+
+    _ASSERTE(ExecutionManager::IsManagedCode(currentPc));
+
+    EECodeInfo codeInfo(currentPc);
 
     PTR_CBYTE methodStart = PTR_CBYTE(codeInfo.GetSavedMethodCode());
 
@@ -4067,11 +4071,11 @@ size_t EECodeManager::GetResumeSp( PREGDISPLAY  pRD )
 
     if (isESPFrame)
     {
-        const size_t curESP = pRD->SP;
+        const size_t curESP = (size_t)(pContext->Esp);
         return curESP + GetPushedArgSize(info, table, curOffs);
     }
 
-    const size_t curEBP = *pRD->GetEbpLocation();
+    const size_t curEBP = (size_t)(pContext->Ebp);
     return GetOutermostBaseFP(curEBP, info);
 }
 #endif // _TARGET_X86_

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -1200,10 +1200,10 @@ ProcessCLRException(IN     PEXCEPTION_RECORD   pExceptionRecord
 
                 pThread->SetFrame(pLimitFrame);
 
+                FixContext(pContextRecord);
+
                 SetIP(pContextRecord, (PCODE)uResumePC);
             }
-
-            FixContext(pContextRecord);
 
 #ifdef STACK_GUARDS_DEBUG
             // We are transitioning back to managed code, so ensure that we are in

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -441,12 +441,23 @@ void ExceptionTracker::UpdateNonvolatileRegisters(CONTEXT *pContextRecord, REGDI
         }                                                                                   \
     } while (0)
 
+#define UPDATEREG_VAL(reg)                                                                  \
+    do {                                                                                    \
+        STRESS_LOG2(LF_GCROOTS, LL_INFO100, "Updating " #reg " %p to %p\n",                 \
+                pContextRecord->reg,                                                        \
+                pRegDisplay->pCurrentContext->reg);                                         \
+        pContextRecord->reg = pRegDisplay->pCurrentContext->reg;                            \
+    } while (0)
+
+
 #if defined(_TARGET_X86_)
 
     UPDATEREG(Ebx);
     UPDATEREG(Esi);
     UPDATEREG(Edi);
     UPDATEREG(Ebp);
+
+    UPDATEREG_VAL(ResumeEsp);
 
 #elif defined(_TARGET_AMD64_)
 

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -384,7 +384,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 #endif // DACCESS_COMPILE
 
     pRD->pCurrentContext->Eip = pRD->ControlPC = m_MachState.GetRetAddr();
-    pRD->pCurrentContext->Esp = pRD->pCurrentContext->ResumeEsp = pRD->SP = (DWORD) m_MachState.esp();
+    pRD->pCurrentContext->Esp = pRD->SP = (DWORD) m_MachState.esp();
 
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = *((DWORD*) m_MachState.p##regname());
     ENUM_CALLEE_SAVED_REGISTERS();
@@ -401,6 +401,11 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     //
 
     ClearRegDisplayArgumentAndScratchRegisters(pRD);
+
+    //
+    // Fix up ResumeSp
+    //
+    pRD->pCurrentContext->ResumeEsp = EECodeManager::GetResumeSp(pRD);
 
 #else // WIN64EXCEPTIONS
 

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -384,7 +384,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 #endif // DACCESS_COMPILE
 
     pRD->pCurrentContext->Eip = pRD->ControlPC = m_MachState.GetRetAddr();
-    pRD->pCurrentContext->Esp = pRD->SP = (DWORD) m_MachState.esp();
+    pRD->pCurrentContext->Esp = pRD->pCurrentContext->ResumeEsp = pRD->SP = (DWORD) m_MachState.esp();
 
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = *((DWORD*) m_MachState.p##regname());
     ENUM_CALLEE_SAVED_REGISTERS();
@@ -401,11 +401,6 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     //
 
     ClearRegDisplayArgumentAndScratchRegisters(pRD);
-
-    //
-    // Fix up ResumeSp
-    //
-    pRD->pCurrentContext->ResumeEsp = EECodeManager::GetResumeSp(pRD);
 
 #else // WIN64EXCEPTIONS
 


### PR DESCRIPTION
This commit fixes RseumeEsp just before resuming, which resolves 4 test failures:
 - JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_r8_i
 - JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_r8_i4
 - JIT/Methodical/Arrays/misc/_il_relinitializearray
 - JIT/Regression/VS-ia64-JIT/V1.2-M01/b12390