### PR TITLE
Unsafe.As workaround (roundtrip via a local to avoid type mismatch)

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6991,7 +6991,7 @@ bool getILIntrinsicImplementationForUnsafe(MethodDesc * ftn,
     else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_AS)->GetMemberDef())
     {
         // Return the argument that was passed in.
-        static const BYTE ilcode[] = { CEE_LDARG_0, CEE_RET };
+        static const BYTE ilcode[] = { CEE_LDARG_0, CEE_STLOC_0, CEE_LDLOC_0, CEE_RET };
         methInfo->ILCode = const_cast<BYTE*>(ilcode);
         methInfo->ILCodeSize = sizeof(ilcode);
         methInfo->maxStack = 1;

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6991,7 +6991,7 @@ bool getILIntrinsicImplementationForUnsafe(MethodDesc * ftn,
     else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_AS)->GetMemberDef())
     {
         // Return the argument that was passed in.
-        static const BYTE ilcode[] = { CEE_LDARG_0, CEE_STLOC_0, CEE_LDLOC_0, CEE_RET };
+        static const BYTE ilcode[] = { CEE_LDC_I4_0, CEE_LDARG_0, CEE_STLOC_0, CEE_LDLOC_0, CEE_RET };
         methInfo->ILCode = const_cast<BYTE*>(ilcode);
         methInfo->ILCodeSize = sizeof(ilcode);
         methInfo->maxStack = 1;


### PR DESCRIPTION
From https://github.com/dotnet/corefxlab/issues/1479#issuecomment-296325631

> The CoreLib internal version of Unsafe.As is missing the workaround for this that was done in the public OOB version of Unsafe.As.

Keeping it in sync with:
https://github.com/dotnet/corefx/blob/master/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il#L268

cc @jkotas, @russellhadley 