### PR TITLE
[x86/Linux] Use CDECL as STDAPICALLTYPE

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/coreclrcommoncallbacks.h
+++ b/src/ToolBox/superpmi/superpmi-shared/coreclrcommoncallbacks.h
@@ -1,0 +1,20 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#ifndef _CoreClrCommonCallbacks
+#define _CoreClrCommonCallbacks
+
+#include "runtimedetails.h"
+
+IExecutionEngine* IEE_t();
+HRESULT GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
+LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
+BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
+void* GetCLRFunction(LPCSTR functionName);
+
+typedef LPVOID (*pfnEEHeapAllocInProcessHeap)(DWORD dwFlags, SIZE_T dwBytes);
+typedef BOOL (*pfnEEHeapFreeInProcessHeap)(DWORD dwFlags, LPVOID lpMem);
+
+#endif

--- a/src/ToolBox/superpmi/superpmi-shim-collector/coreclrcallbacks.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/coreclrcallbacks.cpp
@@ -7,14 +7,11 @@
 #include "coreclrcallbacks.h"
 #include "iexecutionengine.h"
 
-typedef LPVOID(__stdcall* pfnEEHeapAllocInProcessHeap)(DWORD dwFlags, SIZE_T dwBytes);
-typedef BOOL(__stdcall* pfnEEHeapFreeInProcessHeap)(DWORD dwFlags, LPVOID lpMem);
-
 CoreClrCallbacks*           original_CoreClrCallbacks         = nullptr;
 pfnEEHeapAllocInProcessHeap original_EEHeapAllocInProcessHeap = nullptr;
 pfnEEHeapFreeInProcessHeap  original_EEHeapFreeInProcessHeap  = nullptr;
 
-IExecutionEngine* STDMETHODCALLTYPE IEE_t()
+IExecutionEngine* IEE_t()
 {
     interceptor_IEE* iee = new interceptor_IEE();
     iee->original_IEE    = original_CoreClrCallbacks->m_pfnIEE();
@@ -29,21 +26,21 @@ HRESULT STDMETHODCALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer,
 }
 */
 
-LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
+LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
 {
     if (original_EEHeapAllocInProcessHeap == nullptr)
         __debugbreak();
     return original_EEHeapAllocInProcessHeap(dwFlags, dwBytes);
 }
 
-BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem)
+BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem)
 {
     if (original_EEHeapFreeInProcessHeap == nullptr)
         __debugbreak();
     return original_EEHeapFreeInProcessHeap(dwFlags, lpMem);
 }
 
-void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName)
+void* GetCLRFunction(LPCSTR functionName)
 {
     if (strcmp(functionName, "EEHeapAllocInProcessHeap") == 0)
     {

--- a/src/ToolBox/superpmi/superpmi-shim-collector/coreclrcallbacks.h
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/coreclrcallbacks.h
@@ -9,7 +9,7 @@
 #include "runtimedetails.h"
 
 IExecutionEngine* STDMETHODCALLTYPE IEE_t();
-HRESULT STDMETHODCALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
+HRESULT STDAPICALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
 LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
 BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
 void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName);

--- a/src/ToolBox/superpmi/superpmi-shim-collector/coreclrcallbacks.h
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/coreclrcallbacks.h
@@ -6,13 +6,7 @@
 #ifndef _CoreClrCallbacks
 #define _CoreClrCallbacks
 
-#include "runtimedetails.h"
-
-IExecutionEngine* STDMETHODCALLTYPE IEE_t();
-HRESULT STDAPICALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
-LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
-BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
-void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName);
+#include "coreclrcommoncallbacks.h"
 
 extern CoreClrCallbacks* original_CoreClrCallbacks;
 

--- a/src/ToolBox/superpmi/superpmi-shim-counter/coreclrcallbacks.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/coreclrcallbacks.cpp
@@ -7,14 +7,11 @@
 #include "coreclrcallbacks.h"
 #include "iexecutionengine.h"
 
