### PR TITLE
Make a GCHandleStore class and interface for use by the VM

### DIFF
--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -115,7 +115,7 @@ extern "C" GCHeapType g_gc_heap_type;
 extern "C" uint32_t g_max_generation;
 extern "C" MethodTable* g_gc_pFreeObjectMethodTable;
 
-::IGCHandleTable*  CreateGCHandleTable();
+::IGCHandleManager*  CreateGCHandleManager();
 
 namespace WKS {
     ::IGCHeapInternal* CreateGCHeap();
@@ -260,8 +260,8 @@ void updateGCShadow(Object** ptr, Object* val);
 // The single GC heap instance, shared with the VM.
 extern IGCHeapInternal* g_theGCHeap;
 
-// The single GC handle table instance, shared with the VM.
-extern IGCHandleTable* g_theGCHandleTable;
+// The single GC handle manager instance, shared with the VM.
+extern IGCHandleManager* g_theGCHandleManager;
 
 #ifndef DACCESS_COMPILE
 inline bool IsGCInProgress(bool bConsiderGCStart = false)

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -15,7 +15,7 @@
 #include "gc.h"
 
 IGCHeapInternal* g_theGCHeap;
-IGCHandleTable* g_theGCHandleTable;
+IGCHandleManager* g_theGCHandleManager;
 
 #ifdef FEATURE_STANDALONE_GC
 IGCToCLR* g_theGCToCLR;
@@ -143,7 +143,7 @@ namespace SVR
     extern void PopulateDacVars(GcDacVars* dacVars);
 }
 
-bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleTable** gcHandleTable, GcDacVars* gcDacVars)
+bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleManager, GcDacVars* gcDacVars)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -151,10 +151,10 @@ bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleTa
 
     assert(gcDacVars != nullptr);
     assert(gcHeap != nullptr);
-    assert(gcHandleTable != nullptr);
+    assert(gcHandleManager != nullptr);
 
-    IGCHandleTable* handleTable = CreateGCHandleTable();
-    if (handleTable == nullptr)
+    IGCHandleManager* handleManager = CreateGCHandleManager();
+    if (handleManager == nullptr)
     {
         return false;
     }
@@ -192,7 +192,7 @@ bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleTa
     assert(clrToGC == nullptr);
 #endif
 
-    *gcHandleTable = handleTable;
+    *gcHandleManager = handleManager;
     *gcHeap = heap;
     return true;
 }

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -8,9 +8,53 @@
 #include "gchandletableimpl.h"
 #include "objecthandle.h"
 
+GCHandleStore* g_gcGlobalHandleStore;
+
 IGCHandleTable* CreateGCHandleTable()
 {
-    return new(nothrow) GCHandleTable();
+    return new (nothrow) GCHandleTable();
+}
+
+void GCHandleStore::Uproot()
+{
+    Ref_RemoveHandleTableBucket(_underlyingBucket);
+}
+
+bool GCHandleStore::ContainsHandle(OBJECTHANDLE handle)
+{
+    return _underlyingBucket->Contains(handle);
+}
+
+OBJECTHANDLE GCHandleStore::CreateHandleOfType(Object* object, int type)
+{
+    HHANDLETABLE handletable = _underlyingBucket->pTable[GetCurrentThreadHomeHeapNumber()];
+    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
+}
+
+OBJECTHANDLE GCHandleStore::CreateHandleOfType(Object* object, int type, int heapToAffinitizeTo)
+{
+    HHANDLETABLE handletable = _underlyingBucket->pTable[heapToAffinitizeTo];
+    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
+}
+
+OBJECTHANDLE GCHandleStore::CreateHandleWithExtraInfo(Object* object, int type, void* pExtraInfo)
+{
+    HHANDLETABLE handletable = _underlyingBucket->pTable[GetCurrentThreadHomeHeapNumber()];
+    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object), reinterpret_cast<uintptr_t>(pExtraInfo));
+}
+
+OBJECTHANDLE GCHandleStore::CreateDependentHandle(Object* primary, Object* secondary)
+{
+    HHANDLETABLE handletable = _underlyingBucket->pTable[GetCurrentThreadHomeHeapNumber()];
+    OBJECTHANDLE handle = ::HndCreateHandle(handletable, HNDTYPE_DEPENDENT, ObjectToOBJECTREF(primary));
+    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
+
+    return handle;
+}
+
+GCHandleStore::~GCHandleStore()
+{
+    Ref_DestroyHandleTableBucket(_underlyingBucket);
 }
 
 bool GCHandleTable::Initialize()
@@ -23,19 +67,25 @@ void GCHandleTable::Shutdown()
     Ref_Shutdown();
 }
 
-void* GCHandleTable::GetGlobalHandleStore()
+IGCHandleStore* GCHandleTable::GetGlobalHandleStore()
 {
-    return (void*)g_HandleTableMap.pBuckets[0];
+    return g_gcGlobalHandleStore;
 }
 
-void* GCHandleTable::CreateHandleStore(void* context)
+IGCHandleStore* GCHandleTable::CreateHandleStore(void* context)
 {
 #ifndef FEATURE_REDHAWK
-    return (void*)::Ref_CreateHandleTableBucket(ADIndex((DWORD)(uintptr_t)context));
+    HandleTableBucket* newBucket = ::Ref_CreateHandleTableBucket(ADIndex((DWORD)(uintptr_t)context));
+    return new (nothrow) GCHandleStore(newBucket);
 #else
     assert("CreateHandleStore is not implemented when FEATURE_REDHAWK is defined!");
     return nullptr;
 #endif
+}
+
+void GCHandleTable::DestroyHandleStore(IGCHandleStore* store)
+{
+    delete store;
 }
 
 void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
