### PR TITLE
Move handle object manipulation functions to interface

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -34222,7 +34222,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
                     if (g_pConfig->AppDomainLeaks() && str->SetAppDomainNoThrow())
                     {
 #endif
-                        StoreObjectInHandle(m_StressObjs[i], ObjectToOBJECTREF(str));
+                        HndAssignHandle(m_StressObjs[i], ObjectToOBJECTREF(str));
 #if CHECK_APP_DOMAIN_LEAKS
                     }
 #endif
@@ -34255,7 +34255,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
             {
                 // Let the string itself become garbage.
                 // will be realloced next time around
-                StoreObjectInHandle(m_StressObjs[m_CurStressObj], 0);
+                HndAssignHandle(m_StressObjs[m_CurStressObj], 0);
             }
         }
     }

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -143,7 +143,7 @@ bool GCHandleManager::StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* obj
     return !!::HndFirstAssignHandle(handle, ObjectToOBJECTREF(object));
 }
 
-Object* GCHandleManager::CompareAndSwapObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject)
+Object* GCHandleManager::InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject)
 {
     return (Object*)::HndInterlockedCompareExchangeHandle(handle, ObjectToOBJECTREF(object), ObjectToOBJECTREF(comparandObject));
 }

--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -132,3 +132,18 @@ void* GCHandleManager::GetExtraInfoFromHandle(OBJECTHANDLE handle)
 {
     return (void*)::HndGetHandleExtraInfo(handle);
 }
+
+void GCHandleManager::StoreObjectInHandle(OBJECTHANDLE handle, Object* object)
+{
+    ::HndAssignHandle(handle, ObjectToOBJECTREF(object));
+}
+
+bool GCHandleManager::StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object)
+{
+    return !!::HndFirstAssignHandle(handle, ObjectToOBJECTREF(object));
+}
+
+Object* GCHandleManager::CompareAndSwapObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject)
+{
+    return (Object*)::HndInterlockedCompareExchangeHandle(handle, ObjectToOBJECTREF(object), ObjectToOBJECTREF(comparandObject));
+}

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -59,7 +59,7 @@ public:
 
     virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object);
 
-    virtual Object* CompareAndSwapObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject);
+    virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -54,6 +54,12 @@ public:
     virtual void DestroyHandleOfUnknownType(OBJECTHANDLE handle);
 
     virtual void* GetExtraInfoFromHandle(OBJECTHANDLE handle);
+
+    virtual void StoreObjectInHandle(OBJECTHANDLE handle, Object* object);
+
+    virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object);
+
+    virtual Object* CompareAndSwapObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -449,7 +449,7 @@ public:
 
     virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object) = 0;
 
-    virtual Object* CompareAndSwapObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject) = 0;
+    virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -444,6 +444,12 @@ public:
     virtual void DestroyHandleOfUnknownType(OBJECTHANDLE handle) = 0;
 
     virtual void* GetExtraInfoFromHandle(OBJECTHANDLE handle) = 0;
+
+    virtual void StoreObjectInHandle(OBJECTHANDLE handle, Object* object) = 0;
+
+    virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object) = 0;
+
+    virtual Object* CompareAndSwapObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/gc/handletable.inl
+++ b/src/gc/handletable.inl
@@ -22,13 +22,6 @@ inline void HndAssignHandle(OBJECTHANDLE handle, OBJECTREF objref)
     // sanity
     _ASSERTE(handle);
 
-#ifdef _DEBUG_IMPL
-    // handle should not be in unloaded domain
-    ValidateAppDomainForHandle(handle);
-
-    // Make sure the objref is valid before it is assigned to a handle
-    ValidateAssignObjrefForHandle(objref, HndGetHandleTableADIndex(HndGetHandleTable(handle)));
-#endif
     // unwrap the objectref we were given
     _UNCHECKED_OBJECTREF value = OBJECTREF_TO_UNCHECKED_OBJECTREF(objref);
 
