### PR TITLE
[x86/Linux] Clean up ZapUnwindData

### DIFF
--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -985,10 +985,10 @@ PTR_VOID GetUnwindDataBlob(TADDR moduleBase, PTR_RUNTIME_FUNCTION pRuntimeFuncti
 
     return pUnwindInfo;
 
-#elif defined(_TARGET_X86_) && defined(FEATURE_PAL)
+#elif defined(_TARGET_X86_)
     PTR_UNWIND_INFO pUnwindInfo(dac_cast<PTR_UNWIND_INFO>(moduleBase + RUNTIME_FUNCTION__GetUnwindInfoAddress(pRuntimeFunction)));
 
-    *pSize = ALIGN_UP(sizeof(UNWIND_INFO), sizeof(DWORD));
+    *pSize = sizeof(UNWIND_INFO);
 
     return pUnwindInfo;
 

--- a/src/zap/zapcode.cpp
+++ b/src/zap/zapcode.cpp
@@ -1202,7 +1202,7 @@ void ZapUnwindData::Save(ZapWriter * pZapWriter)
 #endif //REDHAWK
 }
 
-#elif defined(_TARGET_X86_) && defined(FEATURE_PAL)
+#elif defined(_TARGET_X86_)
 
 UINT ZapUnwindData::GetAlignment()
 {
@@ -1211,9 +1211,7 @@ UINT ZapUnwindData::GetAlignment()
 
 DWORD ZapUnwindData::GetSize()
 {
-    DWORD dwSize = ZapBlob::GetSize();
-
-    return dwSize;
+    return ZapBlob::GetSize();
 }
 
 void ZapUnwindData::Save(ZapWriter * pZapWriter)


### PR DESCRIPTION
This commit cleans up ZapUnwindData-related methods introduced by #10378.