@@ -43,51 +93,9 @@ void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
     return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);
 }
 
-void GCHandleTable::DestroyHandleStore(void* store)
-{
-    Ref_DestroyHandleTableBucket((HandleTableBucket*) store);
-}
-
-void GCHandleTable::UprootHandleStore(void* store)
-{
-    Ref_RemoveHandleTableBucket((HandleTableBucket*) store);
-}
-
-bool GCHandleTable::ContainsHandle(void* store, OBJECTHANDLE handle)
-{
-    return ((HandleTableBucket*)store)->Contains(handle);
-}
-
-OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* store, Object* object, int type)
-{
-    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[GetCurrentThreadHomeHeapNumber()];
-    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
-}
-
-OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo)
-{
-    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[heapToAffinitizeTo];
-    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
-}
-
 OBJECTHANDLE GCHandleTable::CreateGlobalHandleOfType(Object* object, int type)
 {
     return ::HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], type, ObjectToOBJECTREF(object)); 
-}
-
-OBJECTHANDLE GCHandleTable::CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo)
-{
-    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[GetCurrentThreadHomeHeapNumber()];
-    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object), reinterpret_cast<uintptr_t>(pExtraInfo));
-}
-
-OBJECTHANDLE GCHandleTable::CreateDependentHandle(void* store, Object* primary, Object* secondary)
-{
-    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[GetCurrentThreadHomeHeapNumber()];
-    OBJECTHANDLE handle = ::HndCreateHandle(handletable, HNDTYPE_DEPENDENT, ObjectToOBJECTREF(primary));
-    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
-
-    return handle;
 }
 
 OBJECTHANDLE GCHandleTable::CreateDuplicateHandle(OBJECTHANDLE handle)

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -10,9 +10,9 @@
 
 GCHandleStore* g_gcGlobalHandleStore;
 
-IGCHandleTable* CreateGCHandleTable()
+IGCHandleManager* CreateGCHandleManager()
 {
-    return new (nothrow) GCHandleTable();
+    return new (nothrow) GCHandleManager();
 }
 
 void GCHandleStore::Uproot()
@@ -57,22 +57,22 @@ GCHandleStore::~GCHandleStore()
     Ref_DestroyHandleTableBucket(_underlyingBucket);
 }
 
-bool GCHandleTable::Initialize()
+bool GCHandleManager::Initialize()
 {
     return Ref_Initialize();
 }
 
-void GCHandleTable::Shutdown()
+void GCHandleManager::Shutdown()
 {
     Ref_Shutdown();
 }
 
-IGCHandleStore* GCHandleTable::GetGlobalHandleStore()
+IGCHandleStore* GCHandleManager::GetGlobalHandleStore()
 {
     return g_gcGlobalHandleStore;
 }
 
-IGCHandleStore* GCHandleTable::CreateHandleStore(void* context)
+IGCHandleStore* GCHandleManager::CreateHandleStore(void* context)
 {
 #ifndef FEATURE_REDHAWK
     HandleTableBucket* newBucket = ::Ref_CreateHandleTableBucket(ADIndex((DWORD)(uintptr_t)context));
@@ -83,37 +83,37 @@ IGCHandleStore* GCHandleTable::CreateHandleStore(void* context)
 #endif
 }
 
-void GCHandleTable::DestroyHandleStore(IGCHandleStore* store)
+void GCHandleManager::DestroyHandleStore(IGCHandleStore* store)
 {
     delete store;
 }
 
-void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
+void* GCHandleManager::GetHandleContext(OBJECTHANDLE handle)
 {
     return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);
 }
 
-OBJECTHANDLE GCHandleTable::CreateGlobalHandleOfType(Object* object, int type)
+OBJECTHANDLE GCHandleManager::CreateGlobalHandleOfType(Object* object, int type)
 {
     return ::HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], type, ObjectToOBJECTREF(object)); 
 }
 
-OBJECTHANDLE GCHandleTable::CreateDuplicateHandle(OBJECTHANDLE handle)
+OBJECTHANDLE GCHandleManager::CreateDuplicateHandle(OBJECTHANDLE handle)
 {
     return ::HndCreateHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, ::HndFetchHandle(handle));
 }
 
-void GCHandleTable::DestroyHandleOfType(OBJECTHANDLE handle, int type)
+void GCHandleManager::DestroyHandleOfType(OBJECTHANDLE handle, int type)
 {
     ::HndDestroyHandle(::HndGetHandleTable(handle), type, handle);
 }
 
-void GCHandleTable::DestroyHandleOfUnknownType(OBJECTHANDLE handle)
+void GCHandleManager::DestroyHandleOfUnknownType(OBJECTHANDLE handle)
 {
     ::HndDestroyHandleOfUnknownType(::HndGetHandleTable(handle), handle);
 }
 
-void* GCHandleTable::GetExtraInfoFromHandle(OBJECTHANDLE handle)
+void* GCHandleManager::GetExtraInfoFromHandle(OBJECTHANDLE handle)
 {
     return (void*)::HndGetHandleExtraInfo(handle);
 }

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -35,7 +35,7 @@ private:
 
 extern GCHandleStore* g_gcGlobalHandleStore;
 
