### PR TITLE
Ensure Environment.ExitCode works correctly after app domain unloaded.

### DIFF
--- a/src/coreclr/hosts/inc/coreclrhost.h
+++ b/src/coreclr/hosts/inc/coreclrhost.h
@@ -27,6 +27,10 @@ CORECLR_HOSTING_API(coreclr_initialize,
 
 CORECLR_HOSTING_API(coreclr_shutdown,
             void* hostHandle,
+            unsigned int domainId);
+
+CORECLR_HOSTING_API(coreclr_shutdown_2,
+            void* hostHandle,
             unsigned int domainId,
             int* latchedExitCode);
 

--- a/src/coreclr/hosts/inc/coreclrhost.h
+++ b/src/coreclr/hosts/inc/coreclrhost.h
@@ -27,7 +27,8 @@ CORECLR_HOSTING_API(coreclr_initialize,
 
 CORECLR_HOSTING_API(coreclr_shutdown,
             void* hostHandle,
-            unsigned int domainId);
+            unsigned int domainId,
+            int* latchedExitCode);
 
 CORECLR_HOSTING_API(coreclr_create_delegate,
             void* hostHandle,

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -321,7 +321,7 @@ int ExecuteManagedAssembly(
     {
         coreclr_initialize_ptr initializeCoreCLR = (coreclr_initialize_ptr)dlsym(coreclrLib, "coreclr_initialize");
         coreclr_execute_assembly_ptr executeAssembly = (coreclr_execute_assembly_ptr)dlsym(coreclrLib, "coreclr_execute_assembly");
-        coreclr_shutdown_ptr shutdownCoreCLR = (coreclr_shutdown_ptr)dlsym(coreclrLib, "coreclr_shutdown");
+        coreclr_shutdown_2_ptr shutdownCoreCLR = (coreclr_shutdown_2_ptr)dlsym(coreclrLib, "coreclr_shutdown_2");
 
         if (initializeCoreCLR == nullptr)
         {
@@ -333,7 +333,7 @@ int ExecuteManagedAssembly(
         }
         else if (shutdownCoreCLR == nullptr)
         {
-            fprintf(stderr, "Function coreclr_shutdown not found in the libcoreclr.so\n");
+            fprintf(stderr, "Function coreclr_shutdown_2 not found in the libcoreclr.so\n");
         }
         else
         {

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -416,11 +416,17 @@ int ExecuteManagedAssembly(
                     exitCode = -1;
                 }
 
-                st = shutdownCoreCLR(hostHandle, domainId);
+                int latchedExitCode = 0;
+                st = shutdownCoreCLR(hostHandle, domainId, &latchedExitCode);
                 if (!SUCCEEDED(st))
                 {
                     fprintf(stderr, "coreclr_shutdown failed - status: 0x%08x\n", st);
                     exitCode = -1;
+                }
+
+                if (exitCode != -1)
+                {
+                    exitCode = latchedExitCode;
                 }
             }
         }

--- a/src/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/dlls/mscoree/mscorwks_ntdef.src
@@ -21,6 +21,7 @@ EXPORTS
         coreclr_execute_assembly
         coreclr_initialize
         coreclr_shutdown
+        coreclr_shutdown_2
 
         ; il{d}asm
         MetaDataGetDispenser

--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -3,6 +3,7 @@ coreclr_create_delegate
 coreclr_execute_assembly
 coreclr_initialize
 coreclr_shutdown
+coreclr_shutdown_2
 
 ; il{d}asm
 MetaDataGetDispenser

--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -183,9 +183,9 @@ int coreclr_initialize(
     }
 #endif
 
-    ReleaseHolder<ICLRRuntimeHost2> host;
+    ReleaseHolder<ICLRRuntimeHost4> host;
 
-    hr = CorHost2::CreateObject(IID_ICLRRuntimeHost2, (void**)&host);
+    hr = CorHost2::CreateObject(IID_ICLRRuntimeHost4, (void**)&host);
     IfFailRet(hr);
 
     ConstWStringHolder appDomainFriendlyNameW = StringToUnicode(appDomainFriendlyName);
@@ -284,7 +284,7 @@ int coreclr_shutdown(
             void* hostHandle,
             unsigned int domainId)
 {
-    ReleaseHolder<ICLRRuntimeHost2> host(reinterpret_cast<ICLRRuntimeHost2*>(hostHandle));
+    ReleaseHolder<ICLRRuntimeHost4> host(reinterpret_cast<ICLRRuntimeHost4*>(hostHandle));
 
     HRESULT hr = host->UnloadAppDomain(domainId, true); // Wait until done
     IfFailRet(hr);
@@ -315,9 +315,7 @@ int coreclr_shutdown_2(
             unsigned int domainId,
             int* latchedExitCode)
 {
-    ICLRRuntimeHost4* hostHandleV4 = nullptr;
-    reinterpret_cast<ICLRRuntimeHost2*>(hostHandle)->QueryInterface(IID_ICLRRuntimeHost4, reinterpret_cast<void**>(&hostHandleV4));
-    ReleaseHolder<ICLRRuntimeHost4> host(reinterpret_cast<ICLRRuntimeHost4*>(hostHandleV4));
+    ReleaseHolder<ICLRRuntimeHost4> host(reinterpret_cast<ICLRRuntimeHost4*>(hostHandle));
 
     HRESULT hr = host->UnloadAppDomain2(domainId, true, latchedExitCode); // Wait until done
     IfFailRet(hr);
@@ -354,7 +352,7 @@ int coreclr_create_delegate(
             const char* entryPointMethodName,
             void** delegate)
 {
-    ICLRRuntimeHost2* host = reinterpret_cast<ICLRRuntimeHost2*>(hostHandle);
+    ICLRRuntimeHost4* host = reinterpret_cast<ICLRRuntimeHost4*>(hostHandle);
 
     ConstWStringHolder entryPointAssemblyNameW = StringToUnicode(entryPointAssemblyName);
     ConstWStringHolder entryPointTypeNameW = StringToUnicode(entryPointTypeName);
@@ -399,7 +397,7 @@ int coreclr_execute_assembly(
     }
     *exitCode = -1;
 
-    ICLRRuntimeHost2* host = reinterpret_cast<ICLRRuntimeHost2*>(hostHandle);
+    ICLRRuntimeHost4* host = reinterpret_cast<ICLRRuntimeHost4*>(hostHandle);
 
     ConstWStringArrayHolder argvW;
     argvW.Set(StringArrayToUnicode(argc, argv), argc);

--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -282,11 +282,12 @@ int coreclr_initialize(
 extern "C"
 int coreclr_shutdown(
             void* hostHandle,
-            unsigned int domainId)
+            unsigned int domainId,
+            int* latchedExitCode)
 {
     ReleaseHolder<ICLRRuntimeHost2> host(reinterpret_cast<ICLRRuntimeHost2*>(hostHandle));
 
-    HRESULT hr = host->UnloadAppDomain(domainId, true); // Wait until done
+    HRESULT hr = host->UnloadAppDomain(domainId, true, latchedExitCode); // Wait until done
     IfFailRet(hr);
 
     hr = host->Stop();

--- a/src/inc/corhost.h
+++ b/src/inc/corhost.h
@@ -135,7 +135,7 @@ protected:
                                         // Some functions are only available in ICLRRuntimeHost.
                                         // Some functions are no-op in ICLRRuntimeHost.
 
-    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode);
+    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode = nullptr);
 
 public:
     static ULONG GetHostVersion()
@@ -335,7 +335,7 @@ public:
     STDMETHODIMP STDMETHODCALLTYPE GetCLRControl(
         ICLRControl** pCLRControl);
 
-    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode);
+    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode = nullptr);
 
     STDMETHODIMP GetCurrentAppDomainId(DWORD *pdwAppDomainId);
 

--- a/src/inc/corhost.h
+++ b/src/inc/corhost.h
@@ -135,8 +135,9 @@ protected:
                                         // Some functions are only available in ICLRRuntimeHost.
                                         // Some functions are no-op in ICLRRuntimeHost.
 
-    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode = nullptr);
+    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone);
 
+    STDMETHODIMP UnloadAppDomain2(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode);
 public:
     static ULONG GetHostVersion()
     {
@@ -275,7 +276,7 @@ class CorHost2 :
 #ifndef FEATURE_PAL    
     , public IPrivateManagedExceptionReporting /* This interface is for internal Watson testing only*/
 #endif // FEATURE_PAL    
-    , public ICLRRuntimeHost2
+    , public ICLRRuntimeHost4
     , public CorExecutionManager
 {
     friend struct _DacGlobals;
@@ -335,7 +336,9 @@ public:
     STDMETHODIMP STDMETHODCALLTYPE GetCLRControl(
         ICLRControl** pCLRControl);
 
-    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode = nullptr);
+    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone);
+
+    STDMETHODIMP UnloadAppDomain2(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode);
 
     STDMETHODIMP GetCurrentAppDomainId(DWORD *pdwAppDomainId);
 

--- a/src/inc/corhost.h
+++ b/src/inc/corhost.h
@@ -135,7 +135,7 @@ protected:
                                         // Some functions are only available in ICLRRuntimeHost.
                                         // Some functions are no-op in ICLRRuntimeHost.
 
-    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone);
+    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode);
 
 public:
     static ULONG GetHostVersion()
