### PR TITLE
Update StringBuilder.AppendJoin to approved API 

### DIFF
--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1081,25 +1081,23 @@ namespace System.Text
             return this;
         }
 
-        // Append joined values with a separator between each value.
-        public unsafe StringBuilder AppendJoin(char separator, params object[] values)
-        {
-            // Defer argument validation to the internal function
-            return AppendJoinCore(&separator, 1, values);
-        }
-
-        public unsafe StringBuilder AppendJoin(char separator, params string[] values)
-        {
-            // Defer argument validation to the internal function
-            return AppendJoinCore(&separator, 1, values);
-        }
+        
+        #region AppendJoin
 
         public unsafe StringBuilder AppendJoin(string separator, params object[] values)
         {
             separator = separator ?? string.Empty;
             fixed (char* pSeparator = separator)
             {
-                // Defer argument validation to the internal function
+                return AppendJoinCore(pSeparator, separator.Length, values);
+            }
+        }
+
+        public unsafe StringBuilder AppendJoin<T>(string separator, IEnumerable<T> values)
+        {
+            separator = separator ?? string.Empty;
+            fixed (char* pSeparator = separator)
+            {
                 return AppendJoinCore(pSeparator, separator.Length, values);
             }
         }
@@ -1109,50 +1107,26 @@ namespace System.Text
             separator = separator ?? string.Empty;
             fixed (char* pSeparator = separator)
             {
-                // Defer argument validation to the internal function
                 return AppendJoinCore(pSeparator, separator.Length, values);
             }
+        }
+
+        public unsafe StringBuilder AppendJoin(char separator, params object[] values)
+        {
+            return AppendJoinCore(&separator, 1, values);
         }
 
         public unsafe StringBuilder AppendJoin<T>(char separator, IEnumerable<T> values)
         {
-            // Defer argument validation to the internal function
             return AppendJoinCore(&separator, 1, values);
         }
 
-        public unsafe StringBuilder AppendJoin<T>(string separator, IEnumerable<T> values)
+        public unsafe StringBuilder AppendJoin(char separator, params string[] values)
         {
-            separator = separator ?? string.Empty;
-            fixed (char* pSeparator = separator)
-            {
-                // Defer argument validation to the internal function
-                return AppendJoinCore(pSeparator, separator.Length, values);
-            }
+            return AppendJoinCore(&separator, 1, values);
         }
 
-        private unsafe StringBuilder AppendJoinCore<T>(char* separator, int separatorLength, params T[] values)
-        {
-            if (values == null)
-                throw new ArgumentNullException(nameof(values));
-            Contract.Ensures(Contract.Result<StringBuilder>() != null);
-
-            if (values.Length == 0)
-                return this;
-
-            var value = values[0];
-            if (value != null)
-                Append(value.ToString());
-
-            for (var i = 1; i < values.Length; i++)
-            {
-                Append(separator, separatorLength);
-                value = values[i];
-                if (value != null)
-                    Append(value.ToString());
-            }
-            return this;
-        }
-
+        
         private unsafe StringBuilder AppendJoinCore<T>(char* separator, int separatorLength, IEnumerable<T> values)
         {
             if (values == null)
@@ -1178,6 +1152,32 @@ namespace System.Text
             }
             return this;
         }
+
+        private unsafe StringBuilder AppendJoinCore<T>(char* separator, int separatorLength, T[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException(nameof(values));
+            Contract.Ensures(Contract.Result<StringBuilder>() != null);
+
+            if (values.Length == 0)
+                return this;
+
+            var value = values[0];
+            if (value != null)
+                Append(value.ToString());
+
+            for (var i = 1; i < values.Length; i++)
+            {
+                Append(separator, separatorLength);
+                value = values[i];
+                if (value != null)
+                    Append(value.ToString());
+            }
+            return this;
+        }
+
+        #endregion
+
 
         /*====================================Insert====================================
         **

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1130,8 +1130,7 @@ namespace System.Text
         private unsafe StringBuilder AppendJoinCore<T>(char* separator, int separatorLength, IEnumerable<T> values)
         {
             if (values == null)
-                throw new ArgumentNullException(nameof(values));
-            Contract.Ensures(Contract.Result<StringBuilder>() != null);
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.values);
 
             using (var en = values.GetEnumerator())
             {
@@ -1156,8 +1155,7 @@ namespace System.Text
         private unsafe StringBuilder AppendJoinCore<T>(char* separator, int separatorLength, T[] values)
         {
             if (values == null)
-                throw new ArgumentNullException(nameof(values));
-            Contract.Ensures(Contract.Result<StringBuilder>() != null);
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.values);
 
             if (values.Length == 0)
                 return this;

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1160,16 +1160,14 @@ namespace System.Text
             if (values.Length == 0)
                 return this;
 
-            var value = values[0];
-            if (value != null)
-                Append(value.ToString());
+            if (values[0] != null)
+                Append(values[0].ToString());
 
             for (var i = 1; i < values.Length; i++)
             {
                 Append(separator, separatorLength);
-                value = values[i];
-                if (value != null)
-                    Append(value.ToString());
+                if (values[i] != null)
+                    Append(values[i].ToString());
             }
             return this;
         }

--- a/src/mscorlib/shared/System/Text/StringBuilder.cs
+++ b/src/mscorlib/shared/System/Text/StringBuilder.cs
@@ -1082,13 +1082,29 @@ namespace System.Text
         }
 
         // Append joined values with a separator between each value.
-        public unsafe StringBuilder AppendJoin<T>(char separator, params T[] values)
+        public unsafe StringBuilder AppendJoin(char separator, params object[] values)
         {
             // Defer argument validation to the internal function
             return AppendJoinCore(&separator, 1, values);
         }
 
-        public unsafe StringBuilder AppendJoin<T>(string separator, params T[] values)
+        public unsafe StringBuilder AppendJoin(char separator, params string[] values)
+        {
+            // Defer argument validation to the internal function
+            return AppendJoinCore(&separator, 1, values);
+        }
+
+        public unsafe StringBuilder AppendJoin(string separator, params object[] values)
+        {
+            separator = separator ?? string.Empty;
+            fixed (char* pSeparator = separator)
+            {
+                // Defer argument validation to the internal function
+                return AppendJoinCore(pSeparator, separator.Length, values);
+            }
+        }
+
+        public unsafe StringBuilder AppendJoin(string separator, params string[] values)
         {
             separator = separator ?? string.Empty;
             fixed (char* pSeparator = separator)

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -416,6 +416,7 @@ namespace System
         type,
         stateMachine,
         pHandle,
+        values
     }
 
     //


### PR DESCRIPTION
See https://github.com/dotnet/corefx/issues/3419

- [x] Q: Is it worth specializing the `string[]` overloads to not call `.ToString()` on strings? The array implementation is generic, so I wonder if that optimization is already done.
- [x] Q: Is it worth specializing concat-only loops when the separator is null or empty so that `Append(&string.Empty, 0)` isn't called in the loop?
- [x] Q: Is it better to access each array element twice rather than putting every array element in a local to check for null?
- [x] Q: Do any tests need to be added to https://github.com/dotnet/coreclr/blob/master/tests/src/CoreMangLib/cti/system/text/stringbuilder or just https://github.com/dotnet/corefx/blob/master/src/System.Runtime/tests/System/Text/StringBuilderTests.cs?
<br>

- [x] TODO: corefx PR with tests on this PR


/cc @karelz @AlexGhiondea @joperezr @danmosemsft 