### PR TITLE
Fix error caused by passing -TargetsWindows at end of Command Line

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -335,7 +335,7 @@ set __msbuildLog=/flp:Verbosity=normal;LogFile="%__BuildLog%"
 set __msbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __msbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 
-call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\runtest.proj -BuildWrappers -MsBuildEventLogging=" " -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %__unprocessedBuildArgs% %TargetsWindowsArg%
+call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\runtest.proj -BuildWrappers -MsBuildEventLogging=" " -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %TargetsWindowsArg% %__unprocessedBuildArgs%
 if errorlevel 1 (
     echo Xunit Wrapper build failed
     exit /b 1
@@ -376,7 +376,7 @@ REM === Prep test binaries for Helix publishing
 REM ===
 REM =========================================================================================
 
-call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\helixprep.proj  -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %__unprocessedBuildArgs% %RuntimeIdArg% %TargetsWindowsArg%
+call %__ProjectDir%\run.cmd build -Project=%__ProjectDir%\tests\helixprep.proj  -MsBuildLog=!__msbuildLog! -MsBuildWrn=!__msbuildWrn! -MsBuildErr=!__msbuildErr! %__RunArgs% %__BuildAgainstPackagesArg% %RuntimeIdArg% %TargetsWindowsArg% %__unprocessedBuildArgs%
 
 echo %__MsgPrefix% Prepped test binaries for publishing
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/coreclr/issues/10968. The problem was that I was passing "-TargetsWindows=true/false" after any unprocessed Build Arguments - but since the run tool interprets anything after the string "--" as arguments to pass directly to Msbuild, if any such arg was passed to build.cmd, then "-TargetsWindows=true" wouldn't get interpreted as an arg to the run tool, but rather as an arg to msbuild. The solution is to move "UnprocessedBuildArgs" to the very end of every invocation of msbuild-ing run.exe.

CC @KarenHuang2016 @danmosemsft 