### PR TITLE
Change default clang version to clang3.9 in cross build

### DIFF
--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -155,10 +155,14 @@ if [ "$build_arch" == "armel" ]; then
     cmake_extra_defines="$cmake_extra_defines -DARM_SOFTFP=1"
 fi
 
-if [ "$build_arch" == "arm" -o "$build_arch" == "armel" ]; then
-    overridefile=clang-compiler-override-arm.txt  
+clang_version=$(echo $CC | awk -F- '{ print $NF }')
+# Use O1 option when the clang version is smaller than 3.9
+# Otherwise use O3 option in release build
+if [[ ( ${clang_version%.*} -eq 3  &&  ${clang_version#*.} -lt 9 ) &&
+      (  "$build_arch" == "arm" || "$build_arch" == "armel" ) ]]; then
+    overridefile=clang-compiler-override-arm.txt
 else
-    overridefile=clang-compiler-override.txt  
+    overridefile=clang-compiler-override.txt
 fi
 
 cmake \

--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -246,13 +246,13 @@ function cross_build_coreclr_with_docker {
         # TODO: For arm, we are going to embed RootFS inside Docker image.
         case $__linuxCodeName in
         trusty)
-            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu1404_cross_prereqs_v3"
+            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20172211042239"
             __skipRootFS=1
             __dockerEnvironmentVariables+=" -e ROOTFS_DIR=/crossrootfs/arm"
             __runtimeOS="ubuntu.14.04"
         ;;
         xenial)
-            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu1604_cross_prereqs_v3"
+            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-ef0ac75-20175511035548"
             __skipRootFS=1
             __dockerEnvironmentVariables+=" -e ROOTFS_DIR=/crossrootfs/arm"
             __runtimeOS="ubuntu.16.04"
@@ -265,7 +265,7 @@ function cross_build_coreclr_with_docker {
         # For armel Tizen, we are going to construct RootFS on the fly.
         case $__linuxCodeName in
         tizen)
-            __dockerImage=" t2wish/dotnetcore:ubuntu1404_cross_prereqs_v3"
+            __dockerImage=" t2wish/dotnetcore:ubuntu1404_cross_prereqs_v4"
             __runtimeOS="tizen.4.0.0"
         ;;
         *)
@@ -289,7 +289,7 @@ function cross_build_coreclr_with_docker {
 
     # Cross building coreclr with rootfs in Docker
     (set +x; echo "Start cross build coreclr for $__buildArch $__linuxCodeName")
-    __buildCmd="./build.sh $__buildArch cross $__verboseFlag $__skipMscorlib $__buildConfig -rebuild"
+    __buildCmd="./build.sh $__buildArch cross $__verboseFlag $__skipMscorlib $__buildConfig -rebuild clang3.9"
     $__dockerCmd $__buildCmd
     sudo chown -R $(id -u -n) ./bin
 }


### PR DESCRIPTION
If we use clang3.9 version, we do not need to set optimization option separately.
So remove src/pal/tools/clang-compiler-override-arm.txt file.

Related issue: #9211, https://github.com/dotnet/core-setup/issues/1411