### PR TITLE
Improving robustness of the run-xunit-perf.cmd script.

### DIFF
--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -33,7 +33,9 @@ setlocal
 
   rem find and stage the tests
   for /R %CORECLR_PERF% %%T in (*.%TEST_FILE_EXT%) do (
-    call :run_benchmark %%T
+    call :run_benchmark %%T || (
+      IF /I NOT "%BENCHVIEW_RUN_TYPE%" == "local" exit /b 1
+    )
   )
 
   rem optionally upload results to benchview
@@ -283,22 +285,25 @@ rem ****************************************************************************
 :print_to_console
 rem ****************************************************************************
 rem   Sends text to the console screen, no matter what (even when the script's
-rem   output is redirected). This is useful to output provide information on
-rem   where the script is executing.
+rem   output is redirected). This can be useful to provide information on where
+rem   the script is executing.
 rem ****************************************************************************
-  echo [%DATE%][%TIME:~0,-3%] %* >CON
+  if defined _debug (
+    echo [%DATE%][%TIME:~0,-3%] %* >CON
+  )
+  echo [%DATE%][%TIME:~0,-3%] %*
   exit /b %ERRORLEVEL%
 
 :run_cmd
 rem ****************************************************************************
-rem   Function wrapper used to display to the console screen the command line
-rem   being executed.
+rem   Function wrapper used to send the command line being executed to the
+rem   console screen, before the command is executed.
 rem ****************************************************************************
   if "%~1" == "" (
     call :print_error No command was specified.
     exit /b 1
   )
 
-  echo [%DATE%][%TIME:~0,-3%] $ %* >CON
+  call :print_to_console $ %*
   call %*
   exit /b %ERRORLEVEL%

--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -212,7 +212,13 @@ rem ****************************************************************************
   set BENCHVIEW_MEASUREMENT_PARSER=xunit
   if defined IS_SCENARIO_TEST set BENCHVIEW_MEASUREMENT_PARSER=xunitscenario
 
-  call :run_cmd py.exe "%BENCHVIEW_PATH%\measurement.py" %BENCHVIEW_MEASUREMENT_PARSER% "Perf-%BENCHNAME%.xml" --better desc --drop-first-value --append
+  set LV_MEASUREMENT_ARGS=
+  set LV_MEASUREMENT_ARGS=%LV_MEASUREMENT_ARGS% %BENCHVIEW_MEASUREMENT_PARSER%
+  set LV_MEASUREMENT_ARGS=%LV_MEASUREMENT_ARGS% "Perf-%BENCHNAME%.xml"
+  set LV_MEASUREMENT_ARGS=%LV_MEASUREMENT_ARGS% --better desc
+  set LV_MEASUREMENT_ARGS=%LV_MEASUREMENT_ARGS% --drop-first-value
+  set LV_MEASUREMENT_ARGS=%LV_MEASUREMENT_ARGS% --append
+  call :run_cmd py.exe "%BENCHVIEW_PATH%\measurement.py" %LV_MEASUREMENT_ARGS%
   IF %ERRORLEVEL% NEQ 0 (
     call :print_error Failed to generate BenchView measurement data.
     exit /b 1

--- a/tests/scripts/run-xunit-perf.cmd
+++ b/tests/scripts/run-xunit-perf.cmd
@@ -2,193 +2,294 @@
 @rem The .NET Foundation licenses this file to you under the MIT license.
 @rem See the LICENSE file in the project root for more information.
 
-@setlocal
 @echo off
-Setlocal EnableDelayedExpansion
+@if defined _echo echo on
 
-rem Set defaults for the file extension, architecture and configuration
-set CORECLR_REPO=%CD%
-set TEST_FILE_EXT=exe
-set TEST_ARCH=x64
-set TEST_ARCHITECTURE=x64
-set TEST_CONFIG=Release
-set IS_SCENARIO_TEST=0
+setlocal
+  set ERRORLEVEL=
+  set CORECLR_REPO=%CD%
+  set TEST_FILE_EXT=exe
+  set TEST_ARCH=x64
+  set TEST_ARCHITECTURE=x64
+  set TEST_CONFIG=Release
+  set IS_SCENARIO_TEST=
+  set USAGE_DISPLAYED=
 
-goto :ARGLOOP
+  call :parse_command_line_arguments %*
+  if defined USAGE_DISPLAYED exit /b %ERRORLEVEL%
 
+  call :set_test_architecture || exit /b 1
+  call :verify_core_overlay   || exit /b 1
+  call :set_perf_run_log      || exit /b 1
+  call :setup_sandbox         || exit /b 1
 
-:SETUP
+  call :run_cmd "%CORECLR_REPO%\Tools\dotnetcli\dotnet.exe" restore "%CORECLR_REPO%\tests\src\Common\PerfHarness\project.json"                                        || exit /b 1
+  call :run_cmd "%CORECLR_REPO%\Tools\dotnetcli\dotnet.exe" publish "%CORECLR_REPO%\tests\src\Common\PerfHarness\project.json" -c Release -o "%CORECLR_REPO%\sandbox" || exit /b 1
 
-IF /I [%TEST_ARCHITECTURE%] == [x86jit32] (
-    set TEST_ARCH=x86
-) ELSE (
-    set TEST_ARCH=%TEST_ARCHITECTURE%
-)
+  rem TODO: Remove the version of the package to copy. e.g.) if multiple version exist, then error out?
+  call :run_cmd xcopy /sy "%CORECLR_REPO%\packages\Microsoft.Diagnostics.Tracing.TraceEvent\1.0.3-alpha-experimental\lib\native"\* . >> %RUNLOG%  || exit /b 1
+  call :run_cmd xcopy /sy "%CORECLR_REPO%\bin\tests\Windows_NT.%TEST_ARCH%.%TEST_CONFIG%\Tests\Core_Root"\* . >> %RUNLOG%                         || exit /b 1
 
