### PR TITLE
Fix a double-free encountered when failing to initialize a handle table bucket

### DIFF
--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -608,7 +608,8 @@ HandleTableBucketHolder::~HandleTableBucketHolder()
         }
         delete [] m_bucket->pTable;
     }
-    delete m_bucket;
+
+    // we do not own m_bucket, so we shouldn't delete it here.
 }
 
 bool Ref_Initialize()
@@ -729,8 +730,7 @@ HandleTableBucket* Ref_CreateHandleTableBucket(void* context)
 
     if (!Ref_InitializeHandleTableBucket(result, context))
     {
-        // result has already been freed by Ref_InitializeHandleTableBucket.
-        // no need to do so here.
+        delete result;
         return nullptr;
     }
 

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -729,7 +729,8 @@ HandleTableBucket* Ref_CreateHandleTableBucket(void* context)
 
     if (!Ref_InitializeHandleTableBucket(result, context))
     {
-        delete result;
+        // result has already been freed by Ref_InitializeHandleTableBucket.
+        // no need to do so here.
         return nullptr;
     }
 


### PR DESCRIPTION
Before https://github.com/dotnet/coreclr/pull/11092, `Ref_InitializeHandleTableBucket` would return one of two ways: it would either return `true` or it would throw an `OutOfMemoryException`. As a result, the affected code path was effectively dead. After #11092, though, `Ref_InitializeHandleTableBucket` returns false on allocation failure, which caused us to take this path even after `Ref_InitializeHandleTableBucket` has already freed `result`, resulting in a double-free.

This issue was found with clang static analysis. cc @Maoni0 @sergiy-k @adityamandaleeka PTAL?