### PR TITLE
[Local GC] Move knowledge of the free object method table outside of the GC

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -73,6 +73,7 @@ public:
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
     static bool ForceFullGCToBeBlocking();
     static bool EagerFinalized(Object* obj);
+    static MethodTable* GetFreeObjectMethodTable();
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -73,9 +73,6 @@ public:
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
     static bool ForceFullGCToBeBlocking();
     static bool EagerFinalized(Object* obj);
-    static MethodTable* GetFreeObjectMethodTable();
-    static size_t GetSizeOfArrayBase();
-    static size_t GetArrayOffsetOfNumComponents();
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -73,6 +73,9 @@ public:
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
     static bool ForceFullGCToBeBlocking();
     static bool EagerFinalized(Object* obj);
+    static MethodTable* GetFreeObjectMethodTable();
+    static size_t GetSizeOfArrayBase();
+    static size_t GetArrayOffsetOfNumComponents();
 };
 
 #endif // __GCENV_EE_H__

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -3891,10 +3891,10 @@ public:
     {
         assert (size >= free_object_base_size);
 
-        assert (g_pFreeObjectMethodTable->GetBaseSize() == free_object_base_size);
-        assert (g_pFreeObjectMethodTable->RawGetComponentSize() == 1);
+        assert (g_gc_pFreeObjectMethodTable->GetBaseSize() == free_object_base_size);
+        assert (g_gc_pFreeObjectMethodTable->RawGetComponentSize() == 1);
 
-        RawSetMethodTable( g_pFreeObjectMethodTable );
+        RawSetMethodTable( g_gc_pFreeObjectMethodTable );
 
         size_t* numComponentsPtr = (size_t*) &((uint8_t*) this)[ArrayBase::GetOffsetOfNumComponents()];
         *numComponentsPtr = size - free_object_base_size;
@@ -3919,7 +3919,7 @@ public:
 
     BOOL IsFree () const
     {
-        return (GetMethodTable() == g_pFreeObjectMethodTable);
+        return (GetMethodTable() == g_gc_pFreeObjectMethodTable);
     }
 
 #ifdef FEATURE_STRUCTALIGN
@@ -21090,7 +21090,7 @@ BOOL gc_heap::plan_loh()
         {
             while (o < heap_segment_allocated (seg) && !marked (o))
             {
-                dprintf (1235, ("%Ix(%Id) F (%d)", o, AlignQword (size (o)), ((method_table (o) == g_pFreeObjectMethodTable) ? 1 : 0)));
+                dprintf (1235, ("%Ix(%Id) F (%d)", o, AlignQword (size (o)), ((method_table (o) == g_gc_pFreeObjectMethodTable) ? 1 : 0)));
                 o = o + AlignQword (size (o));
             }
         }
@@ -24346,7 +24346,7 @@ void gc_heap::walk_survivors_for_bgc (void* profiling_context, record_surv_fn fn
 
         while (o < end)
         {
-            if (method_table(o) == g_pFreeObjectMethodTable)
+            if (method_table(o) == g_gc_pFreeObjectMethodTable)
             {
                 o += Align (size (o), align_const);
                 continue;
@@ -24357,7 +24357,7 @@ void gc_heap::walk_survivors_for_bgc (void* profiling_context, record_surv_fn fn
 
             uint8_t* plug_start = o;
 
-            while (method_table(o) != g_pFreeObjectMethodTable)
+            while (method_table(o) != g_gc_pFreeObjectMethodTable)
             {
                 o += Align (size (o), align_const);
                 if (o >= end)
@@ -31543,7 +31543,7 @@ void gc_heap::background_sweep()
                     seg = start_seg;
                     prev_seg = 0;
                     o = generation_allocation_start (gen);
-                    assert (method_table (o) == g_pFreeObjectMethodTable);
+                    assert (method_table (o) == g_gc_pFreeObjectMethodTable);
                     align_const = get_alignment_constant (FALSE);
                     o = o + Align(size (o), align_const);
                     plug_end = o;
@@ -32885,7 +32885,7 @@ void gc_heap::verify_partial ()
                             //dprintf (3, ("VOM: verifying member %Ix in obj %Ix", (size_t)*oo, o));
                             MethodTable *pMT = method_table (*oo);
 
-                            if (pMT == g_pFreeObjectMethodTable)
+                            if (pMT == g_gc_pFreeObjectMethodTable)
                             {
                                 free_ref_p = TRUE;
                                 FATAL_GC_ERROR();
@@ -33319,12 +33319,12 @@ gc_heap::verify_heap (BOOL begin_gc_p)
             }
         }
 
-        if (*((uint8_t**)curr_object) != (uint8_t *) g_pFreeObjectMethodTable)
+        if (*((uint8_t**)curr_object) != (uint8_t *) g_gc_pFreeObjectMethodTable)
         {
 #ifdef FEATURE_LOH_COMPACTION
             if ((curr_gen_num == (max_generation+1)) && (prev_object != 0))
             {
-                assert (method_table (prev_object) == g_pFreeObjectMethodTable);
+                assert (method_table (prev_object) == g_gc_pFreeObjectMethodTable);
             }
 #endif //FEATURE_LOH_COMPACTION
 
@@ -33629,6 +33629,8 @@ HRESULT GCHeap::Initialize ()
     {
         return E_FAIL;
     }
+
+    g_gc_pFreeObjectMethodTable = GCToEEInterface::GetFreeObjectMethodTable();
 
 //Initialize the static members.
 #ifdef TRACE_GC

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -3761,8 +3761,6 @@ size_t gcard_of ( uint8_t*);
 #define GC_MARKED       (size_t)0x1
 #define slot(i, j) ((uint8_t**)(i))[j+1]
 
-#define free_object_base_size (plug_skew + sizeof(ArrayBase))
-
 class CObjectHeader : public Object
 {
 public:
@@ -3772,7 +3770,9 @@ public:
     // by Redhawk's version of Object.
     uint32_t GetNumComponents()
     {
-        return ((ArrayBase *)this)->GetNumComponents();
+        uint8_t* base = reinterpret_cast<uint8_t*>(this);
+        size_t* components = reinterpret_cast<size_t*>(&base[g_arrayBaseNumComponentsOffset]);
+        return static_cast<uint32_t>(*components);
     }
 
     void Validate(BOOL bDeep=TRUE, BOOL bVerifyNextHeader = TRUE)
@@ -3889,27 +3889,28 @@ public:
 
     void SetFree(size_t size)
     {
-        assert (size >= free_object_base_size);
+        assert (size >= g_freeObjectBaseSize);
 
-        assert (g_pFreeObjectMethodTable->GetBaseSize() == free_object_base_size);
-        assert (g_pFreeObjectMethodTable->RawGetComponentSize() == 1);
+        assert (g_gc_pFreeObjectMethodTable->GetBaseSize() == g_freeObjectBaseSize);
+        assert (g_gc_pFreeObjectMethodTable->RawGetComponentSize() == 1);
 
-        RawSetMethodTable( g_pFreeObjectMethodTable );
+        RawSetMethodTable( g_gc_pFreeObjectMethodTable );
 
-        size_t* numComponentsPtr = (size_t*) &((uint8_t*) this)[ArrayBase::GetOffsetOfNumComponents()];
-        *numComponentsPtr = size - free_object_base_size;
+        uint8_t* basePtr = reinterpret_cast<uint8_t*>(this);
+        size_t* numComponentsPtr = reinterpret_cast<size_t*>(&basePtr[g_arrayBaseNumComponentsOffset]);
+        *numComponentsPtr = size - g_freeObjectBaseSize;
 #ifdef VERIFY_HEAP
         //This introduces a bug in the free list management. 
         //((void**) this)[-1] = 0;    // clear the sync block,
         assert (*numComponentsPtr >= 0);
         if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
-            memset (((uint8_t*)this)+sizeof(ArrayBase), 0xcc, *numComponentsPtr);
+            memset (basePtr + g_arrayBaseSize, 0xcc, *numComponentsPtr);
 #endif //VERIFY_HEAP
     }
 
     void UnsetFree()
     {
-        size_t size = free_object_base_size - plug_skew;
+        size_t size = g_freeObjectBaseSize - plug_skew;
 
         // since we only need to clear 2 ptr size, we do it manually
         PTR_PTR m = (PTR_PTR) this;
@@ -3919,7 +3920,7 @@ public:
 
     BOOL IsFree () const
     {
-        return (GetMethodTable() == g_pFreeObjectMethodTable);
+        return (GetMethodTable() == g_gc_pFreeObjectMethodTable);
     }
 
 #ifdef FEATURE_STRUCTALIGN
@@ -3987,8 +3988,8 @@ inline size_t unused_array_size(uint8_t * p)
 {
     assert(((CObjectHeader*)p)->IsFree());
 
-    size_t* numComponentsPtr = (size_t*)(p + ArrayBase::GetOffsetOfNumComponents());
-    return free_object_base_size + *numComponentsPtr;
+    size_t* numComponentsPtr = (size_t*)(p + g_arrayBaseNumComponentsOffset);
+    return g_freeObjectBaseSize + *numComponentsPtr;
 }
 
 heap_segment* heap_segment_rw (heap_segment* ns)
@@ -11901,7 +11902,7 @@ void gc_heap::bgc_loh_alloc_clr (uint8_t* alloc_start,
     }
 #endif //FEATURE_APPDOMAIN_RESOURCE_MONITORING
 
-    size_t size_of_array_base = sizeof(ArrayBase);
+    size_t size_of_array_base = g_arrayBaseSize;
 
     bgc_alloc_lock->loh_alloc_done_with_index (lock_index);
 
@@ -21090,7 +21091,7 @@ BOOL gc_heap::plan_loh()
         {
             while (o < heap_segment_allocated (seg) && !marked (o))
             {
-                dprintf (1235, ("%Ix(%Id) F (%d)", o, AlignQword (size (o)), ((method_table (o) == g_pFreeObjectMethodTable) ? 1 : 0)));
+                dprintf (1235, ("%Ix(%Id) F (%d)", o, AlignQword (size (o)), ((method_table (o) == g_gc_pFreeObjectMethodTable) ? 1 : 0)));
                 o = o + AlignQword (size (o));
             }
         }
@@ -23391,7 +23392,7 @@ void gc_heap::make_unused_array (uint8_t* x, size_t size, BOOL clearp, BOOL rese
 #error "This won't work on big endian platforms"
 #endif
 
-    size_t size_as_object = (uint32_t)(size - free_object_base_size) + free_object_base_size;
+    size_t size_as_object = (uint32_t)(size - g_freeObjectBaseSize) + g_freeObjectBaseSize;
 
     if (size_as_object < size)
     {
@@ -23439,7 +23440,7 @@ void gc_heap::clear_unused_array (uint8_t* x, size_t size)
 
     // The memory could have been cleared in the meantime. We have to mirror the algorithm
     // from make_unused_array since we cannot depend on the object sizes in memory.
-    size_t size_as_object = (uint32_t)(size - free_object_base_size) + free_object_base_size;
+    size_t size_as_object = (uint32_t)(size - g_freeObjectBaseSize) + g_freeObjectBaseSize;
 
     if (size_as_object < size)
     {
@@ -24346,7 +24347,7 @@ void gc_heap::walk_survivors_for_bgc (void* profiling_context, record_surv_fn fn
 
         while (o < end)
         {
-            if (method_table(o) == g_pFreeObjectMethodTable)
+            if (method_table(o) == g_gc_pFreeObjectMethodTable)
             {
                 o += Align (size (o), align_const);
                 continue;
@@ -24357,7 +24358,7 @@ void gc_heap::walk_survivors_for_bgc (void* profiling_context, record_surv_fn fn
 
             uint8_t* plug_start = o;
 
-            while (method_table(o) != g_pFreeObjectMethodTable)
+            while (method_table(o) != g_gc_pFreeObjectMethodTable)
             {
                 o += Align (size (o), align_const);
                 if (o >= end)
@@ -31543,7 +31544,7 @@ void gc_heap::background_sweep()
                     seg = start_seg;
                     prev_seg = 0;
                     o = generation_allocation_start (gen);
-                    assert (method_table (o) == g_pFreeObjectMethodTable);
+                    assert (method_table (o) == g_gc_pFreeObjectMethodTable);
                     align_const = get_alignment_constant (FALSE);
                     o = o + Align(size (o), align_const);
                     plug_end = o;
@@ -32885,7 +32886,7 @@ void gc_heap::verify_partial ()
                             //dprintf (3, ("VOM: verifying member %Ix in obj %Ix", (size_t)*oo, o));
                             MethodTable *pMT = method_table (*oo);
 
-                            if (pMT == g_pFreeObjectMethodTable)
+                            if (pMT == g_gc_pFreeObjectMethodTable)
                             {
                                 free_ref_p = TRUE;
                                 FATAL_GC_ERROR();
@@ -33319,12 +33320,12 @@ gc_heap::verify_heap (BOOL begin_gc_p)
             }
         }
 
-        if (*((uint8_t**)curr_object) != (uint8_t *) g_pFreeObjectMethodTable)
+        if (*((uint8_t**)curr_object) != (uint8_t *) g_gc_pFreeObjectMethodTable)
         {
 #ifdef FEATURE_LOH_COMPACTION
             if ((curr_gen_num == (max_generation+1)) && (prev_object != 0))
             {
-                assert (method_table (prev_object) == g_pFreeObjectMethodTable);
+                assert (method_table (prev_object) == g_gc_pFreeObjectMethodTable);
             }
 #endif //FEATURE_LOH_COMPACTION
 
@@ -33629,6 +33630,11 @@ HRESULT GCHeap::Initialize ()
     {
         return E_FAIL;
     }
+
+    g_gc_pFreeObjectMethodTable = GCToEEInterface::GetFreeObjectMethodTable();
+    g_arrayBaseSize = GCToEEInterface::GetSizeOfArrayBase();
+    g_arrayBaseNumComponentsOffset = GCToEEInterface::GetArrayOffsetOfNumComponents();
+    g_freeObjectBaseSize = plug_skew + g_arrayBaseSize;
 
 //Initialize the static members.
 #ifdef TRACE_GC

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -113,6 +113,7 @@ extern "C" uint8_t* g_gc_lowest_address;
 extern "C" uint8_t* g_gc_highest_address;
 extern "C" GCHeapType g_gc_heap_type;
 extern "C" uint32_t g_max_generation;
+extern "C" MethodTable* g_gc_pFreeObjectMethodTable;
 
 ::IGCHandleTable*  CreateGCHandleTable();
 

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -113,10 +113,6 @@ extern "C" uint8_t* g_gc_lowest_address;
 extern "C" uint8_t* g_gc_highest_address;
 extern "C" GCHeapType g_gc_heap_type;
 extern "C" uint32_t g_max_generation;
-extern "C" MethodTable* g_gc_pFreeObjectMethodTable;
-extern "C" size_t g_arrayBaseNumComponentsOffset;
-extern "C" size_t g_arrayBaseSize;
-extern "C" size_t g_freeObjectBaseSize;
 
 ::IGCHandleTable*  CreateGCHandleTable();
 

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -113,6 +113,10 @@ extern "C" uint8_t* g_gc_lowest_address;
 extern "C" uint8_t* g_gc_highest_address;
 extern "C" GCHeapType g_gc_heap_type;
 extern "C" uint32_t g_max_generation;
+extern "C" MethodTable* g_gc_pFreeObjectMethodTable;
+extern "C" size_t g_arrayBaseNumComponentsOffset;
+extern "C" size_t g_arrayBaseSize;
+extern "C" size_t g_freeObjectBaseSize;
 
 ::IGCHandleTable*  CreateGCHandleTable();
 

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -43,6 +43,7 @@ uint8_t* g_gc_lowest_address  = 0;
 uint8_t* g_gc_highest_address = 0;
 GCHeapType g_gc_heap_type = GC_HEAP_INVALID;
 uint32_t g_max_generation = max_generation;
+MethodTable* g_gc_pFreeObjectMethodTable = nullptr;
 
 #ifdef GC_CONFIG_DRIVEN
 void record_global_mechanism (int mech_index)

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -43,6 +43,10 @@ uint8_t* g_gc_lowest_address  = 0;
 uint8_t* g_gc_highest_address = 0;
 GCHeapType g_gc_heap_type = GC_HEAP_INVALID;
 uint32_t g_max_generation = max_generation;
+MethodTable* g_gc_pFreeObjectMethodTable = nullptr;
+size_t g_arrayBaseNumComponentsOffset = 0;
+size_t g_arrayBaseSize = 0;
+size_t g_freeObjectBaseSize = 0;
 
 #ifdef GC_CONFIG_DRIVEN
 void record_global_mechanism (int mech_index)

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -43,10 +43,6 @@ uint8_t* g_gc_lowest_address  = 0;
 uint8_t* g_gc_highest_address = 0;
 GCHeapType g_gc_heap_type = GC_HEAP_INVALID;
 uint32_t g_max_generation = max_generation;
-MethodTable* g_gc_pFreeObjectMethodTable = nullptr;
-size_t g_arrayBaseNumComponentsOffset = 0;
-size_t g_arrayBaseSize = 0;
-size_t g_freeObjectBaseSize = 0;
 
 #ifdef GC_CONFIG_DRIVEN
 void record_global_mechanism (int mech_index)

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -224,6 +224,12 @@ ALWAYS_INLINE bool GCToEEInterface::ForceFullGCToBeBlocking()
     assert(g_theGCToCLR != nullptr);
     return g_theGCToCLR->ForceFullGCToBeBlocking();
 }
+
+ALWAYS_INLINE MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetFreeObjectMethodTable();
+}
 #undef ALWAYS_INLINE
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -224,31 +224,6 @@ ALWAYS_INLINE bool GCToEEInterface::ForceFullGCToBeBlocking()
     assert(g_theGCToCLR != nullptr);
     return g_theGCToCLR->ForceFullGCToBeBlocking();
 }
-
-ALWAYS_INLINE bool GCToEEInterface::EagerFinalized(Object* obj)
-{
-    assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->EagerFinalized(obj);
-}
-
-ALWAYS_INLINE MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
-{
-    assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->GetFreeObjectMethodTable();
-}
-
-ALWAYS_INLINE size_t GCToEEInterface::GetSizeOfArrayBase()
-{
-    assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->GetSizeOfArrayBase();
-}
-
-ALWAYS_INLINE size_t GCToEEInterface::GetArrayOffsetOfNumComponents()
-{
-    assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->GetArrayOffsetOfNumComponents();
-}
-
 #undef ALWAYS_INLINE
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -225,6 +225,12 @@ ALWAYS_INLINE bool GCToEEInterface::ForceFullGCToBeBlocking()
     return g_theGCToCLR->ForceFullGCToBeBlocking();
 }
 
+ALWAYS_INLINE bool GCToEEInterface::EagerFinalized(Object* obj)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->EagerFinalized(obj);
+}
+
 ALWAYS_INLINE MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
 {
     assert(g_theGCToCLR != nullptr);

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -231,6 +231,24 @@ ALWAYS_INLINE bool GCToEEInterface::EagerFinalized(Object* obj)
     return g_theGCToCLR->EagerFinalized(obj);
 }
 
+ALWAYS_INLINE MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetFreeObjectMethodTable();
+}
+
+ALWAYS_INLINE size_t GCToEEInterface::GetSizeOfArrayBase()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetSizeOfArrayBase();
+}
+
+ALWAYS_INLINE size_t GCToEEInterface::GetArrayOffsetOfNumComponents()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetArrayOffsetOfNumComponents();
+}
+
 #undef ALWAYS_INLINE
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -156,6 +156,16 @@ public:
     // the EE can opt to elevate that collection to be a blocking GC and not a background one.
     virtual
     bool ForceFullGCToBeBlocking() = 0;
+
+    // Retrieves the method table for the free object, a special kind of object used by the GC
+    // to keep the heap traversable. Conceptually, the free object is similar to a managed array
+    // of bytes: it consists of an object header (like all objects) and a "numComponents" field,
+    // followed by some number of bytes of space that's free on the heap.
+    //
+    // The free object allows the GC to traverse the heap because it can inspect the numComponents
+    // field to see how many bytes to skip before the next object on a heap segment begins.
+    virtual
+    MethodTable* GetFreeObjectMethodTable() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -156,26 +156,6 @@ public:
     // the EE can opt to elevate that collection to be a blocking GC and not a background one.
     virtual
     bool ForceFullGCToBeBlocking() = 0;
-
-    // Retrieves the method table for the free object, a special kind of object used by the GC
-    // to keep the heap traversable. Conceptually, the free object is similar to a managed array
-    // of bytes: it consists of an object header (like all objects) and a "numComponents" field,
-    // followed by some number of bytes of space that's free on the heap.
-    //
-    // The free object allows the GC to traverse the heap because it can inspect the numComponents
-    // field to see how many bytes to skip before the next object on a heap segment begins.
-    virtual
-    MethodTable* GetFreeObjectMethodTable() = 0;
-
-    // Owing to a free object's similarity to a managed array object, retrieves the size of the base
-    // of an array object.
-    virtual
-    size_t GetSizeOfArrayBase() = 0;
-
-    // Retrieves the offset of the "numComponents" field of a managed array object, the number of elements
-    // contained in the array.
-    virtual
-    size_t GetArrayOffsetOfNumComponents() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -156,6 +156,26 @@ public:
     // the EE can opt to elevate that collection to be a blocking GC and not a background one.
     virtual
     bool ForceFullGCToBeBlocking() = 0;
+
+    // Retrieves the method table for the free object, a special kind of object used by the GC
+    // to keep the heap traversable. Conceptually, the free object is similar to a managed array
+    // of bytes: it consists of an object header (like all objects) and a "numComponents" field,
+    // followed by some number of bytes of space that's free on the heap.
+    //
+    // The free object allows the GC to traverse the heap because it can inspect the numComponents
+    // field to see how many bytes to skip before the next object on a heap segment begins.
+    virtual
+    MethodTable* GetFreeObjectMethodTable() = 0;
+
+    // Owing to a free object's similarity to a managed array object, retrieves the size of the base
+    // of an array object.
+    virtual
+    size_t GetSizeOfArrayBase() = 0;
+
+    // Retrieves the offset of the "numComponents" field of a managed array object, the number of elements
+    // contained in the array.
+    virtual
+    size_t GetArrayOffsetOfNumComponents() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -286,6 +286,11 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
     return false;
 }
 
+MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
+{
+    return g_pFreeObjectMethodTable;
+}
+
 bool IsGCSpecialThread()
 {
     // TODO: Implement for background GC

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -286,6 +286,22 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
     return false;
 }
 
+MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
+{
+    return g_pFreeObjectMethodTable;
+}
+
+
+size_t GCToEEInterface::GetSizeOfArrayBase()
+{
+    return sizeof(ArrayBase);
+}
+
+size_t GCToEEInterface::GetArrayOffsetOfNumComponents()
+{
+    return ArrayBase::GetOffsetOfNumComponents();
+}
+
 bool IsGCSpecialThread()
 {
     // TODO: Implement for background GC

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -286,22 +286,6 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
     return false;
 }
 
-MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
-{
-    return g_pFreeObjectMethodTable;
-}
-
-
-size_t GCToEEInterface::GetSizeOfArrayBase()
-{
-    return sizeof(ArrayBase);
-}
-
-size_t GCToEEInterface::GetArrayOffsetOfNumComponents()
-{
-    return ArrayBase::GetOffsetOfNumComponents();
-}
-
 bool IsGCSpecialThread()
 {
     // TODO: Implement for background GC

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1394,3 +1394,9 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
 
     return false;
 }
+
+MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
+{
+    assert(g_pFreeObjectMethodTable != nullptr);
+    return g_pFreeObjectMethodTable;
+}

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1394,19 +1394,3 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
 
     return false;
 }
-
-MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
-{
-    assert(g_pFreeObjectMethodTable != nullptr);
-    return g_pFreeObjectMethodTable;
-}
-
-size_t GCToEEInterface::GetSizeOfArrayBase()
-{
-    return sizeof(ArrayBase);
-}
-
-size_t GCToEEInterface::GetArrayOffsetOfNumComponents()
-{
-    return ArrayBase::GetOffsetOfNumComponents();
-}

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1394,3 +1394,19 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
 
     return false;
 }
+
+MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
+{
+    assert(g_pFreeObjectMethodTable != nullptr);
+    return g_pFreeObjectMethodTable;
+}
+
+size_t GCToEEInterface::GetSizeOfArrayBase()
+{
+    return sizeof(ArrayBase);
+}
+
+size_t GCToEEInterface::GetArrayOffsetOfNumComponents()
+{
+    return ArrayBase::GetOffsetOfNumComponents();
+}

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -48,6 +48,7 @@ public:
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
     bool ForceFullGCToBeBlocking();
     bool EagerFinalized(Object* obj);
+    MethodTable* GetFreeObjectMethodTable();
 };
 
 #endif // FEATURE_STANDALONE_GC

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -48,6 +48,9 @@ public:
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
     bool ForceFullGCToBeBlocking();
     bool EagerFinalized(Object* obj);
+    MethodTable* GetFreeObjectMethodTable();
+    size_t GetSizeOfArrayBase();
+    size_t GetArrayOffsetOfNumComponents();
 };
 
 #endif // FEATURE_STANDALONE_GC

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -48,9 +48,6 @@ public:
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
     bool ForceFullGCToBeBlocking();
     bool EagerFinalized(Object* obj);
-    MethodTable* GetFreeObjectMethodTable();
-    size_t GetSizeOfArrayBase();
-    size_t GetArrayOffsetOfNumComponents();
 };
 
 #endif // FEATURE_STANDALONE_GC


### PR DESCRIPTION
The EE provides a method table for a specific type of object, the "free object", which is used by the GC to keep the heap crawlable. A free object is conceptually similar to a managed array in that it consists of an object header and a field indicating how many array elements the object has (i.e. how large the free region is), followed by a region of space known to be free to the GC.

This PR ensures that the GC's knowledge of the free method table is acquired through `GCToEEInterface` upon startup. This PR also has the GC acquire two additional details on startup: 1) the size of `ArrayBase`, and the 2) offset of the `NumComponents` field of `ArrayBase`. These are used to locate the offset of the field into which the size of the free object is stored and to locate the first byte of the free object's free region.