-set CORECLR_OVERLAY=%CORECLR_REPO%\bin\tests\Windows_NT.%TEST_ARCH%.%TEST_CONFIG%\Tests\Core_Root
-set RUNLOG=%CORECLR_REPO%\bin\Logs\perfrun.log
-
-if NOT EXIST %CORECLR_OVERLAY% (
-  echo Can't find test overlay directory '%CORECLR_OVERLAY%'
-  echo Please build and run Release CoreCLR tests
-  exit /B 1
-)
-
-@echo --- setting up sandbox
-if exist sandbox rd /s /q sandbox
-if exist sandbox echo ERROR: Failed to remove the sandbox folder& exit /b 1
-if not exist sandbox mkdir sandbox
-if not exist sandbox echo ERROR: Failed to create the sandbox folder& exit /b 1
-pushd sandbox
-
-@rem stage stuff we need
-
-@rem xunit and perf
-"%CORECLR_REPO%\Tools\dotnetcli\dotnet.exe" restore "%CORECLR_REPO%\tests\src\Common\PerfHarness\project.json"
-"%CORECLR_REPO%\Tools\dotnetcli\dotnet.exe" publish "%CORECLR_REPO%\tests\src\Common\PerfHarness\project.json" -c Release -o %CORECLR_REPO%\sandbox
-xcopy /sy %CORECLR_REPO%\packages\Microsoft.Diagnostics.Tracing.TraceEvent\1.0.3-alpha-experimental\lib\native\* . >> %RUNLOG%
-xcopy /sy %CORECLR_REPO%\bin\tests\Windows_NT.%TEST_ARCH%.%TEST_CONFIG%\Tests\Core_Root\* . >> %RUNLOG%
-
-@rem find and stage the tests
-for /R %CORECLR_PERF% %%T in (*.%TEST_FILE_EXT%) do (
-  call :DOIT %%T
-)
-
-@rem optionally upload results to benchview
-if not [%BENCHVIEW_PATH%] == [] (
-  py "%BENCHVIEW_PATH%\submission.py" measurement.json ^
-                                    --build ..\build.json ^
-                                    --machine-data ..\machinedata.json ^
-                                    --metadata ..\submission-metadata.json ^
-                                    --group "CoreCLR" ^
-                                    --type "%RUN_TYPE%" ^
-                                    --config-name "%TEST_CONFIG%" ^
-                                    --config Configuration "%TEST_CONFIG%" ^
-                                    --config OS "Windows_NT" ^
-                                    --arch "%TEST_ARCHITECTURE%" ^
-                                    --machinepool "PerfSnake"
-  py "%BENCHVIEW_PATH%\upload.py" submission.json --container coreclr
-)
-
-goto :EOF
-
-:DOIT
-set BENCHNAME=%~n1
-set BENCHDIR=%~p1
-set PERFOUT=perf-%BENCHNAME%
-set XMLOUT=%PERFOUT%-summary.xml
-
-echo --- Running %BENCHNAME%
-
-@rem copy benchmark and any input files
-
-xcopy /s %1 . >> %RUNLOG%
-xcopy /s %BENCHDIR%*.txt . >> %RUNLOG%
-
-set CORE_ROOT=%CORECLR_REPO%\sandbox
-
-@rem setup additional environment variables
-if DEFINED TEST_ENV (
-    if EXIST !TEST_ENV! (
-        call %TEST_ENV%
-    )
-)
-
-if [%IS_SCENARIO_TEST%] == [1] (
-  corerun.exe %CORECLR_REPO%\sandbox\%BENCHNAME%.%TEST_FILE_EXT% --perf:runid Perf > %BENCHNAME%.out
-) else (
-  corerun.exe PerfHarness.dll %CORECLR_REPO%\sandbox\%BENCHNAME%.%TEST_FILE_EXT% --perf:runid Perf > %BENCHNAME%.out
-)
-
-@rem optionally generate results for benchview
-if not [%BENCHVIEW_PATH%] == [] (
-  if [%IS_SCENARIO_TEST%] == [1] (
-    py "%BENCHVIEW_PATH%\measurement.py" xunitscenario "Perf-%BENCHNAME%.xml" --better desc --drop-first-value --append
-  ) else (
-    py "%BENCHVIEW_PATH%\measurement.py" xunit "Perf-%BENCHNAME%.xml" --better desc --drop-first-value --append
+  rem find and stage the tests
+  for /R %CORECLR_PERF% %%T in (*.%TEST_FILE_EXT%) do (
+    call :run_benchmark %%T
   )
-  REM Save off the results to the root directory for recovery later in Jenkins
-  xcopy Perf-%BENCHNAME%*.xml %CORECLR_REPO%\
-  xcopy Perf-%BENCHNAME%*.etl %CORECLR_REPO%\
-) else (
-  type %XMLOUT% | findstr "test name"
-  type %XMLOUT% | findstr Duration
-  type %XMLOUT% | findstr InstRetired
-)
 
-goto :EOF
+  rem optionally upload results to benchview
+  if not [%BENCHVIEW_PATH%] == [] (
+    call :upload_to_benchview
+  )
 
-:ARGLOOP
-IF /I [%1] == [-testBinLoc] (
-set CORECLR_PERF=%CORECLR_REPO%\%2
-shift
-shift
-goto :ARGLOOP
-)
-IF /I [%1] == [-scenarioTest] (
-set IS_SCENARIO_TEST=1
-shift
-goto :ARGLOOP
-)
-IF /I [%1] == [-runtype] (
-set RUN_TYPE=%2
-shift
-shift
-goto :ARGLOOP
-)
-IF /I [%1] == [-library] (
-set TEST_FILE_EXT=dll
-shift
-goto :ARGLOOP
-)
-IF /I [%1] == [-uploadtobenchview] (
-set BENCHVIEW_PATH=%2
-shift
-shift
-goto :ARGLOOP
-)
-IF /I [%1] == [-arch] (
-set TEST_ARCHITECTURE=%2
-shift
-shift
-goto :ARGLOOP
-)
-IF /I [%1] == [-testEnv] (
-set TEST_ENV=%2
-shift
-shift
-goto :ARGLOOP
-)
-IF /I [%1] == [-configuration] (
-set TEST_CONFIG=%2
-shift
-shift
-goto :ARGLOOP
-)
-if /I [%1] == [-?] (
-goto :USAGE
-)
-if /I [%1] == [-help] (
-goto :USAGE
-)
+  exit /b %ERRORLEVEL%
 
-if [%CORECLR_PERF%] == [] (
-goto :USAGE
-)
+:run_benchmark
+rem ****************************************************************************
+rem   Executes the xUnit Performance benchmarks
+rem ****************************************************************************
+setlocal
+  set BENCHNAME=%~n1
+  set BENCHDIR=%~p1
+  set PERFOUT=perf-%BENCHNAME%
+  set XMLOUT=%PERFOUT%.xml
 
-goto :SETUP
+  rem copy benchmark and any input files
+  call :run_cmd xcopy /s %~1 . >> %RUNLOG%  || exit /b 1
+  if exist "%BENCHDIR%*.txt" (
+    call :run_cmd xcopy /s %BENCHDIR%*.txt . >> %RUNLOG%  || exit /b 1
+  )
+
+  set CORE_ROOT=%CORECLR_REPO%\sandbox
+
+  rem setup additional environment variables
+  if DEFINED TEST_ENV (
+    if EXIST "%TEST_ENV%" (
+        call "%TEST_ENV%"
+    )
+  )
+
+  set BENCHNAME_LOG_FILE_NAME=%BENCHNAME%.log
+  if defined IS_SCENARIO_TEST (
+    call :run_cmd corerun.exe "%CORECLR_REPO%\sandbox\%BENCHNAME%.%TEST_FILE_EXT%" --perf:runid Perf 1>"%BENCHNAME_LOG_FILE_NAME%" 2>&1
+  ) else (
+    call :run_cmd corerun.exe PerfHarness.dll "%CORECLR_REPO%\sandbox\%BENCHNAME%.%TEST_FILE_EXT%" --perf:runid Perf 1>"%BENCHNAME_LOG_FILE_NAME%" 2>&1
+  )
+
+  IF %ERRORLEVEL% NEQ 0 (
+    call :print_error corerun.exe exited with %ERRORLEVEL% code.
+    if exist "%BENCHNAME_LOG_FILE_NAME%" type "%BENCHNAME_LOG_FILE_NAME%"
+    exit /b 1
+  )
+
+  rem optionally generate results for benchview
+  if not [%BENCHVIEW_PATH%] == [] (
+    call :generate_results_for_benchview || exit /b 1
+  ) else (
+    type "%XMLOUT%" | findstr /i /c:"test name"
+  )
+
+  rem Save off the results to the root directory for recovery later in Jenkins
+  call :run_cmd xcopy "Perf-%BENCHNAME%*.xml" "%CORECLR_REPO%\" || exit /b 1
+  call :run_cmd xcopy "Perf-%BENCHNAME%*.etl" "%CORECLR_REPO%\" || exit /b 1
+
+  exit /b 0
+
+:parse_command_line_arguments
+rem ****************************************************************************
+rem   Parses the script's command line arguments.
+rem ****************************************************************************
+  IF /I [%~1] == [-testBinLoc] (
+    set CORECLR_PERF=%CORECLR_REPO%\%~2
+    shift
+    shift
+    goto :parse_command_line_arguments
+  )
+  IF /I [%~1] == [-scenarioTest] (
+    set IS_SCENARIO_TEST=1
+    shift
+    goto :parse_command_line_arguments
+  )
+  IF /I [%~1] == [-runtype] (
+    set RUN_TYPE=%~2
+    shift
+    shift
+    goto :parse_command_line_arguments
+  )
+  IF /I [%~1] == [-library] (
+    set TEST_FILE_EXT=dll
+    shift
+    goto :parse_command_line_arguments
+  )
+  IF /I [%~1] == [-uploadtobenchview] (
+    set BENCHVIEW_PATH=%~2
+    shift
+    shift
+    goto :parse_command_line_arguments
+  )
+  IF /I [%~1] == [-arch] (
+    set TEST_ARCHITECTURE=%~2
+    shift
+    shift
+    goto :parse_command_line_arguments
+  )
+  IF /I [%~1] == [-testEnv] (
+    set TEST_ENV=%~2
+    shift
+    shift
+    goto :parse_command_line_arguments
+  )
+  IF /I [%~1] == [-configuration] (
+    set TEST_CONFIG=%~2
+    shift
+    shift
+    goto :parse_command_line_arguments
+  )
+
+  if /I [%~1] == [-?] (
+    call :USAGE
+    exit /b 0
+  )
+  if /I [%~1] == [-help] (
+    call :USAGE
+    exit /b 0
+  )
+  if [%CORECLR_PERF%] == [] (
+    call :USAGE
+  )
+
+  exit /b %ERRORLEVEL%
+
+:set_test_architecture
+rem ****************************************************************************
+rem   Sets the test architecture.
+rem ****************************************************************************
+  IF /I [%TEST_ARCHITECTURE%] == [x86jit32] (
+      set TEST_ARCH=x86
+  ) ELSE (
+      set TEST_ARCH=%TEST_ARCHITECTURE%
+  )
+  exit /b 0
+
+:verify_core_overlay
+rem ****************************************************************************
+rem   Verify that the Core_Root folder exist.
+rem ****************************************************************************
+  set CORECLR_OVERLAY=%CORECLR_REPO%\bin\tests\Windows_NT.%TEST_ARCH%.%TEST_CONFIG%\Tests\Core_Root
+  if NOT EXIST "%CORECLR_OVERLAY%" (
+    call :print_error Can't find test overlay directory '%CORECLR_OVERLAY%'. Please build and run Release CoreCLR tests.
+    exit /B 1
+  )
+  exit /b 0
+
+:set_perf_run_log
+rem ****************************************************************************
+rem   Sets the script's output log file.
+rem ****************************************************************************
+  if NOT EXIST "%CORECLR_REPO%\bin\Logs" (
+    call :print_error Cannot find the Logs folder '%CORECLR_REPO%\bin\Logs'.
+    exit /b 1
+  )
+  set RUNLOG=%CORECLR_REPO%\bin\Logs\perfrun.log
+  exit /b 0
+
+:setup_sandbox
+rem ****************************************************************************
+rem   Creates the sandbox folder used by the script to copy binaries locally,
+rem   and execute benchmarks.
+rem ****************************************************************************
+  if exist sandbox rd /s /q sandbox
+  if exist sandbox call :print_error Failed to remove the sandbox folder& exit /b 1
+  if not exist sandbox mkdir sandbox
+  if not exist sandbox call :print_error Failed to create the sandbox folder& exit /b 1
+  cd sandbox
+  exit /b 0
+
+:generate_results_for_benchview
+rem ****************************************************************************
+rem   Generates results for BenchView, by appending new data to the existing
+rem   measurement.json file.
+rem ****************************************************************************
+  set BENCHVIEW_MEASUREMENT_PARSER=xunit
+  if defined IS_SCENARIO_TEST set BENCHVIEW_MEASUREMENT_PARSER=xunitscenario
+
+  call :run_cmd py.exe "%BENCHVIEW_PATH%\measurement.py" %BENCHVIEW_MEASUREMENT_PARSER% "Perf-%BENCHNAME%.xml" --better desc --drop-first-value --append
+  IF %ERRORLEVEL% NEQ 0 (
+    call :print_error Failed to generate BenchView measurement data.
+    exit /b 1
+  )
+endlocal& exit /b %ERRORLEVEL%
+
+:upload_to_benchview
+rem ****************************************************************************
+rem   Generates BenchView's submission data and upload it
+rem ****************************************************************************
+  call :run_cmd py.exe "%BENCHVIEW_PATH%\submission.py" measurement.json ^
+                                                        --build ..\build.json ^
+                                                        --machine-data ..\machinedata.json ^
+                                                        --metadata ..\submission-metadata.json ^
+                                                        --group "CoreCLR" ^
+                                                        --type "%RUN_TYPE%" ^
+                                                        --config-name "%TEST_CONFIG%" ^
+                                                        --config Configuration "%TEST_CONFIG%" ^
+                                                        --config OS "Windows_NT" ^
+                                                        --arch "%TEST_ARCHITECTURE%" ^
+                                                        --machinepool "PerfSnake"
+  IF %ERRORLEVEL% NEQ 0 (
+    call :print_error Creating BenchView submission data failed.
+    exit /b 1
+  )
+
+  REM FIXME: call :run_cmd py.exe "%BENCHVIEW_PATH%\upload.py" submission.json --container coreclr
+  IF %ERRORLEVEL% NEQ 0 (
+    call :print_error Uploading to BenchView failed.
+    exit /b 1
+  )
+  exit /b %ERRORLEVEL%
 
 :USAGE
-echo run-xunit-perf.cmd -testBinLoc ^<path_to_tests^> [-library] [-arch] ^<x86^|x64^> [-configuration] ^<Release^|Debug^> [-uploadToBenchview] ^<path_to_benchview_tools^> [-runtype] ^<rolling^|private^> [-scenarioTest]
+rem ****************************************************************************
+rem   Script's usage.
+rem ****************************************************************************
+  set USAGE_DISPLAYED=1
+  echo run-xunit-perf.cmd -testBinLoc ^<path_to_tests^> [-library] [-arch] ^<x86^|x64^> [-configuration] ^<Release^|Debug^> [-uploadToBenchview] ^<path_to_benchview_tools^> [-runtype] ^<rolling^|private^> [-scenarioTest]
+  echo/
+  echo For the path to the tests you can pass a parent directory and the script will grovel for
+  echo all tests in subdirectories and run them.
+  echo The library flag denotes whether the tests are build as libraries (.dll) or an executable (.exe)
+  echo Architecture defaults to x64 and configuration defaults to release.
+  echo -uploadtoBenchview is used to specify a path to the Benchview tooling and when this flag is
+  echo set we will upload the results of the tests to the coreclr container in benchviewupload.
+  echo Runtype sets the runtype that we upload to Benchview, rolling for regular runs, and private for
+  echo PRs.
+  echo -scenarioTest should be included if you are running a scenario benchmark.
+  exit /b %ERRORLEVEL%
 
-echo For the path to the tests you can pass a parent directory and the script will grovel for
-echo all tests in subdirectories and run them.
-echo The library flag denotes whether the tests are build as libraries (.dll) or an executable (.exe)
-echo Architecture defaults to x64 and configuration defaults to release.
-echo -uploadtoBenchview is used to specify a path to the Benchview tooling and when this flag is
-echo set we will upload the results of the tests to the coreclr container in benchviewupload.
-echo Runtype sets the runtype that we upload to Benchview, rolling for regular runs, and private for
-echo PRs.
-echo -scenarioTest should be included if you are running a scenario benchmark.
+:print_error
+rem ****************************************************************************
+rem   Function wrapper that unifies how errors are output by the script.
+rem   Functions output to the standard error.
+rem ****************************************************************************
+  echo [%DATE%][%TIME:~0,-3%][ERROR] %*   1>&2
+  exit /b %ERRORLEVEL%
 
-goto :EOF
+:print_to_console
+rem ****************************************************************************
+rem   Sends text to the console screen, no matter what (even when the script's
+rem   output is redirected). This is useful to output provide information on
+rem   where the script is executing.
+rem ****************************************************************************
+  echo [%DATE%][%TIME:~0,-3%] %* >CON
+  exit /b %ERRORLEVEL%
+
+:run_cmd
+rem ****************************************************************************
+rem   Function wrapper used to display to the console screen the command line
+rem   being executed.
+rem ****************************************************************************
+  if "%~1" == "" (
+    call :print_error No command was specified.
+    exit /b 1
+  )
+
+  echo [%DATE%][%TIME:~0,-3%] $ %* >CON
+  call %*
+  exit /b %ERRORLEVEL%

--- a/tests/src/Common/PerfHarness/project.json
+++ b/tests/src/Common/PerfHarness/project.json
@@ -12,7 +12,7 @@
           "type": "platform",
           "version": "1.1.0"
         },
