### PR TITLE
Refactor arm codegen

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -482,32 +482,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             break;
 
         case GT_LCL_FLD:
-        {
-            NYI_IF(targetType == TYP_STRUCT, "GT_LCL_FLD: struct load local field not supported");
-            NYI_IF(treeNode->gtRegNum == REG_NA, "GT_LCL_FLD: load local field not into a register is not supported");
-
-            emitAttr size   = emitTypeSize(targetType);
-            unsigned offs   = treeNode->gtLclFld.gtLclOffs;
-            unsigned varNum = treeNode->gtLclVarCommon.gtLclNum;
-            assert(varNum < compiler->lvaCount);
-
-            if (varTypeIsFloating(targetType))
-            {
-                if (treeNode->InReg())
-                {
-                    NYI("GT_LCL_FLD with reg-to-reg floating point move");
-                }
-                else
-                {
-                    emit->emitIns_R_S(ins_Load(targetType), size, targetReg, varNum, offs);
-                }
-            }
-            else
-            {
-                emit->emitIns_R_S(ins_Move_Extend(targetType, treeNode->InReg()), size, targetReg, varNum, offs);
-            }
-        }
-            genProduceReg(treeNode);
+            genCodeForLclFld(treeNode->AsLclFld());
             break;
 
         case GT_STORE_LCL_FLD:

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1221,8 +1221,8 @@ void CodeGen::genCodeForNegNot(GenTree* tree)
 
     assert(!tree->OperIs(GT_NOT) || !varTypeIsFloating(targetType));
 
-    regNumber targetReg  = tree->gtRegNum;
-    instruction ins = genGetInsForOper(tree->OperGet(), targetType);
+    regNumber   targetReg = tree->gtRegNum;
+    instruction ins       = genGetInsForOper(tree->OperGet(), targetType);
 
     // The arithmetic node must be sitting in a register (since it's not contained)
     assert(!tree->isContained());
@@ -1333,8 +1333,7 @@ void CodeGen::genCodeForLclVar(GenTreeLclVar* tree)
     if (!tree->InReg() && !(tree->gtFlags & GTF_SPILLED))
     {
         assert(!isRegCandidate);
-        getEmitter()->emitIns_R_S(ins_Load(tree->TypeGet()), emitTypeSize(tree), tree->gtRegNum,
-                          tree->gtLclNum, 0);
+        getEmitter()->emitIns_R_S(ins_Load(tree->TypeGet()), emitTypeSize(tree), tree->gtRegNum, tree->gtLclNum, 0);
         genProduceReg(tree);
     }
 }
