### PR TITLE
[Local GC] Hide handle table internals from VM side

### DIFF
--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -23,6 +23,16 @@ void GCHandleTable::Shutdown()
     Ref_Shutdown();
 }
 
+void* GCHandleTable::GetGlobalHandleTable()
+{
+    return (void*)g_HandleTableMap.pBuckets[0];
+}
+
+void* GCHandleTable::GetNewHandleTable(void* context)
+{
+    return (void*)::Ref_CreateHandleTableBucket(ADIndex((uintptr_t)context));
+}
+
 void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
 {
     return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -23,9 +23,9 @@ void GCHandleTable::Shutdown()
     Ref_Shutdown();
 }
 
-void* GCHandleTable::GetHandleTableContext(void* handleTable)
+void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
 {
-    return (void*)((uintptr_t)::HndGetHandleTableADIndex((HHANDLETABLE)handleTable).m_dwIndex);
+    return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);
 }
 
 void* GCHandleTable::GetHandleTableForHandle(OBJECTHANDLE handle)

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -28,11 +28,6 @@ void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
     return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);
 }
 
-void* GCHandleTable::GetHandleTableForHandle(OBJECTHANDLE handle)
-{
-    return (void*)::HndGetHandleTable(handle);
-}
-
 OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* table, Object* object, int type)
 {
     return ::HndCreateHandle((HHANDLETABLE)table, type, ObjectToOBJECTREF(object));
@@ -54,6 +49,11 @@ OBJECTHANDLE GCHandleTable::CreateDependentHandle(void* table, Object* primary, 
     ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
 
     return handle;
+}
+
+OBJECTHANDLE GCHandleTable::CreateDuplicateHandle(OBJECTHANDLE handle)
+{
+    return ::HndCreateHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, ObjectFromHandle(handle));
 }
 
 void GCHandleTable::DestroyHandleOfType(OBJECTHANDLE handle, int type)

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -14,6 +14,10 @@ public:
 
     virtual void Shutdown();
 
+    virtual void* GetGlobalHandleTable();
+
+    virtual void* GetNewHandleTable(void* context);
+
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -20,7 +20,15 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
+    virtual void DestroyHandleTable(void* table);
+
+    virtual void UprootHandleTable(void* table);
+
+    virtual bool ContainsHandle(void* table, OBJECTHANDLE handle);
+
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
+
+    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type, int heapToAffinitizeTo);
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo);
 

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -14,7 +14,7 @@ public:
 
     virtual void Shutdown();
 
-    virtual void* GetHandleTableContext(void* handleTable);
+    virtual void* GetHandleContext(OBJECTHANDLE handle);
 
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle);
 

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -16,8 +16,6 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
-    virtual void* GetHandleTableForHandle(OBJECTHANDLE handle);
-
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo);
@@ -25,6 +23,8 @@ public:
     virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary);
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type);
+
+    virtual OBJECTHANDLE CreateDuplicateHandle(OBJECTHANDLE handle);
 
     virtual void DestroyHandleOfType(OBJECTHANDLE handle, int type);
 

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -14,25 +14,25 @@ public:
 
     virtual void Shutdown();
 
-    virtual void* GetGlobalHandleTable();
+    virtual void* GetGlobalHandleStore();
 
-    virtual void* GetNewHandleTable(void* context);
+    virtual void* CreateHandleStore(void* context);
 
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
-    virtual void DestroyHandleTable(void* table);
+    virtual void DestroyHandleStore(void* store);
 
-    virtual void UprootHandleTable(void* table);
+    virtual void UprootHandleStore(void* store);
 
-    virtual bool ContainsHandle(void* table, OBJECTHANDLE handle);
+    virtual bool ContainsHandle(void* store, OBJECTHANDLE handle);
 
-    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
+    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type);
 
-    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type, int heapToAffinitizeTo);
+    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo);
 
-    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo);
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo);
 
-    virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary);
+    virtual OBJECTHANDLE CreateDependentHandle(void* store, Object* primary, Object* secondary);
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type);
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -409,7 +409,7 @@ public:
 
     virtual void Shutdown() = 0;
 
-    virtual void* GetHandleTableContext(void* handleTable) = 0;
+    virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -411,23 +411,23 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
-    virtual void* GetGlobalHandleTable() = 0;
+    virtual void* GetGlobalHandleStore() = 0;
 
-    virtual void* GetNewHandleTable(void* context) = 0;
+    virtual void* CreateHandleStore(void* context) = 0;
 
-    virtual void DestroyHandleTable(void* table) = 0;
+    virtual void DestroyHandleStore(void* store) = 0;
 
