### PR TITLE
[x86/Linux] Relax inst_JMP assert condition

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2692,15 +2692,11 @@ void CodeGen::genExitCode(BasicBlock* block)
 
 void CodeGen::genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKind, GenTreePtr failBlk)
 {
-    // For non-debuggable code, find and use the helper block for
-    // raising the exception. The block may be shared by other trees too.
-    //
-    // Otherwise, the code to throw the exception will be generated inline,
-    // and we will jump around it in the normal non-exception case
-    bool useExnThrowingBlock = !compiler->opts.compDbgCode;
-
-    if (useExnThrowingBlock)
+    if (!compiler->opts.compDbgCode)
     {
+        /* For non-debuggable code, find and use the helper block for
+           raising the exception. The block may be shared by other trees too. */
+
         BasicBlock* tgtBlk;
 
         if (failBlk)
@@ -2731,6 +2727,9 @@ void CodeGen::genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKi
     }
     else
     {
+        /* The code to throw the exception will be generated inline, and
+           we will jump around it in the normal non-exception case */
+
         BasicBlock*  tgtBlk          = nullptr;
         emitJumpKind reverseJumpKind = emitter::emitReverseJumpKind(jumpKind);
         if (reverseJumpKind != jumpKind)

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2692,18 +2692,12 @@ void CodeGen::genExitCode(BasicBlock* block)
 
 void CodeGen::genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKind, GenTreePtr failBlk)
 {
-    /* For non-debuggable code, find and use the helper block for
-       raising the exception. The block may be shared by other trees too.
-
-       Otherwise, the code to throw the exception will be generated inline,
-       and we will jump around it in the normal non-exception case */
+    // For non-debuggable code, find and use the helper block for
+    // raising the exception. The block may be shared by other trees too.
+    //
+    // Otherwise, the code to throw the exception will be generated inline,
+    // and we will jump around it in the normal non-exception case
     bool useExnThrowingBlock = !compiler->opts.compDbgCode;
-
-#if !FEATURE_FIXED_OUT_ARGS
-    /* Allow the use of exception throwing blocks only for EBP frame.
-       (two basic blocks may have different stack level due to push/pop) */
-    useExnThrowingBlock = useExnThrowingBlock && (compiler->rpFrameType != FT_ESP_FRAME);
-#endif
 
     if (useExnThrowingBlock)
     {

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2707,7 +2707,7 @@ void CodeGen::genJumpToThrowHlpBlk(emitJumpKind jumpKind, SpecialCodeKind codeKi
 
     if (useExnThrowingBlock)
     {
-       BasicBlock* tgtBlk;
+        BasicBlock* tgtBlk;
 
         if (failBlk)
         {

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -239,16 +239,18 @@ void CodeGen::instNop(unsigned size)
 void CodeGen::inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock)
 {
 #if !FEATURE_FIXED_OUT_ARGS
-// On the x86 we are pushing (and changing the stack level), but on x64 and other archs we have
-// a fixed outgoing args area that we store into and we never change the stack level when calling methods.
-//
-// Thus only on x86 do we need to assert that the stack level at the target block matches the current stack level.
-//
-#ifndef UNIX_X86_ABI
-    assert(tgtBlock->bbTgtStkDepth * sizeof(int) == genStackLevel || isFramePointerUsed());
-#else
+    // On the x86 we are pushing (and changing the stack level), but on x64 and other archs we have
+    // a fixed outgoing args area that we store into and we never change the stack level when calling methods.
+    //
+    // Thus only on x86 do we need to assert that the stack level at the target block matches the current stack level.
+    //
+    CLANG_FORMAT_COMMENT_ANCHOR;
+
+#ifdef UNIX_X86_ABI
     // bbTgtStkDepth is a (pure) argument count (stack alignment padding should be excluded).
-    assert(tgtBlock->bbTgtStkDepth * sizeof(int) == genStackLevel - curNestedAlignment || isFramePointerUsed());
+    assert((tgtBlock->bbTgtStkDepth * sizeof(int) == (genStackLevel - curNestedAlignment)) || isFramePointerUsed());
+#else
+    assert((tgtBlock->bbTgtStkDepth * sizeof(int) == genStackLevel) || isFramePointerUsed());
 #endif
 #endif // !FEATURE_FIXED_OUT_ARGS
 

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -239,11 +239,11 @@ void CodeGen::instNop(unsigned size)
 void CodeGen::inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock)
 {
 #if !FEATURE_FIXED_OUT_ARGS
-    // On the x86 we are pushing (and changing the stack level), but on x64 and other archs we have
-    // a fixed outgoing args area that we store into and we never change the stack level when calling methods.
-    //
-    // Thus only on x86 do we need to assert that the stack level at the target block matches the current stack level.
-    //
+// On the x86 we are pushing (and changing the stack level), but on x64 and other archs we have
+// a fixed outgoing args area that we store into and we never change the stack level when calling methods.
+//
+// Thus only on x86 do we need to assert that the stack level at the target block matches the current stack level.
+//
 #ifndef UNIX_X86_ABI
     assert(tgtBlock->bbTgtStkDepth * sizeof(int) == genStackLevel || isFramePointerUsed());
 #else

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -244,8 +244,13 @@ void CodeGen::inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock)
     //
     // Thus only on x86 do we need to assert that the stack level at the target block matches the current stack level.
     //
-    assert(tgtBlock->bbTgtStkDepth * sizeof(int) == genStackLevel || compiler->rpFrameType != FT_ESP_FRAME);
+#ifndef UNIX_X86_ABI
+    assert(tgtBlock->bbTgtStkDepth * sizeof(int) == genStackLevel || isFramePointerUsed());
+#else
+    // bbTgtStkDepth is a (pure) argument count (stack alignment padding should be excluded).
+    assert(tgtBlock->bbTgtStkDepth * sizeof(int) == genStackLevel - curNestedAlignment || isFramePointerUsed());
 #endif
+#endif // !FEATURE_FIXED_OUT_ARGS
 
     getEmitter()->emitIns_J(emitter::emitJumpKindToIns(jmp), tgtBlock);
 }


### PR DESCRIPTION
In x86/Linux codegen, jump to another basic block is allowed only when two blocks have the same stack level, or the method is non-ESP framed.

Stack alignment padding is not included for the stack level of target basic block, but included for that of current basic block.

This difference results in the assertion failure discussed in #11061.

This commit relaxes assert condition to fix #11061.


