### PR TITLE
[RyuJIT/ARM32] Update putarg_reg codegen

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -900,18 +900,18 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             break;
 
         case GT_PUTARG_REG:
-        {
-            NYI_IF(targetType == TYP_STRUCT, "GT_PUTARG_REG: struct support not implemented");
-
-            // commas show up here commonly, as part of a nullchk operation
-            GenTree* op1 = treeNode->gtOp.gtOp1->gtEffectiveVal();
-            // If child node is not already in the register we need, move it
-            genConsumeReg(op1);
-            if (treeNode->gtRegNum != op1->gtRegNum)
+            assert(targetType != TYP_STRUCT); // Any TYP_STRUCT register args should have been removed by
+                                              // fgMorphMultiregStructArg
+            // We have a normal non-Struct targetType
             {
-                inst_RV_RV(ins_Move_Extend(targetType, true), treeNode->gtRegNum, op1->gtRegNum, targetType);
+                GenTree* op1 = treeNode->gtOp.gtOp1;
+                // If child node is not already in the register we need, move it
+                genConsumeReg(op1);
+                if (targetReg != op1->gtRegNum)
+                {
+                    inst_RV_RV(ins_Copy(targetType), targetReg, op1->gtRegNum, targetType);
+                }
             }
-        }
             genProduceReg(treeNode);
             break;
 


### PR DESCRIPTION
A copy of the ARM64 codegen. Fixes the following assert failure:
```
Generating: N021 (  2,  2) [000092] -------------       t92 =    lclVar    bool   V02 tmp1         u:3 r4 REG r4 RV $45
                                                              ┌──▌  t92    bool   
Generating: N023 (???,???) [000115] -------------      t115 = ▌  putarg_reg bool   REG r0

Assert failure(PID 7493 [0x00001d45], Thread: 7493 [0x1d45]): Assertion failed 'size == EA_1BYTE' in 'NullableTest:Main():int' (IL size 41)

    File: /home/mskvortsov/git/coreclr/src/jit/emitarm.cpp Line: 2198
    Image: /home/mskvortsov/clr-checked/corerun

Aborted
```
A sample TC is `JIT/jit64/valuetypes/nullable/box-unbox/generics/box-unbox-generics007`, method `Main`. There were 28 of these failures across the testsuite.

cc @dotnet/arm32-contrib 