@@ -335,7 +335,7 @@ public:
     STDMETHODIMP STDMETHODCALLTYPE GetCLRControl(
         ICLRControl** pCLRControl);
 
-    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone);
+    STDMETHODIMP UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode);
 
     STDMETHODIMP GetCurrentAppDomainId(DWORD *pdwAppDomainId);
 

--- a/src/pal/prebuilt/inc/mscoree.h
+++ b/src/pal/prebuilt/inc/mscoree.h
@@ -112,8 +112,13 @@ typedef interface ICLRRuntimeHost ICLRRuntimeHost;
 #define __ICLRRuntimeHost2_FWD_DEFINED__
 typedef interface ICLRRuntimeHost2 ICLRRuntimeHost2;
 
-#endif 	/* __ICLRRuntimeHost2_FWD_DEFINED__ */
+#endif 	/* __ICLRRuntimeHost4_FWD_DEFINED__ */
 
+#ifndef __ICLRRuntimeHost4_FWD_DEFINED__
+#define __ICLRRuntimeHost4_FWD_DEFINED__
+typedef interface ICLRRuntimeHost4 ICLRRuntimeHost4;
+
+#endif  /* __ICLRRuntimeHost4_FWD_DEFINED__ */
 
 #ifndef __ICLRExecutionManager_FWD_DEFINED__
 #define __ICLRExecutionManager_FWD_DEFINED__
