### PR TITLE
Remove unused function in BasicBlock

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -1063,7 +1063,6 @@ struct BasicBlock : private LIR::Range
 
     GenTreeStmt* firstStmt() const;
     GenTreeStmt* lastStmt() const;
-    GenTreeStmt* lastTopLevelStmt();
 
     GenTree* firstNode();
     GenTree* lastNode();


### PR DESCRIPTION
lastTopLevelStmt() is declared in BasicBlock,
but not defined and unused throughout JIT.