-class GCHandleTable : public IGCHandleTable
+class GCHandleManager : public IGCHandleManager
 {
 public:
     virtual bool Initialize();

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -11,10 +11,6 @@
 class GCHandleStore : public IGCHandleStore
 {
 public:
-    GCHandleStore(HandleTableBucket *bucket) 
-        : _underlyingBucket(bucket)
-        { }
-
     virtual void Uproot();
 
     virtual bool ContainsHandle(OBJECTHANDLE handle);
@@ -29,8 +25,7 @@ public:
 
     virtual ~GCHandleStore();
 
-private:
-    HandleTableBucket* _underlyingBucket;
+    HandleTableBucket _underlyingBucket;
 };
 
 extern GCHandleStore* g_gcGlobalHandleStore;

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -6,6 +6,34 @@
 #define GCHANDLETABLE_H_
 
 #include "gcinterface.h"
+#include "objecthandle.h"
+
+class GCHandleStore : public IGCHandleStore
+{
+public:
+    GCHandleStore(HandleTableBucket *bucket) 
+        : _underlyingBucket(bucket)
+        { }
+
+    virtual void Uproot();
+
+    virtual bool ContainsHandle(OBJECTHANDLE handle);
+
+    virtual OBJECTHANDLE CreateHandleOfType(Object* object, int type);
+
+    virtual OBJECTHANDLE CreateHandleOfType(Object* object, int type, int heapToAffinitizeTo);
+
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(Object* object, int type, void* pExtraInfo);
+
+    virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary);
+
+    virtual ~GCHandleStore();
+
+private:
+    HandleTableBucket* _underlyingBucket;
+};
+
+extern GCHandleStore* g_gcGlobalHandleStore;
 
 class GCHandleTable : public IGCHandleTable
 {
@@ -14,25 +42,13 @@ public:
 
     virtual void Shutdown();
 
-    virtual void* GetGlobalHandleStore();
-
-    virtual void* CreateHandleStore(void* context);
-
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
-    virtual void DestroyHandleStore(void* store);
+    virtual IGCHandleStore* GetGlobalHandleStore();
 
-    virtual void UprootHandleStore(void* store);
+    virtual IGCHandleStore* CreateHandleStore(void* context);
 
-    virtual bool ContainsHandle(void* store, OBJECTHANDLE handle);
-
-    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type);
-
-    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo);
-
-    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo);
-
-    virtual OBJECTHANDLE CreateDependentHandle(void* store, Object* primary, Object* secondary);
+    virtual void DestroyHandleStore(IGCHandleStore* store);
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type);
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -402,6 +402,24 @@ typedef struct OBJECTHANDLE__* OBJECTHANDLE;
 typedef uintptr_t OBJECTHANDLE;
 #endif
 
+class IGCHandleStore {
+public:
+
+    virtual void Uproot() = 0;
+
+    virtual bool ContainsHandle(OBJECTHANDLE handle) = 0;
+
+    virtual OBJECTHANDLE CreateHandleOfType(Object* object, int type) = 0;
+
+    virtual OBJECTHANDLE CreateHandleOfType(Object* object, int type, int heapToAffinitizeTo) = 0;
+
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(Object* object, int type, void* pExtraInfo) = 0;
+
+    virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary) = 0;
+
+    virtual ~IGCHandleStore() {};
+};
+
 class IGCHandleTable {
 public:
 
@@ -411,23 +429,11 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
-    virtual void* GetGlobalHandleStore() = 0;
+    virtual IGCHandleStore* GetGlobalHandleStore() = 0;
 
-    virtual void* CreateHandleStore(void* context) = 0;
+    virtual IGCHandleStore* CreateHandleStore(void* context) = 0;
 
-    virtual void DestroyHandleStore(void* store) = 0;
-
-    virtual void UprootHandleStore(void* store) = 0;
-
-    virtual bool ContainsHandle(void* store, OBJECTHANDLE handle) = 0;
-
-    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type) = 0;
-
-    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo) = 0;
-
-    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo) = 0;
-
-    virtual OBJECTHANDLE CreateDependentHandle(void* store, Object* primary, Object* secondary) = 0;
+    virtual void DestroyHandleStore(IGCHandleStore* store) = 0;
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type) = 0;
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -169,12 +169,12 @@ struct segment_info
 
 class Object;
 class IGCHeap;
-class IGCHandleTable;
+class IGCHandleManager;
 
 // Initializes the garbage collector. Should only be called
 // once, during EE startup. Returns true if the initialization
 // was successful, false otherwise.
-bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleTable** gcHandleTable, GcDacVars* gcDacVars);
+bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleTable, GcDacVars* gcDacVars);
 
 // The runtime needs to know whether we're using workstation or server GC 
 // long before the GCHeap is created. This function sets the type of
@@ -420,7 +420,7 @@ public:
     virtual ~IGCHandleStore() {};
 };
 
-class IGCHandleTable {
+class IGCHandleManager {
 public:
 
     virtual bool Initialize() = 0;

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -1003,7 +1003,8 @@ void SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTarge
                     overlapped->m_userObject = NULL;
                 }
                 BashMTForPinnedObject(ObjectToOBJECTREF(value));
-                overlapped->m_pinSelf = CreateAsyncPinningHandle((HHANDLETABLE)pTargetTable,ObjectToOBJECTREF(value));
+
+                overlapped->m_pinSelf = HndCreateHandle((HHANDLETABLE)pTargetTable, HNDTYPE_ASYNCPINNED, ObjectToOBJECTREF(value));
                 *pValue = NULL;
             }
             pValue ++;

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -629,59 +629,62 @@ bool Ref_Initialize()
     if (pBuckets == NULL)
         return false;
 
-    ZeroMemory(pBuckets,
-         INITIAL_HANDLE_TABLE_ARRAY_SIZE * sizeof (HandleTableBucket *));
+    ZeroMemory(pBuckets, INITIAL_HANDLE_TABLE_ARRAY_SIZE * sizeof (HandleTableBucket *));
 
