### PR TITLE
Mark GetGenerationWR2 as GCStressIncompatible across all platforms

### DIFF
--- a/tests/src/GC/API/GC/GetGenerationWR2.csproj
+++ b/tests/src/GC/API/GC/GetGenerationWR2.csproj
@@ -10,7 +10,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <GCStressIncompatible Condition="'$(Platform)' == 'x86'">true</GCStressIncompatible>
+    <GCStressIncompatible>true</GCStressIncompatible>
     
     <CLRTestExecutionArguments></CLRTestExecutionArguments>
   </PropertyGroup>


### PR DESCRIPTION
Upon review, this test can behave poorly in the presence of particularly aggressive GCStress settings. The code that the JIT emits for this function is fully interruptible and, as such, it's possible for a GC to occur between the left and right hand sides of this expression:

```csharp
result = ( GC.GetGeneration( o ) == GC.GetGeneration( wf ));
```

which will cause the test to fail.

cc @sergiy-k @adiaaida , closes https://github.com/dotnet/coreclr/issues/7693