### PR TITLE
Fix incorrect test of structSize during struct promotion

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1459,7 +1459,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE    typeHnd,
         StructPromotionInfo->canPromote = false;
 
         unsigned structSize = info.compCompHnd->getClassSize(typeHnd);
-        if (structSize >= MaxOffset)
+        if (structSize > MaxOffset)
         {
             return; // struct is too large
         }


### PR DESCRIPTION
Fixes the desktop test Crossgen NI and Ngen NI validation

For the Desktop build of crossgen FEATURE_SIMD is not defined so under desktop crossgen we would not struct promote a struct of size 32 (4 pointer sized fields).

For other builds FEATURE_SIMD is defined so we would allow struct promote of struct up to 63 bytes.
With this change we can struct promote a 64 byte struct with 4 SIMD fields.
