### PR TITLE
[Local GC] Ensure that handle creation returns null on failure instead of throwing

### DIFF
--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -47,8 +47,12 @@ OBJECTHANDLE GCHandleStore::CreateDependentHandle(Object* primary, Object* secon
 {
     HHANDLETABLE handletable = _underlyingBucket.pTable[GetCurrentThreadHomeHeapNumber()];
     OBJECTHANDLE handle = ::HndCreateHandle(handletable, HNDTYPE_DEPENDENT, ObjectToOBJECTREF(primary));
-    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
+    if (!handle)
+    {
+        return nullptr;
+    }
 
+    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
     return handle;
 }
 

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -285,12 +285,7 @@ OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF obje
 {
     CONTRACTL
     {
-#ifdef FEATURE_REDHAWK
-        // Redhawk returns NULL on failure.
         NOTHROW;
-#else
-        THROWS;
-#endif
         GC_NOTRIGGER;
         if (object != NULL) 
         { 
@@ -308,8 +303,7 @@ OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF obje
     if (g_pConfig->ShouldInjectFault(INJECTFAULT_HANDLETABLE))
     {
         FAULT_NOT_FATAL();
-        char *a = new char;
-        delete a;
+        return NULL;
     }
 #endif // _DEBUG && !FEATURE_REDHAWK
 
@@ -331,11 +325,7 @@ OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF obje
     // did the allocation succeed?
     if (!handle)
     {
-#ifdef FEATURE_REDHAWK
         return NULL;
-#else
-        ThrowOutOfMemory();
-#endif
     }
 
 #ifdef DEBUG_DestroyedHandleValue

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -961,12 +961,12 @@ BOOL SegmentHandleAsyncPinHandles (TableSegment *pSegment)
 }
 
 // Replace an async pin handle with one from default domain
-void SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTargetTable)
+bool SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTargetTable)
 {
     CONTRACTL
     {
         GC_NOTRIGGER;
-        THROWS;
+        NOTHROW;
         MODE_COOPERATIVE;
     }
     CONTRACTL_END;
@@ -975,7 +975,7 @@ void SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTarge
     if (uBlock == BLOCK_INVALID)
     {
         // There is no pinning handles.
-        return;
+        return true;
     }
     for (uBlock = 0; uBlock < pSegment->bEmptyLine; uBlock ++)
     {
@@ -1005,11 +1005,19 @@ void SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTarge
                 BashMTForPinnedObject(ObjectToOBJECTREF(value));
 
                 overlapped->m_pinSelf = HndCreateHandle((HHANDLETABLE)pTargetTable, HNDTYPE_ASYNCPINNED, ObjectToOBJECTREF(value));
+                if (!overlapped->m_pinSelf)
+                {
+                    // failed to allocate a new handle - callers have to handle this.
+                    return false;
+                }
+
                 *pValue = NULL;
             }
             pValue ++;
         } while (pValue != pLast);
     }
+
+    return true;
 }
 
 // Mark all non-pending AsyncPinHandle ready for cleanup.
@@ -1076,21 +1084,19 @@ void TableRelocateAsyncPinHandles(HandleTable *pTable, HandleTable *pTargetTable
 #endif
 
     // Step 1: replace pinning handles with ones from default domain
-    EX_TRY
+    bool wasSuccessful = true;
+    while (pSegment)
     {
-        while (pSegment)
+        wasSuccessful = wasSuccessful && SegmentRelocateAsyncPinHandles (pSegment, pTargetTable);
+        if (!wasSuccessful)
         {
-            SegmentRelocateAsyncPinHandles (pSegment, pTargetTable);
-            pSegment = pSegment->pNextSegment;
+            break;
         }
-    }
-    EX_CATCH
-    {
-        fGotException = TRUE;
-    }
-    EX_END_CATCH(SwallowAllExceptions);
 
-    if (!fGotException)
+        pSegment = pSegment->pNextSegment;
+    }
+
+    if (wasSuccessful)
     {
         return;
     }
