### PR TITLE
[ARM] Update rootfs for Tizen armel

### DIFF
--- a/cross/armel/tizen/tizen.patch
+++ b/cross/armel/tizen/tizen.patch
@@ -16,18 +16,3 @@ diff -u -r a/usr/lib/libpthread.so b/usr/lib/libpthread.so
  OUTPUT_FORMAT(elf32-littlearm)
 -GROUP ( /lib/libpthread.so.0 /usr/lib/libpthread_nonshared.a )
 +GROUP ( libpthread.so.0 libpthread_nonshared.a )
-diff -u -r a/usr/lib/libpthread.so b/usr/lib/libpthread.so
---- a/etc/os-release  2016-10-17 23:39:36.000000000 +0900
-+++ b/etc/os-release  2017-01-05 14:34:39.099867682 +0900
-@@ -1,7 +1,7 @@
- NAME=Tizen
--VERSION="3.0.0 (Tizen3/Mobile)"
-+VERSION="4.0.0 (Tizen4/Mobile)"
- ID=tizen
--VERSION_ID=3.0.0
--PRETTY_NAME="Tizen 3.0.0 (Tizen3/Mobile)"
-+VERSION_ID=4.0.0
-+PRETTY_NAME="Tizen 4.0.0 (Tizen4/Mobile)"
- ANSI_COLOR="0;36"
--CPE_NAME="cpe:/o:tizen:tizen:3.0.0"
-+CPE_NAME="cpe:/o:tizen:tizen:4.0.0"

--- a/cross/armel/toolchain.cmake
+++ b/cross/armel/toolchain.cmake
@@ -16,7 +16,7 @@ set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target ${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} --sysroot=${CROSS_ROOTFS}")
 
 if("$ENV{__DistroRid}" MATCHES "tizen.*")
-    set(TIZEN_TOOLCHAIN "armv7l-tizen-linux-gnueabi/4.9.2")
+    set(TIZEN_TOOLCHAIN "armv7l-tizen-linux-gnueabi/6.2.1")
     include_directories(SYSTEM ${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}/include/c++/)
     include_directories(SYSTEM ${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}/include/c++/armv7l-tizen-linux-gnueabi)
     add_compile_options(-Wno-deprecated-declarations) # compile-time option

--- a/tests/scripts/arm32_ci_script.sh
+++ b/tests/scripts/arm32_ci_script.sh
@@ -265,7 +265,9 @@ function cross_build_coreclr_with_docker {
         # For armel Tizen, we are going to construct RootFS on the fly.
         case $__linuxCodeName in
         tizen)
-            __dockerImage=" t2wish/dotnetcore:ubuntu1404_cross_prereqs_v4"
+            __dockerImage=" hqueue/dotnetcore:ubuntu1404_cross_prereqs_v4-tizen_rootfs"
+            __skipRootFS=1
+            __dockerEnvironmentVariables+=" -e ROOTFS_DIR=/crossrootfs/armel.tizen.build"
             __runtimeOS="tizen.4.0.0"
         ;;
         *)
@@ -381,7 +383,9 @@ function run_tests_using_docker {
     elif [ "$__buildArch" == "armel" ]; then
         case $__linuxCodeName in
         tizen)
-            __dockerImage=" t2wish/dotnetcore:ubuntu1404_cross_prereqs_v3"
+            __dockerImage=" hqueue/dotnetcore:ubuntu1404_cross_prereqs_v4-tizen_rootfs"
+            __skipRootFS=1
+            __dockerEnvironmentVariables=" -e ROOTFS_DIR=/crossrootfs/armel.tizen.test"
         ;;
         *)
             exit_with_error "ERROR: $__linuxCodeName is not a supported linux name for $__buildArch" false

--- a/tests/scripts/arm32_ci_test.sh
+++ b/tests/scripts/arm32_ci_test.sh
@@ -81,25 +81,11 @@ else
 fi
 
 if [ "$__abi" == "armel" ]; then
-    # TODO: Make use of a single Tizen rootfs for build and test
-
-    # TODO-cleanup: the latest docker image already has mic installed.
-    # Prepare Tizen (armel) environment
-    #echo "deb http://download.tizen.org/tools/latest-release/Ubuntu_14.04 /" >> /etc/apt/sources.list
-    #apt-get update
-    #apt-get -y -qq --force-yes install mic
-
+    # Prepare armel emulation environment
     pushd ${CORECLR_DIR}/cross/armel/tizen
-    mic --non-interactive create fs --pack-to=tizen.tar.gz tizen-dotnet.ks
-    if [ -d ${__ROOTFS_DIR} ]; then
-        mv ${__ROOTFS_DIR} ${__ROOTFS_DIR}_build
-    fi
-    mkdir -p ${__ROOTFS_DIR}
-    tar -zxf mic-output/tizen.tar.gz -C ${__ROOTFS_DIR}
     apt-get update
     apt-get -y -qq --force-yes --reinstall install qemu binfmt-support qemu-user-static
     __qemuARM=$(which qemu-arm-static)
-    cp $__qemuARM ${CORECLR_DIR}/cross/rootfs/armel/usr/bin/
     cp $__qemuARM ${__ROOTFS_DIR}/usr/bin/
     popd
 fi


### PR DESCRIPTION
This is required to build CoreCLR for Tizen armel as a part of .NET Core 2.0.0 for Tizen.

Existing rootfs for armel Tizen is out-of-dated and not suitable for .NET Core 2.0.0 for Tizen.

Two changes are made.
* Update rootfs for Tizen armel to recent version
* Updates CI for Tizen armel to make use of a prebuilt embedded rootfs as Ubuntu arm does.

*Please merge this PR first before following related PR merged.*

Related PR:
https://github.com/dotnet/corefx/pull/18916
https://github.com/dotnet/core-setup/pull/2163