### PR TITLE
JIT: simple fix for the tail call stress assert

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6216,6 +6216,12 @@ bool Compiler::impTailCallRetTypeCompatible(var_types            callerRetType,
         return true;
     }
 
+    // If the class handles are the same and not null, the return types are compatible.
+    if ((callerRetTypeClass != nullptr) && (callerRetTypeClass == calleeRetTypeClass))
+    {
+        return true;
+    }
+
 #if defined(_TARGET_AMD64_) || defined(_TARGET_ARM64_)
     // Jit64 compat:
     if (callerRetType == TYP_VOID)


### PR DESCRIPTION
If class handles match, the return types are compatible, no matter
what the jit types indicate.

Addresses #10047.