### PR TITLE
Inline List.Clear

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -350,6 +350,7 @@ namespace System.Collections.Generic
 
 
         // Clears the contents of List.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Clear()
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())


### PR DESCRIPTION
Even though the two paths are small post jit (non ref and ref) the combination pre-jit in the same function makes it look to big too inline.

Contributes to https://github.com/dotnet/corefx/issues/18390


/cc @jkotas @AndyAyersMS 