### PR TITLE
[Local GC] Move handle creation to IGCHandleTable

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -328,16 +328,6 @@ typedef PTR_PTR_Object PTR_OBJECTREF;
 typedef PTR_Object _UNCHECKED_OBJECTREF;
 typedef PTR_PTR_Object PTR_UNCHECKED_OBJECTREF;
 
-#ifndef DACCESS_COMPILE
-struct OBJECTHANDLE__
-{
-    void* unused;
-};
-typedef struct OBJECTHANDLE__* OBJECTHANDLE;
-#else
-typedef TADDR OBJECTHANDLE;
-#endif
-
 // With no object reference wrapping the following macros are very simple.
 #define ObjectToOBJECTREF(_obj) (OBJECTREF)(_obj)
 #define OBJECTREFToObject(_obj) (Object*)(_obj)

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -37,3 +37,21 @@ OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* table, Object* object, int 
 {
     return ::HndCreateHandle((HHANDLETABLE)table, type, ObjectToOBJECTREF(object));
 }
+
+OBJECTHANDLE GCHandleTable::CreateGlobalHandleOfType(Object* object, int type)
+{
+    return ::HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], type, ObjectToOBJECTREF(object)); 
+}
+
+OBJECTHANDLE GCHandleTable::CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo)
+{
+    return ::HndCreateHandle((HHANDLETABLE)table, type, ObjectToOBJECTREF(object), reinterpret_cast<uintptr_t>(pExtraInfo));
+}
+
+OBJECTHANDLE GCHandleTable::CreateDependentHandle(void* table, Object* primary, Object* secondary)
+{
+    OBJECTHANDLE handle = ::HndCreateHandle((HHANDLETABLE)table, HNDTYPE_DEPENDENT, ObjectToOBJECTREF(primary));
+    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
+
+    return handle;
+}

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -32,3 +32,8 @@ void* GCHandleTable::GetHandleTableForHandle(OBJECTHANDLE handle)
 {
     return (void*)::HndGetHandleTable(handle);
 }
+
+OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* table, Object* object, int type)
+{
+    return ::HndCreateHandle((HHANDLETABLE)table, type, ObjectToOBJECTREF(object));
+}

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -19,6 +19,12 @@ public:
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle);
 
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
+
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo);
+
+    virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary);
+
+    virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -17,6 +17,8 @@ public:
     virtual void* GetHandleTableContext(void* handleTable);
 
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle);
+
+    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -397,6 +397,12 @@ public:
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
 
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
+
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;
+
+    virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary) = 0;
+
+    virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -395,6 +395,8 @@ public:
     virtual void* GetHandleTableContext(void* handleTable) = 0;
 
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
+
+    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -385,6 +385,18 @@ typedef void (* record_surv_fn)(uint8_t* begin, uint8_t* end, ptrdiff_t reloc, v
 typedef void (* fq_walk_fn)(bool, void*);
 typedef void (* fq_scan_fn)(Object** ppObject, ScanContext *pSC, uint32_t dwFlags);
 typedef void (* handle_scan_fn)(Object** pRef, Object* pSec, uint32_t flags, ScanContext* context, bool isDependent);
+
+// Opaque type for tracking object pointers
+#ifndef DACCESS_COMPILE
+struct OBJECTHANDLE__
+{
+    void* unused;
+};
+typedef struct OBJECTHANDLE__* OBJECTHANDLE;
+#else
+typedef uintptr_t OBJECTHANDLE;
+#endif
+
 class IGCHandleTable {
 public:
 

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -871,24 +871,6 @@ void Ref_EndSynchronousGC(uint32_t condemned, uint32_t maxgen)
 */    
 }
 
-
-OBJECTHANDLE CreateDependentHandle(HHANDLETABLE table, OBJECTREF primary, OBJECTREF secondary)
-{ 
-    CONTRACTL
-    {
-        THROWS;
-        GC_NOTRIGGER;
-        MODE_COOPERATIVE;
-    }
-    CONTRACTL_END;
-
-    OBJECTHANDLE handle = HndCreateHandle(table, HNDTYPE_DEPENDENT, primary); 
-
-    SetDependentHandleSecondary(handle, secondary);
-
-    return handle;
-}
-
 void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF objref)
 { 
     CONTRACTL

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -100,13 +100,6 @@ inline void DestroyHandle(OBJECTHANDLE handle)
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, handle);
 }
 
