### PR TITLE
Spill side-effects in impAssignMultiRegTypeToVar.

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -15051,7 +15051,7 @@ void Compiler::impMarkLclDstNotPromotable(unsigned tmpNum, GenTreePtr src, CORIN
 GenTreePtr Compiler::impAssignMultiRegTypeToVar(GenTreePtr op, CORINFO_CLASS_HANDLE hClass)
 {
     unsigned tmpNum = lvaGrabTemp(true DEBUGARG("Return value temp for multireg return."));
-    impAssignTempGen(tmpNum, op, hClass, (unsigned)CHECK_SPILL_NONE);
+    impAssignTempGen(tmpNum, op, hClass, (unsigned)CHECK_SPILL_ALL);
     GenTreePtr ret = gtNewLclvNode(tmpNum, op->gtType);
 
     // TODO-1stClassStructs: Handle constant propagation and CSE-ing of multireg returns.

--- a/tests/src/JIT/Regression/JitBlue/GitHub_10940/GitHub_10940.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_10940/GitHub_10940.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+// This test checks whether or not the JIT properly spills side effects in the importer when dumping multi-reg values
+// to temps. If the JIT does not do so correctly, the calls to GetString() and GetDecimal() will be reordered and the
+// test will fail with exit code 0; if it does do so correctly, the calls will not be reordered and the test will
+// pass.
+
+class Test
+{
+    abstract class ValueSourceBase
+    {
+        public abstract string GetString();
+        public abstract decimal GetDecimal();
+        public abstract int GetReturnValue();
+    }
+
+    class ValueSource : ValueSourceBase
+    {
+        int rv;
+
+        public override string GetString()
+        {
+            rv = 0;
+            return "";
+        }
+
+        public override decimal GetDecimal()
+        {
+            rv = 100;
+            return 0;
+        }
+
+        public override int GetReturnValue()
+        {
+            return rv;
+        }
+    }
+
+    Test(string s, decimal d)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int M(ValueSourceBase vs)
+    {
+        new Test(vs.GetString(), vs.GetDecimal());
+        return vs.GetReturnValue();
+    }
+
+    static int Main()
+    {
+        return M(new ValueSource());
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_10940/GitHub_10940.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_10940/GitHub_10940.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_10940.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
This importer function converts IR from the form
```
    tree
```
to
```
            /- tree
    STMT - =
            \- lclVar
```

in order to conform to the JIT's representation of multi-register values.
Today, it does not check whether or not the tree being spilled has any
side-effects that may interfere with the side-effects of trees that are
already on the evaluation stack, which can lead to bad codegen. This
change fixes this function to spill any side-effects on the stack
before generating the temp assign.

Fixes #10940.