### PR TITLE
Update CheckProjects to not fail for non-dev CORE_ROOT

### DIFF
--- a/tests/src/JIT/CheckProjects/CheckProjects.cs
+++ b/tests/src/JIT/CheckProjects/CheckProjects.cs
@@ -52,9 +52,9 @@ internal class ScanProjectFiles
 
             if (binIndex < 0)
             {
-                Console.WriteLine("CORE_ROOT must be set to full path to repo test dir; was '{0}'.",
-                    coreRoot);
-                return -1;
+                Console.WriteLine("No bin directory found in CORE_ROOT path `{0}`," + 
+                    " so no checking will be performed.", coreRoot);
+                return 100;
             }
 
             string repoRoot = coreRoot.Substring(0, binIndex);
@@ -78,8 +78,8 @@ internal class ScanProjectFiles
 
         if (!Directory.Exists(projectRoot))
         {
-            Console.WriteLine("Project directory does not exist");
-            return -1;
+            Console.WriteLine("Project directory does not exist, so no checking will be performed.");
+            return 100;
         }
 
         DirectoryInfo projectRootDir = new DirectoryInfo(projectRoot);


### PR DESCRIPTION
CheckProjects expects to be able to find the jit test project files
relative to the value of the `CORE_ROOT` environment variable. This
fails when we have test setups like cross-tests or helix where the
test binary tree has been copied away from the repo after building.

Tolerate these cases by returning a success code if the `CORE_ROOT`
path is not pointing at the expected place.

Fixes #11079.
Fixes #10635.