-inline OBJECTHANDLE CreateDuplicateHandle(OBJECTHANDLE handle) {
-    WRAPPER_NO_CONTRACT;
-
-    // Create a new STRONG handle in the same table as an existing handle.  
-    return HndCreateHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, HndFetchHandle(handle));
-}
-
 inline void DestroyWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
@@ -176,13 +169,6 @@ inline void DestroyRefcountedHandle(OBJECTHANDLE handle)
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_REFCOUNTED, handle);
 }
 
-inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
-{
-    WRAPPER_NO_CONTRACT;
-    _ASSERTE(pWinRTWeakReference != NULL);
-    return HndCreateHandle(table, HNDTYPE_WEAK_WINRT, object, reinterpret_cast<uintptr_t>(pWinRTWeakReference));
-}
-
 void DestroyWinRTWeakHandle(OBJECTHANDLE handle);
 
 #endif // FEATURE_COMINTEROP
@@ -192,7 +178,6 @@ void DestroyWinRTWeakHandle(OBJECTHANDLE handle);
 OBJECTREF GetDependentHandleSecondary(OBJECTHANDLE handle);
 
 #ifndef DACCESS_COMPILE
-OBJECTHANDLE CreateDependentHandle(HHANDLETABLE table, OBJECTREF primary, OBJECTREF secondary);
 void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF secondary);
 
 inline void DestroyDependentHandle(OBJECTHANDLE handle)
@@ -268,25 +253,11 @@ public:
 
 int GetCurrentThreadHomeHeapNumber();
 
-inline OBJECTHANDLE CreateGlobalTypedHandle(OBJECTREF object, int type)
-{ 
-    WRAPPER_NO_CONTRACT;
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], type, object); 
-}
-
 inline void DestroyGlobalTypedHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandleOfUnknownType(HndGetHandleTable(handle), handle);
-}
-
-inline OBJECTHANDLE CreateGlobalHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_DEFAULT, object); 
 }
 
 inline void DestroyGlobalHandle(OBJECTHANDLE handle)
@@ -296,26 +267,11 @@ inline void DestroyGlobalHandle(OBJECTHANDLE handle)
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, handle);
 }
 
-inline OBJECTHANDLE CreateGlobalWeakHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_WEAK_DEFAULT, object); 
-}
-
 inline void DestroyGlobalWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_DEFAULT, handle);
-}
-
-inline OBJECTHANDLE CreateGlobalShortWeakHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_WEAK_SHORT, object);     
 }
 
 inline void DestroyGlobalShortWeakHandle(OBJECTHANDLE handle)
@@ -329,26 +285,11 @@ inline void DestroyGlobalShortWeakHandle(OBJECTHANDLE handle)
 typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,DestroyGlobalShortWeakHandle> GlobalShortWeakHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateGlobalLongWeakHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_WEAK_LONG, object); 
-}
-
 inline void DestroyGlobalLongWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_LONG, handle);
-}
-
-inline OBJECTHANDLE CreateGlobalStrongHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_STRONG, object); 
 }
 
 inline void DestroyGlobalStrongHandle(OBJECTHANDLE handle)
@@ -362,13 +303,6 @@ inline void DestroyGlobalStrongHandle(OBJECTHANDLE handle)
 typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,DestroyGlobalStrongHandle> GlobalStrongHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateGlobalPinningHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_PINNED, object); 