-        "xunit.performance.api": "1.0.0-beta-build0002"
+        "xunit.performance.api": "1.0.0-beta-build0003"
       }
     }
   }

--- a/tests/src/Common/external/external.depproj
+++ b/tests/src/Common/external/external.depproj
@@ -24,9 +24,6 @@
     <PackageToInclude Include="xunit.extensibility.core"/>
     <PackageToInclude Include="xunit.extensibility.execution"/>
     <PackageToInclude Include="xunit.runner.utility"/>
-    <PackageToInclude Include="Microsoft.DotNet.xunit.performance"/>
-    <PackageToInclude Include="Microsoft.DotNet.xunit.performance.analysis"/>
-    <PackageToInclude Include="Microsoft.DotNet.xunit.performance.runner.Windows"/>
     <PackageToInclude Include="xunit.performance.api"/>
     <PackageToInclude Include="xunit.performance.core"/>
     <PackageToInclude Include="xunit.performance.execution"/>
@@ -37,7 +34,7 @@
     <PackageToInclude Include="Microsoft.CodeAnalysis.Common"/>
     <PackageToInclude Include="Microsoft.CodeAnalysis.Compilers"/>
     <PackageToInclude Include="Microsoft.CodeAnalysis.CSharp"/>
-    <PackageToInclude Include="Microsoft.CodeAnalysis.VisualBasic"/>    
+    <PackageToInclude Include="Microsoft.CodeAnalysis.VisualBasic"/>
     <PackageToInclude Include="$(XUnitRunnerPackageId)" />
   </ItemGroup>
 
