### PR TITLE
Make EmptyArray private

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -1012,6 +1012,11 @@ namespace System
             this.CopyTo(array, (int)index);
         }
 
+        private static class EmptyArray<T>
+        {
+            internal static readonly T[] Value = new T[0];
+        }
+
         [Pure]
         public static T[] Empty<T>()
         {
@@ -2777,8 +2782,3 @@ namespace System
     }
 }
 
-// Useful in number of places that return an empty byte array to avoid unnecessary memory allocation.
-internal static class EmptyArray<T>
-{
-    public static readonly T[] Value = new T[0];
-}

--- a/src/mscorlib/src/System/Collections/ArrayList.cs
+++ b/src/mscorlib/src/System/Collections/ArrayList.cs
@@ -46,7 +46,7 @@ namespace System.Collections
         private Object _syncRoot;
 
         private const int _defaultCapacity = 4;
-        private static readonly Object[] emptyArray = EmptyArray<Object>.Value;
+        private static readonly Object[] emptyArray = Array.Empty<Object>();
 
         // Constructs a ArrayList. The list is initially empty and has a capacity
         // of zero. Upon adding the first element to the list the capacity is

--- a/src/mscorlib/src/System/Collections/EmptyReadOnlyDictionaryInternal.cs
+++ b/src/mscorlib/src/System/Collections/EmptyReadOnlyDictionaryInternal.cs
@@ -114,7 +114,7 @@ namespace System.Collections
         {
             get
             {
-                return EmptyArray<Object>.Value;
+                return Array.Empty<Object>();
             }
         }
 
@@ -122,7 +122,7 @@ namespace System.Collections
         {
             get
             {
-                return EmptyArray<Object>.Value;
+                return Array.Empty<Object>();
             }
         }
 

--- a/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/CompareInfo.Unix.cs
@@ -298,7 +298,7 @@ namespace System.Globalization
             byte [] keyData;
             if (source.Length == 0)
             { 
-                keyData = EmptyArray<Byte>.Value;
+                keyData = Array.Empty<Byte>();
             }
             else
             {

--- a/src/mscorlib/src/System/IO/BinaryReader.cs
+++ b/src/mscorlib/src/System/IO/BinaryReader.cs
@@ -536,7 +536,7 @@ namespace System.IO
 
             if (count == 0)
             {
-                return EmptyArray<Char>.Value;
+                return Array.Empty<Char>();
             }
 
             // SafeCritical: we own the chars buffer, and therefore can guarantee that the index and count are valid
@@ -580,7 +580,7 @@ namespace System.IO
 
             if (count == 0)
             {
-                return EmptyArray<Byte>.Value;
+                return Array.Empty<Byte>();
             }
 
             byte[] result = new byte[count];

--- a/src/mscorlib/src/System/IO/MemoryStream.cs
+++ b/src/mscorlib/src/System/IO/MemoryStream.cs
@@ -68,7 +68,7 @@ namespace System.IO
             }
             Contract.EndContractBlock();
 
-            _buffer = capacity != 0 ? new byte[capacity] : EmptyArray<byte>.Value;
+            _buffer = capacity != 0 ? new byte[capacity] : Array.Empty<byte>();
             _capacity = capacity;
             _expandable = true;
             _writable = true;

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -1279,7 +1279,7 @@ namespace System.Reflection
             Contract.Requires(caType != null);
 
             if (type.GetElementType() != null)
-                return (caType.IsValueType) ? EmptyArray<Object>.Value : CreateAttributeArrayHelper(caType, 0);
+                return (caType.IsValueType) ? Array.Empty<Object>() : CreateAttributeArrayHelper(caType, 0);
 
             if (type.IsGenericType && !type.IsGenericTypeDefinition)
                 type = type.GetGenericTypeDefinition() as RuntimeType;

--- a/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -245,7 +245,7 @@ namespace System.Reflection.Emit
                     return s_anonymouslyHostedDynamicMethodsModule;
 
                 ConstructorInfo transparencyCtor = typeof(SecurityTransparentAttribute).GetConstructor(Type.EmptyTypes);
