### PR TITLE
[WIP][x86/Linux] Improve R/PInvoke Performance

### DIFF
--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -212,7 +212,7 @@ public:
         UINT32 Edx;
     };
 
-    VOID SetupArguments(char *pSrc, ArgumentRegisters *pArgRegs, char *pDst);
+    VOID ShuffleArguments(char *pSrc, ArgumentRegisters *pArgRegs, char *pDst);
 #endif // _TARGET_X86_ && FEATURE_STUBS_AS_IL
 
 private:
@@ -225,6 +225,24 @@ private:
     UINT16            m_cbRetPop;           // stack bytes popped by callee (for UpdateRegDisplay)
 #if defined(FEATURE_STUBS_AS_IL)
     UINT32            m_cbStackArgSize;     // stack bytes pushed for managed code
+
+    struct ShuffleDescription
+    {
+        enum Destination
+        {
+            TO_ECX,
+            TO_EDX,
+            TO_STK
+        };
+
+        Destination elemDest;
+        int         elemSize;
+
+        VOID Shuffle(char **ppSrc, ArgumentRegisters *pArgRegs, char **ppDst) const;
+    };
+
+    int                  m_nShuffleDescr;
+    ShuffleDescription  *m_pShuffleDescr;
 #else
     Stub*             m_pExecStub;          // UMEntryThunk jumps directly here
     UINT16            m_callConv;           // unmanaged calling convention and flags (CorPinvokeMap)

--- a/src/vm/i386/umthunkstub.S
+++ b/src/vm/i386/umthunkstub.S
@@ -156,10 +156,10 @@ LOCAL_LABEL(UMThunkStub_CopyStackArgs):
     lea     esi, [ebp + 0x8]  // esi = src
 
     //
-    // EXTERN_C VOID STDCALL UMThunkStubSetupArgumentsWorker(UMThunkMarshInfo *pMarshInfo,
-    //                                                       char *pSrc,
-    //                                                       UMThunkMarshInfo::ArgumentRegisters *pArgRegs,
-    //                                                       char *pDst)
+    // EXTERN_C VOID STDCALL UMArgumentShuffleWorker(UMThunkMarshInfo *pMarshInfo,
+    //                                               char *pSrc,
+    //                                               UMThunkMarshInfo::ArgumentRegisters *pArgRegs,
+    //                                               char *pDst)
     push    edx
     push    ecx
     lea     ecx, [esp]
@@ -172,7 +172,7 @@ LOCAL_LABEL(UMThunkStub_CopyStackArgs):
     mov     ecx, dword ptr [ecx + UMEntryThunk__m_pUMThunkMarshInfo]
     push    ecx     // pMarshInfo
     CHECK_STACK_ALIGNMENT
-    call    C_FUNC(UMThunkStubSetupArgumentsWorker)
+    call    C_FUNC(UMArgumentShuffleWorker)
     add     esp, 8
     pop     ecx
     pop     edx


### PR DESCRIPTION
This commit revises reverse P/Invoke callbacks to simply loop over shuffle descriptions (created during during run-time initialization) instead of method signature in order to fix #10225.
