### PR TITLE
Use finally in EC.R rather than catch+throw

### DIFF
--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -153,16 +153,11 @@ namespace System.Threading
                 ExecutionContext.Restore(currentThread, executionContext);
                 callback(state);
             }
-            catch
+            finally
             {
-                // Note: we have a "catch" rather than a "finally" because we want
-                // to stop the first pass of EH here.  That way we can restore the previous
-                // context before any of our callers' EH filters run.  That means we need to
-                // end the scope separately in the non-exceptional case below.
+                // Restore the previous context before returning
                 ecsw.Undo(currentThread);
-                throw;
             }
-            ecsw.Undo(currentThread);
         }
 
         internal static void Restore(Thread currentThread, ExecutionContext executionContext)


### PR DESCRIPTION
Allows the opportunity to benefit from [Finally Cloning](https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/finally-optimizations.md#finally-cloning) by the Jit. 

I didn't quite understand the comment and whether there was some mechanism I wasn't picking up on (e.g. a first chance exception "filter") but not sure what it refers to. 

It was from the original open sourcing, so maybe something was different at that time. Exception from the undo for example? (only seems to be a catch -> Environment.FailFast in the undo path)

I checked Reference Source for 4.7 to see if there was more clarity around this comment and it uses finally for undoing the ec in [ExecutionContext.RunInternal](http://referencesource.microsoft.com/#mscorlib/system/threading/executioncontext.cs,956) and not catch+throw.

/cc @jkotas @AndyAyersMS @stephentoub 
