### PR TITLE
[x86/Linux] Disable USE_CALLER_SP_IN_FUNCLET in EH

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -25,11 +25,15 @@
 #define VSD_STUB_CAN_THROW_AV
 #endif // _TARGET_ARM_ || _TARGET_X86_
 
+#if defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
+// ARM/ARM64 uses Caller-SP to locate PSPSym in the funclet frame.
+#define USE_CALLER_SP_IN_FUNCLET
+#endif // _TARGET_ARM_ || _TARGET_ARM64_
+
 #if defined(_TARGET_ARM_) || defined(_TARGET_ARM64_) || defined(_TARGET_X86_)
 #define ADJUST_PC_UNWOUND_TO_CALL
 #define STACK_RANGE_BOUNDS_ARE_CALLER_SP
 #define USE_FUNCLET_CALL_HELPER
-#define USE_CALLER_SP_IN_FUNCLET
 // For ARM/ARM64, EstablisherFrame is Caller-SP (SP just before executing call instruction).
 // This has been confirmed by AaronGi from the kernel team for Windows.
 //


### PR DESCRIPTION
As x86/Linux uses Core RT-like EH model, its funclet call helpers do not require Caller-SP (unlike those for ARM/ARM64). 

This commit disables USE_CALLER_SP_IN_FUNCLET for x86 to reflect this difference.