### PR TITLE
Fix OOM exception thrown in case insensitive replace for an empty string

### DIFF
--- a/src/mscorlib/src/System/String.Manipulation.cs
+++ b/src/mscorlib/src/System/String.Manipulation.cs
@@ -1022,6 +1022,8 @@ namespace System
         {
             if (oldValue == null)
                 throw new ArgumentNullException(nameof(oldValue));
+            if (oldValue.Length == 0)
+                throw new ArgumentException(SR.Argument_StringZeroLength, nameof(oldValue));
 
             // If they asked to replace oldValue with a null, replace all occurences
             // with the empty string.


### PR DESCRIPTION
Found whilst exposing this API (https://github.com/dotnet/corefx/issues/1271)

The following code fails with an OOM, and takes a bunch of time:
```cs
"abc".Replace("", "def", StringComparison.CurrentCulture)
```