### PR TITLE
ILAsm: Fixed debug information emit

### DIFF
--- a/src/ilasm/asmman.cpp
+++ b/src/ilasm/asmman.cpp
@@ -297,9 +297,10 @@ void AsmMan::EmitDebuggableAttribute(mdToken tkOwner)
     else
     {
         AsmManAssembly *pAssembly = GetAsmRefByName("mscorlib");
-        _ASSERTE(pAssembly != NULL);
-        PREFIX_ASSUME(pAssembly != NULL);
-        fOldStyle = (pAssembly->usVerMajor == 1);
+        if (pAssembly != NULL)
+        {
+            fOldStyle = (pAssembly->usVerMajor == 1);
+        }
     }
 
     bsBytes->appendInt8(1);


### PR DESCRIPTION
Changes for #10608. Made ilasm able to create debugging information when referencing any mscorlib name.