@@ -48,7 +45,7 @@
             Text="Error: looks the package $(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion) not restored or missing xunit.console.exe."
     />
     <ItemGroup>
-      <ReferenceCopyLocalPaths 
+      <ReferenceCopyLocalPaths
         Include="$(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\*.*"
         Exclude="$(PackagesDir)$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\xunit.console.exe.config"
       >

--- a/tests/src/Common/external/project.json
+++ b/tests/src/Common/external/project.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
     "Microsoft.CodeAnalysis.Compilers": "1.1.1",
-    "xunit.performance.api": "1.0.0-beta-build0002",
-    "xunit.performance.core": "1.0.0-beta-build0002",
-    "xunit.performance.execution": "1.0.0-beta-build0002",
-    "xunit.performance.metrics": "1.0.0-beta-build0002",
+    "xunit.performance.api": "1.0.0-beta-build0003",
+    "xunit.performance.core": "1.0.0-beta-build0003",
+    "xunit.performance.execution": "1.0.0-beta-build0003",
+    "xunit.performance.metrics": "1.0.0-beta-build0003",
     "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Newtonsoft.Json": "9.0.1",
     "xunit": "2.2.0-beta2-build3300",

--- a/tests/src/JIT/config/benchmark+roslyn/project.json
+++ b/tests/src/JIT/config/benchmark+roslyn/project.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
     "Microsoft.CodeAnalysis.Compilers": "1.1.1",
