### PR TITLE
In function Assembly.Load ignore AssemblyName.CodeBase even if it is set

### DIFF
--- a/src/mscorlib/Resources/Strings.resx
+++ b/src/mscorlib/Resources/Strings.resx
@@ -2864,9 +2864,6 @@
   <data name="NotSupported_AppX" xml:space="preserve">
     <value>{0} is not supported in AppX.</value>
   </data>
-  <data name="NotSupported_AssemblyLoadCodeBase" xml:space="preserve">
-    <value>Assembly.Load with a Codebase is not supported.</value>
-  </data>
   <data name="NotSupported_AssemblyLoadFromHash" xml:space="preserve">
     <value>Assembly.LoadFrom with hashValue is not supported.</value>
   </data>

--- a/src/mscorlib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/mscorlib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -101,14 +101,20 @@ namespace System.Reflection
         {
             Contract.Ensures(Contract.Result<Assembly>() != null);
             Contract.Ensures(!Contract.Result<Assembly>().ReflectionOnly);
-
+            
+            AssemblyName modifiedAssemblyRef = null;
             if (assemblyRef != null && assemblyRef.CodeBase != null)
             {
-                throw new NotSupportedException(SR.NotSupported_AssemblyLoadCodeBase);
+                modifiedAssemblyRef = (AssemblyName)assemblyRef.Clone();
+                modifiedAssemblyRef.CodeBase = null;
             }
-
+            else
+            {
+                modifiedAssemblyRef = assemblyRef;
+            }
+            
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return RuntimeAssembly.InternalLoadAssemblyName(assemblyRef, null, null, ref stackMark, true /*thrownOnFileNotFound*/, false /*forIntrospection*/);
+            return RuntimeAssembly.InternalLoadAssemblyName(modifiedAssemblyRef, null, null, ref stackMark, true /*thrownOnFileNotFound*/, false /*forIntrospection*/);
         }
 
         // Locate an assembly by its name. The name can be strong or
@@ -119,13 +125,19 @@ namespace System.Reflection
             Contract.Ensures(Contract.Result<Assembly>() != null);
             Contract.Ensures(!Contract.Result<Assembly>().ReflectionOnly);
 
+            AssemblyName modifiedAssemblyRef = null;
             if (assemblyRef != null && assemblyRef.CodeBase != null)
             {
-                throw new NotSupportedException(SR.NotSupported_AssemblyLoadCodeBase);
+                modifiedAssemblyRef = (AssemblyName)assemblyRef.Clone();
+                modifiedAssemblyRef.CodeBase = null;
+            }
+            else
+            {
+                modifiedAssemblyRef = assemblyRef;
             }
 
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return RuntimeAssembly.InternalLoadAssemblyName(assemblyRef, null, null, ref stackMark, true /*thrownOnFileNotFound*/, false /*forIntrospection*/, ptrLoadContextBinder);
+            return RuntimeAssembly.InternalLoadAssemblyName(modifiedAssemblyRef, null, null, ref stackMark, true /*thrownOnFileNotFound*/, false /*forIntrospection*/, ptrLoadContextBinder);
         }
 
         // Loads the assembly with a COFF based IMAGE containing


### PR DESCRIPTION
Fixes #10561 