### PR TITLE
Handle unsupported varargs tests on Unix gracefully.

### DIFF
--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -280,6 +280,16 @@ GetProcAddress(
 
     module = (MODSTRUCT *) hModule;
 
+    /* try to assert on attempt to locate symbol by ordinal */
+    /* this can't be an exact test for HIWORD((DWORD)lpProcName) == 0
+       because of the address range reserved for ordinals contain can
+       be a valid string address on non-Windows systems
+    */
+    if ((DWORD_PTR)lpProcName < VIRTUAL_PAGE_SIZE)
+    {
+        ASSERT("Attempt to locate symbol by ordinal?!\n");
+    }
+
     /* parameter validation */
 
     if ((lpProcName == nullptr) || (*lpProcName == '\0'))
@@ -294,16 +304,6 @@ GetProcAddress(
         TRACE("Invalid module handle %p\n", hModule);
         SetLastError(ERROR_INVALID_HANDLE);
         goto done;
-    }
-    
-    /* try to assert on attempt to locate symbol by ordinal */
-    /* this can't be an exact test for HIWORD((DWORD)lpProcName) == 0
-       because of the address range reserved for ordinals contain can
-       be a valid string address on non-Windows systems
-    */
-    if ((DWORD_PTR)lpProcName < VIRTUAL_PAGE_SIZE)
-    {
-        ASSERT("Attempt to locate symbol by ordinal?!\n");
     }
 
     // Get the symbol's address.

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -5042,12 +5042,14 @@ LPVOID NDirectMethodDesc::FindEntryPoint(HINSTANCE hMod) const
     
     FARPROC pFunc = NULL, pFuncW = NULL;
 
+#ifndef FEATURE_PAL
     // Handle ordinals.
     if (GetEntrypointName()[0] == '#')
     {
         long ordinal = atol(GetEntrypointName()+1);
         return reinterpret_cast<LPVOID>(GetProcAddress(hMod, (LPCSTR)(size_t)((UINT16)ordinal)));
     }
+#endif
 
     // Just look for the unmangled name.  If it is unicode fcn, we are going
     // to need to check for the 'W' API because it takes precedence over the


### PR DESCRIPTION
Some of mcc_i* tests caused segmentation faults on Unix. This commit make these tests exit by throwing a System.EntryPointNotFoundException exception instead of causing a segmentation fault.

Fix #9530