### PR TITLE
[Local GC] Fix some interface violations

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -65,6 +65,7 @@ inline HRESULT HRESULT_FROM_WIN32(unsigned long x)
 #define E_UNEXPECTED            0x8000FFFF
 #define E_NOTIMPL               0x80004001
 #define E_INVALIDARG            0x80070057
+#define COR_E_EXECUTIONENGINE   0x80131506
 
 #define NOERROR                 0x0
 #define ERROR_TIMEOUT           1460

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -408,12 +408,8 @@ BlockAgain:
         dwWaitResult = WaitForGCEvent->Wait(DETECT_DEADLOCK_TIMEOUT, FALSE );
 
         if (dwWaitResult == WAIT_TIMEOUT) {
-            //  Even in retail, stop in the debugger if available.  Ideally, the
-            //  following would use DebugBreak, but debspew.h makes this a null
-            //  macro in retail.  Note that in debug, we don't use the debspew.h
-            //  macros because these take a critical section that may have been
-            //  taken by a suspended thread.
-            FreeBuildDebugBreak();
+            //  Even in retail, stop in the debugger if available.
+            GCToOSInterface::DebugBreak();
             goto BlockAgain;
         }
 

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -28,7 +28,7 @@ inline void FATAL_GC_ERROR()
     GCToOSInterface::DebugBreak();
 #endif // DACCESS_COMPILE
     _ASSERTE(!"Fatal Error in GC.");
-    EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+    GCToEEInterface::HandleFatalError(COR_E_EXECUTIONENGINE);
 }
 
 #ifdef _MSC_VER


### PR DESCRIPTION
This PR fixes two linker errors that arise when building the GC standalone:
 1. A use of `_DebugBreak` in `GCHeap::WaitUntilGCComplete`, replaced with `GCToOSInterface::DebugBreak`
2. A use of `EEPOLICY_HANDLE_FATAL_ERROR` in `FATAL_GC_ERROR`, replaced with `GCToEEInterface::HandleFatalError`.

cc @Maoni0 @adityamandaleeka @sergiy-k @jkotas 