### PR TITLE
Fix and re-enable some GC finalizer tests

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -1,9 +1,6 @@
 <?xml version="1.0" ?>
 <Project DefaultTargets = "GetListOfTestCmds" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
-        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\doublinkgen\*">
-            <Issue>6574</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\GC\Coverage\271010\*">
             <Issue>3392</Issue>
         </ExcludeList>
@@ -42,9 +39,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\muldimjagary\muldimjagary\*">
             <Issue>3392</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlstack\*">
-            <Issue>6553</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldelemnullarr1_il_d\ldelemnullarr1_il_d.cmd">
             <Issue>4851</Issue>

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -70,7 +70,6 @@ GC/Features/BackgroundGC/foregroundgc/foregroundgc.sh
 GC/Features/LOHFragmentation/lohfragmentation/lohfragmentation.sh
 GC/Features/SustainedLowLatency/scenario/scenario.sh
 GC/Regressions/dev10bugs/536168/536168/536168.sh
-GC/Scenarios/DoublinkList/doublinkgen/doublinkgen.sh
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest612/Generated612/Generated612.sh
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest613/Generated613/Generated613.sh
 Loader/classloader/TypeGeneratorTests/TypeGeneratorTest614/Generated614/Generated614.sh


### PR DESCRIPTION
This PR makes a few tests more robust against races against the finalizer thread (https://github.com/dotnet/coreclr/issues/4093). To do this, it runs `GC.Collect`, `GC.WaitForPendingFinalizers`, and `GC.Collect` in a loop for as long as the test success metrics are changing (i.e. finalizers are being run). If they remain the same after a Collect/WFPF/Collect iteration, there's a real issue.

Fixes https://github.com/dotnet/coreclr/issues/4093.