### PR TITLE
[Local GC] Move handle null checking code to VM side

### DIFF
--- a/src/gc/handletable.h
+++ b/src/gc/handletable.h
@@ -216,18 +216,6 @@ FORCEINLINE BOOL HndIsNull(OBJECTHANDLE handle)
 }
 
 
-
-/*
- * inline handle checking
- */
-FORCEINLINE BOOL HndCheckForNullUnchecked(OBJECTHANDLE handle)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    return (handle == NULL || (*(_UNCHECKED_OBJECTREF *)handle) == NULL);
-}
-
-
 /*
  *
  * Checks handle value for null or special value used for free handles in cache.

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -30,8 +30,6 @@
 #define StoreObjectInHandle(handle, object)        HndAssignHandle(handle, object)
 #define InterlockedCompareExchangeObjectInHandle(handle, object, oldObj)        HndInterlockedCompareExchangeHandle(handle, object, oldObj)
 #define StoreFirstObjectInHandle(handle, object)   HndFirstAssignHandle(handle, object)
-#define ObjectHandleIsNull(handle)                 HndIsNull(handle)
-#define IsHandleNullUnchecked(handle)              HndCheckForNullUnchecked(handle)
 
 typedef DPTR(struct HandleTableMap) PTR_HandleTableMap;
 typedef DPTR(struct HandleTableBucket) PTR_HandleTableBucket;

--- a/src/vm/gchandletableutilities.h
+++ b/src/vm/gchandletableutilities.h
@@ -45,6 +45,21 @@ inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
     return UNCHECKED_OBJECTREF_TO_OBJECTREF(*PTR_UNCHECKED_OBJECTREF(handle));
 }
 
+// Quick inline check for whether a handle is null
+inline BOOL IsHandleNullUnchecked(OBJECTHANDLE handle)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return (handle == NULL || (*(_UNCHECKED_OBJECTREF *)handle) == NULL);
+}
+
+inline BOOL ObjectHandleIsNull(OBJECTHANDLE handle)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return *(Object **)handle == NULL;
+}
+
 #ifndef DACCESS_COMPILE
 
 // Handle creation convenience functions


### PR DESCRIPTION
With this change, `ObjectHandleIsNull` and `IsHandleNullUnchecked`, which are used by the VM, are no longer in objecthandle.h.

`IsHandleNullUnchecked` is now a function in vm/gchandletableutilities.h, and the few places that were calling `ObjectHandleIsNull` now just check for NULL directly.