### PR TITLE
Fix the broken link in contributing.md

### DIFF
--- a/Documentation/project-docs/contributing.md
+++ b/Documentation/project-docs/contributing.md
@@ -129,7 +129,7 @@ The following file header is the used for .NET Core. Please use it for new files
 ```
 
 - See [class.cpp](../../src/vm/class.cpp) for an example of the header in a C++ file.
-- See [List.cs](https://github.com/dotnet/corefx/blob/master/src/System.Collections/src/System/Collections/Generic/List.cs) for an example of the header in a C# file.
+- See [List.cs](../../src/mscorlib/src/System/Collections/Generic/List.cs) for an example of the header in a C# file.
 
 Copying Files from Other Projects
 ---------------------------------


### PR DESCRIPTION
The List.cs link is broken in contributing.md. This PR updates the link to List.cs accordingly.

Fix #10822