### PR TITLE
Fix building with only VS2017 installed.

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -53,9 +53,15 @@ xcopy %~dp0Tools-Override\* %~dp0Tools /y >nul
 
 set _toolRuntime=%~dp0Tools
 set _dotnet=%_toolRuntime%\dotnetcli\dotnet.exe
+set _json=%~dp0config.json
 
+:: run.exe depends on running in the root directory, notably because the config.json specifies
+:: a relative path to the binclash logger
+
+pushd %~dp0
 echo Running: %_dotnet% %_toolRuntime%\run.exe %~dp0config.json %*
-call %_dotnet% %_toolRuntime%\run.exe %~dp0config.json %*
+call %_dotnet% %_toolRuntime%\run.exe "%_json%" %*
+popd
 if NOT [%ERRORLEVEL%]==[0] (
   exit /b 1
 )


### PR DESCRIPTION
Fix #10890
The fix was originally made in https://github.com/dotnet/corefx/pull/18700