### PR TITLE
Add compact entry points for ARM

### DIFF
--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -617,6 +617,11 @@ typedef struct _DacGlobals
     ULONG fn__ThreadpoolMgr__AsyncTimerCallbackCompletion;
     ULONG fn__DACNotifyCompilationFinished;
     ULONG fn__ThePreStub;
+
+#ifdef _TARGET_ARM_
+    ULONG fn__ThePreStubCompactARM;
+#endif // _TARGET_ARM_
+
     ULONG fn__ThePreStubPatchLabel;
     ULONG fn__PrecodeFixupThunk;
     ULONG fn__StubDispatchFixupStub;
@@ -2345,6 +2350,7 @@ typedef ArrayDPTR(signed char) PTR_SBYTE;
 typedef ArrayDPTR(const BYTE) PTR_CBYTE;
 typedef DPTR(INT8)    PTR_INT8;
 typedef DPTR(INT16)   PTR_INT16;
+typedef DPTR(UINT16)  PTR_UINT16;
 typedef DPTR(WORD)    PTR_WORD;
 typedef DPTR(USHORT)  PTR_USHORT;
 typedef DPTR(DWORD)   PTR_DWORD;

--- a/src/vm/arm/asmhelpers.S
+++ b/src/vm/arm/asmhelpers.S
@@ -509,6 +509,24 @@ LOCAL_LABEL(UM2MThunk_WrapperHelper_ArgumentsSetup):
         NESTED_END ThePreStub, _TEXT
 
 // ------------------------------------------------------------------
+        NESTED_ENTRY ThePreStubCompactARM, _TEXT, NoHandler
+
+        // r12 - address of compact entry point + PC_REG_RELATIVE_OFFSET
+
+        PROLOG_WITH_TRANSITION_BLOCK
+
+        mov         r0, r12
+
+        bl          C_FUNC(PreStubGetMethodDescForCompactEntryPoint)
+
+        mov         r12, r0                                          // pMethodDesc
+
+        EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
+
+        b           C_FUNC(ThePreStub)
+
+        NESTED_END ThePreStubCompactARM, _TEXT
+// ------------------------------------------------------------------
 // This method does nothing. It's just a fixed function for the debugger to put a breakpoint on.
         LEAF_ENTRY ThePreStubPatch, _TEXT
         nop

--- a/src/vm/arm/asmhelpers.asm
+++ b/src/vm/arm/asmhelpers.asm
@@ -24,6 +24,7 @@
     IMPORT UMThunkStubRareDisableWorker
     IMPORT UM2MDoADCallBack
     IMPORT PreStubWorker
+    IMPORT PreStubGetMethodDescForCompactEntryPoint
     IMPORT NDirectImportWorker
     IMPORT ObjIsInstanceOfNoGC
     IMPORT ArrayStoreCheck
@@ -567,6 +568,26 @@ UM2MThunk_WrapperHelper_ArgumentsSetup
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
         EPILOG_BRANCH_REG   r12
