### PR TITLE
Disable Build number for Preview1

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -139,6 +139,7 @@
   <!-- Packaging properties -->
   <PropertyGroup>
     <PreReleaseLabel>preview1</PreReleaseLabel>
+    <IncludeBuildNumberInPackageVersion>false</IncludeBuildNumberInPackageVersion>
     <PackageDescriptionFile>$(SourceDir).nuget/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(SourceDir).nuget/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(SourceDir).nuget/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>


### PR DESCRIPTION
Disable build number in packages for Preview1 build.

@weshaggard PTAL.

CC @Petermarcu 