### PR TITLE
Fix contract to allow call into GarbageCollect() to throw

### DIFF
--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -6077,7 +6077,7 @@ bool ThreadStore::ShouldTriggerGCForDeadThreads()
 void ThreadStore::TriggerGCForDeadThreadsIfNecessary()
 {
     CONTRACTL {
-        NOTHROW;
+        THROWS;
         GC_TRIGGERS;
     }
     CONTRACTL_END;


### PR DESCRIPTION
I did not intend to mark this function as NOTHROW, and there is no reason to expect NOTHROW here. Other functions that call into GarbageCollect() allow THROWS.