### PR TITLE
Disable symbol package MyGet publish on release/*

### DIFF
--- a/buildpipeline/DotNet-Trusted-Publish.json
+++ b/buildpipeline/DotNet-Trusted-Publish.json
@@ -172,7 +172,7 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "$(MyGetApiKey) $(ConfigurationGroup)",
-        "inlineScript": "param($ApiKey, $ConfigurationGroup)\nif ($ConfigurationGroup -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Build_StagingDirectory\\IndexedSymbolPackages\\*.nupkg $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
+        "inlineScript": "param($ApiKey, $ConfigurationGroup)\nif ($ConfigurationGroup -ne \"Release\") { exit }\nif ($env:SourceBranch.StartsWith(\"release/\")) { exit }\n& $env:CustomNuGetPath push $env:Build_StagingDirectory\\IndexedSymbolPackages\\*.nupkg $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
         "workingFolder": "",
         "failOnStandardError": "true"
       }


### PR DESCRIPTION
Adds `if ($env:SourceBranch.StartsWith("release/")) { exit }` to the symbol package publish step. This will automatically disable symbol package publishing to MyGet for `release/*` branches. This was previously done by making manual changes on the release branch, but this step doesn't need to be manual.

This is the CoreCLR part of https://github.com/dotnet/core-eng/issues/728.