### PR TITLE
Move xplat minidump doc to botr.

### DIFF
--- a/Documentation/botr/README.md
+++ b/Documentation/botr/README.md
@@ -26,6 +26,7 @@ Below is a table of contents.
 - [What Every Dev needs to Know About Exceptions in the Runtime](exceptions.md)
 - [ReadyToRun Overview](readytorun-overview.md)
 - [CLR ABI](clr-abi.md)
+- [Cross-platform Minidumps](xplat-minidump-generation.md)
 
 
 It may be possible that this table is not complete.  You can get a complete list 

--- a/Documentation/botr/xplat-minidump-generation.md
+++ b/Documentation/botr/xplat-minidump-generation.md
@@ -3,7 +3,7 @@
 Core dump generation on Linux and other non-Windows platforms has several challenges. Dumps can be very large and the default name/location of a dump is not consistent across all our supported platforms.  The size of a full core dumps can be controlled somewhat with the "coredump_filter" file/flags but even with the smallest settings may be still too large and may not contain all the managed state needed for debugging. By default, some platforms use _core_ as the name and place the core dump in the current directory from where the program is launched; others add the _pid_ to the name. Configuring the core name and location requires superuser permission. Requiring superuser to make this consistent is not a satisfactory option.
 
 Our goal is to generate core dumps that are on par with WER (Windows Error Reporting) crash dumps on any supported Linux platform. To the very least we want to enable the following: 
-- automatic generation of minimal size minidumps that can be automatically uploaded to a server for triage. The quality and quantity of the information contained in the dump should be on par with the information contained in a traditional Windows mini-dump.
+- automatic generation of minimal size minidumps. The quality and quantity of the information contained in the dump should be on par with the information contained in a traditional Windows mini-dump.
 - simple configurabilty by the user (not _su_!). 
 
 Our solution at this time is to intercept any unhandled exception in the PAL layer of the runtime and have coreclr itself trigger and generate a "mini" core dump. 

--- a/src/debug/createdump/createdump.cpp
+++ b/src/debug/createdump/createdump.cpp
@@ -11,7 +11,7 @@ const char* g_help = "createdump [options] pid\n"
 "-m, --micro - create triage minidump.\n" 
 "-d, --diag - enable diagnostic messages.\n";
 
-bool g_diagnostics = true;
+bool g_diagnostics = false;
 
 //
 // Create a minidump using the DAC's enum memory regions interface
@@ -78,7 +78,7 @@ exit:
 //
 int __cdecl main(const int argc, const char* argv[])
 {
-    MINIDUMP_TYPE minidumpType = MiniDumpNormal;
+    MINIDUMP_TYPE minidumpType = MiniDumpWithPrivateReadWriteMemory;
     const char* dumpPathTemplate = "/tmp/coredump.%d";
     const char* programPath = nullptr;
     pid_t pid = 0;


### PR DESCRIPTION
Change default minidump type to MiniDumpWithPrivateReadWriteMemory.

Remove language about uploading triage dumps.

Turn off diagnostic output.