@@ -254,6 +259,7 @@ EXTERN_GUID(IID_ICLRErrorReportingManager, 0x980d2f1a, 0xbf79, 0x4c08, 0x81, 0x2
 EXTERN_GUID(IID_ICLRErrorReportingManager2, 0xc68f63b1, 0x4d8b, 0x4e0b, 0x95, 0x64, 0x9d, 0x2e, 0xfe, 0x2f, 0xa1, 0x8c);
 EXTERN_GUID(IID_ICLRRuntimeHost, 0x90F1A06C, 0x7712, 0x4762, 0x86, 0xB5, 0x7A, 0x5E, 0xBA, 0x6B, 0xDB, 0x02);
 EXTERN_GUID(IID_ICLRRuntimeHost2, 0x712AB73F, 0x2C22, 0x4807, 0xAD, 0x7E, 0xF5, 0x01, 0xD7, 0xb7, 0x2C, 0x2D);
+EXTERN_GUID(IID_ICLRRuntimeHost4, 0x64F6D366, 0xD7C2, 0x4F1F, 0xB4, 0xB2, 0xE8, 0x16, 0x0C, 0xAC, 0x43, 0xAF);
 EXTERN_GUID(IID_ICLRExecutionManager, 0x1000A3E7, 0xB420, 0x4620, 0xAE, 0x30, 0xFB, 0x19, 0xB5, 0x87, 0xAD, 0x1D);
 EXTERN_GUID(IID_ITypeName, 0xB81FF171, 0x20F3, 0x11d2, 0x8d, 0xcc, 0x00, 0xa0, 0xc9, 0xb0, 0x05, 0x22);
 EXTERN_GUID(IID_ITypeNameBuilder, 0xB81FF171, 0x20F3, 0x11d2, 0x8d, 0xcc, 0x00, 0xa0, 0xc9, 0xb0, 0x05, 0x23);
@@ -1602,8 +1608,7 @@ EXTERN_C const IID IID_ICLRRuntimeHost;
         
         virtual HRESULT STDMETHODCALLTYPE UnloadAppDomain( 
             /* [in] */ DWORD dwAppDomainId,
-            /* [in] */ BOOL fWaitUntilDone,
-            /* [out] */ int *pLatchedExitCode = nullptr) = 0;
+            /* [in] */ BOOL fWaitUntilDone) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE ExecuteInAppDomain( 
             /* [in] */ DWORD dwAppDomainId,
@@ -1820,6 +1825,14 @@ EXTERN_C const IID IID_ICLRRuntimeHost2;
         
     };
     
