### PR TITLE
Fix #11273 by adjusting the fix for VSO 406163.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3187,7 +3187,7 @@ private:
     static fgWalkPreFn impFindValueClasses;
     void impSpillLclRefs(ssize_t lclNum);
 
-    BasicBlock* impPushCatchArgOnStack(BasicBlock* hndBlk, CORINFO_CLASS_HANDLE clsHnd);
+    BasicBlock* impPushCatchArgOnStack(BasicBlock* hndBlk, CORINFO_CLASS_HANDLE clsHnd, bool isSingleBlockFilter);
 
     void impImportBlockCode(BasicBlock* block);
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17055,8 +17055,8 @@ bool Compiler::fgCheckEHCanInsertAfterBlock(BasicBlock* blk, unsigned regionInde
 //
 // Return Value:
 //    A block with the desired characteristics, so the new block will be inserted after this one.
-//    If there is no suitable location, return nullptr. This should basically never happen except in the case of
-//    single-block filters.
+//    If there is no suitable location, return nullptr. This should basically never happen.
+//
 BasicBlock* Compiler::fgFindInsertPoint(unsigned    regionIndex,
                                         bool        putInTryRegion,
                                         BasicBlock* startBlk,

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17284,19 +17284,21 @@ BasicBlock* Compiler::fgFindInsertPoint(unsigned    regionIndex,
 
 DONE:
 
+#if defined(JIT32_GCENCODER)
     // If we are inserting into a filter and the best block is the end of the filter region, we need to
-    // insert after its predecessor instead: the CLR ABI states that the terminal block of a filter region
-    // is its exit block. If the filter region consists of a single block, a new block cannot be inserted
-    // without either splitting the single block before inserting a new block or inserting the new block
-    // before the single block and updating the filter description such that the inserted block is marked
-    // as the entry block for the filter. This work must be done by the caller; this function returns
-    // `nullptr` to indicate this case.
-    if (insertingIntoFilter && (bestBlk == endBlk->bbPrev) && (bestBlk == startBlk))
+    // insert after its predecessor instead: the JIT32 GC encoding used by the x86 CLR ABI  states that the
+    // terminal block of a filter region is its exit block. If the filter region consists of a single block,
+    // a new block cannot be inserted without either splitting the single block before inserting a new block
+    // or inserting the new block before the single block and updating the filter description such that the
+    // inserted block is marked as the entry block for the filter. Becuase this sort of split can be complex
+    // (especially given that it must ensure that the liveness of the exception object is properly tracked),
+    // we avoid this situation by never generating single-block filters on x86 (see impPushCatchArgOnStack).
+    if (insertingIntoFilter && (bestBlk == endBlk->bbPrev))
     {
-        assert(bestBlk != nullptr);
-        assert(bestBlk->bbJumpKind == BBJ_EHFILTERRET);
-        bestBlk = nullptr;
+        assert(bestBlk != startBlk);
+        bestBlk = bestBlk->bbPrev;
     }
+#endif // defined(JIT32_GCENCODER)
 
     return bestBlk;
 }
@@ -17474,21 +17476,6 @@ BasicBlock* Compiler::fgNewBBinRegion(BBjumpKinds jumpKind,
 
     // Now find the insertion point.
     afterBlk = fgFindInsertPoint(regionIndex, putInTryRegion, startBlk, endBlk, nearBlk, nullptr, runRarely);
-
-    // If afterBlk is nullptr, we must be inserting into a single-block filter region. Because the CLR ABI requires
-    // that control exits a filter via the last instruction in the filter range, this situation requires logically
-    // splitting the single block. In practice, we simply insert a new block at the beginning of the filter region
-    // that transfers control flow to the existing single block.
-    if (afterBlk == nullptr)
-    {
-        assert(putInFilter);
-
-        BasicBlock* newFilterEntryBlock = fgNewBBbefore(BBJ_ALWAYS, startBlk, true);
-        newFilterEntryBlock->bbJumpDest = startBlk;
-        fgAddRefPred(startBlk, newFilterEntryBlock);
-
-        afterBlk = newFilterEntryBlock;
-    }
 
 _FoundAfterBlk:;
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2443,7 +2443,7 @@ BasicBlock* Compiler::impPushCatchArgOnStack(BasicBlock* hndBlk, CORINFO_CLASS_H
 #if defined(JIT32_GCENCODER)
     const bool forceInsertNewBlock = isSingleBlockFilter || compStressCompile(STRESS_CATCH_ARG, 5);
 #else
-    const bool forceInsertNewBlock = compStressCompile(STRESS_CATCH_ARG, 5);
+    const bool forceInsertNewBlock                                     = compStressCompile(STRESS_CATCH_ARG, 5);
 #endif // defined(JIT32_GCENCODER)
 
     /* Spill GT_CATCH_ARG to a temp if there are jumps to the beginning of the handler */


### PR DESCRIPTION
Issue #11273 revealed an issue with the fix for VSO 406163: as of today,
the compiler models the incoming exception object in a handler by
looking for `GT_CATCH_ARG` in the first block of a handler and if found
marking the register that contains the exception object as holding a GC
pointer. Unfortunately, this breaks down under the transform that the
original fix (#11134) was performing for single-block filters. That
transformation was from this:

```
    filter start: BBN (BBJ_EHFILTERRET)
```

to this:

```
    filter start: BBN + 1 (BBJ_ALWAYS -> BBN)
                  BBN + 2 (jumpKind)
                  BBN     (BBJ_EHFILTERRET)
```

After this transform, `BBN` still contains the `GT_CATCH_ARG`, but the
register containing the exception object must be live through `BBN + 1`
as well as live in to `BBN`.

There are a number of possible solutions to this problem (e.g. modeling
the liveness of the exception object in some fashion or splitting the
single-block filter either after the catch arg or before the filter
ret), but many of them are complicated by the fact that this
transformation needs to operate on both HIR and LIR and must be be able
to run in a variety of locations, including after registers have been
allocated. Instead, this change takes the approach of ensuring that no
single-block filter regions exist on platforms that target the JIT32 GC
encoder by inserting a spill of the exception object to a local var in
its own block at the start of a filter.