### PR TITLE
Fix triggering of perf correctness runs

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -123,7 +123,16 @@ def static getOSGroup(def os) {
                 
                 if (isPR) {
                     TriggerBuilder builder = TriggerBuilder.triggerOnPullRequest()
-                    builder.setGithubContext("${os} ${arch} CoreCLR Perf Tests")
+                    if (isSmoketest)
+                    {
+                        builder.setGithubContext("${os} ${arch} CoreCLR Perf Tests Correctness")
+                    }
+                    else
+                    {
+                        builder.setGithubContext("${os} ${arch} CoreCLR Perf Tests")
+                        builder.triggerOnlyOnComment()
+                        builder.setCustomTriggerPhrase("(?i).*test\\W+${os}\\W+${arch}\\W+perf.*")
+                    }
                     builder.triggerForBranch(branch)
                     builder.emitTrigger(newJob)
                 }


### PR DESCRIPTION
When I made the change to have the correctness runs fire in a PR without
the trigger phrase I accidentally did it for all PR's not just for the
smoketest runs.  This change fixes that.