+    MIDL_INTERFACE("64F6D366-D7C2-4F1F-B4B2-E8160CAC43AF")
+    ICLRRuntimeHost4 : public ICLRRuntimeHost2
+    {
+        virtual HRESULT STDMETHODCALLTYPE UnloadAppDomain2(
+            /* [in] */ DWORD dwAppDomainId,
+            /* [in] */ BOOL fWaitUntilDone,
+            /* [out] */ int *pLatchedExitCode) = 0;
+    };
     
 #else 	/* C style interface */
 

--- a/src/pal/prebuilt/inc/mscoree.h
+++ b/src/pal/prebuilt/inc/mscoree.h
@@ -1602,7 +1602,8 @@ EXTERN_C const IID IID_ICLRRuntimeHost;
         
         virtual HRESULT STDMETHODCALLTYPE UnloadAppDomain( 
             /* [in] */ DWORD dwAppDomainId,
-            /* [in] */ BOOL fWaitUntilDone) = 0;
+            /* [in] */ BOOL fWaitUntilDone,
+            /* [out] */ int *pLatchedExitCode) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE ExecuteInAppDomain( 
             /* [in] */ DWORD dwAppDomainId,

--- a/src/pal/prebuilt/inc/mscoree.h
+++ b/src/pal/prebuilt/inc/mscoree.h
@@ -1603,7 +1603,7 @@ EXTERN_C const IID IID_ICLRRuntimeHost;
         virtual HRESULT STDMETHODCALLTYPE UnloadAppDomain( 
             /* [in] */ DWORD dwAppDomainId,
             /* [in] */ BOOL fWaitUntilDone,
-            /* [out] */ int *pLatchedExitCode) = 0;
+            /* [out] */ int *pLatchedExitCode = nullptr) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE ExecuteInAppDomain( 
             /* [in] */ DWORD dwAppDomainId,

--- a/src/vm/assembly.cpp
+++ b/src/vm/assembly.cpp
@@ -1849,10 +1849,7 @@ HRESULT RunMain(MethodDesc *pFD ,
         else 
         {
             *pParam->piRetVal = (INT32)threadStart.Call_RetArgSlot(&stackVar);
-            if (pParam->stringArgs == NULL) 
-            {
-                SetLatchedExitCode(*pParam->piRetVal);
-            }
+            SetLatchedExitCode(*pParam->piRetVal);
         }
 
         GCPROTECT_END();
@@ -1965,10 +1962,6 @@ INT32 Assembly::ExecuteMainMethod(PTRARRAYREF *stringArgs, BOOL waitForOtherThre
     IfFailThrow(hr);
     
     END_ENTRYPOINT_THROWS;
-
-    // Sync the latched exit code with the return value of main function.
-    SetLatchedExitCode(iRetVal);
-
     return iRetVal;
 }
 #endif // CROSSGEN_COMPILE

--- a/src/vm/assembly.cpp
+++ b/src/vm/assembly.cpp
@@ -1965,6 +1965,10 @@ INT32 Assembly::ExecuteMainMethod(PTRARRAYREF *stringArgs, BOOL waitForOtherThre
     IfFailThrow(hr);
     
     END_ENTRYPOINT_THROWS;
+
+    // Sync the latched exit code with the return value of main function.
+    SetLatchedExitCode(iRetVal);
+
     return iRetVal;
 }
 #endif // CROSSGEN_COMPILE

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -1199,7 +1199,7 @@ HRESULT  GetCLRRuntimeHost(REFIID riid, IUnknown **ppUnk)
 }
 
 
-STDMETHODIMP CorHost2::UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone)
+STDMETHODIMP CorHost2::UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, int *pLatchedExitCode)
 {
     WRAPPER_NO_CONTRACT;
     STATIC_CONTRACT_SO_TOLERANT;
@@ -1249,14 +1249,16 @@ STDMETHODIMP CorHost2::UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone)
         }
         END_ENTRYPOINT_NOTHROW;
 