-    // Crate the first bucket
-    HandleTableBucket * pBucket = new (nothrow) HandleTableBucket;
-    if (pBucket != NULL)
+    g_gcGlobalHandleStore = new (nothrow) GCHandleStore();
+    if (g_gcGlobalHandleStore == NULL)
     {
-        pBucket->HandleTableIndex = 0;
-
-        int n_slots = getNumberOfSlots();
-
-        HandleTableBucketHolder bucketHolder(pBucket, n_slots);
-
-        // create the handle table set for the first bucket
-        pBucket->pTable = new (nothrow) HHANDLETABLE[n_slots];
-        if (pBucket->pTable == NULL)
-            goto CleanupAndFail;
-
-        ZeroMemory(pBucket->pTable,
-            n_slots * sizeof(HHANDLETABLE));
-        for (int uCPUindex = 0; uCPUindex < n_slots; uCPUindex++)
-        {
-            pBucket->pTable[uCPUindex] = HndCreateHandleTable(s_rgTypeFlags, _countof(s_rgTypeFlags), ADIndex(1));
-            if (pBucket->pTable[uCPUindex] == NULL)
-                goto CleanupAndFail;
-
-            HndSetHandleTableIndex(pBucket->pTable[uCPUindex], 0);
-        }
-
-        pBuckets[0] = pBucket;
-        bucketHolder.SuppressRelease();
-
-        g_HandleTableMap.pBuckets = pBuckets;
-        g_HandleTableMap.dwMaxIndex = INITIAL_HANDLE_TABLE_ARRAY_SIZE;
-        g_HandleTableMap.pNext = NULL;
-
-        g_gcGlobalHandleStore = new (nothrow) GCHandleStore(g_HandleTableMap.pBuckets[0]);
-        if (g_gcGlobalHandleStore == NULL)
-            goto CleanupAndFail;
-
-        // Allocate contexts used during dependent handle promotion scanning. There's one of these for every GC
-        // heap since they're scanned in parallel.
-        g_pDependentHandleContexts = new (nothrow) DhContext[n_slots];
-        if (g_pDependentHandleContexts == NULL)
-            goto CleanupAndFail;
-
-        return true;
+        delete[] pBuckets;
+        return false;
     }
 
+    // Initialize the bucket in the global handle store
+    HandleTableBucket* pBucket = &g_gcGlobalHandleStore->_underlyingBucket;
+
+    pBucket->HandleTableIndex = 0;
+
+    int n_slots = getNumberOfSlots();
+
+    HandleTableBucketHolder bucketHolder(pBucket, n_slots);
+
+    // create the handle table set for the first bucket
+    pBucket->pTable = new (nothrow) HHANDLETABLE[n_slots];
+    if (pBucket->pTable == NULL)
+        goto CleanupAndFail;
+
+    ZeroMemory(pBucket->pTable,
+        n_slots * sizeof(HHANDLETABLE));
+    for (int uCPUindex = 0; uCPUindex < n_slots; uCPUindex++)
+    {
+        pBucket->pTable[uCPUindex] = HndCreateHandleTable(s_rgTypeFlags, _countof(s_rgTypeFlags), ADIndex(1));
+        if (pBucket->pTable[uCPUindex] == NULL)
+            goto CleanupAndFail;
+
+        HndSetHandleTableIndex(pBucket->pTable[uCPUindex], 0);
+    }
+
+    pBuckets[0] = pBucket;
+    bucketHolder.SuppressRelease();
+
+    g_HandleTableMap.pBuckets = pBuckets;
+    g_HandleTableMap.dwMaxIndex = INITIAL_HANDLE_TABLE_ARRAY_SIZE;
+    g_HandleTableMap.pNext = NULL;
+
+    // Allocate contexts used during dependent handle promotion scanning. There's one of these for every GC
+    // heap since they're scanned in parallel.
+    g_pDependentHandleContexts = new (nothrow) DhContext[n_slots];
+    if (g_pDependentHandleContexts == NULL)
+        goto CleanupAndFail;
+
+    return true;
 
 CleanupAndFail:
     if (pBuckets != NULL)
         delete[] pBuckets;
+
+    if (g_gcGlobalHandleStore != NULL)
+        delete g_gcGlobalHandleStore;
+
     return false;
 }
 
@@ -701,9 +704,6 @@ void Ref_Shutdown()
         // don't destroy any of the indexed handle tables; they should
         // be destroyed externally.
 
-        // destroy the global handle table bucket tables
-        Ref_DestroyHandleTableBucket(g_HandleTableMap.pBuckets[0]);
-
         // destroy the handle table bucket array
         HandleTableMap *walk = &g_HandleTableMap;
         while (walk) {
@@ -721,9 +721,22 @@ void Ref_Shutdown()
 }
 
 #ifndef FEATURE_REDHAWK
