### PR TITLE
Disable loop invariant code hoisting for referece GT_CLS_VAR

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6204,9 +6204,10 @@ bool Compiler::optHoistLoopExprsForTree(
             treeIsHoistable = false;
         }
 
-        // Avoid to hoist reference loading
-        if (tree->OperGet() == GT_CLS_VAR && tree->gtType == TYP_REF)
+        if (tree->OperGet() == GT_CLS_VAR)
         {
+            // It is unsafe to mark this as invariant,
+            // as we currently don't prevent it from being hoisted above the call to the class initializer.
             treeIsInvariant = false;
         }
     }

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6184,14 +6184,6 @@ bool Compiler::optHoistLoopExprsForTree(
                     treeIsHoistable = false;
                 }
             }
-            // Currently we must give up on reads from static variables (even if we are in the first block).
-            //
-            if (tree->OperGet() == GT_CLS_VAR)
-            {
-                // TODO-CQ: test that fails if we hoist GT_CLS_VAR: JIT\Directed\Languages\ComponentPascal\pi_r.exe
-                // method Main
-                treeIsHoistable = false;
-            }
         }
 
         // Is the value of the whole tree loop invariant?
@@ -6202,6 +6194,13 @@ bool Compiler::optHoistLoopExprsForTree(
         if (!treeIsInvariant)
         {
             treeIsHoistable = false;
+        }
+
+        // Currently we must give up on reads from static variables (even if we are in the first block).
+        //
+        if (tree->OperGet() == GT_CLS_VAR)
+        {
+            treeIsHoistable = treeIsInvariant = false;
         }
     }
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6193,22 +6193,24 @@ bool Compiler::optHoistLoopExprsForTree(
                 treeIsHoistable = false;
             }
         }
-
-        // Is the value of the whole tree loop invariant?
-        treeIsInvariant =
-            optVNIsLoopInvariant(tree->gtVNPair.GetLiberal(), lnum, &hoistCtxt->m_curLoopVnInvariantCache);
-
-        // Is the value of the whole tree loop invariant?
-        if (!treeIsInvariant)
-        {
-            treeIsHoistable = false;
-        }
-
+        
         if (tree->OperGet() == GT_CLS_VAR)
         {
             // It is unsafe to mark this as invariant,
             // as we currently don't prevent it from being hoisted above the call to the class initializer.
             treeIsInvariant = false;
+        }
+        else
+        {
+            // Is the value of the whole tree loop invariant?
+            treeIsInvariant =
+                optVNIsLoopInvariant(tree->gtVNPair.GetLiberal(), lnum, &hoistCtxt->m_curLoopVnInvariantCache);
+        }
+
+        // Is the value of the whole tree loop invariant?
+        if (!treeIsInvariant)
+        {
+            treeIsHoistable = false;
         }
     }
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6193,7 +6193,7 @@ bool Compiler::optHoistLoopExprsForTree(
                 treeIsHoistable = false;
             }
         }
-        
+
         if (tree->OperGet() == GT_CLS_VAR)
         {
             // It is unsafe to mark this as invariant,

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6205,9 +6205,9 @@ bool Compiler::optHoistLoopExprsForTree(
         }
 
         // Avoid to hoist reference loading
-        if (tree->OperGet() == GT_CLS_VAR && tree->gtType == TYP_BYREF)
+        if (tree->OperGet() == GT_CLS_VAR && tree->gtType == TYP_REF)
         {
-            treeIsHoistable = treeIsInvariant = false;
+            treeIsInvariant = false;
         }
     }
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6184,6 +6184,14 @@ bool Compiler::optHoistLoopExprsForTree(
                     treeIsHoistable = false;
                 }
             }
+            // Currently we must give up on reads from static variables (even if we are in the first block).
+            //
+            if (tree->OperGet() == GT_CLS_VAR)
+            {
+                // TODO-CQ: test that fails if we hoist GT_CLS_VAR: JIT\Directed\Languages\ComponentPascal\pi_r.exe
+                // method Main
+                treeIsHoistable =  false;
+            }
         }
 
         // Is the value of the whole tree loop invariant?
@@ -6196,9 +6204,8 @@ bool Compiler::optHoistLoopExprsForTree(
             treeIsHoistable = false;
         }
 
-        // Currently we must give up on reads from static variables (even if we are in the first block).
-        //
-        if (tree->OperGet() == GT_CLS_VAR)
+        // Avoid to hoist reference loading
+        if (tree->OperGet() == GT_CLS_VAR && tree->gtType == TYP_BYREF)
         {
             treeIsHoistable = treeIsInvariant = false;
         }

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6190,7 +6190,7 @@ bool Compiler::optHoistLoopExprsForTree(
             {
                 // TODO-CQ: test that fails if we hoist GT_CLS_VAR: JIT\Directed\Languages\ComponentPascal\pi_r.exe
                 // method Main
-                treeIsHoistable =  false;
+                treeIsHoistable = false;
             }
         }
 

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b79250/b79250.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b79250/b79250.il
@@ -89,7 +89,7 @@ Start_Orphan_8:
          stind.i4
 End_Orphan_8:
            ldloc LOCAL_0x0
-          conv.ovf.i1.un
+          conv.i1
 Start_Orphan_9:
           nop
 End_Orphan_9:


### PR DESCRIPTION
Disable optimizing loop invariant code hoisting for GT_CLS_VAR completely 

related issue: #10780 