### PR TITLE
Copy Runtime-specific Crossgen to Core_Root

### DIFF
--- a/tests/publishdependency.targets
+++ b/tests/publishdependency.targets
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <CrossGenFiles Include="..\packages\runtime.$(MinOSForArch)-$(PackagePlatform).Microsoft.NETCore.Runtime.CoreCLR\$(CoreClrPackageVersion)\tools\crossgen.exe"/>
+    <CrossGenFiles Include="..\packages\runtime.$(TargetRid).Microsoft.NETCore.Runtime.CoreCLR\$(CoreClrPackageVersion)\tools\crossgen*"/>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
readytorun tests were failing in Helix because we were always copying "Crossgen.exe" to Core_Root, instead of a platform specific crossgen (this was a remnant of my initial change to get tests running in Helix). This should fix that error.