### PR TITLE
Revert "Strip out unused reg code. (#10741)"

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -86,9 +86,11 @@
   <PropertyGroup Condition="'$(OsEnvironment)' == 'Unix'">
     <DebugType>portable</DebugType>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetsOSX)' == 'true'">
     <DefineConstants>PLATFORM_OSX;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+
   <!-- Assembly attributes -->
   <PropertyGroup>
     <AssemblyName>System.Private.CoreLib</AssemblyName>
@@ -625,6 +627,7 @@
     <Compile Condition="'$(FeatureWin32Registry)' == 'true'" Include="$(BclSourcesRoot)\Microsoft\Win32\Registry.cs" />
     <Compile Condition="'$(FeatureWin32Registry)' == 'true'" Include="$(BclSourcesRoot)\Microsoft\Win32\RegistryKey.cs" />
     <Compile Condition="'$(FeatureWin32Registry)' == 'true'" Include="$(BclSourcesRoot)\Microsoft\Win32\RegistryValueKind.cs" />
+    <Compile Condition="'$(FeatureWin32Registry)' == 'true'" Include="$(BclSourcesRoot)\Microsoft\Win32\RegistryView.cs" />
     <Compile Condition="'$(FeatureClassicCominterop)' == 'true'" Include="$(BclSourcesRoot)\Microsoft\Win32\OAVariantLib.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/mscorlib/src/Microsoft/Win32/Registry.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Registry.cs