-}
-
 inline void DestroyGlobalPinningHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
@@ -377,13 +311,6 @@ inline void DestroyGlobalPinningHandle(OBJECTHANDLE handle)
 }
 
 #ifdef FEATURE_COMINTEROP
-inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_REFCOUNTED, object); 
-}
-
 inline void DestroyGlobalRefcountedHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -78,25 +78,11 @@ struct HandleTableBucket
  * Convenience macros and prototypes for the various handle types we define
  */
 
-inline OBJECTHANDLE CreateTypedHandle(HHANDLETABLE table, OBJECTREF object, int type)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, type, object); 
-}
-
 inline void DestroyTypedHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandleOfUnknownType(HndGetHandleTable(handle), handle);
-}
-
-inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_DEFAULT, object); 
 }
 
 inline void DestroyHandle(OBJECTHANDLE handle)
@@ -121,14 +107,6 @@ inline OBJECTHANDLE CreateDuplicateHandle(OBJECTHANDLE handle) {
     return HndCreateHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, HndFetchHandle(handle));
 }
 
-
-inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_WEAK_DEFAULT, object); 
-}
-
 inline void DestroyWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
@@ -136,26 +114,11 @@ inline void DestroyWeakHandle(OBJECTHANDLE handle)
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_DEFAULT, handle);
 }
 
-inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_WEAK_SHORT, object); 
-}
-
 inline void DestroyShortWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_SHORT, handle);
-}
-
-
-inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_WEAK_LONG, object); 
 }
 
 inline void DestroyLongWeakHandle(OBJECTHANDLE handle)
@@ -169,25 +132,11 @@ inline void DestroyLongWeakHandle(OBJECTHANDLE handle)
 typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,DestroyLongWeakHandle> LongWeakHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_STRONG, object); 
-}
-
 inline void DestroyStrongHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_STRONG, handle);
-}
-
-inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_PINNED, object); 
 }
 
 inline void DestroyPinningHandle(OBJECTHANDLE handle)
@@ -201,13 +150,6 @@ inline void DestroyPinningHandle(OBJECTHANDLE handle)
 typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyPinningHandle, NULL> PinningHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_ASYNCPINNED, object); 
-}
-
 inline void DestroyAsyncPinningHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
@@ -219,13 +161,6 @@ inline void DestroyAsyncPinningHandle(OBJECTHANDLE handle)
 typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyAsyncPinningHandle, NULL> AsyncPinningHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_SIZEDREF, object, (uintptr_t)0);
-}
-
 void DestroySizedRefHandle(OBJECTHANDLE handle);
 
 #ifndef FEATURE_REDHAWK
@@ -233,12 +168,6 @@ typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroySizedRefHandle, NU
 #endif
 
 #ifdef FEATURE_COMINTEROP
-inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_REFCOUNTED, object); 
-}
 
 inline void DestroyRefcountedHandle(OBJECTHANDLE handle)
 { 

--- a/src/gc/sample/GCSample.cpp
+++ b/src/gc/sample/GCSample.cpp
@@ -201,7 +201,7 @@ int __cdecl main(int argc, char* argv[])
         return -1;
 
     // Create strong handle and store the object into it
-    OBJECTHANDLE oh = CreateGlobalHandle(pObj);
+    OBJECTHANDLE oh = HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_DEFAULT, pObj);
     if (oh == NULL)
         return -1;
 
@@ -224,7 +224,7 @@ int __cdecl main(int argc, char* argv[])
     }
 
     // Create weak handle that points to our object
