### PR TITLE
Call custom parameterless constructor on structs through Activator

### DIFF
--- a/src/mscorlib/src/System/RuntimeHandles.cs
+++ b/src/mscorlib/src/System/RuntimeHandles.cs
@@ -203,7 +203,7 @@ namespace System
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern Object CreateInstance(RuntimeType type, bool publicOnly, bool noCheck, ref bool canBeCached, ref RuntimeMethodHandleInternal ctor, ref bool bNeedSecurityCheck);
+        internal static extern Object CreateInstance(RuntimeType type, bool publicOnly, ref bool canBeCached, ref RuntimeMethodHandleInternal ctor);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern Object CreateCaInstance(RuntimeType type, IRuntimeMethodInfo ctor);

--- a/src/vm/runtimehandles.h
+++ b/src/vm/runtimehandles.h
@@ -126,12 +126,10 @@ public:
 
     // Static method on RuntimeTypeHandle
     static FCDECL1(Object*, Allocate, ReflectClassBaseObject *refType) ; //A.CI work	
-    static FCDECL6(Object*, CreateInstance, ReflectClassBaseObject* refThisUNSAFE,
+    static FCDECL4(Object*, CreateInstance, ReflectClassBaseObject* refThisUNSAFE,
                                             CLR_BOOL publicOnly,
-                                            CLR_BOOL securityOff,
                                             CLR_BOOL *pbCanBeCached,
-                                            MethodDesc** pConstructor,
-                                            CLR_BOOL *pbNeedSecurityCheck);
+                                            MethodDesc** pConstructor);
 
     static FCDECL2(Object*, CreateCaInstance, ReflectClassBaseObject* refCaType, ReflectMethodObject* pCtorUNSAFE);
 

--- a/tests/src/reflection/ActivateStructDefCtor/ActivateStructDefCtor.il
+++ b/tests/src/reflection/ActivateStructDefCtor/ActivateStructDefCtor.il
@@ -1,0 +1,107 @@
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
+  .ver 2:0:0:0
+}
+.assembly ActivateStructDefCtor
+{
+}
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class private abstract auto ansi sealed beforefieldinit Program
+       extends [System.Runtime]System.Object
+{
+  .class sequential ansi sealed nested private beforefieldinit Foo
+         extends [System.Runtime]System.ValueType
+  {
+    .field public int32 x
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldc.i4.1
+      IL_0002:  stfld      int32 Program/Foo::x
+      IL_0007:  ret
+    } // end of method Foo::.ctor
+  } // end of class Foo
+
+  .field private static int32 Pass
+  .field private static int32 Fail
+
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    // Code size       89 (0x59)
+    .maxstack  2
+    .locals init ([0] int32 testIndex,
+             [1] int32 i,
+             [2] valuetype Program/Foo foo)
+    IL_0000:  ldc.i4.m1
+    IL_0001:  stloc.0
+    IL_0002:  ldc.i4.0
+    IL_0003:  stloc.1
+    IL_0004:  br.s       IL_004f
+
+    IL_0006:  ldloc.0
+    IL_0007:  ldc.i4.1
+    IL_0008:  add
+    IL_0009:  stloc.0
+    IL_000a:  call       !!0 [System.Runtime]System.Activator::CreateInstance<valuetype Program/Foo>()
+    IL_000f:  stloc.2
+    IL_0010:  ldloc.2
+    IL_0011:  ldfld      int32 Program/Foo::x
+    IL_0016:  ldc.i4.1
+    IL_0017:  beq.s      IL_0021
+
+    IL_0019:  ldsfld     int32 Program::Fail
+    IL_001e:  ldloc.0
+    IL_001f:  add
+    IL_0020:  ret
+
+    IL_0021:  ldloc.0
+    IL_0022:  ldc.i4.1
+    IL_0023:  add
+    IL_0024:  stloc.0
+    IL_0025:  ldtoken    Program/Foo
+    IL_002a:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_002f:  call       object [System.Runtime]System.Activator::CreateInstance(class [System.Runtime]System.Type)
+    IL_0034:  unbox.any  Program/Foo
+    IL_0039:  stloc.2
+    IL_003a:  ldloc.2
+    IL_003b:  ldfld      int32 Program/Foo::x
+    IL_0040:  ldc.i4.1
+    IL_0041:  beq.s      IL_004b
+
+    IL_0043:  ldsfld     int32 Program::Fail
+    IL_0048:  ldloc.0
+    IL_0049:  add
+    IL_004a:  ret
+
+    IL_004b:  ldloc.1
+    IL_004c:  ldc.i4.1
+    IL_004d:  add
+    IL_004e:  stloc.1
+    IL_004f:  ldloc.1
+    IL_0050:  ldc.i4.2
+    IL_0051:  blt.s      IL_0006
+
+    IL_0053:  ldsfld     int32 Program::Pass
+    IL_0058:  ret
+  } // end of method Program::Main
+
+  .method private hidebysig specialname rtspecialname static 
+          void  .cctor() cil managed
+  {
+    // Code size       15 (0xf)
+    .maxstack  8
+    IL_0000:  ldc.i4.s   100
+    IL_0002:  stsfld     int32 Program::Pass
+    IL_0007:  ldc.i4.s   101
+    IL_0009:  stsfld     int32 Program::Fail
+    IL_000e:  ret
+  } // end of method Program::.cctor
+} // end of class Program

--- a/tests/src/reflection/ActivateStructDefCtor/ActivateStructDefCtor.ilproj
+++ b/tests/src/reflection/ActivateStructDefCtor/ActivateStructDefCtor.ilproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{F8D9C0E2-F86F-493F-8D18-0D19ADF6E3FD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "/>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "/>
+  <ItemGroup>
+    <Compile Include="ActivateStructDefCtor.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
Fixes #6843
- Disabled caching struct types that have custom parameterless constructors in `ActivatorCache`
- Removed some things relevant to security, which don't apply to CoreCLR