### PR TITLE
Direct-mapping of IL-assembly images without writeable sections

### DIFF
--- a/src/inc/pedecoder.h
+++ b/src/inc/pedecoder.h
@@ -187,6 +187,8 @@ class PEDecoder
 
     DWORD GetImageIdentity() const;
 
+    BOOL HasWriteableSections() const;
+
     // Directory entry access
 
     BOOL HasDirectoryEntry(int entry) const;

--- a/src/utilcode/pedecoder.cpp
+++ b/src/utilcode/pedecoder.cpp
@@ -440,6 +440,37 @@ CHECK PEDecoder::CheckSection(COUNT_T previousAddressEnd, COUNT_T addressStart, 
     CHECK_OK;
 }
 
+BOOL PEDecoder::HasWriteableSections() const
+{
+    CONTRACT_CHECK
+    {
+        INSTANCE_CHECK;
+        PRECONDITION(CheckFormat());
+        NOTHROW;
+        GC_NOTRIGGER;
+        SUPPORTS_DAC;
+        SO_TOLERANT;
+    }
+    CONTRACT_CHECK_END;
+
+    PTR_IMAGE_SECTION_HEADER pSection = FindFirstSection(FindNTHeaders());
+    _ASSERTE(pSection != NULL);
+
+    PTR_IMAGE_SECTION_HEADER pSectionEnd = pSection + VAL16(FindNTHeaders()->FileHeader.NumberOfSections);
+
+    while (pSection < pSectionEnd)
+    {
+        if ((pSection->Characteristics & VAL32(IMAGE_SCN_MEM_WRITE)) != 0)
+        {
+            return TRUE;
+        }
+
+        pSection++;
+    }
+
+    return FALSE;
+}
+
 CHECK PEDecoder::CheckDirectoryEntry(int entry, int forbiddenFlags, IsNullOK ok) const
 {
     CONTRACT_CHECK

--- a/src/vm/pefile.cpp
+++ b/src/vm/pefile.cpp
@@ -376,9 +376,22 @@ void PEFile::LoadLibrary(BOOL allowNativeSkip/*=TRUE*/) // if allowNativeSkip==F
 #endif
         {
             if (GetILimage()->IsFile())
-                GetILimage()->LoadFromMapped();
+            {
+#ifdef PLATFORM_UNIX
+                if (GetILimage()->IsILOnly())
+                {
+                    GetILimage()->Load();
+                }
+                else
+#endif // PLATFORM_UNIX
+                {
+                    GetILimage()->LoadFromMapped();
+                }
+            }
             else
+            {
                 GetILimage()->LoadNoFile();
+            }
         }
     }
 

--- a/src/vm/peimage.h
+++ b/src/vm/peimage.h
@@ -262,7 +262,7 @@ private:
     PTR_PEImageLayout CreateLayoutMapped();
 
     // Create the flat layout
-    PTR_PEImageLayout CreateLayoutFlat();
+    PTR_PEImageLayout CreateLayoutFlat(BOOL bPermitWriteableSections);
 #endif
     // Get an existing layout corresponding to the mask, no AddRef
     PTR_PEImageLayout GetExistingLayoutInternal(DWORD imageLayoutMask);

--- a/src/vm/peimage.h
+++ b/src/vm/peimage.h
@@ -257,6 +257,12 @@ private:
 #ifndef DACCESS_COMPILE
     // Get or create the layout corresponding to the mask, with an AddRef
     PTR_PEImageLayout GetLayoutInternal(DWORD imageLayoutMask, DWORD flags); 
+
+    // Create the mapped layout
+    PTR_PEImageLayout CreateLayoutMapped();
+
+    // Create the flat layout
+    PTR_PEImageLayout CreateLayoutFlat();
 #endif
     // Get an existing layout corresponding to the mask, no AddRef
     PTR_PEImageLayout GetExistingLayoutInternal(DWORD imageLayoutMask);


### PR DESCRIPTION
Before the changes (applies only to the Unix-like platforms):

- If file alignment sections of IL-only assemblies is less than size of virtual page, then the pages are not directly mapped to memory, but instead are copied to anonymous memory.

With the changes (applies only to the Unix-like platforms):

- IL-only assemblies without writeable sections are directly mapped to memory in flat mode (i.e. without separate maps per section).

This means that physical memory for the assemblies is allocated only once with the changes, even if the assemblies are loaded into multiple processes, so memory consumption reduces.

Related issue: #10693 

<br/>
Testing:

- CI
  - Default: Successful
  - Additionally, Ubuntu x64 Checked Build and Test (Jit - CoreFx): Successful 
- CoreCLR test suite: Successful (on Windows, with these changes enabled for testing, although they are supposed to be Unix only)
- Memory consumption: please, see below

Memory consumption of Puzzle.Tizen application (see #10380)

Part | Before | After | Difference
------------ | ------------- | ------------- | -------------
Private (per-application) | 20244 kB | 19552 kB | 692 kB less
Shared (one copy for all applications) | 22132 kB | 22750 kB | 618 kB more
Rss | 42376 kB | 42302 kB | 74 kB less

Per-application part is 692 kB less, which is 10.3% of CoreCLR's per-application memory consumption part.