@@ -2720,9 +2726,8 @@ void TableFreeBulkUnpreparedHandles(HandleTable *pTable, uint32_t uType, const O
 {
     CONTRACTL
     {
-        THROWS;
+        NOTHROW;
         WRAPPER(GC_TRIGGERS);
-        INJECT_FAULT(COMPlusThrowOM());
     }
     CONTRACTL_END;
 

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -1076,6 +1076,7 @@ void TableRelocateAsyncPinHandles(HandleTable *pTable, HandleTable *pTargetTable
 
     BOOL fGotException = FALSE;
     TableSegment *pSegment = pTable->pSegmentList;
+    bool wasSuccessful = true;
     
 #ifdef _DEBUG
     // on debug builds, execute the OOM path 10% of the time.
@@ -1084,7 +1085,6 @@ void TableRelocateAsyncPinHandles(HandleTable *pTable, HandleTable *pTargetTable
 #endif
 
     // Step 1: replace pinning handles with ones from default domain
-    bool wasSuccessful = true;
     while (pSegment)
     {
         wasSuccessful = wasSuccessful && SegmentRelocateAsyncPinHandles (pSegment, pTargetTable);

--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -1423,7 +1423,7 @@ PTR_TableSegment CALLBACK StandardSegmentIterator(PTR_HandleTable pTable, PTR_Ta
 {
     CONTRACTL
     {
-        WRAPPER(THROWS);
+        WRAPPER(NOTHROW);
         WRAPPER(GC_TRIGGERS);
         FORBID_FAULT;
         SUPPORTS_DAC;

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -4280,6 +4280,11 @@ void AppDomain::Init()
         m_handleStore = GCHandleUtilities::GetGCHandleManager()->CreateHandleStore((void*)(uintptr_t)m_dwIndex.m_dwIndex);
     }
 
+    if (!m_handleStore)
+    {
+        COMPlusThrowOM();
+    }
+
 #endif // CROSSGEN_COMPILE
 
 #ifdef FEATURE_TYPEEQUIVALENCE

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1245,7 +1245,13 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        return ::CreateHandleCommon(m_handleStore, OBJECTREFToObject(object), type);
+        OBJECTHANDLE hnd = m_handleStore->CreateHandleOfType(OBJECTREFToObject(object), type);
+        if (!hnd)
+        {
+            COMPlusThrowOM();
+        }
+
+        return hnd;
     }
 
     OBJECTHANDLE CreateHandle(OBJECTREF object)
@@ -1344,7 +1350,13 @@ public:
         }
         CONTRACTL_END;
 
-        return ::CreateDependentHandle(m_handleStore, primary, secondary);
+        OBJECTHANDLE hnd = m_handleStore->CreateDependentHandle(OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
+        if (!hnd)
+        {
+            COMPlusThrowOM();
+        }
+
+        return hnd;
     }
 #endif // DACCESS_COMPILE && !CROSSGEN_COMPILE
 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1244,7 +1244,8 @@ public:
     OBJECTHANDLE CreateTypedHandle(OBJECTREF object, int type)
     {
         WRAPPER_NO_CONTRACT;
-        return m_handleStore->CreateHandleOfType(OBJECTREFToObject(object), type);
+
+        return ::CreateHandleCommon(m_handleStore, OBJECTREFToObject(object), type);
     }
 
     OBJECTHANDLE CreateHandle(OBJECTREF object)
@@ -1317,7 +1318,7 @@ public:
     {
         CONTRACTL
         {
-            THROWS;
+            NOTHROW;
             GC_NOTRIGGER;
             MODE_COOPERATIVE;
         }
@@ -1337,13 +1338,13 @@ public:
     {
         CONTRACTL
         {
-            THROWS;
+            NOTHROW;
             GC_NOTRIGGER;
             MODE_COOPERATIVE;
         }
         CONTRACTL_END;
 
-        return m_handleStore->CreateDependentHandle(OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
+        return ::CreateDependentHandle(m_handleStore, primary, secondary);
     }
 #endif // DACCESS_COMPILE && !CROSSGEN_COMPILE
 

--- a/src/vm/gchandleutilities.h
+++ b/src/vm/gchandleutilities.h
@@ -63,95 +63,132 @@ inline BOOL ObjectHandleIsNull(OBJECTHANDLE handle)
 #ifndef DACCESS_COMPILE
 
 // Handle creation convenience functions
+inline OBJECTHANDLE CreateHandleCommon(IGCHandleStore* store, Object* object, int type)
+{
+    OBJECTHANDLE hnd = store->CreateHandleOfType(object, type);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
+}
 
 inline OBJECTHANDLE CreateHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
 }
 
 inline OBJECTHANDLE CreateWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
 }
 
 inline OBJECTHANDLE CreateShortWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
 }
 
 inline OBJECTHANDLE CreateLongWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
 }
 
 inline OBJECTHANDLE CreateStrongHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
+    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_STRONG);
 }
 
 inline OBJECTHANDLE CreatePinningHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
+    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_PINNED);
 }
 
 inline OBJECTHANDLE CreateAsyncPinningHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
