### PR TITLE
Fix issues exposed by building with MSVC and /permissive-.

### DIFF
--- a/src/vm/sampleprofiler.h
+++ b/src/vm/sampleprofiler.h
@@ -24,7 +24,7 @@ class SampleProfiler
         static void WalkManagedThreads();
 
         // Profiling thread proc.  Invoked on a new thread when profiling is enabled.
-        static DWORD WINAPI SampleProfiler::ThreadProc(void *args);
+        static DWORD WINAPI ThreadProc(void *args);
 
         // True when profiling is enabled.
         static Volatile<BOOL> s_profilingEnabled;


### PR DESCRIPTION
Using full-qualified name to declare members inside class is ill-formed and incorrectly allowed by MSVC.
MSVC now gives error when /permissive- is used.