+
+        NESTED_END
+
+; ------------------------------------------------------------------
+
+        NESTED_ENTRY ThePreStubCompactARM
+
+        ; r12 - address of compact entry point + PC_REG_RELATIVE_OFFSET
+
+        PROLOG_WITH_TRANSITION_BLOCK
+
+        mov         r0, r12
+
+        bl          PreStubGetMethodDescForCompactEntryPoint
+
+        mov         r12, r0                                  ; pMethodDesc
+
+        EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
+
+        b          ThePreStub
 
         NESTED_END
 

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -1333,6 +1333,13 @@ BOOL DoesSlotCallPrestub(PCODE pCode)
 {
     PTR_WORD pInstr = dac_cast<PTR_WORD>(PCODEToPINSTR(pCode));
 
+#ifdef HAS_COMPACT_ENTRYPOINTS
+    if (MethodDescChunk::GetMethodDescFromCompactEntryPoint(pCode, TRUE) != NULL)
+    {
+        return TRUE;
+    }
+#endif // HAS_COMPACT_ENTRYPOINTS
+
     // FixupPrecode
     if (pInstr[0] == 0x46fc && // // mov r12, pc
         pInstr[1] == 0xf8df &&

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -2502,6 +2502,17 @@ inline PCODE GetPreStubEntryPoint()
     return GetEEFuncEntryPoint(ThePreStub);
 }
 
+#if defined(HAS_COMPACT_ENTRYPOINTS) && defined(_TARGET_ARM_)
+
+EXTERN_C void STDCALL ThePreStubCompactARM();
+
+inline PCODE GetPreStubCompactARMEntryPoint()
+{
+    return GetEEFuncEntryPoint(ThePreStubCompactARM);
+}
+
+#endif // defined(HAS_COMPACT_ENTRYPOINTS) && defined(_TARGET_ARM_)
+
 PCODE TheUMThunkPreStub();
 
 PCODE TheVarargNDirectStub(BOOL hasRetBuffArg);

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -2031,23 +2031,18 @@ public:
     // direct call to direct jump.
     //
     // We use (1) for x86 and (2) for 64-bit to get the best performance on each platform.
-    //
+    // For ARM (1) is used.
 
     TADDR AllocateCompactEntryPoints(LoaderAllocator *pLoaderAllocator, AllocMemTracker *pamTracker);
 
     static MethodDesc* GetMethodDescFromCompactEntryPoint(PCODE addr, BOOL fSpeculative = FALSE);
     static SIZE_T SizeOfCompactEntryPoints(int count);
 
-    static BOOL IsCompactEntryPointAtAddress(PCODE addr)
-    {
-#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
-        // Compact entrypoints start at odd addresses
-        LIMITED_METHOD_DAC_CONTRACT;
-        return (addr & 1) != 0;
-#else
-        #error Unsupported platform
-#endif
-    }
+    static BOOL IsCompactEntryPointAtAddress(PCODE addr);
+
+#ifdef _TARGET_ARM_
+    static int GetCompactEntryPointMaxCount ();
+#endif // _TARGET_ARM_
 #endif // HAS_COMPACT_ENTRYPOINTS
 
     FORCEINLINE PTR_MethodTable GetMethodTable()

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -525,6 +525,16 @@ TADDR Precode::AllocateTemporaryEntryPoints(MethodDescChunk *  pChunk,
     // Note that these are just best guesses to save memory. If we guessed wrong,
     // we will allocate a new exact type of precode in GetOrCreatePrecode.
     BOOL fForcedPrecode = pFirstMD->RequiresStableEntryPoint(count > 1);
+
+#ifdef _TARGET_ARM_
+    if (pFirstMD->RequiresMethodDescCallingConvention(count > 1)
+        || count >= MethodDescChunk::GetCompactEntryPointMaxCount ())
+    {
+        // We do not pass method desc on scratch register
+        fForcedPrecode = TRUE;
+    }
+#endif // _TARGET_ARM_
+
     if (!fForcedPrecode && (totalSize > MethodDescChunk::SizeOfCompactEntryPoints(count)))
         return NULL;
 #endif

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -170,6 +170,11 @@ public:
             align = 8;
 #endif // _TARGET_X86_ && HAS_FIXUP_PRECODE
 
+#if defined(_TARGET_ARM_) && defined(HAS_COMPACT_ENTRYPOINTS)
+        // Precodes have to be aligned to allow fast compact entry points check
+        _ASSERTE (align >= sizeof(void*));
+#endif // _TARGET_ARM_ && HAS_COMPACT_ENTRYPOINTS
+
         return align;
     }
 

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -55,6 +55,13 @@
 #ifndef DACCESS_COMPILE 
 
 EXTERN_C void STDCALL ThePreStub();
+
+#if defined(HAS_COMPACT_ENTRYPOINTS) && defined (_TARGET_ARM_)
+
+EXTERN_C void STDCALL ThePreStubCompactARM();
+
+#endif // defined(HAS_COMPACT_ENTRYPOINTS) && defined (_TARGET_ARM_)
+
 EXTERN_C void STDCALL ThePreStubPatch();
 
 //==========================================================================
@@ -1001,6 +1008,21 @@ Stub * MakeInstantiatingStubWorker(MethodDesc *pMD)
     RETURN pstub;
 }
 #endif // defined(FEATURE_SHARE_GENERIC_CODE)
