### PR TITLE
JIT: fix return type mismatch inlining block

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17947,8 +17947,12 @@ GenTreePtr Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, 
         op1               = argInfo.argNode;
         argInfo.argTmpNum = op1->gtLclVarCommon.gtLclNum;
 
-        // Use an equivalent copy if this is the second or subsequent use.
-        if (argInfo.argIsUsed)
+        // Use an equivalent copy if this is the second or subsequent
+        // use, or if we need to retype.
+        //
+        // Note argument type mismatches that prevent inlining should
+        // have been caught in impInlineInitVars.
+        if (argInfo.argIsUsed || (op1->TypeGet() != lclTyp))
         {
             assert(op1->gtOper == GT_LCL_VAR);
             assert(lclNum == op1->gtLclVar.gtLclILoffs);


### PR DESCRIPTION
If caller passes a directly substitutable expression whose
type is compatible with but not the same as the callee argument type,
and that argument is the callee's return value, the jit may
reject inlining the method because of a return type mismatch.

Fix is to retype the expressions we use in the callee's body
as the callee's type.

Closes #11211.