-    "xunit.performance.api": "1.0.0-beta-build0002",
-    "xunit.performance.core": "1.0.0-beta-build0002",
-    "xunit.performance.execution": "1.0.0-beta-build0002",
-    "xunit.performance.metrics": "1.0.0-beta-build0002",
+    "xunit.performance.api": "1.0.0-beta-build0003",
+    "xunit.performance.core": "1.0.0-beta-build0003",
+    "xunit.performance.execution": "1.0.0-beta-build0003",
+    "xunit.performance.metrics": "1.0.0-beta-build0003",
     "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Microsoft.NETCore.Platforms": "2.0.0-preview1-25214-03",
     "System.Console": "4.4.0-beta-24913-02",

--- a/tests/src/JIT/config/benchmark+serialize/project.json
+++ b/tests/src/JIT/config/benchmark+serialize/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "xunit.performance.api": "1.0.0-beta-build0002",
-    "xunit.performance.core": "1.0.0-beta-build0002",
-    "xunit.performance.execution": "1.0.0-beta-build0002",
-    "xunit.performance.metrics": "1.0.0-beta-build0002",
+    "xunit.performance.api": "1.0.0-beta-build0003",
+    "xunit.performance.core": "1.0.0-beta-build0003",
+    "xunit.performance.execution": "1.0.0-beta-build0003",
+    "xunit.performance.metrics": "1.0.0-beta-build0003",
     "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Microsoft.NETCore.Platforms": "2.0.0-preview1-25214-03",
     "Newtonsoft.Json": "7.0.1",

