### PR TITLE
Fix perf penalty for creating dictionaries the easy way.

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -114,7 +114,7 @@ namespace System.Collections.Generic
             this.comparer = comparer ?? EqualityComparer<TKey>.Default;
 
 #if FEATURE_RANDOMIZED_STRING_HASHING
-            if (HashHelpers.s_UseRandomizedStringHashing && comparer == EqualityComparer<string>.Default)
+            if (HashHelpers.s_UseRandomizedStringHashing && this.comparer == EqualityComparer<string>.Default)
             {
                 this.comparer = (IEqualityComparer<TKey>)NonRandomizedStringEqualityComparer.Default;
             }


### PR DESCRIPTION
We went to the trouble of mitigating the perf hit
introduced by using randomized string hashing.

I assume that said perf benefit wasn't meant to be denied
to the 90% case where people use the nullary
constructor to create the Dictionary...