-    OBJECTHANDLE ohWeak = CreateGlobalWeakHandle(HndFetchHandle(oh));
+    OBJECTHANDLE ohWeak = HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_WEAK_DEFAULT, HndFetchHandle(oh));
     if (ohWeak == NULL)
         return -1;
 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1325,8 +1325,16 @@ public:
 
     OBJECTHANDLE CreateDependentHandle(OBJECTREF primary, OBJECTREF secondary)
     {
-        WRAPPER_NO_CONTRACT;
-        return ::CreateDependentHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], primary, secondary);
+        CONTRACTL
+        {
+            THROWS;
+            GC_NOTRIGGER;
+            MODE_COOPERATIVE;
+        }
+        CONTRACTL_END;
+
+        IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
+        return pHandleTable->CreateDependentHandle((void*)m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
     }
 #endif // DACCESS_COMPILE && !CROSSGEN_COMPILE
 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -28,6 +28,7 @@
 #include "ilstubcache.h"
 #include "testhookmgr.h"
 #include "gcheaputilities.h"
+#include "gchandletableutilities.h"
 #include "../binder/inc/applicationcontext.hpp"
 #include "rejit.h"
 
@@ -1239,7 +1240,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        IGCHandleTable *pHandleTable = GCHeapUtilities::GetGCHandleTable();
+        IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
         return pHandleTable->CreateHandleOfType(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], OBJECTREFToObject(object), type);
     }
 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1238,7 +1238,9 @@ public:
     OBJECTHANDLE CreateTypedHandle(OBJECTREF object, int type)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateTypedHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object, type);
+
+        IGCHandleTable *pHandleTable = GCHeapUtilities::GetGCHandleTable();
+        return pHandleTable->CreateHandleOfType(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], OBJECTREFToObject(object), type);
     }
 
     OBJECTHANDLE CreateHandle(OBJECTREF object)

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -866,7 +866,7 @@ void EEStartupHelper(COINITIEE fFlags)
 
         // Initialize remoting
 
-        if (!GCHeapUtilities::GetGCHandleTable()->Initialize())
+        if (!GCHandleTableUtilities::GetGCHandleTable()->Initialize())
         {
             IfFailGo(E_OUTOFMEMORY);
         }
@@ -1856,7 +1856,7 @@ part2:
 #ifdef SHOULD_WE_CLEANUP
                 if (!g_fFastExitProcess)
                 {
-                    GCHeapUtilities::GetGCHandleTable()->Shutdown();
+                    GCHandleTableUtilities::GetGCHandleTable()->Shutdown();
                 }
 #endif /* SHOULD_WE_CLEANUP */
 

--- a/src/vm/gchandletableutilities.h
+++ b/src/vm/gchandletableutilities.h
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef _GCHANDLETABLEUTILITIES_H_
+#define _GCHANDLETABLEUTILITIES_H_
+
+#include "gcinterface.h"
+
+extern "C" IGCHandleTable* g_pGCHandleTable;
+
+class GCHandleTableUtilities
+{
+public:
+    // Retrieves the GC handle table.
+    static IGCHandleTable* GetGCHandleTable() 
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        assert(g_pGCHandleTable != nullptr);
+        return g_pGCHandleTable;
+    }
+
+private:
+    // This class should never be instantiated.
+    GCHandleTableUtilities() = delete;
+};
+
+void ValidateHandleAndAppDomain(OBJECTHANDLE handle);
+
+// Given a handle, returns an OBJECTREF for the object it refers to.
+inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
+{
+    _ASSERTE(handle);
+
+#ifdef _DEBUG_IMPL
+    ValidateHandleAndAppDomain(handle);
+#endif // _DEBUG_IMPL
+
+    // Wrap the raw OBJECTREF and return it
+    return UNCHECKED_OBJECTREF_TO_OBJECTREF(*PTR_UNCHECKED_OBJECTREF(handle));
+}
+
+#ifndef DACCESS_COMPILE
+
+inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+}
+
+inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+}
+
+inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
+}
+
+inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
+}
+
+inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+}
+
+inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
+}
+
+inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+}
+
+#endif // !DACCESS_COMPILE
+
+#endif // _GCHANDLETABLEUTILITIES_H_
+

