### PR TITLE
Ensure we run the Crossgened test executable in R2R tests

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -407,7 +407,7 @@ function precompile_overlay_assemblies {
                 $overlayDir/crossgen /Platform_Assemblies_Paths $overlayDir $filename 1> $filename.stdout 2>$filename.stderr
                 local exitCode=$?
                 if [[ $exitCode != 0 ]]; then
-                    if [ grep -q -e '0x80131018' $filename.stderr ]; then
+                    if grep -q -e '0x80131018' $filename.stderr; then
                         printf "\n\t$filename is not a managed assembly.\n\n"
                     else
                         echo Unable to precompile $filename.

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -407,7 +407,7 @@ function precompile_overlay_assemblies {
                 $overlayDir/crossgen /Platform_Assemblies_Paths $overlayDir $filename 1> $filename.stdout 2>$filename.stderr
                 local exitCode=$?
                 if [[ $exitCode != 0 ]]; then
-                    if grep -q -e '(COR_E_ASSEMBLYEXPECTED)' $filename.stderr; then
+                    if [ grep -q -e '0x80131018' $filename.stderr ]; then
                         printf "\n\t$filename is not a managed assembly.\n\n"
                     else
                         echo Unable to precompile $filename.

--- a/tests/skipCrossGenFiles.arm.txt
+++ b/tests/skipCrossGenFiles.arm.txt
@@ -1,2 +1,3 @@
 mscorlib.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
+System.Private.CoreLib.dll

--- a/tests/skipCrossGenFiles.arm64.txt
+++ b/tests/skipCrossGenFiles.arm64.txt
@@ -3,3 +3,4 @@ Microsoft.CodeAnalysis.VisualBasic.dll
 System.Net.NameResolution.dll
 System.Net.Sockets.dll
 System.Net.Primitives.dll
+System.Private.CoreLib.dll

--- a/tests/skipCrossGenFiles.x64.txt
+++ b/tests/skipCrossGenFiles.x64.txt
@@ -1,2 +1,3 @@
 mscorlib.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
+System.Private.CoreLib.dll

--- a/tests/skipCrossGenFiles.x86.txt
+++ b/tests/skipCrossGenFiles.x86.txt
@@ -1,2 +1,3 @@
 mscorlib.dll
 System.Runtime.WindowsRuntime.UI.Xaml.dll
+System.Private.CoreLib.dll

--- a/tests/src/CLRTest.CrossGen.targets
+++ b/tests/src/CLRTest.CrossGen.targets
@@ -40,11 +40,14 @@ WARNING:   When setting properties based on their current state (for example:
 if [ ! -z ${RunCrossGen+x} ]%3B then
     export COMPlus_ZapRequire=$(ZapRequire)
     export COMPlus_ZapRequireList=$(MSBuildProjectName)
-    if [ ! -f $(MSBuildProjectName).ni.exe ]%3B then
+    if [ ! -f $(MSBuildProjectName).org ]%3B then
         TakeLock
-        if [ ! -f $(MSBuildProjectName).ni.exe ]%3B then
-          echo $_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD $(MSBuildProjectName).exe
-          $_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD $(MSBuildProjectName).exe
+        if [ ! -f $(MSBuildProjectName).org ]%3B then
+          mkdir IL
+          cp $(MSBuildProjectName).exe IL/$(MSBuildProjectName).exe
+          mv $(MSBuildProjectName).exe $(MSBuildProjectName).org
+          echo $_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD/IL%3A$PWD /in $(MSBuildProjectName).org /out $(MSBuildProjectName).exe
+          $_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD/IL%3A$PWD /in $(MSBuildProjectName).org /out $(MSBuildProjectName).exe
           __cgExitCode=$?
           if [ $__cgExitCode -ne 0 ]
           then
@@ -73,12 +76,15 @@ REM CrossGen Script
 if defined RunCrossGen ( 
     set COMPlus_ZapRequire=$(ZapRequire)
     set COMPlus_ZapRequireList=$(MSBuildProjectName)
-    if not exist "$(MSBuildProjectName).ni.exe" (
+    if not exist "$(MSBuildProjectName).org" (
         call :TakeLock
         set CrossGenStatus=0
-        if not exist "$(MSBuildProjectName).ni.exe" (
-            echo "%_DebuggerFullPath% %CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%25cd%25 $(MSBuildProjectName).exe
-            %_DebuggerFullPath% "%CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%25cd%25 $(MSBuildProjectName).exe
+        if not exist "$(MSBuildProjectName).org" (
+            mkdir IL
+            copy $(MSBuildProjectName).exe IL\$(MSBuildProjectName).exe 
+            ren $(MSBuildProjectName).exe $(MSBuildProjectName).org
+            echo "%_DebuggerFullPath% %CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%25cd%25\IL%3B%25cd%25 /in $(MSBuildProjectName).org /out $(MSBuildProjectName).exe
+            %_DebuggerFullPath% "%CORE_ROOT%\crossgen.exe" /Platform_Assemblies_Paths %CORE_ROOT%%3B%25cd%25\IL%3B%25cd%25 /in $(MSBuildProjectName).org /out $(MSBuildProjectName).exe
             set CrossGenStatus=!ERRORLEVEL!
         )
         call :ReleaseLock


### PR DESCRIPTION
CC @RussKeldorph @gkhanna79 

This will fix the Crossgen test failures introduced by https://github.com/dotnet/coreclr/pull/10525. Have tested that a test .cmd with the expected outcome will pass locally, currently in the process of testing building the branch from scratch & running tests.