+    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
 }
 
 inline OBJECTHANDLE CreateRefcountedHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
 }
 
 inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
 }
 
 inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object, int heapToAffinitizeTo)
 {
-    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_SIZEDREF, heapToAffinitizeTo);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_SIZEDREF, heapToAffinitizeTo);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
+}
+
+inline OBJECTHANDLE CreateDependentHandle(IGCHandleStore* store, OBJECTREF primary, OBJECTREF secondary)
+{
+    OBJECTHANDLE hnd = store->CreateDependentHandle(OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 // Global handle creation convenience functions
+inline OBJECTHANDLE CreateGlobalHandleCommon(Object* object, int type)
+{
+    OBJECTHANDLE hnd = GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(object, type);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
+}
 
 inline OBJECTHANDLE CreateGlobalHandle(OBJECTREF object)
 {
     CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
 }
 
 inline OBJECTHANDLE CreateGlobalWeakHandle(OBJECTREF object)
 {
-    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
 }
 
 inline OBJECTHANDLE CreateGlobalShortWeakHandle(OBJECTREF object)
 {
     CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
 }
 
 inline OBJECTHANDLE CreateGlobalLongWeakHandle(OBJECTREF object)
 {
-    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
 }
 
 inline OBJECTHANDLE CreateGlobalStrongHandle(OBJECTREF object)
 {
     CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
+    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_STRONG);
 }
 
 inline OBJECTHANDLE CreateGlobalPinningHandle(OBJECTREF object)
 {
-    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
+    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_PINNED);
 }
 
 inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 {
-    return GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
 }
 
 // Special handle creation convenience functions

--- a/src/vm/gchandleutilities.h
+++ b/src/vm/gchandleutilities.h
@@ -63,9 +63,10 @@ inline BOOL ObjectHandleIsNull(OBJECTHANDLE handle)
 #ifndef DACCESS_COMPILE
 
 // Handle creation convenience functions
-inline OBJECTHANDLE CreateHandleCommon(IGCHandleStore* store, Object* object, int type)
+
+inline OBJECTHANDLE CreateHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    OBJECTHANDLE hnd = store->CreateHandleOfType(object, type);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
     if (!hnd)
     {
         COMPlusThrowOM();
@@ -74,49 +75,92 @@ inline OBJECTHANDLE CreateHandleCommon(IGCHandleStore* store, Object* object, in
     return hnd;
 }
 
-inline OBJECTHANDLE CreateHandle(IGCHandleStore* store, OBJECTREF object)
-{
-    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
-}
-
 inline OBJECTHANDLE CreateWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateShortWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateLongWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateStrongHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_STRONG);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreatePinningHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_PINNED);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateAsyncPinningHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateRefcountedHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return CreateHandleCommon(store, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+    OBJECTHANDLE hnd = store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object, int heapToAffinitizeTo)
@@ -130,65 +174,86 @@ inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object
     return hnd;
 }
 
