### PR TITLE
[RyuJit/ARM32] Fix assertion of failure on "Instruction cannot be encoded"

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1971,58 +1971,6 @@ void CodeGen::genLongToIntCast(GenTree* cast)
 }
 
 //------------------------------------------------------------------------
-// genFloatToFloatCast: Generate code for a cast between float and double
-//
-// Arguments:
-//    treeNode - The GT_CAST node
-//
-// Return Value:
-//    None.
-//
-// Assumptions:
-//    Cast is a non-overflow conversion.
-//    The treeNode must have an assigned register.
-//    The cast is between float and double.
-//
-void CodeGen::genFloatToFloatCast(GenTreePtr treeNode)
-{
-    // float <--> double conversions are always non-overflow ones
-    assert(treeNode->OperGet() == GT_CAST);
-    assert(!treeNode->gtOverflow());
-
-    regNumber targetReg = treeNode->gtRegNum;
-    assert(genIsValidFloatReg(targetReg));
-
-    GenTreePtr op1 = treeNode->gtOp.gtOp1;
-    assert(!op1->isContained());               // Cannot be contained
-    assert(genIsValidFloatReg(op1->gtRegNum)); // Must be a valid float reg.
-
-    var_types dstType = treeNode->CastToType();
-    var_types srcType = op1->TypeGet();
-    assert(varTypeIsFloating(srcType) && varTypeIsFloating(dstType));
-
-    genConsumeOperands(treeNode->AsOp());
-
-    // treeNode must be a reg
-    assert(!treeNode->isContained());
-
-    if (srcType != dstType)
-    {
-        instruction insVcvt = (srcType == TYP_FLOAT) ? INS_vcvt_f2d  // convert Float to Double
-                                                     : INS_vcvt_d2f; // convert Double to Float
-
-        getEmitter()->emitIns_R_R(insVcvt, emitTypeSize(treeNode), treeNode->gtRegNum, op1->gtRegNum);
-    }
-    else if (treeNode->gtRegNum != op1->gtRegNum)
-    {
-        getEmitter()->emitIns_R_R(INS_vmov, emitTypeSize(treeNode), treeNode->gtRegNum, op1->gtRegNum);
-    }
-
-    genProduceReg(treeNode);
-}
-
-//------------------------------------------------------------------------
->>>>>>> Add overflow check logics when using temp registers.
 // genIntToFloatCast: Generate code to cast an int/long to float/double
 //
 // Arguments:

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1428,7 +1428,16 @@ void CodeGen::genIntToIntCast(GenTreePtr treeNode)
             // we only have to check for any bits set in 'typeMask'
 
             noway_assert(castInfo.typeMask != 0);
-            emit->emitIns_R_I(INS_tst, cmpSize, sourceReg, castInfo.typeMask);
+            if (arm_Valid_Imm_For_Instr(INS_tst, castInfo.typeMask, INS_FLAGS_DONT_CARE))
+            {
+                emit->emitIns_R_I(INS_tst, cmpSize, sourceReg, castInfo.typeMask);
+            }
+            else
+            {
+                noway_assert(tmpReg != REG_NA);
+                instGen_Set_Reg_To_Imm(cmpSize, tmpReg, castInfo.typeMask);
+                emit->emitIns_R_R(INS_tst, cmpSize, sourceReg, tmpReg);
+            }
             emitJumpKind jmpNotEqual = genJumpKindForOper(GT_NE, CK_SIGNED);
             genJumpToThrowHlpBlk(jmpNotEqual, SCK_OVERFLOW);
         }

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1428,11 +1428,13 @@ void CodeGen::genIntToIntCast(GenTreePtr treeNode)
             // we only have to check for any bits set in 'typeMask'
 
             noway_assert(castInfo.typeMask != 0);
+#ifdef _TARGET_ARM_
             if (arm_Valid_Imm_For_Instr(INS_tst, castInfo.typeMask, INS_FLAGS_DONT_CARE))
             {
                 emit->emitIns_R_I(INS_tst, cmpSize, sourceReg, castInfo.typeMask);
             }
             else