@@ -1519,8 +1518,8 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
     else
     {
         regNumber targetReg = tree->gtRegNum;
-        emitter* emit = getEmitter();
-        emitAttr cmpAttr;
+        emitter*  emit      = getEmitter();
+        emitAttr  cmpAttr;
 
         genConsumeIfReg(op1);
         genConsumeIfReg(op2);
@@ -1529,7 +1528,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
         {
             assert(op1->TypeGet() == op2->TypeGet());
             instruction ins = INS_vcmp;
-            cmpAttr = emitTypeSize(op1->TypeGet());
+            cmpAttr         = emitTypeSize(op1->TypeGet());
             emit->emitInsBinary(ins, cmpAttr, op1, op2);
             // vmrs with register 0xf has special meaning of transferring flags
             emit->emitIns_R(INS_vmrs, EA_4BYTE, REG_R15);

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -669,19 +669,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             break;
 
         case GT_PUTARG_REG:
-            assert(targetType != TYP_STRUCT); // Any TYP_STRUCT register args should have been removed by
-                                              // fgMorphMultiregStructArg
-            // We have a normal non-Struct targetType
-            {
-                GenTree* op1 = treeNode->gtOp.gtOp1;
-                // If child node is not already in the register we need, move it
-                genConsumeReg(op1);
-                if (targetReg != op1->gtRegNum)
-                {
-                    inst_RV_RV(ins_Copy(targetType), targetReg, op1->gtRegNum, targetType);
-                }
-            }
-            genProduceReg(treeNode);
+            genPutArgReg(treeNode->AsOp());
             break;
 
         case GT_CALL:

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -699,9 +699,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             break;
 
         case GT_CMPXCHG:
-        {
             NYI("GT_CMPXCHG");
-        }
             genProduceReg(treeNode);
             break;
 

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -2466,19 +2466,7 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             break;
 
         case GT_PUTARG_REG:
-            assert(targetType != TYP_STRUCT); // Any TYP_STRUCT register args should have been removed by
-                                              // fgMorphMultiregStructArg
-            // We have a normal non-Struct targetType
-            {
-                GenTree* op1 = treeNode->gtOp.gtOp1;
-                // If child node is not already in the register we need, move it
-                genConsumeReg(op1);
-                if (targetReg != op1->gtRegNum)
-                {
-                    inst_RV_RV(ins_Copy(targetType), targetReg, op1->gtRegNum, targetType);
-                }
-            }
-            genProduceReg(treeNode);
+            genPutArgReg(treeNode->AsOp());
             break;
 
         case GT_CALL:

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -2440,24 +2440,8 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             break;
 
         case GT_RETURNTRAP:
-        {
-            // this is nothing but a conditional call to CORINFO_HELP_STOP_FOR_GC
-            // based on the contents of 'data'
-
-            GenTree* data = treeNode->gtOp.gtOp1;
-            genConsumeRegs(data);
-            emit->emitIns_R_I(INS_cmp, EA_4BYTE, data->gtRegNum, 0);
-
-            BasicBlock* skipLabel = genCreateTempLabel();
-
-            emitJumpKind jmpEqual = genJumpKindForOper(GT_EQ, CK_SIGNED);
-            inst_JMP(jmpEqual, skipLabel);
-            // emit the call to the EE-helper that stops for GC (or other reasons)
-
-            genEmitHelperCall(CORINFO_HELP_STOP_FOR_GC, 0, EA_UNKNOWN);
-            genDefineTempLabel(skipLabel);
-        }
-        break;
+            genCodeForReturnTrap(treeNode->AsOp());
+            break;
 
         case GT_STOREIND:
             genCodeForStoreInd(treeNode->AsStoreInd());
@@ -4016,6 +4000,33 @@ void CodeGen::genLeaInstruction(GenTreeAddrMode* lea)
     }
 
     genProduceReg(lea);
+}
+
+//------------------------------------------------------------------------
+// genCodeForReturnTrap: Produce code for a GT_RETURNTRAP node.
+//
+// Arguments:
+//    tree - the GT_RETURNTRAP node
+//
+void CodeGen::genCodeForReturnTrap(GenTreeOp* tree)
+{
+    assert(tree->OperGet() == GT_RETURNTRAP);
+
+    // this is nothing but a conditional call to CORINFO_HELP_STOP_FOR_GC
+    // based on the contents of 'data'
+
+    GenTree* data = tree->gtOp1;
+    genConsumeRegs(data);
+    getEmitter()->emitIns_R_I(INS_cmp, EA_4BYTE, data->gtRegNum, 0);
+
+    BasicBlock* skipLabel = genCreateTempLabel();
+
+    emitJumpKind jmpEqual = genJumpKindForOper(GT_EQ, CK_SIGNED);
+    inst_JMP(jmpEqual, skipLabel);
+    // emit the call to the EE-helper that stops for GC (or other reasons)
+
+    genEmitHelperCall(CORINFO_HELP_STOP_FOR_GC, 0, EA_UNKNOWN);
+    genDefineTempLabel(skipLabel);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -2094,42 +2094,8 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             break;
 
         case GT_LCL_FLD:
-        {
-            GenTreeLclVarCommon* varNode = treeNode->AsLclVarCommon();
-            assert(varNode->gtLclNum < compiler->lvaCount);
-            unsigned   varNum = varNode->gtLclNum;
-            LclVarDsc* varDsc = &(compiler->lvaTable[varNum]);
-
-            if (targetType == TYP_STRUCT)
-            {
-                NYI("GT_LCL_FLD with TYP_STRUCT");
-            }
-            emitAttr size = emitTypeSize(targetType);
-
-            noway_assert(targetType != TYP_STRUCT);
-            noway_assert(targetReg != REG_NA);
-
-            unsigned offset = treeNode->gtLclFld.gtLclOffs;
-
-            if (varTypeIsFloating(targetType))
-            {
-                if (treeNode->InReg())
-                {
-                    NYI("GT_LCL_FLD with register to register Floating point move");
-                }
-                else
-                {
-                    emit->emitIns_R_S(ins_Load(targetType), size, targetReg, varNum, offset);
-                }
-            }
-            else
-            {
-                size = EA_SET_SIZE(size, EA_8BYTE);
-                emit->emitIns_R_S(ins_Move_Extend(targetType, treeNode->InReg()), size, targetReg, varNum, offset);
-            }
-            genProduceReg(treeNode);
-        }
-        break;
+            genCodeForLclFld(treeNode->AsLclFld());
+            break;
 
         case GT_LCL_VAR:
         {

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -2897,8 +2897,8 @@ void CodeGen::genCodeForNegNot(GenTree* tree)
 
     assert(!tree->OperIs(GT_NOT) || !varTypeIsFloating(targetType));
 
-    regNumber targetReg  = tree->gtRegNum;
-    instruction ins = genGetInsForOper(tree->OperGet(), targetType);
+    regNumber   targetReg = tree->gtRegNum;
+    instruction ins       = genGetInsForOper(tree->OperGet(), targetType);
 
     // The arithmetic node must be sitting in a register (since it's not contained)
     assert(!tree->isContained());
@@ -4319,8 +4319,8 @@ void CodeGen::genCkfinite(GenTreePtr treeNode)
 //
 void CodeGen::genCodeForCompare(GenTreeOp* tree)
 {
-    regNumber targetReg  = tree->gtRegNum;
-    emitter*  emit       = getEmitter();
+    regNumber targetReg = tree->gtRegNum;
+    emitter*  emit      = getEmitter();
 
     // TODO-ARM64-CQ: Check if we can use the currently set flags.
     // TODO-ARM64-CQ: Check for the case where we can simply transfer the carry bit to a register

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1541,6 +1541,50 @@ void CodeGen::genCodeForBinary(GenTree* treeNode)
 }
 
 //------------------------------------------------------------------------
+// genCodeForLclVar: Produce code for a GT_LCL_VAR node.
+//
+// Arguments:
+//    tree - the GT_LCL_VAR node
+//
+void CodeGen::genCodeForLclVar(GenTreeLclVar* tree)
+{
+    var_types targetType = tree->TypeGet();
+    emitter*  emit       = getEmitter();
+
+    unsigned varNum = tree->gtLclNum;
+    assert(varNum < compiler->lvaCount);
+    LclVarDsc* varDsc         = &(compiler->lvaTable[varNum]);
+    bool       isRegCandidate = varDsc->lvIsRegCandidate();
+
+    // lcl_vars are not defs
+    assert((tree->gtFlags & GTF_VAR_DEF) == 0);
+
+    if (isRegCandidate && !(tree->gtFlags & GTF_VAR_DEATH))
+    {
+        assert((tree->InReg()) || (tree->gtFlags & GTF_SPILLED));
+    }
+
+    // If this is a register candidate that has been spilled, genConsumeReg() will
+    // reload it at the point of use.  Otherwise, if it's not in a register, we load it here.
+
+    if (!tree->InReg() && !(tree->gtFlags & GTF_SPILLED))
+    {
+        assert(!isRegCandidate);
+
+        // targetType must be a normal scalar type and not a TYP_STRUCT
+        assert(targetType != TYP_STRUCT);
+
+        instruction ins  = ins_Load(targetType);
+        emitAttr    attr = emitTypeSize(targetType);
+
+        attr = emit->emitInsAdjustLoadStoreAttr(ins, attr);
+
+        emit->emitIns_R_S(ins, attr, tree->gtRegNum, varNum, 0);
+        genProduceReg(tree);
+    }
+}
+
+//------------------------------------------------------------------------
 // genCodeForStoreLclFld: Produce code for a GT_STORE_LCL_FLD node.
 //
 // Arguments:
@@ -1551,7 +1595,6 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     var_types targetType = tree->TypeGet();
     regNumber targetReg  = tree->gtRegNum;
     emitter*  emit       = getEmitter();
-
     noway_assert(targetType != TYP_STRUCT);
 
     // record the offset
@@ -1595,6 +1638,77 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     genUpdateLife(tree);
 
     varDsc->lvRegNum = REG_STK;
+}
+
+//------------------------------------------------------------------------
+// genCodeForStoreLclVar: Produce code for a GT_STORE_LCL_VAR node.
+//
+// Arguments:
+//    tree - the GT_STORE_LCL_VAR node
+//
+void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
+{
+    var_types targetType = tree->TypeGet();
+    regNumber targetReg  = tree->gtRegNum;
+    emitter*  emit       = getEmitter();
+
+    unsigned varNum = tree->gtLclNum;
+    assert(varNum < compiler->lvaCount);
+    LclVarDsc* varDsc = &(compiler->lvaTable[varNum]);
+
+    // Ensure that lclVar nodes are typed correctly.
+    assert(!varDsc->lvNormalizeOnStore() || targetType == genActualType(varDsc->TypeGet()));
+
+    GenTreePtr data = tree->gtOp1->gtEffectiveVal();
+
+    // var = call, where call returns a multi-reg return value
+    // case is handled separately.
+    if (data->gtSkipReloadOrCopy()->IsMultiRegCall())
+    {
+        genMultiRegCallStoreToLocal(tree);
+    }
+    else
+    {
+        genConsumeRegs(data);
+
+        regNumber dataReg = REG_NA;
+        if (data->isContainedIntOrIImmed())
+        {
+            assert(data->IsIntegralConst(0));
+            dataReg = REG_ZR;
+        }
+        else
+        {
+            assert(!data->isContained());
+            dataReg = data->gtRegNum;
+        }
+        assert(dataReg != REG_NA);
+
+        if (targetReg == REG_NA) // store into stack based LclVar
+        {
+            inst_set_SV_var(tree);
+
+            instruction ins  = ins_Store(targetType);
+            emitAttr    attr = emitTypeSize(targetType);
+
+            attr = emit->emitInsAdjustLoadStoreAttr(ins, attr);
+
+            emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
+
+            genUpdateLife(tree);
+
+            varDsc->lvRegNum = REG_STK;
+        }
+        else // store into register (i.e move into register)
+        {
+            if (dataReg != targetReg)
+            {
+                // Assign into targetReg when dataReg (from op1) is not the same register
+                inst_RV_RV(ins_Copy(targetType), targetReg, dataReg, targetType);
+            }
+            genProduceReg(tree);
+        }
+    }
 }
 
 //------------------------------------------------------------------------
@@ -2155,111 +2269,16 @@ void CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             break;
 
         case GT_LCL_VAR:
-        {
-            GenTreeLclVarCommon* varNode = treeNode->AsLclVarCommon();
-
-            unsigned varNum = varNode->gtLclNum;
-            assert(varNum < compiler->lvaCount);
-            LclVarDsc* varDsc         = &(compiler->lvaTable[varNum]);
-            bool       isRegCandidate = varDsc->lvIsRegCandidate();
-
-            // lcl_vars are not defs
-            assert((treeNode->gtFlags & GTF_VAR_DEF) == 0);
-
-            if (isRegCandidate && !(treeNode->gtFlags & GTF_VAR_DEATH))
-            {
-                assert((treeNode->InReg()) || (treeNode->gtFlags & GTF_SPILLED));
-            }
-
-            // If this is a register candidate that has been spilled, genConsumeReg() will
-            // reload it at the point of use.  Otherwise, if it's not in a register, we load it here.
-
-            if (!treeNode->InReg() && !(treeNode->gtFlags & GTF_SPILLED))
-            {
-                assert(!isRegCandidate);
-
-                // targetType must be a normal scalar type and not a TYP_STRUCT
-                assert(targetType != TYP_STRUCT);
-
-                instruction ins  = ins_Load(targetType);
-                emitAttr    attr = emitTypeSize(targetType);
-
-                attr = emit->emitInsAdjustLoadStoreAttr(ins, attr);
-
-                emit->emitIns_R_S(ins, attr, targetReg, varNum, 0);
-                genProduceReg(treeNode);
-            }
-        }
-        break;
+            genCodeForLclVar(treeNode->AsLclVar());
+            break;
 
         case GT_STORE_LCL_FLD:
             genCodeForStoreLclFld(treeNode->AsLclFld());
             break;
 
         case GT_STORE_LCL_VAR:
-        {
-            GenTreeLclVarCommon* varNode = treeNode->AsLclVarCommon();
-
-            unsigned varNum = varNode->gtLclNum;
-            assert(varNum < compiler->lvaCount);
-            LclVarDsc* varDsc = &(compiler->lvaTable[varNum]);
-            unsigned   offset = 0;
-
-            // Ensure that lclVar nodes are typed correctly.
-            assert(!varDsc->lvNormalizeOnStore() || targetType == genActualType(varDsc->TypeGet()));
-
-            GenTreePtr data = treeNode->gtOp.gtOp1->gtEffectiveVal();
-
-            // var = call, where call returns a multi-reg return value
-            // case is handled separately.
-            if (data->gtSkipReloadOrCopy()->IsMultiRegCall())
-            {
-                genMultiRegCallStoreToLocal(treeNode);
-            }
-            else
-            {
-                genConsumeRegs(data);
-
-                regNumber dataReg = REG_NA;
-                if (data->isContainedIntOrIImmed())
-                {
-                    assert(data->IsIntegralConst(0));
-                    dataReg = REG_ZR;
-                }
-                else
-                {
-                    assert(!data->isContained());
-                    dataReg = data->gtRegNum;
-                }
-                assert(dataReg != REG_NA);
-
-                if (targetReg == REG_NA) // store into stack based LclVar
-                {
-                    inst_set_SV_var(varNode);
-
-                    instruction ins  = ins_Store(targetType);
-                    emitAttr    attr = emitTypeSize(targetType);
-
-                    attr = emit->emitInsAdjustLoadStoreAttr(ins, attr);
-
-                    emit->emitIns_S_R(ins, attr, dataReg, varNum, offset);
-
-                    genUpdateLife(varNode);
-
-                    varDsc->lvRegNum = REG_STK;
-                }
-                else // store into register (i.e move into register)
-                {
-                    if (dataReg != targetReg)
-                    {
-                        // Assign into targetReg when dataReg (from op1) is not the same register
-                        inst_RV_RV(ins_Copy(targetType), targetReg, dataReg, targetType);
-                    }
-                    genProduceReg(treeNode);
-                }
-            }
-        }
-        break;
+            genCodeForStoreLclVar(treeNode->AsLclVar());
+            break;
 
         case GT_RETFILT:
             // A void GT_RETFILT is the end of a finally. For non-void filter returns we need to load the result in

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -95,7 +95,7 @@ void CodeGen::genIntrinsic(GenTreePtr treeNode)
 //
 void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 {
-    assert(treeNode->OperGet() == GT_PUTARG_STK);
+    assert(treeNode->OperIs(GT_PUTARG_STK));
     var_types  targetType = treeNode->TypeGet();
     GenTreePtr source     = treeNode->gtOp1;
     emitter*   emit       = getEmitter();
@@ -537,12 +537,12 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 //
 void CodeGen::genPutArgReg(GenTreeOp* tree)
 {
-    assert(tree->OperGet() == GT_PUTARG_STK);
+    assert(tree->OperIs(GT_PUTARG_REG));
     var_types targetType = tree->TypeGet();
     regNumber targetReg  = tree->gtRegNum;
 
-    assert(targetType !=
-           TYP_STRUCT); // Any TYP_STRUCT register args should have been removed by fgMorphMultiregStructArg
+    // Any TYP_STRUCT register args should have been removed by fgMorphMultiregStructArg
+    assert(targetType != TYP_STRUCT);
 
     // We have a normal non-Struct targetType
 

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -541,7 +541,8 @@ void CodeGen::genPutArgReg(GenTreeOp* tree)
     var_types targetType = tree->TypeGet();
     regNumber targetReg  = tree->gtRegNum;
 
-    assert(targetType != TYP_STRUCT); // Any TYP_STRUCT register args should have been removed by fgMorphMultiregStructArg
+    assert(targetType !=
+           TYP_STRUCT); // Any TYP_STRUCT register args should have been removed by fgMorphMultiregStructArg
 
     // We have a normal non-Struct targetType
 

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -526,6 +526,37 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
     }
 }
 
+//---------------------------------------------------------------------
+// genPutArgReg - generate code for a GT_PUTARG_REG node
+//
+// Arguments
+//    treeNode - the GT_PUTARG_REG node
+//
+// Return value:
+//    None
+//
+void CodeGen::genPutArgReg(GenTreeOp* tree)
+{
+    assert(tree->OperGet() == GT_PUTARG_STK);
+    var_types targetType = tree->TypeGet();
+    regNumber targetReg  = tree->gtRegNum;
+
+    assert(targetType != TYP_STRUCT); // Any TYP_STRUCT register args should have been removed by fgMorphMultiregStructArg
+
+    // We have a normal non-Struct targetType
+
+    GenTree* op1 = tree->gtOp1;
+    genConsumeReg(op1);
+
+    // If child node is not already in the register we need, move it
+    if (targetReg != op1->gtRegNum)
+    {
+        inst_RV_RV(ins_Copy(targetType), targetReg, op1->gtRegNum, targetType);
+    }
+
+    genProduceReg(tree);
+}
+
 //----------------------------------------------------------------------------------
 // genMultiRegCallStoreToLocal: store multi-reg return value of a call node to a local
 //

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -166,6 +166,8 @@ void genCodeForShiftLong(GenTreePtr tree);
 void genCodeForShiftRMW(GenTreeStoreInd* storeInd);
 #endif // _TARGET_XARCH_
 
+void genCodeForLclFld(GenTreeLclFld* tree);
+
 void genCodeForCpObj(GenTreeObj* cpObjNode);
 
 void genCodeForCpBlk(GenTreeBlk* cpBlkNode);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -168,6 +168,8 @@ void genCodeForShiftRMW(GenTreeStoreInd* storeInd);
 
 void genCodeForLclFld(GenTreeLclFld* tree);
 
+void genCodeForStoreLclFld(GenTreeLclFld* tree);
+
 void genCodeForCpObj(GenTreeObj* cpObjNode);
 
 void genCodeForCpBlk(GenTreeBlk* cpBlkNode);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -174,6 +174,8 @@ void genCodeForStoreLclFld(GenTreeLclFld* tree);
 
 void genCodeForStoreLclVar(GenTreeLclVar* tree);
 
+void genCodeForReturnTrap(GenTreeOp* tree);
+
 void genCodeForStoreInd(GenTreeStoreInd* tree);
 
 void genCodeForCpObj(GenTreeObj* cpObjNode);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -45,7 +45,12 @@ void genCkfinite(GenTreePtr treeNode);
 void genIntrinsic(GenTreePtr treeNode);
 
 void genPutArgStk(GenTreePutArgStk* treeNode);
+
+void genPutArgReg(GenTreeOp* tree);
+
+#if defined(_TARGET_XARCH_)
 unsigned getBaseVarForPutArgStk(GenTreePtr treeNode);
+#endif // _TARGET_XARCH_
 
 #if defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)
 unsigned getFirstArgWithStackSlot();

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -174,6 +174,8 @@ void genCodeForStoreLclFld(GenTreeLclFld* tree);
 
 void genCodeForStoreLclVar(GenTreeLclVar* tree);
 
+void genCodeForStoreInd(GenTreeStoreInd* tree);
+
 void genCodeForCpObj(GenTreeObj* cpObjNode);
 
 void genCodeForCpBlk(GenTreeBlk* cpBlkNode);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -166,9 +166,13 @@ void genCodeForShiftLong(GenTreePtr tree);
 void genCodeForShiftRMW(GenTreeStoreInd* storeInd);
 #endif // _TARGET_XARCH_
 
+void genCodeForLclVar(GenTreeLclVar* tree);
+
 void genCodeForLclFld(GenTreeLclFld* tree);
 
 void genCodeForStoreLclFld(GenTreeLclFld* tree);
+
+void genCodeForStoreLclVar(GenTreeLclVar* tree);
 
 void genCodeForCpObj(GenTreeObj* cpObjNode);
 

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -42,6 +42,8 @@ void genIntToFloatCast(GenTreePtr treeNode);
 
 void genCkfinite(GenTreePtr treeNode);
 
+void genCodeForCompare(GenTreeOp* tree);
+
 void genIntrinsic(GenTreePtr treeNode);
 
 void genPutArgStk(GenTreePutArgStk* treeNode);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -178,6 +178,8 @@ void genCodeForReturnTrap(GenTreeOp* tree);
 
 void genCodeForStoreInd(GenTreeStoreInd* tree);
 
+void genCodeForSwap(GenTreeOp* tree);
+
 void genCodeForCpObj(GenTreeObj* cpObjNode);
 
 void genCodeForCpBlk(GenTreeBlk* cpBlkNode);

--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -173,6 +173,8 @@ void genCodeForShiftLong(GenTreePtr tree);
 void genCodeForShiftRMW(GenTreeStoreInd* storeInd);
 #endif // _TARGET_XARCH_
 
+void genCodeForNegNot(GenTree* tree);
+
 void genCodeForLclVar(GenTreeLclVar* tree);
 
 void genCodeForLclFld(GenTreeLclFld* tree);


### PR DESCRIPTION
For arm32/arm64, move a lot of code from genCodeForTreeNode() into separate functions. A few functions are identical or close to it, and are moved to codegenarmarch.cpp. Many are relatively similar and should be considered for merging to codegenarmarch.cpp at some point.

codegenxarch.cpp could at some point improve readability by using the same functions, and moving code out of genCodeForTreeNode().
