### PR TITLE
Enable running Crossgen tests on Windows in Helix

### DIFF
--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -68,7 +68,7 @@
       },
       "inputs": {
         "filename": "build-test.cmd",
-        "arguments": "$(PB_BuildType) $(Architecture) buildagainstpackages runtimeid $(Rid) $(TargetsNonWindowsArg) -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority)",
+        "arguments": "$(PB_BuildType) $(Architecture) buildagainstpackages runtimeid $(Rid) $(TargetsNonWindowsArg) $(CrossgenArg) -OfficialBuildId=$(OfficialBuildId) -Priority=$(Priority)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -86,7 +86,7 @@
       },
       "inputs": {
         "filename": "msbuild",
-        "arguments": "helixpublish.proj /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:CloudDropAccountName=$(CloudDropAccountName) /p:ContainerName=$(PB_ContainerName) /p:Platform=$(Architecture) /p:BuildType=$(PB_BuildType) /p:CloudResultsAccountName=$(CloudResultsAccountName) /p:CloudResultsAccessToken=$(CloudResultsAccessToken) /p:TargetsWindows=$(TargetsWindows) /p:OverwriteOnUpload=true /p:Rid=$(Rid) /p:TargetQueues=\"$(TargetQueues)\" /p:TestProduct=$(TestProduct) /p:Branch=$(HelixBranch) /p:HelixApiAccessKey=$(HelixApiAccessKey) /p:HelixApiEndpoint=$(HelixApiEndpoint) /p:FilterToOSGroup=$(FilterToOSGroup) /p:FilterToTestTFM=$(FilterToTestTFM) /p:TimeoutInSeconds=3600 /fileloggerparameters:Verbosity=diag;LogFile=helix.log",
+        "arguments": "helixpublish.proj /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:CloudDropAccountName=$(CloudDropAccountName) /p:ContainerName=$(PB_ContainerName) /p:Platform=$(Architecture) /p:BuildType=$(PB_BuildType) /p:CloudResultsAccountName=$(CloudResultsAccountName) /p:CloudResultsAccessToken=$(CloudResultsAccessToken) /p:TargetsWindows=$(TargetsWindows) /p:OverwriteOnUpload=true /p:Rid=$(Rid) /p:TargetQueues=\"$(TargetQueues)\" /p:TestProduct=$(TestProduct) /p:Branch=$(HelixBranch) /p:HelixApiAccessKey=$(HelixApiAccessKey) /p:HelixApiEndpoint=$(HelixApiEndpoint) /p:FilterToOSGroup=$(FilterToOSGroup) /p:FilterToTestTFM=$(FilterToTestTFM) /p:TimeoutInSeconds=1800 /p:HelixJobType=$(HelixJobType) /fileloggerparameters:Verbosity=diag;LogFile=helix.log",
         "workingFolder": "tests",
         "failOnStandardError": "false"
       }

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -480,6 +480,7 @@
         {
           "Name": "Dotnet-CoreClr-Trusted-BuildTests",
           "Parameters": {
+            "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "true",
             "Rid": "win-x64",
             "TargetQueues": "windows.10.amd64",
@@ -496,6 +497,25 @@
         {
           "Name": "Dotnet-CoreClr-Trusted-BuildTests",
           "Parameters": {
+            "HelixJobType": "test/functional/r2r/cli/",
+            "TargetsWindows": "true",
+            "Rid": "win-x64",
+            "TargetQueues": "windows.10.amd64",
+            "TestContainerSuffix": "windows-r2r",
+            "TargetsNonWindowsArg": " ",
+            "CrossgenArg": "Crossgen"
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "SubType":  "Build-Tests-R2R",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
+            "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "osx-x64",
             "TargetQueues": "osx.1012.amd64",
@@ -512,6 +532,7 @@
         {
           "Name": "Dotnet-CoreClr-Trusted-BuildTests",
           "Parameters": {
+            "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
             "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1610.amd64",

--- a/config.json
+++ b/config.json
@@ -330,6 +330,12 @@
       "values": [ true, false ],
       "defaultValue": true
     },
+    "Crossgen": {
+      "description": "Determines if we're running Crossgen tests",
+      "valueType": "property",
+      "values": [ true, false ],
+      "defaultValue": true
+    },
     "RuntimeId": {
       "description": "Specifies the OS to build Core_Root for",
       "valueType": "property",

--- a/tests/helixprep.proj
+++ b/tests/helixprep.proj
@@ -74,6 +74,7 @@
     Condition="'$(TargetsWindows)' == 'true' ">
 
     <PropertyGroup>
+      <CrossgenVar Condition="'$(Crossgen)' == 'true'">set RunCrossGen=true</CrossgenVar>
       <WrapperCmdContents>
         <![CDATA[
 @ECHO OFF
@@ -81,6 +82,7 @@ setlocal ENABLEDELAYEDEXPANSION
 pushd %~dp0
 
 set CORE_ROOT=%HELIX_CORRELATION_PAYLOAD%
+$(CrossgenVar)
 
 ECHO BEGIN EXECUTION
 ECHO %HELIX_CORRELATION_PAYLOAD%\CoreRun.exe %HELIX_WORKITEM_PAYLOAD%\xunit.console.netcore.exe %HELIX_WORKITEM_PAYLOAD%\$(ProjectName) -noshadow -xml testResults.xml -notrait category=outerloop -notrait category=failing


### PR DESCRIPTION
Just windows for now, since I couldn't think of a clean way to Crossgen a non-Windows Core_Root on Windows without either: 

- Also creating a Windows Core_Root, and using binaries from there to crossgen the non-Windows Core_Root, or;
- Doing the crossgen-ing on Non-Windows in Helix, in which case, it would have to happen N times, once for each TestWrapper .dll, since we send those N jobs from a Windows machine.

I could do the first option, but it's a bit of a hack. Otherwise we can wait until @rartemev's change goes in, which will require a refactor of sending tests to Helix, and allow us to do the crossgen-ing on the target platform.

@MattGal it looks like Mission Control segregates test runs by Queue - does that mean that there will be a race between the R2R tests & the IL tests, since they're both going to the same queue? What's the best way to get these tests to show up "separately" from the IL tests?

@gkhanna79 PTAL as well.