-// ATTENTION: interface changed
-// Note: this function called only from AppDomain::Init()
-HandleTableBucket *Ref_CreateHandleTableBucket(ADIndex uADIndex)
+HandleTableBucket* Ref_CreateHandleTableBucket(void* context)
+{
+    HandleTableBucket* result = new (nothrow) HandleTableBucket();
+    if (result == nullptr)
+        return nullptr;
+
+    if (!Ref_InitializeHandleTableBucket(result, context))
+    {
+        delete result;
+        return nullptr;
+    }
+
+    return result;
+}
+
+bool Ref_InitializeHandleTableBucket(HandleTableBucket* bucket, void* context)
 {
     CONTRACTL
     {
@@ -733,14 +746,12 @@ HandleTableBucket *Ref_CreateHandleTableBucket(ADIndex uADIndex)
     }
     CONTRACTL_END;
 
-    HandleTableBucket *result = NULL;
-    HandleTableMap *walk;
-    
-    walk = &g_HandleTableMap;
+    HandleTableBucket *result = bucket;
+    HandleTableMap *walk = &g_HandleTableMap;
+
     HandleTableMap *last = NULL;
     uint32_t offset = 0;
 
-    result = new HandleTableBucket;
     result->pTable = NULL;
 
     // create handle table set for the bucket
@@ -748,11 +759,11 @@ HandleTableBucket *Ref_CreateHandleTableBucket(ADIndex uADIndex)
 
     HandleTableBucketHolder bucketHolder(result, n_slots);
 
-    result->pTable = new HHANDLETABLE [ n_slots ];
-    ZeroMemory(result->pTable, n_slots * sizeof (HHANDLETABLE));
+    result->pTable = new HHANDLETABLE[n_slots];
+    ZeroMemory(result->pTable, n_slots * sizeof(HHANDLETABLE));
 
     for (int uCPUindex=0; uCPUindex < n_slots; uCPUindex++) {
-        result->pTable[uCPUindex] = HndCreateHandleTable(s_rgTypeFlags, _countof(s_rgTypeFlags), uADIndex);
+        result->pTable[uCPUindex] = HndCreateHandleTable(s_rgTypeFlags, _countof(s_rgTypeFlags), ADIndex((DWORD)(uintptr_t)context));
         if (!result->pTable[uCPUindex])
             COMPlusThrowOM();
     }
@@ -769,7 +780,7 @@ HandleTableBucket *Ref_CreateHandleTableBucket(ADIndex uADIndex)
                     if (Interlocked::CompareExchangePointer(&walk->pBuckets[i], result, NULL) == 0) {
                         // Get a free slot.
                         bucketHolder.SuppressRelease();
-                        return result;
+                        return true;
                     }
                 }
             }

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -19,6 +19,8 @@
 #include "objecthandle.h"
 #include "handletablepriv.h"
 
+#include "gchandletableimpl.h"
+
 #ifdef FEATURE_COMINTEROP
 #include "comcallablewrapper.h"
 #endif // FEATURE_COMINTEROP
@@ -663,6 +665,10 @@ bool Ref_Initialize()
         g_HandleTableMap.dwMaxIndex = INITIAL_HANDLE_TABLE_ARRAY_SIZE;
         g_HandleTableMap.pNext = NULL;
 
+        g_gcGlobalHandleStore = new (nothrow) GCHandleStore(g_HandleTableMap.pBuckets[0]);
+        if (g_gcGlobalHandleStore == NULL)
+            goto CleanupAndFail;
+
         // Allocate contexts used during dependent handle promotion scanning. There's one of these for every GC
         // heap since they're scanned in parallel.
         g_pDependentHandleContexts = new (nothrow) DhContext[n_slots];
@@ -671,6 +677,7 @@ bool Ref_Initialize()
 
         return true;
     }
+
 
 CleanupAndFail:
     if (pBuckets != NULL)

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -106,7 +106,8 @@ typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,ResetOBJECTHANDLE> ObjectInH
  */
 bool Ref_Initialize();
 void Ref_Shutdown();
-HandleTableBucket *Ref_CreateHandleTableBucket(ADIndex uADIndex);
+HandleTableBucket* Ref_CreateHandleTableBucket(void* context);
+bool Ref_InitializeHandleTableBucket(HandleTableBucket* bucket, void* context);
 BOOL Ref_HandleAsyncPinHandles();
 void Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget);
 void Ref_RemoveHandleTableBucket(HandleTableBucket *pBucket);

--- a/src/gc/sample/GCSample.cpp
+++ b/src/gc/sample/GCSample.cpp
@@ -130,8 +130,8 @@ int __cdecl main(int argc, char* argv[])
     //
     GcDacVars dacVars;
     IGCHeap *pGCHeap;
-    IGCHandleTable *pGCHandleTable;
-    if (!InitializeGarbageCollector(nullptr, &pGCHeap, &pGCHandleTable, &dacVars))
+    IGCHandleManager *pGCHandleManager;
+    if (!InitializeGarbageCollector(nullptr, &pGCHeap, &pGCHandleManager, &dacVars))
     {
         return -1;
     }
@@ -140,9 +140,9 @@ int __cdecl main(int argc, char* argv[])
         return -1;
 
     //
-    // Initialize handle table
+    // Initialize handle manager
     //
-    if (!pGCHandleTable->Initialize())
+    if (!pGCHandleManager->Initialize())
         return -1;
 
     //

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -741,7 +741,7 @@ BaseDomain::BaseDomain()
 
 #ifndef CROSSGEN_COMPILE
     // Note that m_handleStore is overridden by app domains
-    m_handleStore = GCHandleTableUtilities::GetGCHandleTable()->GetGlobalHandleStore();
+    m_handleStore = GCHandleUtilities::GetGCHandleManager()->GetGlobalHandleStore();
 #else
     m_handleStore = NULL;
 #endif
@@ -4273,11 +4273,11 @@ void AppDomain::Init()
     // default domain cannot be unloaded.
     if (GetId().m_dwId == DefaultADID)
     {
-        m_handleStore = GCHandleTableUtilities::GetGCHandleTable()->GetGlobalHandleStore();
+        m_handleStore = GCHandleUtilities::GetGCHandleManager()->GetGlobalHandleStore();
     }
     else
     {
-        m_handleStore = GCHandleTableUtilities::GetGCHandleTable()->CreateHandleStore((void*)(uintptr_t)m_dwIndex.m_dwIndex);
+        m_handleStore = GCHandleUtilities::GetGCHandleManager()->CreateHandleStore((void*)(uintptr_t)m_dwIndex.m_dwIndex);
     }
 
 #endif // CROSSGEN_COMPILE
