### PR TITLE
Forbid LEA without index AND base.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -1869,26 +1869,26 @@ bool CodeGen::genCreateAddrMode(GenTreePtr  addr,
         The following indirections are valid address modes on x86/x64:
 
             [                  icon]      * not handled here
-            [reg                   ]      * not handled here
+            [reg                   ]
             [reg             + icon]
-            [reg2 +     reg1       ]
-            [reg2 +     reg1 + icon]
-            [reg2 + 2 * reg1       ]
-            [reg2 + 4 * reg1       ]
-            [reg2 + 8 * reg1       ]
-            [       2 * reg1 + icon]
-            [       4 * reg1 + icon]
-            [       8 * reg1 + icon]
-            [reg2 + 2 * reg1 + icon]
-            [reg2 + 4 * reg1 + icon]
-            [reg2 + 8 * reg1 + icon]
+            [reg1 +     reg2       ]
+            [reg1 +     reg2 + icon]
+            [reg1 + 2 * reg2       ]
+            [reg1 + 4 * reg2       ]
+            [reg1 + 8 * reg2       ]
+            [       2 * reg2 + icon]
+            [       4 * reg2 + icon]
+            [       8 * reg2 + icon]
+            [reg1 + 2 * reg2 + icon]
+            [reg1 + 4 * reg2 + icon]
+            [reg1 + 8 * reg2 + icon]
 
         The following indirections are valid address modes on arm64:
 
             [reg]
             [reg  + icon]
-            [reg2 + reg1]
-            [reg2 + reg1 * natural-scale]
+            [reg1 + reg2]
+            [reg1 + reg2 * natural-scale]
 
      */
 
@@ -2447,6 +2447,11 @@ FOUND_AM:
     noway_assert(rv1 || mul != 1);
 
     noway_assert(FitsIn<INT32>(cns));
+
+    if (rv1 == nullptr && rv2 == nullptr)
+    {
+        return false;
+    }
 
     /* Success - return the various components to the caller */
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4166,6 +4166,7 @@ struct GenTreeAddrMode : public GenTreeOp
     GenTreeAddrMode(var_types type, GenTreePtr base, GenTreePtr index, unsigned scale, unsigned offset)
         : GenTreeOp(GT_LEA, type, base, index)
     {
+        assert(base != nullptr || index != nullptr);
         gtScale  = scale;
         gtOffset = offset;
     }


### PR DESCRIPTION
GT_LEA could have null op1 and null op2. There is no check that at least one operator is presented during a creation process.

This case was not reflected in GenTreeUseEdgeIterator.
It caused an assert  failure on a test with a static pinned array.

```
[FixedAddressValueType]
static int arr[]={1,2,3};

int e = arr[1]; // constant base + constant index * constant size.
```
It required minopts to prevent constant folding during Value numbering.

Fix DevDiv 400702. I spent some time but was not able to create a small repro for it.