-typedef LPVOID(__stdcall* pfnEEHeapAllocInProcessHeap)(DWORD dwFlags, SIZE_T dwBytes);
-typedef BOOL(__stdcall* pfnEEHeapFreeInProcessHeap)(DWORD dwFlags, LPVOID lpMem);
-
 CoreClrCallbacks*           original_CoreClrCallbacks         = nullptr;
 pfnEEHeapAllocInProcessHeap original_EEHeapAllocInProcessHeap = nullptr;
 pfnEEHeapFreeInProcessHeap  original_EEHeapFreeInProcessHeap  = nullptr;
 
-IExecutionEngine* STDMETHODCALLTYPE IEE_t()
+IExecutionEngine* IEE_t()
 {
     interceptor_IEE* iee = new interceptor_IEE();
     iee->original_IEE    = original_CoreClrCallbacks->m_pfnIEE();
@@ -29,21 +26,21 @@ HRESULT STDMETHODCALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer,
 }
 */
 
-LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
+LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
 {
     if (original_EEHeapAllocInProcessHeap == nullptr)
         __debugbreak();
     return original_EEHeapAllocInProcessHeap(dwFlags, dwBytes);
 }
 
-BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem)
+BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem)
 {
     if (original_EEHeapFreeInProcessHeap == nullptr)
         __debugbreak();
     return original_EEHeapFreeInProcessHeap(dwFlags, lpMem);
 }
 
-void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName)
+void* GetCLRFunction(LPCSTR functionName)
 {
     if (strcmp(functionName, "EEHeapAllocInProcessHeap") == 0)
     {

--- a/src/ToolBox/superpmi/superpmi-shim-counter/coreclrcallbacks.h
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/coreclrcallbacks.h
@@ -9,7 +9,7 @@
 #include "runtimedetails.h"
 
 IExecutionEngine* STDMETHODCALLTYPE IEE_t();
-HRESULT STDMETHODCALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
+HRESULT STDAPICALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
 LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
 BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
 void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName);

--- a/src/ToolBox/superpmi/superpmi-shim-counter/coreclrcallbacks.h
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/coreclrcallbacks.h
@@ -6,13 +6,7 @@
 #ifndef _CoreClrCallbacks
 #define _CoreClrCallbacks
 
-#include "runtimedetails.h"
-
-IExecutionEngine* STDMETHODCALLTYPE IEE_t();
-HRESULT STDAPICALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
-LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
-BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
-void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName);
+#include "coreclrcommoncallbacks.h"
 
 extern CoreClrCallbacks* original_CoreClrCallbacks;
 

--- a/src/ToolBox/superpmi/superpmi-shim-simple/coreclrcallbacks.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/coreclrcallbacks.cpp
@@ -7,14 +7,11 @@
 #include "coreclrcallbacks.h"
 #include "iexecutionengine.h"
 
-typedef LPVOID(__stdcall* pfnEEHeapAllocInProcessHeap)(DWORD dwFlags, SIZE_T dwBytes);
-typedef BOOL(__stdcall* pfnEEHeapFreeInProcessHeap)(DWORD dwFlags, LPVOID lpMem);
-
 CoreClrCallbacks*           original_CoreClrCallbacks         = nullptr;
 pfnEEHeapAllocInProcessHeap original_EEHeapAllocInProcessHeap = nullptr;
 pfnEEHeapFreeInProcessHeap  original_EEHeapFreeInProcessHeap  = nullptr;
 
-IExecutionEngine* STDMETHODCALLTYPE IEE_t()
+IExecutionEngine* IEE_t()
 {
     interceptor_IEE* iee = new interceptor_IEE();
     iee->original_IEE    = original_CoreClrCallbacks->m_pfnIEE();
@@ -29,17 +26,17 @@ HRESULT STDMETHODCALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer,
 }
 */
 
-LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
+LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
 {
     return original_EEHeapAllocInProcessHeap(dwFlags, dwBytes);
 }
 
-BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem)
+BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem)
 {
     return original_EEHeapFreeInProcessHeap(dwFlags, lpMem);
 }
 
-void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName)
+void* GetCLRFunction(LPCSTR functionName)
 {
     if (strcmp(functionName, "EEHeapAllocInProcessHeap") == 0)
     {

--- a/src/ToolBox/superpmi/superpmi-shim-simple/coreclrcallbacks.h
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/coreclrcallbacks.h
@@ -9,7 +9,7 @@
 #include "runtimedetails.h"
 
 IExecutionEngine* STDMETHODCALLTYPE IEE_t();
-HRESULT STDMETHODCALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
+HRESULT STDAPICALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
 LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
 BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
 void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName);

--- a/src/ToolBox/superpmi/superpmi-shim-simple/coreclrcallbacks.h
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/coreclrcallbacks.h
@@ -6,13 +6,7 @@
 #ifndef _CoreClrCallbacks
 #define _CoreClrCallbacks
 
-#include "runtimedetails.h"
-
-IExecutionEngine* STDMETHODCALLTYPE IEE_t();
-HRESULT STDAPICALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
-LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
-BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
-void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName);
+#include "coreclrcommoncallbacks.h"
 
 // Added to allow us to persist a copy of the original callbacks
 extern CoreClrCallbacks* original_CoreClrCallbacks;

--- a/src/ToolBox/superpmi/superpmi/coreclrcallbacks.cpp
+++ b/src/ToolBox/superpmi/superpmi/coreclrcallbacks.cpp
@@ -8,7 +8,7 @@
 #include "coreclrcallbacks.h"
 #include "iexecutionengine.h"
 
-IExecutionEngine* STDMETHODCALLTYPE IEE_t()
+IExecutionEngine* IEE_t()
 {
     MyIEE* iee = InitIExecutionEngine();
     return iee;
@@ -24,7 +24,7 @@ HRESULT STDMETHODCALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer,
 
 HANDLE ourHeap = nullptr;
 
-LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
+LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
 {
     if (ourHeap == nullptr)
         ourHeap = HeapCreate(0, 4096, 0);
@@ -39,13 +39,13 @@ LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
     return result;
 }
 
-BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem)
+BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem)
 {
     //  return true;
     return HeapFree(ourHeap, dwFlags, lpMem);
 }
 
-void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName)
+void* GetCLRFunction(LPCSTR functionName)
 {
     if (strcmp(functionName, "EEHeapAllocInProcessHeap") == 0)
         return (void*)EEHeapAllocInProcessHeap;

--- a/src/ToolBox/superpmi/superpmi/coreclrcallbacks.h
+++ b/src/ToolBox/superpmi/superpmi/coreclrcallbacks.h
@@ -9,7 +9,7 @@
 #include "runtimedetails.h"
 
 IExecutionEngine* STDMETHODCALLTYPE IEE_t();
-HRESULT STDMETHODCALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
+HRESULT STDAPICALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
 LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
 BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
 void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName);

--- a/src/ToolBox/superpmi/superpmi/coreclrcallbacks.h
+++ b/src/ToolBox/superpmi/superpmi/coreclrcallbacks.h
@@ -6,13 +6,8 @@
 #ifndef _CoreClrCallbacks
 #define _CoreClrCallbacks
 
-#include "runtimedetails.h"
+#include "coreclrcommoncallbacks.h"
 
-IExecutionEngine* STDMETHODCALLTYPE IEE_t();
-HRESULT STDAPICALLTYPE GetCORSystemDirectory(LPWSTR pbuffer, DWORD cchBuffer, DWORD* pdwlength);
-LPVOID STDMETHODCALLTYPE EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
-BOOL STDMETHODCALLTYPE EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
-void* STDMETHODCALLTYPE GetCLRFunction(LPCSTR functionName);
 CoreClrCallbacks* InitCoreClrCallbacks();
 
 #endif

