### PR TITLE
Exit gracefully when running ildasm -nat against unsupported ni file.

### DIFF
--- a/src/ildasm/dasm.cpp
+++ b/src/ildasm/dasm.cpp
@@ -7370,6 +7370,13 @@ BOOL DumpFile()
         }
         CORCOMPILE_HEADER * pNativeHeader;
         g_pPELoader->getVAforRVA(VAL32(g_CORHeader->ManagedNativeHeader.VirtualAddress), (void**)&pNativeHeader);
+
+        if (pNativeHeader->Signature != CORCOMPILE_SIGNATURE)
+        {
+            printError( g_pFile, "/native only works on NGen images." );
+            goto exit;
+        }
+
         g_pPELoader->getVAforRVA(VAL32(pNativeHeader->ManifestMetaData.VirtualAddress), &g_pMetaData);
         g_cbMetaData = VAL32(pNativeHeader->ManifestMetaData.Size);
     }


### PR DESCRIPTION
`ildasm -nat` only works for fragile native images (ie CoreLib only by default).
Running `ildasm -nat` against unsupported native images would cause a segmentation fault. This PR checks whether `pNativeHeader->Signature` is `CORCOMPILE_SIGNATURE`. If not,  exits with a meaningful error message.

fix #10247