+
+#if defined (HAS_COMPACT_ENTRYPOINTS) && defined (_TARGET_ARM_)
+
+extern "C" MethodDesc * STDCALL PreStubGetMethodDescForCompactEntryPoint (PCODE pCode)
+{
+    _ASSERTE (pCode >= PC_REG_RELATIVE_OFFSET);
+
+    pCode = (PCODE) (pCode - PC_REG_RELATIVE_OFFSET + THUMB_CODE);
+
+    _ASSERTE (MethodDescChunk::IsCompactEntryPointAtAddress (pCode));
+
+    return MethodDescChunk::GetMethodDescFromCompactEntryPoint(pCode, FALSE);
+}
+
+#endif // defined (HAS_COMPACT_ENTRYPOINTS) && defined (_TARGET_ARM_)
 
 //=============================================================================
 // This function generates the real code for a method and installs it into


### PR DESCRIPTION
This pull request adds compact entry points for ARM. 

Related issue: #11076 

For MethodDescChunk with 5 MethodDescs compact entry points will look like this:

```
entry1:
  mov r12, pc
  b CentralJump
entry2:
  mov r12, pc
  b CentralJump
entry3:
  mov r12, pc
  b CentralJump
entry4:
  mov r12, pc
  b CentralJump
entry5:
  mov r12, pc
  b CentralJump
CentraJump:
  ldr pc, pThePreStubCompactARM
  nop
  dw pChunk
  dw pThePreStubCompactARM
```

Compact entry points are encoded in Thumb, each compact entry has 4 byte size, CentralJump is 14 bytes.

ThePreStubCompactARM finds CentralJump by looking into branch offset of compact entry. Then it calculates offset of the compact entry from CentralJump by program counter stored in r12 and, thus, calculates index of MethodDesc in MethodDescChunk. Then,ThePreStubCompactARM loads pointer to MethodDescChunk from CentralJump and obtains MethodDesc, corresponding to the calculated index (this is done by traversing all MethodDescs in MethodDescChunk starting from the first until the MethodDesc with required index is met). After that, ThePreStubCompactARM calls PreStubWorker with obtained MethodDesc, like original ThePreStub.

Estimation on Tizen GUI Xamarin application (https://developer.tizen.org/sites/default/files/documentation/puzzle2.zip) shows, for ReadyToRun mode, that reduction of code heap size is 76 KB, which is 20% of code heap and, approximately, 2.2% of overall per-application CoreCLR memory consumption. For No-Precompilation mode, reduction of code heap size is 216 KB, which is 28% of code heap and, approximately, 2.3% of overall per-application CoreCLR memory consumption.

ReadyToRun mode means the Tizen-default set of precompiled assemblies is in ReadyToRun format, No-Precompilation mode means that there are no precompiled assemblies.

Testing:

- CI: default
- CoreCLR test suite on ARM on Tizen: no regression happened 

Micro-benchmark, provided by @jkotas in https://github.com/dotnet/coreclr/issues/11076#issuecomment-296748946, showed next results:
- Cortex-A7 softfp:
      before: 12.81s (user time)
      after: 10.488s (user time)
- Cortex-A15 softfp:
      before: 5.3s (user time)
      after: 4.68s (user time)

@Dmitri-Botcharnikov @ruben-ayrapetyan 