### PR TITLE
Faster path default EC

### DIFF
--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -70,6 +70,26 @@ namespace System.Threading
                 ExecutionContext.RestoreDefault(currentThread, defaultContext);
             }
         }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void SetDefaults()
+        {
+            var currentThread = Thread.CurrentThread;
+            var defaultContext = ExecutionContext.Default;
+
+            // The common case is that these have not changed, 
+            // so avoid the GC memory barrier cost of a write if not needed.
+            if (currentThread.SynchronizationContext != null)
+            {
+                currentThread.SynchronizationContext = null;
+            }
+
+            if (currentThread.ExecutionContext != defaultContext)
+            {
+                currentThread.ExecutionContext = defaultContext;
+            }
+        }
     }
 
     [Serializable]

--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -71,7 +71,6 @@ namespace System.Threading
             }
         }
 
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void SetDefaults()
         {
@@ -130,6 +129,7 @@ namespace System.Threading
         {
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ExecutionContext Capture()
         {
             ExecutionContext executionContext = Thread.CurrentThread.ExecutionContext;

--- a/src/mscorlib/shared/System/Threading/ExecutionContext.cs
+++ b/src/mscorlib/shared/System/Threading/ExecutionContext.cs
@@ -51,7 +51,7 @@ namespace System.Threading
         {
             // Current thread passed as parameter to avoid extern current native thread lookup call
             Debug.Assert(currentThread == Thread.CurrentThread);
-            // Default context passed as parameter to avoid static inializer checks in NGen'd code
+            // Default context passed as parameter to avoid static initializer checks in NGen'd code
             Debug.Assert(defaultContext == ExecutionContext.Default);
 
             return (currentThread.ExecutionContext == defaultContext && currentThread.SynchronizationContext == null);
@@ -62,7 +62,7 @@ namespace System.Threading
         {
             // Current thread passed as parameter to avoid extern current native thread lookup call
             Debug.Assert(currentThread == Thread.CurrentThread);
-            // Default context passed as parameter to avoid static inializer checks in NGen'd code
+            // Default context passed as parameter to avoid static initializer checks in NGen'd code
             Debug.Assert(defaultContext == ExecutionContext.Default);
 
             // The common case is that these have not changed, so avoid the GC memory barrier 
@@ -228,7 +228,7 @@ namespace System.Threading
 
         internal static void RunDefaultContext(ContextCallback callback, Object state)
         {
-            // Local copies used and passed to minimise static inializer checks in NGen'd code
+            // Local copies used and passed to minimise static initializer checks in NGen'd code
             // and extern current native thread lookup calls
             ExecutionContext defaultContext = Default;
             Thread currentThread = Thread.CurrentThread;
@@ -256,10 +256,11 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void RestoreDefault(Thread currentThread, ExecutionContext defaultContext)
         {
-            // Passed to minimise static inializer checks in NGen'd code
+            // Passed to minimise static initializer checks in NGen'd code
             // and extern current native thread lookup calls
             Debug.Assert(currentThread == Thread.CurrentThread);
             Debug.Assert(defaultContext == ExecutionContext.Default);
+            Debug.Assert(currentThread.ExecutionContext != defaultContext);
 
             ExecutionContext previous = currentThread.ExecutionContext;
             currentThread.ExecutionContext = defaultContext;
@@ -277,7 +278,7 @@ namespace System.Threading
             // Current thread passed as parameter to avoid extern current native thread lookup call
             Debug.Assert(currentThread == Thread.CurrentThread);
 
-            // Local copies used and passed to minimise static inializer checks in NGen'd code
+            // Local copies used and passed to minimise static initializer checks in NGen'd code
             ExecutionContext defaultContext = Default;
             ExecutionContext previous = currentThread.ExecutionContext ?? defaultContext;
             currentThread.ExecutionContext = executionContext;

--- a/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -1055,7 +1055,7 @@ namespace System.Runtime.CompilerServices
             internal void RunWithDefaultContext()
             {
                 Debug.Assert(m_stateMachine != null, "The state machine must have been set before calling Run.");
-                ExecutionContext.Run(ExecutionContext.Default, InvokeMoveNextCallback, m_stateMachine);
+                ExecutionContext.RunDefaultContext(InvokeMoveNextCallback, m_stateMachine);
             }
 
             /// <summary>Gets a delegate to the InvokeMoveNext method.</summary>

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -2448,6 +2448,11 @@ namespace System.Threading.Tasks
                         // No context, just run the task directly.
                         InnerInvoke();
                     }
+                    else if (ec == ExecutionContext.Default)
+                    {
+                        // Invoke it with the default ExecutionContext
+                        ExecutionContext.RunDefaultContext(s_ecCallback, this);
+                    }
                     else
                     {
                         // Invoke it under the captured ExecutionContext

--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -491,6 +491,9 @@ namespace System.Threading
 
         internal static bool Dispatch()
         {
+            // Put threadpool thread on default context
+            Thread.CurrentThread.ExecutionContext = ExecutionContext.Default;
+
             var workQueue = ThreadPoolGlobals.workQueue;
             //
             // The clock is ticking!  We have ThreadPoolGlobals.TP_QUANTUM milliseconds to get some work done, and then
@@ -1002,7 +1005,7 @@ namespace System.Threading
 #if DEBUG
             MarkExecuted(aborted: false);
 #endif
-            ExecutionContext.Run(ExecutionContext.Default, ccb, this);
+            ExecutionContext.RunDefaultContext(ccb, this);
         }
 
         void IThreadPoolWorkItem.MarkAborted(ThreadAbortException tae)

--- a/src/mscorlib/src/System/Threading/ThreadPool.cs
+++ b/src/mscorlib/src/System/Threading/ThreadPool.cs
@@ -492,7 +492,7 @@ namespace System.Threading
         internal static bool Dispatch()
         {
             // Put threadpool thread on default context
-            Thread.CurrentThread.ExecutionContext = ExecutionContext.Default;
+            ExecutionContextSwitcher.SetDefaults();
 
             var workQueue = ThreadPoolGlobals.workQueue;
             //
@@ -943,6 +943,9 @@ namespace System.Threading
                 WaitCallback cb = callback;
                 callback = null;
                 cb(state);
+
+                // Restore Threadpool thread to defaults if changed by callback
+                ExecutionContextSwitcher.SetDefaults();
             }
             else
             {


### PR DESCRIPTION
Trying again, follow up to https://github.com/dotnet/coreclr/pull/11095

Puts the Threadpool threads on the default context.

Less churn when moving between Default contexts (`ExecutionContext.RunDefaultContext`); with lighter context switching.

Also allows the opportunity to benefit from [Finally Cloning](https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/finally-optimizations.md#finally-cloning) by the Jit in `RunDefaultContext`.

Resolves https://github.com/dotnet/coreclr/issues/11126