### PR TITLE
Unify fetching LoadContext for Dynamic Assemblies

### DIFF
--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -785,15 +785,6 @@ ICLRPrivBinder* AssemblySpec::GetBindingContextFromParentAssembly(AppDomain *pDo
         
         // ICLRPrivAssembly implements ICLRPrivBinder and thus, "is a" binder in a manner of semantics.
         pParentAssemblyBinder = pParentPEAssembly->GetBindingContext();
-        if (pParentAssemblyBinder == NULL)
-        {
-            if (pParentPEAssembly->IsDynamic())
-            {
-                // If the parent assembly is dynamically generated, then use its fallback load context
-                // as the binder.
-                pParentAssemblyBinder = pParentPEAssembly->GetFallbackLoadContextBinder();
-            }
-        }
     }
 
     if (GetPreferFallbackLoadContextBinder())
@@ -811,13 +802,12 @@ ICLRPrivBinder* AssemblySpec::GetBindingContextFromParentAssembly(AppDomain *pDo
         //
         // 1) Domain Neutral assembly
         // 2) Entrypoint assembly
-        // 3) RefEmitted assembly
-        // 4) AssemblyLoadContext.LoadFromAssemblyName
+        // 3) AssemblyLoadContext.LoadFromAssemblyName
         //
         // For (1) and (2), we will need to bind against the DefaultContext binder (aka TPA Binder). This happens
         // below if we do not find the parent assembly binder.
         //
-        // For (3) and (4), fetch the fallback load context binder reference.
+        // For (3), fetch the fallback load context binder reference.
         
         pParentAssemblyBinder = GetFallbackLoadContextBinderForRequestingAssembly();
     }

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -5938,19 +5938,7 @@ HMODULE NDirect::LoadLibraryModuleViaHost(NDirectMethodDesc * pMD, AppDomain* pD
     //        The Binding Context can be null or an overridden TPA context
     if (pBindingContext == NULL)
     {
-        pBindingContext = nullptr;
-
-        // If the assembly does not have a binder associated with it explicitly, then check if it is
-        // a dynamic assembly, or not, since they can have a fallback load context associated with them.
-        if (pManifestFile->IsDynamic())
-        {
-            pBindingContext = pManifestFile->GetFallbackLoadContextBinder();
-        } 
-    }
-
-    // If we do not have any binder associated, then return to the default resolution mechanism.
-    if (pBindingContext == nullptr)
-    {
+        // If we do not have any binder associated, then return to the default resolution mechanism.
         return NULL;
     }    
 

--- a/src/vm/pefile.cpp
+++ b/src/vm/pefile.cpp
@@ -2849,12 +2849,22 @@ PTR_ICLRPrivBinder PEFile::GetBindingContext()
     
     PTR_ICLRPrivBinder pBindingContext = NULL;
     
-    // Mscorlib is always bound in context of the TPA Binder. However, since it gets loaded and published
-    // during EEStartup *before* TPAbinder is initialized, we dont have a binding context to publish against.
+    // CoreLibrary is always bound in context of the TPA Binder. However, since it gets loaded and published
+    // during EEStartup *before* DefaultContext Binder (aka TPAbinder) is initialized, we dont have a binding context to publish against.
     // Thus, we will always return NULL for its binding context.
     if (!IsSystem())
     {
         pBindingContext = dac_cast<PTR_ICLRPrivBinder>(GetHostAssembly());
+        if (!pBindingContext)
+        {
+            // If we do not have any binding context, check if we are dealing with
+            // a dynamically emitted assembly and if so, use its fallback load context
+            // binder reference.
+            if (IsDynamic())
+            {
+                pBindingContext = GetFallbackLoadContextBinder();
+            }
+        }
     }
     
     return pBindingContext;

--- a/src/vm/pefile.h
+++ b/src/vm/pefile.h
@@ -631,7 +631,7 @@ protected:
     // To enable this, we maintain a concept of "Fallback LoadContext", which will be set to the Binder of the
     // assembly that created the dynamic assembly. If the creator assembly is dynamic itself, then its fallback
     // load context would be propagated to the assembly being dynamically generated.
-    ICLRPrivBinder *m_pFallbackLoadContextBinder;
+    PTR_ICLRPrivBinder m_pFallbackLoadContextBinder;
 
 protected:
 
@@ -657,13 +657,13 @@ public:
     bool CanUseWithBindingCache()
     { LIMITED_METHOD_CONTRACT; return !HasHostAssembly(); }
 
-    void SetFallbackLoadContextBinder(ICLRPrivBinder *pFallbackLoadContextBinder)
+    void SetFallbackLoadContextBinder(PTR_ICLRPrivBinder pFallbackLoadContextBinder)
     { 
         LIMITED_METHOD_CONTRACT; 
         m_pFallbackLoadContextBinder = pFallbackLoadContextBinder; 
     }
 
-    ICLRPrivBinder *GetFallbackLoadContextBinder()
+    PTR_ICLRPrivBinder GetFallbackLoadContextBinder()
     {
         LIMITED_METHOD_CONTRACT;
 


### PR DESCRIPTION
LoadContext lookup for dynamic assemblies was not properly unified resulting in crash when fetching it for RefEmitted assemblies.

Unify the lookup.

Fixes https://github.com/dotnet/coreclr/issues/11228

@jkotas PTAL.