### PR TITLE
Remove UnmanagedMemoryStream overflow checks.

### DIFF
--- a/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
@@ -84,8 +84,6 @@ namespace System.IO
      */
     public class UnmanagedMemoryStream : Stream
     {
-        private const long UnmanagedMemStreamMaxLength = Int64.MaxValue;
-
         private SafeBuffer _buffer;
         private unsafe byte* _mem;
         private long _length;
@@ -299,13 +297,6 @@ namespace System.IO
                 Contract.EndContractBlock();
                 if (!CanSeek) __Error.StreamIsClosed();
 
-#if !BIT64
-                unsafe {
-                    // On 32 bit machines, ensure we don't wrap around.
-                    if (value > (long) Int32.MaxValue || _mem + value < _mem)
-                        throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_StreamLength);
-                }
-#endif
                 Interlocked.Exchange(ref _position, value);
             }
         }
@@ -334,10 +325,6 @@ namespace System.IO
                     throw new NotSupportedException(SR.NotSupported_UmsSafeBuffer);
                 if (!_isOpen) __Error.StreamIsClosed();
 
-                // Note: subtracting pointers returns an Int64.  Working around
-                // to avoid hitting compiler warning CS0652 on this line. 
-                if (new IntPtr(value - _mem).ToInt64() > UnmanagedMemStreamMaxLength)
-                    throw new ArgumentOutOfRangeException("offset", SR.ArgumentOutOfRange_UnmanagedMemStreamLength);
                 if (value < _mem)
                     throw new IOException(SR.IO_SeekBeforeBegin);
 
@@ -490,8 +477,6 @@ namespace System.IO
         public override long Seek(long offset, SeekOrigin loc)
         {
             if (!_isOpen) __Error.StreamIsClosed();
-            if (offset > UnmanagedMemStreamMaxLength)
-                throw new ArgumentOutOfRangeException(nameof(offset), SR.ArgumentOutOfRange_UnmanagedMemStreamLength);
             switch (loc)
             {
                 case SeekOrigin.Begin:

--- a/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
@@ -325,11 +325,12 @@ namespace System.IO
                     throw new NotSupportedException(SR.NotSupported_UmsSafeBuffer);
                 if (!_isOpen) __Error.StreamIsClosed();
 
+                if (value < _mem)
+                    throw new IOException(SR.IO_SeekBeforeBegin);
                 long newPosition = (long)value - (long)_mem;
                 if (newPosition < 0)
                     throw new ArgumentOutOfRangeException("offset", SR.ArgumentOutOfRange_UnmanagedMemStreamLength);
-                if (value < _mem)
-                    throw new IOException(SR.IO_SeekBeforeBegin);
+
 
                 Interlocked.Exchange(ref _position, newPosition);
             }

--- a/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
@@ -325,10 +325,13 @@ namespace System.IO
                     throw new NotSupportedException(SR.NotSupported_UmsSafeBuffer);
                 if (!_isOpen) __Error.StreamIsClosed();
 
+                long newPosition = (long)value - (long)_mem;
+                if (newPosition < 0)
+                    throw new ArgumentOutOfRangeException("offset", SR.ArgumentOutOfRange_UnmanagedMemStreamLength);
                 if (value < _mem)
                     throw new IOException(SR.IO_SeekBeforeBegin);
 
-                Interlocked.Exchange(ref _position, value - _mem);
+                Interlocked.Exchange(ref _position, newPosition);
             }
         }
 


### PR DESCRIPTION
A few of these checks aren't able to be hit, and one of the checks was causing issues on 32-bit systems.

resolves https://github.com/dotnet/coreclr/issues/11199

cc: @jkotas
