### PR TITLE
Fix ARM32/Linux release CI test failure

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1640,6 +1640,11 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     if (os != 'Tizen') {
                         buildCommands += "chmod a+x ./bin/CoreFxBinDir/corerun"
                     }
+                    // Test environment emulation using docker and qemu has some problem to use lttng library.
+                    // We should remove libcoreclrtraceptprovider.so to avoid test hang.
+                    if (os == 'Ubuntu') {
+                        buildCommand += "rm -f -v bin/CoreFxBinDir/libcoreclrtraceptprovider.so"
+                    }
 
                     // Call the ARM CI script to cross build and test using docker
                     buildCommands += """./tests/scripts/arm32_ci_script.sh \\

--- a/netci.groovy
+++ b/netci.groovy
@@ -1643,7 +1643,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     // Test environment emulation using docker and qemu has some problem to use lttng library.
                     // We should remove libcoreclrtraceptprovider.so to avoid test hang.
                     if (os == 'Ubuntu') {
-                        buildCommand += "rm -f -v bin/CoreFxBinDir/libcoreclrtraceptprovider.so"
+                        buildCommands += "rm -f -v ./bin/CoreFxBinDir/libcoreclrtraceptprovider.so"
                     }
 
                     // Call the ARM CI script to cross build and test using docker

--- a/tests/scripts/arm32_ci_test.sh
+++ b/tests/scripts/arm32_ci_test.sh
@@ -114,7 +114,8 @@ mount -o bind ${CORECLR_DIR} ${__ROOTFS_DIR}${ARM_CHROOT_HOME_DIR}
 
 # Test environment emulation using docker and qemu has some problem to use lttng library.
 # We should remove libcoreclrtraceptprovider.so to avoid test hang.
-rm -f ${__ROOTFS_DIR}${ARM_CHROOT_HOME_DIR}/bin/Product/${__buildDirName}/libcoreclrtraceptprovider.so
+rm -f -v ${__ROOTFS_DIR}${ARM_CHROOT_HOME_DIR}/bin/Product/${__buildDirName}/libcoreclrtraceptprovider.so
+rm -f -v ${__ROOTFS_DIR}${ARM_CHROOT_HOME_DIR}/bin/CoreFxBinDir/libcoreclrtraceptprovider.so
 
 chroot ${__ROOTFS_DIR} /bin/bash -x <<EOF
     cd ${ARM_CHROOT_HOME_DIR}


### PR DESCRIPTION
Fix ARM32/Linux release CI test failure by removing libcoreclrptprovider.so from CoreFX build result.

related issue: #10986 