### PR TITLE
Fix potential GC hole in ConditionalWeakTable

### DIFF
--- a/src/vm/comdependenthandle.cpp
+++ b/src/vm/comdependenthandle.cpp
@@ -17,22 +17,22 @@
 
 
 
-FCIMPL3(VOID, DependentHandle::nInitialize, Object *_primary, Object *_secondary, OBJECTHANDLE *outHandle)
+FCIMPL2(OBJECTHANDLE, DependentHandle::nInitialize, Object *_primary, Object *_secondary)
 {
     FCALL_CONTRACT;
 
-    _ASSERTE(outHandle != NULL && *outHandle == NULL);  // Multiple initializations disallowed 
-
     OBJECTREF primary(_primary);
     OBJECTREF secondary(_secondary);
+    OBJECTHANDLE result = NULL;
 
-    HELPER_METHOD_FRAME_BEGIN_NOPOLL();
+    HELPER_METHOD_FRAME_BEGIN_RET_NOPOLL();
     
     // Create the handle.
-    *outHandle = GetAppDomain()->CreateDependentHandle(primary, secondary);
+    result = GetAppDomain()->CreateDependentHandle(primary, secondary);
 
     HELPER_METHOD_FRAME_END_POLL();
 
+    return result;
 }
 FCIMPLEND
 
@@ -55,22 +55,22 @@ FCIMPLEND
 
 
 
-FCIMPL2(VOID, DependentHandle::nGetPrimary, OBJECTHANDLE handle, Object **outPrimary)
+FCIMPL1(Object*, DependentHandle::nGetPrimary, OBJECTHANDLE handle)
 {
     FCALL_CONTRACT;
-    _ASSERTE(handle != NULL && outPrimary != NULL);
-    *outPrimary = OBJECTREFToObject(ObjectFromHandle(handle));
+    FCUnique(0x54);
+    _ASSERTE(handle != NULL);
+    return OBJECTREFToObject(ObjectFromHandle(handle));
 }
 FCIMPLEND
 
 
 
-FCIMPL3(VOID, DependentHandle::nGetPrimaryAndSecondary, OBJECTHANDLE handle, Object **outPrimary, Object **outSecondary)
+FCIMPL2(Object*, DependentHandle::nGetPrimaryAndSecondary, OBJECTHANDLE handle, Object **outSecondary)
 {
     FCALL_CONTRACT;
-    _ASSERTE(handle != NULL && outPrimary != NULL && outSecondary != NULL);
-    *outPrimary = OBJECTREFToObject(ObjectFromHandle(handle));
     *outSecondary = OBJECTREFToObject(GetDependentHandleSecondary(handle));
+    return OBJECTREFToObject(ObjectFromHandle(handle));
 }
 FCIMPLEND
 

--- a/src/vm/comdependenthandle.cpp
+++ b/src/vm/comdependenthandle.cpp
@@ -69,8 +69,14 @@ FCIMPLEND
 FCIMPL2(Object*, DependentHandle::nGetPrimaryAndSecondary, OBJECTHANDLE handle, Object **outSecondary)
 {
     FCALL_CONTRACT;
-    *outSecondary = OBJECTREFToObject(GetDependentHandleSecondary(handle));
-    return OBJECTREFToObject(ObjectFromHandle(handle));
+    _ASSERTE(handle != NULL && outSecondary != NULL);
+
+    OBJECTREF primary = ObjectFromHandle(handle);
+
+    // Secondary is tracked only if primary is non-null
+    *outSecondary = (primary != NULL) ? OBJECTREFToObject(GetDependentHandleSecondary(handle)) : NULL;
+
+    return OBJECTREFToObject(primary);
 }
 FCIMPLEND
 

--- a/src/vm/comdependenthandle.h
+++ b/src/vm/comdependenthandle.h
@@ -41,12 +41,12 @@
 class DependentHandle
 {
 public:
-    static FCDECL3(VOID,   nInitialize, Object *primary, Object *secondary, OBJECTHANDLE *outHandle);
-    static FCDECL2(VOID,   nGetPrimary, OBJECTHANDLE handle, Object **outPrimary);
-    static FCDECL3(VOID,   nGetPrimaryAndSecondary, OBJECTHANDLE handle, Object **outPrimary, Object **outSecondary);
-    static FCDECL1(VOID,   nFree, OBJECTHANDLE handle);
-    static FCDECL2(VOID,   nSetPrimary, OBJECTHANDLE handle, Object *primary);
-    static FCDECL2(VOID,   nSetSecondary, OBJECTHANDLE handle, Object *secondary);
+    static FCDECL2(OBJECTHANDLE, nInitialize, Object *primary, Object *secondary);
+    static FCDECL1(Object *, nGetPrimary, OBJECTHANDLE handle);
+    static FCDECL2(Object *, nGetPrimaryAndSecondary, OBJECTHANDLE handle, Object **outSecondary);
+    static FCDECL1(VOID, nFree, OBJECTHANDLE handle);
+    static FCDECL2(VOID, nSetPrimary, OBJECTHANDLE handle, Object *primary);
+    static FCDECL2(VOID, nSetSecondary, OBJECTHANDLE handle, Object *secondary);
 };
 
 #endif


### PR DESCRIPTION
- Fix #11270 by fetching secondary only if primary is non-null. The GC stops tracking the secondary once primary becomes null.
- Remove unnecessary out arguments in FCalls while I was on it