@@ -2,12 +2,142 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
 namespace Microsoft.Win32
 {
+    /**
+     * Registry encapsulation. Contains members representing all top level system
+     * keys.
+     *
+     * @security(checkClassLinking=on)
+     */
+    //This class contains only static members and does not need to be serializable.
     internal static class Registry
     {
-        public static readonly RegistryKey CurrentUser = RegistryKey.CurrentUser;
-        public static readonly RegistryKey LocalMachine = RegistryKey.LocalMachine;
+        /**
+         * Current User Key.
+         * 
+         * This key should be used as the root for all user specific settings.
+         */
+        public static readonly RegistryKey CurrentUser = RegistryKey.GetBaseKey(RegistryKey.HKEY_CURRENT_USER);
+
+        /**
+         * Local Machine Key.
+         * 
+         * This key should be used as the root for all machine specific settings.
+         */
+        public static readonly RegistryKey LocalMachine = RegistryKey.GetBaseKey(RegistryKey.HKEY_LOCAL_MACHINE);
+
+        /**
+         * Classes Root Key.
+         * 
+         * This is the root key of class information.
+         */
+        public static readonly RegistryKey ClassesRoot = RegistryKey.GetBaseKey(RegistryKey.HKEY_CLASSES_ROOT);
+
+        /**
+         * Users Root Key.
+         * 
+         * This is the root of users.
+         */
+        public static readonly RegistryKey Users = RegistryKey.GetBaseKey(RegistryKey.HKEY_USERS);
+
+        /**
+         * Performance Root Key.
+         * 
+         * This is where dynamic performance data is stored on NT.
+         */
+        public static readonly RegistryKey PerformanceData = RegistryKey.GetBaseKey(RegistryKey.HKEY_PERFORMANCE_DATA);
+
+        /**
+         * Current Config Root Key.
+         * 
+         * This is where current configuration information is stored.
+         */
+        public static readonly RegistryKey CurrentConfig = RegistryKey.GetBaseKey(RegistryKey.HKEY_CURRENT_CONFIG);
+
+        //
+        // Following function will parse a keyName and returns the basekey for it.
+        // It will also store the subkey name in the out parameter.
+        // If the keyName is not valid, we will throw ArgumentException.
+        // The return value shouldn't be null. 
+        //
+        private static RegistryKey GetBaseKeyFromKeyName(string keyName, out string subKeyName)
+        {
+            if (keyName == null)
+            {
+                throw new ArgumentNullException(nameof(keyName));
+            }
+
+            string basekeyName;
+            int i = keyName.IndexOf('\\');
+            if (i != -1)
+            {
+                basekeyName = keyName.Substring(0, i).ToUpper(System.Globalization.CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                basekeyName = keyName.ToUpper(System.Globalization.CultureInfo.InvariantCulture);
+            }
+            RegistryKey basekey = null;
+
+            switch (basekeyName)
+            {
+                case "HKEY_CURRENT_USER":
+                    basekey = Registry.CurrentUser;
+                    break;
+                case "HKEY_LOCAL_MACHINE":
+                    basekey = Registry.LocalMachine;
+                    break;
+                case "HKEY_CLASSES_ROOT":
+                    basekey = Registry.ClassesRoot;
+                    break;
+                case "HKEY_USERS":
+                    basekey = Registry.Users;
+                    break;
+                case "HKEY_PERFORMANCE_DATA":
+                    basekey = Registry.PerformanceData;
+                    break;
+                case "HKEY_CURRENT_CONFIG":
+                    basekey = Registry.CurrentConfig;
+                    break;
+                default:
+                    throw new ArgumentException(SR.Format(SR.Arg_RegInvalidKeyName, nameof(keyName)));
+            }
+            if (i == -1 || i == keyName.Length)
+            {
+                subKeyName = string.Empty;
+            }
+            else
+            {
+                subKeyName = keyName.Substring(i + 1, keyName.Length - i - 1);
+            }
+            return basekey;
+        }
+
+        public static object GetValue(string keyName, string valueName, object defaultValue)
+        {
+            string subKeyName;
+            RegistryKey basekey = GetBaseKeyFromKeyName(keyName, out subKeyName);
+            BCLDebug.Assert(basekey != null, "basekey can't be null.");
+            RegistryKey key = basekey.OpenSubKey(subKeyName);
+            if (key == null)
+            { // if the key doesn't exist, do nothing
+                return null;
+            }
+            try
+            {
+                return key.GetValue(valueName, defaultValue);
+            }
+            finally
+            {
+                key.Close();
+            }
+        }
     }
 }
 

--- a/src/mscorlib/src/Microsoft/Win32/RegistryValueKind.cs
+++ b/src/mscorlib/src/Microsoft/Win32/RegistryValueKind.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+
 namespace Microsoft.Win32
 {
     internal enum RegistryValueKind
@@ -12,11 +13,8 @@ namespace Microsoft.Win32
         DWord = Win32Native.REG_DWORD,
         MultiString = Win32Native.REG_MULTI_SZ,
         QWord = Win32Native.REG_QWORD,
-        Unknown = 0,
-
-        // REG_NONE is defined as zero but BCL, mistakingly overrode this value.
-        // Now instead of using Win32Native.REG_NONE we use "-1" and play games internally.
-        None = unchecked((int)0xFFFFFFFF),
-    }
+        Unknown = 0,                          // REG_NONE is defined as zero but BCL
+        None = unchecked((int)0xFFFFFFFF), //  mistakingly overrode this value.  
+    }   // Now instead of using Win32Native.REG_NONE we use "-1" and play games internally.
 }
 

--- a/src/mscorlib/src/Microsoft/Win32/RegistryView.cs
+++ b/src/mscorlib/src/Microsoft/Win32/RegistryView.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+//
+//
+// Implements Microsoft.Win32.RegistryView
+//
+// ======================================================================================
+
+using System;
+
+namespace Microsoft.Win32
+{
+    internal enum RegistryView
+    {
+        Default = 0,                           // 0x0000 operate on the default registry view
+        Registry64 = Win32Native.KEY_WOW64_64KEY, // 0x0100 operate on the 64-bit registry view
+        Registry32 = Win32Native.KEY_WOW64_32KEY, // 0x0200 operate on the 32-bit registry view
+    };
+}

--- a/src/mscorlib/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.cs
+++ b/src/mscorlib/src/Microsoft/Win32/SafeHandles/SafeRegistryHandle.cs
@@ -2,9 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+//
+//
+//
+// Implements Microsoft.Win32.SafeHandles.SafeRegistryHandle
+//
+// ======================================================================================
+
 using System;
 using System.Security;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.Versioning;
 
 namespace Microsoft.Win32.SafeHandles
 {

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -820,7 +820,7 @@ namespace System
                     }
                     else
                     {
-                        environmentKey.SetStringValue(variable, value);
+                        environmentKey.SetValue(variable, value);
                     }
                 }
             }