-                CustomAttributeBuilder transparencyAttribute = new CustomAttributeBuilder(transparencyCtor, EmptyArray<Object>.Value);
+                CustomAttributeBuilder transparencyAttribute = new CustomAttributeBuilder(transparencyCtor, Array.Empty<Object>());
                 List<CustomAttributeBuilder> assemblyAttributes = new List<CustomAttributeBuilder>();
                 assemblyAttributes.Add(transparencyAttribute);
 
@@ -683,7 +683,7 @@ namespace System.Reflection.Emit
                 if (attributeType.IsAssignableFrom(typeof(MethodImplAttribute)))
                     return new Object[] { new MethodImplAttribute(GetMethodImplementationFlags()) };
                 else
-                    return EmptyArray<Object>.Value;
+                    return Array.Empty<Object>();
             }
 
             public override Object[] GetCustomAttributes(bool inherit)
@@ -770,12 +770,12 @@ namespace System.Reflection.Emit
 
                 Object[] ICustomAttributeProvider.GetCustomAttributes(Type attributeType, bool inherit)
                 {
-                    return EmptyArray<Object>.Value;
+                    return Array.Empty<Object>();
                 }
 
                 Object[] ICustomAttributeProvider.GetCustomAttributes(bool inherit)
                 {
-                    return EmptyArray<Object>.Value;
+                    return Array.Empty<Object>();
                 }
 
                 bool ICustomAttributeProvider.IsDefined(Type attributeType, bool inherit)

--- a/src/mscorlib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -335,7 +335,7 @@ namespace System.Reflection.Emit
         internal override Type[] GetParameterTypes()
         {
             if (m_parameterTypes == null)
-                m_parameterTypes = EmptyArray<Type>.Value;
+                m_parameterTypes = Array.Empty<Type>();
 
             return m_parameterTypes;
         }
@@ -375,7 +375,7 @@ namespace System.Reflection.Emit
         internal SignatureHelper GetMethodSignature()
         {
             if (m_parameterTypes == null)
-                m_parameterTypes = EmptyArray<Type>.Value;
+                m_parameterTypes = Array.Empty<Type>();
 
             m_signature = SignatureHelper.GetMethodSigHelper(m_module, m_callingConvention, m_inst != null ? m_inst.Length : 0,
                 m_returnType == null ? typeof(void) : m_returnType, m_returnTypeRequiredCustomModifiers, m_returnTypeOptionalCustomModifiers,

--- a/src/mscorlib/src/System/Reflection/Emit/SymbolMethod.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/SymbolMethod.cs
@@ -47,7 +47,7 @@ namespace System.Reflection.Emit
             }
             else
             {
-                m_parameterTypes = EmptyArray<Type>.Value;
+                m_parameterTypes = Array.Empty<Type>();
             }
 
             m_module = mod;

--- a/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -962,7 +962,7 @@ namespace System.Reflection.Emit
 
             if (m_typeInterfaces == null)
             {
-                return EmptyArray<Type>.Value;
+                return Array.Empty<Type>();
             }
 
             return m_typeInterfaces.ToArray();

--- a/src/mscorlib/src/System/Reflection/MdFieldInfo.cs
+++ b/src/mscorlib/src/System/Reflection/MdFieldInfo.cs
@@ -128,12 +128,12 @@ namespace System.Reflection
 
         public override Type[] GetRequiredCustomModifiers()
         {
-            return EmptyArray<Type>.Value;
+            return Array.Empty<Type>();
         }
 
         public override Type[] GetOptionalCustomModifiers()
         {
-            return EmptyArray<Type>.Value;
+            return Array.Empty<Type>();
         }
 
         #endregion

--- a/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -723,7 +723,7 @@ namespace System.Reflection
 
             if (types == null)
             {
-                types = EmptyArray<Type>.Value;
+                types = Array.Empty<Type>();
             }
             return types;
         }

--- a/src/mscorlib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/mscorlib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -480,7 +480,7 @@ namespace System.Reflection
         public override Object[] GetCustomAttributes(bool inherit)
         {
             if (MdToken.IsNullToken(m_tkParamDef))
-                return EmptyArray<Object>.Value;
+                return Array.Empty<Object>();
 
             return CustomAttribute.GetCustomAttributes(this, typeof(object) as RuntimeType);
         }
