### PR TITLE
Changes for issue #10595. Handle assembly references through alias in the correct way.

### DIFF
--- a/src/ilasm/asmman.hpp
+++ b/src/ilasm/asmman.hpp
@@ -196,7 +196,6 @@ class AsmMan
     void*               m_pAssembler;
     
     AsmManFile*         GetFileByName(__in __nullterminated char* szFileName);
-    AsmManAssembly*     GetAsmRefByName(__in __nullterminated const char* szAsmRefName);
     AsmManComType*      GetComTypeByName(__in_opt __nullterminated char* szComTypeName,
                                          __in_opt __nullterminated char* szComEnclosingTypeName = NULL);
     mdToken             GetComTypeTokByName(__in_opt __nullterminated char* szComTypeName,
@@ -274,6 +273,7 @@ public:
 
     mdToken             GetFileTokByName(__in __nullterminated char* szFileName);
     mdToken             GetAsmRefTokByName(__in __nullterminated const char* szAsmRefName);
+    AsmManAssembly*     GetAsmRefByName(__in __nullterminated const char* szAsmRefName);
     mdToken             GetAsmTokByName(__in __nullterminated const char* szAsmName)
         { return (m_pAssembly && (strcmp(m_pAssembly->szName,szAsmName)==0)) ? m_pAssembly->tkTok : 0; };
 

--- a/src/ilasm/asmman.hpp
+++ b/src/ilasm/asmman.hpp
@@ -196,6 +196,7 @@ class AsmMan
     void*               m_pAssembler;
     
     AsmManFile*         GetFileByName(__in __nullterminated char* szFileName);
+    AsmManAssembly*     GetAsmRefByName(__in __nullterminated const char* szAsmRefName);
     AsmManComType*      GetComTypeByName(__in_opt __nullterminated char* szComTypeName,
                                          __in_opt __nullterminated char* szComEnclosingTypeName = NULL);
     mdToken             GetComTypeTokByName(__in_opt __nullterminated char* szComTypeName,
@@ -273,7 +274,6 @@ public:
 
     mdToken             GetFileTokByName(__in __nullterminated char* szFileName);
     mdToken             GetAsmRefTokByName(__in __nullterminated const char* szAsmRefName);
-    AsmManAssembly*     GetAsmRefByName(__in __nullterminated const char* szAsmRefName);
     mdToken             GetAsmTokByName(__in __nullterminated const char* szAsmName)
         { return (m_pAssembly && (strcmp(m_pAssembly->szName,szAsmName)==0)) ? m_pAssembly->tkTok : 0; };
 

--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -131,17 +131,7 @@ mdToken Assembler::ResolveClassRef(mdToken tkResScope, __in __nullterminated con
             if((TypeFromToken(tkResScope) == mdtAssemblyRef) && !IsNilToken(tkResScope))
             {
                 // considering the aliased case '[' dottedName ']' slashedName
-                AsmManAssembly* assembly;
-                AsmManAssembly* assemblyTemp = m_pManifest->m_AsmRefLst.PEEK(RidFromToken(tkResScope) - 1);
-                _ASSERT(assemblyTemp != NULL);
-                do
-                {
-                    // resolving chained aliases like System.Runtime <- Foo <- Bar <- FooBar
-                    assembly = assemblyTemp;
-                    assemblyTemp = m_pManifest->GetAsmRefByName(assembly->szName);
-                }
-                while(assemblyTemp != NULL && assemblyTemp != assembly);
-
+                AsmManAssembly* assembly = m_pManifest->m_AsmRefLst.PEEK(RidFromToken(tkResScope) - 1);
                 tkResScope = GetAsmRef(assembly->szAlias);
             }
             if(IsNilToken(tkResScope) && !m_fIsMscorlib) tkResScope = GetBaseAsmRef();

--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -126,8 +126,26 @@ mdToken Assembler::ResolveClassRef(mdToken tkResScope, __in __nullterminated con
             }
             return tkRet;
         }
-        else  // needs to be resolved
-            if(!m_fIsMscorlib) tkResScope = GetBaseAsmRef();
+        else
+        { // needs to be resolved
+            if((TypeFromToken(tkResScope) == mdtAssemblyRef) && !IsNilToken(tkResScope))
+            {
+                // considering the aliased case '[' dottedName ']' slashedName
+                AsmManAssembly* assembly;
+                AsmManAssembly* assemblyTemp = m_pManifest->m_AsmRefLst.PEEK(RidFromToken(tkResScope) - 1);
+                _ASSERT(assemblyTemp != NULL);
+                do
+                {
+                    // resolving chained aliases like System.Runtime <- Foo <- Bar <- FooBar
+                    assembly = assemblyTemp;
+                    assemblyTemp = m_pManifest->GetAsmRefByName(assembly->szName);
+                }
+                while(assemblyTemp != NULL && assemblyTemp != assembly);
+
+                tkResScope = GetAsmRef(assembly->szAlias);
+            }
+            if(IsNilToken(tkResScope) && !m_fIsMscorlib) tkResScope = GetBaseAsmRef();
+        }
     }
     if(tkResScope == 1)
     {

--- a/tests/src/Regressions/coreclr/GitHub_10595/test10595.il
+++ b/tests/src/Regressions/coreclr/GitHub_10595/test10595.il
@@ -1,0 +1,17 @@
+
+.assembly extern legacy library System.Runtime as SomethingElse {}
+
+.assembly test10595 { }
+
+.class _simple extends [SomethingElse]System.Object {
+    .method static int32 main(class [SomethingElse]System.String[]) {
+    .entrypoint
+    .maxstack	100
+    newobj instance void [SomethingElse]System.Object::.ctor()
+	// newobj instance void [SomethingElse]System.ValueType::.ctor() ; Neither ValueType nor Enum could be created directly using default ctor because it is protected (inaccessible for us here)
+	// newobj instance void [SomethingElse]System.Enum::.ctor()
+	pop
+    ldc.i4 100
+    ret
+    }
+}

--- a/tests/src/Regressions/coreclr/GitHub_10595/test10595.ilproj
+++ b/tests/src/Regressions/coreclr/GitHub_10595/test10595.ilproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="test10595.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Runtime" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Changes for issue #10595. Handle assembly references through alias in the correct way.

ildasm output for sample from issue description.


```
//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.5.22220.0

// Metadata version: v4.0.22220
.assembly extern System.Runtime
{
  .ver 0:0:0:0
}
.assembly TestAssembly
{
  .ver 0:0:0:0
}
.module test1.dll
// MVID: {FA8E4A92-EB5D-4875-9A46-218805862D57}
.imagebase 0x00400000
.file alignment 0x00000200
.stackreserve 0x00100000
.subsystem 0x0003       // WINDOWS_CUI
.corflags 0x00000001    //  ILONLY
// Image base: 0x00000226F5820000

// ================== GLOBAL METHODS =========================

.method privatescope static void  Main$PST06000001() cil managed
{
  .entrypoint
  // Code size       7 (0x7)
  .maxstack  8
  IL_0000:  newobj     instance void [System.Runtime]System.Object::.ctor()
  IL_0005:  pop
  IL_0006:  ret
} // end of global method Main


// =============================================================

// *********** DISASSEMBLY COMPLETE ***********************
```