### PR TITLE
[Local GC] Fix some handle table interface violations in COMDependentHandle

### DIFF
--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -147,6 +147,16 @@ bool GCHandleManager::StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* obj
     return !!::HndFirstAssignHandle(handle, ObjectToOBJECTREF(object));
 }
 
+void GCHandleManager::SetDependentHandleSecondary(OBJECTHANDLE handle, Object* object)
+{
+    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(object));
+}
+
+Object* GCHandleManager::GetDependentHandleSecondary(OBJECTHANDLE handle)
+{
+    return OBJECTREFToObject(::GetDependentHandleSecondary(handle));
+}
+
 Object* GCHandleManager::InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject)
 {
     return (Object*)::HndInterlockedCompareExchangeHandle(handle, ObjectToOBJECTREF(object), ObjectToOBJECTREF(comparandObject));

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -59,6 +59,10 @@ public:
 
     virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object);
 
+    virtual void SetDependentHandleSecondary(OBJECTHANDLE handle, Object* object);
+
+    virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle);
+
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject);
 };
 

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -458,6 +458,10 @@ public:
 
     virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object) = 0;
 
+    virtual void SetDependentHandleSecondary(OBJECTHANDLE handle, Object* object) = 0;
+
+    virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle) = 0;
+
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject) = 0;
 };
 

--- a/src/vm/comdependenthandle.cpp
+++ b/src/vm/comdependenthandle.cpp
@@ -69,8 +69,10 @@ FCIMPL3(VOID, DependentHandle::nGetPrimaryAndSecondary, OBJECTHANDLE handle, Obj
 {
     FCALL_CONTRACT;
     _ASSERTE(handle != NULL && outPrimary != NULL && outSecondary != NULL);
+
+    IGCHandleManager *mgr = GCHandleUtilities::GetGCHandleManager();
     *outPrimary = OBJECTREFToObject(ObjectFromHandle(handle));
-    *outSecondary = OBJECTREFToObject(GetDependentHandleSecondary(handle));
+    *outSecondary = mgr->GetDependentHandleSecondary(handle);
 }
 FCIMPLEND
 
@@ -80,8 +82,8 @@ FCIMPL2(VOID, DependentHandle::nSetPrimary, OBJECTHANDLE handle, Object *_primar
 
     _ASSERTE(handle != NULL);
 
-    OBJECTREF primary(_primary);
-    StoreObjectInHandle(handle, primary);
+    IGCHandleManager *mgr = GCHandleUtilities::GetGCHandleManager();
+    mgr->StoreObjectInHandle(handle, _primary);
 }
 FCIMPLEND
 
@@ -91,7 +93,7 @@ FCIMPL2(VOID, DependentHandle::nSetSecondary, OBJECTHANDLE handle, Object *_seco
 
     _ASSERTE(handle != NULL);
 
-    OBJECTREF secondary(_secondary);
-    SetDependentHandleSecondary(handle, secondary);
+    IGCHandleManager *mgr = GCHandleUtilities::GetGCHandleManager();
+    mgr->SetDependentHandleSecondary(handle, _secondary);
 }
 FCIMPLEND


### PR DESCRIPTION
I found this interface violation when trying to build the GC without using VM headers (it manifests as a linker error). I didn't see any equivalent to `Set/GetDependentHandleSecondary` on the interface yet, so this PR adds and implements it.

cc @adityamandaleeka @Maoni0 @jkotas PTAL?