+        *pLatchedExitCode = GetLatchedExitCode();
+
         return hr;
     }
     else
 
-    return CorRuntimeHostBase::UnloadAppDomain(dwDomainId, fWaitUntilDone);
+    return CorRuntimeHostBase::UnloadAppDomain(dwDomainId, fWaitUntilDone, pLatchedExitCode);
 }
 
-HRESULT CorRuntimeHostBase::UnloadAppDomain(DWORD dwDomainId, BOOL fSync)
+HRESULT CorRuntimeHostBase::UnloadAppDomain(DWORD dwDomainId, BOOL fSync, int *pLatchedExitCode)
 {
     CONTRACTL
     {
@@ -1303,6 +1305,8 @@ HRESULT CorRuntimeHostBase::UnloadAppDomain(DWORD dwDomainId, BOOL fSync)
     hr =  AppDomain::UnloadById(ADID(dwDomainId), fSync);
 
     END_ENTRYPOINT_NOTHROW;
+
+    *pLatchedExitCode = ::GetLatchedExitCode();
 
     return hr;
 }

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -1249,7 +1249,10 @@ STDMETHODIMP CorHost2::UnloadAppDomain(DWORD dwDomainId, BOOL fWaitUntilDone, in
         }
         END_ENTRYPOINT_NOTHROW;
 
-        *pLatchedExitCode = GetLatchedExitCode();
+        if (pLatchedExitCode)
+        {
+            *pLatchedExitCode = GetLatchedExitCode();
+        }
 
         return hr;
     }
@@ -1306,7 +1309,10 @@ HRESULT CorRuntimeHostBase::UnloadAppDomain(DWORD dwDomainId, BOOL fSync, int *p
 
     END_ENTRYPOINT_NOTHROW;
 
-    *pLatchedExitCode = ::GetLatchedExitCode();
+    if (pLatchedExitCode)
+    {
+        *pLatchedExitCode = GetLatchedExitCode();
+    }
 
     return hr;
 }


### PR DESCRIPTION
This PR addresses 2 problems of Environment.ExitCode:

1. Can't get correct exit code of main function.
2. Can't set %errorlevel%.

Details can be found on #6206

Fix #6206