### PR TITLE
Refactor variable strength handle creation

### DIFF
--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -313,6 +313,10 @@ OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF obje
     }
 #endif // _DEBUG && !FEATURE_REDHAWK
 
+    // If we are creating a variable-strength handle, verify that the
+    // requested variable handle type is valid.
+    _ASSERTE(uType != HNDTYPE_VARIABLE || IS_VALID_VHT_VALUE(lExtraInfo));
+
     VALIDATEOBJECTREF(object);
 
     // fetch the handle table pointer

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -907,30 +907,6 @@ void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF objref)
 //----------------------------------------------------------------------------
 
 /*
- * CreateVariableHandle.
- *
- * Creates a variable-strength handle.
- *
- * N.B. This routine is not a macro since we do validation in RETAIL.
- * We always validate the type here because it can come from external callers.
- */
-OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, uint32_t type)
-{
-    WRAPPER_NO_CONTRACT;
-
-    // verify that we are being asked to create a valid type
-    if (!IS_VALID_VHT_VALUE(type))
-    {
-        // bogus value passed in
-        _ASSERTE(FALSE);
-        return NULL;
-    }
-
-    // create the handle
-    return HndCreateHandle(hTable, HNDTYPE_VARIABLE, object, (uintptr_t)type);
-}
-
-/*
 * GetVariableHandleType.
 *
 * Retrieves the dynamic type of a variable-strength handle.

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -189,8 +189,6 @@ inline void DestroyDependentHandle(OBJECTHANDLE handle)
 #endif // !DACCESS_COMPILE
 
 #ifndef DACCESS_COMPILE
-
-OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, uint32_t type);
 uint32_t     GetVariableHandleType(OBJECTHANDLE handle);
 void         UpdateVariableHandleType(OBJECTHANDLE handle, uint32_t type);
 uint32_t     CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType, uint32_t newType);

--- a/src/vm/gchandletableutilities.h
+++ b/src/vm/gchandletableutilities.h
@@ -139,9 +139,21 @@ inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 #ifdef FEATURE_COMINTEROP
 inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table, OBJECTREFToObject(object), HNDTYPE_WEAK_WINRT, (void*)pWinRTWeakReference);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
+                                                                                 OBJECTREFToObject(object),
+                                                                                 HNDTYPE_WEAK_WINRT,
+                                                                                 (void*)pWinRTWeakReference);
 }
 #endif // FEATURE_COMINTEROP
+
+// Creates a variable-strength handle
+inline OBJECTHANDLE CreateVariableHandle(HHANDLETABLE table, OBJECTREF object, uint32_t type)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
+                                                                                 OBJECTREFToObject(object),
+                                                                                 HNDTYPE_VARIABLE,
+                                                                                 (void*)((uintptr_t)type));
+}
 
 #endif // !DACCESS_COMPILE
 


### PR DESCRIPTION
Code on the VM side currently calls a `CreateVariableHandle` function in objecthandle.h directly, which is mostly like any other handle creation function, except it also does some extra validation on the variable handle type.

This change refactors this a bit so that the VM side creates these handles via the interface, and the validation of the type happens on the GC side in `HndCreateHandle`.

@jkotas PTAL