### PR TITLE
Fix current publish build warnings

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -305,25 +305,6 @@
     },
     {
       "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": true,
-      "displayName": "Copy Publish Artifact: PublishLogs",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "1d341bb0-2106-458c-8422-d00bcea6512a",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "CopyRoot": "",
-        "Contents": "$(Pipeline.SourcesDirectory)\\*.log",
-        "ArtifactName": "PublishLogs",
-        "ArtifactType": "Container",
-        "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
-      }
-    },
-    {
-      "enabled": true,
       "continueOnError": true,
       "alwaysRun": true,
       "displayName": "Copy Publish Artifact: debuggerlogs",

--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -277,7 +277,7 @@
         "detailedLog": "false",
         "usePat": "false",
         "retentionDays": "",
-        "dropMetadataContainerName": "DropMetadata"
+        "dropMetadataContainerName": "Drop-OfficialBuildId"
       }
     },
     {
@@ -300,7 +300,7 @@
         "detailedLog": "false",
         "usePat": "false",
         "retentionDays": "",
-        "dropMetadataContainerName": "DropMetadata"
+        "dropMetadataContainerName": "Drop-BuildNumber"
       }
     },
     {


### PR DESCRIPTION
Cleans up publish build warnings.

---

CoreCLR publishes two Drops, one named by OfficialBuildId, another by BuildNumber. Having both makes it so you don't need to translate from one to another to find a CoreCLR build's Drop.

When the `dropMetadataContainerName` is the same, the later step fails. (This was only a warning because the step is "continue on error".) The metadata name is used to create a VSTS Artifact. I changed the metadata name based on what the Drop is named after.

---

Remove "Copy Publish Artifact: PublishLogs" because there are no *.log files being created during the publish build. There is only a `init-tools.cmd` call and direct `msbuild` invocations.