### PR TITLE
Update comment to reflect how RuntimeFeature members should be defined

### DIFF
--- a/src/mscorlib/shared/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/src/mscorlib/shared/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -12,7 +12,9 @@ namespace System.Runtime.CompilerServices
         public static bool IsSupported(string feature)
         {
             // No features are supported for now.
-            // These features should be added as public static readonly string fields in the same class.
+            // These features should be added as public const string fields in the same class.
+            // Example: public const string FeatureName = nameof(FeatureName);
+
             return false;
         }
     }


### PR DESCRIPTION
cc @jkotas @jcouv @dotnet/roslyn-compiler 
Updated per latest comments in https://github.com/dotnet/corefx/issues/17116