### PR TITLE
Fix R2R issue with virtual method resolving to non-generic base

### DIFF
--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1723,6 +1723,12 @@ mdToken CEECompileInfo::TryEncodeMethodAsToken(
         if (!pReferencingModule->IsInCurrentVersionBubble())
             return mdTokenNil;
 
+        // If this is a MemberRef with TypeSpec, we might come to here because we resolved the method
+        // into a non-generic base class in the same version bubble. However, since we don't have the
+        // proper type context during ExternalMethodFixupWorker, we can't really encode using token
+        if (pResolvedToken->pTypeSpec != NULL)
+            return mdTokenNil;
+            
         unsigned methodToken = pResolvedToken->token;
 
         switch (TypeFromToken(methodToken))

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -109,7 +109,7 @@
   </PropertyGroup>
   
   <!-- TODO (#1122): import this from the ToolsDir once it becomes available --> 
-  <Import Project="$(ProjectDir)src\IL.targets" Condition="'$(ProjectLanguage)' == 'IL' And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)'" />
+  <Import Project="$(ProjectDir)src\IL.targets" Condition="'$(ProjectLanguage)' == 'IL'" />
 
 
   <Import Project="CLRTest.Execute.targets" />

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -109,7 +109,7 @@
   </PropertyGroup>
   
   <!-- TODO (#1122): import this from the ToolsDir once it becomes available --> 
-  <Import Project="$(ProjectDir)src\IL.targets" Condition="'$(ProjectLanguage)' == 'IL'" />
+  <Import Project="$(ProjectDir)src\IL.targets" Condition="'$(ProjectLanguage)' == 'IL' And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)'" />
 
 
   <Import Project="CLRTest.Execute.targets" />


### PR DESCRIPTION
Fix https://github.com/dotnet/coreclr/issues/6707

Whenever we call a non-generic virtual method on a generic type instantiated over a generic method parameter (`Foo<T>.VirtFunc` inside `Helpers.GenMethod` in this case), it's possible that the actual method is on a base non-generic type. As a result, crossgen would see that:
* resolveToken resolved to Base.VirtFunc, while exactType = Foo<T>
* it is in the same version bubble
* no runtime lookup is required

It would then proceed to encode the method call as ENCODE_VIRTUAL_ENTRY_REF_TOKEN, where the ref token is the memberref whose parent is the typespec. 
When we actually run the R2R image, we would fail to locate the method using memberref since there is no proper type context in ExternalMethodFixupWorker.

There are a few ways to fix this. We can either 
* in ENCODE_VIRTUAL_ENTRY_REF_TOKEN scenario we see that it is a memberref with a typespec parent, therefore we can infer it will eventually resolve to a method on non-generic type. we can either have some custom logic to resolve the method (bad) or create a typecontext with all __Canons.
* When we try the encode token path, simply recognize that if we have a memberref with typespec parent, we need to bail out. This is much simpler to do. Given that this is a rather obscure case (C# doesn't do this), I don't think it's worth additional complexity. So this is the option I went with. 

You can refer to the code below for more information (not the actual test - it's simply a equivalent scenario)

```csharp
using System;

namespace gen
{
    class Base
    {
        public virtual void VirtFunc()
        {
            Console.WriteLine("Base::VirtFunc");
        }
    }

    class Foo<T> : Base
    {
    }

    class Helpers
    {
        public static void GenMethod<T, V>(V m) where V : Foo<T>
        {
            // C# doesn't do this, but you can make a constrained callvirt Foo<T>.VirtFunc() in IL
            m.VirtFunc();   
        }
    }

    class Program
    {
        static void Main(string[] args)
        {
            Helpers.GenMethod<Object, Foo<Object>>(new Foo<Object>());

            Console.WriteLine("Hello World!");
        }
    }
}
```

@davidwrighton @jkotas PTAL