### PR TITLE
Add System.Runtime.CompilerServices.ReadOnlyAttribute

### DIFF
--- a/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/mscorlib/shared/System.Private.CoreLib.Shared.projitems
@@ -300,6 +300,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\LoadHint.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\MethodCodeType.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\MethodImplOptions.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ReadOnlyAttribute.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\StringFreezingAttribute.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\SuppressIldasmAttribute.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\TupleElementNamesAttribute.cs"/>

--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ReadOnlyAttribute.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ReadOnlyAttribute.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This attribute should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.All, Inherited = false)]
+    public sealed class ReadOnlyAttribute : Attribute
+    {
+        public ReadOnlyAttribute()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Proposal is in: https://github.com/dotnet/corefx/issues/17741

Questions for area owners:

1) Is this the correct branch to use? is a rebase needed?
2) Do I need to run any additional tools? I see that `model.xml` is no longer used in the repo.
3) ~~Is there any additional work needed to copy this to corert repo? or is the mirroring tool going to handle it?~~

cc @VSadov @jcouv @dotnet/roslyn-compiler 