### PR TITLE
Fix a number of reordering issues in shift decomposition.

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -1149,11 +1149,11 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
 
                         Range().Remove(gtLong);
 
-                        // Since we're left shifting at least 64 bits, we can remove the lo part of the shifted value iff
-                        // it has no side effects.
+                        // Since we're left shifting at least 64 bits, we can remove the lo part of the shifted value
+                        // iff it has no side effects.
                         //
-                        // TODO-CQ: we could go perform this removal transitively (i.e. iteratively remove everything that
-                        // feeds the lo operand while there are no side effects)
+                        // TODO-CQ: we could go perform this removal transitively (i.e. iteratively remove everything
+                        // that feeds the lo operand while there are no side effects)
                         if ((loOp1->gtFlags & GTF_ALL_EFFECT) == 0)
                         {
                             Range().Remove(loOp1);
@@ -1237,11 +1237,11 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
                     {
                         assert(count >= 64);
 
-                        // Since we're right shifting at least 64 bits, we can remove the hi part of the shifted value iff
-                        // it has no side effects.
+                        // Since we're right shifting at least 64 bits, we can remove the hi part of the shifted value
+                        // iff it has no side effects.
                         //
-                        // TODO-CQ: we could go perform this removal transitively (i.e. iteratively remove everything that
-                        // feeds the hi operand while there are no side effects)
+                        // TODO-CQ: we could go perform this removal transitively (i.e. iteratively remove everything
+                        // that feeds the hi operand while there are no side effects)
                         if ((hiOp1->gtFlags & GTF_ALL_EFFECT) == 0)
                         {
                             Range().Remove(hiOp1);

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_406158/DevDiv_406158.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_406158/DevDiv_406158.il
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib{}
+.assembly ILGEN_MODULE{}
+.class ILGEN_CLASS
+{
+    .method static unsigned int8 ILGEN_METHOD(int32)
+    {
+        .maxstack  65535
+        .locals init (int16, char)
+        IL_0000: ldc.r8 float64(0x7c9006f1fe68a964)
+        IL_0009: conv.r4
+        IL_000a: conv.ovf.u4
+        IL_000b: nop
+        IL_000c: conv.ovf.i8.un
+        IL_000d: conv.ovf.i8.un
+        IL_000e: ldc.i8 0xa152fc5b9fbc6fbc
+        IL_0017: ldc.i8 0x5a9c2f46c68a4c09
+        IL_0020: cgt.un
+        IL_0022: shr
+        IL_0023: conv.ovf.i8
+        IL_0024: conv.u
+        IL_0025: ret
+    }
+
+    .method static int32 Main()
+    {
+        .entrypoint
+
+        .try
+        {
+            ldc.i4 0
+            call unsigned int8 ILGEN_CLASS::ILGEN_METHOD(int32)
+            pop
+            leave done
+        }
+        catch [mscorlib]System.Exception
+        {
+            pop
+            leave done
+        }
+
+    done:
+        ldc.i4 100
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_406158/DevDiv_406158.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_406158/DevDiv_406158.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup></PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_406158.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Shift decompostition contained a fair number of IR rewrites that were
unintentionally reordering nodes. This change fixes these instances s.t.
they no longer reorder code.