-    virtual void UprootHandleTable(void* table) = 0;
+    virtual void UprootHandleStore(void* store) = 0;
 
-    virtual bool ContainsHandle(void* table, OBJECTHANDLE handle) = 0;
+    virtual bool ContainsHandle(void* store, OBJECTHANDLE handle) = 0;
 
-    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
+    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type) = 0;
 
-    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type, int heapToAffinitizeTo) = 0;
+    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo) = 0;
 
-    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo) = 0;
 
-    virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary) = 0;
+    virtual OBJECTHANDLE CreateDependentHandle(void* store, Object* primary, Object* secondary) = 0;
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type) = 0;
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -411,8 +411,6 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
-    virtual void* GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
-
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;
@@ -420,6 +418,8 @@ public:
     virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary) = 0;
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type) = 0;
+
+    virtual OBJECTHANDLE CreateDuplicateHandle(OBJECTHANDLE handle) = 0;
 
     virtual void DestroyHandleOfType(OBJECTHANDLE handle, int type) = 0;
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -411,6 +411,10 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
+    virtual void* GetGlobalHandleTable() = 0;
+
+    virtual void* GetNewHandleTable(void* context) = 0;
+
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -415,7 +415,15 @@ public:
 
     virtual void* GetNewHandleTable(void* context) = 0;
 
+    virtual void DestroyHandleTable(void* table) = 0;
+
+    virtual void UprootHandleTable(void* table) = 0;
+
+    virtual bool ContainsHandle(void* table, OBJECTHANDLE handle) = 0;
+
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
+
+    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type, int heapToAffinitizeTo) = 0;
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;
 

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -1338,24 +1338,6 @@ void  Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket 
 }
 #endif // !FEATURE_REDHAWK
 
-BOOL Ref_ContainHandle(HandleTableBucket *pBucket, OBJECTHANDLE handle)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-    }
-    CONTRACTL_END;
-
-    int limit = getNumberOfSlots();
-    for (int n = 0; n < limit; n ++ )
-    {
-        if (TableContainHandle(Table(pBucket->pTable[n]), handle))
-            return TRUE;
-    }
-
-    return FALSE;
-}
 /*--------------------------------------------------------------------------*/
 
 

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -111,7 +111,6 @@ BOOL Ref_HandleAsyncPinHandles();
 void Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget);
 void Ref_RemoveHandleTableBucket(HandleTableBucket *pBucket);
 void Ref_DestroyHandleTableBucket(HandleTableBucket *pBucket);