--- a/src/vm/gchandletableutilities.h
+++ b/src/vm/gchandletableutilities.h
@@ -7,6 +7,10 @@
 
 #include "gcinterface.h"
 
+#ifdef FEATURE_COMINTEROP
+#include <weakreference.h>
+#endif
+
 extern "C" IGCHandleTable* g_pGCHandleTable;
 
 class GCHandleTableUtilities
@@ -43,6 +47,13 @@ inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
 
 #ifndef DACCESS_COMPILE
 
+// Handle creation convenience functions
+
+inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+}
+
 inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
@@ -56,11 +67,6 @@ inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
 inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
-}
-
-inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
 }
 
 inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
@@ -87,6 +93,55 @@ inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
 }
+
+// Global handle creation convenience functions
+
+inline OBJECTHANDLE CreateGlobalHandle(OBJECTREF object)
+{
+    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateGlobalWeakHandle(OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateGlobalShortWeakHandle(OBJECTREF object)
+{
+    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+}
+
+inline OBJECTHANDLE CreateGlobalLongWeakHandle(OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+}
+
+inline OBJECTHANDLE CreateGlobalStrongHandle(OBJECTREF object)
+{
+    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
+}
+
+inline OBJECTHANDLE CreateGlobalPinningHandle(OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
+}
+
+inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+}
+
+// Special handle creation convenience functions
+
+#ifdef FEATURE_COMINTEROP
+inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table, OBJECTREFToObject(object), HNDTYPE_WEAK_WINRT, (void*)pWinRTWeakReference);
+}
+#endif // FEATURE_COMINTEROP
 
 #endif // !DACCESS_COMPILE
 

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -45,7 +45,7 @@ void ValidateHandleAndAppDomain(OBJECTHANDLE handle)
     OBJECTREF objRef = ObjectToOBJECTREF(*(Object**)handle);
     VALIDATEOBJECTREF(objRef);
 
-    IGCHandleTable *pHandleTable = GCHeapUtilities::GetGCHandleTable();
+    IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
 
     void* handleTable = pHandleTable->GetHandleTableForHandle(handle);
     DWORD context = (DWORD)pHandleTable->GetHandleTableContext(handleTable);

--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -226,5 +226,54 @@ inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
     return UNCHECKED_OBJECTREF_TO_OBJECTREF(*PTR_UNCHECKED_OBJECTREF(handle));
 }
 
+#ifndef DACCESS_COMPILE
+
+inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+}
+
+inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+}
+
+inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
+}
+
+inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
+}
+
+inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+}
+
+inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
+}
+
+inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+}
+
+#endif // !DACCESS_COMPILE
+
 #endif // _GCHEAPUTILITIES_H_
 

--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -26,7 +26,6 @@ GPTR_DECL(uint32_t,g_card_table);
 // GC will update it when it needs to.
 extern "C" gc_alloc_context g_global_alloc_context;
 
-extern "C" IGCHandleTable* g_pGCHandleTable;
 extern "C" uint32_t* g_card_bundle_table;
 extern "C" uint8_t* g_ephemeral_low;
 extern "C" uint8_t* g_ephemeral_high;
@@ -70,15 +69,6 @@ public:
 
         assert(g_pGCHeap != nullptr);
         return g_pGCHeap;
-    }
-
-    // Retrieves the GC handle table.
-    static IGCHandleTable* GetGCHandleTable() 
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        assert(g_pGCHandleTable != nullptr);
-        return g_pGCHandleTable;
     }
 
     // Returns true if the heap has been initialized, false otherwise.
@@ -208,72 +198,6 @@ private:
     // This class should never be instantiated.
     GCHeapUtilities() = delete;
 };
