### PR TITLE
Remove distro specific RIDs from SOS.NETCore's project.json.

### DIFF
--- a/src/ToolBox/SOS/NETCore/project.json
+++ b/src/ToolBox/SOS/NETCore/project.json
@@ -11,14 +11,5 @@
        "portable-net45+win8" 
       ] 
     } 
-  },
-  "runtimes": {
-    "win7-x86": {},
-    "win7-x64": {},
-    "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {},
-    "centos.7-x64": {},
-    "rhel.7-x64": {},
-    "debian.8-x64": {}
   }
 }


### PR DESCRIPTION
Removed the "runtimes" section from the project.json.

Issue: https://github.com/dotnet/coreclr/issues/10900
