### PR TITLE
[Local GC] Handle table low-hanging interface violations

### DIFF
--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -949,7 +949,7 @@ static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTRE
     if (minAge >= GEN_MAX_AGE || (minAge > thisAge && thisAge < static_cast<int>(g_theGCHeap->GetMaxGeneration())))
     {
         _ASSERTE(!"Fatal Error in HandleTable.");
-        EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+        GCToEEInterface::HandleFatalError(COR_E_EXECUTIONENGINE);
     }
 }
 


### PR DESCRIPTION
Unfortunately this was the only low-hanging fruit I could find in the handle table. The other interface violations look to be more complex to deal with, in particular:
  1. Async pinned handles migrating on app domain unload (and in general, the handle table knowing about `System.Threading.OverlappedData`)
  2. Handle creation will throw on failure instead of returning null.
  3. Some handle table code uses PAL exception handling
  4. Validation routines that reference both EE and GC details (e.g. https://github.com/dotnet/coreclr/blob/master/src/gc/handletablescan.cpp#L964)

cc @adityamandaleeka @sergiy-k @Maoni0 @jkotas