### PR TITLE
Adding missing icu headers for Android

### DIFF
--- a/src/corefx/System.Globalization.Native/icushim.h
+++ b/src/corefx/System.Globalization.Native/icushim.h
@@ -32,6 +32,8 @@
 #include <unicode/usearch.h>
 #include <unicode/utf16.h>
 #include <unicode/utypes.h>
+#include <unicode/urename.h>
+#include <unicode/ustring.h>
 
 // List of all functions from the ICU libraries that are used in the System.Globalization.Native.so
 #define FOR_ALL_UNCONDITIONAL_ICU_FUNCTIONS \


### PR DESCRIPTION
urename.h and ustring.h contain the u_stncpy and its definition; if they are not in the list of icushim.h headers, Android build fails after moving to icu 59.1 from 58.2.

cc @jkotas, @richlander  to locate icu and/or System.Globalization.Native code owners