+#endif // _TARGET_ARM
             {
                 noway_assert(tmpReg != REG_NA);
                 instGen_Set_Reg_To_Imm(cmpSize, tmpReg, castInfo.typeMask);

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1428,18 +1428,20 @@ void CodeGen::genIntToIntCast(GenTreePtr treeNode)
             // we only have to check for any bits set in 'typeMask'
 
             noway_assert(castInfo.typeMask != 0);
-#ifdef _TARGET_ARM_
+#if defined(_TARGET_ARM_)
             if (arm_Valid_Imm_For_Instr(INS_tst, castInfo.typeMask, INS_FLAGS_DONT_CARE))
             {
                 emit->emitIns_R_I(INS_tst, cmpSize, sourceReg, castInfo.typeMask);
             }
             else
-#endif // _TARGET_ARM
             {
                 noway_assert(tmpReg != REG_NA);
                 instGen_Set_Reg_To_Imm(cmpSize, tmpReg, castInfo.typeMask);
                 emit->emitIns_R_R(INS_tst, cmpSize, sourceReg, tmpReg);
             }
+#elif defined(_TARGET_ARM64_)
+            emit->emitIns_R_I(INS_tst, cmpSize, sourceReg, castInfo.typeMask);
+#endif // _TARGET_ARM*
             emitJumpKind jmpNotEqual = genJumpKindForOper(GT_NE, CK_SIGNED);
             genJumpToThrowHlpBlk(jmpNotEqual, SCK_OVERFLOW);
         }

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -337,7 +337,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 bool canStoreTypeMask = emitter::emitIns_valid_imm_for_alu(castInfo.typeMask);
                 if (!canStoreTypeMask)
                 {
-                    info->internalIntCount++;
+                    info->internalIntCount = 1;
                 }
 
                 // For comparing against the max or min value
@@ -346,7 +346,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
 
                 if (!canStoreMaxValue || !canStoreMinValue)
                 {
-                    info->internalIntCount++;
+                    info->internalIntCount = 1;
                 }
             }
         }

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -333,20 +333,30 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 // If we cannot store data in an immediate for instructions,
                 // then we will need to reserve a temporary register.
 
-                // For checking the type
-                bool canStoreTypeMask = emitter::emitIns_valid_imm_for_alu(castInfo.typeMask);
-                if (!canStoreTypeMask)
+                if (!castInfo.signCheckOnly) // In case of only sign check, temp regs are not needeed.
                 {
-                    info->internalIntCount = 1;
-                }
+                    if (castInfo.unsignedSource || castInfo.unsignedDest)
+                    {
+                        // check typeMask
+                        bool canStoreTypeMask = emitter::emitIns_valid_imm_for_alu(castInfo.typeMask);
+                        if (!canStoreTypeMask)
+                        {
+                            info->internalIntCount = 1;
+                        }
+                    }
+                    else
+                    {
+                        // For comparing against the max or min value
+                        bool canStoreMaxValue =
+                            emitter::emitIns_valid_imm_for_cmp(castInfo.typeMax, INS_FLAGS_DONT_CARE);
+                        bool canStoreMinValue =
+                            emitter::emitIns_valid_imm_for_cmp(castInfo.typeMin, INS_FLAGS_DONT_CARE);
 
-                // For comparing against the max or min value
-                bool canStoreMaxValue = emitter::emitIns_valid_imm_for_cmp(castInfo.typeMax, INS_FLAGS_DONT_CARE);
-                bool canStoreMinValue = emitter::emitIns_valid_imm_for_cmp(castInfo.typeMin, INS_FLAGS_DONT_CARE);
-
-                if (!canStoreMaxValue || !canStoreMinValue)
-                {
-                    info->internalIntCount = 1;
+                        if (!canStoreMaxValue || !canStoreMinValue)
+                        {
+                            info->internalIntCount = 1;
+                        }
+                    }
                 }
             }
         }

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -330,16 +330,23 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
                 var_types srcType = castOp->TypeGet();
                 emitAttr  cmpSize = EA_ATTR(genTypeSize(srcType));
 
-                // If we cannot store the comparisons in an immediate for either
-                // comparing against the max or min value, then we will need to
-                // reserve a temporary register.
+                // If we cannot store data in an immediate for instructions,
+                // then we will need to reserve a temporary register.
 
+                // For checking the type
+                bool canStoreTypeMask = emitter::emitIns_valid_imm_for_alu(castInfo.typeMask);
+                if (!canStoreTypeMask)
+                {
+                    info->internalIntCount++;
+                }
+
+                // For comparing against the max or min value
                 bool canStoreMaxValue = emitter::emitIns_valid_imm_for_cmp(castInfo.typeMax, INS_FLAGS_DONT_CARE);
                 bool canStoreMinValue = emitter::emitIns_valid_imm_for_cmp(castInfo.typeMin, INS_FLAGS_DONT_CARE);
 
                 if (!canStoreMaxValue || !canStoreMinValue)
                 {
-                    info->internalIntCount = 1;
+                    info->internalIntCount++;
                 }
             }
         }


### PR DESCRIPTION
#10762, An assertion of failure has occurred during the conv_ovf test case is running.

I figured out the bit set mask for '0xffffff00' which is the imm is not supportted on ARM.
So at first, It would be checked the validation of using instruction with immediate constants.
If not, it would be use the instruction with registers.