### PR TITLE
Enable running R2R tests in Helix on non-Windows

### DIFF
--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -530,6 +530,24 @@
         {
           "Name": "Dotnet-CoreClr-Trusted-BuildTests",
           "Parameters": {
+            "HelixJobType": "test/functional/r2r/cli/",
+            "TargetsWindows": "false",
+            "Rid": "osx-x64",
+            "TargetQueues": "osx.1012.amd64",
+            "TestContainerSuffix": "osx",
+            "CrossgenArg": "Crossgen ",
+            "TargetsNonWindowsArg": "TargetsNonWindows "
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "OSX",
+            "SubType":  "Build-Tests-R2R",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
             "HelixJobType": "test/functional/cli/",
             "TargetsWindows": "false",
             "Rid": "linux-x64",
@@ -540,6 +558,24 @@
           "ReportingParameters": {
             "OperatingSystem": "RedHat 7",
             "SubType":  "Build-Tests",
+            "Type": "build/product/",
+            "PB_BuildType": "Release"
+          }
+        },
+        {
+          "Name": "Dotnet-CoreClr-Trusted-BuildTests",
+          "Parameters": {
+            "HelixJobType": "test/functional/r2r/cli/",
+            "TargetsWindows": "false",
+            "Rid": "linux-x64",
+            "TargetQueues": "debian.82.amd64,fedora.25.amd64,redhat.72.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1610.amd64",
+            "TestContainerSuffix": "linux",
+            "CrossgenArg": "Crossgen ",
+            "TargetsNonWindowsArg": "TargetsNonWindows "
+          },
+          "ReportingParameters": {
+            "OperatingSystem": "RedHat 7",
+            "SubType":  "Build-Tests-R2R",
             "Type": "build/product/",
             "PB_BuildType": "Release"
           }

--- a/tests/helixprep.proj
+++ b/tests/helixprep.proj
@@ -110,7 +110,7 @@ EXIT /B %ERRORLEVEL%
     <PropertyGroup>
       <WrapperShContents>#!/bin/sh%0a</WrapperShContents>
       <WrapperShContents>$(WrapperShContents)%0a</WrapperShContents> 
-      <WrapperShContents>$(WrapperShContents)export CORE_ROOT="$HELIX_CORRELATION_PAYLOAD"%0a</WrapperShContents>
+      <WrapperShContents>$(WrapperShContents)export CORE_ROOT="%24HELIX_CORRELATION_PAYLOAD"%0a</WrapperShContents>
       <WrapperShContents>$(WrapperShContents)%0a</WrapperShContents>
       <WrapperShContents>$(WrapperShContents)for scriptFilePath in %24(find . -type f -iname '%2A.sh' ! -iname "runtests.sh" | sort)%0a</WrapperShContents>
       <WrapperShContents>$(WrapperShContents)do%0a</WrapperShContents>
@@ -118,6 +118,32 @@ EXIT /B %ERRORLEVEL%
       <WrapperShContents>$(WrapperShContents) chmod +x "%24scriptFilePath"%0a</WrapperShContents>
       <WrapperShContents>$(WrapperShContents)done%0a</WrapperShContents>
       <WrapperShContents>$(WrapperShContents)%0a</WrapperShContents>
+
+      <!-- Crossgen FX assemblies, if running R2R tests. 
+      TODO - remove this when we build tests on Linux -->
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)overlayDir=%24CORE_ROOT%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)if [ ! -f %24overlayDir/crossgenCompleted.mrk ]%3B then%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)  filesToPrecompile=%24(find -L %24overlayDir -iname \%2A.dll -not -iname \%2A.ni.dll -not -iname \%2A-ms-win-\%2A -type f )%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)  for fileToPrecompile in %24{filesToPrecompile}%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)  do%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)    filename=%24{fileToPrecompile}%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)    echo Precompiling %24filename%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)    %24overlayDir/crossgen /Platform_Assemblies_Paths %24overlayDir %24filename 1> %24filename.stdout 2>%24filename.stderr%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)    exitCode=%24%3F%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)    if [ %24exitCode != 0 ]%3B then%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)      if grep -q -e '(COR_E_ASSEMBLYEXPECTED)' %24filename.stderr%3B then%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)        printf "\n\t%24filename is not a managed assembly.\n\n"%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)      else%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)        echo Unable to precompile %24filename.%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)      fi%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)    fi%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)    rm %24filename.stdout%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)    rm %24filename.stderr%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)  done%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)  touch %24overlayDir/crossgenCompleted.mrk%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)fi%0a</WrapperShContents>
+      <WrapperShContents Condition="'$(Crossgen)' == 'true'">$(WrapperShContents)%0a</WrapperShContents>
+
       <WrapperShContents>$(WrapperShContents)echo BEGIN EXECUTION%0a</WrapperShContents>
       <WrapperShContents>$(WrapperShContents)echo "%24{HELIX_CORRELATION_PAYLOAD}/corerun" %24HELIX_WORKITEM_PAYLOAD/xunit.console.netcore.exe %24HELIX_WORKITEM_PAYLOAD/$(ProjectName) -noshadow -xml testResults.xml -notrait category=outerloop -notrait category=failing%0a</WrapperShContents>
       <WrapperShContents>$(WrapperShContents)"%24{HELIX_CORRELATION_PAYLOAD}/corerun" %24HELIX_WORKITEM_PAYLOAD/xunit.console.netcore.exe %24HELIX_WORKITEM_PAYLOAD/$(ProjectName) -noshadow -xml testResults.xml -notrait category=outerloop -notrait category=failing%0a</WrapperShContents>


### PR DESCRIPTION
This PR enables R2R tests for non-Windows in Helix by running crossgen on all CoreFX assemblies in Core_Root, in Helix, right before we begin executing. We touch a file named 'crossgenCompleted.mrk' inside of Core_Root once this process is done, then check for the existence of that file before trying to do it again (this way we don't unnecessarily CrossGen anything more than once).

Also, this will attempt to Crossgen every Core_Root .dll without the string '-ms-win-' in the name, but will fail harmlessly against non-FX .dll's. Since the time cost of crossgen-ing a .dll is pretty low, this is an easy way to solve the problem of only wanting to Crossgen CoreFX binaries (i.e. CrossGen will fail for other .dll's, but the failure will be swallowed).

Pending this going in, I'll open an issue against myself to revert this change once we can build tests on Linux, as there will be a better solution available at that time. 

Local testing showed tests passing, and stuff only getting crossgen'd once.

CC @MattGal @gkhanna79 

Resolves https://github.com/dotnet/coreclr/issues/3710