### PR TITLE
[ARM/Linux] Enable build with FEATURE_DBGIPC=0

### DIFF
--- a/src/debug/di/cordb.cpp
+++ b/src/debug/di/cordb.cpp
@@ -20,6 +20,13 @@
 #include "dbgtransportmanager.h"
 #endif // FEATURE_DBGIPC_TRANSPORT_DI
 
+#if defined(PLATFORM_UNIX) || defined(__ANDROID__)
+// _aligned_malloc and _aligned_free are unavailable on POSIX and Android
+#define HAVE_ALIGNED_MALLOC 0
+#else
+#define HAVE_ALIGNED_MALLOC 1
+#endif
+
 //********** Globals. *********************************************************
 #ifndef FEATURE_PAL
 HINSTANCE       g_hInst;                // Instance handle to this piece of code.
@@ -499,7 +506,7 @@ DbiGetThreadContext(HANDLE hThread,
     DT_CONTEXT *lpContext)
 {
     // if we aren't local debugging this isn't going to work
-#if !defined(_ARM_) || defined(FEATURE_DBGIPC_TRANSPORT_DI) || defined(__ANDROID__)
+#if !defined(_ARM_) || defined(FEATURE_DBGIPC_TRANSPORT_DI) || !HAVE_ALIGNED_MALLOC
     _ASSERTE(!"Can't use local GetThreadContext remotely, this needed to go to datatarget");
     return FALSE;
 #else
@@ -538,7 +545,7 @@ BOOL
 DbiSetThreadContext(HANDLE hThread,
     const DT_CONTEXT *lpContext)
 {
-#if !defined(_ARM_) || defined(FEATURE_DBGIPC_TRANSPORT_DI) || defined(__ANDROID__)
+#if !defined(_ARM_) || defined(FEATURE_DBGIPC_TRANSPORT_DI) || !HAVE_ALIGNED_MALLOC
     _ASSERTE(!"Can't use local GetThreadContext remotely, this needed to go to datatarget");
     return FALSE;
 #else

--- a/src/debug/di/cordb.cpp
+++ b/src/debug/di/cordb.cpp
@@ -21,10 +21,10 @@
 #endif // FEATURE_DBGIPC_TRANSPORT_DI
 
 #if defined(PLATFORM_UNIX) || defined(__ANDROID__)
-// _aligned_malloc and _aligned_free are unavailable on POSIX and Android
-#define HAVE_ALIGNED_MALLOC 0
+// Local (in-process) debugging is not supported for UNIX and Android.
+#define SUPPORT_LOCAL_DEBUGGING 0
 #else
-#define HAVE_ALIGNED_MALLOC 1
+#define SUPPORT_LOCAL_DEBUGGING 1
 #endif
 
 //********** Globals. *********************************************************
@@ -506,7 +506,7 @@ DbiGetThreadContext(HANDLE hThread,
     DT_CONTEXT *lpContext)
 {
     // if we aren't local debugging this isn't going to work
-#if !defined(_ARM_) || defined(FEATURE_DBGIPC_TRANSPORT_DI) || !HAVE_ALIGNED_MALLOC
+#if !defined(_ARM_) || defined(FEATURE_DBGIPC_TRANSPORT_DI) || !SUPPORT_LOCAL_DEBUGGING
     _ASSERTE(!"Can't use local GetThreadContext remotely, this needed to go to datatarget");
     return FALSE;
 #else
@@ -545,7 +545,7 @@ BOOL
 DbiSetThreadContext(HANDLE hThread,
     const DT_CONTEXT *lpContext)
 {
-#if !defined(_ARM_) || defined(FEATURE_DBGIPC_TRANSPORT_DI) || !HAVE_ALIGNED_MALLOC
+#if !defined(_ARM_) || defined(FEATURE_DBGIPC_TRANSPORT_DI) || !SUPPORT_LOCAL_DEBUGGING
     _ASSERTE(!"Can't use local GetThreadContext remotely, this needed to go to datatarget");
     return FALSE;
 #else


### PR DESCRIPTION
#11164 allows users to disable DBGIPC support, but it introduces several build errors on ARM. Android has a similar issue, and thus #9961 introduces a workaround for Android.

This commit ports this workaround to Unix platforms.