### PR TITLE
Revert "[x86/Linux] Use appropriate FCALL macro for DoToDecimal" - WIP TESTING DO NOT MERGE

### DIFF
--- a/src/classlibnative/bcltype/currency.cpp
+++ b/src/classlibnative/bcltype/currency.cpp
@@ -16,7 +16,7 @@
 #include "string.h"
 
 
-FCIMPL2_IV(void, COMCurrency::DoToDecimal, DECIMAL * result, CY c)
+FCIMPL2(void, COMCurrency::DoToDecimal, DECIMAL * result, CY c)
 {
     FCALL_CONTRACT;
 

--- a/src/classlibnative/bcltype/currency.h
+++ b/src/classlibnative/bcltype/currency.h
@@ -16,7 +16,7 @@
 class COMCurrency 
 {
 public:
-    static FCDECL2_IV(void, DoToDecimal,  DECIMAL * result, CY c);
+    static FCDECL2   (void, DoToDecimal,  DECIMAL * result, CY c);
 };
 
 #include <poppack.h>


### PR DESCRIPTION
Reverts dotnet/coreclr#10963