### PR TITLE
Use SourceBranch from pipebuild to define Helix Branch

### DIFF
--- a/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -86,7 +86,7 @@
       },
       "inputs": {
         "filename": "msbuild",
-        "arguments": "helixpublish.proj /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:CloudDropAccountName=$(CloudDropAccountName) /p:ContainerName=$(PB_ContainerName) /p:Platform=$(Architecture) /p:BuildType=$(PB_BuildType) /p:CloudResultsAccountName=$(CloudResultsAccountName) /p:CloudResultsAccessToken=$(CloudResultsAccessToken) /p:TargetsWindows=$(TargetsWindows) /p:OverwriteOnUpload=true /p:Rid=$(Rid) /p:TargetQueues=\"$(TargetQueues)\" /p:TestProduct=$(TestProduct) /p:Branch=$(HelixBranch) /p:HelixApiAccessKey=$(HelixApiAccessKey) /p:HelixApiEndpoint=$(HelixApiEndpoint) /p:FilterToOSGroup=$(FilterToOSGroup) /p:FilterToTestTFM=$(FilterToTestTFM) /p:TimeoutInSeconds=1800 /p:HelixJobType=$(HelixJobType) /fileloggerparameters:Verbosity=diag;LogFile=helix.log",
+        "arguments": "helixpublish.proj /p:CloudDropAccessToken=$(CloudDropAccessToken) /p:CloudDropAccountName=$(CloudDropAccountName) /p:ContainerName=$(PB_ContainerName) /p:Platform=$(Architecture) /p:BuildType=$(PB_BuildType) /p:CloudResultsAccountName=$(CloudResultsAccountName) /p:CloudResultsAccessToken=$(CloudResultsAccessToken) /p:TargetsWindows=$(TargetsWindows) /p:OverwriteOnUpload=true /p:Rid=$(Rid) /p:TargetQueues=\"$(TargetQueues)\" /p:TestProduct=$(TestProduct) /p:Branch=$(SourceBranch) /p:HelixApiAccessKey=$(HelixApiAccessKey) /p:HelixApiEndpoint=$(HelixApiEndpoint) /p:FilterToOSGroup=$(FilterToOSGroup) /p:FilterToTestTFM=$(FilterToTestTFM) /p:TimeoutInSeconds=1800 /p:HelixJobType=$(HelixJobType) /fileloggerparameters:Verbosity=diag;LogFile=helix.log",
         "workingFolder": "tests",
         "failOnStandardError": "false"
       }
@@ -204,7 +204,7 @@
     "TestProduct": {
       "value": "coreclr"
     },
-    "HelixBranch": {
+    "SourceBranch": {
       "value": "master"
     },
     "HelixApiAccessKey": {


### PR DESCRIPTION
Previously, we had HelixBranch hard-coded to 'master'. This wasn't changed in the fork to 2.0.0, which meant that Master and 2.0.0 pipebuilds had a race condition - if two jobs with the same label finished around the same time, whichever finished first would have its results shown in Helix for both branches. Matt already fixed this in 2.0.0, but in the future, the Helix Branch variable should come from SourceBranch, which is set in the VSO pipebuild job (I've confirmed that the master job sets this variable to master, 2.0.0 sets it to release/2.0.0, and that it gets passed to pipebuild.exe)

@MattGal PTAL

@gkhanna79 this is what was causing the mismatch between Azure results and Mission Control results yesterday.