### PR TITLE
Remove destructor from GCEvent and instead rely on the OS to clean up

### DIFF
--- a/src/gc/env/gcenv.os.h
+++ b/src/gc/env/gcenv.os.h
@@ -59,9 +59,6 @@ public:
     // Constructs a new uninitialized event.
     GCEvent();
 
-    // Destructs an event.
-    ~GCEvent();
-
     // Closes the event. Attempting to use the event past calling CloseEvent
     // is a logic error.
     void CloseEvent();

--- a/src/gc/env/gcenv.os.h
+++ b/src/gc/env/gcenv.os.h
@@ -50,6 +50,14 @@ struct GCThreadAffinity
 // An event is a synchronization object whose state can be set and reset
 // indicating that an event has occured. It is used pervasively throughout
 // the GC.
+//
+// Note that GCEvent deliberately leaks its contents by not having a non-trivial destructor.
+// This is by design; since many uses of GCEvent have static lifetime, their destructors
+// are run on process exit, potentially concurrently with other threads that may still be
+// operating on the static event. To avoid these sorts of unsafety, GCEvent chooses to
+// not have a destructor at all. The cost of this is leaking a small amount of memory, but
+// this is not a problem since a majority of the uses of GCEvent are static. See CoreCLR#11111
+// for more details on the hazards of static destructors.
 class GCEvent {
 private:
     class Impl;

--- a/src/gc/env/gcenv.os.h
+++ b/src/gc/env/gcenv.os.h
@@ -52,7 +52,7 @@ struct GCThreadAffinity
 // the GC.
 //
 // Note that GCEvent deliberately leaks its contents by not having a non-trivial destructor.
-// This is by design; since many uses of GCEvent have static lifetime, their destructors
+// This is by design; since all uses of GCEvent have static lifetime, their destructors
 // are run on process exit, potentially concurrently with other threads that may still be
 // operating on the static event. To avoid these sorts of unsafety, GCEvent chooses to
 // not have a destructor at all. The cost of this is leaking a small amount of memory, but

--- a/src/gc/unix/events.cpp
+++ b/src/gc/unix/events.cpp
@@ -247,12 +247,6 @@ GCEvent::GCEvent()
 {
 }
 
-GCEvent::~GCEvent()
-{
-    delete m_impl;
-    m_impl = nullptr;
-}
-
 void GCEvent::CloseEvent()
 {
     assert(m_impl != nullptr);

--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -690,12 +690,6 @@ GCEvent::GCEvent()
 {
 }
 
-GCEvent::~GCEvent()
-{
-    delete m_impl;
-    m_impl = nullptr;
-}
-
 void GCEvent::CloseEvent()
 {
     assert(m_impl != nullptr);

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -793,12 +793,6 @@ GCEvent::GCEvent()
 {
 }
 
-GCEvent::~GCEvent()
-{
-    delete m_impl;
-    m_impl = nullptr;
-}
-
 void GCEvent::CloseEvent()
 {
     WRAPPER_NO_CONTRACT;


### PR DESCRIPTION
`GCEvent` is occasionally used in static contexts and there are a lot of platform-specific subtleties involved with the running of static destructors on process exit. It's safer if `GCEvent` just doesn't have a destructor at all and instead lets the OS clean up - there won't be any uses of `GCEvent` whose lifetime is shorter than the lifetime of the process.

Fixes https://github.com/dotnet/coreclr/issues/11111.

cc @Maoni0 @jkotas 