### PR TITLE
Require a frame pointer in methods with throw blocks for sources that…

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17733,10 +17733,12 @@ BasicBlock* Compiler::fgAddCodeRef(BasicBlock* srcBlk, unsigned refData, Special
 
 #if defined(UNIX_X86_ABI)
         codeGen->setFrameRequired(true);
+        codeGen->setFramePointerRequiredGCInfo(true);
 #else  // !defined(UNIX_X86_ABI)
         if (add->acdStkLvl != stkDepth)
         {
             codeGen->setFrameRequired(true);
+            codeGen->setFramePointerRequiredGCInfo(true);
         }
 #endif // !defined(UNIX_X86_ABI)
 #endif // _TARGET_X86_


### PR DESCRIPTION
… have mismatched stack depths.

This requirement effectively disables double-aligned frames (which are
effectively a special case of ESP frames). Without this change it is
possible for the JIT to generate a throw block with sources that have
mismatched offsets, which can lead to GC holes.

Fixes VSO 424019.