--- a/src/mscorlib/src/System/Globalization/JapaneseCalendar.Win32.cs
+++ b/src/mscorlib/src/System/Globalization/JapaneseCalendar.Win32.cs
@@ -36,30 +36,30 @@ namespace System.Globalization
 
             try
             {
-                using (RegistryKey key = Registry.LocalMachine.OpenSubKey(c_japaneseErasHive, writable: false))
+                // Need to access registry
+                RegistryKey key = RegistryKey.GetBaseKey(RegistryKey.HKEY_LOCAL_MACHINE).OpenSubKey(c_japaneseErasHive, false);
+
+                // Abort if we didn't find anything
+                if (key == null) return null;
+
+                // Look up the values in our reg key
+                String[] valueNames = key.GetValueNames();
+                if (valueNames != null && valueNames.Length > 0)
                 {
-                    // Abort if we didn't find anything
-                    if (key == null) return null;
+                    registryEraRanges = new EraInfo[valueNames.Length];
 
-                    // Look up the values in our reg key
-                    String[] valueNames = key.GetValueNames();
-                    if (valueNames != null && valueNames.Length > 0)
+                    // Loop through the registry and read in all the values
+                    for (int i = 0; i < valueNames.Length; i++)
                     {
-                        registryEraRanges = new EraInfo[valueNames.Length];
+                        // See if the era is a valid date
+                        EraInfo era = GetEraFromValue(valueNames[i], key.GetValue(valueNames[i]).ToString());
 
-                        // Loop through the registry and read in all the values
-                        for (int i = 0; i < valueNames.Length; i++)
-                        {
-                            // See if the era is a valid date
-                            EraInfo era = GetEraFromValue(valueNames[i], key.GetValue(valueNames[i]).ToString());
+                        // continue if not valid
+                        if (era == null) continue;
 
-                            // continue if not valid
-                            if (era == null) continue;
-
-                            // Remember we found one.
-                            registryEraRanges[iFoundEras] = era;
-                            iFoundEras++;
-                        }
+                        // Remember we found one.
+                        registryEraRanges[iFoundEras] = era;
+                        iFoundEras++;
                     }
                 }
             }

--- a/src/mscorlib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.Win32.cs
@@ -576,8 +576,8 @@ namespace System
                     // read LastEntry   {(yearN, 1, 1) - MaxValue       }
 
                     // read the FirstEntry and LastEntry key values (ex: "1980", "2038")
