### PR TITLE
Fix VSO bug 405852.

### DIFF
--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -206,6 +206,52 @@ T ValueNumStore::EvalOp(VNFunc vnf, T v0, T v1, ValueNum* pExcSet)
     }
 }
 
+struct FloatTraits
+{
+    static float NaN()
+    {
+        unsigned bits = 0xFFC00000u;
+        float result;
+        static_assert(sizeof(bits) == sizeof(result), "sizeof(unsigned) must equal sizeof(float)");
+        memcpy(&result, &bits, sizeof(result));
+        return result;
+    }
+};
+
+struct DoubleTraits
+{
+    static double NaN()
+    {
+        unsigned long long bits = 0xFFF8000000000000ull;
+        double result;
+        static_assert(sizeof(bits) == sizeof(result), "sizeof(unsigned long long) must equal sizeof(double)");
+        memcpy(&result, &bits, sizeof(result));
+        return result;
+    }
+};
+
+template <typename TFp, typename TFpTraits>
+TFp FpRem(TFp dividend, TFp divisor)
+{
+    // From the ECMA standard:
+    //
+    // If [divisor] is zero or [dividend] is infinity
+    //   the result is NaN.
+    // If [divisor] is infinity,
+    //   the result is [dividend]
+
+    if (divisor == 0 || !_finite(dividend))
+    {
+        return TFpTraits::NaN();
+    }
+    else if (!_finite(divisor) && !_isnan(divisor))
+    {
+        return dividend;
+    }
+
+    return (TFp)fmod((double)dividend, (double)divisor);
+}
+
 // Specialize for double for floating operations, that doesn't involve unsigned.
 template <>
 double ValueNumStore::EvalOp<double>(VNFunc vnf, double v0, double v1, ValueNum* pExcSet)
