### PR TITLE
Refactor ildasm round trip logic

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -448,7 +448,6 @@ echo     1: Build all tests with priority 0 and 1
 echo     666: Build all tests with priority 0, 1 ... 666
 echo -sequential: force a non-parallel build ^(default is to build in parallel
 echo     using all processors^).
-echo -ilasmroundtrip: enables ilasm round trip build and run of the tests before executing them.
 echo -verbose: enables detailed file logging for the msbuild tasks into the msbuild log file.
 exit /b 1
 

--- a/config.json
+++ b/config.json
@@ -270,12 +270,6 @@
       "values": [],
       "defaultValue": ""
     },
-    "IlasmRoundTrip": {
-      "description": "Sets ilasm round trip property.",
-      "valueType": "property",
-      "values": [ true, false ],
-      "defaultValue": true
-    },
     "CreateTestOverlay": {
       "description": "Runs CreateTestOverlay target.",
       "valueType": "target",

--- a/netci.groovy
+++ b/netci.groovy
@@ -1294,6 +1294,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                             scenario == 'default' ||
                             scenario == 'r2r' ||
                             scenario == 'jitdiff' ||
+                            scenario == 'ilrt' ||
                             scenario == 'illink' ||
                             Constants.r2rJitStressScenarios.indexOf(scenario) != -1) {
                         buildOpts += enableCorefxTesting ? ' skiptests' : ''
@@ -1308,11 +1309,6 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
 
                     else if (scenario == 'pri1' || scenario == 'pri1r2r' || scenario == 'gcstress15_pri1r2r'|| scenario == 'coverage') {
                         buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${arch} ${buildOpts} -priority=1"
-                    }
-                    else if (scenario == 'ilrt') {
-                        // First do the build with skiptests and then build the tests with ilasm roundtrip
-                        buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
-                        buildCommands += "set __TestIntermediateDir=int&&build-test.cmd ${lowerConfiguration} ${arch} -ilasmroundtrip"
                     }
                     else if (isLongGc(scenario)) {
                         buildCommands += "build.cmd ${lowerConfiguration} ${arch} ${buildOpts} skiptests"
@@ -1343,6 +1339,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         def runjitmioptsStr = ''
                         def runjitforcerelocsStr = ''
                         def runjitdisasmStr = ''
+                        def runilasmroundtripStr = ''
                         def gcstressStr = ''
                         def runtestArguments = ''
                         def gcTestArguments = ''
@@ -1402,6 +1399,11 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                             runjitdisasmStr = 'jitdisasm crossgen'
                         }
 
+                        if (scenario == 'ilrt')
+                        {
+                            runilasmroundtripStr = 'ilasmroundtrip'
+                        }
+
                         if (isLongGc(scenario)) {
                             gcTestArguments = "${scenario} sequential"
                         }
@@ -1411,7 +1413,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                             illinkArguments = "link %WORKSPACE%\\linker\\linker\\bin\\netcore_Release\\netcoreapp2.0\\win10-${arch}\\publish\\illink.exe"
                         }
 
-                        runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${gcTestArguments} ${illinkArguments} collectdumps"
+                        runtestArguments = "${lowerConfiguration} ${arch} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${runilasmroundtripStr} ${gcTestArguments} ${illinkArguments} collectdumps"
 
                         if (Constants.jitStressModeScenarios.containsKey(scenario)) {
                             def stepScriptLocation = "%WORKSPACE%\\SetStressModes.bat"
@@ -2205,6 +2207,7 @@ combinedScenarios.each { scenario ->
                     def runjitmioptsStr = ''
                     def runjitforcerelocsStr = ''
                     def runjitdisasmStr = ''
+                    def runilasmroundtripStr = ''
                     def gcstressStr = ''
                     def illinkStr = ''
 
@@ -2435,7 +2438,7 @@ combinedScenarios.each { scenario ->
                 --mscorlibDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --coreFxBinDir=\"\${WORKSPACE}/bin/CoreFxBinDir\" \\
                 --limitedDumpGeneration \\
-                ${testEnvOpt} ${serverGCString} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${illinkStr} ${sequentialString} ${playlistString}""")
+                ${testEnvOpt} ${serverGCString} ${gcstressStr} ${crossgenStr} ${runcrossgentestsStr} ${runjitstressStr} ${runjitstressregsStr} ${runjitmioptsStr} ${runjitforcerelocsStr} ${runjitdisasmStr} ${runilasmroundtripStr} ${illinkStr} ${sequentialString} ${playlistString}""")
                             }
                         }
                     }

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -44,6 +44,7 @@ set __LongGCTests=
 set __GCSimulatorTests=
 set __AgainstPackages=
 set __JitDisasm=
