### PR TITLE
[Linux][GDB-JIT] Fix class size calculation

### DIFF
--- a/src/vm/gdbjit.cpp
+++ b/src/vm/gdbjit.cpp
@@ -1095,7 +1095,7 @@ ClassTypeInfo::ClassTypeInfo(TypeHandle typeHandle, int num_members, FunctionMem
     {
         case ELEMENT_TYPE_VALUETYPE:
         case ELEMENT_TYPE_CLASS:
-            m_type_size = pMT->IsValueType() ? typeHandle.GetSize() : typeHandle.AsMethodTable()->GetClass()->GetSize();
+            m_type_size = pMT->IsValueType() ? typeHandle.GetSize() : typeHandle.AsMethodTable()->GetBaseSize();
             break;
         case ELEMENT_TYPE_ARRAY:
         case ELEMENT_TYPE_SZARRAY:


### PR DESCRIPTION
We should use "m_BaseSize" filed of "MethodTable" to get correct class size.

@janvorli PTAL

cc @Dmitri-Botcharnikov @lucenticus @ayuckhulk