### PR TITLE
NS2.0 AssemblyName.ReferenceMatchesDefinition()

### DIFF
--- a/src/mscorlib/src/System/Reflection/AssemblyName.cs
+++ b/src/mscorlib/src/System/Reflection/AssemblyName.cs
@@ -372,26 +372,26 @@ namespace System.Reflection
             nInit();
         }
 
-        static public bool ReferenceMatchesDefinition(AssemblyName reference,
-                                                             AssemblyName definition)
+        /// <summary>
+        /// Compares the simple names disregarding Version, Culture and PKT. While this clearly does not
+        /// match the intent of this api, this api has been broken this way since its debut and we cannot
+        /// change its behavior now.
+        /// </summary>
+        public static bool ReferenceMatchesDefinition(AssemblyName reference, AssemblyName definition)
         {
-            // Optimization for common use case
-            if (Object.ReferenceEquals(reference, definition))
-            {
+            if (object.ReferenceEquals(reference, definition))
                 return true;
-            }
-            return ReferenceMatchesDefinitionInternal(reference, definition, true);
+
+            if (reference == null)
+                throw new ArgumentNullException(nameof(reference));
+
+            if (definition == null)
+                throw new ArgumentNullException(nameof(definition));
+
+            string refName = reference.Name ?? string.Empty;
+            string defName = definition.Name ?? string.Empty;
+            return refName.Equals(defName, StringComparison.OrdinalIgnoreCase);
         }
-
-
-        /// "parse" tells us to parse the simple name of the assembly as if it was the full name
-        /// almost never the right thing to do, but needed for compat
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        static internal extern bool ReferenceMatchesDefinitionInternal(AssemblyName reference,
-                                                                     AssemblyName definition,
-                                                                     bool parse);
-
-
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal extern void nInit(out RuntimeAssembly assembly, bool forIntrospection, bool raiseResolveEvent);

--- a/src/vm/assemblyname.cpp
+++ b/src/vm/assemblyname.cpp
@@ -202,41 +202,4 @@ FCIMPL4(void, AssemblyNameNative::Init, Object * refThisUNSAFE, OBJECTREF * pAss
 }
 FCIMPLEND
 
-/// "parse" tells us to parse the simple name of the assembly as if it was the full name
-/// almost never the right thing to do, but needed for compat
-/* static */
-FCIMPL3(FC_BOOL_RET, AssemblyNameNative::ReferenceMatchesDefinition, AssemblyNameBaseObject* refUNSAFE, AssemblyNameBaseObject* defUNSAFE, CLR_BOOL fParse)
-{
-    FCALL_CONTRACT;
 
-    struct _gc
-    {
-        ASSEMBLYNAMEREF pRef;
-        ASSEMBLYNAMEREF pDef;
-    } gc;
-    gc.pRef = (ASSEMBLYNAMEREF)ObjectToOBJECTREF (refUNSAFE);
-    gc.pDef = (ASSEMBLYNAMEREF)ObjectToOBJECTREF (defUNSAFE);
-
-    BOOL result = FALSE;
-    HELPER_METHOD_FRAME_BEGIN_RET_PROTECT(gc);
-
-    Thread *pThread = GetThread();
-
-    CheckPointHolder cph(pThread->m_MarshalAlloc.GetCheckpoint()); //hold checkpoint for autorelease
-
-    if (gc.pRef == NULL)
-        COMPlusThrow(kArgumentNullException, W("ArgumentNull_AssemblyName"));
-    if (gc.pDef == NULL)
-        COMPlusThrow(kArgumentNullException, W("ArgumentNull_AssemblyName"));
-
-    AssemblySpec refSpec;
-    refSpec.InitializeSpec(&(pThread->m_MarshalAlloc), (ASSEMBLYNAMEREF*) &gc.pRef, fParse, FALSE);
-
-    AssemblySpec defSpec;
-    defSpec.InitializeSpec(&(pThread->m_MarshalAlloc), (ASSEMBLYNAMEREF*) &gc.pDef, fParse, FALSE);
-
-    result=AssemblySpec::RefMatchesDef(&refSpec,&defSpec);
-    HELPER_METHOD_FRAME_END();
-    FC_RETURN_BOOL(result);
-}
-FCIMPLEND

--- a/src/vm/assemblyname.hpp
+++ b/src/vm/assemblyname.hpp
@@ -24,7 +24,6 @@ public:
     static FCDECL1(Object*, GetPublicKeyToken, Object* refThisUNSAFE);
     static FCDECL1(Object*, EscapeCodeBase, StringObject* filenameUNSAFE);
     static FCDECL4(void, Init, Object * refThisUNSAFE, OBJECTREF * pAssemblyRef, CLR_BOOL fForIntrospection, CLR_BOOL fRaiseResolveEvent);
-    static FCDECL3(FC_BOOL_RET, ReferenceMatchesDefinition, AssemblyNameBaseObject* refUNSAFE, AssemblyNameBaseObject* defUNSAFE, CLR_BOOL fParse);
 };
 
 #endif  // _AssemblyName_H

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -632,7 +632,6 @@ FCFuncStart(gAssemblyNameFuncs)
     FCFuncElement("nInit", AssemblyNameNative::Init)
     FCFuncElement("nToString", AssemblyNameNative::ToString)
     FCFuncElement("nGetPublicKeyToken", AssemblyNameNative::GetPublicKeyToken)
-    FCFuncElement("ReferenceMatchesDefinitionInternal", AssemblyNameNative::ReferenceMatchesDefinition)
     FCFuncElement("nGetFileInformation", AssemblyNameNative::GetFileInformation)
 FCFuncEnd()
 


### PR DESCRIPTION
This api was broken from its debut in 2.0 (and yet somehow
scored a 2.9% on .NET api catalog)

 https://connect.microsoft.com/VisualStudio/feedback/details/752902/assemblyname-referencematchesdefinition-returns-true-even-though-the-parameters-dont-match

In 2012, the MSDN docs were changed to match its broken behavior:

   Return Value
   Type: System.Boolean
   true if the simple assembly names are the same; otherwise, false.

   Remarks

   The comparison depends only on the simple assembly name. It ignores version, culture, and public key token.


A more accurate description would be:

   This api takes the simple names of the ref and def.
   Then it parses the simple names *as if they were*
   full-blown assembly names with optional Version, Culture
   and PKT (!)

   Then it applies a RefToDef test to that name using a test
   that's quite separate from the one used by the actual
   CoreCLR loader (so any similarities between
   it and the actual binding rules is purely coincidental.)

   Oh, and that code assumes the Def name came from trusted
   sources so if it's has a null Culture property, it NULL-AV's.

We could replicate this behavior on CoreRT (relying on
its own AssemblyBinder) but the more I progressed, the
more the venture failed to pass the laugh test (though
at least we got a nice AssemblyBinder cleanup
as a side effect.)

So what we'll do is make the api behavior match the
MSDN description (and likely come close enough to the compat bar)
but in a more straightforward fashion.

(The RefMatchesDef routine is used on one case - to
match assembly refs against a list of friend-access
assembly defs. So it's not quite dead code though
it probably should be.)