### PR TITLE
[Ryujit/ARM32] LSRA support for arm32 floating-point register allocation

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -695,7 +695,7 @@ private:
     void processBlockEndLocations(BasicBlock* current);
 
 #ifdef _TARGET_ARM_
-    bool isOverlappedRegRecord(Interval* assignedInterval, RegRecord* physRegRecord);
+    bool isSecondHalfReg(RegRecord* regRec, Interval* interval);
 #endif
 
     RefType CheckBlockType(BasicBlock* block, BasicBlock* prevBlock);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -694,6 +694,10 @@ private:
     void processBlockStartLocations(BasicBlock* current, bool allocationPass);
     void processBlockEndLocations(BasicBlock* current);
 
+#ifdef _TARGET_ARM_
+    bool isOverlappedRegRecord(Interval* assignedInterval, RegRecord* physRegRecord);
+#endif
+
     RefType CheckBlockType(BasicBlock* block, BasicBlock* prevBlock);
 
     // insert refpositions representing prolog zero-inits which will be added later

--- a/src/jit/lsraarm.cpp
+++ b/src/jit/lsraarm.cpp
@@ -227,8 +227,6 @@ void Lowering::TreeNodeInfoInit(GenTree* tree)
     JITDUMP("TreeNodeInfoInit for: ");
     DISPNODE(tree);
 
-    NYI_IF(tree->TypeGet() == TYP_DOUBLE, "lowering double");
-
     switch (tree->OperGet())
     {
         GenTree* op1;

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1950,7 +1950,7 @@ inline bool genIsValidFloatReg(regNumber reg)
     return reg >= REG_FP_FIRST && reg <= REG_FP_LAST;
 }
 
-#if defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
+#ifdef _TARGET_ARM_
 
 /*****************************************************************************
  * Return true if the register is a valid floating point double register
@@ -1960,7 +1960,7 @@ inline bool genIsValidDoubleReg(regNumber reg)
     return genIsValidFloatReg(reg) && (((reg - REG_FP_FIRST) & 0x1) == 0);
 }
 
-#endif // defined(LEGACY_BACKEND) && defined(_TARGET_ARM_)
+#endif // _TARGET_ARM_
 
 //-------------------------------------------------------------------------------------------
 // hasFixedRetBuffReg:


### PR DESCRIPTION
Fix  #9214

Initial implementation of LSRA support for ARM32 floating point register allocation.
This fixes all LSRA failure of TYP_DOUBLE in `JIT/CodeGenBringUpTests/` and addresses more than 16000 NYI assertion related to TYP_DOUBLE in CoreCLR unit tests observed at https://github.com/dotnet/coreclr/issues/8496#issuecomment-294250881.
```
16155, c:\gh\coreclr\src\jit\lsraarm.cpp:230 - NYI: lowering double
```

For TYP_DOUBLE, we should handle overlapping FP registers.   
* Enable lowering and register allocation for TYP_DOUBLE
* Update `previousInterval` together in `tryAllocateFreeReg()` and `unassignPhysReg()`
* Consider TYP_DOUBLE for free registers in `freeRegister()` and `allocateRegisters()`
* Consider TYP_DOUBLE when updating reigsters in `resolveLocalRef()` and  `processBlockStartLocations()`

(This is a part of #8496)

## Example

```
FAILED   - [  14][   8s]JIT/CodeGenBringUpTests/DblAdd/DblAdd.sh
               BEGIN EXECUTION
               /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170414.lsra_fp/corerun DblAdd.exe

               Assert failure(PID 8766 [0x0000223e], Thread: 8766 [0x223e]): Assertion failed 'assignedInterval != nullptr' in 'BringUpTest:Main():int' (IL size 62)

                   File: /opt/code/github/hqueue/coreclr/src/jit/lsra.cpp Line: 6221
                   Image: /mnt/albireo/mywork/device/rpi3/unittests/coreoverlays/coreoverlay.test20170414.lsra_fp/corerun

               ./DblAdd.sh: line 132:  8766 Aborted                 (core dumped) $_DebuggerFullPath "$CORE_ROOT/corerun" DblAdd.exe $CLRTestExecutionArguments
               Expected: 100
               Actual: 134
               END EXECUTION - FAILED
```

# Test
When running with   `COMPlus_AltJit=*   COMPlus_AltJitAssertOnNYI=0` for  `JIT/CodeGenBringUpTests/`

## Before
```
=======================
     Test Results
=======================
# CoreCLR Bin Dir  : 
# Tests Discovered : 139
# Passed           : 104
# Failed           : 35
# Skipped          : 0
=======================
```
Among 35 failures, 34 failurs are due to above LSRA assertion failure.

## After

```
=======================
     Test Results
=======================
# CoreCLR Bin Dir  : 
# Tests Discovered : 139
# Passed           : 138
# Failed           : 1
# Skipped          : 0
=======================
```
All 34 failures due to LSRA assertions are gone.