### PR TITLE
Correct fix for long ilasm params

### DIFF
--- a/src/ilasm/main.cpp
+++ b/src/ilasm/main.cpp
@@ -106,7 +106,6 @@ extern "C" int _cdecl wmain(int argc, __in WCHAR **argv)
 {
     int         i, NumFiles = 0, NumDeltaFiles = 0;
     bool        IsDLL = false, IsOBJ = false;
-    char        szOpt[1024];
     Assembler   *pAsm;
     MappedFileStream *pIn;
     AsmParse    *pParser;
@@ -224,14 +223,13 @@ extern "C" int _cdecl wmain(int argc, __in WCHAR **argv)
                 if((argv[i][0] == L'/') || (argv[i][0] == L'-'))
 #endif
                 {
-                    memset(szOpt,0,sizeof(szOpt));
-                    WszWideCharToMultiByte(uCodePage,0,&argv[i][1],-1,szOpt,sizeof(szOpt),NULL,NULL);
-                    szOpt[3] = 0;
-                    if (!_stricmp(szOpt,"NOA"))
+                    char szOpt[3 + 1] = { 0 };
+                    WszWideCharToMultiByte(uCodePage, 0, &argv[i][1], 3, szOpt, sizeof(szOpt), NULL, NULL);
+                    if (!_stricmp(szOpt, "NOA"))
                     {
                         pAsm->m_fAutoInheritFromObject = FALSE;
                     }
-                    else if (!_stricmp(szOpt,"QUI"))
+                    else if (!_stricmp(szOpt, "QUI"))
                     {
                         pAsm->m_fReportProgress = FALSE;
                         bReportProgress = FALSE;


### PR DESCRIPTION
Changes for #9757 issue. Handle long parameters in the right way.