### PR TITLE
[WIP][RyuJIT/ARM32] Implement the model kill for CORINFO_HELP_ASSGN_BYREF helper

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -631,6 +631,8 @@ regMaskTP Compiler::compHelperCallKillSet(CorInfoHelpFunc helper)
             return RBM_WRITE_BARRIER_SRC_BYREF | RBM_WRITE_BARRIER_DST_BYREF | RBM_CALLEE_TRASH_NOGC;
 #elif defined(_TARGET_X86_)
             return RBM_ESI | RBM_EDI | RBM_ECX;
+#elif defined(_TARGET_ARM_)
+            return RBM_ARG_1 | RBM_ARG_0 | RBM_CALLEE_TRASH_NOGC;
 #else
             NYI("Model kill set for CORINFO_HELP_ASSIGN_BYREF on target arch");
             return RBM_CALLEE_TRASH;


### PR DESCRIPTION
The CORINFO_HELP_ASSIGN_BYREF helper is used in #10721 PR.
So the assertion of setting the model kill for CORINFO_HELP_ASSIGN_BYREF HELPER would be occurred on running some tests.

Related Main Issue : #8496, #11057 