@@ -4580,7 +4580,7 @@ void AppDomain::Terminate()
 
     if (m_handleStore)
     {
-        GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleStore(m_handleStore);
+        GCHandleUtilities::GetGCHandleManager()->DestroyHandleStore(m_handleStore);
         m_handleStore = NULL;
     }
 

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -4578,7 +4578,7 @@ void AppDomain::Terminate()
 
     BaseDomain::Terminate();
 
-    if (m_handleStore) 
+    if (m_handleStore)
     {
         GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleStore(m_handleStore);
         m_handleStore = NULL;
@@ -9197,8 +9197,8 @@ void AppDomain::ClearGCHandles()
     // Keep async pin handles alive by moving them to default domain
     HandleAsyncPinHandles();
 
-    // Remove our handle table as a source of GC roots
-    GCHandleTableUtilities::GetGCHandleTable()->UprootHandleStore(m_handleStore);
+    // Remove our handle store as a source of GC roots
+    m_handleStore->Uproot();
 }
 
 // When an AD is unloaded, we will release all objects in this AD.
@@ -9247,15 +9247,13 @@ void AppDomain::ClearGCRoots()
     // this point, so only need to synchronize the preemptive mode threads.
     ExecutionManager::Unload(GetLoaderAllocator());
 
-    IGCHandleTable* pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
-
     while ((pThread = ThreadStore::GetAllThreadList(pThread, 0, 0)) != NULL)
     {
         // Delete the thread local static store
         pThread->DeleteThreadStaticData(this);
 
         // <TODO>@TODO: A pre-allocated AppDomainUnloaded exception might be better.</TODO>
-        if (pHandleTable->ContainsHandle(m_handleStore, pThread->m_LastThrownObjectHandle))
+        if (m_handleStore->ContainsHandle(pThread->m_LastThrownObjectHandle))
         {
             // Never delete a handle to a preallocated exception object.
             if (!CLRException::IsPreallocatedExceptionHandle(pThread->m_LastThrownObjectHandle))

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -28,7 +28,7 @@
 #include "ilstubcache.h"
 #include "testhookmgr.h"
 #include "gcheaputilities.h"
-#include "gchandletableutilities.h"
+#include "gchandleutilities.h"
 #include "../binder/inc/applicationcontext.hpp"
 #include "rejit.h"
 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1244,9 +1244,7 @@ public:
     OBJECTHANDLE CreateTypedHandle(OBJECTREF object, int type)
     {
         WRAPPER_NO_CONTRACT;
-
-        IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
-        return pHandleTable->CreateHandleOfType(m_handleStore, OBJECTREFToObject(object), type);
+        return m_handleStore->CreateHandleOfType(OBJECTREFToObject(object), type);
     }
 
     OBJECTHANDLE CreateHandle(OBJECTREF object)
@@ -1345,8 +1343,7 @@ public:
         }
         CONTRACTL_END;
 
-        IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
-        return pHandleTable->CreateDependentHandle(m_handleStore, OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
+        return m_handleStore->CreateDependentHandle(OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
     }
 #endif // DACCESS_COMPILE && !CROSSGEN_COMPILE
 
@@ -1402,7 +1399,7 @@ protected:
 
     CLRPrivBinderCoreCLR *m_pTPABinderContext; // Reference to the binding context that holds TPA list details
 
-    void* m_handleStore;
+    IGCHandleStore* m_handleStore;
 
     // The large heap handle table.
     LargeHeapHandleTable        *m_pLargeHeapHandleTable;

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -869,7 +869,7 @@ void EEStartupHelper(COINITIEE fFlags)
 
         // Initialize remoting
 
-        if (!GCHandleTableUtilities::GetGCHandleTable()->Initialize())
+        if (!GCHandleUtilities::GetGCHandleManager()->Initialize())
         {
             IfFailGo(E_OUTOFMEMORY);
         }
@@ -1880,7 +1880,7 @@ part2:
 #ifdef SHOULD_WE_CLEANUP
                 if (!g_fFastExitProcess)
                 {
-                    GCHandleTableUtilities::GetGCHandleTable()->Shutdown();
+                    GCHandleUtilities::GetGCHandleManager()->Shutdown();
                 }
 #endif /* SHOULD_WE_CLEANUP */
 
@@ -2483,17 +2483,17 @@ void InitializeGarbageCollector()
     IGCToCLR* gcToClr = nullptr;
 #endif
 
-    IGCHandleTable *pGcHandleTable;
+    IGCHandleManager *pGcHandleManager;
 
     IGCHeap *pGCHeap;
-    if (!InitializeGarbageCollector(gcToClr, &pGCHeap, &pGcHandleTable, &g_gc_dac_vars)) 
+    if (!InitializeGarbageCollector(gcToClr, &pGCHeap, &pGcHandleManager, &g_gc_dac_vars)) 
     {
         ThrowOutOfMemory();
     }
 
     assert(pGCHeap != nullptr);
     g_pGCHeap = pGCHeap;
-    g_pGCHandleTable = pGcHandleTable;
+    g_pGCHandleManager = pGcHandleManager;
     g_gcDacGlobals = &g_gc_dac_vars;
 
     // Apparently the Windows linker removes global variables if they are never

--- a/src/vm/exstate.cpp
+++ b/src/vm/exstate.cpp
@@ -102,7 +102,7 @@ void ThreadExceptionState::FreeAllStackTraces()
     }
 }
 