@@ -492,7 +492,7 @@ namespace System.Reflection
             Contract.EndContractBlock();
 
             if (MdToken.IsNullToken(m_tkParamDef))
-                return EmptyArray<Object>.Value;
+                return Array.Empty<Object>();
 
             RuntimeType attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
 

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -114,7 +114,7 @@ namespace System
             public T[] ToArray()
             {
                 if (_count == 0)
-                    return EmptyArray<T>.Value;
+                    return Array.Empty<T>();
                 if (_count == 1)
                     return new T[1] { _item };
 
@@ -730,7 +730,7 @@ namespace System
                 {
                     if (ReflectedType.IsGenericParameter)
                     {
-                        return EmptyArray<RuntimeConstructorInfo>.Value;
+                        return Array.Empty<RuntimeConstructorInfo>();
                     }
 
                     ListBuilder<RuntimeConstructorInfo> list = new ListBuilder<RuntimeConstructorInfo>();
@@ -1087,7 +1087,7 @@ namespace System
 
                     // For example, TypeDescs do not have metadata tokens
                     if (MdToken.IsNullToken(tkEnclosingType))
-                        return EmptyArray<RuntimeType>.Value;
+                        return Array.Empty<RuntimeType>();
 
                     ListBuilder<RuntimeType> list = new ListBuilder<RuntimeType>();
 
@@ -3672,7 +3672,7 @@ namespace System
             Type[] types = GetRootElementType().GetTypeHandleInternal().GetInstantiationPublic();
 
             if (types == null)
-                types = EmptyArray<Type>.Value;
+                types = Array.Empty<Type>();
 
             return types;
         }
@@ -3785,7 +3785,7 @@ namespace System
             Type[] constraints = new RuntimeTypeHandle(this).GetConstraints();
 
             if (constraints == null)
-                constraints = EmptyArray<Type>.Value;
+                constraints = Array.Empty<Type>();
 
             return constraints;
         }
@@ -3953,7 +3953,7 @@ namespace System
             }
 
             if (members == null)
-                members = EmptyArray<MemberInfo>.Value;
+                members = Array.Empty<MemberInfo>();
 
             return members;
         }
@@ -4384,7 +4384,7 @@ namespace System
                     finalists = new MethodInfo[] { finalist };
 
                 if (providedArgs == null)
-                    providedArgs = EmptyArray<Object>.Value;
+                    providedArgs = Array.Empty<Object>();
 
                 Object state = null;
 
@@ -4608,7 +4608,7 @@ namespace System
             Object server = null;
 
             if (args == null)
-                args = EmptyArray<Object>.Value;
+                args = Array.Empty<Object>();
 
             int argCnt = args.Length;
 

--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -1234,7 +1234,7 @@ namespace System
 
             if ((count == 0) || (omitEmptyEntries && this.Length == 0))
             {
-                return EmptyArray<String>.Value;
+                return Array.Empty<String>();
             }
 
             if (count == 1)
@@ -1310,7 +1310,7 @@ namespace System
 
             if ((count == 0) || (omitEmptyEntries && this.Length == 0))
             {
-                return EmptyArray<String>.Value;
+                return Array.Empty<String>();
             }
 
             if (count == 1 || (singleSeparator && separator.Length == 0))

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -505,7 +505,7 @@ namespace System.Text
         [Pure]
         public virtual byte[] GetPreamble()
         {
-            return EmptyArray<Byte>.Value;
+            return Array.Empty<Byte>();
         }
 
         private void GetDataItem()
@@ -1353,13 +1353,13 @@ namespace System.Text
         internal virtual char[] GetBestFitUnicodeToBytesData()
         {
             // Normally we don't have any best fit data.
-            return EmptyArray<Char>.Value;
+            return Array.Empty<Char>();
         }
 
         internal virtual char[] GetBestFitBytesToUnicodeData()
         {
             // Normally we don't have any best fit data.
-            return EmptyArray<Char>.Value;
+            return Array.Empty<Char>();
         }
 
         internal void ThrowBytesOverflow()


### PR DESCRIPTION
Change EmptyArray usage to Array.Empty. This is just consistency.
Also make List<T> use Array.Empty. This has negligible value but is consistent.

@jkotas 
