### PR TITLE
[release/2.0.0] Fix current publish build warnings

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -277,7 +277,7 @@
         "detailedLog": "false",
         "usePat": "false",
         "retentionDays": "",
-        "dropMetadataContainerName": "DropMetadata"
+        "dropMetadataContainerName": "Drop-OfficialBuildId"
       }
     },
     {
@@ -300,26 +300,7 @@
         "detailedLog": "false",
         "usePat": "false",
         "retentionDays": "",
-        "dropMetadataContainerName": "DropMetadata"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": true,
-      "displayName": "Copy Publish Artifact: PublishLogs",
-      "timeoutInMinutes": 0,
-      "task": {
-        "id": "1d341bb0-2106-458c-8422-d00bcea6512a",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "CopyRoot": "",
-        "Contents": "$(Pipeline.SourcesDirectory)\\*.log",
-        "ArtifactName": "PublishLogs",
-        "ArtifactType": "Container",
-        "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
+        "dropMetadataContainerName": "Drop-BuildNumber"
       }
     },
     {


### PR DESCRIPTION
* Make VSTS Drop metadata distinct

* Remove PublishLogs artifact publish: no matches

(cherry picked from commit e695a6df23ebd73c0b397fb8057175ef928ddd36)

See https://github.com/dotnet/coreclr/pull/11317 (this fix, merged into master)

@gkhanna79 @Petermarcu @shawnro This will fix these warnings in the CoreCLR publish legs:

> Artifact 'DropMetadata' already exists. If the build is producing multiple Drops, the Drop Metadata Container Name should be unique for each Drop.
> 
> Directory '[...]\PublishLogs' is empty. Nothing will be added to build artifact 'PublishLogs'.