### PR TITLE
Added 'netstandard' corelib name into ilasm reference resolver

### DIFF
--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -276,9 +276,14 @@ mdToken Assembler::GetAsmRef(__in __nullterminated const char* szName)
 
 mdToken Assembler::GetBaseAsmRef()
 {
-    if(RidFromToken(m_pManifest->GetAsmRefTokByName("System.Runtime")) != 0)
+    if (RidFromToken(m_pManifest->GetAsmRefTokByName("System.Runtime")) != 0)
     {
         return GetAsmRef("System.Runtime");
+    }
+
+    if (RidFromToken(m_pManifest->GetAsmRefTokByName("netstandard")) != 0)
+    {
+        return GetAsmRef("netstandard");
     }
 
     return GetAsmRef("mscorlib");


### PR DESCRIPTION
Changes for issue #10590. Added 'netstandard' corelib name into ilasm reference resolver.