-                    int first = (int)dynamicKey.GetValue(FirstEntryValue, -1);
-                    int last = (int)dynamicKey.GetValue(LastEntryValue, -1);
+                    int first = (int)dynamicKey.GetValue(FirstEntryValue, -1, RegistryValueOptions.None);
+                    int last = (int)dynamicKey.GetValue(LastEntryValue, -1, RegistryValueOptions.None);
 
                     if (first == -1 || last == -1 || first > last)
                     {
@@ -587,7 +587,7 @@ namespace System
 
                     // read the first year entry
                     Win32Native.RegistryTimeZoneInformation dtzi;
-                    byte[] regValue = dynamicKey.GetValue(first.ToString(CultureInfo.InvariantCulture)) as byte[];
+                    byte[] regValue = dynamicKey.GetValue(first.ToString(CultureInfo.InvariantCulture), null, RegistryValueOptions.None) as byte[];
                     if (regValue == null || regValue.Length != RegByteLength)
                     {
                         rules = null;
@@ -620,7 +620,7 @@ namespace System
                     // read the middle year entries
                     for (int i = first + 1; i < last; i++)
                     {
-                        regValue = dynamicKey.GetValue(i.ToString(CultureInfo.InvariantCulture)) as byte[];
+                        regValue = dynamicKey.GetValue(i.ToString(CultureInfo.InvariantCulture), null, RegistryValueOptions.None) as byte[];
                         if (regValue == null || regValue.Length != RegByteLength)
                         {
                             rules = null;
@@ -640,7 +640,7 @@ namespace System
                     }
 
                     // read the last year entry
-                    regValue = dynamicKey.GetValue(last.ToString(CultureInfo.InvariantCulture)) as byte[];
+                    regValue = dynamicKey.GetValue(last.ToString(CultureInfo.InvariantCulture), null, RegistryValueOptions.None) as byte[];
                     dtzi = new Win32Native.RegistryTimeZoneInformation(regValue);
                     if (regValue == null || regValue.Length != RegByteLength)
                     {
@@ -719,7 +719,7 @@ namespace System
                 }
 
                 Win32Native.RegistryTimeZoneInformation registryTimeZoneInfo;
-                byte[] regValue = key.GetValue(TimeZoneInfoValue) as byte[];
+                byte[] regValue = key.GetValue(TimeZoneInfoValue, null, RegistryValueOptions.None) as byte[];
                 if (regValue == null || regValue.Length != RegByteLength) return false;
                 registryTimeZoneInfo = new Win32Native.RegistryTimeZoneInformation(regValue);
 
@@ -756,7 +756,7 @@ namespace System
                 //
                 if (result)
                 {
-                    string registryStandardName = key.GetValue(StandardValue, string.Empty) as string;
+                    string registryStandardName = key.GetValue(StandardValue, string.Empty, RegistryValueOptions.None) as string;
                     result = string.Equals(registryStandardName, timeZone.StandardName, StringComparison.Ordinal);
                 }
                 return result;
@@ -884,9 +884,9 @@ namespace System
             daylightName = string.Empty;
 
             // read the MUI_ registry keys
-            string displayNameMuiResource = key.GetValue(MuiDisplayValue, string.Empty) as string;
-            string standardNameMuiResource = key.GetValue(MuiStandardValue, string.Empty) as string;
-            string daylightNameMuiResource = key.GetValue(MuiDaylightValue, string.Empty) as string;
+            string displayNameMuiResource = key.GetValue(MuiDisplayValue, string.Empty, RegistryValueOptions.None) as string;
+            string standardNameMuiResource = key.GetValue(MuiStandardValue, string.Empty, RegistryValueOptions.None) as string;
+            string daylightNameMuiResource = key.GetValue(MuiDaylightValue, string.Empty, RegistryValueOptions.None) as string;
 
             // try to load the strings from the native resource DLL(s)
             if (!string.IsNullOrEmpty(displayNameMuiResource))
@@ -907,15 +907,15 @@ namespace System
             // fallback to using the standard registry keys
             if (string.IsNullOrEmpty(displayName))
             {
-                displayName = key.GetValue(DisplayValue, string.Empty) as string;
+                displayName = key.GetValue(DisplayValue, string.Empty, RegistryValueOptions.None) as string;
             }
             if (string.IsNullOrEmpty(standardName))
             {
-                standardName = key.GetValue(StandardValue, string.Empty) as string;
+                standardName = key.GetValue(StandardValue, string.Empty, RegistryValueOptions.None) as string;
             }
             if (string.IsNullOrEmpty(daylightName))
             {
-                daylightName = key.GetValue(DaylightValue, string.Empty) as string;
+                daylightName = key.GetValue(DaylightValue, string.Empty, RegistryValueOptions.None) as string;
             }
 
             return true;
@@ -964,7 +964,7 @@ namespace System
                 }
 
                 Win32Native.RegistryTimeZoneInformation defaultTimeZoneInformation;
-                byte[] regValue = key.GetValue(TimeZoneInfoValue) as byte[];
+                byte[] regValue = key.GetValue(TimeZoneInfoValue, null, RegistryValueOptions.None) as byte[];
                 if (regValue == null || regValue.Length != RegByteLength)
                 {
                     // the registry value could not be cast to a byte array


### PR DESCRIPTION
This reverts commit ed4f594abf41a71b126152bb8755051d0831e12d (https://github.com/dotnet/coreclr/pull/10741) which @adiaaida has determined via a process of elimination to be the cause of the broken performance runs.

It's not immediately obvious to us why it broke them because we don't know what registry keys it's expecting to read. @adiaaida can provide a repro case to @JeremyKuhne so he can break down his change and figure out the problem. That's probably quicker than debugging all the perf infrastructure.

meantime we want the runs to work.