### PR TITLE
Fix a few errors in cast decomposition.

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -265,7 +265,7 @@ GenTree* DecomposeLongs::DecomposeNode(GenTree* tree)
         default:
         {
             JITDUMP("Illegal TYP_LONG node %s in Decomposition.", GenTree::NodeName(tree->OperGet()));
-            noway_assert(!"Illegal TYP_LONG node in Decomposition.");
+            assert(!"Illegal TYP_LONG node in Decomposition.");
             break;
         }
     }
@@ -607,9 +607,7 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
             hiResult->gtFlags &= ~GTF_UNSIGNED;
             hiResult->gtOp.gtOp1 = hiSrcOp;
 
-            Range().Remove(cast);
             Range().Remove(srcOp);
-            Range().InsertAfter(hiSrcOp, hiResult);
         }
         else
         {
@@ -654,8 +652,8 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
                 loResult = cast->gtGetOp1();
                 hiResult = m_compiler->gtNewZeroConNode(TYP_INT);
 
+                Range().InsertAfter(cast, hiResult);
                 Range().Remove(cast);
-                Range().InsertAfter(loResult, hiResult);
             }
             else
             {
@@ -668,9 +666,10 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
                 GenTree* shiftBy = m_compiler->gtNewIconNode(31, TYP_INT);
                 hiResult         = m_compiler->gtNewOperNode(GT_RSH, TYP_INT, loCopy, shiftBy);
 
-                Range().Remove(cast);
-                Range().InsertAfter(loResult, loCopy, shiftBy, hiResult);
+                Range().InsertAfter(cast, loCopy, shiftBy, hiResult);
                 m_compiler->lvaIncRefCnts(loCopy);
+
+                Range().Remove(cast);
             }
         }
     }

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_406156/DevDiv_406156.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_406156/DevDiv_406156.il
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib{}
+.assembly ILGEN_MODULE{}
+
+.class ILGEN_CLASS
+{
+    .method static unsigned int8 ILGEN_METHOD(int32) noinlining
+    {
+        .maxstack  65535
+        .locals init (int16, char)
+
+        IL_0000: ldc.r8 float64(0x2f293f1943eded91)
+        IL_0009: conv.i
+        IL_000a: brtrue IL_005a
+        IL_000f: ldloc 0x0000
+        IL_0013: conv.i8
+        IL_0014: dup
+        IL_0015: ldc.i8 0x7e24f7eec24ea1f1
+        IL_001e: ldc.i8 0x99d7d5a1fb14c476
+        IL_0027: ldc.i8 0xccab5fe1121b6940
+        IL_0030: neg
+        IL_0031: conv.ovf.u8
+        IL_0032: neg
+        IL_0033: and
+        IL_0034: mul.ovf
+        IL_0035: conv.ovf.i8
+        IL_0036: ldloc.s 0x00
+        IL_0038: shl
+        IL_0039: conv.i
+        IL_003a: shr
+        IL_003b: cgt.un
+        IL_003d: ldloc 0x0001
+        IL_0041: conv.ovf.i8.un
+        IL_0042: conv.i
+        IL_0043: not
+        IL_0044: rem.un
+        IL_0045: neg
+        IL_0046: conv.i8
+        IL_0047: not
+        IL_0048: conv.ovf.u.un
+        IL_0049: neg
+        IL_004a: ldc.i8 0x62dc9bbe9ba06d16
+        IL_0053: conv.i2
+        IL_0054: neg
+        IL_0055: nop
+        IL_0056: and
+        IL_0057: conv.ovf.i8.un
+        IL_0058: conv.ovf.u4
+        IL_0059: pop
+        IL_005a: ldc.r8 float64(0x9b7fef80771a49e8)
+        IL_0063: conv.ovf.u8.un
+        IL_0064: ldloc.s 0x00
+        IL_0066: ldloc.s 0x01
+        IL_0068: conv.ovf.u8.un
+        IL_0069: ldc.i8 0xb8c24be67f1d543f
+        IL_0072: conv.ovf.i8
+        IL_0073: clt.un
+        IL_0075: ldc.i4 0xd331e1cd
+        IL_007a: ldloc.s 0x00
+        IL_007c: shr
+        IL_007d: ldloc 0x0001
+        IL_0081: mul.ovf
+        IL_0082: add
+        IL_0083: rem.un
+        IL_0084: ldc.i8 0xa9415d5c67c0b7b3
+        IL_008d: conv.u8
+        IL_008e: neg
+        IL_008f: conv.i8
+        IL_0090: ldloc 0x0000
+        IL_0094: starg.s 0x00
+        IL_0096: ldloc.s 0x01
+        IL_0098: conv.r.un
+        IL_0099: conv.ovf.i2.un
+        IL_009a: not
+        IL_009b: not
+        IL_009c: conv.r8
+        IL_009d: conv.ovf.i8
+        IL_009e: neg
+        IL_009f: cgt
+        IL_00a1: mul
+        IL_00a2: shr
+        IL_00a3: conv.ovf.i8.un
+        IL_00a4: ldc.i8 0x9e56367dc0f0785c
+        IL_00ad: cgt
+        IL_00af: ret
+    }
+
+    .method static unsigned int8 ILGEN_METHOD_2(int32) noinlining
+    {
+        .maxstack  65535
+        .locals init (int16, char)
+
+        IL_0000: ldarg 0x0000
+        IL_0004: conv.r8
+        IL_0005: conv.ovf.i8
+        IL_0006: ldc.i4 0x3372b383
+        IL_000b: shl
+        IL_000c: conv.ovf.i8.un
+        IL_000d: conv.ovf.u4
+        IL_000e: ret
+    }
+
+    .method static int32 Main()
+    {
+        .entrypoint
+
+        .try
+        {
+            ldc.i4 0
+            call unsigned int8 ILGEN_CLASS::ILGEN_METHOD(int32)
+            pop
+            leave next
+        }
+        catch [mscorlib]System.Exception
+        {
+            pop
+            leave next
+        }
+
+    next:
+        .try
+        {
+            ldc.i4 0
+            call unsigned int8 ILGEN_CLASS::ILGEN_METHOD_2(int32)
+            pop
+            leave done
+        }
+        catch [mscorlib]System.Exception
+        {
+            pop
+            leave done
+        }
+
+    done:
+        ldc.i4 100
+        ret
+    }
+}
+// Reading from 'lir_cpp__1524____Assertion_failed__next____def_____found_def_after_use_.mc' dumping raw IL for MC Indexes to console
+// ProcessName - 'ILGEN'
+.assembly extern mscorlib{}
+.assembly ILGEN_MODULE{}
+.class ILGEN_CLASS
+{
+}
+// Dumped 1

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_406156/DevDiv_406156.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_406156/DevDiv_406156.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup></PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_406156.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
The cursor was not guaranteed to be in the correct location after cast
decomposition due to the location in which the high result was typically
placed. This mispositioning can cause re-decomposition, which can lead
to asserts e.g. when encountering a GT_LONG node that was left behind by
a previously-decomposed node. This change ensures that the high result
immediately follows the cast node so that the cursor will be in the
correct location following decomposition of the cast.