### PR TITLE
[Arm64] Support two GC attributes in pair forms

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -356,20 +356,9 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                     assert(loReg != addrReg);
                     noway_assert((remainingSize == 2 * TARGET_POINTER_SIZE) || (hiReg != addrReg));
 
-                    // Use a ldp instruction if types match
-                    // TODO-ARM64-CQ: Current limitations only allows using ldp/stp when both of the GC types match
-                    if (type0 == type1)
-                    {
-                        // Load from our address expression source
-                        emit->emitIns_R_R_R_I(INS_ldp, emitTypeSize(type0), loReg, hiReg, addrReg, structOffset);
-                    }
-                    else
-                    {
-                        // Load from our address expression source
-                        emit->emitIns_R_R_I(ins_Load(type0), emitTypeSize(type0), loReg, addrReg, structOffset);
-                        emit->emitIns_R_R_I(ins_Load(type1), emitTypeSize(type1), hiReg, addrReg,
-                                            structOffset + TARGET_POINTER_SIZE);
-                    }
+                    // Load from our address expression source
+                    emit->emitIns_R_R_R_I(INS_ldp, emitTypeSize(type0), loReg, hiReg, addrReg, structOffset,
+                                          INS_OPTS_NONE, emitTypeSize(type0));
                 }
 
                 // Emit two store instructions to store the two registers into the outgoing argument area

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1381,6 +1381,10 @@ void* emitter::emitAllocInstr(size_t sz, emitAttr opsz)
         id->idOpSize(EA_SIZE(opsz));
     }
 
+#ifdef _TARGET_ARM64_
+    id->idGCrefReg2(GCT_NONE);
+#endif
+
     // Amd64: ip-relative addressing is supported even when not generating relocatable ngen code
     if (EA_IS_DSP_RELOC(opsz)
 #ifndef _TARGET_AMD64_

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -655,6 +655,9 @@ protected:
         // unnecessarily since the GC-ness of the second register is only needed for call instructions.
         // The instrDescCGCA struct's member keeping the GC-ness of the first return register is _idcSecondRetRegGCType.
         GCtype _idGCref : 2; // GCref operand? (value is a "GCtype")
+#ifdef _TARGET_ARM64_
+        GCtype _idGCref2 : 2; // GCref operand fir register 2? (value is a "GCtype")
+#endif
 
         // Note that we use the _idReg1 and _idReg2 fields to hold
         // the live gcrefReg mask for the call instructions on x86/x64
@@ -668,7 +671,7 @@ protected:
         // x86:   30 bits
         // amd64: 38 bits
         // arm:   32 bits
-        // arm64: 30 bits
+        // arm64: 32 bits
         CLANG_FORMAT_COMMENT_ANCHOR;
 
 #if HAS_TINY_DESC
@@ -718,8 +721,8 @@ protected:
 #define ID_EXTRA_BITFIELD_BITS (16)
 
 #elif defined(_TARGET_ARM64_)
-// For Arm64, we have used 15 bits from the second DWORD.
-#define ID_EXTRA_BITFIELD_BITS (16)
+// For Arm64, we have used 18 bits from the second DWORD.
+#define ID_EXTRA_BITFIELD_BITS (18)
 #elif defined(_TARGET_XARCH_) && !defined(LEGACY_BACKEND)
 // For xarch !LEGACY_BACKEND, we have used 14 bits from the second DWORD.
 #define ID_EXTRA_BITFIELD_BITS (14)
@@ -735,7 +738,7 @@ protected:
         // x86:   38 bits  // if HAS_TINY_DESC is not defined (which it is)
         // amd64: 46 bits
         // arm:   48 bits
-        // arm64: 48 bits
+        // arm64: 50 bits
         CLANG_FORMAT_COMMENT_ANCHOR;
 
         unsigned _idCnsReloc : 1; // LargeCns is an RVA and needs reloc tag
@@ -748,7 +751,7 @@ protected:
         // x86:   40 bits
         // amd64: 48 bits
         // arm:   50 bits
-        // arm64: 50 bits
+        // arm64: 52 bits
         CLANG_FORMAT_COMMENT_ANCHOR;
 
 #define ID_EXTRA_BITS (ID_EXTRA_RELOC_BITS + ID_EXTRA_BITFIELD_BITS)
@@ -764,7 +767,7 @@ protected:
         // x86:   24 bits
         // amd64: 16 bits
         // arm:   14 bits
-        // arm64: 14 bits
+        // arm64: 12 bits
 
         unsigned _idSmallCns : ID_BIT_SMALL_CNS;
 
@@ -1071,6 +1074,17 @@ protected:
             _idReg1 = reg;
             assert(reg == _idReg1);
         }
+
+#ifdef _TARGET_ARM64_
+        GCtype idGCrefReg2() const
+        {
+            return (GCtype)_idGCref2;
+        }
+        void idGCrefReg2(GCtype gctype)
+        {
+            _idGCref2 = gctype;
+        }
+#endif // _TARGET_ARM64_
 
         regNumber idReg2() const
         {

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -656,7 +656,7 @@ protected:
         // The instrDescCGCA struct's member keeping the GC-ness of the first return register is _idcSecondRetRegGCType.
         GCtype _idGCref : 2; // GCref operand? (value is a "GCtype")
 #ifdef _TARGET_ARM64_
-        GCtype _idGCref2 : 2; // GCref operand fir register 2? (value is a "GCtype")
+        GCtype _idGCref2 : 2;
 #endif
 
         // Note that we use the _idReg1 and _idReg2 fields to hold

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -5350,6 +5350,7 @@ void emitter::emitIns_R_R_R_I(instruction ins,
 
     if (attrReg2 != EA_UNKNOWN)
     {
+        assert((fmt == IF_LS_3B) || (fmt == IF_LS_3C));
         if (EA_IS_GCREF(attrReg2))
         {
             /* A special value indicates a GCref pointer value */

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -724,7 +724,8 @@ void emitIns_R_R_R_I(instruction ins,
                      regNumber   reg2,
                      regNumber   reg3,
                      ssize_t     imm,
-                     insOpts     opt = INS_OPTS_NONE);
+                     insOpts     opt      = INS_OPTS_NONE,
+                     emitAttr    attrReg2 = EA_UNKNOWN);
 
 void emitIns_R_R_R_Ext(instruction ins,
                        emitAttr    attr,


### PR DESCRIPTION
Also use in genCodeForCpObj

Fixes #11241