### PR TITLE
Add Marshal.GetExceptionPointers

### DIFF
--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -823,6 +823,10 @@ namespace System.Runtime.InteropServices
             }
         }
 
+        [System.Security.SecurityCritical]  // auto-generated_required
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        public static extern /* struct _EXCEPTION_POINTERS* */ IntPtr GetExceptionPointers();
+        
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern int GetExceptionCode();
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -823,7 +823,6 @@ namespace System.Runtime.InteropServices
             }
         }
 
-        [System.Security.SecurityCritical]  // auto-generated_required
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern /* struct _EXCEPTION_POINTERS* */ IntPtr GetExceptionPointers();
         

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -946,6 +946,7 @@ FCFuncStart(gInteropMarshalFuncs)
     FCFuncElement("DestroyStructure", MarshalNative::DestroyStructure)
     FCFuncElement("UnsafeAddrOfPinnedArrayElement", MarshalNative::FCUnsafeAddrOfPinnedArrayElement)
     FCFuncElement("GetExceptionCode", ExceptionNative::GetExceptionCode)
+    FCFuncElement("GetExceptionPointers", ExceptionNative::GetExceptionPointers)
     QCFuncElement("GetHINSTANCE", COMModule::GetHINSTANCE)
 
     FCFuncElement("OffsetOfHelper", MarshalNative::OffsetOfHelper)


### PR DESCRIPTION
Debugger folks need this to capture exceptions in dumps. We might need to throw PNSE in .NET native (or make up something there). 
Any objections? @jkotas @janvorli @AntonLapounov 
