### PR TITLE
ReadyToRun/Crossgen: Disable cross module generic instantiations from profile data

### DIFF
--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -1199,7 +1199,10 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
             
             PREFIX_ASSUME(pZapSigContext != NULL);
             pModule = pZapSigContext->GetZapSigModule()->GetModuleFromIndex(ix);
-            if (pModule != NULL)
+
+            // For ReadyToRunCompilation we return a null TypeHandle when we reference a non-local module
+            //
+            if ((pModule != NULL) && pModule->IsInCurrentVersionBubble())
             {
                 thRet = psig.GetTypeHandleThrowing(pModule, 
                                                    pTypeContext, 


### PR DESCRIPTION
When we have profile data we can have cross module references in our ZapSig's when building ReadyToRun images. Instead of creating the cross module generic type we instead return
a null TypeHandle to indicate failure so that we don't attempt to add generic types/methods
that have cross module references.  (i.e. MyList<System.Guid> )