### PR TITLE
Remove Unnecessary Copy of Multi-Register Structure Returning

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21585,9 +21585,14 @@ void Compiler::fgAttachStructInlineeToAsg(GenTreePtr tree, GenTreePtr child, COR
     assert(tree->gtOper == GT_ASG);
 
     // We have an assignment, we codegen only V05 = call().
-    // However, if it is a multireg return on x64/ux we want to assign it to a temp.
-    if (child->gtOper == GT_CALL && tree->gtOp.gtOp1->gtOper == GT_LCL_VAR && !child->AsCall()->HasMultiRegRetVal())
+    if (child->gtOper == GT_CALL && tree->gtOp.gtOp1->gtOper == GT_LCL_VAR)
     {
+        // If it is a multireg return on x64/ux, the local variable should be marked as lvIsMultiRegRet
+        if (child->AsCall()->HasMultiRegRetVal())
+        {
+            unsigned lclNum                  = tree->gtOp.gtOp1->gtLclVarCommon.gtLclNum;
+            lvaTable[lclNum].lvIsMultiRegRet = true;
+        }
         return;
     }
 


### PR DESCRIPTION
This PR fix the first codegen issue mentioned in #11030.
During importation, `Buffer<byte>.get_Empty` could be an inline candidate and be replaced by a placeholder `GT_RET_EXP`.   
```
[000059] ------------             *  stmtExpr  void  (IL   ???...  ???)
[000055] --C---------             |  /--*  retExpr   struct(inl return from call [000053])
[000058] -AC-----R---             \--*  =         struct (copy)
[000056] D-----------                \--*  lclVar    struct V06 tmp4      
```  
However, inlining `Buffer<byte>.get_Empty`  failed 
```
INLINER: during 'fgInline' result 'failed this callee' reason 'ldsfld of value class' for 'System.IO.Pipelines.Pipe:get_Buffer():struct:this' calling 'System.Buffers.Buffer`1[Byte][System.Byte]:get_Empty():struct'
```
Then the `retExpr` backs to `call` and one more temp var is introduced.  
```
[000059] ------------             *  stmtExpr  void  (IL   ???...  ???)
[000071] -AC-G--N----             |  /--*  indir     struct
[000070] L-----------             |  |  |  /--*  addr      byref 
[000068] ------------             |  |  |  |  \--*  lclVar    struct V07 tmp5         
[000069] -AC-G-------             |  |  \--*  comma     byref 
[000053] --C-G-------             |  |     |  /--*  call      struct System.Buffers.Buffer`1[Byte][System.Byte].get_Empty,NA
[000067] -AC-G-------             |  |     \--*  =         struct (copy)
[000066] D------N----             |  |        \--*  lclVar    struct V07 tmp5         
[000072] -AC-G---R---             \--*  =         struct (copy)
[000056] D------N----                \--*  lclVar    struct V06 tmp4     
```

This PR avoids generating the redundant temp assignment when an inline candidate that returns multi-register structure gets substituted back to a call (optimized IR showed below).  
```
[000059] ------------             *  stmtExpr  void  (IL   ???...  ???)
[000053] --C-G-------             |  /--*  call      struct System.Buffers.Buffer`1[Byte][System.Byte].get_Empty,NA
[000058] -AC-----R---             \--*  =         struct (copy)
[000056] D-----------                \--*  lclVar    struct V06 tmp4   
```  
The generated code of `Block 2` and `Block 3` comparing is showed below:  

| before                                                                 | after                                                                  | 
|------------------------------------------------------------------------|------------------------------------------------------------------------| 
| call     System.Buffers.Buffer`1[Byte][System.Byte]:get_Empty():struct | call     System.Buffers.Buffer`1[Byte][System.Byte]:get_Empty():struct | 
| mov      gword ptr [rsp+10H], rax                                      | mov      gword ptr [rsp+10H], rax                                      | 
| mov      qword ptr [rsp+18H], rdx                                      | mov      qword ptr [rsp+18H], rdx                                      | 
| vmovdqu  xmm0, qword ptr [rsp+10H]                                     | mov      rax, gword ptr [rsp+10H]                                      | 
| vmovdqu  qword ptr [rsp+20H], xmm0                                     | mov      rdx, qword ptr [rsp+18H]                                      | 
| mov      rax, gword ptr [rsp+20H]                                      | add      rsp, 48                                                       | 
| mov      rdx, qword ptr [rsp+28H]                                      | pop      rbx                                                           | 
| add      rsp, 64                                                       | pop      r13                                                           | 
| pop      rbx                                                           | pop      r14                                                           | 
| pop      r13                                                           | ret                                                                    | 
| pop      r14                                                           |                                                                        | 
| ret                                                                    |                                                                        | 



The second unnecessary copy mentioned in #11030 is introduced by inlined tail call functions, which could not be eliminated until structure value numbering gets implemented ([First Class Structs](https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/first-class-structs.md))

Close #11030 