+set __IlasmRoundTrip=
 set __CollectDumps=
 
 :Arg_Loop
@@ -78,6 +79,7 @@ if /i "%1" == "jitstressregs"         (set COMPlus_JitStressRegs=%2&shift&shift&
 if /i "%1" == "jitminopts"            (set COMPlus_JITMinOpts=1&shift&shift&goto Arg_Loop)
 if /i "%1" == "jitforcerelocs"        (set COMPlus_ForceRelocs=1&shift&shift&goto Arg_Loop)
 if /i "%1" == "jitdisasm"             (set __JitDisasm=1&shift&goto Arg_Loop)
+if /i "%1" == "ilasmroundtrip"        (set __IlasmRoundTrip=1&shift&goto Arg_Loop)
 if /i "%1" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&shift&goto Arg_Loop)
 if /i "%1" == "PerfTests"             (set __PerfTests=true&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"      (set RunCrossGen=true&shift&goto Arg_Loop)
@@ -406,6 +408,11 @@ if defined __JitDisasm (
     set RunningJitDisasm=1
 )
 
+if defined __IlasmRoundTrip (
+    echo Running Ilasm round trip
+    set RunningIlasmRoundTrip=1
+)
+
 set __BuildLogRootName=Tests_GenerateRuntimeLayout
 call :msbuild "%__ProjectFilesDir%\runtest.proj" /p:GenerateRuntimeLayout=true 
 if errorlevel 1 (
@@ -438,6 +445,7 @@ echo jitstressregs n    - Runs the tests with COMPlus_JitStressRegs=n
 echo jitminopts         - Runs the tests with COMPlus_JITMinOpts=1
 echo jitforcerelocs     - Runs the tests with COMPlus_ForceRelocs=1
 echo jitdisasm          - Runs jit-dasm on the tests
+echo ilasmroundtrip     - Runs ilasm round trip on the tests
 echo gcstresslevel n    - Runs the tests with COMPlus_GCStress=n
 echo     0: None                                1: GC on all allocs and 'easy' places
 echo     2: GC on transitions to preemptive GC  4: GC on every allowable JITed instr

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -51,6 +51,7 @@ function print_usage {
     echo '  --jitforcerelocs                 : Runs the tests with COMPlus_ForceRelocs=1'
     echo '  --jitdisasm                      : Runs jit-dasm on the tests'
     echo '  --gcstresslevel=<n>              : Runs the tests with COMPlus_GCStress=n'
+    echo '  --ilasmroundtrip                 : Runs ilasm round trip on the tests'
     echo '    0: None                                1: GC on all allocs and '"'easy'"' places'
     echo '    2: GC on transitions to preemptive GC  4: GC on every allowable JITed instr'
     echo '    8: GC on every allowable NGEN instr   16: GC only on a unique stack trace'
@@ -975,6 +976,7 @@ illinker=
 verbose=0
 doCrossgen=0
 jitdisasm=0
+ilasmroundtrip=
 
 for i in "$@"
 do
@@ -1007,6 +1009,9 @@ do
             ;;
         --jitdisasm)
             jitdisasm=1
+            ;;
+        --ilasmroundtrip)
+            ((ilasmroundtrip = 1))
             ;;
         --testRootDir=*)
             testRootDir=${i#*=}
@@ -1137,6 +1142,11 @@ fi
 if [[ ! "$jitdisasm" -eq 0 ]]; then
     echo "Running jit disasm"
     export RunningJitDisasm=1
+fi
+
+if [ ! -z "$ilasmroundtrip" ]; then
+    echo "Running Ilasm round trip"
+    export RunningIlasmRoundTrip=1
 fi
 
 # If this is a coverage run, make sure the appropriate args have been passed

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -18,45 +18,6 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target
-    Name="GetIlasmRoundTripBashScript"
-    Returns="$(IlasmRoundTripBashScript)">
-    <PropertyGroup>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
-      <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>
-
-      <IlasmRoundTripBashScript Condition="'$(IlasmRoundTrip)'=='true'">
-      <![CDATA[
-# Disable Ilasm round-tripping for Linker tests.
-# Todo: Ilasm round-trip on linked binaries.
-      
-if [ -z "$DoLink" ]; 
-then
-  echo "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
-  "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
-  ERRORLEVEL=$?
-  if [  $ERRORLEVEL -ne 0 ]
-  then
-    echo EXECUTION OF ILDASM - FAILED $ERRORLEVEL
-    exit 1
-  fi
-
-  echo "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-  "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-  ERRORLEVEL=$?
-  if [ $ERRORLEVEL -ne 0 ]
-  then
-    echo EXECUTION OF ILASM - FAILED $ERRORLEVEL
-    exit 1
-  fi
-fi    
-      ]]>
-      </IlasmRoundTripBashScript>
-    </PropertyGroup>
-  </Target>
-
   <!-- This is here because of this bug: http://blogs.msdn.com/b/msbuild/archive/2006/01/03/508629.aspx-->
   <Target Name="FetchExternalPropertiesForXpalt">
     <!--Call GetExecuteShFullPath to get ToRunProject cmd file Path  -->
@@ -275,10 +236,11 @@ fi
       </PropertyGroup>
       <PropertyGroup>
       <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun"</_CLRTestRunFile>
-      <BashCLRTestLaunchCmds Condition="'$(IlasmRoundTrip)'=='true'"><![CDATA[
-if [ -z "$DoLink" ]; then
-  echo $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
-  $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments 
+      <BashCLRTestLaunchCmds><![CDATA[
+if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
+then
+  echo $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments
+  $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments
   if [  $? -ne $CLRTestExpectedExitCode ]
   then
     echo END EXECUTION OF IL{D}ASM BINARY - FAILED $? vs $CLRTestExpectedExitCode
@@ -408,7 +370,6 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 $(BashCLRTestArgPrep)
 $(BashCLRTestExitCodePrep)
 $(JitDisasmBashScript)
-# IlasmRoundTrip Script
 $(IlasmRoundTripBashScript)
 # PreCommands
 $(BashCLRTestPreCommands)

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -18,39 +18,6 @@ WARNING:   When setting properties based on their current state (for example:
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target
-    Name="GetIlasmRoundTripBatchScript"
-    Returns="$(IlasmRoundTripBatchScript)">
-    <PropertyGroup>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
-      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
-      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
-      <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>
-
-       <!-- https://github.com/dotnet/coreclr/issues/2481. Delete /raweh to ildasm once it is resolved.-->
-      <IlasmRoundTripBatchScript Condition="'$(IlasmRoundTrip)'=='true'">
-      <![CDATA[
-REM Disable Ilasm round-tripping for Linker tests.
-REM Todo: Ilasm round-trip on linked binaries.
-IF NOT DEFINED DoLink ( 
-  ECHO %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
-  %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
-  IF NOT "!ERRORLEVEL!"=="0" (
-    ECHO EXECUTION OF ILDASM - FAILED !ERRORLEVEL!
-    Exit /b 1
-  )
-  ECHO %CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-  %CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-  IF NOT "!ERRORLEVEL!"=="0" (
-    ECHO EXECUTION OF ILASM - FAILED !ERRORLEVEL!
-    Exit /b 1
-  )
-)
-      ]]>
-      </IlasmRoundTripBatchScript>
-    </PropertyGroup>
-  </Target>
-
   <!-- This is here because of this bug: http://blogs.msdn.com/b/msbuild/archive/2006/01/03/508629.aspx-->
   <Target Name="FetchExternalProperties">
     <!--Call GetExecuteCmdFullPath to get ToRunProject cmd file Path  -->
@@ -270,7 +237,7 @@ if defined DoLink (
 )              
 ]]>
           </BatchLinkerTestCleanupCmds>
-      </PropertyGroup>      
+      </PropertyGroup>
       <PropertyGroup>      
       <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"%CORE_ROOT%\corerun.exe"</_CLRTestRunFile>
       <BatchCLRTestLaunchCmds><![CDATA[
@@ -279,19 +246,7 @@ IF NOT "%CLRCustomTestLauncher%"=="" (
 ) ELSE (
   set LAUNCHER=%_DebuggerFullPath% $(_CLRTestRunFile)
 )
-      ]]></BatchCLRTestLaunchCmds>
-      <BatchCLRTestLaunchCmds Condition=" '$(IlasmRoundTrip)'=='true' "><![CDATA[
-  $(BatchCLRTestLaunchCmds)
-IF NOT DEFINED DoLink ( 
-  ECHO %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
-  %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
-
-  IF NOT "!ERRORLEVEL!"=="%CLRTestExpectedExitCode%" (
-    ECHO END EXECUTION OF IL{D}ASM BINARY - FAILED !ERRORLEVEL! vs %CLRTestExpectedExitCode%
-    ECHO FAILED
-    Exit /b 1
-  )
-)
+$(BatchIlrtTestLaunchCmds)
       ]]></BatchCLRTestLaunchCmds>
       <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'">
     <![CDATA[
@@ -404,7 +359,6 @@ $(BatchCLRTestEnvironmentCompatibilityCheck)
 
 $(JitDisasmBatchScript)
 
-REM IlasmRoundTrip Script
 $(IlasmRoundTripBatchScript)
 
 REM Precommands

--- a/tests/src/CLRTest.Jit.targets
+++ b/tests/src/CLRTest.Jit.targets
@@ -67,7 +67,99 @@ if defined RunningJitDisasm (
       </JitDisasmBatchScript>
     </PropertyGroup>
   </Target>
-  
+
+  <Target
+      Name="GetIlasmRoundTripBashScript"
+      Returns="$(IlasmRoundTripBashScript)">
+    <PropertyGroup>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
+      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
+      <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>
+
+      <IlasmRoundTripBashScript>
+        <![CDATA[
+# IlasmRoundTrip Script
+
+# Disable Ilasm round-tripping for Linker tests.
+# Todo: Ilasm round-trip on linked binaries.
+
+if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
+then
+    echo "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
+    "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
+    ERRORLEVEL=$?
+    if [ $ERRORLEVEL -ne 0 ]
+    then
+      echo EXECUTION OF ILDASM - FAILED $ERRORLEVEL
+      exit 1
+    fi
+
+    echo "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+    "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+    ERRORLEVEL=$?
+    if [ $ERRORLEVEL -ne 0 ]
+    then
+      echo EXECUTION OF ILASM - FAILED $ERRORLEVEL
+      exit 1
+    fi
+fi
+        ]]>
+      </IlasmRoundTripBashScript>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="GetIlasmRoundTripBatchScript"
+          Returns="$(IlasmRoundTripBatchScript);$(BatchIlrtTestLaunchCmds)">
+    <PropertyGroup>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
+      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
+      <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>
+
+      <!-- https://github.com/dotnet/coreclr/issues/2481. Delete /raweh to ildasm once it is resolved.-->
+      <IlasmRoundTripBatchScript>
+        <![CDATA[
+REM IlasmRoundTrip Script
+
+REM Disable Ilasm round-tripping for Linker tests.
+REM Todo: Ilasm round-trip on linked binaries.
+IF NOT DEFINED DoLink (
+  IF DEFINED RunningIlasmRoundTrip (
+    echo %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
+    %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
+    IF NOT "!ERRORLEVEL!"=="0" (
+      ECHO EXECUTION OF ILDASM - FAILED !ERRORLEVEL!
+      Exit /b 1
+    )
+    ECHO %CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+    %CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+    IF NOT "!ERRORLEVEL!"=="0" (
+      ECHO EXECUTION OF ILASM - FAILED !ERRORLEVEL!
+      Exit /b 1
+    )
+  )
+)
+        ]]>
+      </IlasmRoundTripBatchScript>
+      <BatchIlrtTestLaunchCmds><![CDATA[
+IF NOT DEFINED DoLink (
+  if defined RunningIlasmRoundTrip (
+    ECHO %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
+    %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
+
+    IF NOT "!ERRORLEVEL!"=="%CLRTestExpectedExitCode%" (
+      ECHO END EXECUTION OF IL{D}ASM BINARY - FAILED !ERRORLEVEL! vs %CLRTestExpectedExitCode%
+      ECHO FAILED
+      Exit /b 1
+    )
+  )
+)
+]]>
+      </BatchIlrtTestLaunchCmds>
+    </PropertyGroup>
+  </Target>
+
   <PropertyGroup Condition="$(RunWithGcStress) != ''" >
     <CLRTestBatchPreCommands>
 <![CDATA[


### PR DESCRIPTION
This change factors the Ildasm round trip logic so that it should not
require a separate test build. The ildasmroundtrip flag is no longer
passed to build-test.cmd; instead the wrapper scripts are always
generated with a check for an environment variable that can be set from
runtests.

Also remove separate test build for ilrt in the ci scripts

@dotnet-bot test ci please