### PR TITLE
Remove Alpine for pipe builds

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -103,19 +103,6 @@
         {
           "Name": "DotNet-CoreClr-Trusted-Linux",
           "Parameters": {
-            "DockerTag": "alpine_prereqs",
-            "Rid": "alpine.3.4.3"
-          },
-          "ReportingParameters": {
-            "OperatingSystem": "Alpine 3.4.3",
-            "Type": "build/product/",
-            "Architecture": "x64",
-            "PB_BuildType": null
-          }
-        },
-        {
-          "Name": "DotNet-CoreClr-Trusted-Linux",
-          "Parameters": {
             "DockerTag": "rhel7_prereqs_2",
             "portableBuild": "-portable",
             "Rid": "linux"


### PR DESCRIPTION
skip ci please

This PR removes Alpine from CoreCLR official builds since CoreFX and Core-Setup already do not support it.

@weshaggard @wtgodbe PTAL

FYI - @Petermarcu 