-void ThreadExceptionState::ClearThrowablesForUnload(void* handleStore)
+void ThreadExceptionState::ClearThrowablesForUnload(IGCHandleStore* handleStore)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -112,13 +112,11 @@ void ThreadExceptionState::ClearThrowablesForUnload(void* handleStore)
     ExInfo*           pNode = &m_currentExInfo;
 #endif // WIN64EXCEPTIONS
 
-    IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
-
     for ( ;
           pNode != NULL;
           pNode = pNode->m_pPrevNestedInfo)
     {
-        if (pHandleTable->ContainsHandle(handleStore, pNode->m_hThrowable))
+        if (handleStore->ContainsHandle(pNode->m_hThrowable))
         {
             pNode->DestroyExceptionHandle();
         }

--- a/src/vm/exstate.h
+++ b/src/vm/exstate.h
@@ -56,7 +56,7 @@ class ThreadExceptionState
 public:
     
     void FreeAllStackTraces();
-    void ClearThrowablesForUnload(void* handleStore);
+    void ClearThrowablesForUnload(IGCHandleStore* handleStore);
 
 #ifdef _DEBUG
     typedef enum 

--- a/src/vm/gchandletableutilities.h
+++ b/src/vm/gchandletableutilities.h
@@ -64,54 +64,54 @@ inline BOOL ObjectHandleIsNull(OBJECTHANDLE handle)
 
 // Handle creation convenience functions
 
-inline OBJECTHANDLE CreateHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
 }
 
-inline OBJECTHANDLE CreateWeakHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
 }
 
-inline OBJECTHANDLE CreateShortWeakHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateShortWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
 }
 
-inline OBJECTHANDLE CreateLongWeakHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateLongWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
 }
 
-inline OBJECTHANDLE CreateStrongHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateStrongHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
 }
 
-inline OBJECTHANDLE CreatePinningHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreatePinningHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
 }
 
-inline OBJECTHANDLE CreateAsyncPinningHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateAsyncPinningHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
 }
 
-inline OBJECTHANDLE CreateRefcountedHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateRefcountedHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
 }
 
-inline OBJECTHANDLE CreateSizedRefHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
 }
 
-inline OBJECTHANDLE CreateSizedRefHandle(void* table, OBJECTREF object, int heapToAffinitizeTo)
+inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object, int heapToAffinitizeTo)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF, heapToAffinitizeTo);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_SIZEDREF, heapToAffinitizeTo);
 }
 
 // Global handle creation convenience functions
@@ -157,22 +157,16 @@ inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 // Special handle creation convenience functions
 
 #ifdef FEATURE_COMINTEROP
-inline OBJECTHANDLE CreateWinRTWeakHandle(void* table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
+inline OBJECTHANDLE CreateWinRTWeakHandle(IGCHandleStore* store, OBJECTREF object, IWeakReference* pWinRTWeakReference)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
-                                                                                 OBJECTREFToObject(object),
-                                                                                 HNDTYPE_WEAK_WINRT,
-                                                                                 (void*)pWinRTWeakReference);
+    return store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_WEAK_WINRT, (void*)pWinRTWeakReference);
 }
 #endif // FEATURE_COMINTEROP
 
 // Creates a variable-strength handle
-inline OBJECTHANDLE CreateVariableHandle(void* table, OBJECTREF object, uint32_t type)
+inline OBJECTHANDLE CreateVariableHandle(IGCHandleStore* store, OBJECTREF object, uint32_t type)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
-                                                                                 OBJECTREFToObject(object),
-                                                                                 HNDTYPE_VARIABLE,
-                                                                                 (void*)((uintptr_t)type));
+    return store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_VARIABLE, (void*)((uintptr_t)type));
 }
 
 // Handle destruction convenience functions

--- a/src/vm/gchandleutilities.h
+++ b/src/vm/gchandleutilities.h
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#ifndef _GCHANDLETABLEUTILITIES_H_
-#define _GCHANDLETABLEUTILITIES_H_
+#ifndef _GCHANDLEUTILITIES_H_
+#define _GCHANDLEUTILITIES_H_
 
 #include "gcinterface.h"
 
@@ -11,23 +11,23 @@
 #include <weakreference.h>
 #endif
 
-extern "C" IGCHandleTable* g_pGCHandleTable;
+extern "C" IGCHandleManager* g_pGCHandleManager;
 
-class GCHandleTableUtilities
+class GCHandleUtilities
 {
 public:
     // Retrieves the GC handle table.
-    static IGCHandleTable* GetGCHandleTable() 
+    static IGCHandleManager* GetGCHandleManager() 
     {
         LIMITED_METHOD_CONTRACT;
 
-        assert(g_pGCHandleTable != nullptr);
-        return g_pGCHandleTable;
+        assert(g_pGCHandleManager != nullptr);
+        return g_pGCHandleManager;
     }
 
 private:
     // This class should never be instantiated.
-    GCHandleTableUtilities() = delete;
+    GCHandleUtilities() = delete;
 };
 
 void ValidateHandleAndAppDomain(OBJECTHANDLE handle);
@@ -119,39 +119,39 @@ inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object
 inline OBJECTHANDLE CreateGlobalHandle(OBJECTREF object)
 {
     CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
 }
 
 inline OBJECTHANDLE CreateGlobalWeakHandle(OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
 }
 
 inline OBJECTHANDLE CreateGlobalShortWeakHandle(OBJECTREF object)
 {
     CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
 }
 
 inline OBJECTHANDLE CreateGlobalLongWeakHandle(OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
 }
 
 inline OBJECTHANDLE CreateGlobalStrongHandle(OBJECTREF object)
 {
     CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
+    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
 }
 
 inline OBJECTHANDLE CreateGlobalPinningHandle(OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
+    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
 }
 
 inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
 }
 
 // Special handle creation convenience functions
