### PR TITLE
[x86/Linux] 16-byte aligned BackPatchWorkerAsmStub

### DIFF
--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -1167,20 +1167,32 @@ NESTED_ENTRY BackPatchWorkerAsmStub, _TEXT, NoHandler
     PROLOG_PUSH edx
     PROLOG_END
 
-    // Align Stack Frame
-    mov     ebx, esp
-    and     esp, -16
-
     // Call BackPatchWorkerStaticStub
-    sub     esp, 8     //  16-bytes align padding
-    push    eax        //  push any indirect call address as the second arg to BackPatchWorker
-    push    [ebp + 8]  //  and push return address as the first arg to BackPatchWorker
+    //
+    // Here is expected stack layout at this point:
+    //  | saved edx |
+    //  | saved ecx |
+    //  | saved ebx |
+    //  | saved eax |
+    //  +-----------+ <- ebp
+    //  | saved ebp |
+    //  | saved eip |
+    //  +-----------+ <- CFA of BackPatchWorkerAsmStub
+    //  | saved eip |
+    //  +-----------+ <- CFA of ResolveStub (16-byte aligned)
+    // (Please refer to ResolveStub in vm/i386/virtualcallstubcpu.hpp for details)
+    //
+    #define STACK_ALIGN_PADDING 12
+    sub     esp, STACK_ALIGN_PADDING  //  16-bytes align padding
+    push    eax                       //  any indirect call address as the 2nd arg
+    push    DWORD PTR [ebp + 8]       //  return address (of ResolveStub) as the 1st arg
 
     CHECK_STACK_ALIGNMENT
     call    C_FUNC(BackPatchWorkerStaticStub)
 
-    // Restore Stack Frame
-    mov     esp, ebx
+    // Clean up arguments and alignment padding
+    add     esp, (STACK_ALIGN_PADDING + 2*4)
+    #undef STACK_ALIGN_PADDING
 
     EPILOG_BEG
     EPILOG_POP edx

--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -1162,20 +1162,30 @@ NESTED_END ResolveWorkerChainLookupAsmStub, _TEXT
 NESTED_ENTRY BackPatchWorkerAsmStub, _TEXT, NoHandler
     PROLOG_BEG
     PROLOG_PUSH eax // it may contain siteAddrForRegisterIndirect
+    PROLOG_PUSH ebx
     PROLOG_PUSH ecx
     PROLOG_PUSH edx
     PROLOG_END
 
-    sub     esp, 4     //  for 16 bytes align
-    push    eax        //  push any indirect call address as the second arg to BackPatchWorker
-    push    [ebp+8]    //  and push return address as the first arg to BackPatchWorker
+    // Align Stack Frame
+    mov     ebx, esp
+    and     esp, -16
 
+    // Call BackPatchWorkerStaticStub
+    sub     esp, 8     //  16-bytes align padding
+    push    eax        //  push any indirect call address as the second arg to BackPatchWorker
+    push    [ebp + 8]  //  and push return address as the first arg to BackPatchWorker
+
+    CHECK_STACK_ALIGNMENT
     call    C_FUNC(BackPatchWorkerStaticStub)
-    add     esp, 12
+
+    // Restore Stack Frame
+    mov     esp, ebx
 
     EPILOG_BEG
     EPILOG_POP edx
     EPILOG_POP ecx
+    EPILOG_POP ebx
     EPILOG_POP eax
     EPILOG_END
     ret

--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -1162,7 +1162,6 @@ NESTED_END ResolveWorkerChainLookupAsmStub, _TEXT
 NESTED_ENTRY BackPatchWorkerAsmStub, _TEXT, NoHandler
     PROLOG_BEG
     PROLOG_PUSH eax // it may contain siteAddrForRegisterIndirect
-    PROLOG_PUSH ebx
     PROLOG_PUSH ecx
     PROLOG_PUSH edx
     PROLOG_END
@@ -1172,7 +1171,6 @@ NESTED_ENTRY BackPatchWorkerAsmStub, _TEXT, NoHandler
     // Here is expected stack layout at this point:
     //  | saved edx |
     //  | saved ecx |
-    //  | saved ebx |
     //  | saved eax |
     //  +-----------+ <- ebp
     //  | saved ebp |
@@ -1182,8 +1180,6 @@ NESTED_ENTRY BackPatchWorkerAsmStub, _TEXT, NoHandler
     //  +-----------+ <- CFA of ResolveStub (16-byte aligned)
     // (Please refer to ResolveStub in vm/i386/virtualcallstubcpu.hpp for details)
     //
-    #define STACK_ALIGN_PADDING 12
-    sub     esp, STACK_ALIGN_PADDING  //  16-bytes align padding
     push    eax                       //  any indirect call address as the 2nd arg
     push    DWORD PTR [ebp + 8]       //  return address (of ResolveStub) as the 1st arg
 
@@ -1191,13 +1187,11 @@ NESTED_ENTRY BackPatchWorkerAsmStub, _TEXT, NoHandler
     call    C_FUNC(BackPatchWorkerStaticStub)
 
     // Clean up arguments and alignment padding
-    add     esp, (STACK_ALIGN_PADDING + 2*4)
-    #undef STACK_ALIGN_PADDING
+    add     esp, 2*4
 
     EPILOG_BEG
     EPILOG_POP edx
     EPILOG_POP ecx
-    EPILOG_POP ebx
     EPILOG_POP eax
     EPILOG_END
     ret


### PR DESCRIPTION
Unaligned stack frame are emitted while running JIT.Performance.CodeQuality.Linq (discovered while testing Checked CLR build). 

This commit enforces stack alignment before call BackPatchWorkerStaticStub.