### PR TITLE
Do not report out-of-order consuming if a node wasn't consumed at all

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1087,7 +1087,11 @@ void CodeGen::genCheckConsumeNode(GenTree* const node)
 
     if (verbose)
     {
-        if ((node->gtDebugFlags & GTF_DEBUG_NODE_CG_CONSUMED) != 0)
+        if (node->gtUseNum == -1)
+        {
+            // nothing wrong if the node was not consumed
+        }
+        else if ((node->gtDebugFlags & GTF_DEBUG_NODE_CG_CONSUMED) != 0)
         {
             printf("Node was consumed twice:\n");
             compiler->gtDispTree(node, nullptr, nullptr, true);


### PR DESCRIPTION
Removes misleading reporting of out-of-order consuming:
```
Generating: N013 (  3,  7) [000101] -------------      t101 =    const(h)  int    0xB64A8FD5 ftn REG r3
IN0004:             movw    r3, 0x8fd5
IN0005:             movt    r3, 0xb64a
                                                              ┌──▌  t99    int    arg0 in r0
                                                              ├──▌  t100   int    arg1 in r1
                                                              ├──▌  t101   int    control expr
Generating: N015 ( 20, 20) [000062] --CXG--------       t62 = ▌  call help int    HELPER.CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE $2
Call: GCvars=00000000 {}, gcrefRegs=0000 {}, byrefRegs=0000 {}
IN0006:             blx     r3          // CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
Nodes were consumed out-of-order:
N013 (  3,  7) [000101] -------------             ▌  const(h)  int    0xB64A8FD5 ftn REG r3 RV
N015 ( 20, 20) [000062] --CXG--------             ▌  call help int    HELPER.CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE $201
```
(`t62` is not used anywhere later.)

cc @dotnet/jit-contrib 