### PR TITLE
[x86/Linux] Remove unnecessary ResumeEsp field

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1783,8 +1783,6 @@ typedef struct _CONTEXT {
     ULONG   SegSs;
 
     UCHAR   ExtendedRegisters[MAXIMUM_SUPPORTED_EXTENSION];
-
-    ULONG   ResumeEsp;
 } CONTEXT, *PCONTEXT, *LPCONTEXT;
 
 // To support saving and loading xmm register context we need to know the offset in the ExtendedRegisters

--- a/src/pal/src/arch/i386/asmconstants.h
+++ b/src/pal/src/arch/i386/asmconstants.h
@@ -28,4 +28,3 @@
 #define CONTEXT_Xmm5 CONTEXT_Xmm4+16
 #define CONTEXT_Xmm6 CONTEXT_Xmm5+16
 #define CONTEXT_Xmm7 CONTEXT_Xmm6+16
-#define CONTEXT_ResumeEsp CONTEXT_ExtendedRegisters+512

--- a/src/pal/src/arch/i386/context2.S
+++ b/src/pal/src/arch/i386/context2.S
@@ -42,7 +42,6 @@ LEAF_ENTRY CONTEXT_CaptureContext, _TEXT
     mov   [eax + CONTEXT_Ebp], ebp
     lea   ebx, [esp + 12]
     mov   [eax + CONTEXT_Esp], ebx
-    mov   [eax + CONTEXT_ResumeEsp], ebx
     mov   ebx, [esp + 8]
     mov   [eax + CONTEXT_Eip], ebx
 
@@ -115,7 +114,7 @@ LOCAL_LABEL(Done_Restore_CONTEXT_FLOATING_POINT):
 LOCAL_LABEL(Done_Restore_CONTEXT_EXTENDED_REGISTERS):
 
     // Restore Stack
-    mov   esp, [eax + CONTEXT_ResumeEsp]
+    mov   esp, [eax + CONTEXT_Esp]
 
     // Create a minimal frame
     push  DWORD PTR [eax + CONTEXT_Eip]

--- a/src/pal/src/arch/i386/exceptionhelper.S
+++ b/src/pal/src/arch/i386/exceptionhelper.S
@@ -23,7 +23,7 @@ LEAF_ENTRY ThrowExceptionFromContextInternal, _TEXT
         mov   eax, [esp + 8]  // ebx: CONTEXT *
 
         mov   ebp, [eax + CONTEXT_Ebp]
-        mov   esp, [eax + CONTEXT_ResumeEsp]
+        mov   esp, [eax + CONTEXT_Esp]
         mov   ebx, [eax + CONTEXT_Ebx]
         mov   esi, [eax + CONTEXT_Esi]
         mov   edi, [eax + CONTEXT_Edi]

--- a/src/pal/src/arch/i386/signalhandlerhelper.cpp
+++ b/src/pal/src/arch/i386/signalhandlerhelper.cpp
@@ -70,7 +70,6 @@ void ExecuteHandlerOnOriginalStack(int code, siginfo_t *siginfo, void *context, 
     // We don't care about the other registers state since the stack unwinding restores
     // them for the target frame directly from the signal context.
     context2.Esp = (size_t)sp;
-    context2.ResumeEsp = (size_t)sp;
     context2.Ebp = (size_t)fp;
     context2.Eip = (size_t)signal_handler_worker;
 

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -155,7 +155,6 @@ static void UnwindContextToWinContext(unw_cursor_t *cursor, CONTEXT *winContext)
 #elif defined(_X86_)
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Eip);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Esp);
-    unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->ResumeEsp);
     unw_get_reg(cursor, UNW_X86_EBP, (unw_word_t *) &winContext->Ebp);
     unw_get_reg(cursor, UNW_X86_EBX, (unw_word_t *) &winContext->Ebx);
     unw_get_reg(cursor, UNW_X86_ESI, (unw_word_t *) &winContext->Esi);

--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -506,8 +506,6 @@ void CONTEXTFromNativeContext(const native_context_t *native, LPCONTEXT lpContex
         // although the pc value retrived from native context might not have set the least bit.
         // This becomes especially problematic if the context is on the JIT_WRITEBARRIER.
         lpContext->Pc |= 0x1;
-#elif defined(_X86_)
-        lpContext->ResumeEsp = MCREG_Esp(native->uc_mcontext);
 #endif
     }
 
