### PR TITLE
Introduce API for codegen getting temp registers from gtRsvdRegs

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -557,30 +557,6 @@ regMaskTP CodeGenInterface::genGetRegMask(GenTreePtr tree)
     return regMask;
 }
 
-//------------------------------------------------------------------------
-// getRegistersFromMask: Given a register mask return the two registers
-//                       specified by the mask.
-//
-// Arguments:
-//    regPairMask:  a register mask that has exactly two bits set
-// Return values:
-//    pLoReg:       the address of where to write the first register
-//    pHiReg:       the address of where to write the second register
-//
-void CodeGenInterface::genGetRegPairFromMask(regMaskTP regPairMask, regNumber* pLoReg, regNumber* pHiReg)
-{
-    assert(genCountBits(regPairMask) == 2);
-
-    regMaskTP loMask = genFindLowestBit(regPairMask); // set loMask to a one-bit mask
-    regMaskTP hiMask = regPairMask - loMask;          // set hiMask to the other bit that was in tmpRegMask
-
-    regNumber loReg = genRegNumFromMask(loMask); // set loReg from loMask
-    regNumber hiReg = genRegNumFromMask(hiMask); // set hiReg from hiMask
-
-    *pLoReg = loReg;
-    *pHiReg = hiReg;
-}
-
 // The given lclVar is either going live (being born) or dying.
 // It might be both going live and dying (that is, it is a dead store) under MinOpts.
 // Update regSet.rsMaskVars accordingly.

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -149,8 +149,6 @@ protected:
     regMaskTP genLiveMask(VARSET_VALARG_TP liveSet);
 #endif
 
-    void genGetRegPairFromMask(regMaskTP regPairMask, regNumber* pLoReg, regNumber* pHiReg);
-
     // The following property indicates whether the current method sets up
     // an explicit stack frame or not.
 private:

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -10809,9 +10809,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
 
             if (offset != 0)
             {
-                regMaskTP tmpRegMask = indir->gtRsvdRegs;
-                regNumber tmpReg     = genRegNumFromMask(tmpRegMask);
-                noway_assert(tmpReg != REG_NA);
+                regNumber tmpReg = indir->GetSingleTempReg();
 
                 emitAttr addType = varTypeIsGC(memBase) ? EA_BYREF : EA_PTRSIZE;
 
@@ -10833,7 +10831,6 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
 
                     // Then load/store dataReg from/to [tmpReg + offset]
                     emitIns_R_R_I(ins, ldstAttr, dataReg, tmpReg, offset);
-                    ;
                 }
                 else // large offset
                 {
@@ -10874,9 +10871,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
             else
             {
                 // We require a tmpReg to hold the offset
-                regMaskTP tmpRegMask = indir->gtRsvdRegs;
-                regNumber tmpReg     = genRegNumFromMask(tmpRegMask);
-                noway_assert(tmpReg != REG_NA);
+                regNumber tmpReg = indir->GetSingleTempReg();
 
                 // First load/store tmpReg with the large offset constant
                 codeGen->instGen_Set_Reg_To_Imm(EA_PTRSIZE, tmpReg, offset);
@@ -11047,9 +11042,8 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
             assert(!src1->isContained());
         }
     }
