### PR TITLE
Fix unittest `LPSTRTest`

### DIFF
--- a/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTest.cs
+++ b/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTest.cs
@@ -31,6 +31,25 @@ class Test
     }
     #endregion
 
+    #region "Helper"
+    // ************************************************************
+    // Returns the appropriate exit code
+    // *************************************************************
+    static int ExitTest()
+    {
+        if (fails == 0)
+        {
+            Console.WriteLine("PASS");
+            return 100;
+        }
+        else
+        {
+            Console.WriteLine("FAIL - " + fails + " failure(s) occurred");
+            return 101;
+        }
+    }
+    #endregion
+
     #region ReversePInvoke
 
     public static string Call_DelMarshal_InOut(string s)
@@ -219,6 +238,6 @@ class Test
             ReportFailure("Method ReverseP_MarshalStrB_InOut[Managed Side],return value is false");
         }
         #endregion
-        return 100;
+        return ExitTest();
     }
 }

--- a/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTestNative.cpp
+++ b/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTestNative.cpp
@@ -123,16 +123,16 @@ extern "C" DLL_EXPORT int __cdecl Writeline(char * pFormat, int i, char c, doubl
 }
 
 
-typedef LPCTSTR (__stdcall * Test_DelMarshal_InOut)(/*[in]*/ LPCSTR s);
+typedef LPCWSTR (__stdcall * Test_DelMarshal_InOut)(/*[in]*/ LPCSTR s);
 extern "C" DLL_EXPORT BOOL __cdecl RPinvoke_DelMarshal_InOut(Test_DelMarshal_InOut d, /*[in]*/ LPCSTR s)
 {
-    LPCTSTR str = d(s);
-    const char *ret = "Return";    
+    LPCWSTR str = d(s);
+    LPCWSTR ret = W("Return");    
 
-    size_t lenstr = _tcslen(str);
-    size_t lenret = _tcslen(ret);
+    size_t lenstr = wcslen(str);
+    size_t lenret = wcslen(ret);
 
-    if((lenret != lenstr)||(_tcsncmp(str,ret,lenstr)!=0))
+    if((lenret != lenstr)||(wcsncmp(str,ret,lenstr)!=0))
     {
         printf("Error in RPinvoke_DelMarshal_InOut, Returned value didn't match\n");
         return FALSE;


### PR DESCRIPTION
The test case Interop.StringMarshalling.LPSTR.LPSTRTest
always returned exit code 100(pass) even if it actually failed.
This implements `ExitTest()` in the same manner with `LPTSTRTest`.