### PR TITLE
Fix run-xunit-perf.cmd for local use

### DIFF
--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -94,7 +94,7 @@ if DEFINED TEST_ENV (
     )
 )
 
-corerun.exe PerfHarness.dll %WORKSPACE%\sandbox\%BENCHNAME%.%TEST_FILE_EXT% --perf:runid Perf > %BENCHNAME%.out
+corerun.exe PerfHarness.dll %CORECLR_REPO%\sandbox\%BENCHNAME%.%TEST_FILE_EXT% --perf:runid Perf > %BENCHNAME%.out
 
 @rem optionally generate results for benchview
 if not [%BENCHVIEW_PATH%] == [] (


### PR DESCRIPTION
run-xunit-perf.cmd  specifies the full path to the benchmark using
%WORKSPACE%, which a user may not set locally. This change modifies it to
use %CORECLR_ROOT%.