-    bool      isMulOverflow = false;
-    bool      isUnsignedMul = false;
-    regNumber extraReg      = REG_NA;
+
+    bool isMulOverflow = false;
     if (dst->gtOverflowEx())
     {
         if (ins == INS_add)
@@ -11063,7 +11057,6 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
         else if (ins == INS_mul)
         {
             isMulOverflow = true;
-            isUnsignedMul = ((dst->gtFlags & GTF_UNSIGNED) != 0);
             assert(intConst == nullptr); // overflow format doesn't support an int constant operand
         }
         else
@@ -11079,17 +11072,20 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
     {
         if (isMulOverflow)
         {
-            // Make sure that we have an internal register
-            assert(genCountBits(dst->gtRsvdRegs) == 2);
+            // This should be simply:
+            //    regNumber extraReg = dst->GetSingleTempReg();
+            //
+            // However, since LSRA might give us an internal temp register that is the same as the dst
+            // register, and the codegen here reuses the temp register after a definition of the target
+            // register, we requested two internal registers. If one is the target register, we simply
+            // use the other one. We can use ExtractTempReg() since it only asserts that there is at
+            // least one available temporary register (not that there is exactly one, for instance).
+            // Here, masking out tgtReg, there will be either 1 or 2.
 
-            // There will be two bits set in tmpRegsMask.
-            // Remove the bit for 'dst->gtRegNum' from 'tmpRegsMask'
-            regMaskTP tmpRegsMask = dst->gtRsvdRegs & ~genRegMask(dst->gtRegNum);
-            assert(tmpRegsMask != RBM_NONE);
-            regMaskTP tmpRegMask = genFindLowestBit(tmpRegsMask); // set tmpRegMsk to a one-bit mask
-            extraReg             = genRegNumFromMask(tmpRegMask); // set tmpReg from that mask
+            regNumber extraReg = dst->ExtractTempReg(~genRegMask(dst->gtRegNum));
+            assert(extraReg != dst->gtRegNum);
 
-            if (isUnsignedMul)
+            if ((dst->gtFlags & GTF_UNSIGNED) != 0)
             {
                 if (attr == EA_4BYTE)
                 {
@@ -11109,7 +11105,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
                     emitIns_R_R_R(ins, attr, dst->gtRegNum, src1->gtRegNum, src2->gtRegNum);
                 }
 
-                // zero-sign bit comparision to detect overflow.
+                // zero-sign bit comparison to detect overflow.
                 emitIns_R_I(INS_cmp, attr, extraReg, 0);
             }
             else
@@ -11137,7 +11133,7 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
                     bitShift = 63;
                 }
 
-                // Sign bit comparision to detect overflow.
+                // Sign bit comparison to detect overflow.
                 emitIns_R_R_I(INS_cmp, attr, extraReg, dst->gtRegNum, bitShift, INS_OPTS_ASR);
             }
         }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9124,7 +9124,7 @@ void Compiler::fgSimpleLowering()
                         else
                         {
                             con             = gtNewIconNode(arrLen->ArrLenOffset(), TYP_I_IMPL);
-                            con->gtRsvdRegs = 0;
+                            con->gtRsvdRegs = RBM_NONE;
 
                             add             = gtNewOperNode(GT_ADD, TYP_REF, arr, con);
                             add->gtRsvdRegs = arr->gtRsvdRegs;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -17403,3 +17403,68 @@ regMaskTP ReturnTypeDesc::GetABIReturnRegs()
 
     return resultMask;
 }