-
-// Handle-related utilities.
-
-void ValidateHandleAndAppDomain(OBJECTHANDLE handle);
-
-// Given a handle, returns an OBJECTREF for the object it refers to.
-inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
-{
-    _ASSERTE(handle);
-
-#ifdef _DEBUG_IMPL
-    ValidateHandleAndAppDomain(handle);
-#endif // _DEBUG_IMPL
-
-    // Wrap the raw OBJECTREF and return it
-    return UNCHECKED_OBJECTREF_TO_OBJECTREF(*PTR_UNCHECKED_OBJECTREF(handle));
-}
-
-#ifndef DACCESS_COMPILE
-
-inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
-}
-
-inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
-}
-
-inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
-}
-
-inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
-}
-
-inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
-}
-
-inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
-}
-
-inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
-}
-
-inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
-}
-
-inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
-}
-
-#endif // !DACCESS_COMPILE
 
 #endif // _GCHEAPUTILITIES_H_
 

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -5074,9 +5074,13 @@ void Thread::SafeUpdateLastThrownObject(void)
     {
         EX_TRY
         {
-            // Using CreateDuplicateHandle here ensures that the AD of the last thrown object matches the domain of
-            // the current throwable.
-            SetLastThrownObjectHandle(CreateDuplicateHandle(hThrowable));
+            IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
+            void* table = pHandleTable->GetHandleTableForHandle(hThrowable);
+
+            // Creating a duplicate handle here ensures that the AD of the last thrown object
+            // matches the domain of the current throwable.
+            OBJECTHANDLE duplicateHandle = pHandleTable->CreateHandleOfType(table, OBJECTREFToObject(ObjectFromHandle(hThrowable)), HNDTYPE_DEFAULT);
+            SetLastThrownObjectHandle(duplicateHandle);
         }
         EX_CATCH
         {

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -143,6 +143,7 @@
 #include "mscoree.h"
 #include "appdomainstack.h"
 #include "gcheaputilities.h"
+#include "gchandletableutilities.h"
 #include "gcinfotypes.h"
 #include <clrhost.h>
 

--- a/src/vm/vars.hpp
+++ b/src/vm/vars.hpp
@@ -72,6 +72,8 @@ typedef unsigned short wchar_t;
 
 #include "profilepriv.h"
 
+#include "gcinterface.h"
+
 class ClassLoader;
 class LoaderHeap;
 class IGCHeap;
@@ -96,23 +98,6 @@ class RCWCleanupList;
 #endif // FEATURE_COMINTEROP
 class BBSweep;
 struct IAssemblyUsageLog;
-
-//
-// object handles are opaque types that track object pointers
-//
-#ifndef DACCESS_COMPILE
-
-struct OBJECTHANDLE__
-{
-    void* unused;
-};
-typedef struct OBJECTHANDLE__* OBJECTHANDLE;
-
-#else
-
-typedef TADDR OBJECTHANDLE;
-
-#endif
 
 //
 // loader handles are opaque types that track object pointers that have a lifetime


### PR DESCRIPTION
This change adds handle creation functions to the IGCHandleTable interface, and modifies the VM to use the interface for handle creation rather than calling functions in objecthandle.h directly.

Rather than adding a separate function for each `Create__<type>__Handle` function (of which there are many) to the interface, I consolidated them to a few major categories and added the `Create__<type>__Handle` functions to a header on the VM side that will call the appropriate thing on the interface. This minimizes changes to VM source while also not adding clutter to the interface.

I've also moved the handle-related code that was in gcheaputilities to its own file, since there is now a lot more code there.

Most of the handle creation functions are pretty straightforward, but there are a couple of interesting cases:
- I removed `CreateDuplicateHandle` entirely since it's only used in one place in the VM and instead modified the caller to achieve the same result with the other functionality we already have on the interface.
- Rather than adding an interface method specific to WinRT weak handles, I made `CreateHandleWithExtraInfo` which takes a `void*` that can be anything the user wants. `CreateWinRTWeakHandle` is now a convenience function that lives in the VM side and calls `CreateHandleWithExtraInfo` with the `IWeakReference` as the extra info.

@Maoni0 @jkotas @swgillespie @sergiy-k 