### PR TITLE
Use RuntimeHelpers.IsReferenceOrContainsReferences in Dictionary.Remove methods

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -48,6 +48,7 @@ namespace System.Collections.Generic
     using System.Collections;
     using System.Diagnostics;
     using System.Diagnostics.Contracts;
+    using System.Runtime.CompilerServices;
     using System.Runtime.Serialization;
 
     /// <summary>
@@ -614,8 +615,15 @@ namespace System.Collections.Generic
                         }
                         entry.hashCode = -1;
                         entry.next = freeList;
-                        entry.key = default(TKey);
-                        entry.value = default(TValue);
+
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+                        {
+                            entry.key = default(TKey);
+                        }
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+                        {
+                            entry.value = default(TValue);
+                        }
                         freeList = i;
                         freeCount++;
                         version++;
@@ -664,8 +672,15 @@ namespace System.Collections.Generic
 
                         entry.hashCode = -1;
                         entry.next = freeList;
-                        entry.key = default(TKey);
-                        entry.value = default(TValue);
+
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+                        {
+                            entry.key = default(TKey);
+                        }
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+                        {
+                            entry.value = default(TValue);
+                        }
                         freeList = i;
                         freeCount++;
                         version++;


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/11106

Simple microbenchmarking of `Remove(TKey)` overload with `Dictionary<int, int>` and `Dictionary<Guid, object>`  shows 4-5% perf improvement.

The diff in codegen is small too.
The instructions removed after the change:
`Dictionary<Guid, object>` 
```ASM
       498D442410           lea      rax, bword ptr [r12+16]
       660F57C0             xorpd    xmm0, xmm0
       F30F7F00             movdqu   qword ptr [rax], xmm0
```
`Dictionary<int, int>` 
```ASM
       33C0                 xor      eax, eax
       4189442408           mov      dword ptr [r12+8], eax
       418944240C           mov      dword ptr [r12+12], eax
```