-BOOL Ref_ContainHandle(HandleTableBucket *pBucket, OBJECTHANDLE handle);
 
 /*
  * GC-time scanning entrypoints

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -993,17 +993,6 @@ void BaseDomain::InitVSD()
 }
 
 #ifndef CROSSGEN_COMPILE
-BOOL BaseDomain::ContainsOBJECTHANDLE(OBJECTHANDLE handle)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-    }
-    CONTRACTL_END;
-
-    return Ref_ContainHandle(m_hHandleTableBucket,handle);
-}
 
 DWORD BaseDomain::AllocateContextStaticsOffset(DWORD* pOffsetSlot)
 {

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1343,8 +1343,6 @@ public:
     }
 #endif // DACCESS_COMPILE && !CROSSGEN_COMPILE
 
-    BOOL ContainsOBJECTHANDLE(OBJECTHANDLE handle);
-
     IUnknown *GetFusionContext() {LIMITED_METHOD_CONTRACT;  return m_pFusionContext; }
     
     CLRPrivBinderCoreCLR *GetTPABinderContext() {LIMITED_METHOD_CONTRACT;  return m_pTPABinderContext; }

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1240,63 +1240,70 @@ public:
     //****************************************************************************************
     // Handles
 
-#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE) // needs GetCurrentThreadHomeHeapNumber
+#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
     OBJECTHANDLE CreateTypedHandle(OBJECTREF object, int type)
     {
         WRAPPER_NO_CONTRACT;
 
         IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
-        return pHandleTable->CreateHandleOfType(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], OBJECTREFToObject(object), type);
+        return pHandleTable->CreateHandleOfType(m_gcHandleTable, OBJECTREFToObject(object), type);
     }
 
     OBJECTHANDLE CreateHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
         CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL)
-        return ::CreateHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object);
+        return ::CreateHandle(m_gcHandleTable, object);
     }
 
     OBJECTHANDLE CreateWeakHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateWeakHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object);
+        return ::CreateWeakHandle(m_gcHandleTable, object);
     }
 
     OBJECTHANDLE CreateShortWeakHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateShortWeakHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object);
+        return ::CreateShortWeakHandle(m_gcHandleTable, object);
     }
 
     OBJECTHANDLE CreateLongWeakHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
         CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL)
-        return ::CreateLongWeakHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object);
+        return ::CreateLongWeakHandle(m_gcHandleTable, object);
     }
 
     OBJECTHANDLE CreateStrongHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateStrongHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object);
+        return ::CreateStrongHandle(m_gcHandleTable, object);
     }
 
     OBJECTHANDLE CreatePinningHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-#if CHECK_APP_DOMAIN_LEAKS     
+#if CHECK_APP_DOMAIN_LEAKS
         if(IsAppDomain())
             object->TryAssignAppDomain((AppDomain*)this,TRUE);
 #endif
-        return ::CreatePinningHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object);
+        return ::CreatePinningHandle(m_gcHandleTable, object);
     }
 
     OBJECTHANDLE CreateSizedRefHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-        OBJECTHANDLE h = ::CreateSizedRefHandle(
-            m_hHandleTableBucket->pTable[GCHeapUtilities::IsServerHeap() ? (m_dwSizedRefHandles % m_iNumberOfProcessors) : GetCurrentThreadHomeHeapNumber()], 
-            object);
+        OBJECTHANDLE h;
+        if (GCHeapUtilities::IsServerHeap())
+        {
+            h = ::CreateSizedRefHandle(m_gcHandleTable, object, m_dwSizedRefHandles % m_iNumberOfProcessors);
+        }
+        else
+        {
+            h = ::CreateSizedRefHandle(m_gcHandleTable, object);
+        }
+
         InterlockedIncrement((LONG*)&m_dwSizedRefHandles);
         return h;
     }
@@ -1305,7 +1312,7 @@ public:
     OBJECTHANDLE CreateRefcountedHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateRefcountedHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object);
+        return ::CreateRefcountedHandle(m_gcHandleTable, object);
     }
 
     OBJECTHANDLE CreateWinRTWeakHandle(OBJECTREF object, IWeakReference* pWinRTWeakReference)
@@ -1318,14 +1325,14 @@ public:
         }
         CONTRACTL_END;
 
-        return ::CreateWinRTWeakHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object, pWinRTWeakReference);
+        return ::CreateWinRTWeakHandle(m_gcHandleTable, object, pWinRTWeakReference);
     }
 #endif // FEATURE_COMINTEROP
 
     OBJECTHANDLE CreateVariableHandle(OBJECTREF object, UINT type)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateVariableHandle(m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], object, type);
+        return ::CreateVariableHandle(m_gcHandleTable, object, type);
     }
 
     OBJECTHANDLE CreateDependentHandle(OBJECTREF primary, OBJECTREF secondary)
@@ -1339,7 +1346,7 @@ public:
         CONTRACTL_END;
 
         IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
-        return pHandleTable->CreateDependentHandle((void*)m_hHandleTableBucket->pTable[GetCurrentThreadHomeHeapNumber()], OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
+        return pHandleTable->CreateDependentHandle(m_gcHandleTable, OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
     }
 #endif // DACCESS_COMPILE && !CROSSGEN_COMPILE
 
@@ -1395,8 +1402,7 @@ protected:
 
     CLRPrivBinderCoreCLR *m_pTPABinderContext; // Reference to the binding context that holds TPA list details
 
-
-    HandleTableBucket *m_hHandleTableBucket;
+    void* m_gcHandleTable;
 
     // The large heap handle table.
     LargeHeapHandleTable        *m_pLargeHeapHandleTable;

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1246,39 +1246,39 @@ public:
         WRAPPER_NO_CONTRACT;
 
         IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
-        return pHandleTable->CreateHandleOfType(m_gcHandleTable, OBJECTREFToObject(object), type);
+        return pHandleTable->CreateHandleOfType(m_handleStore, OBJECTREFToObject(object), type);
     }
 
     OBJECTHANDLE CreateHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
         CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL)
-        return ::CreateHandle(m_gcHandleTable, object);
+        return ::CreateHandle(m_handleStore, object);
     }
 
     OBJECTHANDLE CreateWeakHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateWeakHandle(m_gcHandleTable, object);
+        return ::CreateWeakHandle(m_handleStore, object);
     }
 
     OBJECTHANDLE CreateShortWeakHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateShortWeakHandle(m_gcHandleTable, object);
+        return ::CreateShortWeakHandle(m_handleStore, object);
     }
 
     OBJECTHANDLE CreateLongWeakHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
         CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL)
-        return ::CreateLongWeakHandle(m_gcHandleTable, object);
+        return ::CreateLongWeakHandle(m_handleStore, object);
     }
 
     OBJECTHANDLE CreateStrongHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateStrongHandle(m_gcHandleTable, object);
+        return ::CreateStrongHandle(m_handleStore, object);
     }
 
     OBJECTHANDLE CreatePinningHandle(OBJECTREF object)
@@ -1288,7 +1288,7 @@ public:
         if(IsAppDomain())
             object->TryAssignAppDomain((AppDomain*)this,TRUE);
 #endif
-        return ::CreatePinningHandle(m_gcHandleTable, object);
+        return ::CreatePinningHandle(m_handleStore, object);
     }
 
     OBJECTHANDLE CreateSizedRefHandle(OBJECTREF object)
@@ -1297,11 +1297,11 @@ public:
         OBJECTHANDLE h;
         if (GCHeapUtilities::IsServerHeap())
         {
-            h = ::CreateSizedRefHandle(m_gcHandleTable, object, m_dwSizedRefHandles % m_iNumberOfProcessors);
+            h = ::CreateSizedRefHandle(m_handleStore, object, m_dwSizedRefHandles % m_iNumberOfProcessors);
         }
         else
         {
-            h = ::CreateSizedRefHandle(m_gcHandleTable, object);
+            h = ::CreateSizedRefHandle(m_handleStore, object);
         }
 
         InterlockedIncrement((LONG*)&m_dwSizedRefHandles);
@@ -1312,7 +1312,7 @@ public:
     OBJECTHANDLE CreateRefcountedHandle(OBJECTREF object)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateRefcountedHandle(m_gcHandleTable, object);
+        return ::CreateRefcountedHandle(m_handleStore, object);
     }
 
     OBJECTHANDLE CreateWinRTWeakHandle(OBJECTREF object, IWeakReference* pWinRTWeakReference)
@@ -1325,14 +1325,14 @@ public:
         }
         CONTRACTL_END;
 
-        return ::CreateWinRTWeakHandle(m_gcHandleTable, object, pWinRTWeakReference);
+        return ::CreateWinRTWeakHandle(m_handleStore, object, pWinRTWeakReference);
     }
 #endif // FEATURE_COMINTEROP
 
     OBJECTHANDLE CreateVariableHandle(OBJECTREF object, UINT type)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateVariableHandle(m_gcHandleTable, object, type);
+        return ::CreateVariableHandle(m_handleStore, object, type);
     }
 
     OBJECTHANDLE CreateDependentHandle(OBJECTREF primary, OBJECTREF secondary)
@@ -1346,7 +1346,7 @@ public:
         CONTRACTL_END;
 
         IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
-        return pHandleTable->CreateDependentHandle(m_gcHandleTable, OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
+        return pHandleTable->CreateDependentHandle(m_handleStore, OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
     }
 #endif // DACCESS_COMPILE && !CROSSGEN_COMPILE
 
@@ -1402,7 +1402,7 @@ protected:
 
     CLRPrivBinderCoreCLR *m_pTPABinderContext; // Reference to the binding context that holds TPA list details
 
-    void* m_gcHandleTable;
+    void* m_handleStore;
 
     // The large heap handle table.
     LargeHeapHandleTable        *m_pLargeHeapHandleTable;

--- a/src/vm/exstate.cpp
+++ b/src/vm/exstate.cpp
@@ -102,7 +102,7 @@ void ThreadExceptionState::FreeAllStackTraces()
     }
 }
 
-void ThreadExceptionState::ClearThrowablesForUnload(HandleTableBucket* pHndTblBucket)
+void ThreadExceptionState::ClearThrowablesForUnload(void* handleTable)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -112,11 +112,13 @@ void ThreadExceptionState::ClearThrowablesForUnload(HandleTableBucket* pHndTblBu
     ExInfo*           pNode = &m_currentExInfo;
 #endif // WIN64EXCEPTIONS
 
+    IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
+
     for ( ;
           pNode != NULL;
           pNode = pNode->m_pPrevNestedInfo)
     {
-        if (pHndTblBucket->Contains(pNode->m_hThrowable))
+        if (pHandleTable->ContainsHandle(handleTable, pNode->m_hThrowable))
         {
             pNode->DestroyExceptionHandle();
         }

--- a/src/vm/exstate.cpp
+++ b/src/vm/exstate.cpp
@@ -102,7 +102,7 @@ void ThreadExceptionState::FreeAllStackTraces()
     }
 }
 
-void ThreadExceptionState::ClearThrowablesForUnload(void* handleTable)
+void ThreadExceptionState::ClearThrowablesForUnload(void* handleStore)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -118,7 +118,7 @@ void ThreadExceptionState::ClearThrowablesForUnload(void* handleTable)
           pNode != NULL;
           pNode = pNode->m_pPrevNestedInfo)
     {
-        if (pHandleTable->ContainsHandle(handleTable, pNode->m_hThrowable))
+        if (pHandleTable->ContainsHandle(handleStore, pNode->m_hThrowable))
         {
             pNode->DestroyExceptionHandle();
         }

--- a/src/vm/exstate.h
+++ b/src/vm/exstate.h
@@ -56,7 +56,7 @@ class ThreadExceptionState
 public:
     
     void FreeAllStackTraces();
-    void ClearThrowablesForUnload(HandleTableBucket* pHndTblBucket);
+    void ClearThrowablesForUnload(void* handleTable);
 
 #ifdef _DEBUG
     typedef enum 

--- a/src/vm/exstate.h
+++ b/src/vm/exstate.h
@@ -56,7 +56,7 @@ class ThreadExceptionState
 public:
     
     void FreeAllStackTraces();
-    void ClearThrowablesForUnload(void* handleTable);
+    void ClearThrowablesForUnload(void* handleStore);
 
 #ifdef _DEBUG
     typedef enum 

--- a/src/vm/gchandletableutilities.h
+++ b/src/vm/gchandletableutilities.h
@@ -64,49 +64,54 @@ inline BOOL ObjectHandleIsNull(OBJECTHANDLE handle)
 
 // Handle creation convenience functions
 
-inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
 }
 
-inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateWeakHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
 }
 
-inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateShortWeakHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
 }
 
-inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateLongWeakHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
 }
 
-inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateStrongHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
 }
 
-inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreatePinningHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
 }
 
-inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
-}
-
-inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateAsyncPinningHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
 }
 
-inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateRefcountedHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+}
+
+inline OBJECTHANDLE CreateSizedRefHandle(void* table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+}
+
+inline OBJECTHANDLE CreateSizedRefHandle(void* table, OBJECTREF object, int heapToAffinitizeTo)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF, heapToAffinitizeTo);
 }
 
 // Global handle creation convenience functions
@@ -152,7 +157,7 @@ inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 // Special handle creation convenience functions
 
 #ifdef FEATURE_COMINTEROP
-inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
+inline OBJECTHANDLE CreateWinRTWeakHandle(void* table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
                                                                                  OBJECTREFToObject(object),
@@ -162,7 +167,7 @@ inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, 
 #endif // FEATURE_COMINTEROP
 
 // Creates a variable-strength handle
-inline OBJECTHANDLE CreateVariableHandle(HHANDLETABLE table, OBJECTREF object, uint32_t type)
+inline OBJECTHANDLE CreateVariableHandle(void* table, OBJECTREF object, uint32_t type)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
                                                                                  OBJECTREFToObject(object),

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -48,8 +48,7 @@ void ValidateHandleAndAppDomain(OBJECTHANDLE handle)
 
     IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
 
-    void* handleTable = pHandleTable->GetHandleTableForHandle(handle);
-    DWORD context = (DWORD)pHandleTable->GetHandleTableContext(handleTable);
+    DWORD context = (DWORD)pHandleTable->GetHandleContext(handle);
 
     ADIndex appDomainIndex = ADIndex(context);
     AppDomain *domain = SystemDomain::GetAppDomainAtIndex(appDomainIndex);

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -5075,11 +5075,10 @@ void Thread::SafeUpdateLastThrownObject(void)
         EX_TRY
         {
             IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
-            void* table = pHandleTable->GetHandleTableForHandle(hThrowable);
 
             // Creating a duplicate handle here ensures that the AD of the last thrown object
             // matches the domain of the current throwable.
-            OBJECTHANDLE duplicateHandle = pHandleTable->CreateHandleOfType(table, OBJECTREFToObject(ObjectFromHandle(hThrowable)), HNDTYPE_DEFAULT);
+            OBJECTHANDLE duplicateHandle = pHandleTable->CreateDuplicateHandle(hThrowable);
             SetLastThrownObjectHandle(duplicateHandle);
         }
         EX_CATCH


### PR DESCRIPTION
This change moves us closer to a clean separation between GC and VM when it comes to handles.

The VM side will no longer need to know about `HandleTableBucket`s and home heap numbers and all the details about how we choose to manage handles in the GC, and instead will just know about one type of handle store (which, internally, will be a `HandleTableBucket`*). It will be able to create these stores, add to them, destroy them, and so on. AppDomains will create their own handle stores and there will also be a global one.

I removed the parts of the interface that were using the actual HHANDLETABLE concept (like `GetHandleTableForHandle`) so the interface only exposes one type of "collection of handles".

@Maoni0 @jkotas @swgillespie @sergiy-k 