@@ -49,13 +42,6 @@ inline void* HndInterlockedCompareExchangeHandle(OBJECTHANDLE handle, OBJECTREF 
     // sanity
     _ASSERTE(handle);
 
-#ifdef _DEBUG_IMPL
-    // handle should not be in unloaded domain
-    ValidateAppDomainForHandle(handle);
-
-    // Make sure the objref is valid before it is assigned to a handle
-    ValidateAssignObjrefForHandle(objref, HndGetHandleTableADIndex(HndGetHandleTable(handle)));
-#endif
     // unwrap the objectref we were given
     _UNCHECKED_OBJECTREF value = OBJECTREF_TO_UNCHECKED_OBJECTREF(objref);
     _UNCHECKED_OBJECTREF oldValue = OBJECTREF_TO_UNCHECKED_OBJECTREF(oldObjref);
@@ -88,13 +74,6 @@ inline BOOL HndFirstAssignHandle(OBJECTHANDLE handle, OBJECTREF objref)
     // sanity
     _ASSERTE(handle);
 
-#ifdef _DEBUG_IMPL
-    // handle should not be in unloaded domain
-    ValidateAppDomainForHandle(handle);
-
-    // Make sure the objref is valid before it is assigned to a handle
-    ValidateAssignObjrefForHandle(objref, HndGetHandleTableADIndex(HndGetHandleTable(handle)));
-#endif
     // unwrap the objectref we were given
     _UNCHECKED_OBJECTREF value = OBJECTREF_TO_UNCHECKED_OBJECTREF(objref);
     _UNCHECKED_OBJECTREF null = NULL;

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -21,16 +21,6 @@
 #include <weakreference.h>
 #endif // FEATURE_COMINTEROP
 
-/*
- * Convenience macros for accessing handles.  StoreFirstObjectInHandle is like
- * StoreObjectInHandle, except it only succeeds if transitioning from NULL to
- * non-NULL.  In other words, if this handle is being initialized for the first
- * time.
- */
-#define StoreObjectInHandle(handle, object)        HndAssignHandle(handle, object)
-#define InterlockedCompareExchangeObjectInHandle(handle, object, oldObj)        HndInterlockedCompareExchangeHandle(handle, object, oldObj)
-#define StoreFirstObjectInHandle(handle, object)   HndFirstAssignHandle(handle, object)
-
 typedef DPTR(struct HandleTableMap) PTR_HandleTableMap;
 typedef DPTR(struct HandleTableBucket) PTR_HandleTableBucket;
 typedef DPTR(PTR_HandleTableBucket) PTR_PTR_HandleTableBucket;
@@ -94,7 +84,7 @@ inline void ResetOBJECTHANDLE(OBJECTHANDLE handle)
 {
     WRAPPER_NO_CONTRACT;
 
-    StoreObjectInHandle(handle, NULL);
+    HndAssignHandle(handle, NULL);
 }
 
 #ifndef FEATURE_REDHAWK

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -80,17 +80,6 @@ void GCHandleValidatePinnedObject(OBJECTREF obj);
 
 int GetCurrentThreadHomeHeapNumber();
 
-inline void ResetOBJECTHANDLE(OBJECTHANDLE handle)
-{
-    WRAPPER_NO_CONTRACT;
-
-    HndAssignHandle(handle, NULL);
-}
-
-#ifndef FEATURE_REDHAWK
-typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,ResetOBJECTHANDLE> ObjectInHandleHolder;
-#endif
-
 /*
  * Table maintenance routines
  */

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -4679,7 +4679,8 @@ OBJECTREF AppDomain::GetExposedObject()
         obj = (APPDOMAINREF) AllocateObject(pMT);
         obj->SetDomain(this);
 
-        if(StoreFirstObjectInHandle(m_ExposedObject, (OBJECTREF) obj) == FALSE) {
+        if (!StoreFirstObjectInHandle(m_ExposedObject, (OBJECTREF) obj))
+        {
             obj = (APPDOMAINREF) GetRawExposedObject();
             _ASSERTE(obj);
         }

--- a/src/vm/gchandleutilities.h
+++ b/src/vm/gchandleutilities.h
@@ -193,7 +193,7 @@ inline void* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, OBJEC
 {
     ValidateHandleAssignment(handle, object);
 
-    return GCHandleUtilities::GetGCHandleManager()->CompareAndSwapObjectInHandle(handle, OBJECTREFToObject(object), OBJECTREFToObject(comparandObject));
+    return GCHandleUtilities::GetGCHandleManager()->InterlockedCompareExchangeObjectInHandle(handle, OBJECTREFToObject(object), OBJECTREFToObject(comparandObject));
 }
 
 inline void ResetOBJECTHANDLE(OBJECTHANDLE handle)

--- a/src/vm/gchandleutilities.h
+++ b/src/vm/gchandleutilities.h
@@ -196,6 +196,11 @@ inline void* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, OBJEC
     return GCHandleUtilities::GetGCHandleManager()->CompareAndSwapObjectInHandle(handle, OBJECTREFToObject(object), OBJECTREFToObject(comparandObject));
 }
 
+inline void ResetOBJECTHANDLE(OBJECTHANDLE handle)
+{
+    GCHandleUtilities::GetGCHandleManager()->StoreObjectInHandle(handle, NULL);
+}
+
 // Handle destruction convenience functions
 
 inline void DestroyHandle(OBJECTHANDLE handle)
@@ -336,6 +341,7 @@ typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyRefcountedHandle> 
 typedef Holder<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyLongWeakHandle>            LongWeakHandleHolder;
 typedef Holder<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyGlobalStrongHandle>        GlobalStrongHandleHolder;
 typedef Holder<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyGlobalShortWeakHandle>     GlobalShortWeakHandleHolder;
+typedef Holder<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, ResetOBJECTHANDLE>                ObjectInHandleHolder;
 
 class RCOBJECTHANDLEHolder : public RefCountedOHWrapper
 {

--- a/src/vm/gchandleutilities.h
+++ b/src/vm/gchandleutilities.h
@@ -169,6 +169,23 @@ inline OBJECTHANDLE CreateVariableHandle(IGCHandleStore* store, OBJECTREF object
     return store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_VARIABLE, (void*)((uintptr_t)type));
 }
 
+// Handle object manipulation convenience functions
+
+inline void StoreObjectInHandle(OBJECTHANDLE handle, OBJECTREF object)
+{
+    GCHandleUtilities::GetGCHandleManager()->StoreObjectInHandle(handle, OBJECTREFToObject(object));
+}
+
+inline bool StoreFirstObjectInHandle(OBJECTHANDLE handle, OBJECTREF object)
+{
+    return GCHandleUtilities::GetGCHandleManager()->StoreObjectInHandleIfNull(handle, OBJECTREFToObject(object));
+}
+
+inline void* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, OBJECTREF object, OBJECTREF comparandObject)
+{
+    return GCHandleUtilities::GetGCHandleManager()->CompareAndSwapObjectInHandle(handle, OBJECTREFToObject(object), OBJECTREFToObject(comparandObject));
+}
+
 // Handle destruction convenience functions
 
 inline void DestroyHandle(OBJECTHANDLE handle)

