### PR TITLE
Fix some static analysis warnings

### DIFF
--- a/src/ilasm/prebuilt/asmparse.cpp
+++ b/src/ilasm/prebuilt/asmparse.cpp
@@ -4,12 +4,13 @@
 
 #line 2 "asmparse.y"
 
- // Licensed to the .NET Foundation under one or more agreements.
- // The .NET Foundation licenses this file to you under the MIT license.
- // See the LICENSE file in the project root for more information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //
 // File asmparse.y
 //
+
 #include "ilasmpch.h"
 
 #include "grammar_before.cpp"
@@ -1729,7 +1730,7 @@ YYSTATIC YYCONST short yyrecover[] = {
 #endif
 
 /* SCCSWHAT( "@(#)yypars.c	3.1 88/11/16 22:00:49	" ) */
-#line 3 "D:\\ProjectK3\\src\\tools\\devdiv\\x86\\yypars.c"
+#line 3 "O:\\tfs\\cgm\\src\\Tools\\devdiv\\amd64\\yypars.c"
 #if ! defined(YYAPI_PACKAGE)
 /*
 **  YYAPI_TOKENNAME		: name used for return value of yylex	
@@ -1852,8 +1853,17 @@ YYLOCAL YYNEAR YYPASCAL YYPARSER()
 
 	YYAPI_TOKENNAME = YYAPI_TOKENNONE;
 	yystate = 0;
-	yyps= &yys[-1];
-	yypv= &yyv[-1];
+
+#ifdef _PREFAST_
+#pragma warning(push)
+#pragma warning(disable:6200) // Index '-1' is out of valid index range...for non-stack buffer...
+#endif
+    yyps= &yys[-1];
+    yypv= &yyv[-1];
+#ifdef _PREFAST_
+#pragma warning(pop)
+#endif
+
 #endif
 
 #ifdef YYDUMP
@@ -4872,7 +4882,7 @@ case 834:
 case 835:
 #line 2045 "asmparse.y"
 { PASMM->SetManifestResAsmRef(yypvt[-0].string); } break;/* End of actions */
-#line 329 "D:\\ProjectK3\\src\\tools\\devdiv\\x86\\yypars.c"
+#line 329 "O:\\tfs\\cgm\\src\\Tools\\devdiv\\amd64\\yypars.c"
 			}
 		}
 		goto yystack;  /* stack new state and value */

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -1295,7 +1295,7 @@ const char* Compiler::eeGetMethodName(CORINFO_METHOD_HANDLE method, const char**
         // If it's something unknown from a RET VM, or from SuperPMI, then use our own helper name table.
         if ((strcmp(name, "AnyJITHelper") == 0) || (strcmp(name, "Yickish helper name") == 0))
         {
-            if (ftnNum < CORINFO_HELP_COUNT)
+            if ((unsigned)ftnNum < CORINFO_HELP_COUNT)
             {
                 name = jitHlpFuncTable[ftnNum];
             }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4335,7 +4335,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, BYTE*
 
     DECODE_OPCODE:
 
-        if (opcode >= CEE_COUNT)
+        if ((unsigned)opcode >= CEE_COUNT)
         {
             BADCODE3("Illegal opcode", ": %02X", (int)opcode);
         }
@@ -5231,7 +5231,7 @@ unsigned Compiler::fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, B
 
         /* Get the size of additional parameters */
 
-        noway_assert(opcode < CEE_COUNT);
+        noway_assert((unsigned)opcode < CEE_COUNT);
 
         sz = opcodeSizes[opcode];
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -2838,6 +2838,11 @@ void Compiler::optUnrollLoops()
     // to outermost order
     for (unsigned lnum = optLoopCount - 1; lnum != ~0U; --lnum)
     {
+        // This is necessary due to an apparent analysis limitation since
+        // optLoopCount must be strictly greater than 0 upon entry and lnum
+        // cannot wrap due to the loop termination condition.
+        PREFAST_ASSUME(lnum != 0U - 1);
+
         BasicBlock* block;
         BasicBlock* head;
         BasicBlock* bottom;

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -360,7 +360,7 @@ CorInfoType CEEInfo::asCorInfoType(CorElementType eeType,
     _ASSERTE((CorInfoType) map[ELEMENT_TYPE_PTR] == CORINFO_TYPE_PTR);
     _ASSERTE((CorInfoType) map[ELEMENT_TYPE_TYPEDBYREF] == CORINFO_TYPE_REFANY);
 
-    CorInfoType res = (eeType < ELEMENT_TYPE_MAX) ? ((CorInfoType) map[eeType]) : CORINFO_TYPE_UNDEF;
+    CorInfoType res = ((unsigned)eeType < ELEMENT_TYPE_MAX) ? ((CorInfoType) map[eeType]) : CORINFO_TYPE_UNDEF;
 
     if (clsRet)
         *clsRet = CORINFO_CLASS_HANDLE(typeHndUpdated.AsPtr());

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -663,7 +663,7 @@ SystemVClassificationType CorInfoType2UnixAmd64Classification(CorElementType eeT
     _ASSERTE((SystemVClassificationType)toSystemVAmd64ClassificationTypeMap[ELEMENT_TYPE_TYPEDBYREF] == SystemVClassificationTypeTypedReference);
     _ASSERTE((SystemVClassificationType)toSystemVAmd64ClassificationTypeMap[ELEMENT_TYPE_BYREF] == SystemVClassificationTypeIntegerByRef);
 
-    return (((int)eeType) < ELEMENT_TYPE_MAX) ? (toSystemVAmd64ClassificationTypeMap[eeType]) : SystemVClassificationTypeUnknown;
+    return (((unsigned)eeType) < ELEMENT_TYPE_MAX) ? (toSystemVAmd64ClassificationTypeMap[eeType]) : SystemVClassificationTypeUnknown;
 };
 
 #define SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES                    8 // Size of an eightbyte in bytes.


### PR DESCRIPTION
Most fixes are just addressing the use of (signed) enum-typed variables
as array indices.  Casting to unsigned allows us to cheaply include the
lower bound checks in the existing upper bound checks.  I would prefer
to force the underlying types of enumerations to be unsigned, but that
is a relatively new C++ feature and could have broader consequences than
I want to risk at this point.

The one other fix to asmparse.cpp just suppresses a warning that,
while technically valid, is not causing a real problem.  Perhaps this
will get better if/when #2305 is addressed.