### PR TITLE
Fix few clang analyzer warnings

### DIFF
--- a/src/pal/src/file/disk.cpp
+++ b/src/pal/src/file/disk.cpp
@@ -68,6 +68,7 @@ GetDiskFreeSpaceW(
     PathCharString dirNameBufferPathString;
     size_t length;
     char * dirNameBuffer;
+    const char * dirName;
     int size;
 
     PERF_ENTRY(GetDiskFreeSpaceW);
@@ -125,7 +126,7 @@ GetDiskFreeSpaceW(
         if ( size != 0 )
         {
             FILEDosToUnixPathA( dirNameBuffer );
-            statfsRetVal = statfs( dirNameBuffer, &fsInfoBuffer );
+            dirName = dirNameBuffer;
         }
         else
         {
@@ -136,8 +137,10 @@ GetDiskFreeSpaceW(
     }
     else
     {
-        statfsRetVal = statfs( "/", &fsInfoBuffer );
+        dirName = "/";
     }
+
+    statfsRetVal = statfs( dirName, &fsInfoBuffer );
 
     if ( statfsRetVal == 0 )
     {

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -2999,8 +2999,11 @@ OUT  PLARGE_INTEGER lpFileSize)
             &dwFileSizeHigh
             );
 
-        lpFileSize->u.LowPart = dwFileSizeLow;
-        lpFileSize->u.HighPart = dwFileSizeHigh;
+        if (NO_ERROR == palError)
+        {
+            lpFileSize->u.LowPart = dwFileSizeLow;
+            lpFileSize->u.HighPart = dwFileSizeHigh;
+        }
     }
     else
     {


### PR DESCRIPTION
This change fixes two issues reported by the clang analyzer. In both cases, uninitialized
variable value was used in an error code path.