### PR TITLE
Add missing opcodes for morph cast narrowing.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -450,14 +450,16 @@ GenTreePtr Compiler::fgMorphCast(GenTreePtr tree)
             // For these operations the lower 32 bits of the result only depends
             // upon the lower 32 bits of the operands
             //
-            if ((oper->OperGet() == GT_ADD) || (oper->OperGet() == GT_MUL) || (oper->OperGet() == GT_AND) ||
-                (oper->OperGet() == GT_OR) || (oper->OperGet() == GT_XOR))
+            if (oper->OperIs(GT_ADD, GT_SUB, GT_MUL, GT_AND, GT_OR, GT_XOR, GT_NOT, GT_NEG, GT_LSH))
             {
                 DEBUG_DESTROY_NODE(tree);
 
                 // Insert narrowing casts for op1 and op2
                 oper->gtOp.gtOp1 = gtNewCastNode(TYP_INT, oper->gtOp.gtOp1, dstType);
-                oper->gtOp.gtOp2 = gtNewCastNode(TYP_INT, oper->gtOp.gtOp2, dstType);
+                if (oper->gtOp.gtOp2 != nullptr)
+                {
+                    oper->gtOp.gtOp2 = gtNewCastNode(TYP_INT, oper->gtOp.gtOp2, dstType);
+                }
 
                 // Clear the GT_MUL_64RSLT if it is set
                 if (oper->gtOper == GT_MUL && (oper->gtFlags & GTF_MUL_64RSLT))


### PR DESCRIPTION
The narrowing can be applied to GT_SUB, GT_NOT, GT_NEG, and GT_LSH in addition to
GT_ADD, GT_MUL, GT_AND, GT_OR, and GT_XOR that were already supported.

jit-diff reports:

No diffs in benchmarks.

Frameworks:
```
Summary:
(Note: Lower is better)
Total bytes of diff: -309 (0.00 % of base)
    diff is an improvement.
Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes
Top file improvements by size (bytes):
        -124 : System.Private.CoreLib.dasm (0.00 % of base)
         -64 : System.Text.Encoding.CodePages.dasm (-0.11 % of base)
         -36 : System.Runtime.Extensions.dasm (-0.03 % of base)
         -35 : System.Runtime.Numerics.dasm (-0.06 % of base)
         -17 : System.IO.Compression.dasm (-0.03 % of base)
9 total files with size differences (9 improved, 0 regressed).
Top method improvements by size (bytes):
         -36 : System.Runtime.Extensions.dasm - BufferedStream:Seek(long,int):long:this
         -35 : System.Runtime.Numerics.dasm - BigIntegerCalculator:Square(int,int,int,int)
         -26 : System.Text.Encoding.CodePages.dasm - DecoderFallbackBufferHelper:InternalFallback(ref,int):int:this
         -25 : System.Private.CoreLib.dasm - ResourceReader:GetResourceData(ref,byref,byref):this
         -24 : System.Private.CoreLib.dasm - FileStream:Seek(long,int):long:this
22 total methods with size differences (22 improved, 0 regressed).
```
Tests:

```
Summary:
(Note: Lower is better)
Total bytes of diff: -3154 (0.00 % of base)
    diff is an improvement.
Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes
Top file improvements by size (bytes):
        -371 : JIT\Methodical\int64\arrays\_il_dbglcs_long\_il_dbglcs_long.dasm (-5.73 % of base)
        -371 : JIT\Methodical\int64\arrays\_il_dbglcs_ulong\_il_dbglcs_ulong.dasm (-5.55 % of base)
        -174 : JIT\Methodical\int64\arrays\_il_rellcs_long\_il_rellcs_long.dasm (-7.13 % of base)
        -170 : JIT\Methodical\int64\arrays\_il_rellcs_ulong\_il_rellcs_ulong.dasm (-6.61 % of base)
        -112 : JIT\Methodical\unsafecsharp\_dbgunsafe-3\_dbgunsafe-3.dasm (-0.49 % of base)
50 total files with size differences (50 improved, 0 regressed).
Top method improvements by size (bytes):
        -371 : JIT\Methodical\int64\arrays\_il_dbglcs_long\_il_dbglcs_long.dasm - LCS:findLCS(ref,ref,ref,ref)
        -371 : JIT\Methodical\int64\arrays\_il_dbglcs_ulong\_il_dbglcs_ulong.dasm - LCS:findLCS(ref,ref,ref,ref)
        -174 : JIT\Methodical\int64\arrays\_il_rellcs_long\_il_rellcs_long.dasm - LCS:findLCS(ref,ref,ref,ref)
        -170 : JIT\Methodical\int64\arrays\_il_rellcs_ulong\_il_rellcs_ulong.dasm - LCS:findLCS(ref,ref,ref,ref)
         -63 : JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16049\b16049\b16049.dasm - ILGEN_622380794:main():int
102 total methods with size differences (102 improved, 0 regressed).
```

I'm not planning to merge this until after the 2.0 stabilization.
/cc @dotnet/jit-contrib