### PR TITLE
[x86/Linux] Use appropriate FCALL macro for SafeBuffer methods

### DIFF
--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -3012,8 +3012,8 @@ class SafeBuffer : SafeHandle
   public:
     static FCDECL1(UINT, SizeOfType, ReflectClassBaseObject* typeUNSAFE);
     static FCDECL1(UINT, AlignedSizeOfType, ReflectClassBaseObject* typeUNSAFE);
-    static FCDECL3(void, PtrToStructure, BYTE* ptr, FC_TypedByRef structure, UINT32 sizeofT);
-    static FCDECL3(void, StructureToPtr, FC_TypedByRef structure, BYTE* ptr, UINT32 sizeofT);
+    static FCDECL3_IVI(void, PtrToStructure, BYTE* ptr, FC_TypedByRef structure, UINT32 sizeofT);
+    static FCDECL3_VII(void, StructureToPtr, FC_TypedByRef structure, BYTE* ptr, UINT32 sizeofT);
 };
 
 #ifdef USE_CHECKED_OBJECTREFS

--- a/src/vm/safehandle.cpp
+++ b/src/vm/safehandle.cpp
@@ -483,7 +483,7 @@ FCIMPL1(UINT, SafeBuffer::AlignedSizeOfType, ReflectClassBaseObject* typeUNSAFE)
 }
 FCIMPLEND
 
-FCIMPL3(void, SafeBuffer::PtrToStructure, BYTE* ptr, FC_TypedByRef structure, UINT32 sizeofT)
+FCIMPL3_IVI(void, SafeBuffer::PtrToStructure, BYTE* ptr, FC_TypedByRef structure, UINT32 sizeofT)
 {
 	FCALL_CONTRACT;
 
@@ -494,7 +494,7 @@ FCIMPL3(void, SafeBuffer::PtrToStructure, BYTE* ptr, FC_TypedByRef structure, UI
 }
 FCIMPLEND
 
-FCIMPL3(void, SafeBuffer::StructureToPtr, FC_TypedByRef structure, BYTE* ptr, UINT32 sizeofT)
+FCIMPL3_VII(void, SafeBuffer::StructureToPtr, FC_TypedByRef structure, BYTE* ptr, UINT32 sizeofT)
 {
 	FCALL_CONTRACT;
 


### PR DESCRIPTION
SafeBuffer::PtrToStructure and SafeBuffer::StructureToPtr takes byref arguments, but are not annotated by appropriate macros(such as FCXXXX3_IVI / FCXXXX3_VII). 

This results in argument order mismatch called from JIT, which results in assert failures while running the following FX unittests:
 - System.Security.Cryptography.X509Certificates.Tests
 - System.IO.UnmanagedMemoryStream.Tests
 - System.Security.SecureString.Tests
 - System.Runtime.InteropServices.Tests
 - System.Net.Primitives.Functional.Tests

This commit uses appropriate macros for these methods in order to fix assert failures.