### PR TITLE
Move DynamicHelperFrame::UpdateRegDisplay into cgenx86.cpp

### DIFF
--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -2330,11 +2330,7 @@ public:
     virtual void GcScanRoots(promote_func *fn, ScanContext* sc);
 
 #ifdef _TARGET_X86_
-    virtual void UpdateRegDisplay(const PREGDISPLAY pRD)
-    {
-        WRAPPER_NO_CONTRACT;
-        UpdateRegDisplayHelper(pRD, 0);
-    }
+    virtual void UpdateRegDisplay(const PREGDISPLAY pRD);
 #endif
 
     virtual ETransitionType GetTransitionType()

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -1732,6 +1732,12 @@ EXTERN_C PVOID STDCALL VirtualMethodFixupWorker(Object * pThisPtr,  CORCOMPILE_V
 
 #ifdef FEATURE_READYTORUN
 
+void DynamicHelperFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
+{
+    WRAPPER_NO_CONTRACT;
+    UpdateRegDisplayHelper(pRD, 0);
+}
+
 //
 // Allocation of dynamic helpers
 //

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -932,6 +932,14 @@ void TailCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     RETURN;
 }
 
+#ifdef FEATURE_READYTORUN
+void DynamicHelperFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
+{
+    WRAPPER_NO_CONTRACT;
+    UpdateRegDisplayHelper(pRD, 0);
+}
+#endif // FEATURE_READYTORUN
+
 //------------------------------------------------------------------------
 // This is declared as returning WORD instead of PRD_TYPE because of
 // header issues with cgencpu.h including dbginterface.h.
@@ -1731,12 +1739,6 @@ EXTERN_C PVOID STDCALL VirtualMethodFixupWorker(Object * pThisPtr,  CORCOMPILE_V
 
 
 #ifdef FEATURE_READYTORUN
-
-void DynamicHelperFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
-{
-    WRAPPER_NO_CONTRACT;
-    UpdateRegDisplayHelper(pRD, 0);
-}
 
 //
 // Allocation of dynamic helpers


### PR DESCRIPTION
It is currently implemented in frames.h, but cgenx86.cpp seems to be an appropriate place.