@@ -183,92 +183,92 @@ inline void DestroyHandle(OBJECTHANDLE handle)
     }
     CONTRACTL_END;
 
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_DEFAULT);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_DEFAULT);
 }
 
 inline void DestroyWeakHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_DEFAULT);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_WEAK_DEFAULT);
 }
 
 inline void DestroyShortWeakHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_SHORT);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_WEAK_SHORT);
 }
 
 inline void DestroyLongWeakHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_LONG);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_WEAK_LONG);
 }
 
 inline void DestroyStrongHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_STRONG);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_STRONG);
 }
 
 inline void DestroyPinningHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_PINNED);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_PINNED);
 }
 
 inline void DestroyAsyncPinningHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_ASYNCPINNED);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_ASYNCPINNED);
 }
 
 inline void DestroyRefcountedHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_REFCOUNTED);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_REFCOUNTED);
 }
 
 inline void DestroyDependentHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_DEPENDENT);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_DEPENDENT);
 }
 
 inline void  DestroyVariableHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_VARIABLE);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_VARIABLE);
 }
 
 inline void DestroyGlobalHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_DEFAULT);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_DEFAULT);
 }
 
 inline void DestroyGlobalWeakHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_DEFAULT);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_WEAK_DEFAULT);
 }
 
 inline void DestroyGlobalShortWeakHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_SHORT);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_WEAK_SHORT);
 }
 
 inline void DestroyGlobalLongWeakHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_LONG);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_WEAK_LONG);
 }
 
 inline void DestroyGlobalStrongHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_STRONG);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_STRONG);
 }
 
 inline void DestroyGlobalPinningHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_PINNED);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_PINNED);
 }
 
 inline void DestroyGlobalRefcountedHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_REFCOUNTED);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_REFCOUNTED);
 }
 
 inline void DestroyTypedHandle(OBJECTHANDLE handle)
 {
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfUnknownType(handle);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfUnknownType(handle);
 }
 
 #ifdef FEATURE_COMINTEROP
@@ -287,14 +287,14 @@ inline void DestroyWinRTWeakHandle(OBJECTHANDLE handle)
     // Release the WinRT weak reference if we have one. We're assuming that this will not reenter the
     // runtime, since if we are pointing at a managed object, we should not be using HNDTYPE_WEAK_WINRT
     // but rather HNDTYPE_WEAK_SHORT or HNDTYPE_WEAK_LONG.
-    void* pExtraInfo = GCHandleTableUtilities::GetGCHandleTable()->GetExtraInfoFromHandle(handle);
+    void* pExtraInfo = GCHandleUtilities::GetGCHandleManager()->GetExtraInfoFromHandle(handle);
     IWeakReference* pWinRTWeakReference = reinterpret_cast<IWeakReference*>(pExtraInfo);
     if (pWinRTWeakReference != nullptr)
     {
         pWinRTWeakReference->Release();
     }
 
-    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_WINRT);
+    GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, HNDTYPE_WEAK_WINRT);
 }
 #endif
 
@@ -344,5 +344,5 @@ public:
 
 #endif // !DACCESS_COMPILE
 
-#endif // _GCHANDLETABLEUTILITIES_H_
+#endif // _GCHANDLEUTILITIES_H_
 

--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -25,7 +25,7 @@ uint32_t* g_card_bundle_table = nullptr;
 // This is the global GC heap, maintained by the VM.
 GPTR_IMPL(IGCHeap, g_pGCHeap);
 
-IGCHandleTable* g_pGCHandleTable = nullptr;
+IGCHandleManager* g_pGCHandleManager = nullptr;
 
 GcDacVars g_gc_dac_vars;
 GPTR_IMPL(GcDacVars, g_gcDacGlobals);
@@ -46,9 +46,9 @@ void ValidateHandleAndAppDomain(OBJECTHANDLE handle)
     OBJECTREF objRef = ObjectToOBJECTREF(*(Object**)handle);
     VALIDATEOBJECTREF(objRef);
 
-    IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
+    IGCHandleManager *pHandleManager = GCHandleUtilities::GetGCHandleManager();
 
-    DWORD context = (DWORD)pHandleTable->GetHandleContext(handle);
+    DWORD context = (DWORD)pHandleManager->GetHandleContext(handle);
 
     ADIndex appDomainIndex = ADIndex(context);
     AppDomain *domain = SystemDomain::GetAppDomainAtIndex(appDomainIndex);

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -5074,7 +5074,7 @@ void Thread::SafeUpdateLastThrownObject(void)
     {
         EX_TRY
         {
-            IGCHandleTable *pHandleTable = GCHandleTableUtilities::GetGCHandleTable();
+            IGCHandleManager *pHandleTable = GCHandleUtilities::GetGCHandleManager();
 
             // Creating a duplicate handle here ensures that the AD of the last thrown object
             // matches the domain of the current throwable.

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -143,7 +143,7 @@
 #include "mscoree.h"
 #include "appdomainstack.h"
 #include "gcheaputilities.h"
-#include "gchandletableutilities.h"
+#include "gchandleutilities.h"
 #include "gcinfotypes.h"
 #include <clrhost.h>
 


### PR DESCRIPTION
This change formalizes the handle store concept that we just introduced, and replaces all the functions on `IGCHandleTable` that were taking `void* store` as the first argument with class methods on `IGCHandleStore`.

The diff isn't that bad, but it's thrown off by the reordering of things, so I recommend using the "Split" view and focusing on the right side :smile:.

@jkotas @sergiy-k @swgillespie @Maoni0 