### PR TITLE
Remove EditorBrowsable from ReadOnlyAttribute

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/ReadOnlyAttribute.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/ReadOnlyAttribute.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
+using System;
 
 namespace System.Runtime.CompilerServices
 {
@@ -10,7 +10,6 @@ namespace System.Runtime.CompilerServices
     /// Reserved to be used by the compiler for tracking metadata.
     /// This attribute should not be used by developers in source code.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
     [AttributeUsage(AttributeTargets.All, Inherited = false)]
     public sealed class ReadOnlyAttribute : Attribute
     {


### PR DESCRIPTION
In CoreCLR, `ReadOnlyAttribute` lives in `System.Runtime`, which made it possible to use `EditorBrowsableAttribute` which lives in the same binary.
On desktop, `ReadOnlyAttribute` lives in `mscorlib`, which cannot reference `EditorBrowsableAttribute` which lives in `System.Runtime`.
To keep the two types compatible, remove this attribute from both.

cc @jkotas @jaredpar @jcouv @stephentoub 