### PR TITLE
[Preview] Undo VM portion of #9789

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -1439,11 +1439,6 @@ static CORINFO_FIELD_ACCESSOR getFieldIntrinsic(FieldDesc * field)
     {
         return CORINFO_FIELD_INTRINSIC_ZERO;
     }
-    else
-    if (MscorlibBinder::GetField(FIELD__BITCONVERTER__ISLITTLEENDIAN) == field)
-    {
-        return CORINFO_FIELD_INTRINSIC_ISLITTLEENDIAN;
-    }
 
     return (CORINFO_FIELD_ACCESSOR)-1;
 }


### PR DESCRIPTION
Maintain compat with JIT32 for 2.0 Preview.  #9789 introduced a performance optimization involving a change to the JIT and JIT interface.  Since this optimization was not added to JIT32, we should disable it for Preview, returning behavior to that prior to #9789 for Preview.  Since JIT32 is being removed post-Preview, this change does not need to go into master.

Fixes #11088.