### PR TITLE
[x86/Linux] Use GCInfo for funclet unwinding

### DIFF
--- a/src/gcdump/i386/gcdumpx86.cpp
+++ b/src/gcdump/i386/gcdumpx86.cpp
@@ -452,7 +452,10 @@ size_t              GCDump::DumpGCTable(PTR_CBYTE      table,
                     /* non-ptr arg push */
 
                     curOffs += (val & 0x07);
+#ifndef UNIX_X86_ABI
+                    // For x86/Linux, non-ptr arg pushes can be reported even for EBP frames
                     _ASSERTE(!header.ebpFrame);
+#endif // UNIX_X86_ABI
                     argCnt++;
 
                     DumpEncoding(bp, table-bp); bp = table;

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -4405,6 +4405,12 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     emitFullyInt   = fullyInt;
     emitFullGCinfo = fullPtrMap;
 
+#ifndef UNIX_X86_ABI
+    emitFullArgInfo = !emitHasFramePtr;
+#else
+    emitFullArgInfo = fullPtrMap;
+#endif
+
 #if EMITTER_STATS
     GCrefsTable.record(emitGCrFrameOffsCnt);
     emitSizeTable.record(static_cast<unsigned>(emitSizeMethod));
@@ -6817,7 +6823,7 @@ void emitter::emitStackPushLargeStk(BYTE* addr, GCtype gcType, unsigned count)
         *u2.emitArgTrackTop++ = (BYTE)gcType;
         assert(u2.emitArgTrackTop <= u2.emitArgTrackTab + emitMaxStackDepth);
 
-        if (!emitHasFramePtr || needsGC(gcType))
+        if (emitFullArgInfo || needsGC(gcType))
         {
             if (emitFullGCinfo)
             {
@@ -6889,7 +6895,7 @@ void emitter::emitStackPopLargeStk(BYTE* addr, bool isCall, unsigned char callIn
 
         // This is an "interesting" argument
 
-        if (!emitHasFramePtr || needsGC(gcType))
+        if (emitFullArgInfo || needsGC(gcType))
         {
             argRecCnt += 1;
         }
@@ -7037,7 +7043,7 @@ void emitter::emitStackKillArgs(BYTE* addr, unsigned count, unsigned char callIn
 
         /* We're about to kill the corresponding (pointer) arg records */
 
-        if (emitHasFramePtr)
+        if (!emitFullArgInfo)
         {
             u2.emitGcArgTrackCnt -= gcCnt.Value();
         }

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -2040,6 +2040,7 @@ public:
     /*         The following logic keeps track of live GC ref values        */
     /************************************************************************/
 
+    bool emitFullArgInfo; // full arg info (including non-ptr arg)?
     bool emitFullGCinfo; // full GC pointer maps?
     bool emitFullyInt;   // fully interruptible code?
 

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -2041,8 +2041,8 @@ public:
     /************************************************************************/
 
     bool emitFullArgInfo; // full arg info (including non-ptr arg)?
-    bool emitFullGCinfo; // full GC pointer maps?
-    bool emitFullyInt;   // fully interruptible code?
+    bool emitFullGCinfo;  // full GC pointer maps?
+    bool emitFullyInt;    // fully interruptible code?
 
 #if EMIT_TRACK_STACK_DEPTH
     unsigned emitCntStackDepth; // 0 in prolog/epilog, One DWORD elsewhere

--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -2424,7 +2424,9 @@ DONE_VLT:
 
                     assert((codeDelta & 0x7) == codeDelta);
                     *dest++ = 0xB0 | (BYTE)codeDelta;
+#ifndef UNIX_X86_ABI
                     assert(!compiler->isFramePointerUsed());
+#endif
 
                     /* Remember the new 'last' offset */
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16204,11 +16204,6 @@ void Compiler::fgSetOptions()
     if (info.compXcptnsCount > 0)
     {
         codeGen->setFramePointerRequiredEH(true);
-#ifdef UNIX_X86_ABI
-        assert(!codeGen->isGCTypeFixed());
-        // Enforce fully interruptible codegen for funclet unwinding
-        genInterruptible = true;
-#endif // UNIX_X86_ABI
     }
 
 #else // !_TARGET_X86_
@@ -16219,6 +16214,15 @@ void Compiler::fgSetOptions()
     }
 
 #endif // _TARGET_X86_
+
+#ifdef UNIX_X86_ABI
+    if (info.compXcptnsCount > 0)
+    {
+        assert(!codeGen->isGCTypeFixed());
+        // Enforce fully interruptible codegen for funclet unwinding
+        genInterruptible = true;
+    }
+#endif // UNIX_X86_ABI
 
     fgCheckArgCnt();
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16202,7 +16202,14 @@ void Compiler::fgSetOptions()
     // to use a frame pointer because of EH. But until all the code uses
     // the same test, leave info.compXcptnsCount here.
     if (info.compXcptnsCount > 0)
+    {
         codeGen->setFramePointerRequiredEH(true);
+#ifdef UNIX_X86_ABI
+        assert(!codeGen->isGCTypeFixed());
+        // Enforce fully interruptible codegen for funclet unwinding
+        genInterruptible = true;
+#endif // UNIX_X86_ABI
+    }
 
 #else // !_TARGET_X86_
 

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -2413,16 +2413,16 @@ unsigned scanArgRegTableI(PTR_CBYTE     table,
     _ASSERTE(*castto(table, unsigned short *)++ == 0xBABE);
 #endif
 
-    bool      isPartialArgInfo;
+    bool      hasPartialArgInfo;
 
 #ifndef UNIX_X86_ABI
-    isPartialArgInfo = info->ebpFrame;
+    hasPartialArgInfo = info->ebpFrame;
 #else
     // For x86/Linux, interruptible code always has full arg info
     //
     // This should be aligned with emitFullArgInfo setting at
     // emitter::emitEndCodeGen (in JIT)
-    isPartialArgInfo = false;
+    hasPartialArgInfo = false;
 #endif
 
   /*
@@ -2623,7 +2623,7 @@ unsigned scanArgRegTableI(PTR_CBYTE     table,
 
                         argOfs--;
                     }
-                    else if (isPartialArgInfo)
+                    else if (hasPartialArgInfo)
                         argCnt--;
                     else /* full arg info && not a ref */
                         argOfs--;
@@ -2634,11 +2634,11 @@ unsigned scanArgRegTableI(PTR_CBYTE     table,
                 }
                 while (argOfs);
 
-                _ASSERTE(!isPartialArgInfo     ||
+                _ASSERTE(!hasPartialArgInfo    ||
                          isZero(argHigh)       ||
                         (argHigh == CONSTRUCT_ptrArgTP(1, (argCnt-1))));
 
-                if (isPartialArgInfo)
+                if (hasPartialArgInfo)
                 {
                     while (!intersect(argHigh, ptrArgs) && (!isZero(argHigh)))
                         argHigh >>= 1;
@@ -2658,7 +2658,7 @@ unsigned scanArgRegTableI(PTR_CBYTE     table,
                     /* Full arg info reports all pushes, and thus
                        argOffs has to be consistent with argCnt */
 
-                    _ASSERTE(isPartialArgInfo || argCnt == argOfs);
+                    _ASSERTE(hasPartialArgInfo || argCnt == argOfs);
 
                     /* store arg count */
 
@@ -2704,7 +2704,7 @@ unsigned scanArgRegTableI(PTR_CBYTE     table,
             }
             else {
                 /* non-ptr arg push */
-                _ASSERTE(!isPartialArgInfo);
+                _ASSERTE(!hasPartialArgInfo);
                 ptrOffs += (val & 0x07);
                 if (ptrOffs > curOffs) {
                     iptr = isThis = false;
@@ -2767,7 +2767,7 @@ unsigned scanArgRegTableI(PTR_CBYTE     table,
 
             // For partial arg info, need to find the next higest pointer for argHigh
 
-            if (isPartialArgInfo)
+            if (hasPartialArgInfo)
             {
                 for(argHigh = ptrArgTP(0); !isZero(argMask); argMask >>= 1)
                 {
@@ -2806,7 +2806,7 @@ REPORT_REFS:
     info->thisPtrResult  = thisPtrReg;
     _ASSERTE(thisPtrReg == REGI_NA || (regNumToMask(thisPtrReg) & info->regMaskResult));
 
-    if (isPartialArgInfo)
+    if (hasPartialArgInfo)
     {
         return 0;
     }


### PR DESCRIPTION
This commit revises x86/Linux unwinder to use GCInfo(GetPushedArgSize) for funclet unwinding.

This commit includes the following additional changes:
 - Enforce fully interruptible codegen for functions with EH funclet
 - Enforce full arg info emission even for EBP frames
