### PR TITLE
[x86/Linux] Fix incorrect initialization in LazyMachState::unwindLazyState

### DIFF
--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -1295,10 +1295,10 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
     ctx.Esi = lazyState->_esi = baseState->_esi;
     ctx.Ebx = lazyState->_ebx = baseState->_ebx;
 
-    nonVolRegPtrs.Edi = &(lazyState->_edi);
-    nonVolRegPtrs.Esi = &(lazyState->_esi);
-    nonVolRegPtrs.Ebx = &(lazyState->_ebx);
-    nonVolRegPtrs.Ebp = &(lazyState->_ebp);
+    nonVolRegPtrs.Edi = &(baseState->_edi);
+    nonVolRegPtrs.Esi = &(baseState->_esi);
+    nonVolRegPtrs.Ebx = &(baseState->_ebx);
+    nonVolRegPtrs.Ebp = &(baseState->_ebp);
 
     PCODE pvControlPc;
 


### PR DESCRIPTION
The current implementation initializes nonVolRegPtrs.Reg as lazyState->Reg, which may result in incorrect update when Reg is not stored. This incorrect initialization results in several Pri2 test failures:
 - CoreMangLib.cti.system.intptr.IntPtrToInt64.IntPtrToInt64
 - CoreMangLib.cti.system.uintptr.UIntPtrCtor_UInt64.UIntPtrCtor_UInt64
 - CoreMangLib.cti.system.uintptr.UIntPtrToUInt32.UIntPtrToUInt32
 - CoreMangLib.cti.system.string.StringChars.StringChars

This commit resolves these test failures.