### PR TITLE
[ARM32/Linux] Copy tests.zip only for CI test and use x86 unittest

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1632,7 +1632,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     }
 
                     // Unzip the Windows test binaries first. Exit with 0
-                    buildCommands += "unzip -q -o ./bin/tests/tests.zip -d ./bin/tests/Windows_NT.x64.${configuration} || exit 0"
+                    buildCommands += "unzip -q -o ./bin/tests/tests.zip -d ./bin/tests/Windows_NT.x86.${configuration} || exit 0"
 
                     // Unpack the corefx binaries
                     buildCommands += "mkdir ./bin/CoreFxBinDir"
@@ -1652,7 +1652,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     --${arm_abi} \\
                     --linuxCodeName=${linuxCodeName} \\
                     --buildConfig=${lowerConfiguration} \\
-                    --testRootDir=./bin/tests/Windows_NT.x64.${configuration} \\
+                    --testRootDir=./bin/tests/Windows_NT.x86.${configuration} \\
                     --coreFxBinDir=./bin/CoreFxBinDir \\
                     --testDirFile=./tests/testsRunningInsideARM.txt"""
 
@@ -1961,7 +1961,7 @@ combinedScenarios.each { scenario ->
                                     def WindowTestsName = projectFolder + '/' +
                                                           Utilities.getFullJobName(project,
                                                                                    getJobName(lowerConfiguration,
-                                                                                              'x64' ,
+                                                                                              'x86' ,
                                                                                               'windows_nt',
                                                                                               'default',
                                                                                               true),
@@ -1969,9 +1969,9 @@ combinedScenarios.each { scenario ->
                                     def corefxFolder = Utilities.getFolderName('dotnet/corefx') + '/' +
                                                        Utilities.getFolderName(branch)
 
-                                    // Copy the Windows test binaries and the Corefx build binaries
+                                    // Copy the Windows test binaries
                                     copyArtifacts(WindowTestsName) {
-                                        excludePatterns('**/testResults.xml', '**/*.ni.dll')
+                                        includePatterns('bin/tests/tests.zip')
                                         buildSelector {
                                             latestSuccessful(true)
                                         }


### PR DESCRIPTION
- Use x86 unittest instead of x64: 32bit architecture
- Copy tests.zip only from x86 Windows build for CI test