-inline OBJECTHANDLE CreateDependentHandle(IGCHandleStore* store, OBJECTREF primary, OBJECTREF secondary)
-{
-    OBJECTHANDLE hnd = store->CreateDependentHandle(OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
-    if (!hnd)
-    {
-        COMPlusThrowOM();
-    }
-
-    return hnd;
-}
-
 // Global handle creation convenience functions
-inline OBJECTHANDLE CreateGlobalHandleCommon(Object* object, int type)
-{
-    OBJECTHANDLE hnd = GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(object, type);
-    if (!hnd)
-    {
-        COMPlusThrowOM();
-    }
-
-    return hnd;
-}
 
 inline OBJECTHANDLE CreateGlobalHandle(OBJECTREF object)
 {
     CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+    OBJECTHANDLE hnd = GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateGlobalWeakHandle(OBJECTREF object)
 {
-    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+    OBJECTHANDLE hnd = GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateGlobalShortWeakHandle(OBJECTREF object)
 {
     CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+    OBJECTHANDLE hnd = GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateGlobalLongWeakHandle(OBJECTREF object)
 {
-    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+    OBJECTHANDLE hnd = GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateGlobalStrongHandle(OBJECTREF object)
 {
     CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_STRONG);
+    OBJECTHANDLE hnd = GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateGlobalPinningHandle(OBJECTREF object)
 {
-    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_PINNED);
+    OBJECTHANDLE hnd = GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 {
-    return CreateGlobalHandleCommon(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+    OBJECTHANDLE hnd = GCHandleUtilities::GetGCHandleManager()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 // Special handle creation convenience functions
@@ -196,14 +261,26 @@ inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 #ifdef FEATURE_COMINTEROP
 inline OBJECTHANDLE CreateWinRTWeakHandle(IGCHandleStore* store, OBJECTREF object, IWeakReference* pWinRTWeakReference)
 {
-    return store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_WEAK_WINRT, (void*)pWinRTWeakReference);
+    OBJECTHANDLE hnd = store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_WEAK_WINRT, (void*)pWinRTWeakReference);
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 #endif // FEATURE_COMINTEROP
 
 // Creates a variable-strength handle
 inline OBJECTHANDLE CreateVariableHandle(IGCHandleStore* store, OBJECTREF object, uint32_t type)
 {
-    return store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_VARIABLE, (void*)((uintptr_t)type));
+    OBJECTHANDLE hnd = store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_VARIABLE, (void*)((uintptr_t)type));
+    if (!hnd)
+    {
+        COMPlusThrowOM();
+    }
+
+    return hnd;
 }
 
 // Handle destruction convenience functions


### PR DESCRIPTION
`HndCreateHandle` today throws an `OutOfMemoryException` when it fails to allocate a new handle. It's inappropriate for anything on the GC side of the interface to throw exceptions, and particularly OOM exceptions, since those are both EE-specific details. This PR addresses this problem to do what Redhawk does and return null when a handle can't be created.

The change to `HndCreateHandle` itself is simple, since CoreRT/ProjectN already return null on allocation failure. The rest of this PR addresses places that expect `HndCreateHandle` to throw instead of returning null:

1. `TableRelocateAsyncPinHandles` and `SegmentRelocateAsyncPinHandles` - `TableRelocateAsyncPinHandles` tries to catch the OOM exception that `HndCreateHandle` throws (called by `SegmentRelocateAsyncPinHandles`. To remedy this, `SegmentRelocateAsyncPinHandles` checks `HndCreateHandle`'s return and, if null, returns `false` to `TableRelocateAsyncPinHandles`, which it interprets as an OOM in the same way that it did before (by catching the exception).
2. All calls of `IGCHandleManager::CreateHandleOfType` from the EE must check whether its return value is null and throw an OOM if so. Luckily, all calls to this API are routed through helpers in `gchandleutilities.h`, so this check only has to be done in a limited number of places. I did find one handle creation scenario (in `appdomain.hpp` that didn't use the common helpers, so I changed it to use the helpers for the sake of uniformity.

This PR also modifies `Ref_InitializeHandleTableBucket` to not throw. `Ref_InitializeHandleTableBucket` already returns false on failure.

cc @adityamandaleeka @Maoni0 @sergiy-k @jkotas 