### PR TITLE
Implement the createdump policy options and env variables

### DIFF
--- a/src/debug/createdump/crashinfo.h
+++ b/src/debug/createdump/crashinfo.h
@@ -34,7 +34,7 @@ public:
     CrashInfo(pid_t pid, DataTarget& dataTarget);
     virtual ~CrashInfo();
     bool EnumerateAndSuspendThreads();
-    bool GatherCrashInfo(const char* pszExePath, MINIDUMP_TYPE minidumpType);
+    bool GatherCrashInfo(const char* programPath, MINIDUMP_TYPE minidumpType);
     void ResumeThreads();
     static bool GetStatus(pid_t pid, pid_t* ppid, pid_t* tgid, char** name);
 
@@ -63,7 +63,7 @@ public:
 private:
     bool GetAuxvEntries();
     bool EnumerateModuleMappings();
-    bool EnumerateMemoryRegionsWithDAC(const char* pszExePath, MINIDUMP_TYPE minidumpType);
+    bool EnumerateMemoryRegionsWithDAC(const char* programPath, MINIDUMP_TYPE minidumpType);
     bool GetDSOInfo();
     bool ReadMemory(void* address, void* buffer, size_t size);
     void InsertMemoryRegion(uint64_t address, size_t size);


### PR DESCRIPTION
Added these command line options:

-f, --name - dump path and file name. The pid can be placed in the name with %d. The default is "/tmp/coredump.%d"
-n, --normal - create minidump (default).
-h, --withheap - create minidump with heap.
-m, --micro - create triage minidump.
-d, --diag - enable diagnostic messages.

Added these environment variables:

COMPlus_DbgMiniDumpType - if set to "1" generate MiniDumpNormal, "2" MiniDumpWithPrivateReadWriteMemory, "3" MiniDumpFilterTriage. Default is MiniDumpNormal.
COMPlus_DbgMiniDumpName - if set, use as the template to create the dump path and file name. The pid can be placed in the name with %d. The default is "/tmp/coredump.%d".