+
+#ifndef LEGACY_BACKEND
+
+//------------------------------------------------------------------------
+// The following functions manage the gtRsvdRegs set of temporary registers
+// created by LSRA during code generation.
+
+//------------------------------------------------------------------------
+// AvailableTempRegCount: return the number of available temporary registers in the (optional) given set
+// (typically, RBM_ALLINT or RBM_ALLFLOAT).
+//
+// Arguments:
+//    mask - (optional) Check for available temporary registers only in this set.
+//
+// Return Value:
+//    Count of available temporary registers in given set.
+//
+unsigned GenTree::AvailableTempRegCount(regMaskTP mask /* = (regMaskTP)-1 */) const
+{
+    return genCountBits(gtRsvdRegs & mask);
+}
+
+//------------------------------------------------------------------------
+// GetSingleTempReg: There is expected to be exactly one available temporary register
+// in the given mask in the gtRsvdRegs set. Get that register. No future calls to get
+// a temporary register are expected. Removes the register from the set, but only in
+// DEBUG to avoid doing unnecessary work in non-DEBUG builds.
+//
+// Arguments:
+//    mask - (optional) Get an available temporary register only in this set.
+//
+// Return Value:
+//    Available temporary register in given mask.
+//
+regNumber GenTree::GetSingleTempReg(regMaskTP mask /* = (regMaskTP)-1 */)
+{
+    regMaskTP availableSet = gtRsvdRegs & mask;
+    assert(genCountBits(availableSet) == 1);
+    regNumber tempReg = genRegNumFromMask(availableSet);
+    INDEBUG(gtRsvdRegs &= ~availableSet;) // Remove the register from the set, so it can't be used again.
+    return tempReg;
+}
+
+//------------------------------------------------------------------------
+// ExtractTempReg: Find the lowest number temporary register from the gtRsvdRegs set
+// that is also in the optional given mask (typically, RBM_ALLINT or RBM_ALLFLOAT),
+// and return it. Remove this register from the temporary register set, so it won't
+// be returned again.
+//
+// Arguments:
+//    mask - (optional) Extract an available temporary register only in this set.
+//
+// Return Value:
+//    Available temporary register in given mask.
+//
+regNumber GenTree::ExtractTempReg(regMaskTP mask /* = (regMaskTP)-1 */)
+{
+    regMaskTP availableSet = gtRsvdRegs & mask;
+    assert(genCountBits(availableSet) >= 1);
+    regMaskTP tempRegMask = genFindLowestBit(availableSet);
+    gtRsvdRegs &= ~tempRegMask;
+    return genRegNumFromMask(tempRegMask);
+}
+
+#endif // !LEGACY_BACKEND

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -733,6 +733,13 @@ public:
     ValueNumPair gtVNPair;
 
     regMaskSmall gtRsvdRegs; // set of fixed trashed  registers
+
+#ifndef LEGACY_BACKEND
+    unsigned AvailableTempRegCount(regMaskTP mask = (regMaskTP)-1) const;
+    regNumber GetSingleTempReg(regMaskTP mask = (regMaskTP)-1);
+    regNumber ExtractTempReg(regMaskTP mask = (regMaskTP)-1);
+#endif // !LEGACY_BACKEND
+
 #ifdef LEGACY_BACKEND
     regMaskSmall gtUsedRegs; // set of used (trashed) registers
 #endif                       // LEGACY_BACKEND

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -425,7 +425,7 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             if (tree->gtOverflow())
             {
                 // Need a register different from target reg to check for overflow.
-                info->internalIntCount = 2;
+                info->internalIntCount = 1;
             }
             __fallthrough;
 

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -288,7 +288,11 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
         case GT_MUL:
             if (tree->gtOverflow())
             {
-                // Need a register different from target reg to check for overflow.
+                // Need a register different from target reg to check for overflow;
+                // code generation requires the temp reg to live beyond the definition
+                // of the target reg. Since we have no way to tell LSRA that, we request
+                // two temp registers, and use one that is not the target reg.
+                // TODO-ARM64-CQ: Figure out a way to only reserve one.
                 info->internalIntCount = 2;
             }
             __fallthrough;
@@ -605,9 +609,10 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
             info->srcCount = 2;
             info->dstCount = 1;
 
-            // We need one internal register when generating code for GT_ARR_INDEX, however the
-            // register allocator always may just give us the same one as it gives us for the 'dst'
-            // as a workaround we will just ask for two internal registers.
+            // We need one internal register when generating code for GT_ARR_INDEX. However, the
+            // register allocator may give us the same one it gives us for 'dst'.
+            // As a workaround we will just ask for two internal registers.
+            // TODO-ARM64-CQ: Figure out a way to only reserve one.
             //
             info->internalIntCount = 2;
 


### PR DESCRIPTION
LSRA puts a set of temporary registers needed by a node in the
gtRsvdRegs register mask. Currently, evey codegen function that
needs to use a temporary register manually manipulates this mask.

Introduce a few functions to make this simpler and more regular:

1. GetSingleTempReg() // Gets a temp; asserts there is exactly one temp reg.
2. ExtractTempReg() // Gets the lowest temp, removes it from gtRsvdRegs so subsequent calls don't see it.
3. AvailableTempRegs() // Returns a count of available temp registers.

All take an optional register mask, so you can extract a register from
just the set specified by the mask (typically RBM_ALLINT or RBM_ALLFLOAT).