--- a/tests/src/JIT/config/benchmark/project.json
+++ b/tests/src/JIT/config/benchmark/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "xunit.performance.api": "1.0.0-beta-build0002",
-    "xunit.performance.core": "1.0.0-beta-build0002",
-    "xunit.performance.execution": "1.0.0-beta-build0002",
-    "xunit.performance.metrics": "1.0.0-beta-build0002",
+    "xunit.performance.api": "1.0.0-beta-build0003",
+    "xunit.performance.core": "1.0.0-beta-build0003",
+    "xunit.performance.execution": "1.0.0-beta-build0003",
+    "xunit.performance.metrics": "1.0.0-beta-build0003",
     "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Microsoft.NETCore.Platforms": "2.0.0-preview1-25214-03",
     "System.Collections.NonGeneric": "4.4.0-beta-24913-02",

--- a/tests/src/performance/project.json
+++ b/tests/src/performance/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "xunit.performance.api": "1.0.0-beta-build0002",
-    "xunit.performance.core": "1.0.0-beta-build0002",
-    "xunit.performance.execution": "1.0.0-beta-build0002",
-    "xunit.performance.metrics": "1.0.0-beta-build0002",
+    "xunit.performance.api": "1.0.0-beta-build0003",
+    "xunit.performance.core": "1.0.0-beta-build0003",
+    "xunit.performance.execution": "1.0.0-beta-build0003",
+    "xunit.performance.metrics": "1.0.0-beta-build0003",
     "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.3-alpha-experimental",
     "Microsoft.NETCore.Platforms": "2.0.0-preview1-25214-03",
     "System.Collections.NonGeneric": "4.4.0-beta-24913-02",


### PR DESCRIPTION
- Added error checking to the script and make it fail fast
- Updated the xUnit Performance API version (build0002 -> build0003). This fixes error: `Unable to create custom test framework discoverer type 'xunit.performance.execution.{Platform}'`