### PR TITLE
[ARM/Linux] Honor unaligned prefix for ldobj instruction

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -14806,6 +14806,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     // Could point anywhere, example a boxed class static int
                     op1->gtFlags |= GTF_IND_TGTANYWHERE | GTF_GLOB_REF;
                     assertImp(varTypeIsArithmetic(op1->gtType));
+
+                    if (prefixFlags & PREFIX_UNALIGNED)
+                    {
+                        op1->gtFlags |= GTF_IND_UNALIGNED;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
It seems that importer currently ignores unaligned. prefix when it imports ldobj instruction, which results in #11200.

This commit attempts to (partially) fix #11200 on the following cases (when the object is of primitive type):
 - System.Runtime.CompilerServices.UnsafeTests.ReadUnaligned_ByRef_Double
 - System.Runtime.CompilerServices.UnsafeTests.ReadUnaligned_Ptr_Double