--- a/src/vm/gchandleutilities.h
+++ b/src/vm/gchandleutilities.h
@@ -30,7 +30,8 @@ private:
     GCHandleUtilities() = delete;
 };
 
-void ValidateHandleAndAppDomain(OBJECTHANDLE handle);
+void ValidateObjectAndAppDomain(OBJECTREF objRef, ADIndex appDomainIndex);
+void ValidateHandleAssignment(OBJECTHANDLE handle, OBJECTREF objRef);
 
 // Given a handle, returns an OBJECTREF for the object it refers to.
 inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
@@ -38,7 +39,10 @@ inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
     _ASSERTE(handle);
 
 #ifdef _DEBUG_IMPL
-    ValidateHandleAndAppDomain(handle);
+    DWORD context = (DWORD)GCHandleUtilities::GetGCHandleManager()->GetHandleContext(handle);
+    OBJECTREF objRef = ObjectToOBJECTREF(*(Object**)handle);
+
+    ValidateObjectAndAppDomain(objRef, ADIndex(context));
 #endif // _DEBUG_IMPL
 
     // Wrap the raw OBJECTREF and return it
@@ -173,16 +177,22 @@ inline OBJECTHANDLE CreateVariableHandle(IGCHandleStore* store, OBJECTREF object
 
 inline void StoreObjectInHandle(OBJECTHANDLE handle, OBJECTREF object)
 {
+    ValidateHandleAssignment(handle, object);
+
     GCHandleUtilities::GetGCHandleManager()->StoreObjectInHandle(handle, OBJECTREFToObject(object));
 }
 
 inline bool StoreFirstObjectInHandle(OBJECTHANDLE handle, OBJECTREF object)
 {
+    ValidateHandleAssignment(handle, object);
+
     return GCHandleUtilities::GetGCHandleManager()->StoreObjectInHandleIfNull(handle, OBJECTREFToObject(object));
 }
 
 inline void* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, OBJECTREF object, OBJECTREF comparandObject)
 {
+    ValidateHandleAssignment(handle, object);
+
     return GCHandleUtilities::GetGCHandleManager()->CompareAndSwapObjectInHandle(handle, OBJECTREFToObject(object), OBJECTREFToObject(comparandObject));
 }
 


### PR DESCRIPTION
This change moves functions related to modifying objects in handles to the IGCHandleManager interface.

I thought about having `StoreObjectInHandle` purely on the VM side, but there is some bookkeeping the GC has to do apart from just setting the pointer: It has to call the handle write barrier and also fire some ETW events. I believe our plan is to eventually have the logic and manifest for GC-related events purely on the GC side anyway.

Edit: this is done with my latest commits. ~~We should of course move the handle and app domain validation stuff that's being done over to the VM side. I already moved some of it when I moved `ObjectFromHandle` to the VM. We can refactor that to cover all the validation done by these functions and call it from the VM side stubs before they call the interface methods.~~

@jkotas @Maoni0 @swgillespie @sergiy-k 