### PR TITLE
Get rid of "#if FEATURE_RANDOMIZED_STRING_HASHING" in shared partition.

### DIFF
--- a/src/mscorlib/shared/System/StringComparer.cs
+++ b/src/mscorlib/shared/System/StringComparer.cs
@@ -171,9 +171,6 @@ namespace System
 
     [Serializable]
     internal sealed class CultureAwareComparer : StringComparer
-#if FEATURE_RANDOMIZED_STRING_HASHING
-        , IWellKnownStringEqualityComparer
-#endif
     {
         private readonly CompareInfo _compareInfo;
         private readonly CompareOptions _options;
@@ -223,17 +220,10 @@ namespace System
             int hashCode = _compareInfo.GetHashCode();
             return _options == CompareOptions.None ? hashCode : ~hashCode;
         }
-
-#if FEATURE_RANDOMIZED_STRING_HASHING
-        IEqualityComparer IWellKnownStringEqualityComparer.GetEqualityComparerForSerialization() => this;
-#endif
     }
 
     [Serializable]
     internal sealed class OrdinalComparer : StringComparer 
-#if FEATURE_RANDOMIZED_STRING_HASHING           
-        , IWellKnownStringEqualityComparer
-#endif
     {
         public override int Compare(string x, string y) => string.CompareOrdinal(x, y);
 
@@ -255,17 +245,10 @@ namespace System
         // Equals/GetHashCode methods for the comparer itself. 
         public override bool Equals(object obj) => obj is OrdinalComparer;
         public override int GetHashCode() => nameof(OrdinalComparer).GetHashCode();
-
-#if FEATURE_RANDOMIZED_STRING_HASHING           
-        IEqualityComparer IWellKnownStringEqualityComparer.GetEqualityComparerForSerialization() => this;
-#endif
     }
 
     [Serializable]
     internal sealed class OrdinalIgnoreCaseComparer : StringComparer
-#if FEATURE_RANDOMIZED_STRING_HASHING
-        , IWellKnownStringEqualityComparer
-#endif
     {
         public override int Compare(string x, string y) => string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
 
@@ -287,19 +270,5 @@ namespace System
         // Equals/GetHashCode methods for the comparer itself. 
         public override bool Equals(object obj) => obj is OrdinalIgnoreCaseComparer;
         public override int GetHashCode() => nameof(OrdinalIgnoreCaseComparer).GetHashCode();
-
-#if FEATURE_RANDOMIZED_STRING_HASHING
-        IEqualityComparer IWellKnownStringEqualityComparer.GetEqualityComparerForSerialization() => this;
-#endif
     }
-
-#if FEATURE_RANDOMIZED_STRING_HASHING           
-    // This interface is implemented by string comparers in the framework that can opt into
-    // randomized hashing behaviors. 
-    internal interface IWellKnownStringEqualityComparer
-    {
-        // Get an IEqaulityComparer that can be serailzied (e.g., it exists in older versions). 
-        IEqualityComparer GetEqualityComparerForSerialization();
-    }
-#endif
 }

--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -382,13 +382,7 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.info);
             }
             info.AddValue(VersionName, version);
-
-#if FEATURE_RANDOMIZED_STRING_HASHING
-            info.AddValue(ComparerName, HashHelpers.GetEqualityComparerForSerialization(comparer), typeof(IEqualityComparer<TKey>));
-#else
             info.AddValue(ComparerName, comparer, typeof(IEqualityComparer<TKey>));
-#endif
-
             info.AddValue(HashSizeName, buckets == null ? 0 : buckets.Length); //This is the length of the bucket array.
             if (buckets != null)
             {

--- a/src/mscorlib/src/System/Collections/Hashtable.cs
+++ b/src/mscorlib/src/System/Collections/Hashtable.cs
@@ -938,14 +938,8 @@ namespace System.Collections
                 // If the comparer is null or a compatible comparer, serialize Hashtable
                 // in a format that can be deserialized on Everett and RTM.            
                 //
-                // Also, if the Hashtable is using randomized hashing, serialize the old
-                // view of the _keycomparer so perevious frameworks don't see the new types
 #pragma warning disable 618
-#if FEATURE_RANDOMIZED_STRING_HASHING
-                IEqualityComparer keyComparerForSerilization = (IEqualityComparer)HashHelpers.GetEqualityComparerForSerialization(_keycomparer);
-#else
-            IEqualityComparer keyComparerForSerilization = _keycomparer;
-#endif
+                IEqualityComparer keyComparerForSerilization = _keycomparer;
 
                 if (keyComparerForSerilization == null)
                 {
@@ -1561,29 +1555,5 @@ namespace System.Collections
 
         // This is the maximum prime smaller than Array.MaxArrayLength
         public const int MaxPrimeArrayLength = 0x7FEFFFFD;
-
-#if FEATURE_RANDOMIZED_STRING_HASHING
-
-        public static object GetEqualityComparerForSerialization(object comparer)
-        {
-            if (comparer == null)
-            {
-                return null;
-            }
-
-            IWellKnownStringEqualityComparer cmp = comparer as IWellKnownStringEqualityComparer;
-
-            if (cmp != null)
-            {
-                return cmp.GetEqualityComparerForSerialization();
-            }
-
-            return comparer;
-        }
-
-        private const int bufferSize = 1024;
-        private static int currentIndex = bufferSize;
-        private static readonly object lockObj = new Object();
-#endif // FEATURE_RANDOMIZED_STRING_HASHING
     }
 }


### PR DESCRIPTION
Since CoreCLR defines it (for now) and CoreRT doesn't, let's not have
"#if's" on this in shared code. It just creates confusion.

The only ones are in StringComparer.cs and fortunately, they are quite
expendable as...

1. It's only purpose is serialize Hashtables and Dictionaries in
   a way that CLR 1.1 can deserialize them. We don't care about that in
   .NET Core.

2. In CoreCLR as of today, this infrastructure is not changing the serialization
   blob one iota since all the GetEqualityComparerForSerialization() methods
   return "this."

So this removes the appearance of downgrading the comparers to non-randomized
versions for serialization purposes (and yes, we could go on and remove
all the other "let's do it for Everett and RTM" stuff in Hashtable.cs, but
I want to keep this PR on topic. Hashtable.cs is not going to be imported
into CoreRT so it's low priority for me.)