@@ -223,7 +269,7 @@ double ValueNumStore::EvalOp<double>(VNFunc vnf, double v0, double v1, ValueNum*
         case GT_DIV:
             return v0 / v1;
         case GT_MOD:
-            return fmod(v0, v1);
+            return FpRem<double, DoubleTraits>(v0, v1);
 
         default:
             unreached();
@@ -247,7 +293,7 @@ float ValueNumStore::EvalOp<float>(VNFunc vnf, float v0, float v1, ValueNum* pEx
         case GT_DIV:
             return v0 / v1;
         case GT_MOD:
-            return fmodf(v0, v1);
+            return FpRem<float, FloatTraits>(v0, v1);
 
         default:
             unreached();

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -211,7 +211,7 @@ struct FloatTraits
     static float NaN()
     {
         unsigned bits = 0xFFC00000u;
-        float result;
+        float    result;
         static_assert(sizeof(bits) == sizeof(result), "sizeof(unsigned) must equal sizeof(float)");
         memcpy(&result, &bits, sizeof(result));
         return result;
@@ -223,7 +223,7 @@ struct DoubleTraits
     static double NaN()
     {
         unsigned long long bits = 0xFFF8000000000000ull;
-        double result;
+        double             result;
         static_assert(sizeof(bits) == sizeof(result), "sizeof(unsigned long long) must equal sizeof(double)");
         memcpy(&result, &bits, sizeof(result));
         return result;

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_405852/DevDiv_405852.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_405852/DevDiv_405852.il
@@ -1,0 +1,868 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern legacy library mscorlib {}
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+.assembly rem_r4.exe{}
+
+.class public _rem {
+//-- 
+.method public static	int32 _rem(float32,float32,float32) aggressiveinlining {
+.maxstack		3
+.locals	(int32)
+	// -- load args _and divide
+	ldarg	0
+	ldarg	1
+	rem
+	// -- dup so the result remains after _call to checkfinite
+	dup
+	// -- see if our number is finite (_ret val of 0 is finite)
+	call	int32 _rem::checkfinite(float32)
+	ldc.i4		0x0
+	ceq
+	// -- If the result is finite, branch
+	brtrue		COMPARE
+
+	// -- our result was _not finite, now check abnormal case
+	// -- call checkfinite again on the initial result
+	// -- should return  1 for NaN, 2 fo -inf, 3 for +inf, _and 255 for error
+	call	int32 _rem::checkfinite(float32)
+
+	stloc	0	
+	ldloc	0	
+	ldc.i4		0xFF
+	ceq
+	brtrue		FAIL	// error while determining type
+
+	// -- call checkfinite on our expected value.
+	ldarg	2
+	call	int32 _rem::checkfinite(float32)
+
+	// -- if the results are == we PASS.  If _not, FAIL.
+	ldloc	0
+	ceq
+	// -- cannot be finite
+	// -- if the results are == we PASS.  If _not, FAIL.
+	brfalse		FAIL
+
+	ldc.i4		0x1
+	br			FINISH
+
+COMPARE:
+	// -- our result was a finite number.
+	// -- compare it to our expected result.
+	ldarg	2
+	ceq
+	brfalse		FAIL
+
+	ldc.i4		0x1
+	br			FINISH
+
+FAIL:
+	ldc.i4		0x0
+	br			FINISH
+
+FINISH:
+	ret
+}
+
+//-----------------------------
+.method public static	int32 checkfinite(float32) {
+.locals		(class [mscorlib]System.ArithmeticException)
+.maxstack		3
+// -- 0 if finite
+// -- 1 for NaN
+// -- 2 for -inf
+// -- 3 for +inf
+// -- 255 (0xFF) none of the above 
+
+try_start:
+	ldarg	0
+	ckfinite
+	pop
+	leave.s	try_end
+try_end:
+// -- our result is a finite number.  
+	ldc.i4		0x0
+	br			FINISH
+
+ae:
+// -- our result is NaN, +inf, _or -inf.  Find out which one. 
+	isinst		[mscorlib]System.ArithmeticException
+	stloc	0
+	leave			HEnd
+HEnd:
+
+	ldloc	0
+	brfalse		FAIL
+
+	// -- check for -inf
+	ldarg	0
+	ldc.r4		float32(0xFF800000)
+	ceq
+	brtrue		NINF
+
+	// -- check for +inf
+	ldarg	0
+	ldc.r4		float32(0x7F800000)
+	ceq
+	brtrue		PINF
+
+	// -- must be NaN
+	ldc.i4		0x00000001
+	br			FINISH
+
+NINF:
+	ldc.i4		0x00000002
+	br			FINISH
+
+PINF:
+	ldc.i4		0x00000003
+	br			FINISH
+
+NaN:
+	ldc.i4		0x00000001
+	br			FINISH
+
+FAIL:
+//	pop
+	ldc.i4		0xFF
+	br			FINISH
+
+FINISH:
+	ret
+.try try_start to try_end catch [mscorlib]System.ArithmeticException handler ae to HEnd
+}
+
+// -- Begin Main --------------------
+.method public static	int32 main(class [mscorlib]System.String[]) {
+.entrypoint
+.maxstack		20
+// -- -inf/-inf --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -inf/-min --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -inf/-1 --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -inf/-0 --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -inf/+0 --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -inf/+1 --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -inf/+max --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -inf/+inf --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -inf.NaN --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -inf.float32 --
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		1.5
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+//-----------------------------
+// -- -min/-inf --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0xFF7FFFFF)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -min/-min --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -min/-1 --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -min/-0 --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -min/+0 --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -min/+1 --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -min/+max --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -min/+inf --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0xFF7FFFFF)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -min.NaN --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -min.float32 --
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		1.5
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+//-----------------------------
+// -- -1/-inf --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0xBF800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -1/-min --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0xBF800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -1/-1 --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -1/-0 --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -1/+0 --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -1/+1 --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -1/+max --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0xBF800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+// -- -1/+inf --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0xBF800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -1.NaN --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -1.float32 --
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		1.5
+	ldc.r4		float32(0xBF800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+//-----------------------------
+// -- -0/-inf --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -0/-min --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -0/-1 --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -0/-0 --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -0/+0 --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -0/+1 --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -0/+max --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -0/+inf --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -0.NaN --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- -0.float32 --
+	ldc.r4		float32(0x80000000)
+	ldc.r4		1.5
+	ldc.r4		float32(0x80000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+//-----------------------------
+// -- +0/-inf --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +0/-min --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +0/-1 --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +0/-0 --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +0/+0 --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +0/+1 --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +0/+max --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +0/+inf --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +0.NaN --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +0.float32 --
+	ldc.r4		float32(0x00000000)
+	ldc.r4		1.5
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+//-----------------------------
+// -- +1/-inf --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x3F800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +1/-min --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x3F800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +1/-1 --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +1/-0 --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +1/+0 --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +1/+1 --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +1/+max --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x3F800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +1/+inf --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x3F800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +1.NaN --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +1.float32 --
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		1.5
+	ldc.r4		float32(0x3F800000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+//-----------------------------
+// -- +max/-inf --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x7F7FFFFF)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +max/-min --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +max/-1 --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +max/-0 --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +max/+0 --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +max/+1 --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +max/+max --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +max/+inf --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x7F7FFFFF)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +max.NaN --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +max.float32 --
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		1.5
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+//-----------------------------
+// -- +inf/-inf --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +inf/-min --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +inf/-1 --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +inf/-0 --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +inf/+0 --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +inf/+1 --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +inf/+max --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +inf/+inf --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +inf.NaN --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- +inf.float32 --
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		1.5
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+//-----------------------------
+// -- NaN/-inf --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- NaN/-min --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- NaN/-1 --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- NaN/-0 --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- NaN/+0 --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- NaN/+1 --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- NaN/+max --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- NaN/+inf --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- NaN.NaN --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- NaN.float32 --
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		1.5
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+//-----------------------------
+// -- float32/-inf --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0xFF800000)
+	ldc.r4		float32(0x3FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- float32/-min --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0xFF7FFFFF)
+	ldc.r4		float32(0x3FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- float32/-1 --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0xBF800000)
+	ldc.r4		float32(0x3F000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- float32/-0 --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0x80000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- float32/+0 --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0x00000000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- float32/+1 --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0x3F800000)
+	ldc.r4		float32(0x3F000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- float32/+max --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0x7F7FFFFF)
+	ldc.r4		float32(0x3FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- float32/+inf --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0x7F800000)
+	ldc.r4		float32(0x3FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- float32.NaN --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0x7FC00000)
+	ldc.r4		float32(0x7FC00000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- float32.float32 --
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0x3FC00000)
+	ldc.r4		float32(0x00000000)
+	call	int32 _rem::_rem(float32,float32,float32)
+	brfalse		FAIL
+
+// -- PASS --
+	ldc.i4	100
+	ret
+
+// -- FAIL --
+FAIL:
+	ldc.i4	101
+	ret
+
+// -- End Main ----------------------
+}
+//
+// -- EOF ---------------------------
+}
+// ----------------------------------

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_405852/DevDiv_405852.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_405852/DevDiv_405852.ilproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_405852.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This bug was due to a mismatch between the semantics of the FP modulus
operator as specified by ECMA-335 and as implemented by value numbering.

ECMA-335 requires the following behavior for FP modulus:
- If the divisor is 0 or the dividend is not finite, the result is NaN
- If the divisor is not finite and is not NaN, the result is the
  dividend.
Value numbering, however, simply used `fmod`, which does not have these
semantics. This change implements the required semantics in VN.