### PR TITLE
[RyuJIT/ARM32] Update lclFld codegen

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -491,7 +491,21 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             unsigned varNum = treeNode->gtLclVarCommon.gtLclNum;
             assert(varNum < compiler->lvaCount);
 
-            emit->emitIns_R_S(ins_Move_Extend(targetType, treeNode->InReg()), size, targetReg, varNum, offs);
+            if (varTypeIsFloating(targetType))
+            {
+                if (treeNode->InReg())
+                {
+                    NYI("GT_LCL_FLD with reg-to-reg floating point move");
+                }
+                else
+                {
+                    emit->emitIns_R_S(ins_Load(targetType), size, targetReg, varNum, offs);
+                }
+            }
+            else
+            {
+                emit->emitIns_R_S(ins_Move_Extend(targetType, treeNode->InReg()), size, targetReg, varNum, offs);
+            }
         }
             genProduceReg(treeNode);
             break;


### PR DESCRIPTION
Fixes runtime failures of
```
JIT/jit64/valuetypes/nullable/box-unbox/box-unbox/box-unbox011
JIT/jit64/valuetypes/nullable/box-unbox/generics/box-unbox-generics011
JIT/jit64/valuetypes/nullable/box-unbox/interface/box-unbox-interface016
JIT/jit64/valuetypes/nullable/box-unbox/value/box-unbox-value011
...
```
cc @dotnet/arm32-contrib 