### PR TITLE
Enable property to skip build number in packaging.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -139,6 +139,7 @@
   <!-- Packaging properties -->
   <PropertyGroup>
     <PreReleaseLabel>preview2</PreReleaseLabel>
+    <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == ''">true</IncludeBuildNumberInPackageVersion>
     <PackageDescriptionFile>$(SourceDir).nuget/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(SourceDir).nuget/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(SourceDir).nuget/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>


### PR DESCRIPTION
@weshaggard PTAL

This will be ported to release/2.0.0 for stabilization.

CC @RussKeldorph @leecow 