@@ -978,7 +976,6 @@ CONTEXT_GetThreadContextFromThreadState(
                 lpContext->Esi = pState->esi;
                 lpContext->Ebp = pState->ebp;
                 lpContext->Esp = pState->esp;
-                lpContext->ResumeEsp = pState->esp;
                 lpContext->SegSs = pState->ss;
                 lpContext->EFlags = pState->eflags;
                 lpContext->Eip = pState->eip;

--- a/src/unwinder/i386/unwinder_i386.cpp
+++ b/src/unwinder/i386/unwinder_i386.cpp
@@ -105,21 +105,7 @@ OOPStackUnwinderX86::VirtualUnwind(
     ENUM_CALLEE_SAVED_REGISTERS();
 #undef CALLEE_SAVED_REGISTER
 
-    SIZE_T paramSize = codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo);
-    SIZE_T paddingSize = 0;
-
-#ifdef UNIX_X86_ABI
-    // On UNIX_X86_ABI, function call may have stack alignment padding.
-    if (paramSize % 16 != 0)
-    {
-        paddingSize += 16 - (paramSize % 16);
-    }
-#endif // UNIX_X86_ABI
-
-    ContextRecord->Esp = rd.SP - paramSize;
-    ContextRecord->ResumeEsp = ExecutionManager::IsManagedCode((PCODE) rd.ControlPC)
-                             ? rd.SP + paddingSize
-                             : ContextRecord->Esp;
+    ContextRecord->Esp = rd.SP - codeInfo.GetCodeManager()->GetStackParameterSize(&codeInfo);
     ContextRecord->Eip = rd.ControlPC;
 
     // For x86, the value of Establisher Frame Pointer is Caller SP

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -135,7 +135,7 @@ void FixContext(PCONTEXT pContextRecord)
 
 #ifdef _TARGET_X86_
     size_t resumeSp = EECodeManager::GetResumeSp(pContextRecord);
-    FIXUPREG(ResumeEsp, resumeSp);
+    FIXUPREG(Esp, resumeSp);
 #endif // _TARGET_X86_
 
 #undef FIXUPREG

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -331,7 +331,6 @@ void TransitionFrame::UpdateRegDisplayHelper(const PREGDISPLAY pRD, UINT cbStack
 
     pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);;
     pRD->pCurrentContext->Esp = CallerSP;
-    pRD->pCurrentContext->ResumeEsp = CallerSP + cbStackPop;
 
     UpdateRegDisplayFromCalleeSavedRegisters(pRD, regs);
     ClearRegDisplayArgumentAndScratchRegisters(pRD);
@@ -384,7 +383,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 #endif // DACCESS_COMPILE
 
     pRD->pCurrentContext->Eip = pRD->ControlPC = m_MachState.GetRetAddr();
-    pRD->pCurrentContext->Esp = pRD->pCurrentContext->ResumeEsp = pRD->SP = (DWORD) m_MachState.esp();
+    pRD->pCurrentContext->Esp = pRD->SP = (DWORD) m_MachState.esp();
 
 #define CALLEE_SAVED_REGISTER(regname) pRD->pCurrentContext->regname = *((DWORD*) m_MachState.p##regname());
     ENUM_CALLEE_SAVED_REGISTERS();
@@ -689,7 +688,6 @@ void InlinedCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 
     pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);
     pRD->pCurrentContext->Esp = (DWORD) dac_cast<TADDR>(m_pCallSiteSP);
-    pRD->pCurrentContext->ResumeEsp = (DWORD) dac_cast<TADDR>(m_pCallSiteSP) + stackArgSize;
     pRD->pCurrentContext->Ebp = (DWORD) m_pCalleeSavedFP;
 
     ClearRegDisplayArgumentAndScratchRegisters(pRD);
@@ -829,7 +827,7 @@ void HijackFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->IsCallerSPValid      = FALSE;        // Don't add usage of this field.  This is only temporary.
 
     pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);
-    pRD->pCurrentContext->Esp = pRD->pCurrentContext->ResumeEsp = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
+    pRD->pCurrentContext->Esp = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
 
 #define RESTORE_REG(reg) { pRD->pCurrentContext->reg = m_Args->reg; pRD->pCurrentContextPointers->reg = &m_Args->reg; }
 #define CALLEE_SAVED_REGISTER(reg) RESTORE_REG(reg)
@@ -908,7 +906,7 @@ void TailCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->IsCallerSPValid      = FALSE;        // Don't add usage of this field.  This is only temporary.
 
     pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);
-    pRD->pCurrentContext->Esp = pRD->pCurrentContext->ResumeEsp = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
+    pRD->pCurrentContext->Esp = (DWORD)(pRD->PCTAddr + sizeof(TADDR));
 
     UpdateRegDisplayFromCalleeSavedRegisters(pRD, &m_regs);
     ClearRegDisplayArgumentAndScratchRegisters(pRD);


### PR DESCRIPTION
#10749 (which revises CLR to fix up SP just before resuming) eliminates the need for tracking resume SP for each stack unwind step.

This commit eliminates unnecessary resume SP tracking code.