### PR TITLE
Update jit RunBenchmarks test to no longer use XPath

### DIFF
--- a/tests/src/JIT/config/benchmark/project.json
+++ b/tests/src/JIT/config/benchmark/project.json
@@ -28,8 +28,6 @@
     "System.Threading.ThreadPool": "4.4.0-beta-24913-02",
     "System.Diagnostics.Process": "4.4.0-beta-24913-02",
     "System.Xml.XmlDocument": "4.4.0-beta-24913-02",
-    "System.Xml.XPath": "4.4.0-beta-24913-02",
-    "System.Xml.XPath.XmlDocument": "4.4.0-beta-24913-02",
     "xunit": "2.2.0-beta2-build3300",
     "xunit.console.netcore": "1.0.2-prerelease-00177",
     "xunit.runner.utility": "2.2.0-beta2-build3300"


### PR DESCRIPTION
Rewrite to use linq-to-xml instead. Verified at least that this
can still parse the adjoining xml file. Also now able to crossgen
this test case.

Closes #11082.