### PR TITLE
[ARM/Linux] Support unaligned struct read/write

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -14693,6 +14693,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 assertImp(varTypeIsStruct(op2));
 
                 op1 = impAssignStructPtr(op1, op2, resolvedToken.hClass, (unsigned)CHECK_SPILL_ALL);
+
+                if (op1->OperIsBlkOp() && (prefixFlags & PREFIX_UNALIGNED))
+                {
+                    op1->gtFlags |= GTF_BLK_UNALIGNED;
+                }
                 goto SPILL_APPEND;
             }
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -14816,7 +14816,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 if (prefixFlags & PREFIX_UNALIGNED)
                 {
-                  op1->gtFlags |= GTF_IND_UNALIGNED;
+                    op1->gtFlags |= GTF_IND_UNALIGNED;
                 }
 
                 impPushOnStack(op1, tiRetVal);

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -14805,11 +14805,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     // Could point anywhere, example a boxed class static int
                     op1->gtFlags |= GTF_IND_TGTANYWHERE | GTF_GLOB_REF;
                     assertImp(varTypeIsArithmetic(op1->gtType));
-
-                    if (prefixFlags & PREFIX_UNALIGNED)
-                    {
-                        op1->gtFlags |= GTF_IND_UNALIGNED;
-                    }
                 }
                 else
                 {
@@ -14818,6 +14813,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     op1 = gtNewObjNode(resolvedToken.hClass, op1);
                 }
                 op1->gtFlags |= GTF_EXCEPT;
+
+                if (prefixFlags & PREFIX_UNALIGNED)
+                {
+                  op1->gtFlags |= GTF_IND_UNALIGNED;
+                }
 
                 impPushOnStack(op1, tiRetVal);
                 break;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -9911,6 +9911,12 @@ GenTreePtr Compiler::fgMorphCopyBlock(GenTreePtr tree)
             JITDUMP(" rhs is unaligned");
             requiresCopyBlock = true;
         }
+
+        if (asg->gtFlags & GTF_BLK_UNALIGNED)
+        {
+            JITDUMP(" asg is unaligned");
+            requiresCopyBlock = true;
+        }
 #endif // _TARGET_ARM_
 
         if (dest->OperGet() == GT_OBJ && dest->AsBlk()->gtBlkOpGcUnsafe)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -9905,6 +9905,14 @@ GenTreePtr Compiler::fgMorphCopyBlock(GenTreePtr tree)
             requiresCopyBlock = true;
         }
 
+#if defined(_TARGET_ARM_)
+        if ((rhs->OperIsIndir()) && (rhs->gtFlags & GTF_IND_UNALIGNED))
+        {
+            JITDUMP(" rhs is unaligned");
+            requiresCopyBlock = true;
+        }
+#endif // _TARGET_ARM_
+
         if (dest->OperGet() == GT_OBJ && dest->AsBlk()->gtBlkOpGcUnsafe)
         {
             requiresCopyBlock = true;


### PR DESCRIPTION
#11224 partially addresses unaligned access issues (discussed in #11200), but unaligned struct read/write still raises System.DataMisalignedException.

This commit supports unaligned struct read/write to fix #11200.