### PR TITLE
Add Dev/Ino fields to Interop.Sys.FileStatus

### DIFF
--- a/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Stat.cs
+++ b/src/mscorlib/shared/Interop/Unix/System.Native/Interop.Stat.cs
@@ -27,6 +27,8 @@ internal static partial class Interop
             internal long MTime;
             internal long CTime;
             internal long BirthTime;
+            internal long Dev;
+            internal long Ino;
         }
 
         internal static class FileTypes


### PR DESCRIPTION
To fix https://github.com/dotnet/corefx/issues/18521, I need to modify SystemNative_Stat and friends to pass back in the FileStatus struct the st_dev/st_ino values.  But before I can do that in corefx, coreclr's version of FileStatus needs to be increased in size to contain the two additional fields; otherwise, attempting to change System.Native.so/dylib to write to those fields in corefx will stomp over memory when used by coreclr.

Contributes to https://github.com/dotnet/corefx/issues/18521
cc: @janvorli, @JeremyKuhne 