### PR TITLE
Fix test dependency on System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/tests/src/JIT/config/benchmark/project.json
+++ b/tests/src/JIT/config/benchmark/project.json
@@ -18,7 +18,7 @@
     "System.Reflection.Extensions": "4.4.0-beta-24913-02",
     "System.Reflection.TypeExtensions": "4.4.0-preview1-25214-03",
     "System.Runtime": "4.4.0-beta-24913-02",
-    "System.Runtime.CompilerServices.Unsafe": "4.4.0-preview1-25210-01",
+    "System.Runtime.CompilerServices.Unsafe": "4.4.0-preview1-25214-03",
     "System.Runtime.Extensions": "4.4.0-beta-24913-02",
     "System.Runtime.Numerics": "4.4.0-beta-24913-02",
     "System.Text.RegularExpressions": "4.4.0-beta-24913-02",


### PR DESCRIPTION
The test build complains that its dependencies aren't up-to-date.  Running the fix-up tool pull this updated version of the dependency.