### PR TITLE
Fix GCInfo library used by ARM/ARM64 protononjit builds

### DIFF
--- a/src/gcinfo/CMakeLists.txt
+++ b/src/gcinfo/CMakeLists.txt
@@ -23,5 +23,15 @@ endif(CLR_CMAKE_PLATFORM_UNIX)
 add_subdirectory(lib)
 add_subdirectory(crossgen)
 
+if (CLR_CMAKE_PLATFORM_ARCH_I386)
+    # On x86, build RyuJIT/ARM32 cross-compiling altjit.
+    add_subdirectory(gcinfo_arm)
+endif ()
+
+if (CLR_CMAKE_PLATFORM_ARCH_AMD64)
+    # On amd64, build RyuJIT/ARM64 cross-compiling altjit.
+    add_subdirectory(gcinfo_arm64)
+endif ()
+
 _install (FILES gcinfoencoder.cpp
                DESTINATION gcinfo)

--- a/src/gcinfo/gcinfo_arm/CMakeLists.txt
+++ b/src/gcinfo/gcinfo_arm/CMakeLists.txt
@@ -1,0 +1,7 @@
+remove_definitions(-D_TARGET_X86_=1)
+add_definitions(-D_TARGET_ARM_)
+
+add_library_clr(gcinfo_arm
+    STATIC
+    ${GCINFO_SOURCES}
+)

--- a/src/gcinfo/gcinfo_arm64/CMakeLists.txt
+++ b/src/gcinfo/gcinfo_arm64/CMakeLists.txt
@@ -1,0 +1,7 @@
+remove_definitions(-D_TARGET_AMD64_=1)
+add_definitions(-D_TARGET_ARM64_)
+
+add_library_clr(gcinfo_arm64
+    STATIC
+    ${GCINFO_SOURCES}
+)

--- a/src/jit/protononjit/CMakeLists.txt
+++ b/src/jit/protononjit/CMakeLists.txt
@@ -13,10 +13,12 @@ if (CLR_CMAKE_PLATFORM_ARCH_I386)
     remove_definitions(-D_TARGET_X86_=1)
     add_definitions(-D_TARGET_ARM_)
     set(JIT_ARCH_ALTJIT_SOURCES ${JIT_ARM_SOURCES})
+    set(JIT_ARCH_LINK_LIBRARIES gcinfo_arm)
 elseif(CLR_CMAKE_PLATFORM_ARCH_AMD64)
     remove_definitions(-D_TARGET_AMD64_=1)
     add_definitions(-D_TARGET_ARM64_)
     set(JIT_ARCH_ALTJIT_SOURCES ${JIT_ARM64_SOURCES})
+    set(JIT_ARCH_LINK_LIBRARIES gcinfo_arm64)
 else()
     clr_unknown_arch()
 endif()
@@ -49,7 +51,7 @@ set_property(TARGET protononjit APPEND_STRING PROPERTY LINK_DEPENDS ${JIT_EXPORT
 
 set(RYUJIT_LINK_LIBRARIES
    utilcodestaticnohost
-   gcinfo
+   ${JIT_ARCH_LINK_LIBRARIES}
 )
 
 if(CLR_CMAKE_PLATFORM_UNIX)


### PR DESCRIPTION
Otherwise, using the normal GCInfo library, the altjits will
assert creating GC info.