--- a/src/dlls/mscoree/mscoree.cpp
+++ b/src/dlls/mscoree/mscoree.cpp
@@ -48,7 +48,7 @@ HINSTANCE g_hThisInst;  // This library.
 
 #include <process.h> // for __security_init_cookie()
 
-extern "C" IExecutionEngine* __stdcall IEE();
+extern "C" IExecutionEngine* IEE();
 
 #ifdef NO_CRT_INIT
 #define _CRT_INIT(hInstance, dwReason, lpReserved) (TRUE)

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -5110,7 +5110,7 @@ BOOL IsIPInModule(HMODULE_TGT hModule, PCODE ip);
 struct CoreClrCallbacks
 {
     typedef IExecutionEngine* (__stdcall * pfnIEE_t)();
-    typedef HRESULT (__stdcall * pfnGetCORSystemDirectory_t)(SString& pbuffer);
+    typedef HRESULT (STDAPICALLTYPE * pfnGetCORSystemDirectory_t)(SString& pbuffer);
     typedef void* (__stdcall * pfnGetCLRFunction_t)(LPCSTR functionName);
 
     HINSTANCE                   m_hmodCoreCLR;

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -5109,9 +5109,9 @@ BOOL IsIPInModule(HMODULE_TGT hModule, PCODE ip);
 //----------------------------------------------------------------------------------------
 struct CoreClrCallbacks
 {
-    typedef IExecutionEngine* (__stdcall * pfnIEE_t)();
-    typedef HRESULT (STDAPICALLTYPE * pfnGetCORSystemDirectory_t)(SString& pbuffer);
-    typedef void* (__stdcall * pfnGetCLRFunction_t)(LPCSTR functionName);
+    typedef IExecutionEngine* (* pfnIEE_t)();
+    typedef HRESULT (* pfnGetCORSystemDirectory_t)(SString& pbuffer);
+    typedef void* (* pfnGetCLRFunction_t)(LPCSTR functionName);
 
     HINSTANCE                   m_hmodCoreCLR;
     pfnIEE_t                    m_pfnIEE;
@@ -5516,6 +5516,6 @@ extern SpinConstants g_SpinConstants;
 
 // ======================================================================================
 
-void* __stdcall GetCLRFunction(LPCSTR FunctionName);
+void* GetCLRFunction(LPCSTR FunctionName);
 
 #endif // __UtilCode_h__

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -252,7 +252,7 @@ inline void *__cdecl operator new(size_t, void *_P)
 #define STDMETHODCALLTYPE    __stdcall
 #define STDMETHODVCALLTYPE   __cdecl
 
-#define STDAPICALLTYPE       __stdcall
+#define STDAPICALLTYPE       __cdecl
 #define STDAPIVCALLTYPE      __cdecl
 
 #define STDMETHODIMP         HRESULT STDMETHODCALLTYPE

--- a/src/strongname/api/strongnamecoreclr.cpp
+++ b/src/strongname/api/strongnamecoreclr.cpp
@@ -39,15 +39,15 @@ FunctionPointer ApiShim(LPCSTR szApiName)
 // Shim APIs, passing off into the desktop VM
 //
 
-IExecutionEngine * __stdcall SnIEE()
+IExecutionEngine* SnIEE()
 {
-    typedef IExecutionEngine * ( __stdcall *IEEFn_t)();
+    typedef IExecutionEngine* (* IEEFn_t)();
     return ApiShim<IEEFn_t>("IEE")();
 }
 
-STDAPI SnGetCorSystemDirectory(SString&  pbuffer)
+HRESULT SnGetCorSystemDirectory(SString&  pbuffer)
 {
-    typedef HRESULT (__stdcall *GetCorSystemDirectoryFn_t)(SString&);
+    typedef HRESULT (*GetCorSystemDirectoryFn_t)(SString&);
     return ApiShim<GetCorSystemDirectoryFn_t>("GetCORSystemDirectory")(pbuffer);
 }
 

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -2386,7 +2386,7 @@ BOOL CanRunManagedCode(LoaderLockCheck::kind checkKind, HINSTANCE hInst /*= 0*/)
 //  no longer maintains a ref count since the EE doesn't support being
 //  unloaded and re-loaded. It simply ensures the EE has been started.
 // ---------------------------------------------------------------------------
-HRESULT STDMETHODCALLTYPE CoInitializeEE(DWORD fFlags)
+HRESULT STDAPICALLTYPE CoInitializeEE(DWORD fFlags)
 {
     CONTRACTL
     {
@@ -2417,7 +2417,7 @@ HRESULT STDMETHODCALLTYPE CoInitializeEE(DWORD fFlags)
 // Description:
 //  Must be called by client on shut down in order to free up the system.
 // ---------------------------------------------------------------------------
-void STDMETHODCALLTYPE CoUninitializeEE(BOOL fIsDllUnloading)
+void STDAPICALLTYPE CoUninitializeEE(BOOL fIsDllUnloading)
 {
     LIMITED_METHOD_CONTRACT;
     //BEGIN_ENTRYPOINT_VOIDRET;

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -75,7 +75,7 @@ SVAL_IMPL_INIT(ECustomDumpFlavor, CCLRErrorReportingManager, g_ECustomDumpFlavor
 #ifndef DACCESS_COMPILE
 
 extern void STDMETHODCALLTYPE EEShutDown(BOOL fIsDllUnloading);
-extern HRESULT STDMETHODCALLTYPE CoInitializeEE(DWORD fFlags);
+extern HRESULT STDAPICALLTYPE CoInitializeEE(DWORD fFlags);
 extern void PrintToStdOutA(const char *pszString);
 extern void PrintToStdOutW(const WCHAR *pwzString);
 extern BOOL g_fEEHostedStartup;

--- a/src/vm/hosting.cpp
+++ b/src/vm/hosting.cpp
@@ -444,6 +444,11 @@ LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes)
     WRAPPER_NO_CONTRACT;
     STATIC_CONTRACT_SO_TOLERANT;
 
+#ifdef _DEBUG
+    // Check whether (indispensable) implicit casting in ClrAllocInProcessHeapBootstrap is safe.
+    static FastAllocInProcessHeapFunc pFunc = EEHeapAllocInProcessHeap;
+#endif
+
     static HANDLE ProcessHeap = NULL;
 
     // We need to guarentee a very small stack consumption in allocating.  And we can't allow
@@ -505,6 +510,11 @@ BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem)
         MODE_ANY;
     }
     CONTRACTL_END;
+
+#ifdef _DEBUG
+    // Check whether (indispensable) implicit casting in ClrFreeInProcessHeapBootstrap is safe.
+    static FastFreeInProcessHeapFunc pFunc = EEHeapFreeInProcessHeap;
+#endif
 
     // Take a look at comment in EEHeapFree and EEHeapAllocInProcessHeap, obviously someone
     // needs to take a little time to think more about this code.

--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -2525,12 +2525,12 @@ HMODULE CLRGetCurrentModuleHandle()
 
 #endif // !FEATURE_PAL
 
-extern LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
-extern BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
-extern void ShutdownRuntimeWithoutExiting(int exitCode);
-extern BOOL IsRuntimeStarted(DWORD *pdwStartupFlags);
+LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
+BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
+void ShutdownRuntimeWithoutExiting(int exitCode);
+BOOL IsRuntimeStarted(DWORD *pdwStartupFlags);
 
-void * __stdcall GetCLRFunction(LPCSTR FunctionName)
+void *GetCLRFunction(LPCSTR FunctionName)
 {
 
     void* func = NULL;


### PR DESCRIPTION
This commit sets STDAPICALLTYPE as CDECL in order to fix Interop.MarshalAPI.String.StringMarshalingTest failure due to calling convention mismatch (in Checked build).