### PR TITLE
Fix clang build error when enabling NODEBASH_STATS

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -450,7 +450,7 @@ bool GenTree::IsNodeProperlySized() const
 
 #define BASH_HASH_SIZE 211
 
-inline hashme(genTreeOps op1, genTreeOps op2)
+inline unsigned hashme(genTreeOps op1, genTreeOps op2)
 {
     return ((op1 * 104729) ^ (op2 * 56569)) % BASH_HASH_SIZE;
 }


### PR DESCRIPTION
After enabling NODEBASH_STATS in Linux, following error occurs when building CoreCLR with clang.

```
/opt/code/github/hqueue/coreclr/src/jit/gentree.cpp:453:8: error: C++ requires a type specifier for all declarations
inline hashme(genTreeOps op1, genTreeOps op2)
~~~~~~ ^
```
